### PR TITLE
fix(hooks): match clippy pre-commit config to CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,1 @@
-/nix/store/xczf8kbqhv1xa7mkdzarxaji2kp92v43-pre-commit-config.json
+/nix/store/0bqamirimhgdkjks7wy3zs70rd193mra-pre-commit-config.json

--- a/flake.nix
+++ b/flake.nix
@@ -209,6 +209,10 @@
                 enable = true;
                 packageOverrides.cargo = rustToolchainWithWasm;
                 packageOverrides.clippy = rustToolchainWithWasm;
+                settings = {
+                  allFeatures = true;
+                  denyWarnings = true;
+                };
               };
 
               # Nix


### PR DESCRIPTION
## Summary
- Add `allFeatures` and `denyWarnings` settings to clippy pre-commit hook
- Now local pre-commit clippy matches CI: `--all-features -D warnings`

## Problem
Local commits weren't catching the same clippy issues that failed in CI because:
1. Pre-commit clippy didn't use `--all-features`
2. Pre-commit clippy didn't use `-D warnings` (treat warnings as errors)

## Test plan
- [x] `nix flake check` passes
- [x] Pre-commit config regenerated with new args
- [ ] Future commits will catch clippy warnings locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)