### PR TITLE
fix(ci): use PAT for release tag creation to trigger release-build

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -192,9 +192,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
+      # Use PAT (not GITHUB_TOKEN) so tag creation triggers release-build.yml
+      # GITHUB_TOKEN events don't trigger other workflows (GitHub security feature)
       - name: Run release-plz release
         uses: release-plz/action@99b33d83e322fcd1b1fa126f8c4a74744aae3c8d # v0.5
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes release-build.yml and release-publish.yml not triggering after release PR merges.

### Root Cause
`GITHUB_TOKEN` events don't trigger other workflows (GitHub security feature to prevent infinite loops). The release job was using `GITHUB_TOKEN` to create tags, so the `push: tags: v*` trigger in release-build.yml never fired.

### Fix
Use `WEBSITE_DISPATCH_TOKEN` (PAT) instead of `GITHUB_TOKEN` for the release step.

### For v0.6.0
Already manually triggered release-build (run 21272549762).

🤖 Generated with [Claude Code](https://claude.com/claude-code)