### PR TITLE
ci: allow Apache-2.0 WITH LLVM-exception license

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -68,6 +68,7 @@ jobs:
   #
   # License Policy:
   # - Permissive licenses (MIT, Apache-2.0, BSD-*, ISC, Zlib, 0BSD): Always allowed
+  # - Apache-2.0 WITH LLVM-exception: Permissive (used by Wasmtime/Cranelift), allowed
   # - Unicode-3.0, CDLA-Permissive-2.0: Data/content licenses, allowed
   # - MPL-2.0: Weak copyleft (file-level), allowed for dependencies
   # - LGPL-3.0: Weak copyleft (linking), allowed for build tools (e.g., rust-cache action)
@@ -87,6 +88,6 @@ jobs:
           fail-on-severity: high
           # See License Policy comment above before adding new licenses
           allow-licenses: >-
-            MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
-            GPL-3.0-only, MPL-2.0, Zlib, 0BSD, Unicode-3.0,
-            CDLA-Permissive-2.0, LGPL-3.0
+            MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception,
+            BSD-2-Clause, BSD-3-Clause, ISC, GPL-3.0-only, MPL-2.0,
+            Zlib, 0BSD, Unicode-3.0, CDLA-Permissive-2.0, LGPL-3.0


### PR DESCRIPTION
## Summary
- Add `Apache-2.0 WITH LLVM-exception` to dependency-review allowed licenses
- This license is used by Wasmtime, Cranelift, and related LLVM project dependencies
- It's a permissive license (Apache-2.0 with an exception that removes patent clause complications for linking)

## Why
PR #242 (Dependabot Rust deps update) is blocked because the new Wasmtime 41.0.0 uses this license. This is a well-established permissive open source license used by the LLVM ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)