### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "rustc-hash",
  "rustledger-booking",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "glob",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "ariadne",
  "chrono",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.8.8"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.89"
 license = "GPL-3.0-only"
@@ -119,14 +119,14 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.8.8", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.8.8", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.8.8", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.8.8", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.8.8", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.8.8", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.8.8", path = "crates/rustledger-plugin", default-features = false }
-rustledger-importer = { version = "0.8.8", path = "crates/rustledger-importer" }
+rustledger-core = { version = "0.9.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.9.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.9.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.9.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.9.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.9.0", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.9.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-importer = { version = "0.9.0", path = "crates/rustledger-importer" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.8.8
+Version:        0.9.0
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 


### PR DESCRIPTION
## Summary

Manual release for v0.9.0 due to breaking API changes that require a minor version bump.

### Breaking Changes
- **rustledger-loader**: New enum variant `LoadError::GlobNoMatch`
- **rustledger-parser**: New field `ParseResult.comments`

### Features
- Support glob patterns in include directives (#365)

### Bug Fixes
- Format: preserve comments, metadata, and blank lines
- Format: metadata indent now respects --indent flag  
- Packaging: split packages to separate bean-compat binaries
- Homebrew: use classic linker on macOS to avoid Xcode 15 crashes

### Performance
- Booking: add fast path for transactions without cost specs

## Release notes

This release introduces **glob pattern support** in `include` directives, allowing patterns like `include "accounts/*.beancount"`. It also includes significant formatter improvements and performance optimizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)