### PR TITLE
ci: add workflow_dispatch with debug option to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -62,7 +62,7 @@ jobs:
 
           echo ""
           echo "=== Running cargo-semver-checks on rustledger-parser ==="
-          ./cargo-semver-checks semver-checks check-release \
+          ./cargo-semver-checks check-release \
             --manifest-path crates/rustledger-parser/Cargo.toml \
             2>&1 || echo "Exit code: $?"
 


### PR DESCRIPTION
## Summary
- Add manual trigger capability (`workflow_dispatch`) to release-plz workflow
- Add optional `debug_semver` input (boolean)
- When enabled, runs `cargo-semver-checks` directly before release-plz and sets `RUST_LOG` for verbose output

## Why
Investigating why CI reports "API compatible changes" when local tests detect breaking changes. This allows us to trigger the workflow manually with debug logging to diagnose the discrepancy.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger release-plz workflow with `debug_semver=true`
- [ ] Check logs for cargo-semver-checks output

🤖 Generated with [Claude Code](https://claude.com/claude-code)