### PR TITLE
fix(ci): add pipefail to detect crates.io publish failures

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -90,6 +90,7 @@ jobs:
             rustledger-lsp
           )
 
+          set -o pipefail
           FAILED=()
           for crate in "${CRATES[@]}"; do
             echo "::group::Publishing $crate"


### PR DESCRIPTION
## Summary
- The publish script used `cargo publish ... 2>&1 | tee /tmp/publish.log` but `| tee` swallows the exit code of `cargo publish`
- This caused a 403 error publishing `rustledger-lsp` to be silently reported as success
- Fix: add `set -o pipefail` so pipe failures propagate correctly

## Context
`rustledger-lsp` v0.11.0 was not published to crates.io because its trusted publishing (OIDC) config is missing on crates.io. The script didn't detect this failure. After merging this fix, the trusted publisher needs to be configured on crates.io for `rustledger-lsp`, then re-run the publish workflow.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)