### PR TITLE
docs: sync crate list with Cargo.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ rustledger is a pure Rust implementation of Beancount, the double-entry bookkeep
 
 ## Architecture
 
-The project is a Cargo workspace with 9 crates:
+The project is a Cargo workspace with 12 crates:
 
 | Crate | Purpose |
 |-------|---------|
@@ -78,8 +78,11 @@ The project is a Cargo workspace with 9 crates:
 | `rustledger-validate` | Validation with 27 error codes |
 | `rustledger-query` | BQL query engine |
 | `rustledger-plugin` | Native and WASM plugin system (20 plugins) |
+| `rustledger-importer` | CSV/OFX import framework |
 | `rustledger` | CLI tool (`rledger check`, `rledger query`, etc.) |
 | `rustledger-wasm` | WebAssembly library target |
+| `rustledger-ffi-wasi` | JSON API for embedding in any language |
+| `rustledger-lsp` | Language Server Protocol implementation |
 
 ## Code Standards
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ rledger format --in-place ledger.beancount
 | `rustledger-importer` | CSV/OFX import framework |
 | `rustledger-lsp` | Language Server Protocol for editor integration |
 | `rustledger-wasm` | WebAssembly bindings for JavaScript/TypeScript |
+| `rustledger-ffi-wasi` | JSON API for embedding in any language |
 
 <details>
 <summary><strong>Booking methods (7)</strong></summary>


### PR DESCRIPTION
## Summary

Updates documentation to accurately reflect all 12 crates in the workspace.

## What Changed

### CLAUDE.md
- Updated crate count from 9 to 12
- Added missing crates:
  - `rustledger-ffi-wasi` - JSON API for embedding in any language
  - `rustledger-lsp` - Language Server Protocol implementation
  - `rustledger-importer` - CSV/OFX import framework

### README.md
- Added missing `rustledger-ffi-wasi` crate to the crates table

## Why This Was Needed

The documentation was out of sync with `Cargo.toml`, which lists 12 workspace members. The FFI-WASI, LSP, and importer crates were added but not documented in these overview files.

## Testing

- [x] Verified all 12 crates match `Cargo.toml` members
- [x] Confirmed crate descriptions are accurate

## Related

This fix was identified by the automated documentation-code sync checker workflow.


> AI generated by [Documentation-Code Sync Checker](https://github.com/rustledger/rustledger/actions/runs/21805428022)

<!-- gh-aw-workflow-id: docs-sync-checker -->