### PR TITLE
fix: support single-character commodity names (e.g., T, V, F)

### DIFF
--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -62,13 +62,14 @@ pub enum Token<'src> {
     #[regex(r"([A-Z]|[^\x00-\x7F])([A-Za-z0-9-]|[^\x00-\x7F])*(:([A-Z0-9]|[^\x00-\x7F])([A-Za-z0-9-]|[^\x00-\x7F])*)+")]
     Account(&'src str),
 
-    /// A currency/commodity code like USD, EUR, AAPL, BTC.
+    /// A currency/commodity code like USD, EUR, AAPL, BTC, or single-char tickers like T, V, F.
     /// Uppercase letters, can contain digits, apostrophes, dots, underscores, hyphens.
-    /// Note: This pattern is lower priority than Account, Keywords, and Flags.
-    /// Currency must have at least 2 characters to avoid conflict with single-letter flags.
+    /// Single-character currencies (e.g., T for AT&T, V for Visa) are valid NYSE/NASDAQ tickers.
+    /// Note: Single-char currencies are disambiguated from transaction flags in the parser.
     /// Also supports `/` prefix for options/futures contracts (e.g., `/ESM24`, `/LOX21_211204_P100.25`).
     /// The `/` prefix requires an uppercase letter first to avoid matching `/1.14` as currency.
-    #[regex(r"/[A-Z][A-Z0-9'._-]*|[A-Z][A-Z0-9'._-]+")]
+    /// Priority 3 ensures Currency wins over Flag for single uppercase letters.
+    #[regex(r"/[A-Z][A-Z0-9'._-]*|[A-Z][A-Z0-9'._-]*", priority = 3)]
     Currency(&'src str),
 
     /// A tag like #tag-name.
@@ -269,11 +270,14 @@ pub enum Token<'src> {
 
 impl Token<'_> {
     /// Returns true if this is a transaction flag (* or !).
+    /// Single-character currencies (e.g., T, P, C) can also be used as flags.
     pub const fn is_txn_flag(&self) -> bool {
-        matches!(
-            self,
-            Self::Star | Self::Pending | Self::Flag(_) | Self::Hash
-        )
+        match self {
+            Self::Star | Self::Pending | Self::Flag(_) | Self::Hash => true,
+            // Single-char currencies can be used as transaction flags
+            Self::Currency(s) => s.len() == 1,
+            _ => false,
+        }
     }
 
     /// Returns true if this is a keyword that starts a directive.
@@ -552,6 +556,33 @@ mod tests {
         let tokens = tokenize("USD");
         assert_eq!(tokens.len(), 1);
         assert!(matches!(tokens[0].0, Token::Currency("USD")));
+    }
+
+    #[test]
+    fn test_tokenize_single_char_currency() {
+        // Single-char NYSE/NASDAQ tickers: T (AT&T), V (Visa), F (Ford), X (US Steel)
+        let tokens = tokenize("T");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Currency("T")));
+
+        let tokens = tokenize("V");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Currency("V")));
+
+        let tokens = tokenize("F");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(tokens[0].0, Token::Currency("F")));
+    }
+
+    #[test]
+    fn test_single_char_currency_is_txn_flag() {
+        // Single-char currencies should be recognized as potential transaction flags
+        let token = Token::Currency("T");
+        assert!(token.is_txn_flag());
+
+        // Multi-char currencies should NOT be transaction flags
+        let token = Token::Currency("USD");
+        assert!(!token.is_txn_flag());
     }
 
     #[test]

--- a/crates/rustledger-parser/src/token_parser.rs
+++ b/crates/rustledger-parser/src/token_parser.rs
@@ -430,6 +430,8 @@ fn tok_flag<'src>() -> impl Parser<'src, &'src [SpannedToken<'src>], char, TokEx
             Token::Pending => '!',
             Token::Hash => '#', // Forecast plugin uses # as a flag
             Token::Flag(s) => s.chars().next().unwrap_or('?'),
+            // Single-char currencies can be used as transaction flags (e.g., T, P, C)
+            Token::Currency(s) if s.len() == 1 => s.chars().next().unwrap_or('?'),
             _ => '?',
         })
 }

--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -225,6 +225,14 @@ fn parse_flag(stream: &mut TokenStream<'_>) -> ParseRes<char> {
                 stream.advance();
                 return Ok(c);
             }
+            // Single-char currencies can be used as transaction flags (e.g., T, P, C)
+            // This matches Python beancount's behavior where single uppercase letters
+            // are disambiguated based on context
+            Token::Currency(s) if s.len() == 1 => {
+                let c = s.chars().next().unwrap();
+                stream.advance();
+                return Ok(c);
+            }
             _ => {}
         }
     }
@@ -837,6 +845,7 @@ fn parse_transaction_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedI
     let date = parse_date(stream)?;
 
     // Flag (txn keyword or flag character)
+    // Single-char currencies (e.g., T, V) can also be used as transaction flags
     let flag = if let Some(t) = stream.peek() {
         match &t.token {
             Token::Txn => {
@@ -844,6 +853,7 @@ fn parse_transaction_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedI
                 '*'
             }
             Token::Star | Token::Pending | Token::Hash | Token::Flag(_) => parse_flag(stream)?,
+            Token::Currency(s) if s.len() == 1 => parse_flag(stream)?,
             Token::String(_) => '*', // Implied txn
             _ => return Err(()),
         }
@@ -1351,6 +1361,8 @@ fn parse_dated_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedItem> {
         | Token::Hash
         | Token::Flag(_)
         | Token::String(_) => parse_transaction_directive(stream),
+        // Single-char currencies can be transaction flags (e.g., "2024-01-01 T 'desc'")
+        Token::Currency(s) if s.len() == 1 => parse_transaction_directive(stream),
         Token::Balance => parse_balance_directive(stream),
         Token::Open => parse_open_directive(stream),
         Token::Close => parse_close_directive(stream),


### PR DESCRIPTION
## Summary

- NYSE and NASDAQ have single-letter stock tickers like T (AT&T), V (Visa), F (Ford), and X (US Steel)
- Previously rustledger rejected these because the lexer required currencies to have 2+ characters to avoid conflict with single-letter transaction flags
- This change adds parser-level context disambiguation matching Python beancount's behavior

## Changes

**Lexer (`logos_lexer.rs`)**:
- Updated Currency regex from `[A-Z][A-Z0-9'._-]+` to `[A-Z][A-Z0-9'._-]*` to allow single-char
- Added `priority = 3` to Currency token to resolve overlap with Flag token (priority 2)

**Parser (`winnow_parser.rs`)**:
- `parse_flag()`: Accept single-char Currency tokens as transaction flags
- `parse_transaction_directive()`: Handle single-char Currency in flag position
- `parse_dated_directive()`: Route single-char Currency to transaction parser

## Test plan

- [x] Existing test suite passes
- [x] Manual test with single-char commodities (T, V, F)
- [x] Verified "2024-01-01 T 'Transfer'" parses as transaction with T flag
- [x] Verified "10 T {25.00 USD}" parses as 10 units of currency T

Fixes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)