### PR TITLE
chore(ci): auto-cleanup old release-plz branches

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -64,13 +64,22 @@ jobs:
           CURRENT_BRANCH=$(echo "$PR_DATA" | jq -r '.head_branch // empty' 2>/dev/null || echo "")
           echo "Current release branch: $CURRENT_BRANCH"
 
-          # Find and delete old release-plz branches
-          for branch in $(git ls-remote --heads origin 'release-plz-*' | awk -F'/' '{print $NF}'); do
-            if [ "$branch" != "$CURRENT_BRANCH" ]; then
-              echo "Deleting old branch: $branch"
-              git push origin --delete "$branch" || echo "Failed to delete $branch (may already be deleted)"
-            fi
-          done
+          # Safety check: don't proceed if we couldn't determine the current branch
+          if [ -z "$CURRENT_BRANCH" ]; then
+            echo "Could not determine current release branch; skipping cleanup"
+            exit 0
+          fi
+
+          # Find and delete old release-plz branches (with validation)
+          git ls-remote --heads origin 'release-plz-*' \
+            | awk -F'/' '{print $NF}' \
+            | grep -E '^release-plz-[0-9T-]+Z$' \
+            | while IFS= read -r branch; do
+                if [ "$branch" != "$CURRENT_BRANCH" ]; then
+                  echo "Deleting old branch: $branch"
+                  git push origin --delete "$branch" || echo "Failed to delete $branch (may already be deleted)"
+                fi
+              done
 
       # Enable auto-merge for release PRs (will merge when checks pass and approved)
       - name: Enable auto-merge for release PR


### PR DESCRIPTION
## Summary

Automatically delete old `release-plz-*` branches when a new release PR is created.

## Problem

GitHub's `delete_branch_on_merge` setting only deletes branches when PRs are **merged**. When release-plz creates a new release PR, it closes the old one without merging, leaving stale branches behind.

## Solution

Added a cleanup step that runs when a new release PR is created:
1. Gets the current PR's branch name
2. Lists all remote `release-plz-*` branches
3. Deletes any that don't match the current branch

## Test plan

- [x] Verify workflow syntax is valid
- [ ] Next release-plz run will clean up any stale branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)