### PR TITLE
chore: improve benchmark chart labels

### DIFF
--- a/.github/badges/validation-spec.json
+++ b/.github/badges/validation-spec.json
@@ -147,7 +147,7 @@
         "enter": {
           "y": {"scale": "y", "field": "label", "band": 0.5},
           "x": {"signal": "datum.is_small ? scale('x', datum.time_ms) + 16 : (datum.tool == 'rustledger' ? 48 : 40)"},
-          "text": {"signal": "datum.is_small ? (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x vs python · ' + format(datum.time_ms, '.0f') + ' ms' : format(datum.slower_factor, '.1f') + 'x slower · ' + format(datum.time_ms, '.0f') + ' ms') : (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x vs python' : format(datum.slower_factor, '.1f') + 'x slower')"},
+          "text": {"signal": "datum.is_small ? (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x faster than beancount · ' + format(datum.time_ms, '.0f') + ' ms' : format(datum.slower_factor, '.1f') + 'x slower than rustledger · ' + format(datum.time_ms, '.0f') + ' ms') : (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x faster than beancount' : format(datum.slower_factor, '.1f') + 'x slower than rustledger')"},
           "fill": {"signal": "datum.is_small ? '#e6edf3' : '#ffffff'"},
           "fontSize": {"value": 10},
           "fontWeight": {"value": 600},

--- a/scripts/generate-bench-charts.py
+++ b/scripts/generate-bench-charts.py
@@ -178,7 +178,7 @@ def generate_vega_bar_spec(
                         "y": {"scale": "y", "field": "label", "band": 0.5},
                         "x": {"signal": "datum.is_small ? scale('x', datum.time_ms) + 10 : 8"},
                         "text": {
-                            "signal": "datum.is_small ? (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x vs beancount · ' + format(datum.time_ms, '.0f') + ' ms' : format(datum.slower_factor, '.1f') + 'x slower · ' + format(datum.time_ms, '.0f') + ' ms') : (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x vs beancount' : format(datum.slower_factor, '.1f') + 'x slower')"
+                            "signal": "datum.is_small ? (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x faster than beancount · ' + format(datum.time_ms, '.0f') + ' ms' : format(datum.slower_factor, '.1f') + 'x slower than rustledger · ' + format(datum.time_ms, '.0f') + ' ms') : (datum.tool == 'rustledger' ? format(datum.faster_factor, '.0f') + 'x faster than beancount' : format(datum.slower_factor, '.1f') + 'x slower than rustledger')"
                         },
                         "fill": {
                             "signal": "datum.is_small ? (datum.tool == 'rustledger' ? '#f74c00' : '#e6edf3') : '#000000'"


### PR DESCRIPTION
## Summary

### Benchmark chart labels
- Updates benchmark chart text to be more descriptive
- rustledger: `27x vs beancount` → `27x faster than beancount`
- other tools: `2.0x slower` → `2.0x slower than rustledger`

### Fix crates.io publish (critical)
- **Root cause**: CARGO_REGISTRY_TOKEN wasn't being passed to `cargo publish`
- Adds `id` to crates-io-auth-action step and passes token via env var
- Replaces silent `|| true` with proper error handling
- Allows "already been uploaded" as success (for reruns)
- Fails the job if any crate fails to publish

This fixes why v0.5.2 never published to crates.io despite showing "success".

## Test plan

- [x] Charts will be regenerated on next benchmark run
- [ ] Next release should properly publish to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)