### PR TITLE
fix(ci): exclude CLI crate from coverage to prevent LLVM linker OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,17 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage report
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        # Only cover core crates - rustledger (CLI) pulls in wasmtime which causes LLVM linker OOM
+        run: |
+          cargo llvm-cov --all-features --lcov --output-path lcov.info \
+            --package rustledger-core \
+            --package rustledger-parser \
+            --package rustledger-booking \
+            --package rustledger-loader \
+            --package rustledger-validate \
+            --package rustledger-query \
+            --package rustledger-plugin \
+            --package rustledger-importer
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary

The `rustledger` CLI crate pulls in wasmtime which causes the LLVM linker to crash with a bus error during coverage instrumentation on GitHub's limited-memory runners.

Run coverage only on core library crates:
- rustledger-core
- rustledger-parser
- rustledger-booking
- rustledger-loader
- rustledger-validate
- rustledger-query
- rustledger-plugin
- rustledger-importer

These contain the actual business logic worth measuring coverage for. The CLI crate is mostly just argument parsing and orchestration.

## Test plan

- [ ] Coverage job completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)