### PR TITLE
feat: support unicode and emoji in account names

### DIFF
--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -54,11 +54,12 @@ pub enum Token<'src> {
     /// An account name like Assets:Bank:Checking, Aktiva:Bank:Girokonto, or Ciste-jmeni:Stav.
     /// Must start with a capitalized word (account type prefix) and have at least one sub-account.
     /// Account type prefix can contain hyphens (e.g., Ciste-jmeni for Czech "Čisté jmění").
-    /// Sub-accounts must start with uppercase letter, digit, or CJK character (matching Python beancount).
-    /// Supports Unicode letters (e.g., Expenses:École-républicaine, Assets:沪深300).
-    /// `\p{Lo}` matches CJK characters and other scripts without case distinction.
+    /// Sub-accounts must start with uppercase letter, digit, or non-ASCII character (matching Python beancount).
+    /// Supports Unicode letters, symbols, and emojis (e.g., Expenses:École, Assets:沪深300, Assets:CORP✨).
+    /// Pattern matches beancount's lexer.l: `([A-Z]|UTF-8-ONLY)([A-Za-z0-9-]|UTF-8-ONLY)*`.
+    /// `[^\x00-\x7F]` matches any non-ASCII UTF-8 character (equivalent to beancount's UTF-8-ONLY).
     /// The account type prefix is validated later against options (`name_assets`, etc.).
-    #[regex(r"\p{Lu}\p{L}*(-\p{L}+)*(:[\p{Lu}\p{Lo}0-9][\p{L}0-9-]*)+")]
+    #[regex(r"([A-Z]|[^\x00-\x7F])([A-Za-z0-9-]|[^\x00-\x7F])*(:([A-Z0-9]|[^\x00-\x7F])([A-Za-z0-9-]|[^\x00-\x7F])*)+")]
     Account(&'src str),
 
     /// A currency/commodity code like USD, EUR, AAPL, BTC.
@@ -500,6 +501,45 @@ mod tests {
         assert!(matches!(
             tokens[0].0,
             Token::Account("Assets:Bank:Checking")
+        ));
+    }
+
+    #[test]
+    fn test_tokenize_account_unicode() {
+        // Test various Unicode characters in account names
+        // Matching beancount's UTF-8-ONLY support (any non-ASCII character)
+
+        // Emoji (Unicode Symbol category So)
+        let tokens = tokenize("Assets:CORP✨");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Account("Assets:CORP✨")));
+
+        // CJK characters (Unicode Letter category Lo)
+        let tokens = tokenize("Assets:沪深300");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Account("Assets:沪深300")));
+
+        // Full CJK component
+        let tokens = tokenize("Assets:日本銀行");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Account("Assets:日本銀行")));
+
+        // Non-ASCII letters (accented)
+        let tokens = tokenize("Assets:Café");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Account("Assets:Café")));
+
+        // Currency symbol (Unicode Symbol category Sc)
+        let tokens = tokenize("Assets:€uro");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Account("Assets:€uro")));
+
+        // Emoji in middle of component
+        let tokens = tokenize("Assets:Test💰Account");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(
+            tokens[0].0,
+            Token::Account("Assets:Test💰Account")
         ));
     }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -527,27 +527,30 @@ fn validate_account_name(account: &str, account_types: &[String]) -> Option<Stri
             return Some(format!("component {} is empty", i + 1));
         }
 
-        // First character must be uppercase letter, non-ASCII letter (like CJK), or digit
-        // CJK characters don't have case but are valid in account names.
+        // First character must be uppercase ASCII letter, ASCII digit, or any non-ASCII character.
+        // This matches beancount's lexer.l: `([A-Z]|UTF-8-ONLY)` for account type start,
+        // and `([A-Z0-9]|UTF-8-ONLY)` for sub-account start.
+        // Non-ASCII includes CJK, emojis, symbols, and any other Unicode character.
         // Safety: we just checked part.is_empty() above, so this is guaranteed to succeed
         let Some(first_char) = part.chars().next() else {
             // This branch is unreachable due to the is_empty check above,
             // but we handle it defensively to avoid unwrap
             return Some(format!("component {} is empty", i + 1));
         };
-        // Accept: uppercase letters, non-ASCII alphabetic (CJK, etc.), or digits
-        let is_valid_start = first_char.is_uppercase()
+        // Accept: uppercase ASCII letters, ASCII digits, or any non-ASCII character
+        let is_valid_start = first_char.is_ascii_uppercase()
             || first_char.is_ascii_digit()
-            || (first_char.is_alphabetic() && !first_char.is_ascii());
+            || !first_char.is_ascii();
         if !is_valid_start {
             return Some(format!(
                 "component '{part}' must start with uppercase letter or digit"
             ));
         }
 
-        // Remaining characters: letters (including Unicode), numbers, dashes
+        // Remaining characters: ASCII letters, ASCII digits, hyphens, or any non-ASCII character.
+        // This matches beancount's lexer.l: `([A-Za-z0-9-]|UTF-8-ONLY)*`
         for c in part.chars().skip(1) {
-            if !c.is_alphanumeric() && c != '-' {
+            if !c.is_ascii_alphanumeric() && c != '-' && c.is_ascii() {
                 return Some(format!(
                     "component '{part}' contains invalid character '{c}'"
                 ));
@@ -2041,7 +2044,13 @@ mod tests {
             "Equity:Opening-Balances",
             "Income:Salary2024",
             "Expenses:Food:Restaurant",
-            "Assets:401k", // Component starting with digit
+            "Assets:401k",          // Component starting with digit
+            "Assets:CORP✨",        // Emoji in component (beancount UTF-8-ONLY support)
+            "Assets:沪深300",       // CJK characters
+            "Assets:Café",          // Non-ASCII letter (é)
+            "Assets:日本銀行",      // Full non-ASCII component
+            "Assets:Test💰Account", // Emoji in middle
+            "Assets:€uro",          // Currency symbol at start of component
         ];
 
         for name in valid_names {


### PR DESCRIPTION
## Summary

- Support Unicode/emoji characters in account names to match Python beancount
- Allow any non-ASCII UTF-8 character (2-4 bytes) per beancount's UTF-8-ONLY pattern

## Examples

These account names are now supported:
- `Assets:Dépenses` (accented characters)
- `Assets:日本語` (non-Latin scripts)
- `Assets:🏦Bank` (emoji)

## Changes

- **Parser**: Updated Account regex from `\p{L}` (letters only) to `[^\x00-\x7F]` (any non-ASCII)
- **Validation**: Updated account validation to accept non-ASCII characters

## Test plan

- [x] Added unit tests for Unicode account names
- [x] Parse compatibility tests: 694/694 files pass (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)