### PR TITLE
chore: release v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "rustledger-booking",
  "rustledger-core",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.85"
 license = "GPL-3.0-only"
@@ -111,14 +111,14 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.7.1", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.7.1", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.7.1", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.7.1", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.7.1", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.7.1", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.7.1", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.7.1", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.7.2", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.7.2", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.7.2", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.7.2", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.7.2", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.7.2", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.7.2", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.7.2", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/CHANGELOG.md
+++ b/crates/rustledger-booking/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Bug Fixes
+
+- *(validate)* derive balance tolerance from transaction amounts
+
+### Performance
+
+- skip redundant residual recalculation and add HashMap capacity hints
+- optimize booking posting expansion and loader file handling
+- optimize booking hot path and validation sorting
+- *(booking)* lazy evaluation for cost currency inference
+
 ## [0.7.1](https://github.com/rustledger/rustledger/compare/v0.7.0...v0.7.1) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger-core/CHANGELOG.md
+++ b/crates/rustledger-core/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Bug Fixes
+
+- *(validate)* derive balance tolerance from transaction amounts
+
+### Performance
+
+- reduce allocations in validation and booking loops
+- avoid intermediate allocations in parser tag/meta handling
+- add units cache to Inventory for O(1) lookups
+- optimize booking hot path and validation sorting
+
 ## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger-ffi-wasi/CHANGELOG.md
+++ b/crates/rustledger-ffi-wasi/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Performance
+
+- box heavy Value variants and avoid balance prefix alloc
+
 ## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger-loader/CHANGELOG.md
+++ b/crates/rustledger-loader/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Performance
+
+- optimize booking posting expansion and loader file handling
+
 ## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger-lsp/CHANGELOG.md
+++ b/crates/rustledger-lsp/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Bug Fixes
+
+- *(lsp)* address PR review comments
+
+### Documentation
+
+- add comprehensive PR review policy
+
+### Features
+
+- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
+- *(lsp)* add resolve handlers and file watching
+- *(lsp)* add execute command and completion resolve
+- *(lsp)* add call hierarchy and signature help
+- *(lsp)* add code lens, document color, goto declaration
+- *(lsp)* add document highlight, linked editing, on-type formatting
+- *(lsp)* add type hierarchy for account navigation
+- *(lsp)* add find references for accounts, currencies, payees
+- *(lsp)* add range formatting, document links, inlay hints, selection range
+- *(lsp)* add workspace symbols, rename, formatting, folding
+- *(lsp)* add code actions for quick fixes
+- *(lsp)* add semantic tokens for syntax highlighting
+- *(lsp)* add Phase 5 - document symbols (outline view)
+- *(lsp)* add Phase 4 - navigation features (definition, hover)
+- *(lsp)* add Phase 3 - autocompletion support
+- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
+- *(lsp)* add rustledger-lsp crate skeleton (WIP)
+
+### Performance
+
+- *(lsp,wasm)* add caching and optimize position lookups
+
+### Refactoring
+
+- remove dead code and fix duplication
+
 ## [0.7.1](https://github.com/rustledger/rustledger/compare/v0.7.0...v0.7.1) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger-parser/CHANGELOG.md
+++ b/crates/rustledger-parser/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Performance
+
+- avoid intermediate allocations in parser tag/meta handling
+
 ## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
 
 ### Features

--- a/crates/rustledger-query/CHANGELOG.md
+++ b/crates/rustledger-query/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Bug Fixes
+
+- *(validate)* derive balance tolerance from transaction amounts
+
+### Performance
+
+- box heavy Value variants and avoid balance prefix alloc
+
 ## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger-validate/CHANGELOG.md
+++ b/crates/rustledger-validate/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Bug Fixes
+
+- *(validate)* derive balance tolerance from transaction amounts
+- *(validate)* always check balance assertions for empty accounts
+
+### Performance
+
+- box heavy Value variants and avoid balance prefix alloc
+- reduce allocations in validation and booking loops
+- optimize booking hot path and validation sorting
+
 ## [0.7.1](https://github.com/rustledger/rustledger/compare/v0.7.0...v0.7.1) - 2026-01-25
 
 ### Bug Fixes

--- a/crates/rustledger/CHANGELOG.md
+++ b/crates/rustledger/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25
+
+### Bug Fixes
+
+- *(booking)* sort directives by date before lot matching
+
+### Performance
+
+- box heavy Value variants and avoid balance prefix alloc
+
+### Style
+
+- apply cargo fmt
+
 ## [0.7.1](https://github.com/rustledger/rustledger/compare/v0.7.0...v0.7.1) - 2026-01-25
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `rustledger-core`: 0.7.1 -> 0.7.2
* `rustledger-parser`: 0.7.1 -> 0.7.2
* `rustledger-loader`: 0.7.1 -> 0.7.2
* `rustledger-booking`: 0.7.1 -> 0.7.2
* `rustledger-validate`: 0.7.1 -> 0.7.2
* `rustledger-query`: 0.7.1 -> 0.7.2
* `rustledger-plugin`: 0.7.1 -> 0.7.2
* `rustledger-importer`: 0.7.1 -> 0.7.2
* `rustledger`: 0.7.1 -> 0.7.2
* `rustledger-wasm`: 0.7.1 -> 0.7.2
* `rustledger-ffi-wasi`: 0.7.1 -> 0.7.2
* `rustledger-lsp`: 0.7.1 -> 0.7.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustledger-core`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Bug Fixes

- *(validate)* derive balance tolerance from transaction amounts

### Performance

- reduce allocations in validation and booking loops
- avoid intermediate allocations in parser tag/meta handling
- add units cache to Inventory for O(1) lookups
- optimize booking hot path and validation sorting
</blockquote>

## `rustledger-parser`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Performance

- avoid intermediate allocations in parser tag/meta handling
</blockquote>

## `rustledger-loader`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Performance

- optimize booking posting expansion and loader file handling
</blockquote>

## `rustledger-booking`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Bug Fixes

- *(validate)* derive balance tolerance from transaction amounts

### Performance

- skip redundant residual recalculation and add HashMap capacity hints
- optimize booking posting expansion and loader file handling
- optimize booking hot path and validation sorting
- *(booking)* lazy evaluation for cost currency inference
</blockquote>

## `rustledger-validate`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Bug Fixes

- *(validate)* derive balance tolerance from transaction amounts
- *(validate)* always check balance assertions for empty accounts

### Performance

- box heavy Value variants and avoid balance prefix alloc
- reduce allocations in validation and booking loops
- optimize booking hot path and validation sorting
</blockquote>

## `rustledger-query`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Bug Fixes

- *(validate)* derive balance tolerance from transaction amounts

### Performance

- box heavy Value variants and avoid balance prefix alloc
</blockquote>

## `rustledger-plugin`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- add missing imports for tests after refactor
- *(plugin)* deterministic ordering for auto_accounts plugin
- *(plugin)* preserve typed values in custom directives
- *(plugin)* serialize custom directive values without debug format
- *(plugin)* preserve user-defined metadata through plugin processing
- *(plugin)* preserve source locations through plugin processing

### Features

- *(plugin)* implement beancount-compatible entry sorting

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(plugin)* split convert.rs into to_wrapper and from_wrapper modules
- *(plugin)* split native plugins into individual files
- *(wasm)* split editor.rs into modular structure
- *(plugin)* split native.rs into native/ module

### Testing

- *(plugin)* add comprehensive plugin manager coverage tests

### Style

- apply cargo fmt
</blockquote>

## `rustledger-importer`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Refactoring

- consolidate rledger-* binaries into single rledger binary
</blockquote>

## `rustledger`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Bug Fixes

- *(booking)* sort directives by date before lot matching

### Performance

- box heavy Value variants and avoid balance prefix alloc

### Style

- apply cargo fmt
</blockquote>

## `rustledger-wasm`

<blockquote>

## [0.7.0](https://github.com/rustledger/rustledger/releases/tag/v0.7.0) - 2026-01-25

### Bug Fixes

- *(ffi,wasm)* remove duplicate "Query parse error" prefix

### Features

- *(ffi-py)* add Fava integration APIs and BQL improvements
- *(bql)* add CREATE TABLE, INSERT, interval(), and SELECT FROM table

### Refactoring

- consolidate rledger-* binaries into single rledger binary
- *(wasm)* split lib.rs into focused modules
- *(wasm)* split editor.rs into modular structure

### Testing

- *(wasm)* add comprehensive editor coverage tests

### Style

- apply cargo fmt
</blockquote>

## `rustledger-ffi-wasi`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Performance

- box heavy Value variants and avoid balance prefix alloc
</blockquote>

## `rustledger-lsp`

<blockquote>

## [0.7.2](https://github.com/rustledger/rustledger/compare/v0.7.1...v0.7.2) - 2026-01-25

### Bug Fixes

- *(lsp)* address PR review comments

### Documentation

- add comprehensive PR review policy

### Features

- [**breaking**] upgrade to Rust 2024 edition and MSRV 1.85
- *(lsp)* add resolve handlers and file watching
- *(lsp)* add execute command and completion resolve
- *(lsp)* add call hierarchy and signature help
- *(lsp)* add code lens, document color, goto declaration
- *(lsp)* add document highlight, linked editing, on-type formatting
- *(lsp)* add type hierarchy for account navigation
- *(lsp)* add find references for accounts, currencies, payees
- *(lsp)* add range formatting, document links, inlay hints, selection range
- *(lsp)* add workspace symbols, rename, formatting, folding
- *(lsp)* add code actions for quick fixes
- *(lsp)* add semantic tokens for syntax highlighting
- *(lsp)* add Phase 5 - document symbols (outline view)
- *(lsp)* add Phase 4 - navigation features (definition, hover)
- *(lsp)* add Phase 3 - autocompletion support
- *(lsp)* implement Phase 1 & 2 - main loop with diagnostics
- *(lsp)* add rustledger-lsp crate skeleton (WIP)

### Performance

- *(lsp,wasm)* add caching and optimize position lookups

### Refactoring

- remove dead code and fix duplication
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).