### PR TITLE
fix: use cargo fmt in treefmt for consistent formatting

### DIFF
--- a/treefmt.toml
+++ b/treefmt.toml
@@ -4,12 +4,12 @@
 
 [global]
 excludes = [
-    "target/*",
-    "result/*",
-    ".direnv/*",
-    "spec/fixtures/lima-tests/*",
-    "spec/fixtures/examples/*",
-    "*.lock",
+  "target/*",
+  "result/*",
+  ".direnv/*",
+  "spec/fixtures/lima-tests/*",
+  "spec/fixtures/examples/*",
+  "*.lock",
 ]
 
 [formatter.nix]
@@ -17,8 +17,8 @@ command = "nixpkgs-fmt"
 includes = ["*.nix"]
 
 [formatter.rust]
-command = "rustfmt"
-options = ["--edition", "2021"]
+command = "cargo"
+options = ["fmt", "--"]
 includes = ["*.rs"]
 
 [formatter.toml]


### PR DESCRIPTION
## Summary

Fixes the recurring formatting mismatch between treefmt (pre-commit hook) and CI (`cargo fmt --check`).

**Root cause:** treefmt invoked `rustfmt --edition 2021` directly, ignoring `rustfmt.toml` settings like `max_width = 100`.

**Fix:** Use `cargo fmt` instead, which respects `rustfmt.toml`.

## Changes

```toml
# Before
[formatter.rust]
command = "rustfmt"
options = ["--edition", "2021"]

# After  
[formatter.rust]
command = "cargo"
options = ["fmt", "--"]
```

## Test plan

- [x] Pre-commit hook passes
- [ ] CI formatting check passes