### PR TITLE
fix: use checked arithmetic in expression parser to prevent overflow panics

### DIFF
--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -329,7 +329,7 @@ fn parse_term(stream: &mut TokenStream<'_>) -> ParseRes<Decimal> {
             Token::Star => {
                 stream.advance();
                 let rhs = parse_primary(stream)?;
-                result *= rhs;
+                result = result.checked_mul(rhs).ok_or(())?;
             }
             Token::Slash => {
                 stream.advance();
@@ -337,7 +337,7 @@ fn parse_term(stream: &mut TokenStream<'_>) -> ParseRes<Decimal> {
                 if rhs.is_zero() {
                     return Err(());
                 }
-                result /= rhs;
+                result = result.checked_div(rhs).ok_or(())?;
             }
             _ => break,
         }
@@ -354,12 +354,12 @@ fn parse_expr(stream: &mut TokenStream<'_>) -> ParseRes<Decimal> {
             Token::Plus => {
                 stream.advance();
                 let rhs = parse_term(stream)?;
-                result += rhs;
+                result = result.checked_add(rhs).ok_or(())?;
             }
             Token::Minus => {
                 stream.advance();
                 let rhs = parse_term(stream)?;
-                result -= rhs;
+                result = result.checked_sub(rhs).ok_or(())?;
             }
             _ => break,
         }


### PR DESCRIPTION
## Summary

- Use `checked_mul`, `checked_div`, `checked_add`, `checked_sub` instead of unchecked operators in `parse_term` and `parse_expr`
- Prevents panic when parsing malformed input with extremely large numbers

## Problem

The fuzzer found a crash when parsing input containing expressions like `44222222222*2222222222222222222`. The `rust_decimal::Decimal` type panics on overflow when using standard arithmetic operators.

## Fix

Replace unchecked arithmetic:
```rust
result *= rhs;  // panics on overflow
```

With checked arithmetic:
```rust
result = result.checked_mul(rhs).ok_or(())?;  // returns error on overflow
```

## Test plan

- [x] Verified the fuzz crash input no longer panics
- [x] All existing parser tests pass

Fixes fuzz crash: `crash-85b9d63e3ad36402207ce43c875ac54aaf98a60d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)