### PR TITLE
fix: download cargo-semver-checks to /tmp in debug step

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -56,13 +56,15 @@ jobs:
         if: inputs.debug_semver == true
         run: |
           echo "=== Installing cargo-semver-checks ==="
+          cd /tmp
           curl -sL https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.45.0/cargo-semver-checks-x86_64-unknown-linux-musl.tar.gz | tar xzf -
           chmod +x cargo-semver-checks
           ./cargo-semver-checks --version
+          cd -
 
           echo ""
           echo "=== Running cargo-semver-checks on rustledger-parser ==="
-          ./cargo-semver-checks check-release \
+          /tmp/cargo-semver-checks check-release \
             --manifest-path crates/rustledger-parser/Cargo.toml \
             2>&1 || echo "Exit code: $?"
 


### PR DESCRIPTION
## Summary
Fixes the debug workflow that was leaving `cargo-semver-checks` binary in the working directory, causing release-plz to fail with "uncommitted changes" error.

## Changes
- Download cargo-semver-checks to `/tmp` instead of working directory
- Run from `/tmp` to keep working tree clean

## Test plan
- [ ] Merge this PR
- [ ] Re-run debug workflow with `debug_semver=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)