### PR TITLE
chore: add CLA and commercial licensing notice

### DIFF
--- a/.claassistant
+++ b/.claassistant
@@ -1,0 +1,3 @@
+{
+  "cla-doc": "CLA.md"
+}

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,42 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to rustledger.
+
+By submitting a pull request or otherwise contributing to this project, you agree to the following terms:
+
+## 1. Definitions
+
+- **"You"** means the individual or legal entity making the Contribution.
+- **"Contribution"** means any code, documentation, or other material you submit to this project.
+- **"Project"** means the rustledger software and associated materials.
+
+## 2. Grant of Rights
+
+You hereby grant to the Project maintainers and their successors:
+
+1. **Copyright License**: A perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works under any license terms, including proprietary licenses.
+
+2. **Patent License**: A perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contribution(s) alone or by combination of your Contribution(s) with the Project.
+
+## 3. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. If your employer has rights to intellectual property that you create, you have received permission to make Contributions on behalf of that employer, or your employer has waived such rights.
+3. Your Contribution is your original creation and does not violate any third-party rights.
+
+## 4. No Obligation
+
+You understand that:
+
+1. The Project maintainers are under no obligation to accept or include your Contribution.
+2. The Project may be distributed under different license terms in the future, including proprietary licenses.
+
+## 5. Support
+
+You are not expected to provide support for your Contributions, except to the extent you desire to provide support.
+
+---
+
+By signing below (via CLA Assistant), you agree to these terms.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ rledger-format --in-place ledger.beancount
 
 See [CLAUDE.md](CLAUDE.md) for architecture and development setup.
 
+By submitting a pull request, you agree to the [Contributor License Agreement](CLA.md).
+
 ## License
 
 [GPL-3.0](LICENSE)
+
+**Commercial licensing available** - [contact us](https://rustledger.github.io/#contact) for proprietary license options.


### PR DESCRIPTION
## Summary

- Add Contributor License Agreement (CLA.md)
- Add .claassistant config for CLA Assistant GitHub App
- Update README with CLA reference and commercial licensing contact

## Manual step required

After merging, install CLA Assistant on the repo:
1. Go to https://cla-assistant.io/
2. Sign in with GitHub
3. Select rustledger/rustledger repo
4. It will use CLA.md automatically

## Test plan

- [x] CLA.md contains proper license grant terms
- [x] README links to CLA and contact form

🤖 Generated with [Claude Code](https://claude.com/claude-code)