### PR TITLE
fix(query): apply SQL truthiness in WHERE clause and boolean operators

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -137,17 +137,18 @@ impl Executor<'_> {
     }
 
     /// Evaluate a predicate expression in the context of a posting.
+    ///
+    /// Uses SQL/beanquery truthiness via [`Self::to_bool`], so that functions
+    /// such as `grep(pattern, text)` (which return the matched substring or
+    /// NULL) can be used directly in a `WHERE` clause without an explicit
+    /// `IS NOT NULL` comparison.
     pub(super) fn evaluate_predicate(
         &self,
         expr: &Expr,
         ctx: &PostingContext,
     ) -> Result<bool, QueryError> {
         let value = self.evaluate_expr(expr, ctx)?;
-        match value {
-            Value::Boolean(b) => Ok(b),
-            Value::Null => Ok(false),
-            _ => Err(QueryError::Type("expected boolean expression".to_string())),
-        }
+        self.to_bool(&value)
     }
 
     /// Evaluate an expression in the context of a posting.

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -272,13 +272,36 @@ impl Executor<'_> {
         Ok(Value::Number(op(a, b)))
     }
 
-    /// Convert a value to boolean.
+    /// Convert a value to boolean using SQL/beanquery truthiness rules.
+    ///
+    /// Booleans pass through directly. NULL is false. Other types follow
+    /// Python beanquery's implicit truthiness so that functions like
+    /// `grep(pattern, text)` — which return the matched substring on success
+    /// and NULL on failure — work in `WHERE` and as operands of `AND`/`OR`/
+    /// `NOT` without an explicit comparison.
+    ///
+    /// - Strings: non-empty is true.
+    /// - Integers / numbers: non-zero is true.
+    /// - Sets / metadata / objects: non-empty is true.
+    /// - Other structured types (Date, Amount, Position, …): always true.
     pub(super) fn to_bool(&self, val: &Value) -> Result<bool, QueryError> {
-        match val {
-            Value::Boolean(b) => Ok(*b),
-            Value::Null => Ok(false),
-            _ => Err(QueryError::Type("expected boolean".to_string())),
-        }
+        Ok(match val {
+            Value::Boolean(b) => *b,
+            Value::Null => false,
+            Value::String(s) => !s.is_empty(),
+            Value::Integer(i) => *i != 0,
+            Value::Number(n) => !n.is_zero(),
+            Value::StringSet(s) => !s.is_empty(),
+            Value::Set(s) => !s.is_empty(),
+            Value::Metadata(m) => !m.is_empty(),
+            Value::Object(o) => !o.is_empty(),
+            // Date, Amount, Position, Inventory, Interval — present implies truthy.
+            Value::Date(_)
+            | Value::Amount(_)
+            | Value::Position(_)
+            | Value::Inventory(_)
+            | Value::Interval(_) => true,
+        })
     }
 
     /// Apply a binary operator to pre-evaluated values (for subquery context).

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -6798,6 +6798,46 @@ fn test_grep_with_null_narration() {
     }
 }
 
+/// Regression for issue #738: `grep(pattern, text)` returns the matched
+/// substring or NULL, and must be usable directly in a `WHERE` clause via
+/// SQL/beanquery truthiness. Previously failed with "expected boolean".
+#[test]
+fn test_grep_in_where_clause_truthy() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Income:Salary")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Coffee")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 3, 15), "Salary Payment")
+                .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(1000), "USD")))
+                .with_posting(Posting::auto("Income:Salary")),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2024, 3, 16), "Coffee shop")
+                .with_posting(Posting::new("Expenses:Coffee", Amount::new(dec!(5), "USD")))
+                .with_posting(Posting::auto("Assets:Bank")),
+        ),
+    ];
+
+    // The bare grep() call in WHERE must filter to the matching narration.
+    let result = execute_query(
+        "SELECT narration FROM #entries WHERE grep('Salary', narration)",
+        &directives,
+    );
+
+    assert_eq!(
+        result.rows.len(),
+        1,
+        "expected only the Salary transaction, got rows: {:?}",
+        result.rows
+    );
+    if let Value::String(narration) = &result.rows[0][0] {
+        assert!(narration.contains("Salary"), "got narration: {narration}");
+    } else {
+        panic!("expected String narration, got {:?}", result.rows[0][0]);
+    }
+}
+
 #[test]
 fn test_open_meta_from_postings_table() {
     let mut open = Open::new(date(2024, 1, 1), "Assets:Bank");


### PR DESCRIPTION
## Summary

`grep(pattern, text)` in Python beanquery returns the matched substring on success and NULL on failure (matching Python's `re.search().group(0)`), and works in `WHERE` clauses through Python's implicit truthiness. The issue author thought beanquery's `grep` returns a boolean, but the real story is that **rustledger's `WHERE` evaluator was too strict**:

\`\`\`sql
SELECT * FROM entries WHERE grep('Salary', narration)
\`\`\`

Failed with `error: failed to execute query: type error: expected boolean` even though `grep` itself was returning the correct String/NULL values from #729.

## Root cause

`evaluate_predicate` and `to_bool` in `rustledger-query` only accepted `Value::Boolean` and `Value::Null`, returning `Err("expected boolean")` for everything else. This rejected the String return value of `grep()` on a successful match.

## Fix

Switch both functions to SQL/beanquery-style truthiness:

| Value | Truthy when |
|---|---|
| `Boolean(b)` | `b` |
| `Null` | always false |
| `String(s)` | `!s.is_empty()` |
| `Integer(i)` / `Number(n)` | non-zero |
| `StringSet` / `Set` / `Metadata` / `Object` | non-empty |
| `Date` / `Amount` / `Position` / `Inventory` / `Interval` | present implies true |

`evaluate_predicate` now delegates to `to_bool` so WHERE and AND/OR/NOT agree on the rules.

## Test plan

- [x] New `test_grep_in_where_clause_truthy` covers the exact pattern from #738 — `WHERE grep('Salary', narration)` filters to only the matching transaction without an explicit `IS NOT NULL`.
- [x] Existing `test_grep_with_null_narration` (using `IS NOT NULL`) still passes.
- [x] Full \`cargo test --all-features\` passes (3,000+ tests).
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)