### PR TITLE
chore(deps): add cargo-vet exemption for thiserror 2.0.18

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1141,12 +1141,20 @@ criteria = "safe-to-deploy"
 version = "2.0.17"
 criteria = "safe-to-deploy"
 
+[[exemptions.thiserror]]
+version = "2.0.18"
+criteria = "safe-to-deploy"
+
 [[exemptions.thiserror-impl]]
 version = "1.0.69"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
 version = "2.0.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror-impl]]
+version = "2.0.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread_local]]


### PR DESCRIPTION
Adds safe-to-deploy exemptions for `thiserror` and `thiserror-impl` 2.0.18 to unblock Dependabot PR #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)