### PR TITLE
chore(ci): run CodeQL only on push to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+# CodeQL Analysis
+# Runs on push to main and weekly schedule (not on PRs for faster CI)
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly on Sundays at 00:00 UTC
+    - cron: '0 0 * * 0'
+  # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python, actions]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
Switch CodeQL from default setup to advanced setup to skip PR/merge queue scans.

**Before:** CodeQL ran on every PR and merge queue entry (~5-10 min)
**After:** CodeQL runs only on push to main + weekly schedule

## Changes
- Disabled CodeQL default setup via API
- Added custom `.github/workflows/codeql.yml`
- Triggers: `push` to main, weekly `schedule`, manual `workflow_dispatch`
- Languages: `javascript-typescript`, `python`, `actions`

## Why
- PRs are still protected by weekly scans catching new CVEs
- Security issues in PRs get scanned when merged anyway
- Rust security is handled by `cargo-deny` (better coverage)

## Test plan
- [x] CodeQL default setup disabled
- [ ] Workflow runs on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)