### PR TITLE
fix(query): support CONVERT function in aggregate context

### DIFF
--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -3,7 +3,7 @@
 //! This module includes metadata, conversion, casting, and helper functions.
 
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, MetaValue};
+use rustledger_core::{Amount, Inventory, MetaValue, Position};
 
 use crate::ast::FunctionCall;
 use crate::error::QueryError;
@@ -137,15 +137,26 @@ impl Executor<'_> {
                 }
             }
             Value::Inventory(inv) => {
-                let mut total = Decimal::ZERO;
+                // Convert each position, keeping originals when no conversion available
+                // (matches Python beancount behavior)
+                let mut result = Inventory::default();
                 for pos in inv.positions() {
                     if pos.units.currency == target_currency {
-                        total += pos.units.number;
+                        result.add(Position::simple(pos.units.clone()));
                     } else if let Some(converted) = convert_amount(&pos.units) {
-                        total += converted.number;
+                        result.add(Position::simple(converted));
+                    } else {
+                        // No conversion available - keep original (Python beancount behavior)
+                        result.add(Position::simple(pos.units.clone()));
                     }
                 }
-                Ok(Value::Amount(Amount::new(total, &target_currency)))
+                // If result has single currency matching target, return as Amount
+                let positions = result.positions();
+                if positions.len() == 1 && positions[0].units.currency == target_currency {
+                    Ok(Value::Amount(positions[0].units.clone()))
+                } else {
+                    Ok(Value::Inventory(Box::new(result)))
+                }
             }
             Value::Number(n) => {
                 // Just wrap the number as an amount with the target currency

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -985,15 +985,26 @@ impl<'a> Executor<'a> {
                         }
                     }
                     Value::Inventory(inv) => {
-                        let mut total = Decimal::ZERO;
+                        // Convert each position, keeping originals when no conversion available
+                        // (matches Python beancount behavior)
+                        let mut result = Inventory::default();
                         for pos in inv.positions() {
                             if pos.units.currency == target_currency {
-                                total += pos.units.number;
+                                result.add(Position::simple(pos.units.clone()));
                             } else if let Some(converted) = convert_amount(&pos.units) {
-                                total += converted.number;
+                                result.add(Position::simple(converted));
+                            } else {
+                                // No conversion available - keep original (Python beancount behavior)
+                                result.add(Position::simple(pos.units.clone()));
                             }
                         }
-                        Ok(Value::Amount(Amount::new(total, &target_currency)))
+                        // If result has single currency matching target, return as Amount
+                        let positions = result.positions();
+                        if positions.len() == 1 && positions[0].units.currency == target_currency {
+                            Ok(Value::Amount(positions[0].units.clone()))
+                        } else {
+                            Ok(Value::Inventory(Box::new(result)))
+                        }
                     }
                     Value::Number(n) => Ok(Value::Amount(Amount::new(*n, &target_currency))),
                     Value::Null => Ok(Value::Null),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -5146,3 +5146,66 @@ fn test_convert_number_to_currency() {
         other => panic!("Expected Amount, got {other:?}"),
     }
 }
+
+#[test]
+fn test_convert_unconvertible_currency_kept_original() {
+    // Test: when no price is available for conversion, keep original currency
+    // (matches Python beancount behavior - returns original amount, not silent skip)
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank:EUR")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank:JPY")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank:USD")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        // EUR account - will be kept as-is (target currency)
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 1), "Opening EUR")
+                .with_posting(Posting::new(
+                    "Assets:Bank:EUR",
+                    Amount::new(dec!(1000), "EUR"),
+                ))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1000), "EUR"),
+                )),
+        ),
+        // JPY account - NO price defined, should be kept as JPY
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 1), "Opening JPY")
+                .with_posting(Posting::new(
+                    "Assets:Bank:JPY",
+                    Amount::new(dec!(50000), "JPY"),
+                ))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-50000), "JPY"),
+                )),
+        ),
+    ];
+
+    // Query positions converting to EUR - JPY has no conversion rate
+    let result = execute_query(
+        "SELECT convert(sum(position), 'EUR') WHERE account ~ '^Assets:Bank' GROUP BY 1",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    // Should return an Inventory with both EUR and JPY (JPY kept as original)
+    match &result.rows[0][0] {
+        Value::Inventory(inv) => {
+            let positions = inv.positions();
+            assert_eq!(
+                positions.len(),
+                2,
+                "Expected 2 positions (EUR + unconverted JPY)"
+            );
+            // Check both currencies are present
+            let currencies: Vec<_> = positions
+                .iter()
+                .map(|p| p.units.currency.as_ref())
+                .collect();
+            assert!(currencies.contains(&"EUR"), "Should have EUR");
+            assert!(currencies.contains(&"JPY"), "Should have JPY (unconverted)");
+        }
+        other => panic!("Expected Inventory with mixed currencies, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Fix `convert(sum(position), 'EUR')` failing with "unknown function: convert" error.

**Root Cause**: The `CONVERT` function was implemented in `eval_convert()` which works with expressions, but not in `evaluate_function_on_values()` which handles pre-evaluated `Value` arguments in aggregate context.

**Fix**: Add `CONVERT` case to `evaluate_function_on_values()` that handles:
- Position values (extract units and convert)
- Amount values (convert directly)  
- Inventory values (convert each position, keep originals when no rate available)
- Number values (wrap as amount with target currency)
- Optional date argument for historical price lookup

### Python Beancount Compatibility

Updated behavior to match Python beancount's `convert.py`:
- When a conversion rate is unavailable, Python returns the **original amount unchanged** (not NULL, not skip)
- For inventories with mixed currencies where some can't be converted, returns an `Inventory` with:
  - Successfully converted positions in target currency
  - Unconvertible positions in their original currency
- Only returns a single `Amount` when all positions convert to target currency

### Before
```
$ rledger query ledger.bean "SELECT account, convert(sum(position), 'EUR') WHERE account = 'Assets:Bank:CHF' GROUP BY account"
error: failed to execute query: unknown function: convert
```

### After
```
$ rledger query ledger.bean "SELECT account, convert(sum(position), 'EUR') WHERE account = 'Assets:Bank:CHF' GROUP BY account"
┌───────────────────┬──────────────┐
│ account           │ convert(...) │
├───────────────────┼──────────────┤
│ Assets:Bank:CHF   │ 3194.10 EUR  │
└───────────────────┴──────────────┘
```

## Test plan

- [x] `convert(sum(position), 'EUR')` - original bug case (issue #565 regression test)
- [x] `convert(sum(position), 'CHF')` - already target currency
- [x] `convert(sum(position), 'EUR', date)` - with explicit date
- [x] Multiple currencies in inventory with conversion rates
- [x] Basic amount conversion (non-aggregate)
- [x] Number to currency wrapping
- [x] **Unconvertible currency kept in original** - JPY without price → keeps JPY in result
- [x] Full test suite passes (264 tests)
- [x] Clippy clean

Fixes #565

🤖 Generated with [Claude Code](https://claude.ai/code)