### PR TITLE
fix(docs): fix dead link to contributing guide

### DIFF
--- a/docs/development/contributing-plugins.md
+++ b/docs/development/contributing-plugins.md
@@ -503,4 +503,4 @@ fn parse_config(config: &Option<String>) -> PluginConfig {
 
 - [Custom Plugins Guide](../guides/custom-plugins.md) - WASM plugins for personal use
 - [Plugins Reference](../reference/plugins.md) - All available plugins
-- [Contributing Guide](./contributing.md) - General contribution guidelines
+- [Contributing Guide](https://github.com/rustledger/rustledger/blob/main/CONTRIBUTING.md) - General contribution guidelines


### PR DESCRIPTION
## Summary

- Fix dead link in `development/contributing-plugins.md` that pointed to non-existent `./contributing.md`
- Updated to link to GitHub CONTRIBUTING.md

This was blocking the docs site deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)