### PR TITLE
ci: add rustledger-ffi-wasi.wasm to GitHub releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -311,9 +311,36 @@ jobs:
           name: wasm-package
           path: crates/rustledger-wasm/pkg/
 
+  build-ffi-wasi:
+    name: Build FFI-WASI
+    needs: validate-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          targets: wasm32-wasip1
+      - name: Build FFI-WASI binary
+        run: cargo build --release --target wasm32-wasip1 -p rustledger-ffi-wasi
+      - name: Package FFI-WASI
+        run: |
+          VERSION=$RELEASE_TAG
+          cp target/wasm32-wasip1/release/rustledger-ffi-wasi.wasm "rustledger-ffi-wasi-${VERSION}.wasm"
+          shasum -a 256 "rustledger-ffi-wasi-${VERSION}.wasm" > "rustledger-ffi-wasi-${VERSION}.wasm.sha256"
+      - name: Upload FFI-WASI artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ffi-wasi-package
+          path: |
+            rustledger-ffi-wasi-*.wasm
+            rustledger-ffi-wasi-*.sha256
+
   release:
     name: Create Release
-    needs: [build, build-wasm]
+    needs: [build, build-wasm, build-ffi-wasi]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -357,6 +384,7 @@ jobs:
           files: |
             artifacts/*.tar.gz
             artifacts/*.zip
+            artifacts/*.wasm
             artifacts/*.sha256
         env:
           # Use PAT instead of GITHUB_TOKEN to trigger release-publish.yml workflow


### PR DESCRIPTION
## Summary
- Add `build-ffi-wasi` job to release workflow that builds the WASI FFI binary
- Targets `wasm32-wasip1` and outputs versioned `.wasm` file with sha256 checksum
- Updates release job to include `.wasm` files in GitHub release assets

## Test plan
- [ ] Verify CI passes
- [ ] Next release will include `rustledger-ffi-wasi-v{VERSION}.wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)