### PR TITLE
fix(ci): add GH_TOKEN to compatibility test file fetch

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Fetch compatibility test files
         if: steps.cache-compat-files.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Downloading compatibility test files..."
           ./scripts/fetch-compat-test-files.sh


### PR DESCRIPTION
## Summary

Fixes the compatibility test showing N/A% and 0 files.

### Root Cause
The `gh repo clone` command in the fetch script requires `GH_TOKEN` authentication. Without it, all 100+ repo clones fail silently with "Warning: Failed to clone", resulting in 0 test files.

### Fix
Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the fetch step environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)