### PR TITLE
feat(ci): trigger rustfava WASM update on release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -276,11 +276,12 @@ jobs:
   # Trigger Rustfava WASM update
   update-rustfava:
     name: Update Rustfava WASM version
+    needs: [publish-npm-wasm]
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

When a new rustledger version is released, dispatch an event to rustfava to update its WASM version automatically.

## Problem

The rustfava WASM version was hardcoded and required manual updates. This led to rustfava lagging behind rustledger releases (e.g., v0.7.0 vs v0.8.5).

## Solution

Add a new job `update-rustfava` to the release-publish workflow that:
1. Generates a GitHub App token with access to rustfava
2. Dispatches a `rustledger-release` event to rustfava with the new version

Rustfava will have a corresponding workflow that:
1. Listens for `rustledger-release` events
2. Updates `RUSTLEDGER_VERSION` in `engine.py`
3. Creates a PR with the update

## Related

- Rustfava PR with receiving workflow: https://github.com/rustledger/rustfava/pull/80

🤖 Generated with [Claude Code](https://claude.com/claude-code)