### PR TITLE
fix(ci): correct create-github-app-token action SHA

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@9d6f79bcec259fa6188e167ad878eb3326c818db # v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Fix the docs-update workflow which has been failing since 2026-03-31.

## Problem

The SHA `9d6f79bcec259fa6188e167ad878eb3326c818db` doesn't exist in the `actions/create-github-app-token` repo:

```
##[error]Unable to resolve action `actions/create-github-app-token@9d6f79bcec259fa6188e167ad878eb3326c818db`, 
unable to find version `9d6f79bcec259fa6188e167ad878eb3326c818db`
```

This prevents docs changes from triggering website rebuilds, causing the rustledger.github.io deploy to fail with stale docs.

## Fix

Update to the correct SHA for v2.2.2: `fee1f7d63c2ff003460e3d139729b119787bc349`

## Impact

Once merged, any docs change will trigger the website to rebuild with the latest docs, fixing the current deploy failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)