### PR TITLE
fix(ci): simplify Mergify commit message template

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,8 +16,6 @@ queue_rules:
     commit_message_template: |
       {{ title }} (#{{ number }})
 
-      {{ body | get_section("Release notes") or body }}
-
   - name: release
     merge_method: merge
     batch_size: 1


### PR DESCRIPTION
## Summary
Remove `get_section("Release notes")` from commit message template which fails with "section level not found" when the PR body doesn't have that section.

Dependabot PRs don't have a "Release notes" section, causing the queue to fail.

## Related
- Fixes queue failure on #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)