### PR TITLE
fix(release): add macOS linker workaround to non-PGO builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,11 @@ jobs:
         if: ${{ !matrix.pgo }}
         shell: bash
         run: |
+          # macOS: Use classic linker to avoid Xcode 15 crashes on long symbol names
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            export RUSTFLAGS="-C link-arg=-Wl,-ld_classic"
+          fi
+
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }} --no-default-features --features bean-compat
           else


### PR DESCRIPTION
## Summary
- Adds the macOS classic linker workaround (`-C link-arg=-Wl,-ld_classic`) to the non-PGO build step
- Fixes x86_64-apple-darwin builds which use the non-PGO path since PGO requires running the binary natively

The v0.2.0 release failed because the x86_64-apple-darwin target was missing this workaround in the "Build without PGO" step.

## Test plan
- [ ] Merge this PR
- [ ] Delete v0.2.0 tag and re-create to trigger new release
- [ ] Verify x86_64-apple-darwin builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)