### PR TITLE
fix(ci): allow dots in branch name validation pattern

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -24,7 +24,7 @@ jobs:
             exit 0
           fi
 
-          PATTERN="^(feat|feature|fix|docs|chore|refactor|release|hotfix|claude|dependabot|copilot)/[a-zA-Z0-9][a-zA-Z0-9/_-]*$"
+          PATTERN="^(feat|feature|fix|docs|chore|refactor|release|hotfix|claude|dependabot|copilot)/[a-zA-Z0-9][a-zA-Z0-9/_.-]*$"
 
           if [[ "$BRANCH" =~ $PATTERN ]]; then
             echo "✅ Branch name '$BRANCH' is valid"
@@ -33,7 +33,7 @@ jobs:
             echo ""
             echo "Branch names must follow: <type>/<description>"
             echo "  Types: feat, feature, fix, docs, chore, refactor, release, hotfix, claude, dependabot, copilot"
-            echo "  Description: letters, numbers, hyphens, underscores, slashes"
+            echo "  Description: letters, numbers, hyphens, underscores, slashes, dots"
             echo ""
             echo "Examples:"
             echo "  feat/add-csv-export"


### PR DESCRIPTION
## Summary
- Updated branch name validation regex to allow dots (`.`) in branch names
- Fixes validation failures for dependabot branches with version numbers (e.g., `dependabot/cargo/bytes-1.11.1`)

## Test plan
- [x] PR #298 should pass branch validation after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)