### PR TITLE
fix: correct cargo-semver-checks invocation in debug step

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -64,8 +64,9 @@ jobs:
 
           echo ""
           echo "=== Running cargo-semver-checks on rustledger-parser ==="
-          /tmp/cargo-semver-checks check-release \
+          /tmp/cargo-semver-checks semver-checks check-release \
             --manifest-path crates/rustledger-parser/Cargo.toml \
+            --verbose \
             2>&1 || echo "Exit code: $?"
 
       # Use PAT to create PR so it triggers CI workflows automatically


### PR DESCRIPTION
## Summary
- Fixes the debug step invocation to use `semver-checks check-release` subcommand
- The binary is named `cargo-semver-checks` but requires `semver-checks` as first argument when invoked directly
- Added `--verbose` flag for more detailed output

This should allow us to see actual cargo-semver-checks output in CI to diagnose why it reports "API compatible changes" when local tests detect breaking changes.

## Test plan
- [x] Push to branch
- [ ] Merge to main
- [ ] Trigger workflow_dispatch with debug_semver=true
- [ ] Review the debug step output

🤖 Generated with [Claude Code](https://claude.com/claude-code)