### PR TITLE
fix(ci): disable cargo-semver-checks, rely on commit messages

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,8 +6,10 @@
 # - https://github.com/release-plz/release-plz
 
 [workspace]
-# Enable semver checking for API breaking changes
-semver_check = true
+# Disable cargo-semver-checks - it doesn't detect all breaking changes
+# (e.g., adding required fields to structs). Rely on commit messages instead.
+# See: https://github.com/Blockstream/greenlight uses same approach
+semver_check = false
 
 # Create changelog entries from conventional commits
 changelog_update = true


### PR DESCRIPTION
## Summary

Disable `semver_check` so release-plz relies on commit messages for version bumps.

## Problem

cargo-semver-checks reports "API compatible changes" for `feat(importer)!:` even though:
- The commit has `!` marker
- The commit footer has `BREAKING CHANGE: CsvConfig and ImporterConfig have new public fields`

This is because cargo-semver-checks doesn't detect all breaking changes (e.g., adding required fields to structs).

## Solution

Set `semver_check = false` like [Blockstream/greenlight](https://github.com/Blockstream/greenlight/blob/main/release-plz.toml) does.

This makes release-plz use conventional commit messages (`feat!:`, `BREAKING CHANGE:`) to determine version bumps.

## Test plan

- [ ] Merge this PR
- [ ] Close release PR #458
- [ ] Trigger release-plz workflow
- [ ] Verify new release PR proposes v0.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)