### PR TITLE
fix(query): make BQL regex matching case-insensitive

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -16,7 +16,7 @@ use std::sync::RwLock;
 use rustc_hash::FxHashMap;
 
 use chrono::Datelike;
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 use rust_decimal::Decimal;
 use rustledger_core::{Amount, Directive, InternedStr, Inventory, Metadata, Position};
 #[cfg(test)]
@@ -200,7 +200,11 @@ impl<'a> Executor<'a> {
             }
         }
         // Slow path: compile and insert with write lock
-        let compiled = Regex::new(pattern).ok();
+        // Use case-insensitive matching to match Python beancount behavior
+        let compiled = RegexBuilder::new(pattern)
+            .case_insensitive(true)
+            .build()
+            .ok();
         let mut cache = match self.regex_cache.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -3234,3 +3234,44 @@ fn test_parallel_execution_matches_sequential() {
         other => panic!("expected Number or Amount result, got {other:?}"),
     }
 }
+
+// Regression test for issue #532: BQL regex should be case-insensitive
+// https://github.com/rustledger/rustledger/issues/532
+#[test]
+fn test_regex_case_insensitive() {
+    let directives = make_test_directives();
+
+    // Test lowercase pattern matches uppercase account component
+    let result = execute_query(
+        r#"SELECT DISTINCT account WHERE account ~ "food""#,
+        &directives,
+    );
+    assert_eq!(
+        result.len(),
+        1,
+        "lowercase 'food' should match 'Expenses:Food'"
+    );
+
+    // Test uppercase pattern matches mixed-case account
+    let result = execute_query(
+        r#"SELECT DISTINCT account WHERE account ~ "EXPENSES""#,
+        &directives,
+    );
+    // Should match Expenses:Food and Expenses:Transport
+    assert_eq!(
+        result.len(),
+        2,
+        "uppercase 'EXPENSES' should match 'Expenses:*' accounts"
+    );
+
+    // Test mixed-case pattern
+    let result = execute_query(
+        r#"SELECT DISTINCT account WHERE account ~ "eXpEnSeS""#,
+        &directives,
+    );
+    assert_eq!(
+        result.len(),
+        2,
+        "mixed-case pattern should match case-insensitively"
+    );
+}

--- a/tests/regressions/README.md
+++ b/tests/regressions/README.md
@@ -62,11 +62,16 @@ When adding a test from a new issue:
 | [#223](https://github.com/rustledger/rustledger/issues/223) | Lot matching with reverse-chronological order | Fixed |
 | [#230](https://github.com/rustledger/rustledger/issues/230) | Cost without currency lot matching | Fixed |
 | [#251](https://github.com/rustledger/rustledger/issues/251) | Tolerance handling | Fixed |
+| [#273](https://github.com/rustledger/rustledger/issues/273) | Inventory lots with same price but different dates | Fixed |
+| [#274](https://github.com/rustledger/rustledger/issues/274) | Transaction interpolation rounding issue | Fixed |
 | [#276](https://github.com/rustledger/rustledger/issues/276) | Multi-posting lot boundary crossing | Fixed |
 | [#277](https://github.com/rustledger/rustledger/issues/277) | CostSpec serialization in Python compat layer | Fixed |
 | [#278](https://github.com/rustledger/rustledger/issues/278) | Zerosum plugin duplicate Open directives | Fixed |
 | [#279](https://github.com/rustledger/rustledger/issues/279) | Crypto FIFO with multi-lot sales | Fixed |
+| [#283](https://github.com/rustledger/rustledger/issues/283) | BQL convert() should use latest price | Fixed |
 | [#333](https://github.com/rustledger/rustledger/issues/333) | Cost spec scale in interpolation | Fixed |
+| [#365](https://github.com/rustledger/rustledger/issues/365) | Glob patterns in include directives | Fixed |
 | [#516](https://github.com/rustledger/rustledger/issues/516) | coherent_cost plugin false positive on cost+price | Fixed |
 | [#520](https://github.com/rustledger/rustledger/issues/520) | currency_accounts missing Open directives | Fixed |
 | [#521](https://github.com/rustledger/rustledger/issues/521) | currency_accounts should use cost/price currency | Fixed |
+| [#532](https://github.com/rustledger/rustledger/issues/532) | BQL regex case-insensitive matching | Fixed |

--- a/tests/regressions/issue-532.beancount
+++ b/tests/regressions/issue-532.beancount
@@ -1,0 +1,10 @@
+; Issue: https://github.com/rustledger/rustledger/issues/532
+; Description: BQL regex matching should be case-insensitive (like Python beancount)
+; Expected: No errors (actual regex behavior tested in bql_integration_test.rs)
+
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Food
+
+2024-01-15 * "Grocery Store" "Weekly groceries"
+  Expenses:Food  50.00 USD
+  Assets:Cash


### PR DESCRIPTION
## Summary

- Use `RegexBuilder` with `case_insensitive(true)` for BQL `~` operator to match Python beancount behavior
- Add integration test verifying case-insensitive matching
- Add regression test file `tests/regressions/issue-532.beancount`

Closes #532

## Test plan

- [x] New integration test `test_regex_case_insensitive` passes
- [x] All 166 existing query tests pass
- [x] Regression test file added

🤖 Generated with [Claude Code](https://claude.com/claude-code)