### PR TITLE
fix(ci): skip gitleaks for Dependabot PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,9 +18,12 @@ permissions:
 
 jobs:
   # Secret scanning with gitleaks
+  # Skips for Dependabot PRs (no access to GITLEAKS_LICENSE secret)
   gitleaks:
     name: Gitleaks Secret Scan
     runs-on: ubuntu-latest
+    # Skip for Dependabot - it only updates dependencies, not code with secrets
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem
Dependabot PRs fail gitleaks check because Dependabot doesn't have access to `GITLEAKS_LICENSE` secret.

## Solution
Skip gitleaks for Dependabot PRs (`github.actor != 'dependabot[bot]'`).

This is safe because:
- Dependabot only updates dependencies, not code that could contain secrets
- Pre-commit hooks still run gitleaks locally for all contributors
- Main branch pushes are still scanned

🤖 Generated with [Claude Code](https://claude.com/claude-code)