### PR TITLE
fix(lsp): use full ledger for code lens balance verification

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -167,6 +167,7 @@ pub fn handle_code_lens_resolve(
         // Calculate actual balance up to this date.
         // Use full ledger directives if available (multi-file mode), otherwise fall back
         // to single-file directives.
+        // TODO: Consider caching booked directives in LedgerState for large ledgers.
         let actual_balance = calculate_balance_at_date(
             ledger_directives.unwrap_or(&parse_result.directives),
             account,

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -796,11 +796,14 @@ impl MainLoopState {
 
         let (_text, parse_result) = self.get_document_data(&uri);
 
-        // Get full ledger directives for multi-file balance verification (issue #470)
-        let ledger_guard = self.ledger_state.read();
-        let ledger_directives = ledger_guard.directives();
-        let resolved = handle_code_lens_resolve(lens, &parse_result, ledger_directives);
-        drop(ledger_guard);
+        // Clone directives while holding the lock, then drop the guard before
+        // running the expensive balance calculation (issue #470).
+        let ledger_directives = {
+            let ledger_guard = self.ledger_state.read();
+            ledger_guard.directives().map(|d| d.to_vec())
+        };
+
+        let resolved = handle_code_lens_resolve(lens, &parse_result, ledger_directives.as_deref());
 
         serde_json::to_value(resolved).map_err(|e| e.to_string())
     }


### PR DESCRIPTION
## Summary

- Fixes issue where balance assertions depending on transactions in other included files showed "Unresolved lens ..." in editors
- Code lens resolve handler now uses full ledger directives when available
- Added test demonstrating multi-file balance verification

## Root Cause

The code lens resolve handler was calling `calculate_balance_at_date(parse_result, ...)` with only the current file's parse result, missing transactions from other included files. This caused balance assertions like:

```beancount
; bank.bean - expects 4950 USD (5000 - 50 from credit_card.bean)
2024-01-21 balance Assets:Bank:Checking 4950 USD
```

...to fail verification because the -50 USD transaction was in `credit_card.bean`.

## Changes

- `handle_code_lens_resolve` now accepts optional `ledger_directives: Option<&[Spanned<Directive>]>`
- `calculate_balance_at_date` uses full ledger when available, falls back to single-file
- `handle_code_lens_resolve_request` in main_loop.rs passes ledger directives from state
- Added `test_code_lens_resolve_multifile_balance` demonstrating the fix

## Test plan

- [x] All 94 LSP tests pass
- [x] New multi-file test verifies both single-file (fails) and multi-file (passes) cases
- [ ] Manual testing with nvim and the test case from issue #470

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)