### PR TITLE
docs: remove unneeded Helix config fields

### DIFF
--- a/crates/rustledger-lsp/README.md
+++ b/crates/rustledger-lsp/README.md
@@ -89,11 +89,6 @@ Add to `~/.config/helix/languages.toml`:
 ```toml
 [[language]]
 name = "beancount"
-scope = "source.beancount"
-injection-regex = "beancount"
-file-types = ["beancount", "bean"]
-comment-token = ";"
-indent = { tab-width = 2, unit = "  " }
 language-servers = ["rledger-lsp"]
 
 [language-server.rledger-lsp]


### PR DESCRIPTION
## Summary

It's only necessary to set the `language-servers` array, not to overwrite the other fields which are already configured in the `languages.toml` distributed with Helix.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (changes to docs only)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

## Changes

- Remove unnecessary fields from Helix configuration in LSP docs.

## Testing

Validated with local Helix configuration.

### For Reviewers

**Review checklist** (see [CONTRIBUTING.md](../CONTRIBUTING.md#what-reviewers-check)):

1. Correctness - Does the code do what it claims?
2. Tests - Are there sufficient tests?
3. Beancount compatibility - Does it match Python beancount?
4. Performance - Any obvious issues?
5. Security - Any vulnerabilities?
6. Documentation - Are public APIs documented?
