### PR TITLE
fix(mcp-server): update @rustledger/wasm dependency to 0.5.0

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.4.0"
+    "@rustledger/wasm": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Update `@rustledger/wasm` dependency from `^0.4.0` to `^0.5.0`
- The MCP server uses `getReferences` which was added in v0.5.0
- Bump MCP server version to 0.5.0 to match

## Fixes
Fixes the TypeScript build error:
```
src/handlers.ts(235,25): error TS2339: Property 'getReferences' does not exist on type 'ParsedLedger'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)