### PR TITLE
feat(loader): add path traversal protection

### DIFF
--- a/crates/rustledger-loader/tests/fixtures/path_traversal.beancount
+++ b/crates/rustledger-loader/tests/fixtures/path_traversal.beancount
@@ -1,0 +1,7 @@
+; Test file that attempts path traversal
+option "title" "Path Traversal Test"
+
+; This include tries to escape the fixtures directory
+include "../../Cargo.toml"
+
+2024-01-01 open Assets:Bank USD

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -8,7 +8,7 @@ use rustledger_booking::interpolate;
 use rustledger_core::Directive;
 use rustledger_loader::{LoadError, Loader};
 use rustledger_plugin::{
-    wrappers_to_directives, NativePluginRegistry, PluginInput, PluginManager, PluginOptions,
+    NativePluginRegistry, PluginInput, PluginManager, PluginOptions, wrappers_to_directives,
 };
 use rustledger_validate::validate;
 use std::io::{self, Write};
@@ -123,6 +123,20 @@ fn run(args: &Args) -> Result<ExitCode> {
                         stdout,
                         "error: include cycle detected: {}",
                         cycle.join(" -> ")
+                    )?;
+                }
+                error_count += 1;
+            }
+            LoadError::PathTraversal {
+                include_path,
+                base_dir,
+            } => {
+                if !args.quiet {
+                    writeln!(
+                        stdout,
+                        "error: path traversal not allowed: {} escapes {}",
+                        include_path,
+                        base_dir.display()
                     )?;
                 }
                 error_count += 1;


### PR DESCRIPTION
## Summary
- Add security feature to prevent malicious ledger files from accessing files outside the ledger directory
- New `with_path_security(bool)` method to enable/disable protection
- New `with_root_dir(PathBuf)` method to set custom root directory
- New `PathTraversal` error variant for security violations

## Motivation
This protects against attacks where a crafted .beancount file uses relative paths like `include "../../../etc/passwd"` to escape the intended directory.

## Test plan
- [x] Unit tests for path traversal detection
- [x] Test that valid relative includes still work
- [x] Test custom root directory configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)