### PR TITLE
fix: address security alerts and Mergify auto-approve regex

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -46,8 +46,8 @@ pull_request_rules:
     conditions:
       - author=dependabot[bot]
       - or:
-        - title~=bump .* from .* to .*  # patch/minor
-        - title~=update .* requirement
+        - title~=.*bump .* from .* to .*  # patch/minor (handles prefixes like "chore(deps):")
+        - title~=.*update .* requirement
       - -title~=major  # exclude major updates
     actions:
       review:

--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -2,8 +2,11 @@
 # This prevents cargo-deny check failures when Dependabot updates dependencies
 name: Cargo Vet Auto
 
+# SECURITY: Using pull_request_target to avoid untrusted checkout vulnerability (CodeQL alert #82).
+# This workflow only runs for dependabot[bot] and only modifies supply-chain/ files.
+# The PR's Cargo.lock is fetched explicitly after checking out the base branch.
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'Cargo.lock'
 
@@ -24,11 +27,20 @@ jobs:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
-      - name: Checkout repository
+      # SECURITY: Checkout base branch first (trusted code), then fetch only Cargo.lock from PR
+      - name: Checkout base branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.base_ref }}
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Fetch PR's Cargo.lock
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Fetch only Cargo.lock from the PR branch (not arbitrary code)
+          gh api "repos/${{ github.repository }}/contents/Cargo.lock?ref=${{ github.event.pull_request.head.sha }}" \
+            --jq '.content' | base64 -d > Cargo.lock
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -52,7 +64,7 @@ jobs:
             # Use GitHub API to create commits (signed by GitHub)
             # This is required because branch protection requires signed commits
             REPO="${{ github.repository }}"
-            BRANCH="${{ github.head_ref }}"
+            BRANCH="${{ github.event.pull_request.head.ref }}"
             COMMIT_MSG="chore: regenerate cargo-vet exemptions"
 
             # Get the current commit SHA


### PR DESCRIPTION
## Summary

- **Fix Mergify regex** to match Dependabot titles with prefixes like `chore(deps):` (fixes PR #255 not being auto-approved/merged)
- **Fix CodeQL alert #82**: untrusted checkout vulnerability in `cargo-vet-auto.yml`
  - Switch from `pull_request` to `pull_request_target` trigger  
  - Checkout base branch (trusted) instead of PR head
  - Fetch only `Cargo.lock` from PR via GitHub API

## Security Alerts Addressed

| Alert | Type | Severity | Fix |
|-------|------|----------|-----|
| Dependabot #3, #4, #5 | hono vulnerabilities | Medium | Unblocks PR #255 (hono update) |
| CodeQL #82 | Untrusted checkout | Medium | Use `pull_request_target` + explicit file fetch |

## Test plan

- [ ] Verify CI passes
- [ ] After merge, PR #255 should be auto-approved and merged by Mergify
- [ ] Future Dependabot PRs with `chore(deps):` prefix should be auto-approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)