### PR TITLE
chore: rename beancount-rs references to rustledger

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-# Direnv configuration for beancount-rs
+# Direnv configuration for rustledger
 # See: https://direnv.net/
 
 # Use Nix flake development shell

--- a/crates/rustledger/tests/fixtures/valid-ledger.beancount
+++ b/crates/rustledger/tests/fixtures/valid-ledger.beancount
@@ -1,6 +1,6 @@
 ; Valid beancount file for integration testing
 ; This file should parse and validate successfully with both
-; Python beancount and beancount-rs
+; Python beancount and rustledger
 
 option "title" "Integration Test Ledger"
 option "operating_currency" "USD"

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# Justfile for beancount-rs
+# Justfile for rustledger
 # https://github.com/casey/just
 
 # Default recipe - show help
@@ -485,5 +485,5 @@ release-prep version:
 # Create release build
 release-build:
     cargo build --release
-    @echo "Binary at: target/release/beancount-rs"
-    @ls -lh target/release/beancount-rs
+    @echo "Binaries at: target/release/rledger-*"
+    @ls -lh target/release/rledger-*


### PR DESCRIPTION
## Summary
- Update leftover `beancount-rs` references to `rustledger` in `.envrc`, `justfile`, and test fixtures

## Test plan
- [x] Grep confirms no remaining `beancount-rs` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)