### PR TITLE
fix(ci): use KSXGitHub/github-actions-deploy-aur for AUR updates

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -376,10 +376,15 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Prepare PKGBUILD
-        id: prepare
         run: |
           VERSION=${RELEASE_TAG#v}
-          SOURCE_SHA256=$(curl -sL "https://github.com/rustledger/rustledger/archive/refs/tags/${RELEASE_TAG}.tar.gz" | sha256sum | cut -d' ' -f1)
+          SOURCE_SHA256=$(curl -fsSL "https://github.com/rustledger/rustledger/archive/refs/tags/${RELEASE_TAG}.tar.gz" | sha256sum | cut -d' ' -f1)
+
+          # Validate checksum (should be 64 hex chars)
+          if ! echo "$SOURCE_SHA256" | grep -qE '^[a-f0-9]{64}$'; then
+            echo "::error::Invalid source checksum: $SOURCE_SHA256"
+            exit 1
+          fi
 
           # Update PKGBUILD with new version and checksum
           cp packaging/arch/rustledger/PKGBUILD /tmp/PKGBUILD
@@ -391,7 +396,7 @@ jobs:
           cat /tmp/PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v3
+        uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
         with:
           pkgname: rustledger
           pkgbuild: /tmp/PKGBUILD
@@ -411,8 +416,17 @@ jobs:
       - name: Prepare PKGBUILD
         run: |
           VERSION=${RELEASE_TAG#v}
-          X86_64_SHA256=$(curl -sL "https://github.com/rustledger/rustledger/releases/download/${RELEASE_TAG}/rustledger-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz.sha256" | cut -d' ' -f1)
-          AARCH64_SHA256=$(curl -sL "https://github.com/rustledger/rustledger/releases/download/${RELEASE_TAG}/rustledger-${RELEASE_TAG}-aarch64-unknown-linux-gnu.tar.gz.sha256" | cut -d' ' -f1)
+          X86_64_SHA256=$(curl -fsSL "https://github.com/rustledger/rustledger/releases/download/${RELEASE_TAG}/rustledger-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz.sha256" | cut -d' ' -f1)
+          AARCH64_SHA256=$(curl -fsSL "https://github.com/rustledger/rustledger/releases/download/${RELEASE_TAG}/rustledger-${RELEASE_TAG}-aarch64-unknown-linux-gnu.tar.gz.sha256" | cut -d' ' -f1)
+
+          # Validate checksums (should be 64 hex chars)
+          for name in X86_64 AARCH64; do
+            val=$(eval echo "\$${name}_SHA256")
+            if ! echo "$val" | grep -qE '^[a-f0-9]{64}$'; then
+              echo "::error::Invalid ${name} checksum: $val"
+              exit 1
+            fi
+          done
 
           # Update PKGBUILD with new version and checksums
           cp packaging/arch/rustledger-bin/PKGBUILD /tmp/PKGBUILD
@@ -425,7 +439,7 @@ jobs:
           cat /tmp/PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v3
+        uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
         with:
           pkgname: rustledger-bin
           pkgbuild: /tmp/PKGBUILD


### PR DESCRIPTION
## Summary

Replace custom AUR update implementation with the well-tested [KSXGitHub/github-actions-deploy-aur](https://github.com/KSXGitHub/github-actions-deploy-aur) action.

The previous custom implementation failed because:
1. GitHub Actions containers run as root
2. `makepkg` has a safety check that prevents running as root
3. Hand-rolled SSH setup had multiple issues (host keys, private key format, path expansion)

The `github-actions-deploy-aur` action properly handles:
- Non-root user creation (creates a `builder` user)
- SSH key setup with `ssh-keyscan` for host keys
- `.SRCINFO` generation via `makepkg --printsrcinfo`
- Proper Arch Linux container with all dependencies

Split into two parallel jobs for `rustledger` (source) and `rustledger-bin` (binary) packages.

## Test plan

- [ ] Merge PR
- [ ] Re-run `release-publish.yml` with `tag=v0.9.0`
- [ ] Verify both AUR packages are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)