### PR TITLE
fix(ci): fix opencode workflow comment trigger condition

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -27,7 +27,9 @@ jobs:
   # Triggered by /oc or /opencode in comments
   opencode-comment:
     if: |
-      github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' && (
+      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+      github.event.comment.user.type != 'Bot' &&
+      (
         contains(github.event.comment.body, ' /oc') ||
         startsWith(github.event.comment.body, '/oc') ||
         contains(github.event.comment.body, ' /opencode') ||


### PR DESCRIPTION
## Summary
- Fix operator precedence bug in the `if` condition that caused the workflow to run on ALL `issue_comment` events
- Add check to skip bot comments to prevent feedback loops

## Problem
The `if` condition was:
```yaml
github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' && (...)
```

Due to `&&` having higher precedence than `||`, this evaluated as:
```
(issue_comment) || (pull_request_review_comment && contains_command)
```

This caused the workflow to trigger on **every** issue comment, creating a spam loop where the bot kept posting "Comments must mention /opencode" messages.

## Fix
- Add parentheses to ensure both event types require the `/oc` or `/opencode` command
- Add `github.event.comment.user.type != 'Bot'` to skip bot comments

## Test plan
- [x] Verify PR #609 stops receiving spam comments after this is merged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)