### PR TITLE
fix: implement implicit GROUP BY for aggregate queries (issue #575)

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -33,6 +33,34 @@ impl<'a> Executor<'a> {
             _ => false,
         }
     }
+
+    /// Extract non-aggregate expressions from SELECT targets for implicit GROUP BY.
+    ///
+    /// When aggregate functions are mixed with non-aggregated columns and no explicit
+    /// GROUP BY is provided, Python beancount implicitly groups by the non-aggregated
+    /// columns. This function extracts those columns.
+    ///
+    /// For example, in `SELECT sum(number), currency, account`:
+    /// - `sum(number)` is an aggregate
+    /// - `currency` and `account` are non-aggregates that should be grouped by
+    ///
+    /// Duplicate expressions are filtered out to avoid redundant evaluation during
+    /// grouping and unnecessarily larger group keys.
+    pub(super) fn extract_implicit_group_by_exprs(targets: &[Target]) -> Vec<Expr> {
+        let mut non_aggregate_exprs = Vec::new();
+        for target in targets {
+            // Skip wildcard - it expands to all columns, not useful for grouping
+            if matches!(target.expr, Expr::Wildcard) {
+                continue;
+            }
+            // Only include non-aggregate expressions, and deduplicate
+            if !Self::is_aggregate_expr(&target.expr) && !non_aggregate_exprs.contains(&target.expr)
+            {
+                non_aggregate_exprs.push(target.expr.clone());
+            }
+        }
+        non_aggregate_exprs
+    }
     pub(super) fn make_group_key(values: &[Value]) -> String {
         use std::fmt::Write;
         let mut key = String::new();

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -53,9 +53,30 @@ impl Executor<'_> {
             .iter()
             .any(|t| Self::is_aggregate_expr(&t.expr));
 
+        // Track whether grouping is applied (explicit or implicit) for fallback sort
+        let mut has_grouping = false;
+
         if is_aggregate {
+            // Determine GROUP BY expressions:
+            // - If explicit GROUP BY is provided, use it
+            // - Otherwise, implicitly group by non-aggregate columns in SELECT
+            //   (matches Python beancount behavior)
+            let group_by_exprs: Option<Vec<Expr>> = if query.group_by.is_some() {
+                query.group_by.clone()
+            } else {
+                let implicit = Self::extract_implicit_group_by_exprs(&query.targets);
+                if implicit.is_empty() {
+                    None // Pure aggregate like SELECT count(*)
+                } else {
+                    Some(implicit)
+                }
+            };
+
+            // Track if grouping is applied for deterministic fallback sort
+            has_grouping = group_by_exprs.is_some();
+
             // Group and aggregate
-            let grouped = self.group_postings(&postings, query.group_by.as_ref())?;
+            let grouped = self.group_postings(&postings, group_by_exprs.as_ref())?;
             for (_, group) in grouped {
                 // Use extended_targets to include hidden columns for ORDER BY
                 let row = self.evaluate_aggregate_row(&extended_targets, &group)?;
@@ -150,10 +171,9 @@ impl Executor<'_> {
         // Apply ORDER BY
         if let Some(order_by) = &query.order_by {
             self.sort_results(&mut result, order_by)?;
-        } else if query.group_by.is_some() && !result.rows.is_empty() && !result.columns.is_empty()
-        {
-            // When there's GROUP BY but no ORDER BY, sort by the first column
-            // for deterministic output (matches Python beancount behavior)
+        } else if has_grouping && !result.rows.is_empty() && !result.columns.is_empty() {
+            // When there's GROUP BY (explicit or implicit) but no ORDER BY, sort by
+            // the first column for deterministic output (matches Python beancount behavior)
             let first_col = result.columns[0].clone();
             let default_order = vec![OrderSpec {
                 expr: Expr::Column(first_col),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -5348,3 +5348,145 @@ fn test_issue_567_value_sum_position_with_implicit_price() {
         other => panic!("Expected Amount, got {other:?}"),
     }
 }
+
+// ============================================================================
+// Issue #575: Implicit GROUP BY for aggregate queries
+// ============================================================================
+
+/// Regression test for issue #575: Query returns just one row
+/// <https://github.com/rustledger/rustledger/issues/575>
+///
+/// When aggregate functions are mixed with non-aggregated columns and no explicit
+/// GROUP BY is provided, Python beancount implicitly groups by the non-aggregated
+/// columns. This test verifies that rustledger matches this behavior.
+#[test]
+fn test_issue_575_implicit_group_by() {
+    let directives = make_issue_575_directives();
+    let result = execute_query(
+        r"SELECT sum(number), currency, account ORDER BY account",
+        &directives,
+    );
+
+    // Should return 3 rows (one per unique account+currency combination)
+    // Python beancount output:
+    //   sum(num  cur       account
+    //   -------  ---  -----------------
+    //   -550.00  EUR  Assets:Bank
+    //      5     ABC  Assets:Investment
+    //    50.00  EUR  Expenses:Food
+    assert_eq!(
+        result.len(),
+        3,
+        "Should return 3 rows when implicitly grouping by currency and account"
+    );
+
+    // Check that we have the expected accounts (sorted by account name)
+    let accounts: Vec<&str> = result
+        .rows
+        .iter()
+        .map(|row| match &row[2] {
+            Value::String(s) => s.as_str(),
+            other => panic!("Expected String for account name in column 2, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(
+        accounts,
+        vec!["Assets:Bank", "Assets:Investment", "Expenses:Food"]
+    );
+
+    // Check the sum for Assets:Bank (-50 - 500 = -550 EUR)
+    if let Value::Number(n) = &result.rows[0][0] {
+        assert_eq!(*n, dec!(-550), "Assets:Bank should have sum -550");
+    } else {
+        panic!("Expected Number for Assets:Bank sum");
+    }
+
+    // Check the sum for Assets:Investment (5 ABC)
+    if let Value::Number(n) = &result.rows[1][0] {
+        assert_eq!(*n, dec!(5), "Assets:Investment should have sum 5");
+    } else {
+        panic!("Expected Number for Assets:Investment sum");
+    }
+
+    // Check the sum for Expenses:Food (50 EUR)
+    if let Value::Number(n) = &result.rows[2][0] {
+        assert_eq!(*n, dec!(50), "Expenses:Food should have sum 50");
+    } else {
+        panic!("Expected Number for Expenses:Food sum");
+    }
+}
+
+/// Test that pure aggregate queries without non-aggregate columns still work
+#[test]
+fn test_pure_aggregate_no_implicit_group_by() {
+    let directives = make_issue_575_directives();
+    let result = execute_query(r"SELECT count(*)", &directives);
+
+    // Should return 1 row with the total count
+    assert_eq!(result.len(), 1, "Pure aggregate should return 1 row");
+
+    if let Value::Integer(n) = &result.rows[0][0] {
+        // 4 postings total (2 from grocery, 2 from stock purchase)
+        assert_eq!(*n, 4, "Should count all 4 postings");
+    } else {
+        panic!("Expected Integer for count(*)");
+    }
+}
+
+/// Test explicit GROUP BY still works and takes precedence
+#[test]
+fn test_explicit_group_by_overrides_implicit() {
+    let directives = make_issue_575_directives();
+    let result = execute_query(
+        r"SELECT sum(number), currency GROUP BY currency ORDER BY currency",
+        &directives,
+    );
+
+    // Should return 2 rows (one per currency: ABC and EUR)
+    assert_eq!(
+        result.len(),
+        2,
+        "Explicit GROUP BY currency should return 2 rows"
+    );
+
+    // Check currencies
+    let currencies: Vec<&str> = result
+        .rows
+        .iter()
+        .map(|row| match &row[1] {
+            Value::String(s) => s.as_str(),
+            other => panic!("Expected String for currency in column 1, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(currencies, vec!["ABC", "EUR"]);
+}
+
+fn make_issue_575_directives() -> Vec<Directive> {
+    // Recreate the exact ledger from issue #575
+    vec![
+        Directive::Open(Open::new(date(2026, 3, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2026, 3, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2026, 3, 1), "Assets:Investment")),
+        Directive::Open(Open::new(date(2026, 3, 1), "Expenses:Food")),
+        Directive::Open(Open::new(date(2026, 3, 1), "Income:Salary")),
+        // Transaction 1: Groceries (50 EUR from bank to food)
+        Directive::Transaction(
+            Transaction::new(date(2026, 3, 26), "Grocery shopping")
+                .with_payee("Grocery Store")
+                .with_posting(Posting::new("Expenses:Food", Amount::new(dec!(50), "EUR")))
+                .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-50), "EUR"))),
+        ),
+        // Transaction 2: Buy stock (5 ABC @ 100 EUR each = 500 EUR)
+        Directive::Transaction(
+            Transaction::new(date(2026, 3, 27), "Buy Stock")
+                .with_posting(
+                    Posting::new("Assets:Investment", Amount::new(dec!(5), "ABC")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(100))
+                            .with_currency("EUR"),
+                    ),
+                )
+                .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-500), "EUR"))),
+        ),
+    ]
+}


### PR DESCRIPTION
## Summary

- Implemented implicit GROUP BY when aggregate functions are mixed with non-aggregated columns
- Added `extract_implicit_group_by_exprs()` helper to extract non-aggregate expressions
- Modified `execute_select()` to use implicit grouping when no explicit GROUP BY is provided

## Problem

Query `SELECT sum(number), currency, account ORDER BY account` returned 1 row instead of 3.

**Python beancount output (expected):**
```
sum(num  cur       account
-------  ---  -----------------
-550.00  EUR  Assets:Bank
   5     ABC  Assets:Investment
  50.00  EUR  Expenses:Food
```

**Rustledger output (before fix):**
```
sum  currency  account
----  --------  -------------
-495  EUR       Expenses:Food

1 row(s)
```

## Root Cause

When aggregate functions are mixed with non-aggregated columns and no explicit GROUP BY is provided, Python beancount implicitly groups by the non-aggregated columns. Rustledger was treating all postings as a single group.

## Fix

In `execute_select()`, when an aggregate query has no explicit GROUP BY:
1. Extract non-aggregate column expressions from SELECT targets
2. Use them as implicit GROUP BY expressions
3. Pass to `group_postings()` for proper grouping

## Test plan

- [x] `cargo test -p rustledger-query` - all 189 tests pass
- [x] `cargo clippy -p rustledger-query -- -D warnings` - no warnings
- [x] Added 3 regression tests:
  - `test_issue_575_implicit_group_by` - main regression test
  - `test_pure_aggregate_no_implicit_group_by` - verifies pure aggregates still work
  - `test_explicit_group_by_overrides_implicit` - verifies explicit GROUP BY takes precedence

Fixes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)