### PR TITLE
fix: enable WebSearch and WebFetch for Claude reviews

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 10"
+          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,WebSearch,WebFetch,Bash(git*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,3 +38,4 @@ jobs:
 
             Be constructive and specific. If changes look good, say so briefly.
           claude_args: "--max-turns 5"
+          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,WebSearch,WebFetch,Bash(git*)"


### PR DESCRIPTION
## Summary

Enables `WebSearch` and `WebFetch` tools in Claude Code review workflows.

These were disabled by default, causing reviews to fail when Claude needed to look up security advisories or documentation.

## Changes

- Added `allowed_tools` to `claude-review.yml` and `claude-interactive.yml`
- Enables: Edit, MultiEdit, Glob, Grep, LS, Read, Write, WebSearch, WebFetch, Bash(git*)

## Test plan

- [ ] Trigger a review on PR #2 to verify WebSearch now works