### PR TITLE
fix(security): update bytes to 1.11.1 (CVE-2026-25541)

### DIFF
--- a/crates/rustledger-parser/fuzz/Cargo.lock
+++ b/crates/rustledger-parser/fuzz/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -942,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,19 +958,21 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.7.0"
+version = "0.8.5"
 dependencies = [
  "chrono",
  "rkyv 0.8.14",
  "rust_decimal",
  "rust_decimal_macros",
+ "rustc-hash",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "rustledger-parser"
-version = "0.7.0"
+version = "0.8.5"
 dependencies = [
  "ariadne",
  "chrono",
@@ -976,6 +984,7 @@ dependencies = [
  "rustledger-core",
  "serde",
  "thiserror",
+ "winnow",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update `bytes` crate in fuzzing lockfile from 1.11.0 to 1.11.1
- Addresses integer overflow vulnerability in `BytesMut::reserve`
- CVE-2026-25541 (medium severity)

## Security Advisory
https://github.com/rustledger/rustledger/security/dependabot/7

## Test plan
- [x] Lockfile updated
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)