### PR TITLE
chore(ci): make Gemini review non-blocking

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -40,6 +40,7 @@ jobs:
             echo 'EOF';
           } >> $GITHUB_OUTPUT
       - name: Gemini Code Review
+        continue-on-error: true  # Don't block merges if quota exceeded
         uses: rubensflinco/gemini-code-review-action@1.0.5
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Add continue-on-error so quota exhaustion doesn't block merges.