### PR TITLE
fix(ci): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -3,6 +3,10 @@ name: Branch Name
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate branch name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   merge_group:
     branches: [main]
+
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -13,6 +13,9 @@ on:
       - 'crates/rustledger-core/src/inventory.rs'
       - 'crates/rustledger-booking/src/**'
 
+permissions:
+  contents: read
+
 env:
   TLA_VERSION: "1.8.0"
 


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to workflows missing permission declarations.

**Affected files:**
- `ci.yml` - 7 alerts resolved
- `tla.yml` - 1 alert resolved  
- `branch-name.yml` - 1 alert resolved

This follows the principle of least privilege and resolves 9 CodeQL security warnings about missing workflow permissions.

## Test plan

- [x] Workflows still function correctly (only adds read permission they already implicitly had)

🤖 Generated with [Claude Code](https://claude.com/claude-code)