### PR TITLE
fix(ci): discard local changes before switching to benchmarks branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -249,6 +249,9 @@ jobs:
           # Save the generated files
           cp -r .github/badges /tmp/badges
 
+          # Discard local changes before switching branches
+          git checkout -- .
+
           # Fetch and checkout benchmarks branch (create if doesn't exist)
           git fetch origin benchmarks || true
           if git rev-parse --verify origin/benchmarks >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Fixes the benchmark workflow failing at the "Commit results to benchmarks branch" step.

The workflow generates badge files in `.github/badges/` while on main, then tries to checkout the benchmarks branch. Git fails because it won't overwrite locally modified files.

**Fix:** Add `git checkout -- .` after copying files to `/tmp` to discard local changes before switching branches.

## Test plan

- [x] Workflow will be triggered after merge to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)