### PR TITLE
fix(ci): use explicit github_token for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Review this pull request. Focus on:
             - Code correctness and potential bugs


### PR DESCRIPTION
## Summary

Fixes the Claude Code Review action failures.

### Root Cause

The Claude Code Action was failing with:
```
Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.
```

This happens because the action uses OIDC token exchange by default, which requires the workflow file in the PR to match the version on main. Any PR that modifies the workflow file (or any time there's a mismatch) causes all reviews to fail.

### Fix

Explicitly provide `github_token: ${{ secrets.GITHUB_TOKEN }}` instead of relying on OIDC token exchange.

## Test plan

- [ ] Claude Code Review passes on this PR
- [ ] Future PRs get code reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)