### PR TITLE
fix(ci): detect breaking changes with ! marker in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,9 +12,10 @@
 # feat: -> minor, fix: -> patch, BREAKING CHANGE: or type!: -> major
 semver_check = true
 
-# Detect breaking changes from conventional commit '!' marker (e.g., feat!:, fix!:)
+# Detect breaking changes from conventional commit '!' marker
+# Matches: feat!:, fix!:, feat(scope)!:, fix(importer)!:, etc.
 # Also matches BREAKING CHANGE in commit body
-custom_major_increment_regex = "^\\w+!:|BREAKING CHANGE:"
+custom_major_increment_regex = "^\\w+(\\(.*\\))?!:|BREAKING CHANGE:"
 
 # Create changelog entries from conventional commits
 changelog_update = true
@@ -51,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Commit types to include in changelog
 # Breaking changes (with !) are listed first
 commit_parsers = [
-  { message = "^\\w+!:", group = "Breaking Changes" },
+  { message = "^\\w+(\\(.*\\))?!:", group = "Breaking Changes" },
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug Fixes" },
   { message = "^perf", group = "Performance" },


### PR DESCRIPTION
## Summary

- Add `custom_major_increment_regex` to detect `!` breaking change markers
- Add "Breaking Changes" group to changelog parsers

## Problem

Release-plz wasn't detecting `feat(importer)!:` as a breaking change, causing it to propose version 0.9.2 instead of 0.10.0.

The semver check correctly detected the breaking API change (adding fields to structs), but release-plz's version bump logic only recognized `BREAKING CHANGE:` in commit bodies, not the `!` marker in commit prefixes.

## Solution

Added regex pattern `^\w+!:|BREAKING CHANGE:` to match:
- `feat!:` - feature with breaking change
- `fix!:` - fix with breaking change  
- `refactor!:` - refactor with breaking change
- `BREAKING CHANGE:` - footer notation

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-plz to regenerate release PR
- [ ] Verify new release PR proposes v0.10.0 (not v0.9.2)

## References

- [Release-plz Configuration](https://release-plz.dev/docs/config)
- [Conventional Commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)