### PR TITLE
fix(ci): use -F for boolean in gh api

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -94,7 +94,7 @@ jobs:
             gh api "repos/$REPO/git/refs/heads/$BRANCH" \
               -X PATCH \
               -f sha="$NEW_COMMIT" \
-              -f force=false
+              -F force=false
 
             echo "Exemptions updated (signed via GitHub API)"
           fi

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -231,7 +231,7 @@ jobs:
             gh api "repos/$REPO/git/refs/heads/$PR_BRANCH" \
               -X PATCH \
               -f sha="$NEW_COMMIT" \
-              -f force=false
+              -F force=false
 
             echo "Package versions synced to PR branch (signed via GitHub API)"
           fi


### PR DESCRIPTION
The `gh api` command requires `-F` (capital) for typed values like booleans.
Using `-f force=false` passes the string "false" instead of boolean `false`.

Error was:
```
For 'properties/force', "false" is not a boolean. (HTTP 422)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)