### PR TITLE
feat!: upgrade to Rust 2024 edition and MSRV 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
 
   # MSRV check - verify minimum supported Rust version (rust-version in Cargo.toml)
   msrv:
-    name: MSRV (1.75)
+    name: MSRV (1.85)
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: ""  # Disable sccache for MSRV check
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.75
+      - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV compatibility
         run: cargo check --workspace --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-# TODO: Upgrade to resolver = "3" when MSRV is bumped to 1.84+
-# Resolver 3 enables workspace-level multi-package publishing
-resolver = "2"
+resolver = "3"
 members = [
   "crates/rustledger-core",
   "crates/rustledger-parser",
@@ -18,8 +16,8 @@ members = [
 
 [workspace.package]
 version = "0.4.0"
-edition = "2021"
-rust-version = "1.75"
+edition = "2024"
+rust-version = "1.85"
 license = "GPL-3.0-only"
 repository = "https://github.com/rustledger/rustledger"
 homepage = "https://rustledger.github.io"

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -2,8 +2,8 @@
 //!
 //! Fills in missing posting amounts to balance transactions.
 
-use rust_decimal::prelude::Signed;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::Signed;
 use rustledger_core::{Amount, IncompleteAmount, InternedStr, Transaction};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -235,8 +235,8 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
         // Get currencies with non-zero residuals
         let non_zero_residuals: Vec<(InternedStr, Decimal)> = residuals
             .iter()
-            .filter(|(_, &v)| !v.is_zero())
-            .map(|(k, &v)| (k.clone(), v))
+            .filter(|&(_, v)| !v.is_zero())
+            .map(|(k, v)| (k.clone(), *v))
             .collect();
 
         if unassigned_missing.len() > 1 && non_zero_residuals.len() > 1 {

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -25,11 +25,11 @@
 mod interpolate;
 mod pad;
 
-pub use interpolate::{interpolate, InterpolationError, InterpolationResult};
-pub use pad::{expand_pads, merge_with_padding, process_pads, PadError, PadResult};
+pub use interpolate::{InterpolationError, InterpolationResult, interpolate};
+pub use pad::{PadError, PadResult, expand_pads, merge_with_padding, process_pads};
 
-use rust_decimal::prelude::Signed;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::Signed;
 use rustledger_core::{Amount, IncompleteAmount, InternedStr, Transaction};
 use std::collections::HashMap;
 

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -469,9 +469,11 @@ mod tests {
         let result = process_pads(&directives);
 
         assert_eq!(result.errors.len(), 1);
-        assert!(result.errors[0]
-            .message
-            .contains("no corresponding balance"));
+        assert!(
+            result.errors[0]
+                .message
+                .contains("no corresponding balance")
+        );
     }
 
     #[test]

--- a/crates/rustledger-core/benches/inventory_bench.rs
+++ b/crates/rustledger-core/benches/inventory_bench.rs
@@ -4,7 +4,7 @@
 
 #![allow(missing_docs)]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use chrono::NaiveDate;
 use rust_decimal::Decimal;

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -11,10 +11,10 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+use crate::Amount;
 use crate::intern::InternedStr;
 #[cfg(feature = "rkyv")]
 use crate::intern::{AsDecimal, AsInternedStr, AsNaiveDate};
-use crate::Amount;
 
 /// A cost represents the acquisition cost of a position (lot).
 ///

--- a/crates/rustledger-core/src/intern.rs
+++ b/crates/rustledger-core/src/intern.rs
@@ -52,10 +52,10 @@ pub type AsVecInternedStr = rkyv::with::Map<AsInternedStr>;
 #[cfg(feature = "rkyv")]
 mod rkyv_impl {
     use super::InternedStr;
+    use rkyv::Place;
     use rkyv::rancor::Fallible;
     use rkyv::string::ArchivedString;
     use rkyv::with::{ArchiveWith, DeserializeWith, SerializeWith};
-    use rkyv::Place;
 
     /// Wrapper to serialize `InternedStr` as String with rkyv.
     /// Use with `#[rkyv(with = AsInternedStr)]` on `InternedStr` fields.
@@ -538,9 +538,9 @@ pub use rkyv_decimal::AsDecimal;
 
 #[cfg(feature = "rkyv")]
 mod rkyv_decimal {
+    use rkyv::Place;
     use rkyv::rancor::Fallible;
     use rkyv::with::{ArchiveWith, DeserializeWith, SerializeWith};
-    use rkyv::Place;
     use rust_decimal::Decimal;
 
     /// Wrapper to serialize `Decimal` as fixed 16-byte binary with rkyv.
@@ -588,9 +588,9 @@ pub use rkyv_date::AsNaiveDate;
 #[cfg(feature = "rkyv")]
 mod rkyv_date {
     use chrono::{Datelike, NaiveDate};
+    use rkyv::Place;
     use rkyv::rancor::Fallible;
     use rkyv::with::{ArchiveWith, DeserializeWith, SerializeWith};
-    use rkyv::Place;
 
     /// Wrapper to serialize `NaiveDate` as i32 (days from Common Era) with rkyv.
     /// This is 4 bytes instead of 10+ for string, and faster to serialize.

--- a/crates/rustledger-core/src/inventory.rs
+++ b/crates/rustledger-core/src/inventory.rs
@@ -4,8 +4,8 @@
 //! [`Position`]s. It provides methods for adding and reducing positions
 //! using different booking methods (FIFO, LIFO, STRICT, NONE).
 
-use rust_decimal::prelude::Signed;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::Signed;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -53,11 +53,11 @@ pub mod position;
 pub use amount::{Amount, IncompleteAmount};
 pub use cost::{Cost, CostSpec};
 pub use directive::{
-    sort_directives, Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document,
-    Event, MetaValue, Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, Query,
-    Transaction,
+    Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
+    Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, Query, Transaction,
+    sort_directives,
 };
-pub use format::{format_directive, FormatConfig};
+pub use format::{FormatConfig, format_directive};
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{BookingError, BookingMethod, BookingResult, Inventory};
 pub use position::Position;

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -4,8 +4,8 @@
 //! optionally with an associated cost basis (lot). Positions with costs are used
 //! for tracking investments and calculating capital gains.
 
-use rust_decimal::prelude::Signed;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::Signed;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for importers.
 
-use crate::csv_importer::CsvImporter;
 use crate::ImportResult;
+use crate::csv_importer::CsvImporter;
 use anyhow::Result;
 use std::path::Path;
 

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -1,7 +1,7 @@
 //! CSV file importer.
 
-use crate::config::{ColumnSpec, CsvConfig, ImporterConfig};
 use crate::ImportResult;
+use crate::config::{ColumnSpec, CsvConfig, ImporterConfig};
 use anyhow::{Context, Result};
 use chrono::NaiveDate;
 use rust_decimal::Decimal;

--- a/crates/rustledger-importer/src/registry.rs
+++ b/crates/rustledger-importer/src/registry.rs
@@ -177,10 +177,12 @@ mod tests {
         let unknown_path = Path::new("document.pdf");
         let result = registry.extract(unknown_path);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("No importer found"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No importer found")
+        );
     }
 
     #[test]

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -18,8 +18,8 @@
 
 use crate::Options;
 use rust_decimal::Decimal;
-use rustledger_core::intern::StringInterner;
 use rustledger_core::Directive;
+use rustledger_core::intern::StringInterner;
 use rustledger_parser::Spanned;
 use sha2::{Digest, Sha256};
 use std::fs;

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -35,8 +35,8 @@ mod source_map;
 
 #[cfg(feature = "cache")]
 pub use cache::{
-    invalidate_cache, load_cache_entry, reintern_directives, save_cache_entry, CacheEntry,
-    CachedOptions, CachedPlugin,
+    CacheEntry, CachedOptions, CachedPlugin, invalidate_cache, load_cache_entry,
+    reintern_directives, save_cache_entry,
 };
 pub use options::Options;
 pub use source_map::{SourceFile, SourceMap};

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests are based on patterns from beancount's test suite.
 
-use rustledger_loader::{load, LoadError, Loader};
+use rustledger_loader::{LoadError, Loader, load};
 use std::path::Path;
 
 fn fixtures_path(name: &str) -> std::path::PathBuf {

--- a/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
+++ b/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
@@ -147,11 +147,7 @@ pub fn handle_incoming_calls(
         }
     }
 
-    if calls.is_empty() {
-        None
-    } else {
-        Some(calls)
-    }
+    if calls.is_empty() { None } else { Some(calls) }
 }
 
 /// Handle outgoing calls request.

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -278,12 +278,14 @@ mod tests {
         assert_eq!(lenses.len(), 3);
 
         // First lens is for the open directive
-        assert!(lenses[0]
-            .command
-            .as_ref()
-            .unwrap()
-            .title
-            .contains("2 transactions"));
+        assert!(
+            lenses[0]
+                .command
+                .as_ref()
+                .unwrap()
+                .title
+                .contains("2 transactions")
+        );
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/document_links.rs
+++ b/crates/rustledger-lsp/src/handlers/document_links.rs
@@ -48,11 +48,7 @@ pub fn handle_document_links(
         }
     }
 
-    if links.is_empty() {
-        None
-    } else {
-        Some(links)
-    }
+    if links.is_empty() { None } else { Some(links) }
 }
 
 /// Handle a document link resolve request.
@@ -104,7 +100,7 @@ pub fn handle_document_link_resolve(link: DocumentLink) -> DocumentLink {
 fn resolve_full_path(path: &str, base_dir: &Option<String>) -> Option<String> {
     if Path::new(path).is_absolute() {
         Some(path.to_string())
-    } else if let Some(ref base) = base_dir {
+    } else if let Some(base) = base_dir {
         let base_path = Path::new(base);
         Some(base_path.join(path).to_string_lossy().to_string())
     } else {

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -79,11 +79,7 @@ pub fn handle_formatting(
     });
     edits.dedup_by(|a, b| a.range == b.range);
 
-    if edits.is_empty() {
-        None
-    } else {
-        Some(edits)
-    }
+    if edits.is_empty() { None } else { Some(edits) }
 }
 
 /// Format a posting line for alignment.

--- a/crates/rustledger-lsp/src/handlers/hover.rs
+++ b/crates/rustledger-lsp/src/handlers/hover.rs
@@ -180,22 +180,54 @@ fn count_currency_usages(currency: &str, parse_result: &ParseResult) -> usize {
 /// Get information about a directive keyword.
 fn get_directive_info(keyword: &str) -> Option<String> {
     let info = match keyword {
-        "open" => "## `open` Directive\n\nOpens an account for use in transactions.\n\n```beancount\n2024-01-01 open Assets:Bank USD\n```",
-        "close" => "## `close` Directive\n\nCloses an account. No transactions allowed after this date.\n\n```beancount\n2024-12-31 close Assets:OldBank\n```",
-        "commodity" => "## `commodity` Directive\n\nDefines a currency or commodity.\n\n```beancount\n2024-01-01 commodity USD\n```",
-        "balance" => "## `balance` Directive\n\nAsserts the balance of an account at a given date.\n\n```beancount\n2024-01-01 balance Assets:Bank 1000.00 USD\n```",
-        "pad" => "## `pad` Directive\n\nAutomatically pads an account to match a balance assertion.\n\n```beancount\n2024-01-01 pad Assets:Bank Equity:Opening-Balances\n```",
-        "event" => "## `event` Directive\n\nRecords a named event with a value.\n\n```beancount\n2024-01-01 event \"location\" \"New York\"\n```",
-        "note" => "## `note` Directive\n\nAttaches a note to an account.\n\n```beancount\n2024-01-01 note Assets:Bank \"Account opened\"\n```",
-        "document" => "## `document` Directive\n\nLinks a document to an account.\n\n```beancount\n2024-01-01 document Assets:Bank \"/path/to/statement.pdf\"\n```",
-        "query" => "## `query` Directive\n\nDefines a named BQL query.\n\n```beancount\n2024-01-01 query \"expenses\" \"SELECT account, sum(amount)\"\n```",
-        "custom" => "## `custom` Directive\n\nA custom directive for extensions.\n\n```beancount\n2024-01-01 custom \"budget\" Expenses:Food 500.00 USD\n```",
-        "price" => "## `price` Directive\n\nRecords a price for a commodity.\n\n```beancount\n2024-01-01 price BTC 45000.00 USD\n```",
-        "txn" | "*" => "## Transaction\n\nA complete (balanced) transaction.\n\n```beancount\n2024-01-01 * \"Payee\" \"Description\"\n  Assets:Bank  -100.00 USD\n  Expenses:Food\n```",
-        "!" => "## Transaction (Incomplete)\n\nAn incomplete or flagged transaction.\n\n```beancount\n2024-01-01 ! \"Payee\" \"Needs review\"\n  Assets:Bank  -100.00 USD\n  Expenses:Unknown\n```",
-        "include" => "## `include` Directive\n\nIncludes another Beancount file.\n\n```beancount\ninclude \"other-file.beancount\"\n```",
-        "option" => "## `option` Directive\n\nSets a Beancount option.\n\n```beancount\noption \"operating_currency\" \"USD\"\n```",
-        "plugin" => "## `plugin` Directive\n\nLoads a plugin.\n\n```beancount\nplugin \"beancount.plugins.auto_accounts\"\n```",
+        "open" => {
+            "## `open` Directive\n\nOpens an account for use in transactions.\n\n```beancount\n2024-01-01 open Assets:Bank USD\n```"
+        }
+        "close" => {
+            "## `close` Directive\n\nCloses an account. No transactions allowed after this date.\n\n```beancount\n2024-12-31 close Assets:OldBank\n```"
+        }
+        "commodity" => {
+            "## `commodity` Directive\n\nDefines a currency or commodity.\n\n```beancount\n2024-01-01 commodity USD\n```"
+        }
+        "balance" => {
+            "## `balance` Directive\n\nAsserts the balance of an account at a given date.\n\n```beancount\n2024-01-01 balance Assets:Bank 1000.00 USD\n```"
+        }
+        "pad" => {
+            "## `pad` Directive\n\nAutomatically pads an account to match a balance assertion.\n\n```beancount\n2024-01-01 pad Assets:Bank Equity:Opening-Balances\n```"
+        }
+        "event" => {
+            "## `event` Directive\n\nRecords a named event with a value.\n\n```beancount\n2024-01-01 event \"location\" \"New York\"\n```"
+        }
+        "note" => {
+            "## `note` Directive\n\nAttaches a note to an account.\n\n```beancount\n2024-01-01 note Assets:Bank \"Account opened\"\n```"
+        }
+        "document" => {
+            "## `document` Directive\n\nLinks a document to an account.\n\n```beancount\n2024-01-01 document Assets:Bank \"/path/to/statement.pdf\"\n```"
+        }
+        "query" => {
+            "## `query` Directive\n\nDefines a named BQL query.\n\n```beancount\n2024-01-01 query \"expenses\" \"SELECT account, sum(amount)\"\n```"
+        }
+        "custom" => {
+            "## `custom` Directive\n\nA custom directive for extensions.\n\n```beancount\n2024-01-01 custom \"budget\" Expenses:Food 500.00 USD\n```"
+        }
+        "price" => {
+            "## `price` Directive\n\nRecords a price for a commodity.\n\n```beancount\n2024-01-01 price BTC 45000.00 USD\n```"
+        }
+        "txn" | "*" => {
+            "## Transaction\n\nA complete (balanced) transaction.\n\n```beancount\n2024-01-01 * \"Payee\" \"Description\"\n  Assets:Bank  -100.00 USD\n  Expenses:Food\n```"
+        }
+        "!" => {
+            "## Transaction (Incomplete)\n\nAn incomplete or flagged transaction.\n\n```beancount\n2024-01-01 ! \"Payee\" \"Needs review\"\n  Assets:Bank  -100.00 USD\n  Expenses:Unknown\n```"
+        }
+        "include" => {
+            "## `include` Directive\n\nIncludes another Beancount file.\n\n```beancount\ninclude \"other-file.beancount\"\n```"
+        }
+        "option" => {
+            "## `option` Directive\n\nSets a Beancount option.\n\n```beancount\noption \"operating_currency\" \"USD\"\n```"
+        }
+        "plugin" => {
+            "## `plugin` Directive\n\nLoads a plugin.\n\n```beancount\nplugin \"beancount.plugins.auto_accounts\"\n```"
+        }
         _ => return None,
     };
 

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -79,11 +79,7 @@ pub fn handle_inlay_hints(
         }
     }
 
-    if hints.is_empty() {
-        None
-    } else {
-        Some(hints)
-    }
+    if hints.is_empty() { None } else { Some(hints) }
 }
 
 /// Handle an inlay hint resolve request.

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -88,11 +88,7 @@ pub fn handle_range_formatting(
     });
     edits.dedup_by(|a, b| a.range == b.range);
 
-    if edits.is_empty() {
-        None
-    } else {
-        Some(edits)
-    }
+    if edits.is_empty() { None } else { Some(edits) }
 }
 
 /// Format a posting line for alignment.

--- a/crates/rustledger-lsp/src/handlers/selection_range.rs
+++ b/crates/rustledger-lsp/src/handlers/selection_range.rs
@@ -8,7 +8,7 @@ use lsp_types::{Position, Range, SelectionRange, SelectionRangeParams};
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 
-use super::utils::{is_word_char, LineIndex};
+use super::utils::{LineIndex, is_word_char};
 
 /// Handle a selection range request.
 pub fn handle_selection_range(

--- a/crates/rustledger-lsp/src/handlers/type_hierarchy.rs
+++ b/crates/rustledger-lsp/src/handlers/type_hierarchy.rs
@@ -134,11 +134,7 @@ pub fn handle_subtypes(
         })
         .collect();
 
-    if items.is_empty() {
-        None
-    } else {
-        Some(items)
-    }
+    if items.is_empty() { None } else { Some(items) }
 }
 
 /// Get the parent account by removing the last segment.

--- a/crates/rustledger-lsp/src/lib.rs
+++ b/crates/rustledger-lsp/src/lib.rs
@@ -37,7 +37,7 @@ mod snapshot;
 mod vfs;
 
 pub use main_loop::run_main_loop;
-pub use server::{start_stdio, Server};
+pub use server::{Server, start_stdio};
 pub use snapshot::Snapshot;
 pub use vfs::Vfs;
 

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -73,7 +73,7 @@ use lsp_types::{
     WorkspaceSymbolParams,
 };
 use parking_lot::RwLock;
-use rustledger_parser::{parse, ParseResult};
+use rustledger_parser::{ParseResult, parse};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -924,7 +924,7 @@ impl MainLoopState {
             None => {
                 return Ok(serde_json::json!({
                     "error": "No document open"
-                }))
+                }));
             }
         };
 

--- a/crates/rustledger-lsp/src/snapshot.rs
+++ b/crates/rustledger-lsp/src/snapshot.rs
@@ -3,8 +3,8 @@
 //! Each LSP request receives an immutable snapshot of the world state.
 //! This allows requests to be processed concurrently without locks.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Global revision counter for cancellation detection.
 static REVISION: AtomicU64 = AtomicU64::new(0);

--- a/crates/rustledger-lsp/src/vfs.rs
+++ b/crates/rustledger-lsp/src/vfs.rs
@@ -6,7 +6,7 @@
 //! Documents cache their parse results to avoid re-parsing on every request.
 
 use ropey::Rope;
-use rustledger_parser::{parse, ParseResult};
+use rustledger_parser::{ParseResult, parse};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/rustledger-parser/benches/parser_bench.rs
+++ b/crates/rustledger-parser/benches/parser_bench.rs
@@ -4,7 +4,7 @@
 
 #![allow(missing_docs)]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use rustledger_parser::logos_lexer::tokenize;
 use rustledger_parser::parse;

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -504,9 +504,11 @@ mod tests {
         assert!(tokens.iter().any(|(t, _)| matches!(t, Token::String(_))));
         assert!(tokens.iter().any(|(t, _)| matches!(t, Token::Tag(_))));
         assert!(tokens.iter().any(|(t, _)| matches!(t, Token::Newline)));
-        assert!(tokens
-            .iter()
-            .any(|(t, _)| matches!(t, Token::Indent(_) | Token::DeepIndent(_))));
+        assert!(
+            tokens
+                .iter()
+                .any(|(t, _)| matches!(t, Token::Indent(_) | Token::DeepIndent(_)))
+        );
         assert!(tokens.iter().any(|(t, _)| matches!(t, Token::Account(_))));
         assert!(tokens.iter().any(|(t, _)| matches!(t, Token::Number(_))));
         assert!(tokens.iter().any(|(t, _)| matches!(t, Token::Currency(_))));

--- a/crates/rustledger-parser/src/token_parser.rs
+++ b/crates/rustledger-parser/src/token_parser.rs
@@ -23,10 +23,10 @@ use rustledger_core::{
     Query, Transaction,
 };
 
-use crate::error::{ParseError, ParseErrorKind};
-use crate::logos_lexer::{tokenize, Token};
-use crate::span::{Span, Spanned};
 use crate::ParseResult;
+use crate::error::{ParseError, ParseErrorKind};
+use crate::logos_lexer::{Token, tokenize};
+use crate::span::{Span, Spanned};
 
 // ============================================================================
 // Constants for Error Detection
@@ -138,8 +138,8 @@ fn index_to_byte_span(tokens: &[SpannedToken<'_>], start_idx: usize, end_idx: us
 // ============================================================================
 
 /// Match a date token and extract the `NaiveDate`.
-fn tok_date<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], NaiveDate, TokExtra<'src>> + Clone {
+fn tok_date<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], NaiveDate, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::Date(_)))
         .try_map(|t: SpannedToken<'src>, span| {
@@ -189,8 +189,8 @@ fn tok_date<'src>(
 }
 
 /// Match a number token and extract the Decimal.
-fn tok_number<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Decimal, TokExtra<'src>> + Clone {
+fn tok_number<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Decimal, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::Number(_)))
         .try_map(|t: SpannedToken<'src>, span| {
@@ -206,8 +206,8 @@ fn tok_number<'src>(
 }
 
 /// Match a string token and extract the content (without quotes).
-fn tok_string<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], String, TokExtra<'src>> + Clone {
+fn tok_string<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], String, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::String(_)))
         .map(|t: SpannedToken<'src>| {
@@ -245,8 +245,8 @@ fn tok_string<'src>(
 }
 
 /// Match an account token and extract the string.
-fn tok_account<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
+fn tok_account<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::Account(_)))
         .map(|t: SpannedToken<'src>| {
@@ -260,8 +260,8 @@ fn tok_account<'src>(
 }
 
 /// Match a currency token and extract the string.
-fn tok_currency<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
+fn tok_currency<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::Currency(_)))
         .map(|t: SpannedToken<'src>| {
@@ -275,8 +275,8 @@ fn tok_currency<'src>(
 }
 
 /// Match a tag token and extract the string (without # prefix).
-fn tok_tag<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
+fn tok_tag<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::Tag(_)))
         .map(|t: SpannedToken<'src>| {
@@ -291,8 +291,8 @@ fn tok_tag<'src>(
 }
 
 /// Match a link token and extract the string (without ^ prefix).
-fn tok_link<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
+fn tok_link<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::Link(_)))
         .map(|t: SpannedToken<'src>| {
@@ -307,8 +307,8 @@ fn tok_link<'src>(
 }
 
 /// Match a metadata key token and extract the key (without colon).
-fn tok_meta_key<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
+fn tok_meta_key<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], &'src str, TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::MetaKey(_)))
         .map(|t: SpannedToken<'src>| {
@@ -372,8 +372,8 @@ fn tok_indent<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], (), TokEx
 }
 
 /// Match a deep indent token (4+ spaces) - for posting metadata.
-fn tok_deep_indent<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtra<'src>> + Clone {
+fn tok_deep_indent<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::DeepIndent(_)))
         .to(())
@@ -456,11 +456,7 @@ fn tok_expr<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], Decimal, To
             .then(atom)
             .map(|(signs, n): (Vec<char>, Decimal)| {
                 let neg_count = signs.iter().filter(|&&c| c == '-').count();
-                if neg_count % 2 == 1 {
-                    -n
-                } else {
-                    n
-                }
+                if neg_count % 2 == 1 { -n } else { n }
             });
 
         // Term: unary combined with * and /
@@ -494,16 +490,16 @@ fn tok_expr<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], Decimal, To
 }
 
 /// Parse an amount (number + currency).
-fn tok_amount<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Amount, TokExtra<'src>> + Clone {
+fn tok_amount<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Amount, TokExtra<'src>> + Clone {
     tok_expr()
         .then(tok_currency())
         .map(|(number, currency)| Amount::new(number, currency))
 }
 
 /// Parse an incomplete amount (for postings).
-fn tok_incomplete_amount<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], IncompleteAmount, TokExtra<'src>> + Clone {
+fn tok_incomplete_amount<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], IncompleteAmount, TokExtra<'src>> + Clone {
     choice((
         // Full amount: number + currency
         tok_expr()
@@ -543,8 +539,8 @@ fn tok_hash<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtr
 }
 
 /// Parse a single cost component.
-fn tok_cost_component<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], TokCostComponent, TokExtra<'src>> + Clone {
+fn tok_cost_component<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], TokCostComponent, TokExtra<'src>> + Clone {
     choice((
         // Date (must come before number to avoid conflicts)
         tok_date().map(TokCostComponent::Date),
@@ -651,8 +647,8 @@ fn build_tok_cost_spec(components: Vec<TokCostComponent>, is_total_brace: bool) 
 
 /// Parse cost components with optional commas/slashes as delimiters.
 /// Allows empty components: {, 100.0 USD, , }
-fn tok_cost_components<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Vec<TokCostComponent>, TokExtra<'src>> + Clone {
+fn tok_cost_components<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Vec<TokCostComponent>, TokExtra<'src>> + Clone {
     // A delimiter is a comma or slash
     let delimiter = tok_comma().or(tok_slash()).to(());
 
@@ -667,8 +663,8 @@ fn tok_cost_components<'src>(
 }
 
 /// Parse a cost specification: { ... }, {{ ... }}, or {# ... }.
-fn tok_cost_spec<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], CostSpec, TokExtra<'src>> + Clone {
+fn tok_cost_spec<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], CostSpec, TokExtra<'src>> + Clone {
     choice((
         // Total cost: {{ ... }} (legacy syntax)
         tok_ldoublebrace()
@@ -690,8 +686,8 @@ fn tok_cost_spec<'src>(
 
 /// Parse a price annotation: @ [amount] or @@ [amount].
 /// Amount can be missing for incomplete inputs.
-fn tok_price_annotation<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], PriceAnnotation, TokExtra<'src>> + Clone {
+fn tok_price_annotation<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], PriceAnnotation, TokExtra<'src>> + Clone {
     // Complete amount: expr + currency (use tok_expr() for arithmetic)
     let complete_amount = tok_expr()
         .then(tok_currency())
@@ -740,8 +736,8 @@ fn tok_boolean<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], bool, To
 }
 
 /// Parse a metadata value.
-fn tok_meta_value<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], MetaValue, TokExtra<'src>> + Clone {
+fn tok_meta_value<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], MetaValue, TokExtra<'src>> + Clone {
     choice((
         tok_string().map(MetaValue::String),
         tok_boolean().map(MetaValue::Bool),
@@ -779,8 +775,8 @@ enum ParsedItem {
 // ============================================================================
 
 /// Parse an option directive.
-fn tok_option_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_option_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_option()
         .ignore_then(tok_string())
         .then(tok_string())
@@ -789,8 +785,8 @@ fn tok_option_directive<'src>(
 }
 
 /// Parse an include directive.
-fn tok_include_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_include_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_include()
         .ignore_then(tok_string())
         .then_ignore(tok_comment().or_not())
@@ -798,8 +794,8 @@ fn tok_include_directive<'src>(
 }
 
 /// Parse a plugin directive.
-fn tok_plugin_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_plugin_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_plugin()
         .ignore_then(tok_string())
         .then(tok_string().or_not())
@@ -808,8 +804,8 @@ fn tok_plugin_directive<'src>(
 }
 
 /// Parse a pushtag directive.
-fn tok_pushtag_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_pushtag_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_pushtag()
         .ignore_then(tok_tag())
         .then_ignore(tok_comment().or_not())
@@ -817,8 +813,8 @@ fn tok_pushtag_directive<'src>(
 }
 
 /// Parse a poptag directive.
-fn tok_poptag_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_poptag_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_poptag()
         .ignore_then(tok_tag())
         .then_ignore(tok_comment().or_not())
@@ -826,8 +822,8 @@ fn tok_poptag_directive<'src>(
 }
 
 /// Parse a pushmeta directive.
-fn tok_pushmeta_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_pushmeta_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_pushmeta()
         .ignore_then(tok_meta_key())
         .then(tok_meta_value())
@@ -836,8 +832,8 @@ fn tok_pushmeta_directive<'src>(
 }
 
 /// Parse a popmeta directive.
-fn tok_popmeta_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_popmeta_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     tok_popmeta()
         .ignore_then(tok_meta_key())
         .then_ignore(tok_comment().or_not())
@@ -861,8 +857,8 @@ enum PostingOrMeta {
 }
 
 /// Parse posting-level metadata (4+ spaces indent).
-fn tok_posting_meta<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (String, MetaValue), TokExtra<'src>> + Clone {
+fn tok_posting_meta<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (String, MetaValue), TokExtra<'src>> + Clone {
     tok_newline()
         .ignore_then(tok_deep_indent())
         .ignore_then(tok_meta_key())
@@ -872,8 +868,8 @@ fn tok_posting_meta<'src>(
 }
 
 /// Parse a posting line with its metadata.
-fn tok_posting_with_meta<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Posting, TokExtra<'src>> + Clone {
+fn tok_posting_with_meta<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Posting, TokExtra<'src>> + Clone {
     // Optional flag
     let flag = tok_flag().or_not();
 
@@ -920,8 +916,8 @@ fn tok_posting_with_meta<'src>(
 }
 
 /// Parse a metadata line inside a directive, returning None for comment-only lines.
-fn tok_meta_or_comment<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Option<(String, MetaValue)>, TokExtra<'src>> + Clone
+fn tok_meta_or_comment<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Option<(String, MetaValue)>, TokExtra<'src>> + Clone
 {
     // Actual metadata line
     let meta_line = tok_newline()
@@ -941,9 +937,8 @@ fn tok_meta_or_comment<'src>(
 }
 
 /// Parse metadata lines, filtering out comment-only lines.
-fn tok_meta_lines<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Vec<(String, MetaValue)>, TokExtra<'src>> + Clone
-{
+fn tok_meta_lines<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Vec<(String, MetaValue)>, TokExtra<'src>> + Clone {
     tok_meta_or_comment()
         .repeated()
         .collect::<Vec<_>>()
@@ -951,8 +946,8 @@ fn tok_meta_lines<'src>(
 }
 
 /// Parse posting or metadata inside a transaction.
-fn tok_posting_or_meta<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Option<PostingOrMeta>, TokExtra<'src>> + Clone {
+fn tok_posting_or_meta<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Option<PostingOrMeta>, TokExtra<'src>> + Clone {
     let meta_entry = tok_newline()
         .ignore_then(tok_indent())
         .ignore_then(tok_meta_key())
@@ -1012,8 +1007,8 @@ fn tok_posting_or_meta<'src>(
 }
 
 /// Parse a transaction directive.
-fn tok_transaction_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_transaction_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     let header_item = choice((
         tok_string().map(TxnHeaderItem::String),
         tok_tag().map(|t| TxnHeaderItem::Tag(t.to_string())),
@@ -1080,8 +1075,8 @@ fn tok_transaction_directive<'src>(
 
 /// Parse a balance directive.
 /// Format: DATE balance ACCOUNT NUMBER [~ TOLERANCE] CURRENCY [COST]
-fn tok_balance_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_balance_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     // Amount with optional tolerance: EXPR [~ TOLERANCE] CURRENCY
     // e.g., "200 USD", "200 ~ 0.002 USD", "(1 + 5) / 2.1 USD"
     let tolerance = tok_tilde().ignore_then(tok_expr());
@@ -1113,8 +1108,8 @@ fn tok_balance_directive<'src>(
 }
 
 /// Parse an open directive.
-fn tok_open_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_open_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_open())
         .then(tok_account())
@@ -1136,8 +1131,8 @@ fn tok_open_directive<'src>(
 }
 
 /// Parse a close directive.
-fn tok_close_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_close_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_close())
         .then(tok_account())
@@ -1153,8 +1148,8 @@ fn tok_close_directive<'src>(
 }
 
 /// Parse a commodity directive.
-fn tok_commodity_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_commodity_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_commodity())
         .then(tok_currency())
@@ -1170,8 +1165,8 @@ fn tok_commodity_directive<'src>(
 }
 
 /// Parse a pad directive.
-fn tok_pad_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_pad_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_pad())
         .then(tok_account())
@@ -1188,8 +1183,8 @@ fn tok_pad_directive<'src>(
 }
 
 /// Parse an event directive.
-fn tok_event_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_event_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_event())
         .then(tok_string())
@@ -1206,8 +1201,8 @@ fn tok_event_directive<'src>(
 }
 
 /// Parse a query directive.
-fn tok_query_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_query_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_query())
         .then(tok_string())
@@ -1224,8 +1219,8 @@ fn tok_query_directive<'src>(
 }
 
 /// Parse a note directive.
-fn tok_note_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_note_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_note())
         .then(tok_account())
@@ -1242,8 +1237,8 @@ fn tok_note_directive<'src>(
 }
 
 /// Parse a document directive (with optional tags and links).
-fn tok_document_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_document_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     // Tags and links after the path
     let tag_or_link = choice((
         tok_tag().map(|t| (Some(t.to_string()), None)),
@@ -1279,8 +1274,8 @@ fn tok_document_directive<'src>(
 }
 
 /// Parse a price directive.
-fn tok_price_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_price_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_price())
         .then(tok_currency())
@@ -1297,8 +1292,8 @@ fn tok_price_directive<'src>(
 }
 
 /// Parse a custom directive.
-fn tok_custom_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
+fn tok_custom_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (NaiveDate, Directive), TokExtra<'src>> {
     tok_date()
         .then_ignore(tok_custom())
         .then(tok_string())
@@ -1318,8 +1313,8 @@ fn tok_custom_directive<'src>(
 }
 
 /// Parse a dated directive.
-fn tok_dated_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
+fn tok_dated_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], ParsedItem, TokExtra<'src>> {
     choice((
         tok_transaction_directive(),
         tok_balance_directive(),
@@ -1346,8 +1341,8 @@ fn tok_shebang<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], (), TokE
 }
 
 /// Match an Emacs directive (e.g., #+STARTUP: showall).
-fn tok_emacs_directive<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtra<'src>> + Clone {
+fn tok_emacs_directive<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtra<'src>> + Clone {
     any()
         .filter(|t: &SpannedToken<'_>| matches!(t.token, Token::EmacsDirective(_)))
         .to(())
@@ -1356,8 +1351,8 @@ fn tok_emacs_directive<'src>(
 /// Match an org-mode style header line (e.g., "* Options", "** Section").
 /// These are lines starting with one or more `*` at the beginning of a line,
 /// used for organization but ignored by beancount.
-fn tok_org_header_line<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtra<'src>> + Clone {
+fn tok_org_header_line<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], (), TokExtra<'src>> + Clone {
     // Match one or more Star tokens followed by any non-newline tokens until newline
     tok_star()
         .repeated()
@@ -1406,9 +1401,8 @@ fn tok_skip_to_newline<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], 
 }
 
 /// Parse a complete file with error recovery.
-fn tok_file_parser<'src>(
-) -> impl Parser<'src, &'src [SpannedToken<'src>], Vec<(ParsedItem, usize, usize)>, TokExtra<'src>>
-{
+fn tok_file_parser<'src>()
+-> impl Parser<'src, &'src [SpannedToken<'src>], Vec<(ParsedItem, usize, usize)>, TokExtra<'src>> {
     // Skip leading newlines
     tok_newline().repeated().ignore_then(
         // Try to parse an entry, or skip a bad line on failure

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -3,7 +3,7 @@
 //! Tests cover all directive types, error recovery, edge cases, and real-world scenarios.
 
 use rustledger_core::Directive;
-use rustledger_parser::{parse, parse_directives, ParseResult};
+use rustledger_parser::{ParseResult, parse, parse_directives};
 
 // ============================================================================
 // Helper Functions

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -61,12 +61,12 @@ pub mod runtime;
 pub mod types;
 
 pub use convert::{
-    directive_to_wrapper, directives_to_wrappers, wrapper_to_directive, wrappers_to_directives,
-    ConversionError,
+    ConversionError, directive_to_wrapper, directives_to_wrappers, wrapper_to_directive,
+    wrappers_to_directives,
 };
 pub use native::{NativePlugin, NativePluginRegistry};
 #[cfg(feature = "wasm-runtime")]
 pub use runtime::{
-    validate_plugin_module, Plugin, PluginManager, RuntimeConfig, WatchingPluginManager,
+    Plugin, PluginManager, RuntimeConfig, WatchingPluginManager, validate_plugin_module,
 };
 pub use types::{PluginError, PluginErrorSeverity, PluginInput, PluginOptions, PluginOutput};

--- a/crates/rustledger-plugin/src/python/download.rs
+++ b/crates/rustledger-plugin/src/python/download.rs
@@ -216,6 +216,6 @@ mod tests {
         assert!(PYTHON_VERSION.starts_with("3."));
         assert!(DOWNLOAD_URL.contains("cpython-wasi"));
         assert_eq!(EXPECTED_SHA256.len(), 64); // SHA256 hex = 64 chars
-                                               // DOWNLOAD_SIZE_MB is a compile-time constant; clippy catches assertions on constants
+        // DOWNLOAD_SIZE_MB is a compile-time constant; clippy catches assertions on constants
     }
 }

--- a/crates/rustledger-plugin/src/python/runtime.rs
+++ b/crates/rustledger-plugin/src/python/runtime.rs
@@ -3,9 +3,9 @@
 //! This module provides the runtime for executing Python beancount plugins
 //! in a sandboxed WASM environment using `CPython` compiled to WASI.
 
+use super::PythonError;
 use super::compat::BEANCOUNT_COMPAT_PY;
 use super::download;
-use super::PythonError;
 use crate::types::{PluginError, PluginErrorSeverity, PluginInput, PluginOutput};
 use anyhow::Result;
 use std::sync::Arc;

--- a/crates/rustledger-query/benches/query_bench.rs
+++ b/crates/rustledger-query/benches/query_bench.rs
@@ -4,12 +4,12 @@
 
 #![allow(missing_docs)]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use chrono::NaiveDate;
 use rust_decimal_macros::dec;
 use rustledger_core::{Amount, Directive, Posting, Transaction};
-use rustledger_query::{parse as parse_query, Executor};
+use rustledger_query::{Executor, parse as parse_query};
 
 /// Generate sample directives for benchmarking.
 fn generate_directives(num_transactions: usize) -> Vec<Directive> {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -4,7 +4,7 @@
 
 use rust_decimal_macros::dec;
 use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
-use rustledger_query::{parse, Executor, QueryResult, Value};
+use rustledger_query::{Executor, QueryResult, Value, parse};
 
 // ============================================================================
 // Helper Functions

--- a/crates/rustledger-validate/benches/validate_bench.rs
+++ b/crates/rustledger-validate/benches/validate_bench.rs
@@ -4,7 +4,7 @@
 
 #![allow(missing_docs)]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use chrono::NaiveDate;
 use rust_decimal_macros::dec;

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -994,7 +994,13 @@ fn validate_balance(state: &mut LedgerState, bal: &Balance, errors: &mut Vec<Val
             let message = if is_explicit {
                 format!(
                     "Balance exceeds explicit tolerance for {}: expected {} {} ~ {}, got {} {} (difference: {})",
-                    bal.account, expected, bal.amount.currency, tolerance, actual, bal.amount.currency, difference
+                    bal.account,
+                    expected,
+                    bal.amount.currency,
+                    tolerance,
+                    actual,
+                    bal.amount.currency,
+                    difference
                 )
             } else {
                 format!(
@@ -1166,9 +1172,11 @@ mod tests {
         ];
 
         let errors = validate(&directives);
-        assert!(errors
-            .iter()
-            .any(|e| e.code == ErrorCode::BalanceAssertionFailed));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == ErrorCode::BalanceAssertionFailed)
+        );
     }
 
     #[test]
@@ -1190,9 +1198,11 @@ mod tests {
         ];
 
         let errors = validate(&directives);
-        assert!(errors
-            .iter()
-            .any(|e| e.code == ErrorCode::TransactionUnbalanced));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == ErrorCode::TransactionUnbalanced)
+        );
     }
 
     #[test]
@@ -1213,9 +1223,11 @@ mod tests {
         ];
 
         let errors = validate(&directives);
-        assert!(errors
-            .iter()
-            .any(|e| e.code == ErrorCode::CurrencyNotAllowed));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == ErrorCode::CurrencyNotAllowed)
+        );
     }
 
     #[test]

--- a/crates/rustledger-validate/tests/tla_proptest.rs
+++ b/crates/rustledger-validate/tests/tla_proptest.rs
@@ -9,7 +9,7 @@ use chrono::NaiveDate;
 use proptest::prelude::*;
 use rust_decimal::Decimal;
 use rustledger_core::{Amount, Balance, Directive, IncompleteAmount, Open, Posting, Transaction};
-use rustledger_validate::{validate, ErrorCode};
+use rustledger_validate::{ErrorCode, validate};
 
 // ============================================================================
 // Test Strategies

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -7,7 +7,7 @@ use rust_decimal_macros::dec;
 use rustledger_core::{
     Amount, Balance, Close, Directive, NaiveDate, Open, Pad, Posting, PriceAnnotation, Transaction,
 };
-use rustledger_validate::{validate, ErrorCode};
+use rustledger_validate::{ErrorCode, validate};
 
 // ============================================================================
 // Helper Functions
@@ -413,7 +413,9 @@ fn test_basic_validation() {
     let errors = validate(&directives);
 
     // Should pass basic validation
-    assert!(!errors
-        .iter()
-        .any(|e| e.code == ErrorCode::TransactionUnbalanced));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.code == ErrorCode::TransactionUnbalanced)
+    );
 }

--- a/crates/rustledger-wasm/src/editor.rs
+++ b/crates/rustledger-wasm/src/editor.rs
@@ -522,22 +522,54 @@ fn get_currency_hover_info(currency: &str, parse_result: &ParseResult) -> Option
 /// Get hover information about a directive keyword.
 fn get_directive_hover_info(keyword: &str) -> Option<String> {
     let info = match keyword {
-        "open" => "## `open` Directive\n\nOpens an account for use in transactions.\n\n```beancount\n2024-01-01 open Assets:Bank USD\n```",
-        "close" => "## `close` Directive\n\nCloses an account. No transactions allowed after this date.\n\n```beancount\n2024-12-31 close Assets:OldBank\n```",
-        "commodity" => "## `commodity` Directive\n\nDefines a currency or commodity.\n\n```beancount\n2024-01-01 commodity USD\n```",
-        "balance" => "## `balance` Directive\n\nAsserts the balance of an account at a given date.\n\n```beancount\n2024-01-01 balance Assets:Bank 1000.00 USD\n```",
-        "pad" => "## `pad` Directive\n\nAutomatically pads an account to match a balance assertion.\n\n```beancount\n2024-01-01 pad Assets:Bank Equity:Opening-Balances\n```",
-        "event" => "## `event` Directive\n\nRecords a named event with a value.\n\n```beancount\n2024-01-01 event \"location\" \"New York\"\n```",
-        "note" => "## `note` Directive\n\nAttaches a note to an account.\n\n```beancount\n2024-01-01 note Assets:Bank \"Account opened\"\n```",
-        "document" => "## `document` Directive\n\nLinks a document to an account.\n\n```beancount\n2024-01-01 document Assets:Bank \"/path/to/statement.pdf\"\n```",
-        "query" => "## `query` Directive\n\nDefines a named BQL query.\n\n```beancount\n2024-01-01 query \"expenses\" \"SELECT account, sum(amount)\"\n```",
-        "custom" => "## `custom` Directive\n\nA custom directive for extensions.\n\n```beancount\n2024-01-01 custom \"budget\" Expenses:Food 500.00 USD\n```",
-        "price" => "## `price` Directive\n\nRecords a price for a commodity.\n\n```beancount\n2024-01-01 price BTC 45000.00 USD\n```",
-        "txn" | "*" => "## Transaction\n\nA complete (balanced) transaction.\n\n```beancount\n2024-01-01 * \"Payee\" \"Description\"\n  Assets:Bank  -100.00 USD\n  Expenses:Food\n```",
-        "!" => "## Transaction (Incomplete)\n\nAn incomplete or flagged transaction.\n\n```beancount\n2024-01-01 ! \"Payee\" \"Needs review\"\n  Assets:Bank  -100.00 USD\n  Expenses:Unknown\n```",
-        "include" => "## `include` Directive\n\nIncludes another Beancount file.\n\n```beancount\ninclude \"other-file.beancount\"\n```",
-        "option" => "## `option` Directive\n\nSets a Beancount option.\n\n```beancount\noption \"operating_currency\" \"USD\"\n```",
-        "plugin" => "## `plugin` Directive\n\nLoads a plugin.\n\n```beancount\nplugin \"beancount.plugins.auto_accounts\"\n```",
+        "open" => {
+            "## `open` Directive\n\nOpens an account for use in transactions.\n\n```beancount\n2024-01-01 open Assets:Bank USD\n```"
+        }
+        "close" => {
+            "## `close` Directive\n\nCloses an account. No transactions allowed after this date.\n\n```beancount\n2024-12-31 close Assets:OldBank\n```"
+        }
+        "commodity" => {
+            "## `commodity` Directive\n\nDefines a currency or commodity.\n\n```beancount\n2024-01-01 commodity USD\n```"
+        }
+        "balance" => {
+            "## `balance` Directive\n\nAsserts the balance of an account at a given date.\n\n```beancount\n2024-01-01 balance Assets:Bank 1000.00 USD\n```"
+        }
+        "pad" => {
+            "## `pad` Directive\n\nAutomatically pads an account to match a balance assertion.\n\n```beancount\n2024-01-01 pad Assets:Bank Equity:Opening-Balances\n```"
+        }
+        "event" => {
+            "## `event` Directive\n\nRecords a named event with a value.\n\n```beancount\n2024-01-01 event \"location\" \"New York\"\n```"
+        }
+        "note" => {
+            "## `note` Directive\n\nAttaches a note to an account.\n\n```beancount\n2024-01-01 note Assets:Bank \"Account opened\"\n```"
+        }
+        "document" => {
+            "## `document` Directive\n\nLinks a document to an account.\n\n```beancount\n2024-01-01 document Assets:Bank \"/path/to/statement.pdf\"\n```"
+        }
+        "query" => {
+            "## `query` Directive\n\nDefines a named BQL query.\n\n```beancount\n2024-01-01 query \"expenses\" \"SELECT account, sum(amount)\"\n```"
+        }
+        "custom" => {
+            "## `custom` Directive\n\nA custom directive for extensions.\n\n```beancount\n2024-01-01 custom \"budget\" Expenses:Food 500.00 USD\n```"
+        }
+        "price" => {
+            "## `price` Directive\n\nRecords a price for a commodity.\n\n```beancount\n2024-01-01 price BTC 45000.00 USD\n```"
+        }
+        "txn" | "*" => {
+            "## Transaction\n\nA complete (balanced) transaction.\n\n```beancount\n2024-01-01 * \"Payee\" \"Description\"\n  Assets:Bank  -100.00 USD\n  Expenses:Food\n```"
+        }
+        "!" => {
+            "## Transaction (Incomplete)\n\nAn incomplete or flagged transaction.\n\n```beancount\n2024-01-01 ! \"Payee\" \"Needs review\"\n  Assets:Bank  -100.00 USD\n  Expenses:Unknown\n```"
+        }
+        "include" => {
+            "## `include` Directive\n\nIncludes another Beancount file.\n\n```beancount\ninclude \"other-file.beancount\"\n```"
+        }
+        "option" => {
+            "## `option` Directive\n\nSets a Beancount option.\n\n```beancount\noption \"operating_currency\" \"USD\"\n```"
+        }
+        "plugin" => {
+            "## `plugin` Directive\n\nLoads a plugin.\n\n```beancount\nplugin \"beancount.plugins.auto_accounts\"\n```"
+        }
         _ => return None,
     };
 

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -43,7 +43,7 @@ use wasm_bindgen::prelude::*;
 
 use rustledger_booking::interpolate;
 use rustledger_core::Directive;
-use rustledger_parser::{parse as parse_beancount, ParseResult as ParserResult};
+use rustledger_parser::{ParseResult as ParserResult, parse as parse_beancount};
 use rustledger_validate::validate as validate_ledger;
 
 use convert::{directive_to_json, value_to_cell};
@@ -557,7 +557,7 @@ pub fn validate_source(source: &str) -> Result<JsValue, JsError> {
 /// Returns a `QueryResult` with columns, rows, and any errors.
 #[wasm_bindgen]
 pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
-    use rustledger_query::{parse as parse_query, Executor};
+    use rustledger_query::{Executor, parse as parse_query};
 
     let load = load_and_interpolate(source);
 
@@ -625,7 +625,7 @@ pub fn version() -> String {
 /// Returns a `FormatResult` with the formatted source or errors.
 #[wasm_bindgen]
 pub fn format(source: &str) -> Result<JsValue, JsError> {
-    use rustledger_core::{format_directive, FormatConfig};
+    use rustledger_core::{FormatConfig, format_directive};
 
     let parse_result = parse_beancount(source);
     let lookup = LineLookup::new(source);
@@ -706,8 +706,8 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
 #[wasm_bindgen(js_name = "runPlugin")]
 pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
     use rustledger_plugin::{
-        directives_to_wrappers, wrappers_to_directives, NativePluginRegistry, PluginInput,
-        PluginOptions,
+        NativePluginRegistry, PluginInput, PluginOptions, directives_to_wrappers,
+        wrappers_to_directives,
     };
 
     let load = load_and_interpolate(source);
@@ -932,7 +932,7 @@ impl ParsedLedger {
     /// Run a BQL query on this ledger.
     #[wasm_bindgen]
     pub fn query(&self, query_str: &str) -> Result<JsValue, JsError> {
-        use rustledger_query::{parse as parse_query, Executor};
+        use rustledger_query::{Executor, parse as parse_query};
 
         if !self.parse_errors.is_empty() {
             let result = QueryResult {
@@ -991,7 +991,7 @@ impl ParsedLedger {
     /// Format the ledger source.
     #[wasm_bindgen]
     pub fn format(&self) -> Result<JsValue, JsError> {
-        use rustledger_core::{format_directive, FormatConfig};
+        use rustledger_core::{FormatConfig, format_directive};
 
         if !self.parse_errors.is_empty() {
             let result = FormatResult {
@@ -1057,8 +1057,8 @@ impl ParsedLedger {
     #[wasm_bindgen(js_name = "runPlugin")]
     pub fn run_plugin(&self, plugin_name: &str) -> Result<JsValue, JsError> {
         use rustledger_plugin::{
-            directives_to_wrappers, wrappers_to_directives, NativePluginRegistry, PluginInput,
-            PluginOptions,
+            NativePluginRegistry, PluginInput, PluginOptions, directives_to_wrappers,
+            wrappers_to_directives,
         };
 
         if !self.parse_errors.is_empty() {

--- a/crates/rustledger/benches/pipeline_bench.rs
+++ b/crates/rustledger/benches/pipeline_bench.rs
@@ -7,7 +7,7 @@
 
 #![allow(missing_docs)]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use rustledger_booking::interpolate;
 use rustledger_core::Directive;

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -6,15 +6,15 @@ use anyhow::{Context, Result};
 use chrono::NaiveDate;
 use clap::{Parser, ValueEnum};
 use rayon::prelude::*;
-use rustledger_booking::{interpolate, InterpolationError};
+use rustledger_booking::{InterpolationError, interpolate};
 use rustledger_core::Directive;
 use rustledger_loader::{
-    load_cache_entry, reintern_directives, save_cache_entry, CacheEntry, CachedOptions,
-    CachedPlugin, LoadError, LoadResult, Loader,
+    CacheEntry, CachedOptions, CachedPlugin, LoadError, LoadResult, Loader, load_cache_entry,
+    reintern_directives, save_cache_entry,
 };
 #[cfg(feature = "python-plugin-wasm")]
 use rustledger_plugin::PluginManager;
-use rustledger_plugin::{wrappers_to_directives, NativePluginRegistry, PluginInput, PluginOptions};
+use rustledger_plugin::{NativePluginRegistry, PluginInput, PluginOptions, wrappers_to_directives};
 use rustledger_validate::validate;
 use serde::Serialize;
 use std::io::{self, Write};

--- a/crates/rustledger/src/cmd/doctor.rs
+++ b/crates/rustledger/src/cmd/doctor.rs
@@ -757,7 +757,7 @@ fn cmd_display_context<W: Write>(file: &PathBuf, writer: &mut W) -> Result<()> {
 }
 
 fn cmd_roundtrip<W: Write>(file: &PathBuf, writer: &mut W) -> Result<()> {
-    use crate::format::{format_directive, FormatConfig};
+    use crate::format::{FormatConfig, format_directive};
 
     writeln!(writer, "Round-trip test for {}", file.display())?;
     writeln!(writer, "{}", "=".repeat(60))?;

--- a/crates/rustledger/src/cmd/extract_cmd.rs
+++ b/crates/rustledger/src/cmd/extract_cmd.rs
@@ -13,7 +13,7 @@
 use crate::cmd::completions::ShellType;
 use anyhow::Result;
 use clap::Parser;
-use rustledger_core::{format_directive, FormatConfig};
+use rustledger_core::{FormatConfig, format_directive};
 use rustledger_importer::ImporterConfig;
 use std::io::{self, Write};
 use std::path::PathBuf;

--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -1,7 +1,7 @@
 //! Shared implementation for bean-format and rledger-format commands.
 
 use crate::cmd::completions::ShellType;
-use crate::format::{format_directive, FormatConfig};
+use crate::format::{FormatConfig, format_directive};
 use anyhow::{Context, Result};
 use clap::Parser;
 use rustledger_loader::Loader;

--- a/crates/rustledger/src/cmd/query.rs
+++ b/crates/rustledger/src/cmd/query.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rustledger_core::Directive;
 use rustledger_loader::Loader;
-use rustledger_query::{parse as parse_query, Executor, Value};
+use rustledger_query::{Executor, Value, parse as parse_query};
 use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
 use rustyline::{DefaultEditor, Editor};


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Minimum supported Rust version is now 1.85

- Upgrade edition from 2021 to 2024
- Upgrade MSRV from 1.75 to 1.85
- Upgrade resolver from 2 to 3 (enables workspace publishing)
- Fix pattern matching for Rust 2024 stricter rules

## Benefits

| Feature | Description |
|---------|-------------|
| Rust 2024 Edition | Cleaner async, better error handling |
| `resolver = "3"` | Simpler workspace publishing to crates.io |
| `LazyLock`/`LazyCell` | In std, replaces `lazy_static!` |
| `#[expect(lint)]` | Better than `#[allow]` |
| Async closures | RFC 3668 |

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)