### PR TITLE
ci(release): skip release-plz if tag already exists

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -268,13 +268,17 @@ jobs:
       - name: Check if release tag exists
         id: check-tag
         run: |
-          VERSION=$(grep -A5 '^\[workspace\.package\]' Cargo.toml | grep '^version' | head -1 | sed 's/version = "\(.*\)"/\1/')
-          if [ -z "$VERSION" ]; then
-            VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          # Use cargo metadata for robust version extraction (handles formatting variations)
+          METADATA=$(cargo metadata --no-deps --format-version 1)
+          VERSION=$(echo "$METADATA" | jq -r '. as $m | $m.packages[] | select(.name == "rustledger").version')
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            # Fallback to first package version
+            VERSION=$(echo "$METADATA" | jq -r '.packages[0].version')
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          if git ls-remote --tags origin "v$VERSION" | grep -q "v$VERSION"; then
+          # Use exact match to avoid v0.7.5 matching v0.7.50
+          if git ls-remote --tags origin "v$VERSION" | grep -q "refs/tags/v$VERSION$"; then
             echo "::notice::Tag v$VERSION already exists - skipping release-plz (release already triggered)"
             echo "skip=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

- Add pre-check before `release-plz release` to detect existing tags
- Skip release-plz if tag exists (release already triggered by tag)

## Problem

During v0.7.5 release, `release-plz release` failed with:
```
failed to create ref refs/tags/v0.7.5
Response body: {"message":"Reference already exists"...}
```

The tag was created during a partial run, causing the workflow to fail even though the release completed successfully via downstream workflows.

## Solution

Check if the release tag exists before running `release-plz release`. If it does, skip the command since:
1. The tag creation already triggered `release-build.yml`
2. `release-publish.yml` handles crates.io/npm publishing
3. Running release-plz would fail anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)