### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 license = "GPL-3.0-only"
@@ -110,14 +110,14 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.5.2", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.5.2", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.5.2", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.5.2", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.5.2", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.5.2", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.5.2", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.5.2", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.6.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.6.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.6.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.6.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.6.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.6.0", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.6.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.6.0", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.5.2"
+    "@rustledger/wasm": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary

Manually bumps version to 0.6.0 due to breaking API changes.

### Breaking Changes
- Added `file_id` field to `Spanned<T>` struct
- Added `warnings` field to `ParseResult`
- Added new enum variants to `Token` and `ParseErrorKind`
- Added new fields to `ValidationOptions` and `ValidationError`
- Added new fields to `LoadResult` and `Options`

### Why Manual Bump
cargo-semver-checks is temporarily disabled due to rustdoc v57 incompatibility.
The `BREAKING CHANGE:` footer in this commit will trigger release-plz to
create a proper 0.6.0 release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)