### PR TITLE
fix(ci): copy full PKGBUILD from repo to AUR

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -338,7 +338,8 @@ jobs:
           git clone ssh://aur@aur.archlinux.org/rustledger.git /tmp/aur-rustledger
           cd /tmp/aur-rustledger
 
-          # Update PKGBUILD
+          # Copy PKGBUILD from repo and update version/checksums
+          cp "$GITHUB_WORKSPACE/packaging/arch/rustledger/PKGBUILD" PKGBUILD
           sed -i "s/^pkgver=.*/pkgver=${{ steps.checksums.outputs.version }}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
           sed -i "s/^sha256sums=.*/sha256sums=('${{ steps.checksums.outputs.source_sha256 }}')/" PKGBUILD
@@ -363,7 +364,8 @@ jobs:
           git clone ssh://aur@aur.archlinux.org/rustledger-bin.git /tmp/aur-rustledger-bin
           cd /tmp/aur-rustledger-bin
 
-          # Update PKGBUILD
+          # Copy PKGBUILD from repo and update version/checksums
+          cp "$GITHUB_WORKSPACE/packaging/arch/rustledger-bin/PKGBUILD" PKGBUILD
           sed -i "s/^pkgver=.*/pkgver=${{ steps.checksums.outputs.version }}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
           sed -i "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${{ steps.checksums.outputs.x86_64_sha256 }}')/" PKGBUILD


### PR DESCRIPTION
## Summary
- Copy the full PKGBUILD from `packaging/arch/*/PKGBUILD` to AUR instead of just updating version/checksums in the existing AUR file
- The AUR had stale PKGBUILD content with wrong binary names (`rledger-check` instead of `bean-check`, etc.)

## Problem
Testing revealed the AUR packages fail to install because the existing AUR PKGBUILD referenced non-existent binaries. Our CI was only updating version/checksums, not replacing the broken package() function.

## Test plan
- [ ] Merge PR
- [ ] Trigger release-publish workflow with v0.8.6
- [ ] Verify AUR packages install correctly in Arch Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)