### PR TITLE
fix: temporarily disable semver checks due to rustdoc v57 incompatibility

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,12 +48,8 @@ jobs:
           # Use PAT for checkout so PR triggers CI workflows
           token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
 
-      # Pin to 1.92.0 because cargo-semver-checks 0.45.0 doesn't support rustdoc format v57
-      # which is produced by Rust 1.93.0+. Remove this pin once cargo-semver-checks is updated.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7
-        with:
-          toolchain: 1.92.0
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       # Debug: Run cargo-semver-checks directly to diagnose issues
       - name: Debug - Run cargo-semver-checks directly
@@ -193,11 +189,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Pin to 1.92.0 for consistency with release-plz job (see comment above)
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7
-        with:
-          toolchain: 1.92.0
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       - name: Run release-plz release
         uses: release-plz/action@99b33d83e322fcd1b1fa126f8c4a74744aae3c8d # v0.5

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,7 +10,11 @@
 [workspace]
 # Use conventional commits to determine version bumps
 # feat: -> minor, fix: -> patch, BREAKING CHANGE: -> major
-semver_check = true
+#
+# TEMPORARILY DISABLED: cargo-semver-checks 0.45.0 doesn't support rustdoc v57
+# produced by Rust 1.93.0+. Re-enable when cargo-semver-checks is updated.
+# See: https://github.com/obi1kenobi/cargo-semver-checks/issues/1553
+semver_check = false
 
 # Create changelog entries from conventional commits
 changelog_update = true


### PR DESCRIPTION
## Summary

Temporarily disables semver checks until cargo-semver-checks supports rustdoc v57.

### Root Cause
- cargo-semver-checks 0.45.0 doesn't support rustdoc format v57 (produced by Rust 1.93.0+)
- cargo-semver-checks uses nightly Rust internally, regardless of installed stable version
- When cargo-semver-checks fails, release-plz falls back to "API compatible"
- This caused breaking changes to be versioned as 0.5.3 instead of 0.6.0

### Changes
- Set `semver_check = false` in release-plz.toml with explanatory comment
- Reverted the Rust 1.92.0 pin (doesn't help since cargo-semver-checks uses its own nightly)

### Re-enable When
Monitor https://github.com/obi1kenobi/cargo-semver-checks/issues/1553 - maintainer promised a fix release soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)