### PR TITLE
fix(ci): recognize manual release PRs in release workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -241,11 +241,13 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: release-plz
-    # Only run if this is a merge of a release-plz PR
-    # Merge commit message contains branch name: "Merge pull request #N from rustledger/release-plz-..."
+    # Run if this is a merge of a release-plz PR OR a manual release PR
+    # - Automatic: "Merge pull request #N from rustledger/release-plz-..."
+    # - Manual: Commit message contains "chore: release" (per RELEASING.md)
     if: |
       github.event_name == 'push' &&
-      contains(github.event.head_commit.message, 'release-plz-')
+      (contains(github.event.head_commit.message, 'release-plz-') ||
+       contains(github.event.head_commit.message, 'chore: release'))
     steps:
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

The release job now triggers on both:
- **Automatic**: release-plz PRs (branch contains `release-plz-`)
- **Manual**: Release PRs (commit message contains `chore: release`)

## Why

PR #461 manually bumped versions to v0.10.0 using `release-plz set-version` (as documented in RELEASING.md). However, the release job didn't run because it only looked for `release-plz-` in the commit message, not `chore: release`.

This caused v0.10.0 to not be released even though the PR was merged.

## Fix

Updated the workflow condition to also match `chore: release` in the commit message, which aligns with RELEASING.md documentation (line 195).

## Test plan

- [x] Manually created v0.10.0 tag to trigger the current release
- [ ] Future manual releases using `chore: release` will trigger automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)