### PR TITLE
fix(ci): use merge queue for Mergify auto-merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,8 +21,8 @@ pull_request_rules:
       - check-success=build
       - -draft
     actions:
-      merge:
-        method: squash
+      queue:
+        merge_method: squash
         commit_message_template: |
           {{ title }} (#{{ number }})
 
@@ -36,8 +36,8 @@ pull_request_rules:
       - check-success=build
       - -draft
     actions:
-      merge:
-        method: merge
+      queue:
+        merge_method: merge
         commit_message_template: |
           {{ title }} (#{{ number }})
 


### PR DESCRIPTION
## Summary
- Changes Mergify auto-merge actions from `merge:` to `queue:` for both Dependabot and release-plz PRs
- The repository has merge queue enabled, so direct merges fail with HTTP 405 ("Changes must be made through the merge queue")
- This is why Dependabot PRs weren't auto-merging despite passing all conditions

## Test plan
- [ ] Verify Mergify queues Dependabot PRs after this merges
- [ ] Check that existing Dependabot PRs get processed through the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)