### PR TITLE
docs: sync crate list with Cargo.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ rustledger is a pure Rust implementation of Beancount, the double-entry bookkeep
 
 ## Architecture
 
-The project is a Cargo workspace with 9 crates:
+The project is a Cargo workspace with 12 crates:
 
 | Crate | Purpose |
 |-------|---------|
@@ -78,8 +78,11 @@ The project is a Cargo workspace with 9 crates:
 | `rustledger-validate` | Validation with 27 error codes |
 | `rustledger-query` | BQL query engine |
 | `rustledger-plugin` | Native and WASM plugin system (20 plugins) |
+| `rustledger-importer` | CSV/OFX import framework |
 | `rustledger` | CLI tool (`rledger check`, `rledger query`, etc.) |
 | `rustledger-wasm` | WebAssembly library target |
+| `rustledger-ffi-wasi` | JSON API for embedding in any language |
+| `rustledger-lsp` | Language Server Protocol implementation |
 
 ## Code Standards
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ rledger format --in-place ledger.beancount
 | `rustledger-importer` | CSV/OFX import framework |
 | `rustledger-lsp` | Language Server Protocol for editor integration |
 | `rustledger-wasm` | WebAssembly bindings for JavaScript/TypeScript |
+| `rustledger-ffi-wasi` | JSON API for embedding in any language |
 
 <details>
 <summary><strong>Booking methods (7)</strong></summary>


### PR DESCRIPTION
Update documentation to reflect all 12 crates in the workspace.

Replaces #328 with a signed commit.

## Changes
- CLAUDE.md: Update count from 9 to 12, add rustledger-ffi-wasi, rustledger-lsp, rustledger-importer  
- README.md: Add rustledger-ffi-wasi to crates table

---
Originally generated by Documentation-Code Sync Checker workflow.