### PR TITLE
fix(ci): add missing tool parameter to cargo-vet install

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install cargo-vet
         uses: taiki-e/install-action@30791125b88ed3200de59e9b5edbf78d1949e41f # v2
+        with:
+          tool: cargo-vet
 
       - name: Regenerate exemptions
         run: cargo vet regenerate exemptions


### PR DESCRIPTION
## Summary

The `taiki-e/install-action` requires specifying which tool to install via the `tool` parameter. Without `tool: cargo-vet`, the action did nothing and `cargo vet` command was unavailable.

## Test plan

- [ ] Merge this PR
- [ ] Re-run cargo-vet-auto workflow on PR #242 (Dependabot Rust deps)
- [ ] Verify exemptions are regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)