### PR TITLE
fix: gitignore downloaded compat test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ traces/
 spec/fixtures/lima-tests/
 spec/fixtures/examples/
 spec/fixtures/python-tests/
+tests/compat-full/
+tests/compat-results/
 
 # Benchmark results
 target/criterion/


### PR DESCRIPTION
## Summary

- Add `tests/compat-full/` and `tests/compat-results/` to `.gitignore`
- Fixes release-plz workflow failures due to "uncommitted changes" errors

## Problem

The release-plz workflow was failing because:
1. The nightly compat test workflow downloads files to `tests/compat-full/`
2. These files are not gitignored
3. When release-plz runs after compat tests, it sees these as uncommitted changes and errors out

## Test plan

- [x] release-plz workflow should pass after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)