### PR TITLE
fix(ci): use homebrew-core explicitly in release tests

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -103,8 +103,11 @@ jobs:
       - name: Update Homebrew
         run: brew update
 
-      - name: Install rustledger
-        run: brew install rustledger
+      - name: Untap custom tap (use homebrew-core)
+        run: brew untap rustledger/rustledger 2>/dev/null || true
+
+      - name: Install rustledger from homebrew-core
+        run: brew install homebrew/core/rustledger
 
       - name: Check installed version
         run: |


### PR DESCRIPTION
## Summary

Fixes the Homebrew test failure in release-test.yml caused by glibc version mismatch.

## Problem

The test was installing from our custom tap (`rustledger/rustledger`) which uses prebuilt binaries compiled against glibc 2.39. The Homebrew test container has an older glibc version, causing the binary to fail with:

```
GLIBC_2.39' not found (required by rledger)
```

## Solution

Now that rustledger is in homebrew-core (which builds from source), explicitly:
1. Untap the custom tap if present
2. Install from `homebrew/core/rustledger`

This ensures the binary is built against the container's glibc version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)