### PR TITLE
fix(ci): clean untracked files before switching to benchmarks branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -250,8 +250,9 @@ jobs:
           # Save the generated files
           cp -r .github/badges /tmp/badges
 
-          # Discard local changes before switching branches
+          # Discard local changes and untracked files before switching branches
           git checkout -- .
+          git clean -fd
 
           # Fetch and checkout benchmarks branch (create if doesn't exist)
           git fetch origin benchmarks || true


### PR DESCRIPTION
## Summary
- Fixes nightly benchmark workflow failing at "Commit results to benchmarks branch"
- `git checkout -- .` only discards tracked file changes
- Added `git clean -fd` to remove untracked files (like generated chart images) before switching branches

## Test plan
- Re-run benchmark workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)