### PR TITLE
fix(query): allow ORDER BY on expressions not in SELECT

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -31,8 +31,7 @@ impl Executor<'_> {
             }
         }
 
-        // Find ORDER BY expressions that are in GROUP BY but not in SELECT.
-        // These need to be added as hidden columns for sorting.
+        // Find ORDER BY expressions not in SELECT and add as hidden columns.
         let hidden_targets = self.find_hidden_order_by_targets(query);
         let num_hidden = hidden_targets.len();
 
@@ -203,10 +202,12 @@ impl Executor<'_> {
         Ok(result)
     }
 
-    /// Find ORDER BY expressions that are in GROUP BY but not in SELECT.
+    /// Find ORDER BY expressions not already in SELECT.
     ///
-    /// These expressions need to be added as hidden columns so sorting can work.
-    /// Returns targets with aliases set to the full expression string for matching.
+    /// These are added as hidden columns for sorting, then stripped from the final output.
+    /// For aggregate queries with explicit GROUP BY, only expressions in GROUP BY or
+    /// aggregate expressions are allowed. Returns targets with aliases set to the full
+    /// expression string for column-name matching in `sort_results`.
     fn find_hidden_order_by_targets(&self, query: &SelectQuery) -> Vec<Target> {
         let Some(order_by) = &query.order_by else {
             return Vec::new();
@@ -398,8 +399,15 @@ impl Executor<'_> {
             let result_row = self.evaluate_subquery_row(&extended_targets, row, &column_map)?;
 
             if query.distinct {
-                // O(1) hash-based deduplication
-                let row_hash = hash_row(&result_row);
+                // DISTINCT should only consider visible columns, not hidden sort columns.
+                let visible: Vec<Value>;
+                let hash_target = if num_hidden > 0 {
+                    visible = result_row[..result_row.len() - num_hidden].to_vec();
+                    &visible
+                } else {
+                    &result_row
+                };
+                let row_hash = hash_row(hash_target);
                 if seen_hashes.insert(row_hash) {
                     result.add_row(result_row);
                 }

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -50,9 +50,17 @@ impl Executor<'_> {
                         })?
                 }
                 _ => {
-                    return Err(QueryError::Evaluation(
-                        "ORDER BY expression must reference a selected column".to_string(),
-                    ));
+                    // For other expression kinds (binary ops, literals, etc.),
+                    // look up by string representation (matches hidden column aliases).
+                    let expr_str = spec.expr.to_string();
+                    column_indices
+                        .get(expr_str.as_str())
+                        .copied()
+                        .ok_or_else(|| {
+                            QueryError::Evaluation(format!(
+                                "ORDER BY expression not found in SELECT: {expr_str}"
+                            ))
+                        })?
                 }
             };
             let ascending = spec.direction != SortDirection::Desc;

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6660,7 +6660,7 @@ fn test_order_by_expression_not_in_select() {
     assert_eq!(result.columns.len(), 1, "hidden column should be stripped");
     assert_eq!(result.columns[0], "account");
 
-    // Accounts should be sorted by type: Assets(0) < Expenses(4) < Income(3)
+    // Accounts should be sorted by type: Assets(0) < Income(3) < Expenses(4)
     // account_sortkey produces "0-Assets:Cash", "3-Income:Salary", "4-Expenses:Food"
     let accounts: Vec<&str> = result
         .rows
@@ -6671,10 +6671,18 @@ fn test_order_by_expression_not_in_select() {
         })
         .collect();
 
-    // Assets should come before Expenses and Income
-    let first_assets = accounts.iter().position(|a| a.starts_with("Assets"));
-    let first_expenses = accounts.iter().position(|a| a.starts_with("Expenses"));
-    let first_income = accounts.iter().position(|a| a.starts_with("Income"));
+    let first_assets = accounts
+        .iter()
+        .position(|a| a.starts_with("Assets"))
+        .expect("expected an Assets account in query results");
+    let first_expenses = accounts
+        .iter()
+        .position(|a| a.starts_with("Expenses"))
+        .expect("expected an Expenses account in query results");
+    let first_income = accounts
+        .iter()
+        .position(|a| a.starts_with("Income"))
+        .expect("expected an Income account in query results");
     assert!(
         first_assets < first_income && first_income < first_expenses,
         "accounts should be sorted by type via account_sortkey: got {accounts:?}"
@@ -6705,4 +6713,20 @@ fn test_order_by_function_not_in_select_simple() {
 
     assert!(!result.rows.is_empty());
     assert_eq!(result.columns.len(), 1, "hidden column should be stripped");
+
+    // Verify rows are actually sorted by length
+    let accounts: Vec<&str> = result
+        .rows
+        .iter()
+        .filter_map(|r| match &r[0] {
+            Value::String(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        accounts
+            .windows(2)
+            .all(|pair| pair[0].len() <= pair[1].len()),
+        "accounts should be sorted by ascending length: got {accounts:?}"
+    );
 }


### PR DESCRIPTION
## Summary

- Generalize the hidden-column mechanism so any ORDER BY expression not in SELECT is added as a hidden column for sorting, then stripped from the final output
- Previously only worked for GROUP BY expressions; now works for all queries (e.g., `ORDER BY account_sortkey(account)` when only `account` is SELECTed)
- Applied to both the direct posting path and the system table path (`FROM #postings`)

## Test plan

- [x] `test_order_by_expression_not_in_select` — `ORDER BY account_sortkey(account)` with only `account` in SELECT
- [x] `test_order_by_function_not_in_select_simple` — `ORDER BY length(account)`
- [x] All 290 existing BQL integration tests pass (no regressions)
- [x] `cargo clippy` clean

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)