### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 license = "GPL-3.0-only"
@@ -98,14 +98,14 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.5.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.5.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.5.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.5.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.5.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.5.0", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.5.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.5.0", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.5.1", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.5.1", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.5.1", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.5.1", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.5.1", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.5.1", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.5.1", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.5.1", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-lsp/CHANGELOG.md
+++ b/crates/rustledger-lsp/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19
+
+### Bug Fixes
+
+- *(lsp)* address PR review comments
+
+### Documentation
+
+- add comprehensive PR review policy
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+- *(lsp)* add resolve handlers and file watching
+- *(lsp)* add execute command and completion resolve
+- *(lsp)* add call hierarchy and signature help
+- *(lsp)* add code lens, document color, goto declaration
+- *(lsp)* add document highlight, linked editing, on-type formatting
+- *(lsp)* add type hierarchy for account navigation
+- *(lsp)* add find references for accounts, currencies, payees
+- *(lsp)* add range formatting, document links, inlay hints, selection range
+- *(lsp)* add workspace symbols, rename, formatting, folding
+- *(lsp)* add code actions for quick fixes
+- *(lsp)* add semantic tokens for syntax highlighting
+- *(lsp)* add Phase 5 - document symbols (outline view)
+- *(lsp)* add Phase 4 - navigation features (definition, hover)
+- *(lsp)* add Phase 3 - autocompletion support
+- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
+- *(lsp)* add rustledger-lsp crate skeleton (WIP)
+
+### Performance
+
+- *(lsp,wasm)* add caching and optimize position lookups
+
+### Refactoring
+
+- remove dead code and fix duplication
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Bug Fixes

--- a/crates/rustledger-parser/CHANGELOG.md
+++ b/crates/rustledger-parser/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19
+
+### Miscellaneous
+
+- update Cargo.toml dependencies
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Bug Fixes

--- a/crates/rustledger-wasm/CHANGELOG.md
+++ b/crates/rustledger-wasm/CHANGELOG.md
@@ -6,6 +6,74 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19
+
+### Bug Fixes
+
+- address Copilot review feedback
+- push benchmark results to separate branch
+- add nontrapping-float-to-int flag to wasm-opt
+- add bulk-memory flag to wasm-opt for newer Rust
+- correctly apply interpolation result in WASM bindings
+- add interpolation to WASM validate and query
+
+### Documentation
+
+- fix documentation inconsistencies and add crate READMEs
+- streamline README
+- replace install dropdown with scannable table
+- document all installation channels in README
+- fix README accuracy issues
+- fix plugin count (20 not 14) and mention Python support
+- show complete lists for booking methods and plugins
+- redesign README for clarity and scannability
+- use npm 'next' tag for prerelease badge
+- remove static badges, keep only dynamic ones
+- add distribution channel badges to README
+- add Nix installation to README
+- add cargo binstall to README
+- add all installation methods to README
+- comprehensive README improvements
+- use cargo add instead of hardcoded versions
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+- add editor_references tool (find all references)
+- *(wasm)* add LSP-like editor integration
+- add Scoop bucket for Windows
+- add AUR packaging
+- add Docker distribution
+- *(core)* implement string interning for performance
+- add shell completions, refactor WASM module, add release workflow
+- add format, pads, plugins to WASM module
+
+### Miscellaneous
+
+- add CLA and commercial licensing notice
+- update AUR checksums and remove version from README
+- migrate to semver 0.x.y versioning
+- *(release)* improve release assets
+
+### Performance
+
+- *(lsp,wasm)* add caching and optimize position lookups
+- add binary cache and full string interning
+
+### Refactoring
+
+- *(bench)* fair benchmarks with two separate charts
+- *(wasm)* improve module with best practices
+
+### Ci
+
+- add benchmark history tracking and chart generation
+- add nightly benchmark comparison vs Python beancount
+
+### Style
+
+- fix all import ordering for CI rustfmt
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Bug Fixes

--- a/crates/rustledger/CHANGELOG.md
+++ b/crates/rustledger/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19
+
+### Miscellaneous
+
+- update Cargo.lock dependencies
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `rustledger-core`: 0.5.0 -> 0.5.1
* `rustledger-parser`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `rustledger-loader`: 0.5.0 -> 0.5.1
* `rustledger-booking`: 0.5.0 -> 0.5.1
* `rustledger-validate`: 0.5.0 -> 0.5.1
* `rustledger-query`: 0.5.0 -> 0.5.1
* `rustledger-plugin`: 0.5.0 -> 0.5.1
* `rustledger-importer`: 0.5.0 -> 0.5.1
* `rustledger`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `rustledger-wasm`: 0.5.0 -> 0.5.1
* `rustledger-lsp`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustledger-core`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-parser`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Miscellaneous

- update Cargo.toml dependencies
</blockquote>

## `rustledger-loader`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-booking`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-validate`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-query`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-plugin`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-importer`

<blockquote>

## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Miscellaneous

- update Cargo.lock dependencies
</blockquote>

## `rustledger-wasm`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Bug Fixes

- address Copilot review feedback
- push benchmark results to separate branch
- add nontrapping-float-to-int flag to wasm-opt
- add bulk-memory flag to wasm-opt for newer Rust
- correctly apply interpolation result in WASM bindings
- add interpolation to WASM validate and query

### Documentation

- fix documentation inconsistencies and add crate READMEs
- streamline README
- replace install dropdown with scannable table
- document all installation channels in README
- fix README accuracy issues
- fix plugin count (20 not 14) and mention Python support
- show complete lists for booking methods and plugins
- redesign README for clarity and scannability
- use npm 'next' tag for prerelease badge
- remove static badges, keep only dynamic ones
- add distribution channel badges to README
- add Nix installation to README
- add cargo binstall to README
- add all installation methods to README
- comprehensive README improvements
- use cargo add instead of hardcoded versions

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
- add editor_references tool (find all references)
- *(wasm)* add LSP-like editor integration
- add Scoop bucket for Windows
- add AUR packaging
- add Docker distribution
- *(core)* implement string interning for performance
- add shell completions, refactor WASM module, add release workflow
- add format, pads, plugins to WASM module

### Miscellaneous

- add CLA and commercial licensing notice
- update AUR checksums and remove version from README
- migrate to semver 0.x.y versioning
- *(release)* improve release assets

### Performance

- *(lsp,wasm)* add caching and optimize position lookups
- add binary cache and full string interning

### Refactoring

- *(bench)* fair benchmarks with two separate charts
- *(wasm)* improve module with best practices

### Ci

- add benchmark history tracking and chart generation
- add nightly benchmark comparison vs Python beancount

### Style

- fix all import ordering for CI rustfmt
</blockquote>

## `rustledger-lsp`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Bug Fixes

- *(lsp)* address PR review comments

### Documentation

- add comprehensive PR review policy

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
- *(lsp)* add resolve handlers and file watching
- *(lsp)* add execute command and completion resolve
- *(lsp)* add call hierarchy and signature help
- *(lsp)* add code lens, document color, goto declaration
- *(lsp)* add document highlight, linked editing, on-type formatting
- *(lsp)* add type hierarchy for account navigation
- *(lsp)* add find references for accounts, currencies, payees
- *(lsp)* add range formatting, document links, inlay hints, selection range
- *(lsp)* add workspace symbols, rename, formatting, folding
- *(lsp)* add code actions for quick fixes
- *(lsp)* add semantic tokens for syntax highlighting
- *(lsp)* add Phase 5 - document symbols (outline view)
- *(lsp)* add Phase 4 - navigation features (definition, hover)
- *(lsp)* add Phase 3 - autocompletion support
- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
- *(lsp)* add rustledger-lsp crate skeleton (WIP)

### Performance

- *(lsp,wasm)* add caching and optimize position lookups

### Refactoring

- remove dead code and fix duplication
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).