### PR TITLE
ci: add opencode workflow with pinned action version

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -41,7 +41,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
         with:
           persist-credentials: false
 
@@ -63,7 +63,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
         with:
           persist-credentials: false
 
@@ -108,7 +108,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
         with:
           persist-credentials: false
 
@@ -147,7 +147,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
         with:
           persist-credentials: false
 
@@ -199,6 +199,8 @@ jobs:
   get-open-issues:
     if: github.event_name == 'workflow_dispatch' && inputs.action == 'review-all-open'
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
     outputs:
       issues: ${{ steps.get-issues.outputs.issues }}
     steps:
@@ -227,7 +229,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow for opencode AI assistant integration.

### Trigger Methods

| Method | Action |
|--------|--------|
| Add label `opencode:fix` | Review issue → create PR if valid |
| Add label `opencode:review` | Review issue → comment only |
| Comment `/oc` or `/opencode` | Context-aware response |
| Manual `review-all-open` | Batch review all open issues |

Labels are **auto-removed** after processing, so you can re-apply to trigger again.

### Security
- Pin `anomalyco/opencode/github` to SHA `9f3c2bd861691e2415c027f87e23302b57026a6e`
- Write permissions for branches/PRs/issues (main protected by merge queue)

## Setup

Create these labels in your repo:
- `opencode:fix` (suggested color: `#28a745`)
- `opencode:review` (suggested color: `#0366d6`)

## Test plan

- [x] Workflow syntax is valid
- [ ] Add `opencode:review` label to test issue
- [ ] Add `opencode:fix` label to test issue

🤖 Generated with [Claude Code](https://claude.ai/code)