### PR TITLE
chore: fix release versioning and automation

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,7 @@
 # SECRETS REQUIRED
 # ----------------
 # - CARGO_REGISTRY_TOKEN: crates.io publish
+# - WEBSITE_DISPATCH_TOKEN: PAT for creating release (triggers release-publish.yml)
 #
 name: Release Build
 on:
@@ -31,8 +32,36 @@ env:
   CARGO_TERM_COLOR: always
   RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 jobs:
+  # Validate that tag version matches Cargo.toml version
+  validate-version:
+    name: Validate Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - name: Validate tag matches Cargo.toml version
+        run: |
+          # Extract version from tag (strip 'v' prefix)
+          TAG_VERSION="${RELEASE_TAG#v}"
+
+          # Extract version from Cargo.toml
+          CARGO_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+
+          echo "Tag version: $TAG_VERSION"
+          echo "Cargo.toml version: $CARGO_VERSION"
+
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Version mismatch! Tag is $TAG_VERSION but Cargo.toml has $CARGO_VERSION"
+            echo "::error::Please update Cargo.toml version before tagging. Use: cargo release <patch|minor|major>"
+            exit 1
+          fi
+
+          echo "Version validated successfully!"
+
   build:
     name: Build ${{ matrix.target }}
+    needs: validate-version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -243,6 +272,7 @@ jobs:
 
   build-wasm:
     name: Build WASM
+    needs: validate-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -317,7 +347,8 @@ jobs:
             artifacts/*.zip
             artifacts/*.sha256
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT instead of GITHUB_TOKEN to trigger release-publish.yml workflow
+          GITHUB_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
 
   publish-crates:
     name: Publish to crates.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-only"
@@ -88,14 +88,14 @@ rkyv = "0.8"
 tokio = { version = "1", features = ["full"] }
 
 # Internal crates
-rustledger-core = { version = "0.1.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.1.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.1.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.1.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.1.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.1.0", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.1.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.1.0", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.2.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.2.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.2.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.2.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.2.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.2.0", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.2.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.2.0", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,37 @@
+# cargo-release configuration
+# Run: cargo release [patch|minor|major] --execute
+#
+# This will:
+# 1. Bump version in all Cargo.toml files
+# 2. Update Cargo.lock
+# 3. Commit the version bump
+# 4. Create a git tag (v{version})
+# 5. Push the commit and tag to origin
+#
+# The tag push triggers the release-build.yml workflow.
+
+# Use workspace versioning - all crates share the same version
+shared-version = true
+
+# Tag format: v0.2.0
+tag-prefix = "v"
+tag-name = "{{prefix}}{{version}}"
+
+# Commit message format
+pre-release-commit-message = "chore: release v{{version}}"
+
+# Don't publish to crates.io from cargo-release (handled by CI)
+publish = false
+
+# Push to origin after tagging
+push = true
+
+# Sign tags with GPG (disable if you don't have GPG set up)
+sign-tag = false
+sign-commit = false
+
+# Allow releasing from main branch only
+allow-branch = ["main"]
+
+# Pre-release hook to verify everything builds
+pre-release-hook = ["cargo", "check", "--workspace"]


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.2.0 (was missed in v0.2.0 tag)
- Add `cargo-release` config for automated version bumps
- Add version validation job to `release-build.yml` (fails early if tag doesn't match Cargo.toml)
- Use `WEBSITE_DISPATCH_TOKEN` PAT for release creation to trigger `release-publish.yml` automatically

## Background
The v0.2.0 release had `version = "0.1.0"` in Cargo.toml because there was no automation to bump versions before tagging. Additionally, `release-publish.yml` never triggered because `GITHUB_TOKEN` doesn't trigger downstream workflows.

## Future Release Process
```bash
cargo release patch --execute   # 0.2.0 → 0.2.1
cargo release minor --execute   # 0.2.0 → 0.3.0  
cargo release major --execute   # 0.2.0 → 1.0.0
```

This will automatically bump versions, commit, tag, and push - triggering the full release pipeline.

## Test plan
- [ ] CI passes
- [ ] Version validation would fail on v0.2.0 tag (expected - demonstrates the check works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)