### PR TITLE
fix(ci): disable sccache for semver check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
   semver:
     name: Semver Check
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""  # Disable sccache - action manages its own toolchain
     # Only run on PRs to catch breaking changes before merge
     if: github.event_name == 'pull_request'
     steps:


### PR DESCRIPTION
The cargo-semver-checks-action manages its own toolchain and doesn't have sccache available.

Fixes the "No such file or directory" error on PR #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)