### PR TITLE
fix(ci): macOS runner names and strict Scoop version check

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -187,33 +187,18 @@ jobs:
       - name: Check installed version
         shell: pwsh
         run: |
+          $output = rledger --version
+          if ($output -match '(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)') {
+            $installed = $matches[1]
+          } else {
+            $installed = "unknown"
+          }
           $expected = "${{ needs.prepare.outputs.version }}"
-          # Try rledger first (new binary name), fall back to rledger-check (old name)
-          try {
-            $output = rledger --version 2>&1
-            if ($LASTEXITCODE -eq 0 -and $output -match '(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)') {
-              $installed = $matches[1]
-              $binary = "rledger"
-            } else {
-              throw "rledger not found"
-            }
-          } catch {
-            # Fall back to old binary name
-            $output = rledger-check --version 2>&1
-            if ($output -match '(\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)') {
-              $installed = $matches[1]
-              $binary = "rledger-check"
-            } else {
-              $installed = "unknown"
-              $binary = "none"
-            }
-          }
-          Write-Host "Binary: $binary, Installed: $installed, Expected: $expected"
+          Write-Host "Installed: $installed, Expected: $expected"
           if ($installed -ne $expected) {
-            Write-Host "ℹ Scoop has an older version (bucket update may be pending)"
+            Write-Error "Version mismatch! Scoop bucket needs to be updated."
+            exit 1
           }
-          # Store which binary to use for later steps
-          echo "RLEDGER_BIN=$binary" >> $env:GITHUB_ENV
 
       - name: Create test file
         shell: pwsh
@@ -224,12 +209,7 @@ jobs:
 
       - name: Test rledger check
         shell: pwsh
-        run: |
-          if ($env:RLEDGER_BIN -eq "rledger") {
-            rledger check test.beancount
-          } else {
-            rledger-check test.beancount
-          }
+        run: rledger check test.beancount
 
   test-aur:
     name: Test AUR (Arch Linux)


### PR DESCRIPTION
## Summary
Fix release-test.yml workflow issues:

### macOS Runner Updates
- `macos-13` is deprecated (retiring December 2025)
- Use `macos-15-intel` for x86_64 builds
- Use `macos-15` for aarch64 builds

### Scoop Version Check
- Changed from warning to hard failure if version mismatches
- Ensures Scoop bucket is properly updated before tests pass

## Context
Per [GitHub's documentation](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners), Intel x86_64 builds should now use `macos-15-intel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)