### PR TITLE
fix(ci): fetch Cargo.toml files in cargo-vet-auto workflow

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -46,14 +46,14 @@ jobs:
           gh api "repos/$REPO/contents/Cargo.lock?ref=$PR_SHA" \
             --jq '.content' | base64 -d > Cargo.lock
 
-          # Get list of changed files in the PR
-          CHANGED_FILES=$(gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename')
-
-          # Fetch any changed Cargo.toml files (safe: these only contain dependency specs)
-          for file in $CHANGED_FILES; do
+          # Get list of changed files and fetch any Cargo.toml files
+          # Using --paginate to handle PRs with many files, and while read to handle spaces in paths
+          gh api --paginate "repos/$REPO/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename' | while IFS= read -r file; do
             if [[ "$file" == *"Cargo.toml" ]]; then
               echo "Fetching $file from PR"
+              # Ensure parent directory exists (might be new in the PR)
+              mkdir -p "$(dirname "$file")"
               gh api "repos/$REPO/contents/$file?ref=$PR_SHA" \
                 --jq '.content' | base64 -d > "$file"
             fi


### PR DESCRIPTION
## Summary

- Fixes the "Update Exemptions" workflow failing on Dependabot PRs with major version bumps
- Now fetches changed `Cargo.toml` files in addition to `Cargo.lock` from the PR

## Problem

The workflow was only fetching `Cargo.lock` from Dependabot PRs. For minor/patch updates this works fine, but major version bumps (like `toml` 0.8 → 0.9) also modify `Cargo.toml` to update the version requirement.

Without the updated manifests, `cargo metadata --locked` fails:
```
error: cannot update the lock file because --locked was passed
```

## Solution

Fetch any changed `Cargo.toml` files from the PR before running `cargo vet`. This is safe because:
1. `Cargo.toml` files only contain dependency specifications, not executable code
2. We only fetch files that match `*Cargo.toml` pattern
3. The workflow still only runs for `dependabot[bot]` PRs

## Test plan

- [ ] Merge this PR
- [ ] Re-run the "Update Exemptions" workflow on PR #512 to verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)