### PR TITLE
docs: add missing READMEs and Liberapay funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+liberapay: rustledger

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Parse and validate your ledger faster than Python beancount.
 [![CI](https://github.com/rustledger/rustledger/actions/workflows/ci.yml/badge.svg)](https://github.com/rustledger/rustledger/actions/workflows/ci.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/rustledger/rustledger)](https://github.com/rustledger/rustledger/releases)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+[![Liberapay](https://img.shields.io/liberapay/gives/rustledger.svg?logo=liberapay)](https://liberapay.com/rustledger)
 
 </div>
 
@@ -176,3 +177,9 @@ By submitting a pull request, you agree to the [Contributor License Agreement](C
 [GPL-3.0](LICENSE)
 
 **Commercial licensing available** - [contact us](https://rustledger.github.io/#contact) for proprietary license options.
+
+## Funding
+
+rustledger is free and open source. If you find it useful, consider supporting development:
+
+[![Support on Liberapay](https://img.shields.io/badge/Support%20on-Liberapay-F6C915?logo=liberapay)](https://liberapay.com/rustledger)

--- a/crates/rustledger-importer/README.md
+++ b/crates/rustledger-importer/README.md
@@ -1,0 +1,76 @@
+# rustledger-importer
+
+Import framework for rustledger - extract transactions from bank files.
+
+## Overview
+
+This crate provides infrastructure for extracting Beancount transactions from bank statements, credit card statements, and other financial documents. It follows the design of Python beancount's `bean-extract`.
+
+## Supported Formats
+
+| Format | Description |
+|--------|-------------|
+| CSV | Configurable CSV importer with column mapping |
+| OFX/QFX | Open Financial Exchange format |
+
+## Example
+
+```rust
+use rustledger_importer::{ImporterConfig, extract_from_file};
+use std::path::Path;
+
+// Create a CSV importer configuration
+let config = ImporterConfig::csv()
+    .account("Assets:Bank:Checking")
+    .currency("USD")
+    .date_column("Date")
+    .narration_column("Description")
+    .amount_column("Amount")
+    .build();
+
+// Extract transactions from a file
+let result = extract_from_file(Path::new("bank.csv"), &config)?;
+
+for directive in result.directives {
+    println!("{:?}", directive);
+}
+```
+
+## Key Types
+
+| Type | Description |
+|------|-------------|
+| `Importer` | Trait for file importers |
+| `ImporterConfig` | Builder for configuring CSV imports |
+| `ImportResult` | Result containing directives and warnings |
+| `ImporterRegistry` | Registry of available importers |
+| `OfxImporter` | OFX/QFX file importer |
+
+## Importer Trait
+
+Implement the `Importer` trait to add support for new file formats:
+
+```rust
+use rustledger_importer::{Importer, ImportResult};
+use std::path::Path;
+use anyhow::Result;
+
+struct MyImporter;
+
+impl Importer for MyImporter {
+    fn name(&self) -> &str { "my-importer" }
+
+    fn identify(&self, path: &Path) -> bool {
+        path.extension().is_some_and(|e| e == "myext")
+    }
+
+    fn extract(&self, path: &Path) -> Result<ImportResult> {
+        // Parse file and return directives
+        Ok(ImportResult::empty())
+    }
+}
+```
+
+## License
+
+GPL-3.0

--- a/crates/rustledger-wasm/README.md
+++ b/crates/rustledger-wasm/README.md
@@ -1,0 +1,77 @@
+# rustledger-wasm
+
+WebAssembly bindings for rustledger, enabling Beancount functionality in JavaScript/TypeScript.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| `parse()` | Parse Beancount source to JSON |
+| `validateSource()` | Validate ledger with error reporting |
+| `query()` | Run BQL queries |
+| `format()` | Format source with consistent alignment |
+| `expandPads()` | Expand pad directives |
+| `runPlugin()` | Run native plugins (with `plugins` feature) |
+| `bqlCompletions()` | BQL query completions (with `completions` feature) |
+| `ParsedLedger` | Stateful class with LSP-like editor features |
+
+## Example
+
+```javascript
+import init, { parse, validateSource, query } from '@rustledger/wasm';
+
+await init();
+
+const source = `
+2024-01-01 open Assets:Bank USD
+2024-01-15 * "Coffee"
+  Expenses:Food  5.00 USD
+  Assets:Bank   -5.00 USD
+`;
+
+const result = parse(source);
+if (result.errors.length === 0) {
+    const validation = validateSource(source);
+    console.log('Valid:', validation.valid);
+
+    const balances = query(source, 'BALANCES');
+    console.log('Balances:', balances.rows);
+}
+```
+
+## Stateful API
+
+For multiple operations on the same source, use `ParsedLedger` to avoid re-parsing:
+
+```javascript
+import { ParsedLedger } from '@rustledger/wasm';
+
+const ledger = new ParsedLedger(source);
+
+if (ledger.isValid()) {
+    const balances = ledger.balances();
+    const formatted = ledger.format();
+
+    // Editor features
+    const completions = ledger.getCompletions(5, 10);
+    const hover = ledger.getHoverInfo(3, 5);
+    const definition = ledger.getDefinition(4, 3);
+}
+
+ledger.free(); // Release WASM memory
+```
+
+## Cargo Features
+
+- `plugins` (default) - Include native plugin support
+- `completions` (default) - Include BQL query completions
+
+## Building
+
+```bash
+wasm-pack build --target web crates/rustledger-wasm
+```
+
+## License
+
+GPL-3.0


### PR DESCRIPTION
## Summary

- Add README.md for `rustledger-wasm` crate (WASM bindings documentation)
- Add README.md for `rustledger-importer` crate (import framework documentation)
- Add Liberapay badge to main README header
- Add Funding section at bottom of main README
- Add `.github/FUNDING.yml` to enable GitHub's Sponsor button

## Test plan

- [ ] Verify READMEs render correctly on GitHub
- [ ] Verify Liberapay badge displays correctly
- [ ] Verify Sponsor button appears on repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)