### PR TITLE
chore: release v0.5.1

### DIFF
--- a/crates/rustledger-booking/CHANGELOG.md
+++ b/crates/rustledger-booking/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features

--- a/crates/rustledger-core/CHANGELOG.md
+++ b/crates/rustledger-core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features

--- a/crates/rustledger-importer/CHANGELOG.md
+++ b/crates/rustledger-importer/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features

--- a/crates/rustledger-loader/CHANGELOG.md
+++ b/crates/rustledger-loader/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features

--- a/crates/rustledger-plugin/CHANGELOG.md
+++ b/crates/rustledger-plugin/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features

--- a/crates/rustledger-query/CHANGELOG.md
+++ b/crates/rustledger-query/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features

--- a/crates/rustledger-validate/CHANGELOG.md
+++ b/crates/rustledger-validate/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+
 ## [0.5.0](https://github.com/rustledger/rustledger/compare/v0.4.0...v0.5.0) - 2026-01-19
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `rustledger-core`: 0.5.1
* `rustledger-parser`: 0.5.1
* `rustledger-loader`: 0.5.1
* `rustledger-booking`: 0.5.1
* `rustledger-validate`: 0.5.1
* `rustledger-query`: 0.5.1
* `rustledger-plugin`: 0.5.1
* `rustledger-importer`: 0.5.1
* `rustledger`: 0.5.1
* `rustledger-wasm`: 0.5.1
* `rustledger-lsp`: 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustledger-core`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-parser`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Miscellaneous

- update Cargo.toml dependencies
</blockquote>

## `rustledger-loader`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-booking`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-validate`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-query`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-plugin`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger-importer`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/releases/tag/v0.5.1) - 2026-01-20

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
</blockquote>

## `rustledger`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Miscellaneous

- update Cargo.lock dependencies
</blockquote>

## `rustledger-wasm`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Bug Fixes

- address Copilot review feedback
- push benchmark results to separate branch
- add nontrapping-float-to-int flag to wasm-opt
- add bulk-memory flag to wasm-opt for newer Rust
- correctly apply interpolation result in WASM bindings
- add interpolation to WASM validate and query

### Documentation

- fix documentation inconsistencies and add crate READMEs
- streamline README
- replace install dropdown with scannable table
- document all installation channels in README
- fix README accuracy issues
- fix plugin count (20 not 14) and mention Python support
- show complete lists for booking methods and plugins
- redesign README for clarity and scannability
- use npm 'next' tag for prerelease badge
- remove static badges, keep only dynamic ones
- add distribution channel badges to README
- add Nix installation to README
- add cargo binstall to README
- add all installation methods to README
- comprehensive README improvements
- use cargo add instead of hardcoded versions

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
- add editor_references tool (find all references)
- *(wasm)* add LSP-like editor integration
- add Scoop bucket for Windows
- add AUR packaging
- add Docker distribution
- *(core)* implement string interning for performance
- add shell completions, refactor WASM module, add release workflow
- add format, pads, plugins to WASM module

### Miscellaneous

- add CLA and commercial licensing notice
- update AUR checksums and remove version from README
- migrate to semver 0.x.y versioning
- *(release)* improve release assets

### Performance

- *(lsp,wasm)* add caching and optimize position lookups
- add binary cache and full string interning

### Refactoring

- *(bench)* fair benchmarks with two separate charts
- *(wasm)* improve module with best practices

### Ci

- add benchmark history tracking and chart generation
- add nightly benchmark comparison vs Python beancount

### Style

- fix all import ordering for CI rustfmt
</blockquote>

## `rustledger-lsp`

<blockquote>

## [0.5.1](https://github.com/rustledger/rustledger/compare/v0.5.0...v0.5.1) - 2026-01-19

### Bug Fixes

- *(lsp)* address PR review comments

### Documentation

- add comprehensive PR review policy

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
- *(lsp)* add resolve handlers and file watching
- *(lsp)* add execute command and completion resolve
- *(lsp)* add call hierarchy and signature help
- *(lsp)* add code lens, document color, goto declaration
- *(lsp)* add document highlight, linked editing, on-type formatting
- *(lsp)* add type hierarchy for account navigation
- *(lsp)* add find references for accounts, currencies, payees
- *(lsp)* add range formatting, document links, inlay hints, selection range
- *(lsp)* add workspace symbols, rename, formatting, folding
- *(lsp)* add code actions for quick fixes
- *(lsp)* add semantic tokens for syntax highlighting
- *(lsp)* add Phase 5 - document symbols (outline view)
- *(lsp)* add Phase 4 - navigation features (definition, hover)
- *(lsp)* add Phase 3 - autocompletion support
- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
- *(lsp)* add rustledger-lsp crate skeleton (WIP)

### Performance

- *(lsp,wasm)* add caching and optimize position lookups

### Refactoring

- remove dead code and fix duplication
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).