### PR TITLE
feat(loader): add GPG encrypted file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,7 @@ dependencies = [
  "rust_decimal",
  "rustledger-core",
  "rustledger-parser",
+ "tempfile",
  "thiserror 2.0.17",
 ]
 

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -18,5 +18,8 @@ rustledger-parser.workspace = true
 rust_decimal.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -8,7 +8,7 @@ use rustledger_booking::interpolate;
 use rustledger_core::Directive;
 use rustledger_loader::{LoadError, Loader};
 use rustledger_plugin::{
-    wrappers_to_directives, NativePluginRegistry, PluginInput, PluginManager, PluginOptions,
+    NativePluginRegistry, PluginInput, PluginManager, PluginOptions, wrappers_to_directives,
 };
 use rustledger_validate::validate;
 use std::io::{self, Write};
@@ -137,6 +137,17 @@ fn run(args: &Args) -> Result<ExitCode> {
                         "error: path traversal not allowed: {} escapes {}",
                         include_path,
                         base_dir.display()
+                    )?;
+                }
+                error_count += 1;
+            }
+            LoadError::Decryption { path, message } => {
+                if !args.quiet {
+                    writeln!(
+                        stdout,
+                        "error: failed to decrypt {}: {}",
+                        path.display(),
+                        message
                     )?;
                 }
                 error_count += 1;


### PR DESCRIPTION
## Summary
Add automatic decryption for GPG-encrypted beancount files, matching Python beancount behavior.

## Changes
- Add `is_encrypted_file()` to detect `.gpg` files or `.asc` files with PGP headers
- Add `decrypt_gpg_file()` that shells out to `gpg --batch --decrypt`
- Add `LoadError::Decryption` variant for clear error reporting
- Auto-decrypt in `load_recursive()` before parsing

## How it works
- Files with `.gpg` extension → automatically decrypted
- Files with `.asc` extension → checked for `-----BEGIN PGP MESSAGE-----` header, then decrypted
- Regular `.beancount` files → loaded normally (no change)

Uses the system `gpg` command, so it works with the user's existing GPG keyring and gpg-agent.

## Test plan
- [x] Unit tests for file detection
- [x] Unit tests for decryption error handling
- [x] All existing tests pass
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)