### PR TITLE
fix(build): disable LTO entirely on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Build
         shell: bash
         run: |
+          # Disable LTO on macOS - Apple's linker crashes on long symbol names from wasmtime
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            export CARGO_PROFILE_RELEASE_LTO=false
+          fi
+
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }}
           else


### PR DESCRIPTION
## Summary
- Thin LTO still triggers Apple linker crash on long symbol names from wasmtime
- Use `CARGO_PROFILE_RELEASE_LTO=false` env var override for macOS builds only
- Other platforms continue to use thin LTO from Cargo.toml

## Test plan
- [ ] macOS x86_64 build succeeds
- [ ] macOS aarch64 build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)