### PR TITLE
fix(ci): prevent benchmark timeout with parallel jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,26 +11,23 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  benchmark:
-    name: Performance Benchmarks
+  # For PRs: Run base and PR benchmarks in parallel jobs for better caching
+  benchmark-base:
+    name: Benchmark Base
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.base_ref }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Install critcmp
-        run: cargo install critcmp
-      # For PRs: benchmark both base and PR, then compare
-      - name: Checkout base branch
-        if: github.event_name == 'pull_request'
-        run: git checkout ${{ github.base_ref }}
+          prefix-key: bench-base
       - name: Run base benchmarks
         id: base_bench
-        if: github.event_name == 'pull_request'
         continue-on-error: true
         run: |
           cargo bench -p rustledger-core --bench inventory_bench -- --save-baseline base
@@ -38,33 +35,87 @@ jobs:
           cargo bench -p rustledger-query --bench query_bench -- --save-baseline base
           cargo bench -p rustledger-validate --bench validate_bench -- --save-baseline base
           cargo bench -p rustledger --bench pipeline_bench -- --save-baseline base
-      - name: Checkout PR branch
-        if: github.event_name == 'pull_request'
-        run: git checkout ${{ github.head_ref }}
+      - name: Upload base baseline
+        if: steps.base_bench.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: base-baseline
+          path: target/criterion
+          retention-days: 1
+
+  benchmark-pr:
+    name: Benchmark PR
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          prefix-key: bench-pr
       - name: Run PR benchmarks
-        if: github.event_name == 'pull_request'
         run: |
           cargo bench -p rustledger-core --bench inventory_bench -- --save-baseline pr
           cargo bench -p rustledger-parser --bench parser_bench -- --save-baseline pr
           cargo bench -p rustledger-query --bench query_bench -- --save-baseline pr
           cargo bench -p rustledger-validate --bench validate_bench -- --save-baseline pr
           cargo bench -p rustledger --bench pipeline_bench -- --save-baseline pr
+      - name: Upload PR baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-baseline
+          path: target/criterion
+          retention-days: 1
+
+  compare-benchmarks:
+    name: Compare Benchmarks
+    if: github.event_name == 'pull_request'
+    needs: [benchmark-base, benchmark-pr]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install critcmp
+        run: cargo install critcmp
+      - name: Download base baseline
+        uses: actions/download-artifact@v4
+        with:
+          name: base-baseline
+          path: target/criterion
+        continue-on-error: true
+      - name: Download PR baseline
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-baseline
+          path: target/criterion-pr
+      - name: Merge baselines
+        run: |
+          # Move PR baselines into the main criterion directory
+          if [ -d "target/criterion-pr" ]; then
+            cp -r target/criterion-pr/* target/criterion/ 2>/dev/null || true
+          fi
       - name: Compare benchmarks
-        if: github.event_name == 'pull_request' && steps.base_bench.outcome == 'success'
         id: compare
         run: |
           echo "## Benchmark Comparison" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Comparing \`${{ github.base_ref }}\` (base) vs \`${{ github.head_ref }}\` (pr)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          critcmp base pr >> $GITHUB_STEP_SUMMARY 2>&1 || true
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-          # Save comparison for PR comment
-          critcmp base pr > bench_comparison.txt 2>&1 || true
+          if [ -d "target/criterion/base" ] && [ -d "target/criterion/pr" ]; then
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            critcmp base pr >> $GITHUB_STEP_SUMMARY 2>&1 || true
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            critcmp base pr > bench_comparison.txt 2>&1 || true
+          else
+            echo "⚠️ Base benchmarks unavailable - showing PR benchmarks only" >> $GITHUB_STEP_SUMMARY
+            echo "base baseline exists: $([ -d 'target/criterion/base' ] && echo 'yes' || echo 'no')" >> $GITHUB_STEP_SUMMARY
+            echo "pr baseline exists: $([ -d 'target/criterion/pr' ] && echo 'yes' || echo 'no')" >> $GITHUB_STEP_SUMMARY
+            echo "PR benchmarks completed successfully." > bench_comparison.txt
+          fi
       - name: Post benchmark comparison as PR comment
-        if: github.event_name == 'pull_request' && steps.base_bench.outcome == 'success'
         uses: actions/github-script@v7
         with:
           script: |
@@ -114,9 +165,21 @@ jobs:
                 body: body
               });
             }
-      # For main branch pushes: just run benchmarks to ensure they work
-      - name: Run benchmarks (main)
-        if: github.ref == 'refs/heads/main'
+
+  # For main branch pushes: just run benchmarks to ensure they work
+  benchmark-main:
+    name: Performance Benchmarks
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          prefix-key: bench-main
+      - name: Run benchmarks
         run: |
           cargo bench -p rustledger-core --bench inventory_bench
           cargo bench -p rustledger-parser --bench parser_bench


### PR DESCRIPTION
## Summary

Fixes the benchmark workflow timeout issue (exit code 143 = SIGTERM) by:

- **Splitting into parallel jobs**: Base and PR benchmarks now run simultaneously instead of sequentially switching branches
- **Adding 30-minute timeout per job**: Prevents runaway jobs from blocking CI
- **Separate cache keys**: Each job (`bench-base`, `bench-pr`, `bench-main`) has its own cache, improving cache hit rates
- **Using artifacts**: Benchmark results are shared between jobs via artifacts
- **Graceful fallback**: If base benchmarks timeout/fail, the comparison job still succeeds

### Problem

The previous workflow would timeout because:
1. Checkout base branch → compile everything (wasmtime deps take ~5+ minutes)
2. Checkout PR branch → recompile everything (cache invalidated by branch switch)

This sequential approach meant compiling the entire project twice, with each compilation taking 10+ minutes, easily exceeding reasonable timeout limits.

### Solution

```
Before:           After:
[Job 1]           [Job 1: benchmark-base]  ─┐
├─ checkout base  ├─ checkout base          │ parallel
├─ compile        ├─ compile                │
├─ benchmark      ├─ benchmark              │
├─ checkout pr    └─ upload artifact        │
├─ recompile                                │
├─ benchmark      [Job 2: benchmark-pr]   ─┤
└─ compare        ├─ checkout pr            │
                  ├─ compile                │
                  ├─ benchmark              │
                  └─ upload artifact        │
                                            │
                  [Job 3: compare]        ──┘
                  ├─ download artifacts
                  └─ compare & comment
```

## Test plan

- [x] Workflow YAML is valid
- [ ] CI runs benchmarks without timeout
- [ ] Benchmark comparison is posted to PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)