### PR TITLE
fix(homebrew): use classic linker on macOS to avoid Xcode 15 crashes

### DIFF
--- a/packaging/homebrew/rustledger.rb
+++ b/packaging/homebrew/rustledger.rb
@@ -15,7 +15,7 @@ class Rustledger < Formula
 
   def install
     # macOS: Use classic linker to avoid Xcode 15+ crashes on long symbol names
-    ENV["RUSTFLAGS"] = "-C link-arg=-Wl,-ld_classic" if OS.mac?
+    ENV.append "RUSTFLAGS", "-C link-arg=-Wl,-ld_classic" if OS.mac?
 
     # Build all binaries from the rustledger crate
     system "cargo", "install", *std_cargo_args(path: "crates/rustledger")


### PR DESCRIPTION
Fixes Homebrew build failure on macOS by using the classic linker.

**Problem:** Xcode 15+ has a new linker that crashes on long symbol names (like those generated by wasmtime).

**Solution:** Set `RUSTFLAGS="-C link-arg=-Wl,-ld_classic"` on macOS, matching the official release build script.

**Related:** https://github.com/Homebrew/homebrew-core/pull/267704