### PR TITLE
feat: implement price caching for rledger price command

### DIFF
--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -1,0 +1,324 @@
+//! Disk-based price cache to reduce API calls.
+//!
+//! Stores fetched prices in a JSON file at `~/.cache/rledger/prices.json`.
+//! Entries expire after the configured TTL (default: 30 minutes).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use super::PriceResponse;
+
+/// Maximum age before stale entries are pruned on save (7 days).
+const PRUNE_AGE_SECS: u64 = 7 * 24 * 3600;
+
+/// A disk-backed price cache.
+pub struct PriceCache {
+    path: PathBuf,
+    ttl: Duration,
+    entries: HashMap<String, CachedPrice>,
+    dirty: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedPrice {
+    price: String,
+    currency: String,
+    date: String,
+    source: String,
+    cached_at: u64,
+}
+
+impl PriceCache {
+    /// Load cache from disk, or create empty if not found.
+    pub fn load(ttl_secs: u64) -> Self {
+        let path = cache_file_path();
+        let ttl = Duration::from_secs(ttl_secs);
+
+        let entries = if path.exists() {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+                Err(_) => HashMap::new(),
+            }
+        } else {
+            HashMap::new()
+        };
+
+        Self {
+            path,
+            ttl,
+            entries,
+            dirty: false,
+        }
+    }
+
+    /// Look up a cached price. Returns `None` if missing or expired.
+    ///
+    /// Historical prices (with a specific date in the key) never expire.
+    /// Latest prices expire after the configured TTL.
+    /// This matches Python bean-price behavior.
+    pub fn get(&self, key: &str) -> Option<PriceResponse> {
+        let entry = self.entries.get(key)?;
+
+        // Historical prices never expire; latest prices use TTL
+        let is_latest = key.ends_with(":latest");
+        if is_latest {
+            let now = now_secs();
+            if self.ttl.is_zero() || now.saturating_sub(entry.cached_at) > self.ttl.as_secs() {
+                return None; // Expired or caching disabled
+            }
+        }
+
+        let price: Decimal = entry.price.parse().ok()?;
+        let date = NaiveDate::parse_from_str(&entry.date, "%Y-%m-%d").ok()?;
+
+        Some(PriceResponse {
+            price,
+            currency: entry.currency.clone(),
+            date,
+            source: entry.source.clone(),
+        })
+    }
+
+    /// Insert a price into the cache.
+    pub fn insert(&mut self, key: &str, response: &PriceResponse) {
+        self.entries.insert(
+            key.to_string(),
+            CachedPrice {
+                price: response.price.to_string(),
+                currency: response.currency.clone(),
+                date: response.date.format("%Y-%m-%d").to_string(),
+                source: response.source.clone(),
+                cached_at: now_secs(),
+            },
+        );
+        self.dirty = true;
+    }
+
+    /// Save cache to disk (only if modified). Prunes stale entries.
+    pub fn save(&mut self) {
+        if !self.dirty {
+            return;
+        }
+
+        // Prune entries older than PRUNE_AGE_SECS
+        let now = now_secs();
+        self.entries
+            .retain(|_, v| now.saturating_sub(v.cached_at) < PRUNE_AGE_SECS);
+
+        // Ensure parent directory exists
+        if let Some(parent) = self.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        if let Ok(json) = serde_json::to_string_pretty(&self.entries)
+            && std::fs::write(&self.path, json).is_ok()
+        {
+            self.dirty = false;
+        }
+    }
+
+    /// Clear all cached entries and delete the cache file.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.dirty = false;
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Build a cache key from the request parameters.
+///
+/// Includes source name since different sources can return different prices
+/// for the same symbol (matching Python bean-price behavior).
+pub fn cache_key(source: &str, ticker: &str, currency: &str, date: Option<NaiveDate>) -> String {
+    let date_part = match date {
+        Some(d) => d.format("%Y-%m-%d").to_string(),
+        None => "latest".to_string(),
+    };
+    format!("{source}:{ticker}:{currency}:{date_part}")
+}
+
+fn cache_file_path() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from(".cache"))
+        .join("rledger")
+        .join("prices.json")
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_key_with_date() {
+        let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        assert_eq!(
+            cache_key("yahoo", "AAPL", "USD", Some(date)),
+            "yahoo:AAPL:USD:2024-01-15"
+        );
+    }
+
+    #[test]
+    fn test_cache_key_without_date() {
+        assert_eq!(
+            cache_key("yahoo", "AAPL", "USD", None),
+            "yahoo:AAPL:USD:latest"
+        );
+    }
+
+    #[test]
+    fn test_historical_price_never_expires() {
+        let mut cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache-hist.json"),
+            ttl: Duration::from_secs(0), // TTL=0 would expire latest prices
+            entries: HashMap::new(),
+            dirty: false,
+        };
+
+        let response = PriceResponse {
+            price: Decimal::new(15000, 2),
+            currency: "USD".to_string(),
+            date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            source: "yahoo".to_string(),
+        };
+
+        // Insert with a dated key (not "latest")
+        cache.insert("yahoo:AAPL:USD:2024-01-15", &response);
+        // Historical prices should never expire even with TTL=0
+        assert!(cache.get("yahoo:AAPL:USD:2024-01-15").is_some());
+    }
+
+    #[test]
+    fn test_insert_and_get() {
+        let mut cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache.json"),
+            ttl: Duration::from_secs(3600),
+            entries: HashMap::new(),
+            dirty: false,
+        };
+
+        let response = PriceResponse {
+            price: Decimal::new(15000, 2), // 150.00
+            currency: "USD".to_string(),
+            date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            source: "yahoo".to_string(),
+        };
+
+        cache.insert("yahoo:AAPL:USD:latest", &response);
+        assert!(cache.dirty);
+
+        let cached = cache.get("yahoo:AAPL:USD:latest");
+        assert!(cached.is_some());
+        let cached = cached.unwrap();
+        assert_eq!(cached.price, response.price);
+        assert_eq!(cached.currency, "USD");
+        assert_eq!(cached.source, "yahoo");
+    }
+
+    #[test]
+    fn test_get_expired_returns_none() {
+        let mut cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache.json"),
+            ttl: Duration::from_secs(0), // Expire immediately
+            entries: HashMap::new(),
+            dirty: false,
+        };
+
+        let response = PriceResponse {
+            price: Decimal::new(15000, 2),
+            currency: "USD".to_string(),
+            date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            source: "yahoo".to_string(),
+        };
+
+        cache.insert("yahoo:AAPL:USD:latest", &response);
+        // TTL is 0, so latest prices are always expired
+        assert!(cache.get("yahoo:AAPL:USD:latest").is_none());
+    }
+
+    #[test]
+    fn test_get_missing_returns_none() {
+        let cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache.json"),
+            ttl: Duration::from_secs(3600),
+            entries: HashMap::new(),
+            dirty: false,
+        };
+
+        assert!(cache.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_save_and_load_round_trip() {
+        let path = std::env::temp_dir().join("rustledger-test-cache-roundtrip.json");
+        let _ = std::fs::remove_file(&path); // Clean up from previous runs
+
+        let response = PriceResponse {
+            price: Decimal::new(15000, 2),
+            currency: "USD".to_string(),
+            date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            source: "yahoo".to_string(),
+        };
+
+        // Save
+        {
+            let mut cache = PriceCache {
+                path: path.clone(),
+                ttl: Duration::from_secs(3600),
+                entries: HashMap::new(),
+                dirty: false,
+            };
+            cache.insert("yahoo:AAPL:USD:latest", &response);
+            cache.save();
+            assert!(!cache.dirty, "dirty should be cleared after save");
+        }
+
+        // Load and verify
+        {
+            let cache = PriceCache {
+                path: path.clone(),
+                ttl: Duration::from_secs(3600),
+                entries: serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap(),
+                dirty: false,
+            };
+            let cached = cache.get("yahoo:AAPL:USD:latest");
+            assert!(cached.is_some(), "should find cached entry after load");
+            assert_eq!(cached.unwrap().price, response.price);
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache-clear.json"),
+            ttl: Duration::from_secs(3600),
+            entries: HashMap::new(),
+            dirty: false,
+        };
+
+        let response = PriceResponse {
+            price: Decimal::new(15000, 2),
+            currency: "USD".to_string(),
+            date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            source: "yahoo".to_string(),
+        };
+
+        cache.insert("key", &response);
+        cache.clear();
+        assert!(cache.entries.is_empty());
+        assert!(cache.get("key").is_none());
+    }
+}

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -6,6 +6,7 @@
 //! - Configurable commodity-to-source mappings
 //! - Fallback chains for reliability
 
+pub mod cache;
 pub mod external;
 pub mod sources;
 

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -73,6 +73,14 @@ pub struct PriceArgs {
     /// List configured sources and exit.
     #[arg(long)]
     list_sources: bool,
+
+    /// Disable the price cache for this run.
+    #[arg(long)]
+    no_cache: bool,
+
+    /// Clear the price cache before fetching.
+    #[arg(long)]
+    clear_cache: bool,
 }
 
 /// Main entry point with custom binary name (for bean-price compatibility).
@@ -105,8 +113,28 @@ pub fn main_with_name(bin_name: &str) -> ExitCode {
 
 /// Run the price command.
 pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
+    use crate::cmd::price::cache::{PriceCache, cache_key};
+
     // Create the registry with config
     let registry = PriceSourceRegistry::new(price_config);
+
+    // Handle --clear-cache (works even with --no-cache or cache_ttl=0)
+    let cache_ttl = price_config.effective_cache_ttl();
+    if args.clear_cache {
+        let mut c = PriceCache::load(cache_ttl);
+        c.clear();
+        if args.verbose {
+            eprintln!("Price cache cleared");
+        }
+    }
+
+    // Initialize cache (if enabled)
+    let cache_enabled = cache_ttl > 0 && !args.no_cache;
+    let mut cache = if cache_enabled {
+        Some(PriceCache::load(cache_ttl))
+    } else {
+        None
+    };
 
     // Handle --list-sources
     if args.list_sources {
@@ -182,28 +210,44 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     let mut handle = stdout.lock();
 
     // Fetch prices
+    let source_name_for_cache = args
+        .source
+        .as_deref()
+        .unwrap_or(price_config.effective_default_source());
+
     for symbol in &symbols_to_fetch {
+        // Check cache first
+        let key = cache_key(source_name_for_cache, symbol, &args.currency, date);
+        if let Some(ref c) = cache
+            && let Some(cached) = c.get(&key)
+        {
+            if args.verbose {
+                eprintln!("{symbol}: cached (source: {})", cached.source);
+            }
+            write_price(&mut handle, symbol, &cached, args.beancount)?;
+            continue;
+        }
+
+        // Fetch from network
         let result = if let Some(source_name) = &args.source {
-            // Use explicit source
             fetch_with_source(&registry, source_name, symbol, &args.currency, date)
         } else {
-            // Use mapping/default
             registry.fetch_price(symbol, &args.currency, date, &combined_mapping)
         };
 
         match result {
             Ok(response) => {
-                if args.beancount {
-                    // Output as beancount price directive
-                    let date_str = response.date.format("%Y-%m-%d");
-                    writeln!(
-                        handle,
-                        "{date_str} price {symbol} {} {}",
-                        response.price, response.currency
-                    )?;
-                } else {
-                    writeln!(handle, "{symbol}: {} {}", response.price, response.currency)?;
+                if let Some(ref mut c) = cache {
+                    // Use the actual source that responded (may differ from
+                    // default due to fallback chains)
+                    let actual_key = cache_key(&response.source, symbol, &args.currency, date);
+                    c.insert(&actual_key, &response);
+                    // Also store under the default source key for fast lookup
+                    if actual_key != key {
+                        c.insert(&key, &response);
+                    }
                 }
+                write_price(&mut handle, symbol, &response, args.beancount)?;
             }
             Err(e) => {
                 if args.verbose {
@@ -213,6 +257,11 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
                 }
             }
         }
+    }
+
+    // Save cache to disk
+    if let Some(ref mut c) = cache {
+        c.save();
     }
 
     Ok(())
@@ -237,6 +286,26 @@ fn fetch_with_source(
     };
 
     source.fetch_price(&request)
+}
+
+/// Write a price response to the output.
+fn write_price(
+    handle: &mut impl Write,
+    symbol: &str,
+    response: &crate::cmd::price::PriceResponse,
+    beancount: bool,
+) -> Result<()> {
+    if beancount {
+        let date_str = response.date.format("%Y-%m-%d");
+        writeln!(
+            handle,
+            "{date_str} price {symbol} {} {}",
+            response.price, response.currency
+        )?;
+    } else {
+        writeln!(handle, "{symbol}: {} {}", response.price, response.currency)?;
+    }
+    Ok(())
 }
 
 /// Run with an ad-hoc external command.
@@ -383,5 +452,26 @@ mod tests {
     fn test_price_args_list_sources() {
         let args = Args::parse_from(["price", "--list-sources"]);
         assert!(args.price_args.list_sources);
+    }
+
+    #[test]
+    fn test_price_args_no_cache() {
+        let args = Args::parse_from(["price", "--no-cache", "AAPL"]);
+        assert!(args.price_args.no_cache);
+        assert!(!args.price_args.clear_cache);
+    }
+
+    #[test]
+    fn test_price_args_clear_cache() {
+        let args = Args::parse_from(["price", "--clear-cache", "AAPL"]);
+        assert!(args.price_args.clear_cache);
+        assert!(!args.price_args.no_cache);
+    }
+
+    #[test]
+    fn test_price_args_clear_and_no_cache_together() {
+        let args = Args::parse_from(["price", "--clear-cache", "--no-cache", "AAPL"]);
+        assert!(args.price_args.clear_cache);
+        assert!(args.price_args.no_cache);
     }
 }

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -80,10 +80,11 @@ pub struct PriceConfig {
     /// timeout handling in the future.
     pub timeout: Option<u64>,
 
-    /// Cache TTL in seconds (0 = disabled).
+    /// Cache TTL in seconds (0 = disabled, default: 1800 = 30 minutes).
     ///
-    /// TODO: Caching is not yet implemented. This field is reserved for
-    /// future use to cache price responses and reduce API calls.
+    /// Cached prices are stored in the platform cache directory
+    /// (e.g., `~/.cache/rledger/prices.json` on Linux).
+    /// Use `--no-cache` to bypass or `--clear-cache` to reset.
     pub cache_ttl: Option<u64>,
 
     /// Custom price source definitions.
@@ -551,6 +552,13 @@ impl PriceConfig {
     /// Get the effective timeout in seconds.
     pub fn effective_timeout(&self) -> u64 {
         self.timeout.unwrap_or(30)
+    }
+
+    /// Get the effective cache TTL in seconds (0 = disabled).
+    ///
+    /// Default: 1800 seconds (30 minutes), matching Python bean-price.
+    pub fn effective_cache_ttl(&self) -> u64 {
+        self.cache_ttl.unwrap_or(1800)
     }
 }
 


### PR DESCRIPTION
## Summary
Add disk-based price cache to reduce API calls when running `rledger price`, matching Python `bean-price` caching behavior.

## Changes
- **New**: `crates/rustledger/src/cmd/price/cache.rs` — JSON-based disk cache at `~/.cache/rledger/prices.json`
- **Modified**: `price_cmd.rs` — `--no-cache` and `--clear-cache` CLI flags; cache integration in fetch loop
- **Modified**: `config.rs` — `effective_cache_ttl()` method (default: 1800s = 30 min); updated docs

## Behavior
- Cache enabled by default (30 min TTL, matching Python bean-price)
- `--no-cache` bypasses cache for a single run
- `--clear-cache` deletes cached entries before fetching
- `cache_ttl = 0` in config disables caching entirely
- Stale entries (>7 days) automatically pruned on save
- Verbose mode (`-v`) shows when results come from cache

## Config
```toml
[price]
cache_ttl = 1800  # 30 minutes (default)
# cache_ttl = 0   # disable caching
```

## Test plan
- [x] 6 unit tests for cache module (insert, get, expire, clear, key format)
- [x] 191 total rustledger tests pass
- [x] Clippy clean

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)