### PR TITLE
fix: use correct --allowedTools flag in claude_args

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -25,5 +25,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 10"
-          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,WebSearch,WebFetch,Bash(git*)"
+          claude_args: "--max-turns 10 --allowedTools WebSearch,WebFetch"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,5 +37,4 @@ jobs:
             - Documentation completeness
 
             Be constructive and specific. If changes look good, say so briefly.
-          claude_args: "--max-turns 5"
-          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,WebSearch,WebFetch,Bash(git*)"
+          claude_args: "--max-turns 5 --allowedTools WebSearch,WebFetch"


### PR DESCRIPTION
Fixes invalid `allowed_tools` parameter. Uses `--allowedTools` in `claude_args` instead.