### PR TITLE
chore(supply-chain): temporarily ignore wasmtime vulnerabilities

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,14 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
-ignore = []
+# TEMPORARY: Ignore wasmtime vulnerabilities until PR #439 merges
+# (PR #439 updates wasmtime to 42.0.1 which fixes these)
+# TODO: Remove these ignores after wasmtime update merges
+ignore = [
+  "RUSTSEC-2026-0020",  # Guest-controlled resource exhaustion
+  "RUSTSEC-2026-0021",  # Panic adding excessive fields
+  "RUSTSEC-2026-0022",  # Panic when dropping call_async future
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

- Temporarily ignore RUSTSEC-2026-0020, RUSTSEC-2026-0021, RUSTSEC-2026-0022 in cargo-deny
- These are wasmtime vulnerabilities fixed in version 42.0.1
- Unblocks PR #439 (wasmtime update) which is currently failing cargo-deny

## Context

Circular dependency blocked merging:
1. PR #439 (wasmtime bump) fails semver check (needs v0.10.0 released)
2. PR #454 (release-plz fix) failed cargo-deny (wasmtime vulns)
3. Can't release v0.10.0 until #454 merges

This PR allows #439 to merge, which will remove the vulnerabilities. After #439 merges, we should remove these ignores.

## Test plan

- [ ] Merge this PR
- [ ] Merge PR #439 (wasmtime update)
- [ ] Create follow-up PR to remove the temporary ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)