### PR TITLE
fix: untrack pre-commit config symlink for release-plz compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 /result
 /result-*
 .direnv/
+.pre-commit-config.yaml
 
 # Coverage
 *.profraw

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,0 @@
-/nix/store/s553xmw9zzlay6injkx6lwrxg7xvh4bl-pre-commit-config.json


### PR DESCRIPTION
## Summary
- Remove `.pre-commit-config.yaml` symlink from git tracking
- Add it to `.gitignore`

## Problem
The release-plz workflow fails because `.pre-commit-config.yaml` is a symlink to a Nix store path (`/nix/store/...`). When release-plz copies the repo directory to a temp location, it can't handle external symlinks:

```
cannot strip prefix "/home/runner/work/rustledger/rustledger" from "/nix/store/s553xmw9zzlay6injkx6lwrxg7xvh4bl-pre-commit-config.json"
```

## Solution
Since Nix generates this file locally via the devShell, it doesn't need to be tracked in git. Each developer's `nix develop` will create their own local symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)