### PR TITLE
chore(ci): increase Claude code review max turns

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,4 +37,4 @@ jobs:
             - Documentation completeness
 
             Be constructive and specific. If changes look good, say so briefly.
-          claude_args: "--max-turns 5 --allowedTools WebSearch,WebFetch"
+          claude_args: "--max-turns 20 --allowedTools WebSearch,WebFetch"


### PR DESCRIPTION
## Summary
Increase max-turns from 5 to 20 to allow thorough review of larger PRs.

5 turns was insufficient - the reviewer kept hitting the limit on PRs with many file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)