### PR TITLE
chore(release): improve release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
           # Windows
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -67,8 +69,8 @@ jobs:
           # Create archive with all binaries
           ARCHIVE="rustledger-${VERSION}-${{ matrix.target }}.tar.gz"
           tar -czvf "../../../${ARCHIVE}" \
-            rledger-check rledger-format rledger-query rledger-report rledger-doctor \
-            bean-check bean-format bean-query bean-report bean-doctor
+            rledger-check rledger-format rledger-query rledger-report rledger-doctor rledger-extract rledger-price \
+            bean-check bean-format bean-query bean-report bean-doctor bean-extract bean-price
 
           # Create checksum
           cd ../../..
@@ -85,8 +87,8 @@ jobs:
           # Create archive with all binaries
           $ARCHIVE = "rustledger-${VERSION}-${{ matrix.target }}.zip"
           $binaries = @(
-            "rledger-check.exe", "rledger-format.exe", "rledger-query.exe", "rledger-report.exe", "rledger-doctor.exe",
-            "bean-check.exe", "bean-format.exe", "bean-query.exe", "bean-report.exe", "bean-doctor.exe"
+            "rledger-check.exe", "rledger-format.exe", "rledger-query.exe", "rledger-report.exe", "rledger-doctor.exe", "rledger-extract.exe", "rledger-price.exe",
+            "bean-check.exe", "bean-format.exe", "bean-query.exe", "bean-report.exe", "bean-doctor.exe", "bean-extract.exe", "bean-price.exe"
           )
           Compress-Archive -Path $binaries -DestinationPath "../../../${ARCHIVE}"
 
@@ -172,6 +174,42 @@ jobs:
           cargo publish -p rustledger --no-verify || true
 
           echo "All crates published!"
+  # Build and upload WASM to GitHub release
+  upload-wasm:
+    name: Upload WASM to Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build WASM package
+        run: |
+          cd crates/rustledger-wasm
+          wasm-pack build --target web --release
+      - name: Package WASM
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          cd crates/rustledger-wasm/pkg
+          # Update package.json version
+          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION#v}\"/" package.json
+          sed -i 's/"name": "rustledger-wasm"/"name": "@rustledger\/wasm"/' package.json
+          # Create archive
+          tar -czvf "../../../rustledger-wasm-${VERSION}.tar.gz" .
+          cd ../../..
+          shasum -a 256 "rustledger-wasm-${VERSION}.tar.gz" > "rustledger-wasm-${VERSION}.tar.gz.sha256"
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            rustledger-wasm-*.tar.gz
+            rustledger-wasm-*.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Publish WASM package to npm
   publish-wasm:
     name: Publish to npm

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ wasm-pack build crates/rustledger-wasm --target web
 | `rledger-query` | Run BQL queries (interactive shell or one-shot) |
 | `rledger-report` | Generate balance, account, and statistics reports |
 | `rledger-doctor` | Debugging tools: context, linked transactions, missing opens |
+| `rledger-extract` | Import transactions from CSV/OFX bank statements |
+| `rledger-price` | Fetch commodity prices from online sources |
 
 ### Examples
 
@@ -116,6 +118,26 @@ bean-query ledger.beancount "SELECT ..."
 bean-report ledger.beancount balances
 bean-doctor ledger.beancount context 42
 ```
+
+### Shell Completions
+
+All CLI commands support generating shell completions:
+
+```bash
+# Bash (add to ~/.bashrc)
+rledger-check --generate-completions bash >> ~/.bashrc
+
+# Zsh (add to ~/.zshrc)
+rledger-check --generate-completions zsh >> ~/.zshrc
+
+# Fish
+rledger-check --generate-completions fish > ~/.config/fish/completions/rledger-check.fish
+
+# PowerShell
+rledger-check --generate-completions powershell >> $PROFILE
+```
+
+Generate completions for each command you use (`rledger-check`, `rledger-query`, etc.).
 
 ## Library Usage
 


### PR DESCRIPTION
## Summary

Improves release workflow to include more assets:

### New Targets
- **Windows ARM64** (`aarch64-pc-windows-msvc`) - for Surface Pro X, etc.

### New Binaries
- `rledger-extract` / `bean-extract` - CSV/OFX import
- `rledger-price` / `bean-price` - commodity price fetching

### WASM Release Asset
- WASM package now uploaded directly to GitHub releases
- Users don't need npm to download WASM build

### Documentation
- Added shell completions section to README
- Added extract/price commands to CLI table

## Release Assets After This Change

| Asset Type | Count |
|------------|-------|
| Native targets | 8 (was 7) |
| CLI binaries per target | 14 (was 10) |
| WASM package | 1 (new) |

## Test plan
- [ ] CI passes
- [ ] Next release includes all new assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)