### PR TITLE
docs: update parser documentation to reflect Winnow migration

### DIFF
--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -1,4 +1,4 @@
-//! Beancount parser using chumsky parser combinators.
+//! Beancount parser using Logos lexer and Winnow parser combinators.
 //!
 //! This crate provides a parser for the Beancount file format. It produces
 //! a stream of [`Directive`]s from source text, along with any parse errors.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ This document describes rustledger's crate structure and data flow.
 | Crate | Purpose | Key Types |
 |-------|---------|-----------|
 | `rustledger-core` | Fundamental types | `Amount`, `Position`, `Inventory`, `Decimal`, `Account`, `Currency` |
-| `rustledger-parser` | Lexer and recursive descent parser | `Directive`, `Transaction`, `Posting`, `ParseError` |
+| `rustledger-parser` | Logos lexer + Winnow parser | `Directive`, `Transaction`, `Posting`, `ParseError` |
 
 ### Processing Layer
 

--- a/docs/PERFORMANCE_ROADMAP.md
+++ b/docs/PERFORMANCE_ROADMAP.md
@@ -199,16 +199,16 @@ rledger check ledger.beancount             # Use cache (default)
 
 ---
 
-## Phase 6: Lexer + Arena Allocator (Future)
+## Phase 6: Lexer + Arena Allocator
 
 **Goal**: Replace parser combinators with fast lexer, use arena for AST
 **Expected Impact**: 30-50% faster parsing
 
-### 6.1 Logos Lexer + Chumsky Parser via logosky
+### 6.1 Logos Lexer + Winnow Parser ✅ DONE
 - Use [logos](https://github.com/maciejhirsz/logos) crate for SIMD-accelerated tokenization
-- Use [logosky](https://crates.io/crates/logosky) to bridge Logos output to Chumsky
+- Use [winnow](https://github.com/winnow-rs/winnow) parser combinators (replaced Chumsky)
 - Zero-copy token stream - no allocations during lexing
-- Enable existing `lexer.rs` (currently disabled)
+- Manual token stream for simplicity and performance
 
 ### 6.2 Bumpalo Arena for AST Nodes
 - Use [bumpalo](https://github.com/fitzgen/bumpalo) for AST allocation
@@ -240,7 +240,8 @@ rledger check ledger.beancount             # Use cache (default)
 | 3 | Full interning | ✅ Done | +6% |
 | 4 | Parallelization (rayon) | ✅ Done | +5% |
 | 5 | Binary cache (rkyv) | ✅ Done | 2.3x on cache hit |
-| 6 | Logos + Bumpalo | 🔮 Future | +40% projected |
+| 6.1 | Logos + Winnow parser | ✅ Done | Replaced Chumsky |
+| 6.2 | Bumpalo arena | 🔮 Future | +40% projected |
 | 7 | Memory-mapped files | 🔮 Future | Large files only |
 
 ## Actual Performance
@@ -360,9 +361,9 @@ cargo bench --bench pipeline_bench
 ## Research & References
 
 ### Parser Performance
-- [Winnow](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/) - potentially faster than Chumsky for some use cases
-- [Chumsky](https://github.com/zesterer/chumsky) - current parser, good error recovery
-- [logosky](https://crates.io/crates/logosky) - zero-copy bridge from Logos to Chumsky
+- [Winnow](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/) - current parser, faster compile times than Chumsky
+- [Logos](https://github.com/maciejhirsz/logos) - current lexer, SIMD-accelerated tokenization
+- [Chumsky](https://github.com/zesterer/chumsky) - previous parser, kept for benchmarking
 
 ### Serialization
 - [rkyv](https://github.com/rkyv/rkyv) - zero-copy deserialization, [faster than bincode](https://david.kolo.ski/blog/rkyv-is-faster-than/)

--- a/docs/adr/0003-parser-design.md
+++ b/docs/adr/0003-parser-design.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (Updated January 2026)
+Accepted (Updated February 2026)
 
 ## Context
 
@@ -22,7 +22,7 @@ Options considered:
 
 ## Decision
 
-Use **Logos for lexing** and **Chumsky for parsing** (parser combinators).
+Use **Logos for lexing** and **Winnow for parsing** (parser combinators).
 
 ### Lexer (Logos)
 
@@ -37,18 +37,18 @@ Tokens include:
 - Dates, numbers, strings, accounts, currencies
 - Operators and punctuation
 
-### Parser (Chumsky)
+### Parser (Winnow)
 
-The parser (`token_parser.rs`) uses Chumsky parser combinators:
+The parser (`winnow_parser.rs`) uses a manual token stream with winnow-style parsing:
 
 - Composable parsers for each directive type
-- Built-in error recovery mechanisms
-- Rich error types with expected/found tokens
-- Span tracking propagated automatically
+- Manual token stream for simplicity and performance
+- Error recovery continues parsing after errors
+- Span tracking propagated through all parse results
 
 Architecture:
 ```text
-Source (&str) → Logos tokenize() → Vec<SpannedToken> → Chumsky parser → Directives
+Source (&str) → Logos tokenize() → Vec<SpannedToken> → Winnow parser → Directives
 ```
 
 ## Consequences
@@ -56,33 +56,35 @@ Source (&str) → Logos tokenize() → Vec<SpannedToken> → Chumsky parser → 
 ### Positive
 
 - Logos provides excellent lexer performance (SIMD-accelerated)
-- Chumsky offers expressive, composable parser combinators
-- Good error recovery built into the framework
+- Winnow is lightweight with minimal compile-time overhead
+- Manual token stream approach is simpler than trait-based streams
 - Type-safe parser composition catches errors at compile time
 - No external grammar DSL files to maintain
 
 ### Negative
 
-- Chumsky has a learning curve for complex combinators
-- Compile times slightly longer due to heavy generics
-- Debug output can be verbose
+- Manual token stream requires more boilerplate
+- Less built-in error recovery than some frameworks
+- Must handle overflow/edge cases explicitly (e.g., checked arithmetic)
 
 ### Neutral
 
-- Parser is ~2000 lines, manageable for the grammar size
+- Parser is ~1500 lines, manageable for the grammar size
 - Error messages require tuning for user-friendliness
 
 ## Notes
 
 The parser is organized into sections:
 
-1. Token input types and helpers
+1. Token stream types and helpers
 2. Primitive parsers (date, number, string, account)
-3. Directive parsers (transaction, balance, open, etc.)
-4. Expression parsers (amount, cost, metadata, postings)
-5. Top-level file parser with error recovery
+3. Expression parsers (arithmetic with checked overflow)
+4. Amount and cost parsers
+5. Directive parsers (transaction, balance, open, etc.)
+6. Top-level file parser with error recovery
 
 ## History
 
 - **Original decision**: Hand-written recursive descent parser
-- **January 2026**: Migrated to Logos + Chumsky for better performance and maintainability
+- **January 2026**: Migrated to Logos + Chumsky for better performance
+- **February 2026**: Migrated from Chumsky to Winnow for faster compile times and simpler code


### PR DESCRIPTION
## Summary

- Update ADR-0003 to reflect Winnow as current parser (not Chumsky)
- Fix ARCHITECTURE.md parser description
- Update PERFORMANCE_ROADMAP.md to mark Logos+Winnow as done
- Fix lib.rs docstring

## Context

The parser was migrated from Chumsky to Winnow for faster compile times and simpler code. The documentation still referenced Chumsky as the current parser.

## Changes

| File | Change |
|------|--------|
| `docs/adr/0003-parser-design.md` | Updated to describe Winnow parser |
| `docs/ARCHITECTURE.md` | Changed "recursive descent parser" to "Logos lexer + Winnow parser" |
| `docs/PERFORMANCE_ROADMAP.md` | Marked Phase 6.1 (Logos+Winnow) as done |
| `crates/rustledger-parser/src/lib.rs` | Fixed docstring |

🤖 Generated with [Claude Code](https://claude.com/claude-code)