### PR TITLE
ci: pin rust-toolchain 1.89 to commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       RUSTC_WRAPPER: ""  # Disable sccache for MSRV check
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: dtolnay/rust-toolchain@1.89
+      - uses: dtolnay/rust-toolchain@9710f9012180ecfb08dcfc878269be6dc6f1d80e # 1.89
       - uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
       - name: Check MSRV compatibility
         run: cargo check --workspace --all-features


### PR DESCRIPTION
Addresses security suggestion from PR #245 - pins dtolnay/rust-toolchain to commit hash instead of tag reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)