### PR TITLE
fix(ci): use case-insensitive regex in Mergify auto-approve rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -46,9 +46,9 @@ pull_request_rules:
     conditions:
       - author=dependabot[bot]
       - or:
-        - title~=.*bump .* from .* to .*  # patch/minor (handles prefixes like "chore(deps):")
-        - title~=.*update .* requirement
-      - -title~=major  # exclude major updates
+        - title~=(?i).*bump .* from .* to .*  # patch/minor (case-insensitive)
+        - title~=(?i).*update .* requirement
+      - -title~=(?i)major  # exclude major updates
     actions:
       review:
         type: APPROVE
@@ -58,7 +58,7 @@ pull_request_rules:
   - name: Request review for major updates
     conditions:
       - author=dependabot[bot]
-      - title~=major
+      - title~=(?i)major
     actions:
       comment:
         message: |


### PR DESCRIPTION
## Summary

Dependabot uses "Bump" (capital B) in PR titles like:
```
chore(ci): Bump docker/build-push-action from 6.18.0 to 6.19.2
```

But the Mergify auto-approve rules were using lowercase `bump` in the regex patterns, causing the rules not to match.

### Changes

Added `(?i)` flag for case-insensitive matching to:
- `title~=(?i).*bump .* from .* to .*`
- `title~=(?i).*update .* requirement`
- `title~=(?i)major`

This will allow Dependabot PRs to be auto-approved and auto-merged as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)