### PR TITLE
fix(query): add position column to FROM postings table path

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use chrono::Datelike;
-use rustledger_core::{Amount, Cost, Position, Transaction};
+use rustledger_core::{Amount, Position, Transaction};
 
 use crate::ast::{Expr, Literal, Target};
 use crate::error::QueryError;
@@ -233,22 +233,19 @@ impl Executor<'_> {
                     .collect(),
             )),
             "position" => {
-                // Position includes both units and cost
+                // Position includes both units and cost.
+                // Uses resolve() to handle both per-unit and total cost syntax.
                 if let Some(units) = posting.amount() {
                     if let Some(cost_spec) = &posting.cost
-                        && let (Some(number_per), Some(currency)) =
-                            (&cost_spec.number_per, &cost_spec.currency)
+                        && let Some(cost) = cost_spec.resolve(units.number, ctx.transaction.date)
                     {
-                        // Use Cost::new() to auto-quantize the cost number
-                        let cost = Cost::new(*number_per, currency.clone())
-                            .with_date_opt(cost_spec.date)
-                            .with_label_opt(cost_spec.label.clone());
-                        return Ok(Value::Position(Box::new(Position::with_cost(
+                        Ok(Value::Position(Box::new(Position::with_cost(
                             units.clone(),
                             cost,
-                        ))));
+                        ))))
+                    } else {
+                        Ok(Value::Position(Box::new(Position::simple(units.clone()))))
                     }
-                    Ok(Value::Position(Box::new(Position::simple(units.clone()))))
                 } else {
                     Ok(Value::Null)
                 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2026,7 +2026,9 @@ impl<'a> Executor<'a> {
     ///
     /// The table has columns:
     /// - `date`, `flag`, `payee`, `narration`: from parent transaction
-    /// - `account`, `number`, `currency`: posting units
+    /// - `account`: posting account
+    /// - `position`: posting units with cost (as `Value::Position`)
+    /// - `number`, `currency`: posting units
     /// - `cost_number`, `cost_currency`, `cost_date`, `cost_label`: cost basis info
     /// - `price`: posting price
     /// - `balance`: running balance for the account
@@ -2037,6 +2039,7 @@ impl<'a> Executor<'a> {
             "payee".to_string(),
             "narration".to_string(),
             "account".to_string(),
+            "position".to_string(),
             "number".to_string(),
             "currency".to_string(),
             "cost_number".to_string(),
@@ -2116,6 +2119,20 @@ impl<'a> Executor<'a> {
                     (Value::Null, Value::Null, Value::Null, Value::Null)
                 };
 
+                // Build position using resolve() to handle both per-unit and
+                // total cost syntax, matching evaluate_column("position")
+                let position_val = if let Some(units) = posting.amount() {
+                    if let Some(cost_spec) = &posting.cost
+                        && let Some(cost) = cost_spec.resolve(units.number, txn.date)
+                    {
+                        Value::Position(Box::new(Position::with_cost(units.clone(), cost)))
+                    } else {
+                        Value::Position(Box::new(Position::simple(units.clone())))
+                    }
+                } else {
+                    Value::Null
+                };
+
                 let price_val = posting
                     .price
                     .as_ref()
@@ -2134,6 +2151,7 @@ impl<'a> Executor<'a> {
                         .map_or(Value::Null, |p| Value::String(p.to_string())),
                     Value::String(txn.narration.to_string()),
                     Value::String(posting.account.to_string()),
+                    position_val,
                     number,
                     currency,
                     cost_number,

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -5382,6 +5382,85 @@ fn test_aggregate_context_weight_on_values() {
 }
 
 // ============================================================================
+// Postings Table: position column (#677)
+// ============================================================================
+
+#[test]
+fn test_postings_table_position_column_simple() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 15), "Groceries")
+                .with_posting(Posting::new("Expenses:Food", Amount::new(dec!(50), "USD")))
+                .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-50), "USD"))),
+        ),
+    ];
+
+    let result = execute_query(
+        "SELECT account, position FROM #postings WHERE account = 'Expenses:Food'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][1] {
+        Value::Position(pos) => {
+            assert_eq!(pos.units.number, dec!(50));
+            assert_eq!(pos.units.currency.as_ref(), "USD");
+            assert!(pos.cost.is_none());
+        }
+        other => panic!("Expected Position, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_postings_table_position_column_with_cost() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 15), "Buy stock")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1500), "USD"))),
+        ),
+    ];
+
+    let result = execute_query(
+        "SELECT account, position FROM #postings WHERE account = 'Assets:Brokerage'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][1] {
+        Value::Position(pos) => {
+            assert_eq!(pos.units.number, dec!(10));
+            assert_eq!(pos.units.currency.as_ref(), "AAPL");
+            let cost = pos.cost.as_ref().expect("should have cost");
+            assert_eq!(cost.number, dec!(150));
+            assert_eq!(cost.currency.as_ref(), "USD");
+        }
+        other => panic!("Expected Position, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_postings_table_position_in_select_star() {
+    let directives = make_postings_test_directives();
+    let result = execute_query("SELECT * FROM #postings", &directives);
+
+    assert!(
+        result.columns.contains(&"position".to_string()),
+        "position should be in SELECT * columns"
+    );
+}
+
+// ============================================================================
 // System Table Error Message Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary
Add the missing `position` column to `build_postings_table()`, fixing 16 conformance test failures for queries using `FROM postings`.

Based on Copilot's work in #698, rebased on current main (which includes #702) and formatted.

## Changes
- `executor/mod.rs`: Add `"position"` to column list, construct `Value::Position` from units + resolved cost
- 3 integration tests: simple position, position with cost, SELECT *

Supersedes #698 (format failure due to stale base)
Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)