### PR TITLE
fix(ci): fix release-plz sync and bump to 0.7.3

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -82,7 +82,7 @@ jobs:
 
       # Clean up old release-plz branches (from closed/superseded PRs)
       - name: Cleanup old release-plz branches
-        if: steps.release-plz.outputs.pr_created == 'true'
+        if: steps.release-plz.outputs.pr != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_DATA: ${{ steps.release-plz.outputs.pr }}
@@ -109,7 +109,7 @@ jobs:
 
       # Enable auto-merge for release PRs (will merge when checks pass and approved)
       - name: Enable auto-merge for release PR
-        if: steps.release-plz.outputs.pr_created == 'true'
+        if: steps.release-plz.outputs.pr != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_DATA: ${{ steps.release-plz.outputs.pr }}
@@ -122,10 +122,11 @@ jobs:
             echo "Could not extract PR number from output"
           fi
 
-      # Sync npm versions to the release PR branch (not main!)
+      # Sync all package versions to the release PR branch (not main!)
       # This ensures the version sync is included when the PR merges
-      - name: Sync npm package versions
-        if: steps.release-plz.outputs.pr_created == 'true' || steps.release-plz.outputs.pr_updated == 'true'
+      - name: Sync package versions (npm, rpm)
+        # Use pr output instead of pr_created/pr_updated flags (more reliable)
+        if: steps.release-plz.outputs.pr != ''
         env:
           GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
           PR_DATA: ${{ steps.release-plz.outputs.pr }}
@@ -162,16 +163,27 @@ jobs:
             echo "Updated packages/mcp-server/package.json to version $VERSION"
           fi
 
+          # Update RPM spec file
+          if [ -f "packaging/rpm/rustledger.spec" ]; then
+            # Update Version field
+            sed -i "s/^Version:.*$/Version:        $VERSION/" packaging/rpm/rustledger.spec
+            # Update Source0 URL
+            sed -i "s|/v[0-9.]*\.tar\.gz|/v$VERSION.tar.gz|" packaging/rpm/rustledger.spec
+            # Update %setup directory name
+            sed -i "s/rustledger-[0-9.]*/rustledger-$VERSION/" packaging/rpm/rustledger.spec
+            echo "Updated packaging/rpm/rustledger.spec to version $VERSION"
+          fi
+
           # Check if there are changes to commit
-          if git diff --quiet packages/; then
-            echo "No npm package changes needed"
+          if git diff --quiet packages/ packaging/; then
+            echo "No package version changes needed"
           else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add packages/
-            git commit -m "chore: sync npm package versions to $VERSION"
+            git add packages/ packaging/
+            git commit -m "chore: sync package versions to $VERSION"
             git push origin "$PR_BRANCH"
-            echo "npm package versions synced to PR branch"
+            echo "Package versions synced to PR branch"
           fi
 
   # Create release when PR is merged

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "rustledger-booking",
  "rustledger-core",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 rust-version = "1.85"
 license = "GPL-3.0-only"
@@ -111,14 +111,14 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.7.2", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.7.2", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.7.2", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.7.2", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.7.2", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.7.2", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.7.2", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.7.2", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.7.3", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.7.3", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.7.3", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.7.3", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.7.3", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.7.3", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.7.3", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.7.3", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.6.0",
+  "version": "0.7.3",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.6.0"
+    "@rustledger/wasm": "^0.7.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.1.0
+Version:        0.7.3
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.1.0.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.7.3.tar.gz
 
 BuildRequires:  rust >= 1.75
 BuildRequires:  cargo
@@ -21,7 +21,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.1.0
+%setup -q -n rustledger-0.7.3
 
 %build
 cargo build --release
@@ -47,5 +47,9 @@ install -m 755 target/release/bean-price %{buildroot}%{_bindir}/
 %{_bindir}/bean-*
 
 %changelog
+* Sat Jan 25 2026 rustledger <rustledger@users.noreply.github.com> - 0.7.3-1
+- Update to version 0.7.3
+- Add CI automation for version sync
+
 * Tue Jan 14 2026 rustledger <rustledger@users.noreply.github.com> - 0.1.0-1
 - Switch to semver 0.x.y versioning


### PR DESCRIPTION
## Summary

- Bump version to 0.7.3 across all packages
- Fix release-plz sync step that was silently failing

## Problem

The release-plz workflow's sync step (which updates npm/rpm versions) was being **skipped** because the condition `pr_created == 'true'` wasn't matching the action's actual output format.

This caused:
- `packages/mcp-server/package.json` to be stuck at 0.6.0
- `packaging/rpm/rustledger.spec` to be stuck at 0.1.0

## Solution

1. Changed condition from `pr_created == 'true'` to `pr != ''` (checks if PR data exists)
2. Added RPM spec sync to the workflow
3. Bumped all package versions to 0.7.3

## Version changes

| Package | Before | After |
|---------|--------|-------|
| Cargo workspace | 0.7.2 | 0.7.3 |
| npm mcp-server | 0.6.0 | 0.7.3 |
| RPM spec | 0.1.0 | 0.7.3 |

## Test plan

- [ ] CI passes
- [ ] Next release PR should include synced npm/rpm versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)