### PR TITLE
ci: add docs validation workflow

### DIFF
--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -51,12 +51,13 @@ jobs:
         working-directory: website
         run: bun install --frozen-lockfile
 
-      - name: Copy docs from PR to website
+      - name: Sync docs from PR to website
         run: |
-          # Remove placeholder docs and copy from this PR
-          rm -rf website/docs/getting-started website/docs/commands website/docs/guides \
-                 website/docs/migration website/docs/reference website/docs/development
-          cp -r rustledger/docs/* website/docs/
+          # Use rsync to properly sync docs, deleting files that don't exist in PR
+          # This catches dead links to files that were removed
+          rsync -av --delete \
+            --exclude='.vitepress' \
+            rustledger/docs/ website/docs/
 
       - name: Build docs with VitePress
         working-directory: website


### PR DESCRIPTION
## Summary

Add a CI workflow that validates docs by building them with VitePress when `docs/**` changes.

## Problem

Currently, dead links and other docs errors aren't caught until the website tries to deploy, which happens after docs changes are merged. This caused the recent deploy failures (PR #631 fix wasn't caught before merge).

## Solution

Add `.github/workflows/docs-validate.yml` that:
1. Triggers on PRs and pushes that modify `docs/**`
2. Checks out the website repo (for VitePress config)
3. Copies docs from the PR
4. Runs VitePress build to validate

If VitePress finds dead links or other errors, the CI fails and the PR can't be merged.

## Example

If someone adds a link to a non-existent file:
```markdown
See the [Contributing Guide](./contributing.md)
```

The CI will fail with:
```
(!) Found dead link ./contributing in file development/contributing-plugins.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)