### PR TITLE
feat(validate)!: make ValidationOptions non-exhaustive

### DIFF
--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -275,7 +275,20 @@ struct AccountState {
 }
 
 /// Validation options.
+///
+/// This struct is marked `#[non_exhaustive]` to allow adding new options
+/// in future minor versions without breaking semver. Use the builder methods
+/// to construct:
+///
+/// ```
+/// use rustledger_validate::ValidationOptions;
+///
+/// let options = ValidationOptions::default()
+///     .with_check_documents(false)
+///     .with_warn_future_dates(true);
+/// ```
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ValidationOptions {
     /// Whether to require commodity declarations.
     pub require_commodities: bool,
@@ -314,6 +327,63 @@ impl Default for ValidationOptions {
             infer_tolerance_from_cost: true,
             tolerance_multiplier: Decimal::new(5, 1), // 0.5
         }
+    }
+}
+
+impl ValidationOptions {
+    /// Create new validation options with defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether to require commodity declarations.
+    #[must_use]
+    pub const fn with_require_commodities(mut self, require: bool) -> Self {
+        self.require_commodities = require;
+        self
+    }
+
+    /// Set whether to check if document files exist.
+    #[must_use]
+    pub const fn with_check_documents(mut self, check: bool) -> Self {
+        self.check_documents = check;
+        self
+    }
+
+    /// Set whether to warn about future-dated entries.
+    #[must_use]
+    pub const fn with_warn_future_dates(mut self, warn: bool) -> Self {
+        self.warn_future_dates = warn;
+        self
+    }
+
+    /// Set the base directory for resolving relative document paths.
+    #[must_use]
+    pub fn with_document_base(mut self, base: impl Into<std::path::PathBuf>) -> Self {
+        self.document_base = Some(base.into());
+        self
+    }
+
+    /// Set valid account type prefixes.
+    #[must_use]
+    pub fn with_account_types(mut self, types: Vec<String>) -> Self {
+        self.account_types = types;
+        self
+    }
+
+    /// Set whether to infer tolerance from cost.
+    #[must_use]
+    pub const fn with_infer_tolerance_from_cost(mut self, infer: bool) -> Self {
+        self.infer_tolerance_from_cost = infer;
+        self
+    }
+
+    /// Set the tolerance multiplier.
+    #[must_use]
+    pub const fn with_tolerance_multiplier(mut self, multiplier: Decimal) -> Self {
+        self.tolerance_multiplier = multiplier;
+        self
     }
 }
 

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -793,12 +793,10 @@ fn run(args: &Args) -> Result<ExitCode> {
 
     // Build validation options with account types from loader options
     // Set document_base to the file's directory for relative path resolution
-    let document_base = file.parent().map(std::path::Path::to_path_buf);
-    let validation_options = ValidationOptions {
-        account_types,
-        document_base,
-        ..Default::default()
-    };
+    let mut validation_options = ValidationOptions::default().with_account_types(account_types);
+    if let Some(base) = file.parent() {
+        validation_options = validation_options.with_document_base(base);
+    }
     let validation_errors = validate_with_options(&directives, validation_options);
     let validation_error_count = validation_errors
         .iter()


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to `ValidationOptions` struct
- Add builder methods for all fields
- Update `check.rs` to use builder pattern

## Why

The semver check was failing on PRs #184 and #185 because `ValidationOptions` had new public fields added after v0.5.2 was published. Adding fields to a constructible struct is a breaking change.

By making the struct `#[non_exhaustive]` and providing builder methods, future field additions will not break semver.

## Migration

Before:
```rust
let options = ValidationOptions {
    check_documents: false,
    account_types: vec!["Assets".into()],
    ..Default::default()
};
```

After:
```rust
let options = ValidationOptions::default()
    .with_check_documents(false)
    .with_account_types(vec!["Assets".into()]);
```

## Builder Methods Added

- `with_require_commodities(bool)`
- `with_check_documents(bool)`
- `with_warn_future_dates(bool)`
- `with_document_base(impl Into<PathBuf>)`
- `with_account_types(Vec<String>)`
- `with_infer_tolerance_from_cost(bool)`
- `with_tolerance_multiplier(Decimal)`

## BREAKING CHANGE

This will trigger a version bump to 0.6.0 via release-plz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)