### PR TITLE
fix(ci): use minor_increment for pre-1.0 breaking changes

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,13 +9,14 @@
 
 [workspace]
 # Use conventional commits to determine version bumps
-# feat: -> minor, fix: -> patch, BREAKING CHANGE: or type!: -> major
+# feat: -> minor, fix: -> patch
 semver_check = true
 
-# Detect breaking changes from conventional commit '!' marker
+# For pre-1.0 versions, breaking changes bump the minor version (0.9.x -> 0.10.0)
 # Matches: feat!:, fix!:, feat(scope)!:, fix(importer)!:, etc.
 # Also matches BREAKING CHANGE in commit body
-custom_major_increment_regex = "^\\w+(\\(.*\\))?!:|BREAKING CHANGE:"
+# Note: When ready for 1.0, change this to custom_major_increment_regex
+custom_minor_increment_regex = "^\\w+(\\(.*\\))?!:|BREAKING CHANGE:"
 
 # Create changelog entries from conventional commits
 changelog_update = true


### PR DESCRIPTION
## Summary

- Changed `custom_major_increment_regex` to `custom_minor_increment_regex` in release-plz.toml
- For pre-1.0 semver (0.x.y), breaking changes should bump the **minor** version (0.9.x → 0.10.0), not major (0.9.x → 1.0.0)
- This ensures release-plz correctly proposes v0.10.0 for the breaking change in `feat(importer)!: add locale-aware number parsing`

## Context

PR #442 added `custom_major_increment_regex` to detect breaking changes, but this would bump to 1.0.0. Per [release-plz docs](https://release-plz.dev/docs/config), for pre-1.0 versions, `custom_minor_increment_regex` is the correct setting.

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger release-plz workflow
- [ ] Verify release PR proposes v0.10.0 instead of v0.9.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)