### PR TITLE
fix(doctor): convert byte offsets to line numbers in context command

### DIFF
--- a/crates/rustledger/src/cmd/doctor/context.rs
+++ b/crates/rustledger/src/cmd/doctor/context.rs
@@ -4,6 +4,15 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+/// Convert a byte offset to a 1-based line number.
+fn byte_offset_to_line(source: &str, offset: usize) -> usize {
+    source[..offset.min(source.len())]
+        .chars()
+        .filter(|&c| c == '\n')
+        .count()
+        + 1
+}
+
 pub(super) fn cmd_context<W: Write>(file: &PathBuf, line: usize, writer: &mut W) -> Result<()> {
     let mut loader = Loader::new();
     let load_result = loader
@@ -32,8 +41,11 @@ pub(super) fn cmd_context<W: Write>(file: &PathBuf, line: usize, writer: &mut W)
     writeln!(writer)?;
     for spanned in &load_result.directives {
         let span = &spanned.span;
-        // Check if line falls within directive's span (approximate)
-        if span.start <= line && span.end >= line {
+        // Convert byte offsets to line numbers for comparison
+        let span_start_line = byte_offset_to_line(&source, span.start);
+        let span_end_line = byte_offset_to_line(&source, span.end);
+
+        if span_start_line <= line && span_end_line >= line {
             writeln!(writer, "Directive at this location:")?;
             writeln!(writer, "{:?}", spanned.value)?;
             break;


### PR DESCRIPTION
## Summary
- Fix `rledger doctor context` to display the correct directive for a given line number
- The command was comparing byte offsets with line numbers, causing incorrect results

## Problem
The `rledger doctor context` command was comparing directive span byte offsets directly with user-provided line numbers:

```rust
// Before: comparing byte offsets with line numbers (wrong!)
if span.start <= line && span.end >= line {
```

For example, with a file like:
```beancount
2026-01-01 open Equity:Opening-Balances USD
2026-01-01 open Assets:Vanguard:IRA:Trad:VFIFX VFIFX

2026-01-01 * "Opening balance for Vanguard traditional IRA"
  ...
```

When asking for context at line 4 (the transaction), it would show an Open directive instead because byte offset comparisons do not match line numbers.

## Solution
Added a `byte_offset_to_line` helper function that converts byte offsets to 1-based line numbers by counting newlines:

```rust
fn byte_offset_to_line(source: &str, offset: usize) -> usize {
    source[..offset.min(source.len())]
        .chars()
        .filter(|&c| c == '\n')
        .count()
        + 1
}
```

## Test plan
- [x] Manually verified with reproduction case from issue
- [x] Line 1 correctly shows first Open directive
- [x] Line 4 correctly shows Transaction directive
- [x] All existing tests pass
- [x] Clippy passes

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)