### PR TITLE
fix(ci): enable in-place checks for merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,10 +4,15 @@
 # Auto-merges PRs from trusted bots when CI passes.
 # Requires Mergify GitHub App: https://github.com/apps/mergify
 
+# Required for "Require branches to be up to date" branch protection
+merge_queue:
+  max_parallel_checks: 1
+
 # Queue rules define how PRs are merged
 queue_rules:
   - name: default
     merge_method: squash
+    batch_size: 1
     commit_message_template: |
       {{ title }} (#{{ number }})
 
@@ -15,6 +20,7 @@ queue_rules:
 
   - name: release
     merge_method: merge
+    batch_size: 1
     commit_message_template: |
       {{ title }} (#{{ number }})
 


### PR DESCRIPTION
## Summary
Fix Mergify queue failure caused by branch protection setting "Require branches to be up to date before merging".

Adds:
- `merge_queue.max_parallel_checks: 1`
- `batch_size: 1` for all queue rules

This enables in-place checks (testing on the actual PR branch) instead of draft PR checks.

## Related
- Fixes queue failure on #374 and other Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)