### PR TITLE
fix(ci): add tag_name to gh-release action for workflow_dispatch

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -341,6 +341,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           draft: false
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Summary
Fixes the release workflow when triggered via `workflow_dispatch`.

The `softprops/action-gh-release` action requires either:
- `github.ref` to be a tag ref (e.g., `refs/tags/v0.5.0`), OR
- An explicit `tag_name` parameter

When triggered via `workflow_dispatch`, `github.ref` is the branch ref, not the tag, causing the error:
```
⚠️ GitHub Releases requires a tag
```

## Fix
Add `tag_name: ${{ env.RELEASE_TAG }}` to use the input tag explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)