### PR TITLE
fix(ci): fetch benchmark history before generating chart

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -117,6 +117,12 @@ jobs:
           echo "rust_ms=$avg" >> $GITHUB_OUTPUT
           echo "rustledger: ${avg}ms"
 
+      - name: Fetch existing history from benchmarks branch
+        run: |
+          mkdir -p .github/badges
+          curl -sSf https://raw.githubusercontent.com/${{ github.repository }}/benchmarks/.github/badges/benchmark-history.json \
+            -o .github/badges/benchmark-history.json 2>/dev/null || echo "[]" > .github/badges/benchmark-history.json
+
       - name: Update results and generate chart
         run: |
           python3 << 'EOF'
@@ -134,14 +140,9 @@ jobs:
           now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
           date_short = datetime.utcnow().strftime('%Y-%m-%d')
 
-          # Load existing history
+          # Load existing history (fetched from benchmarks branch)
           history_file = Path('.github/badges/benchmark-history.json')
-          history_file.parent.mkdir(parents=True, exist_ok=True)
-
-          if history_file.exists():
-              history = json.loads(history_file.read_text())
-          else:
-              history = []
+          history = json.loads(history_file.read_text())
 
           # Append new result (keep last 90 days)
           history.append({


### PR DESCRIPTION
## Summary

Fixes the missing benchmark chart in the README.

**Problem:** The chart generation tried to load history from the main branch (where it doesn't exist), resulting in an empty history array and no chart being generated.

**Fix:** Add a step to fetch the existing `benchmark-history.json` from the benchmarks branch via curl before generating the chart.

## Test plan

- [ ] Merge PR
- [ ] Trigger benchmark workflow
- [ ] Verify chart appears in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)