### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-only"
@@ -90,14 +90,14 @@ rkyv = "0.8"
 tokio = { version = "1", features = ["full"] }
 
 # Internal crates
-rustledger-core = { version = "0.2.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.2.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.2.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.2.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.2.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.2.0", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.2.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.2.0", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.3.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.3.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.3.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.3.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.3.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.3.0", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.3.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.3.0", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## Summary

Bump version to 0.3.0 for release.

## Changes in v0.3.0

- **4x faster parsing** with Logos lexer + token-based parser (#81)
- Added Contributor License Agreement (#83)
- Commercial licensing now available

## After merge

Tag will be created manually:
```bash
git tag v0.3.0 && git push origin v0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)