### PR TITLE
fix(check): emit E1005 (invalid account name) as parse-phase diagnostic

### DIFF
--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -158,6 +158,20 @@ impl ErrorCode {
             Severity::Error
         }
     }
+
+    /// Whether this error represents a parse-phase concern rather than a
+    /// semantic/validate-phase concern.
+    ///
+    /// Some checks — notably account-name structure (E1005) — are lexical in
+    /// nature and are conceptually part of parsing, even though rustledger
+    /// currently runs them during validation because the set of valid account
+    /// roots is not known until options have been resolved. Python beancount's
+    /// parser rejects these inputs at parse time, so we tag them as parse-phase
+    /// for consumers that distinguish the two (e.g. the conformance harness).
+    #[must_use]
+    pub const fn is_parse_phase(&self) -> bool {
+        matches!(self, Self::InvalidAccountName)
+    }
 }
 
 /// Severity level for validation messages.
@@ -244,5 +258,32 @@ impl ValidationError {
         self.span = Some(spanned.span);
         self.file_id = Some(spanned.file_id);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_account_name_is_parse_phase() {
+        // E1005 is a lexical/structural account-name check and must be
+        // reported as a parse-phase diagnostic, matching Python beancount.
+        assert!(ErrorCode::InvalidAccountName.is_parse_phase());
+    }
+
+    #[test]
+    fn other_account_errors_are_validate_phase() {
+        // Lifecycle errors remain semantic (validate-phase) concerns.
+        assert!(!ErrorCode::AccountNotOpen.is_parse_phase());
+        assert!(!ErrorCode::AccountAlreadyOpen.is_parse_phase());
+        assert!(!ErrorCode::AccountClosed.is_parse_phase());
+    }
+
+    #[test]
+    fn non_account_errors_are_validate_phase() {
+        assert!(!ErrorCode::TransactionUnbalanced.is_parse_phase());
+        assert!(!ErrorCode::BalanceAssertionFailed.is_parse_phase());
+        assert!(!ErrorCode::UnknownOption.is_parse_phase());
     }
 }

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -1116,12 +1116,17 @@ pub fn run(args: &Args) -> Result<ExitCode> {
 
     if !validation_errors.is_empty() {
         if json_mode {
+            let mut parse_phase_errors = 0usize;
             for err in &validation_errors {
                 let severity = if err.code.is_warning() {
                     "warning"
                 } else {
                     "error"
                 };
+                let is_parse_phase = err.code.is_parse_phase();
+                if is_parse_phase && !err.code.is_warning() {
+                    parse_phase_errors += 1;
+                }
                 diagnostics.push(JsonDiagnostic {
                     file: main_file_str.clone(),
                     line: 1, // Validation errors don't have precise locations yet
@@ -1129,14 +1134,19 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                     end_line: 1,
                     end_column: 1,
                     severity: severity.to_string(),
-                    phase: "validate".to_string(),
+                    phase: if is_parse_phase {
+                        "parse".to_string()
+                    } else {
+                        "validate".to_string()
+                    },
                     code: err.code.code().to_string(),
                     message: err.message.clone(),
                     hint: None,
                     context: Some(format!("{}", err.date)),
                 });
             }
-            validate_error_count += local_validation_error_count;
+            parse_error_count += parse_phase_errors;
+            validate_error_count += local_validation_error_count - parse_phase_errors;
         } else if !args.quiet {
             report::report_validation_errors(
                 &validation_errors,

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -153,6 +153,60 @@ fn test_check_json_output() {
     }
 }
 
+/// Regression for issue #736 case 1: an account whose root type is not one
+/// of the configured account names (defaults: Assets/Liabilities/Equity/
+/// Income/Expenses) must be reported as a parse-phase diagnostic in JSON
+/// output. This matches Python beancount, where the lexer itself rejects
+/// such account names, and satisfies the pta-standards conformance harness
+/// which classifies errors by the `phase` field.
+#[test]
+fn test_check_invalid_account_root_is_parse_phase() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(tmp.path(), "2024-01-01 open Savings:Emergency\n").expect("write");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--format", "json", "--no-cache"])
+        .arg(tmp.path())
+        .output()
+        .expect("Failed to run rledger check");
+
+    // Skip if this rledger build doesn't support --no-cache or --format json.
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("--no-cache") || stderr.contains("--format") {
+            eprintln!("Skipping: required flags not supported");
+            return;
+        }
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("check --format json should produce valid JSON");
+
+    let diagnostics = json["diagnostics"]
+        .as_array()
+        .expect("diagnostics array missing");
+    let e1005 = diagnostics
+        .iter()
+        .find(|d| d["code"] == "E1005")
+        .expect("expected E1005 diagnostic for Savings:Emergency");
+
+    assert_eq!(
+        e1005["phase"], "parse",
+        "E1005 must be phase=parse for conformance compatibility, got: {}",
+        e1005
+    );
+    assert_eq!(
+        json["parse_error_count"], 1,
+        "parse_error_count should include E1005; got json: {json}"
+    );
+    assert_eq!(
+        json["validate_error_count"], 0,
+        "validate_error_count should not include E1005; got json: {json}"
+    );
+}
+
 // =============================================================================
 // rledger query tests
 // =============================================================================

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -194,8 +194,7 @@ fn test_check_invalid_account_root_is_parse_phase() {
 
     assert_eq!(
         e1005["phase"], "parse",
-        "E1005 must be phase=parse for conformance compatibility, got: {}",
-        e1005
+        "E1005 must be phase=parse for conformance compatibility, got: {e1005}"
     );
     assert_eq!(
         json["parse_error_count"], 1,


### PR DESCRIPTION
## Summary

E1005 (invalid account name) checks whether an account's root is one of the configured account types. This is a lexical/structural concern — Python beancount's lexer itself rejects inputs like `2024-01-01 open Savings:Emergency` at parse time, because the account regex is parameterised by the `name_*` options. rustledger runs the same check in the validator (because it needs the resolved option values), but conceptually it's a parse-phase error.

Add `ErrorCode::is_parse_phase()` and have the JSON reporter in `rustledger check` honor it: E1005 now gets `phase: "parse"` and contributes to `parse_error_count` instead of `validate_error_count`.

This fixes case 1 of #736 (`invalid-account-root`) and brings rustledger in line with the pta-standards conformance harness classification introduced in rustledger/pta-standards#30 (which uses the `phase` field).

## Before / After

Input:
\`\`\`beancount
2024-01-01 open Savings:Emergency
\`\`\`

**Before:**
\`\`\`json
{"error_count":1, "parse_error_count":0, "validate_error_count":1,
 "diagnostics":[{"code":"E1005","phase":"validate", ...}]}
\`\`\`
Fails the `invalid-account-root` conformance test because the harness expects `parse: "error"`.

**After:**
\`\`\`json
{"error_count":1, "parse_error_count":1, "validate_error_count":0,
 "diagnostics":[{"code":"E1005","phase":"parse", ...}]}
\`\`\`

## Scope

Only `E1005` is reclassified. Other E1xxx account errors (`AccountNotOpen`, `AccountAlreadyOpen`, `AccountClosed`, `AccountCloseNotEmpty`) remain validate-phase — they are genuinely semantic/lifecycle concerns, not structural ones. The `is_parse_phase()` method makes it easy to add more codes to the list in the future if needed.

## Test plan

- [x] New unit tests in `rustledger_validate::error` pin the `is_parse_phase` contract: E1005 is parse, other account errors are validate, unrelated errors (TransactionUnbalanced, BalanceAssertionFailed, UnknownOption) are validate.
- [x] New integration test in `cli_commands_test` runs \`rledger check --format json --no-cache\` on the exact input from the issue and asserts \`phase="parse"\`, \`parse_error_count=1\`, \`validate_error_count=0\`.
- [x] Full \`cargo test --all-features\` passes.
- [x] \`cargo clippy --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

Refs #736 (case 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)