### PR TITLE
fix(ci): remove leading spaces from SSH known_hosts entries

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -386,20 +386,32 @@ jobs:
 
           # Add AUR host keys (more reliable than ssh-keyscan in containers)
           # Keys from: https://aur.archlinux.org/.ssh/known_hosts
-          cat >> ~/.ssh/known_hosts << 'EOF'
-          aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN
-          aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk=
-          aur.archlinux.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMiLrP8pVi5BFX2i3vepSUnpedeiewE5XptnUnau+ZoeUOPkpoCgZZuYfpaIQfhhJJI5qgnjJmr4hyJbe/zxow=
-          EOF
+          # Using printf to avoid YAML heredoc indentation issues
+          printf '%s\n' \
+            'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN' \
+            'aur.archlinux.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKF9vAFWdgm9Bi8uc+tYRBmXASBb5cB5iZsB7LOWWFeBrLp3r14w0/9S2vozjgqY5sJLDPONWoTTaVTbhe3vwO8CBKZTEt1AcWxuXNlRnk9FliR1/eNB9uz/7y1R0+c1Md+P98AJJSJWKN12nqIDIhjl2S1vOUvm7FNY43fU2knIhEbHybhwWeg+0wxpKwcAd/JeL5i92Uv03MYftOToUijd1pqyVFdJvQFhqD4v3M157jxS5FTOBrccAEjT+zYmFyD8WvKUa9vUclRddNllmBJdy4NyLB8SvVZULUPrP3QOlmzemeKracTlVOUG1wsDbxknF1BwSCU7CmU6UFP90kpWIyz66bP0bl67QAvlIc52Yix7pKJPbw85+zykvnfl2mdROsaT8p8R9nwCdFsBc9IiD0NhPEHcyHRwB8fokXTajk2QnGhL+zP5KnkmXnyQYOCUYo3EKMXIlVOVbPDgRYYT/XqvBuzq5S9rrU70KoI/S5lDnFfx/+lPLdtcnnEPk=' \
+            'aur.archlinux.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLMiLrP8pVi5BFX2i3vepSUnpedeiewE5XptnUnau+ZoeUOPkpoCgZZuYfpaIQfhhJJI5qgnjJmr4hyJbe/zxow=' \
+            > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
 
-          cat >> ~/.ssh/config << 'EOF'
-          Host aur.archlinux.org
-            IdentityFile ~/.ssh/aur
-            User aur
-            StrictHostKeyChecking yes
-          EOF
+          # SSH config
+          printf '%s\n' \
+            'Host aur.archlinux.org' \
+            '  IdentityFile ~/.ssh/aur' \
+            '  User aur' \
+            '  StrictHostKeyChecking yes' \
+            > ~/.ssh/config
           chmod 600 ~/.ssh/config
+
+          # Quick SSH connectivity check (non-interactive, with timeout)
+          echo "Testing SSH connection to AUR..."
+          if ssh -o BatchMode=yes -o ConnectTimeout=10 aur@aur.archlinux.org true 2>/dev/null; then
+            echo "SSH connection successful"
+          else
+            echo "SSH quick check failed - showing debug info:"
+            cat ~/.ssh/known_hosts
+            ssh -o BatchMode=yes -o ConnectTimeout=10 -vT aur@aur.archlinux.org 2>&1 | head -30 || true
+          fi
 
       - name: Get release checksums
         id: checksums


### PR DESCRIPTION
## Summary
- Fix known_hosts entries having invalid leading whitespace due to YAML indentation
- SSH known_hosts format requires entries to start at column 0 (no leading spaces)
- Also fix SSH config indentation
- Add verification output to debug future SSH issues

## Root Cause
The HEREDOC content was indented to match the YAML structure:
```yaml
          cat >> ~/.ssh/known_hosts << 'EOF'
          aur.archlinux.org ssh-ed25519 AAAA...  ← leading spaces!
          EOF
```

But SSH requires:
```
aur.archlinux.org ssh-ed25519 AAAA...  ← no leading spaces
```

## Test plan
- [ ] Merge and re-run release-publish workflow
- [ ] Verify AUR job succeeds with proper SSH authentication
- [ ] Check verification output shows correct known_hosts format

🤖 Generated with [Claude Code](https://claude.com/claude-code)