### PR TITLE
fix(build): use thin LTO to fix macOS linker crash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ unnecessary_wraps = "allow"
 multiple_crate_versions = "allow"
 
 [profile.release]
-lto = true
+lto = "thin"  # Full LTO causes Apple linker crash with long symbol names
 codegen-units = 1
 strip = true
 


### PR DESCRIPTION
## Problem

macOS builds are failing with:
```
ld: Assertion failed: (name.size() <= maxLength), function makeSymbolStringInPlace
```

This is an Apple linker bug that occurs when symbol names are too long. Full LTO combines all symbols into one compilation unit, exposing very long mangled names from wasmtime and other crates.

## Solution

Change `lto = true` to `lto = "thin"`. Thin LTO:
- Still provides cross-crate optimization
- Processes crates in parallel (faster builds)
- Avoids the symbol table overflow

## Test plan
- [ ] macOS builds succeed in release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)