### PR TITLE
fix(nix): include .beancount test fixtures in source filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,19 @@
           # Crane lib with our toolchain
           craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchainWithWasm;
 
+          # Source filter that includes test fixtures (.beancount files)
+          srcFilter = path: type:
+            (craneLib.filterCargoSources path type) ||
+            (builtins.match ".*\\.beancount$" path != null);
+
+          src = lib.cleanSourceWith {
+            src = ./.;
+            filter = srcFilter;
+          };
+
           # Common arguments for crane builds
           commonArgs = {
-            src = craneLib.cleanCargoSource ./.;
+            inherit src;
             strictDeps = true;
 
             buildInputs = [


### PR DESCRIPTION
## Summary

- Fixed Nix build failure caused by missing test fixtures
- The `cleanCargoSource` function was filtering out `.beancount` files, causing `test_directive_count_matches` to fail
- Created a custom source filter that includes both Cargo sources and `.beancount` files

## Root Cause

When building via `nix run github:rustledger/rustledger/vX.Y.Z`, crane's `cleanCargoSource` excludes non-Cargo files like `.beancount` test fixtures. The integration test `test_directive_count_matches` then fails because it can't find `valid-ledger.beancount`.

## Test plan

- [ ] Verify `nix flake check` passes
- [ ] Test `nix build` includes `.beancount` fixtures
- [ ] Verify Release Channel Testing workflow passes for next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)