### PR TITLE
chore(ci): switch to Gemini 3 Flash

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -47,7 +47,7 @@ jobs:
           github_repository: ${{ github.repository }}
           github_pull_request_number: ${{ github.event.pull_request.number }}
           git_commit_hash: ${{ github.event.pull_request.head.sha }}
-          model: "gemini-2.5-flash"
+          model: "gemini-3-flash-preview"
           pull_request_diff: |-
             ${{ steps.get_diff.outputs.pull_request_diff }}
           pull_request_chunk_size: "3500"


### PR DESCRIPTION
Switch from gemini-2.5-flash to gemini-3-flash-preview. This uses a separate quota pool, avoiding the rate limit we hit.