### PR TITLE
chore(nix): set RUST_MIN_STACK for debug test builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -366,6 +366,7 @@
             # Environment variables
             RUST_BACKTRACE = "1";
             RUST_LOG = "info";
+            RUST_MIN_STACK = "8388608"; # 8MB stack for debug builds
 
             # For rust-analyzer
             RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";


### PR DESCRIPTION
## Summary
- Set `RUST_MIN_STACK=8388608` (8MB) in nix dev shell
- Matches CI environment configuration
- Prevents stack overflow in query executor tests during local development

## Test plan
- [x] Verified test passes with env var set
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)