### PR TITLE
fix: align example WASM plugins with rustledger-plugin types

### DIFF
--- a/examples/wasm-plugin-currency-check/Cargo.toml
+++ b/examples/wasm-plugin-currency-check/Cargo.toml
@@ -4,12 +4,15 @@ version = "0.1.0"
 edition = "2021"
 description = "Plugin that validates currency usage across accounts"
 
+[workspace]
+
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [profile.release]
 opt-level = "s"

--- a/examples/wasm-plugin-currency-check/src/lib.rs
+++ b/examples/wasm-plugin-currency-check/src/lib.rs
@@ -8,7 +8,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-// Plugin types (matching beancount-plugin/src/types.rs)
+// Plugin types (matching rustledger-plugin/src/types.rs)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PluginInput {
     pub directives: Vec<DirectiveWrapper>,
@@ -31,29 +31,19 @@ pub struct PluginOptions {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PluginError {
     pub message: String,
+    pub source_file: Option<String>,
+    pub line_number: Option<u32>,
     pub severity: String,
-    pub date: Option<String>,
-    pub account: Option<String>,
 }
 
 impl PluginError {
     pub fn warning(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            source_file: None,
+            line_number: None,
             severity: "warning".to_string(),
-            date: None,
-            account: None,
         }
-    }
-
-    pub fn with_date(mut self, date: &str) -> Self {
-        self.date = Some(date.to_string());
-        self
-    }
-
-    pub fn with_account(mut self, account: &str) -> Self {
-        self.account = Some(account.to_string());
-        self
     }
 }
 
@@ -160,9 +150,9 @@ fn pack_error(message: &str) -> u64 {
         directives: Vec::new(),
         errors: vec![PluginError {
             message: message.to_string(),
+            source_file: None,
+            line_number: None,
             severity: "error".to_string(),
-            date: None,
-            account: None,
         }],
     };
     let bytes = rmp_serde::to_vec(&output).unwrap_or_default();
@@ -208,14 +198,10 @@ fn check_currencies(input: PluginInput) -> PluginOutput {
                     if !declared_currencies.is_empty()
                         && !declared_currencies.contains(&units.currency)
                     {
-                        errors.push(
-                            PluginError::warning(format!(
-                                "Currency '{}' used but not declared as commodity",
-                                units.currency
-                            ))
-                            .with_date(&wrapper.date)
-                            .with_account(&posting.account),
-                        );
+                        errors.push(PluginError::warning(format!(
+                            "Currency '{}' used but not declared as commodity (date: {}, account: {})",
+                            units.currency, wrapper.date, posting.account
+                        )));
                     }
                 }
 
@@ -225,14 +211,10 @@ fn check_currencies(input: PluginInput) -> PluginOutput {
                         if !declared_currencies.is_empty()
                             && !declared_currencies.contains(currency)
                         {
-                            errors.push(
-                                PluginError::warning(format!(
-                                    "Cost currency '{}' not declared as commodity",
-                                    currency
-                                ))
-                                .with_date(&wrapper.date)
-                                .with_account(&posting.account),
-                            );
+                            errors.push(PluginError::warning(format!(
+                                "Cost currency '{}' not declared as commodity (date: {}, account: {})",
+                                currency, wrapper.date, posting.account
+                            )));
                         }
                     }
                 }
@@ -245,15 +227,12 @@ fn check_currencies(input: PluginInput) -> PluginOutput {
         if currencies.len() > 1 {
             // Only warn for expense/income accounts
             if account.starts_with("Expenses:") || account.starts_with("Income:") {
-                let currency_list: Vec<_> = currencies.iter().collect();
-                errors.push(
-                    PluginError::warning(format!(
-                        "Account '{}' uses multiple currencies: {}",
-                        account,
-                        currency_list.join(", ")
-                    ))
-                    .with_account(account),
-                );
+                let currency_list: Vec<&str> = currencies.iter().map(|s| s.as_str()).collect();
+                errors.push(PluginError::warning(format!(
+                    "Account '{}' uses multiple currencies: {}",
+                    account,
+                    currency_list.join(", ")
+                )));
             }
         }
     }

--- a/examples/wasm-plugin-duplicate-detect/Cargo.toml
+++ b/examples/wasm-plugin-duplicate-detect/Cargo.toml
@@ -4,12 +4,15 @@ version = "0.1.0"
 edition = "2021"
 description = "Plugin that detects potentially duplicate transactions"
 
+[workspace]
+
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
 rmp-serde = "1.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [profile.release]
 opt-level = "s"

--- a/examples/wasm-plugin-duplicate-detect/src/lib.rs
+++ b/examples/wasm-plugin-duplicate-detect/src/lib.rs
@@ -8,7 +8,6 @@
 //! Configure with: "days=N" to look for duplicates within N days (default 3)
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 // Plugin types
 #[derive(Debug, Serialize, Deserialize)]
@@ -33,24 +32,19 @@ pub struct PluginOptions {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PluginError {
     pub message: String,
+    pub source_file: Option<String>,
+    pub line_number: Option<u32>,
     pub severity: String,
-    pub date: Option<String>,
-    pub account: Option<String>,
 }
 
 impl PluginError {
     pub fn warning(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            source_file: None,
+            line_number: None,
             severity: "warning".to_string(),
-            date: None,
-            account: None,
         }
-    }
-
-    pub fn with_date(mut self, date: &str) -> Self {
-        self.date = Some(date.to_string());
-        self
     }
 }
 
@@ -133,9 +127,9 @@ fn pack_error(message: &str) -> u64 {
         directives: Vec::new(),
         errors: vec![PluginError {
             message: message.to_string(),
+            source_file: None,
+            line_number: None,
             severity: "error".to_string(),
-            date: None,
-            account: None,
         }],
     };
     let bytes = rmp_serde::to_vec(&output).unwrap_or_default();
@@ -236,14 +230,11 @@ fn detect_duplicates(input: PluginInput) -> PluginOutput {
                 let key = (i.min(j), i.max(j));
                 if !reported.contains(&key) {
                     reported.insert(key);
-                    errors.push(
-                        PluginError::warning(format!(
-                            "Potential duplicate: '{}' on {} and '{}' on {} \
-                             (same payee {:?}, amount {} {})",
-                            narr1, date1, narr2, date2, fp1.payee, fp1.amount, fp1.currency
-                        ))
-                        .with_date(date1),
-                    );
+                    errors.push(PluginError::warning(format!(
+                        "Potential duplicate: '{}' on {} and '{}' on {} \
+                         (same payee {:?}, amount {} {})",
+                        narr1, date1, narr2, date2, fp1.payee, fp1.amount, fp1.currency
+                    )));
                 }
             }
         }

--- a/examples/wasm-plugin-template/src/lib.rs
+++ b/examples/wasm-plugin-template/src/lib.rs
@@ -1,4 +1,4 @@
-//! Example WASM plugin for ironcount.
+//! Example WASM plugin for rustledger.
 //!
 //! This plugin adds a "processed" tag to all transactions.
 //!
@@ -12,7 +12,7 @@
 use serde::{Deserialize, Serialize};
 use std::alloc::Layout;
 
-// Plugin data types (must match beancount-plugin types)
+// Plugin data types (must match rustledger-plugin types)
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AmountData {

--- a/examples/wasm-plugin/Cargo.toml
+++ b/examples/wasm-plugin/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 description = "Example Beancount WASM plugin"
 
+[workspace]
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/wasm-plugin/src/lib.rs
+++ b/examples/wasm-plugin/src/lib.rs
@@ -1,4 +1,4 @@
-//! Example WASM Plugin for Ironcount
+//! Example WASM Plugin for rustledger
 //!
 //! This plugin demonstrates how to create a WASM plugin that:
 //! 1. Receives directives from the host
@@ -18,7 +18,7 @@
 //! # target/wasm32-unknown-unknown/release/example_plugin.wasm
 //! ```
 //!
-//! # Using with ironcount
+//! # Using with rustledger
 //!
 //! ```beancount
 //! plugin "path/to/example_plugin.wasm"
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // Plugin Interface Types
-// These must match the types in beancount-plugin/src/types.rs
+// These must match the types in rustledger-plugin/src/types.rs
 // ============================================================================
 
 /// Input to the plugin from the host.
@@ -67,30 +67,30 @@ pub struct PluginOptions {
 pub struct PluginError {
     /// Error message.
     pub message: String,
+    /// Source file path (if any).
+    pub source_file: Option<String>,
+    /// Line number in source file (if any).
+    pub line_number: Option<u32>,
     /// Severity level.
     pub severity: String,
-    /// Associated date (if any).
-    pub date: Option<String>,
-    /// Associated account (if any).
-    pub account: Option<String>,
 }
 
 impl PluginError {
     pub fn error(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            source_file: None,
+            line_number: None,
             severity: "error".to_string(),
-            date: None,
-            account: None,
         }
     }
 
     pub fn warning(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            source_file: None,
+            line_number: None,
             severity: "warning".to_string(),
-            date: None,
-            account: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Fix PluginError struct** in example plugins to use correct fields (`source_file`, `line_number`) instead of wrong fields (`date`, `account`) that cause MessagePack deserialization failures
- **Add `[workspace]`** to Cargo.toml files to enable standalone builds
- **Add missing `serde_json` dependency** to currency-check and duplicate-detect examples
- **Update doc comments** from "ironcount/beancount-plugin" references to "rustledger"

## Test plan

- [x] `cargo check` passes for all 4 example plugins
- [x] `cargo test` passes for all example plugins with tests
- [ ] Build WASM targets: `cargo build --target wasm32-unknown-unknown --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)