### PR TITLE
fix: pin Rust version for cargo-semver-checks compatibility

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,8 +48,12 @@ jobs:
           # Use PAT for checkout so PR triggers CI workflows
           token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
 
+      # Pin to 1.92.0 because cargo-semver-checks 0.45.0 doesn't support rustdoc format v57
+      # which is produced by Rust 1.93.0+. Remove this pin once cargo-semver-checks is updated.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7
+        with:
+          toolchain: 1.92.0
 
       # Debug: Run cargo-semver-checks directly to diagnose issues
       - name: Debug - Run cargo-semver-checks directly
@@ -189,8 +193,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pin to 1.92.0 for consistency with release-plz job (see comment above)
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7
+        with:
+          toolchain: 1.92.0
 
       - name: Run release-plz release
         uses: release-plz/action@99b33d83e322fcd1b1fa126f8c4a74744aae3c8d # v0.5


### PR DESCRIPTION
## Summary

**Root cause identified**: cargo-semver-checks 0.45.0 doesn't support rustdoc format v57 (produced by Rust 1.93.0+).

When cargo-semver-checks fails with "unsupported rustdoc format" error, release-plz falls back to treating all changes as "API compatible" (see [release-plz issue #2294](https://github.com/release-plz/release-plz/issues/2294)), which caused breaking changes to be incorrectly versioned as patch bumps (0.5.3 instead of 0.6.0).

This PR pins Rust to 1.92.0 until cargo-semver-checks releases an update supporting rustdoc v57.

## Evidence from debug run

```
error: unsupported rustdoc format v57 for file: ...rustledger_parser.json
(supported formats are v53, v55, v56)
Exit code: 1
```

## Test plan
- [x] Push branch
- [ ] Merge to main
- [ ] Trigger workflow_dispatch with debug_semver=true
- [ ] Verify cargo-semver-checks now correctly detects breaking changes
- [ ] Verify version bump is to 0.6.0 (not 0.5.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)