### PR TITLE
chore(ci): update taiki-e/install-action to v2.70.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install nextest
         if: matrix.install == 'nextest'
-        uses: taiki-e/install-action@735e5933943122c5ac182670a935f54a949265c1 # v2
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
         with:
           tool: cargo-nextest
         continue-on-error: true


### PR DESCRIPTION
## Summary

- Update `taiki-e/install-action` from v2.52.4 to v2.70.3 for nextest installation

## Problem

The current pinned version (v2.52.4 from May 2025) consistently fails with **403 errors** when downloading pre-built `cargo-nextest` binaries. This triggers the fallback step which compiles nextest from source, wasting ~3 minutes on every Test job.

Evidence from recent runs:
```
curl: (22) The requested URL returned error: 403
```

All recent CI runs show the same pattern:
| Run | Install nextest | Fallback (compile) | 
|-----|-----------------|-------------------|
| PR #616 | 59s (failed) | 2m 48s |
| main | 58s (failed) | 2m 49s |

## Solution

Update to v2.70.3 (latest), which is what nextest's own CI uses (v2.70.2).

## Expected Impact

- Test job duration: ~9min → ~6min (saving ~3min per PR)
- No more compilation of cargo-nextest from source

## Test Plan

- [ ] CI passes on this PR
- [ ] "Install nextest" step succeeds without fallback
- [ ] Test job completes faster than before

🤖 Generated with [Claude Code](https://claude.ai/code)