### PR TITLE
chore: add code coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,26 @@ jobs:
       - run: cargo doc --all-features --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage report
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # All checks pass - required for branch protection
   build:
     name: build


### PR DESCRIPTION
## Summary
- Add GitHub Actions job to generate and upload code coverage reports to Codecov
- Uses cargo-llvm-cov for accurate coverage measurement across the workspace

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Check that coverage report is uploaded to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)