### PR TITLE
fix(ci): use standard brew install command in Linux test

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -154,7 +154,7 @@ jobs:
         run: brew untap rustledger/rustledger 2>/dev/null || true
 
       - name: Install rustledger from homebrew-core
-        run: brew install homebrew/core/rustledger
+        run: brew install rustledger
 
       - name: Check installed version
         run: |


### PR DESCRIPTION
## Summary

- Changed `brew install homebrew/core/rustledger` to `brew install rustledger` in the Linux Homebrew test
- This matches what users actually type and is consistent with the macOS test

## Why

The explicit `homebrew/core/rustledger` path works but doesn't reflect real user behavior. Since we already `untap` any custom tap before installing, the simpler command works identically.

## Test plan

- [ ] Verify Linux Homebrew test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)