### PR TITLE
fix(ci): use GitHub API for signed commits

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -77,10 +77,9 @@ jobs:
             done
 
             # Create new tree
-            NEW_TREE=$(echo "$TREE_ENTRIES" | gh api "repos/$REPO/git/trees" \
-              --input - \
-              -f base_tree="$BASE_TREE" \
-              --jq '.sha')
+            NEW_TREE=$(jq -n --argjson tree "$TREE_ENTRIES" --arg base "$BASE_TREE" \
+              '{tree: $tree, base_tree: $base}' | \
+              gh api "repos/$REPO/git/trees" --input - --jq '.sha')
             echo "New tree: $NEW_TREE"
 
             # Create commit (GitHub will sign this)

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -214,10 +214,9 @@ jobs:
             done
 
             # Create new tree
-            NEW_TREE=$(echo "$TREE_ENTRIES" | gh api "repos/$REPO/git/trees" \
-              --input - \
-              -f base_tree="$BASE_TREE" \
-              --jq '.sha')
+            NEW_TREE=$(jq -n --argjson tree "$TREE_ENTRIES" --arg base "$BASE_TREE" \
+              '{tree: $tree, base_tree: $base}' | \
+              gh api "repos/$REPO/git/trees" --input - --jq '.sha')
             echo "New tree: $NEW_TREE"
 
             # Create commit (GitHub will sign this)


### PR DESCRIPTION
## Problem

Branch protection requires signed commits. The previous approach (pushing with GitHub App token) authenticates the push but doesn't sign commits - they show as "unsigned".

## Solution

Use the GitHub Git Data API to create commits:
1. Create blobs for modified files
2. Create a tree referencing those blobs
3. Create a commit with that tree
4. Update the branch reference

Commits created via the GitHub API are automatically signed by GitHub.

## Files Changed

- `release-plz.yml`: Sync commit now created via API
- `cargo-vet-auto.yml`: Exemption commit now created via API

## Test Plan

- [ ] Trigger release-plz workflow
- [ ] Verify sync commit shows as "Verified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)