### PR TITLE
fix(lsp): prevent 'Unresolved lens ...' for balance assertions

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -133,10 +133,13 @@ pub fn handle_code_lens(
 /// Computes expensive balance verification on demand.
 pub fn handle_code_lens_resolve(lens: CodeLens, parse_result: &ParseResult) -> CodeLens {
     let mut resolved = lens.clone();
+    let mut processed_balance = false;
 
     if let Some(data) = &lens.data
         && data.get("kind").and_then(|v| v.as_str()) == Some("balance")
     {
+        processed_balance = true;
+
         let account = data.get("account").and_then(|v| v.as_str()).unwrap_or("");
         let date_str = data.get("date").and_then(|v| v.as_str()).unwrap_or("");
         let expected_amount = data
@@ -173,14 +176,22 @@ pub fn handle_code_lens_resolve(lens: CodeLens, parse_result: &ParseResult) -> C
                     "actual": format!("{} {}", actual_amount, expected_currency),
                 })]),
             });
-        } else {
-            // For mismatches, explicitly clear command - diagnostic will show the error.
-            // This handles edge cases where a cached lens might have a stale command.
-            resolved.command = None;
         }
+        // For mismatches, command stays None - diagnostic will show the error.
     }
 
-    // If no data to resolve, return as-is (already has command)
+    // Ensure a command is set for non-balance lenses or malformed balance data.
+    // This prevents "Unresolved lens ..." from appearing in the editor.
+    // We don't apply this to processed balance assertions - those intentionally
+    // have no command when mismatched (shown via diagnostics instead).
+    if !processed_balance && resolved.command.is_none() {
+        resolved.command = Some(Command {
+            title: "Balance assertion".to_string(),
+            command: "rledger.noop".to_string(),
+            arguments: None,
+        });
+    }
+
     resolved
 }
 
@@ -446,6 +457,55 @@ mod tests {
             cmd.title.contains("✓"),
             "Should show checkmark for passing balance. Got: {}",
             cmd.title
+        );
+    }
+
+    #[test]
+    fn test_code_lens_resolve_missing_data() {
+        // Test that resolve always returns a command, even with missing/malformed data.
+        // This prevents "Unresolved lens ..." from appearing in the editor.
+        let source = r#"2024-01-01 open Assets:Bank USD"#;
+        let result = parse(source);
+
+        // Lens with no data at all
+        let lens = CodeLens {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            command: None,
+            data: None,
+        };
+
+        let resolved = handle_code_lens_resolve(lens, &result);
+        assert!(
+            resolved.command.is_some(),
+            "Lens must always have a command after resolve"
+        );
+    }
+
+    #[test]
+    fn test_code_lens_resolve_wrong_kind() {
+        // Test that resolve handles data with wrong/missing "kind" field
+        let source = r#"2024-01-01 open Assets:Bank USD"#;
+        let result = parse(source);
+
+        let lens = CodeLens {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            command: None,
+            data: Some(serde_json::json!({
+                "kind": "unknown",
+                "account": "Assets:Bank",
+            })),
+        };
+
+        let resolved = handle_code_lens_resolve(lens, &result);
+        assert!(
+            resolved.command.is_some(),
+            "Lens must always have a command after resolve"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Fixed codelens resolve handler to always return a command, preventing "Unresolved lens ..." from appearing in the editor
- Added tests for missing data and wrong kind edge cases

## Root Cause

The `handle_code_lens_resolve` function was creating balance assertion lenses with `command: None`, relying on lazy resolution. However, if the resolution condition failed (e.g., missing or malformed data), the lens was returned unchanged (still with no command), causing VS Code to display "Unresolved lens ..." instead of the expected balance verification.

## Fix

Added a fallback command at the end of `handle_code_lens_resolve` that sets a default "Balance assertion" command if resolution fails for any reason.

## Test plan

- [x] Added `test_code_lens_resolve_missing_data` - verifies lens with no data returns a command
- [x] Added `test_code_lens_resolve_wrong_kind` - verifies lens with wrong kind returns a command
- [x] Existing tests still pass

Fixes comment by @lutzky

🤖 Generated with [Claude Code](https://claude.com/claude-code)