### PR TITLE
chore: release v0.7.0

### DIFF
--- a/crates/rustledger-booking/CHANGELOG.md
+++ b/crates/rustledger-booking/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(booking,ffi)* run booking in FFI and normalize total prices
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-core/CHANGELOG.md
+++ b/crates/rustledger-core/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- add missing imports for tests after refactor
+- address all clippy warnings in synthetic_generation tests
+- address warnings in synthetic_generation tests
+
+### Features
+
+- *(synthetic)* add rledger-doctor generate-synthetic subcommand
+- *(test)* add synthetic beancount file generation for compat testing
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- *(plugin)* split convert.rs into to_wrapper and from_wrapper modules
+- *(core)* split inventory booking methods into module
+- *(core)* split format.rs into focused modules
+
+### Testing
+
+- *(core)* add comprehensive inventory and format coverage tests
+
+### Style
+
+- apply cargo fmt
+- apply cargo fmt
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-ffi-wasi/CHANGELOG.md
+++ b/crates/rustledger-ffi-wasi/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(ffi-wasi)* add Metadata and Interval Value variant handling
+- *(ffi,wasm)* remove duplicate "Query parse error" prefix
+- *(booking,ffi)* run booking in FFI and normalize total prices
+- *(ffi-wasi)* match beancount clamp_opt behavior
+- push benchmark results to separate branch
+
+### Documentation
+
+- update install options in README
+- fix documentation inconsistencies and add crate READMEs
+- streamline README
+- replace install dropdown with scannable table
+- document all installation channels in README
+- fix README accuracy issues
+- fix plugin count (20 not 14) and mention Python support
+- show complete lists for booking methods and plugins
+- redesign README for clarity and scannability
+- use npm 'next' tag for prerelease badge
+- remove static badges, keep only dynamic ones
+- add distribution channel badges to README
+- add Nix installation to README
+- add cargo binstall to README
+- add all installation methods to README
+- comprehensive README improvements
+- use cargo add instead of hardcoded versions
+
+### Features
+
+- *(ffi-wasi)* add clamp-entries command for JSON input
+- comprehensive benchmark infrastructure overhaul
+- enhance compatibility CI with comprehensive testing
+- add Scoop bucket for Windows
+- add AUR packaging
+- add Docker distribution
+- *(core)* implement string interning for performance
+
+### Miscellaneous
+
+- add CLA and commercial licensing notice
+- update AUR checksums and remove version from README
+- migrate to semver 0.x.y versioning
+- *(release)* improve release assets
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- *(ffi-wasi)* split commands into separate modules
+- *(ffi-wasi)* split main.rs into modular structure
+- rename rustledger-ffi-py to rustledger-ffi-wasi
+- *(bench)* fair benchmarks with two separate charts
+
+### Ci
+
+- add benchmark history tracking and chart generation
+- add nightly benchmark comparison vs Python beancount
+
+### Style
+
+- apply cargo fmt

--- a/crates/rustledger-importer/CHANGELOG.md
+++ b/crates/rustledger-importer/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Documentation

--- a/crates/rustledger-loader/CHANGELOG.md
+++ b/crates/rustledger-loader/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(loader)* use WASI-compatible path normalization
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-lsp/CHANGELOG.md
+++ b/crates/rustledger-lsp/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(lsp)* address PR review comments
+
+### Documentation
+
+- add comprehensive PR review policy
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+- *(lsp)* add resolve handlers and file watching
+- *(lsp)* add execute command and completion resolve
+- *(lsp)* add call hierarchy and signature help
+- *(lsp)* add code lens, document color, goto declaration
+- *(lsp)* add document highlight, linked editing, on-type formatting
+- *(lsp)* add type hierarchy for account navigation
+- *(lsp)* add find references for accounts, currencies, payees
+- *(lsp)* add range formatting, document links, inlay hints, selection range
+- *(lsp)* add workspace symbols, rename, formatting, folding
+- *(lsp)* add code actions for quick fixes
+- *(lsp)* add semantic tokens for syntax highlighting
+- *(lsp)* add Phase 5 - document symbols (outline view)
+- *(lsp)* add Phase 4 - navigation features (definition, hover)
+- *(lsp)* add Phase 3 - autocompletion support
+- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
+- *(lsp)* add rustledger-lsp crate skeleton (WIP)
+
+### Performance
+
+- *(lsp,wasm)* add caching and optimize position lookups
+
+### Refactoring
+
+- remove dead code and fix duplication
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-parser/CHANGELOG.md
+++ b/crates/rustledger-parser/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Features
+
+- *(test)* add synthetic beancount file generation for compat testing
+
+### Miscellaneous
+
+- update remaining references to single rledger binary
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- address PR review comments
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-plugin/CHANGELOG.md
+++ b/crates/rustledger-plugin/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- add missing imports for tests after refactor
+- *(plugin)* deterministic ordering for auto_accounts plugin
+- *(plugin)* preserve typed values in custom directives
+- *(plugin)* serialize custom directive values without debug format
+- *(plugin)* preserve user-defined metadata through plugin processing
+- *(plugin)* preserve source locations through plugin processing
+
+### Features
+
+- *(plugin)* implement beancount-compatible entry sorting
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- *(plugin)* split convert.rs into to_wrapper and from_wrapper modules
+- *(plugin)* split native plugins into individual files
+- *(wasm)* split editor.rs into modular structure
+- *(plugin)* split native.rs into native/ module
+
+### Testing
+
+- *(plugin)* add comprehensive plugin manager coverage tests
+
+### Style
+
+- apply cargo fmt
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-query/CHANGELOG.md
+++ b/crates/rustledger-query/CHANGELOG.md
@@ -6,6 +6,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(query)* NUMBER returns NULL for multi-currency inventories
+- *(query)* support ORDER BY with GROUP BY expressions not in SELECT
+- add missing imports for tests after refactor
+- *(ffi,wasm)* remove duplicate "Query parse error" prefix
+- *(query)* SUM now works on integer columns (day, month, year)
+- *(bql)* improve robustness and add comprehensive tests
+
+### Features
+
+- *(query)* support nested aggregate functions for holdings reports
+- *(ffi-py)* add Fava integration APIs and BQL improvements
+- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table
+- *(bql)* add nested function calls, getprice(), and only() functions
+
+### Miscellaneous
+
+- *(query)* remove unused imports from executor modules
+
+### Refactoring
+
+- *(query)* split executor into focused modules
+- *(query)* split executor eval functions into category modules
+- *(query)* split executor.rs into module with types.rs
+
+### Testing
+
+- add coverage tests for nested aggregate functions
+- remove misleading duplicate test
+- *(query)* add comprehensive BQL executor coverage tests
+
+### Style
+
+- remove unnecessary raw string hashes
+- apply cargo fmt
+- apply cargo fmt
+- apply cargo fmt
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-validate/CHANGELOG.md
+++ b/crates/rustledger-validate/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- add missing imports for tests after refactor
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- *(validate)* split validators into focused modules
+- *(validate)* extract error types to error.rs
+
+### Style
+
+- apply cargo fmt
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger-wasm/CHANGELOG.md
+++ b/crates/rustledger-wasm/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(ffi,wasm)* remove duplicate "Query parse error" prefix
+
+### Features
+
+- *(ffi-py)* add Fava integration APIs and BQL improvements
+- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- *(wasm)* split lib.rs into focused modules
+- *(wasm)* split editor.rs into modular structure
+
+### Testing
+
+- *(wasm)* add comprehensive editor coverage tests
+
+### Style
+
+- apply cargo fmt
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes

--- a/crates/rustledger/CHANGELOG.md
+++ b/crates/rustledger/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
+
+### Bug Fixes
+
+- *(test)* handle broken pipe gracefully in stdin test
+- *(booking)* run booking before interpolation in check command
+
+### Features
+
+- *(synthetic)* add rledger-doctor generate-synthetic subcommand
+- *(ffi-py)* add Fava integration APIs and BQL improvements
+- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table
+
+### Miscellaneous
+
+- update remaining references to single rledger binary
+
+### Refactoring
+
+- consolidate rledger-* binaries into single rledger binary
+- *(cli)* split doctor.rs into command modules
+- *(cli)* split report_cmd into focused modules
+
+### Testing
+
+- *(cli)* add comprehensive CLI command integration tests
+
+### Style
+
+- apply cargo fmt
+- apply cargo fmt
+- apply cargo fmt
+
 ## [0.6.0](https://github.com/rustledger/rustledger/releases/tag/v0.6.0) - 2026-01-23
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `rustledger-core`: 0.7.0
* `rustledger-parser`: 0.7.0
* `rustledger-loader`: 0.7.0
* `rustledger-booking`: 0.7.0
* `rustledger-validate`: 0.7.0
* `rustledger-query`: 0.7.0
* `rustledger-plugin`: 0.7.0
* `rustledger-importer`: 0.7.0
* `rustledger`: 0.7.0
* `rustledger-wasm`: 0.7.0
* `rustledger-ffi-wasi`: 0.7.0
* `rustledger-lsp`: 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustledger-core`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- add missing imports for tests after refactor
- address all clippy warnings in synthetic_generation tests
- address warnings in synthetic_generation tests

### Features

- *(synthetic)* add rledger-doctor generate-synthetic subcommand
- *(test)* add synthetic beancount file generation for compat testing

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(plugin)* split convert.rs into to_wrapper and from_wrapper modules
- *(core)* split inventory booking methods into module
- *(core)* split format.rs into focused modules

### Testing

- *(core)* add comprehensive inventory and format coverage tests

### Style

- apply cargo fmt
- apply cargo fmt
</blockquote>

## `rustledger-parser`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Features

- *(test)* add synthetic beancount file generation for compat testing

### Miscellaneous

- update remaining references to single rledger binary

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- address PR review comments
</blockquote>

## `rustledger-loader`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(loader)* use WASI-compatible path normalization

### Refactoring

- consolidate rledger-* binaries into single rledger binary
</blockquote>

## `rustledger-booking`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(booking,ffi)* run booking in FFI and normalize total prices

### Refactoring

- consolidate rledger-* binaries into single rledger binary
</blockquote>

## `rustledger-validate`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- add missing imports for tests after refactor

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(validate)* split validators into focused modules
- *(validate)* extract error types to error.rs

### Style

- apply cargo fmt
</blockquote>

## `rustledger-query`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(query)* NUMBER returns NULL for multi-currency inventories
- *(query)* support ORDER BY with GROUP BY expressions not in SELECT
- add missing imports for tests after refactor
- *(ffi,wasm)* remove duplicate "Query parse error" prefix
- *(query)* SUM now works on integer columns (day, month, year)
- *(bql)* improve robustness and add comprehensive tests

### Features

- *(query)* support nested aggregate functions for holdings reports
- *(ffi-py)* add Fava integration APIs and BQL improvements
- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table
- *(bql)* add nested function calls, getprice(), and only() functions

### Miscellaneous

- *(query)* remove unused imports from executor modules

### Refactoring

- *(query)* split executor into focused modules
- *(query)* split executor eval functions into category modules
- *(query)* split executor.rs into module with types.rs

### Testing

- add coverage tests for nested aggregate functions
- remove misleading duplicate test
- *(query)* add comprehensive BQL executor coverage tests

### Style

- remove unnecessary raw string hashes
- apply cargo fmt
- apply cargo fmt
- apply cargo fmt
</blockquote>

## `rustledger-plugin`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- add missing imports for tests after refactor
- *(plugin)* deterministic ordering for auto_accounts plugin
- *(plugin)* preserve typed values in custom directives
- *(plugin)* serialize custom directive values without debug format
- *(plugin)* preserve user-defined metadata through plugin processing
- *(plugin)* preserve source locations through plugin processing

### Features

- *(plugin)* implement beancount-compatible entry sorting

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(plugin)* split convert.rs into to_wrapper and from_wrapper modules
- *(plugin)* split native plugins into individual files
- *(wasm)* split editor.rs into modular structure
- *(plugin)* split native.rs into native/ module

### Testing

- *(plugin)* add comprehensive plugin manager coverage tests

### Style

- apply cargo fmt
</blockquote>

## `rustledger-importer`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Refactoring

- consolidate rledger-* binaries into single rledger binary
</blockquote>

## `rustledger`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(test)* handle broken pipe gracefully in stdin test
- *(booking)* run booking before interpolation in check command

### Features

- *(synthetic)* add rledger-doctor generate-synthetic subcommand
- *(ffi-py)* add Fava integration APIs and BQL improvements
- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table

### Miscellaneous

- update remaining references to single rledger binary

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(cli)* split doctor.rs into command modules
- *(cli)* split report_cmd into focused modules

### Testing

- *(cli)* add comprehensive CLI command integration tests

### Style

- apply cargo fmt
- apply cargo fmt
- apply cargo fmt
</blockquote>

## `rustledger-wasm`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(ffi,wasm)* remove duplicate "Query parse error" prefix

### Features

- *(ffi-py)* add Fava integration APIs and BQL improvements
- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(wasm)* split lib.rs into focused modules
- *(wasm)* split editor.rs into modular structure

### Testing

- *(wasm)* add comprehensive editor coverage tests

### Style

- apply cargo fmt
</blockquote>

## `rustledger-ffi-wasi`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(ffi-wasi)* add Metadata and Interval Value variant handling
- *(ffi,wasm)* remove duplicate "Query parse error" prefix
- *(booking,ffi)* run booking in FFI and normalize total prices
- *(ffi-wasi)* match beancount clamp_opt behavior
- push benchmark results to separate branch

### Documentation

- update install options in README
- fix documentation inconsistencies and add crate READMEs
- streamline README
- replace install dropdown with scannable table
- document all installation channels in README
- fix README accuracy issues
- fix plugin count (20 not 14) and mention Python support
- show complete lists for booking methods and plugins
- redesign README for clarity and scannability
- use npm 'next' tag for prerelease badge
- remove static badges, keep only dynamic ones
- add distribution channel badges to README
- add Nix installation to README
- add cargo binstall to README
- add all installation methods to README
- comprehensive README improvements
- use cargo add instead of hardcoded versions

### Features

- *(ffi-wasi)* add clamp-entries command for JSON input
- comprehensive benchmark infrastructure overhaul
- enhance compatibility CI with comprehensive testing
- add Scoop bucket for Windows
- add AUR packaging
- add Docker distribution
- *(core)* implement string interning for performance

### Miscellaneous

- add CLA and commercial licensing notice
- update AUR checksums and remove version from README
- migrate to semver 0.x.y versioning
- *(release)* improve release assets

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(ffi-wasi)* split commands into separate modules
- *(ffi-wasi)* split main.rs into modular structure
- rename rustledger-ffi-py to rustledger-ffi-wasi
- *(bench)* fair benchmarks with two separate charts

### Ci

- add benchmark history tracking and chart generation
- add nightly benchmark comparison vs Python beancount

### Style

- apply cargo fmt
</blockquote>

## `rustledger-lsp`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(lsp)* address PR review comments

### Documentation

- add comprehensive PR review policy

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
- *(lsp)* add resolve handlers and file watching
- *(lsp)* add execute command and completion resolve
- *(lsp)* add call hierarchy and signature help
- *(lsp)* add code lens, document color, goto declaration
- *(lsp)* add document highlight, linked editing, on-type formatting
- *(lsp)* add type hierarchy for account navigation
- *(lsp)* add find references for accounts, currencies, payees
- *(lsp)* add range formatting, document links, inlay hints, selection range
- *(lsp)* add workspace symbols, rename, formatting, folding
- *(lsp)* add code actions for quick fixes
- *(lsp)* add semantic tokens for syntax highlighting
- *(lsp)* add Phase 5 - document symbols (outline view)
- *(lsp)* add Phase 4 - navigation features (definition, hover)
- *(lsp)* add Phase 3 - autocompletion support
- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
- *(lsp)* add rustledger-lsp crate skeleton (WIP)

### Performance

- *(lsp,wasm)* add caching and optimize position lookups

### Refactoring

- remove dead code and fix duplication
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).