### PR TITLE
fix(booking): detect ambiguous lot match + track per-account methods

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -38,10 +38,27 @@ pub enum BookingError {
     /// Insufficient units in matching lots.
     #[error("insufficient units: need {requested} but only {available} available")]
     InsufficientUnits {
+        /// The account being reduced.
+        account: InternedStr,
         /// Requested reduction amount.
         requested: Decimal,
         /// Available amount.
         available: Decimal,
+    },
+
+    /// Multiple lots with differing costs matched the reduction.
+    ///
+    /// Raised by STRICT booking when a partial cost spec like `{}` matches
+    /// more than one non-identical lot. Mirrors Python beancount's
+    /// `AmbiguousMatchError`.
+    #[error("ambiguous lot match: {num_matches} lots match for {currency} in account {account}")]
+    AmbiguousMatch {
+        /// The account being reduced.
+        account: InternedStr,
+        /// The currency being reduced.
+        currency: InternedStr,
+        /// The number of matching lots.
+        num_matches: usize,
     },
 
     /// Interpolation failed after booking.
@@ -80,8 +97,12 @@ pub struct CapitalGain {
 pub struct BookingEngine {
     /// Inventory per account.
     inventories: FxHashMap<InternedStr, Inventory>,
-    /// Default booking method.
+    /// Default booking method, used for accounts without an explicit
+    /// booking method on their `open` directive.
     booking_method: BookingMethod,
+    /// Per-account booking method overrides (from `open` directives).
+    /// Looked up first, falling back to `booking_method` if absent.
+    account_methods: FxHashMap<InternedStr, BookingMethod>,
 }
 
 impl BookingEngine {
@@ -91,16 +112,37 @@ impl BookingEngine {
         Self {
             inventories: FxHashMap::default(),
             booking_method: BookingMethod::Fifo,
+            account_methods: FxHashMap::default(),
         }
     }
 
-    /// Create a booking engine with a specific booking method.
+    /// Create a booking engine with a specific default booking method.
     #[must_use]
     pub fn with_method(method: BookingMethod) -> Self {
         Self {
             inventories: FxHashMap::default(),
             booking_method: method,
+            account_methods: FxHashMap::default(),
         }
+    }
+
+    /// Register the booking method for a specific account.
+    ///
+    /// Call this for each `open` directive *before* booking transactions for
+    /// that account, so the engine uses the per-account method (e.g. FIFO,
+    /// LIFO, NONE) rather than the engine-wide default. Subsequent calls
+    /// overwrite the previous method for the account.
+    pub fn set_account_method(&mut self, account: InternedStr, method: BookingMethod) {
+        self.account_methods.insert(account, method);
+    }
+
+    /// Resolve the booking method for an account, falling back to the
+    /// engine-wide default if not registered.
+    fn method_for(&self, account: &InternedStr) -> BookingMethod {
+        self.account_methods
+            .get(account)
+            .copied()
+            .unwrap_or(self.booking_method)
     }
 
     /// Get the inventory for an account.
@@ -163,12 +205,15 @@ impl BookingEngine {
                         // This ensures subsequent postings in the same transaction see
                         // the updated inventory state (e.g., after first posting exhausts a lot).
                         //
-                        // Errors from reduce (ambiguous match, no matching lot, insufficient
-                        // units) are intentionally not surfaced here — the validator runs the
-                        // same lot-matching logic and reports them as E4xxx diagnostics with
-                        // proper context. Surfacing them here would produce duplicate errors.
-                        if let Ok(booking_result) =
-                            inv.reduce(units, Some(cost_spec), self.booking_method)
+                        // Booking errors (ambiguous match, no matching lot, insufficient
+                        // units) are propagated so callers see them once. The full
+                        // pipeline path in `rustledger check` filters failed transactions
+                        // out of the validator's input to avoid double-reporting against
+                        // the validator's independent lot-matching pass.
+                        let method = self.method_for(&posting.account);
+                        let booking_result = inv
+                            .reduce(units, Some(cost_spec), method)
+                            .map_err(|e| convert_core_booking_error(e, &posting.account, units))?;
                         {
                             // Check if multiple lots were matched
                             if booking_result.matched.len() > 1 {
@@ -374,6 +419,9 @@ impl BookingEngine {
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
             if let Some(IncompleteAmount::Complete(units)) = &posting.units {
+                // Resolve the per-account booking method before mutably
+                // borrowing the inventories map.
+                let method = self.method_for(&posting.account);
                 let inv = self.inventories.entry(posting.account.clone()).or_default();
 
                 // Determine if this is a reduction using is_reduced_by logic:
@@ -382,7 +430,7 @@ impl BookingEngine {
 
                 if is_reduction {
                     // Reduce from inventory
-                    let _ = inv.reduce(units, posting.cost.as_ref(), self.booking_method);
+                    let _ = inv.reduce(units, posting.cost.as_ref(), method);
                 } else {
                     // Add to inventory
                     let position = if let Some(cost_spec) = &posting.cost {
@@ -455,6 +503,43 @@ impl BookingEngine {
         let result = interpolate(&booked.transaction)?;
 
         Ok(result)
+    }
+}
+
+/// Convert a core inventory `BookingError` into the booking-layer error,
+/// attaching the account context that the core layer doesn't carry.
+fn convert_core_booking_error(
+    err: rustledger_core::BookingError,
+    account: &InternedStr,
+    units: &Amount,
+) -> BookingError {
+    use rustledger_core::BookingError as CoreError;
+    match err {
+        CoreError::AmbiguousMatch {
+            num_matches,
+            currency,
+        } => BookingError::AmbiguousMatch {
+            account: account.clone(),
+            currency,
+            num_matches,
+        },
+        CoreError::NoMatchingLot { .. } => BookingError::NoMatchingLot {
+            account: account.clone(),
+            units: format!("{units}"),
+        },
+        CoreError::InsufficientUnits {
+            requested,
+            available,
+            ..
+        } => BookingError::InsufficientUnits {
+            account: account.clone(),
+            requested,
+            available,
+        },
+        CoreError::CurrencyMismatch { .. } => BookingError::NoMatchingLot {
+            account: account.clone(),
+            units: format!("{units}"),
+        },
     }
 }
 

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -136,6 +136,30 @@ impl BookingEngine {
         self.account_methods.insert(account, method);
     }
 
+    /// Scan a sequence of directives and register any per-account booking
+    /// methods found on `open` directives. Open directives whose booking
+    /// method is absent or fails to parse are silently ignored (they fall
+    /// back to the engine-wide default).
+    ///
+    /// This is a convenience wrapper around [`Self::set_account_method`] for
+    /// the common pipeline pattern of scanning all directives once before
+    /// the booking loop. Call this before booking any transactions so the
+    /// engine uses each account's declared method rather than the
+    /// engine-wide default for every account.
+    pub fn register_account_methods<'a, I>(&mut self, directives: I)
+    where
+        I: IntoIterator<Item = &'a rustledger_core::Directive>,
+    {
+        for directive in directives {
+            if let rustledger_core::Directive::Open(open) = directive
+                && let Some(method_str) = &open.booking
+                && let Ok(method) = method_str.parse::<BookingMethod>()
+            {
+                self.set_account_method(open.account.clone(), method);
+            }
+        }
+    }
+
     /// Resolve the booking method for an account, falling back to the
     /// engine-wide default if not registered.
     fn method_for(&self, account: &InternedStr) -> BookingMethod {

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -159,9 +159,14 @@ impl BookingEngine {
                     let is_reduction = inv.is_reduced_by(units);
 
                     if is_reduction {
-                        // Use reduce (not try_reduce) to actually update the working inventory
+                        // Use reduce (not try_reduce) to actually update the working inventory.
                         // This ensures subsequent postings in the same transaction see
-                        // the updated inventory state (e.g., after first posting exhausts a lot)
+                        // the updated inventory state (e.g., after first posting exhausts a lot).
+                        //
+                        // Errors from reduce (ambiguous match, no matching lot, insufficient
+                        // units) are intentionally not surfaced here — the validator runs the
+                        // same lot-matching logic and reports them as E4xxx diagnostics with
+                        // proper context. Surfacing them here would produce duplicate errors.
                         if let Ok(booking_result) =
                             inv.reduce(units, Some(cost_spec), self.booking_method)
                         {

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -340,16 +340,21 @@ impl Inventory {
 }
 
 impl Inventory {
-    /// STRICT booking: require exactly one matching lot, or that all matched
-    /// lots are identical (same cost number + currency), in which case the
-    /// choice between them is irrelevant and we fall back to insertion order
-    /// (FIFO).
+    /// STRICT booking: require exactly one matching lot, unless either:
     ///
-    /// If multiple lots with *different* costs match — for example a wildcard
-    /// reduction `-5 AAPL {}` against an inventory holding both `{150 USD}`
-    /// and `{160 USD}` — the reduction is genuinely ambiguous and we return
-    /// `AmbiguousMatch`, matching Python beancount's `AmbiguousMatchError`
-    /// and the formal `STRICTCorrect.tla` specification.
+    /// - all matching lots are identical in cost, in which case the choice
+    ///   between them is irrelevant and we fall back to the same ordering as
+    ///   FIFO (oldest `cost.date` first — see [`Self::reduce_ordered`]), or
+    /// - the reduction exactly matches the total units available across the
+    ///   matching lots (full liquidation), in which case all of them may be
+    ///   drained together without ambiguity.
+    ///
+    /// If multiple lots with *different* costs match and the reduction does
+    /// not qualify for the full-liquidation exception — for example a
+    /// wildcard reduction `-5 AAPL {}` against an inventory holding both
+    /// `{150 USD}` and `{160 USD}` — the reduction is genuinely ambiguous and
+    /// we return `AmbiguousMatch`, matching Python beancount's
+    /// `AmbiguousMatchError` and the formal `STRICTCorrect.tla` specification.
     ///
     /// # The "interchangeable lots" heuristic
     ///
@@ -358,8 +363,8 @@ impl Inventory {
     /// deliberately ignore `cost.date` and `cost.label`: the user's cost spec
     /// could not have constrained those fields without naming them, so two
     /// lots that differ only on date/label could not have been distinguished
-    /// by the spec the user wrote, and FIFO is unambiguous within that
-    /// equivalence class.
+    /// by the spec the user wrote, and the date-ordered fallback is
+    /// unambiguous within that equivalence class.
     ///
     /// A stricter spec-derived check would compare each pair of matched lots
     /// on every cost field the spec did *not* constrain. The simpler

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -340,8 +340,14 @@ impl Inventory {
 }
 
 impl Inventory {
-    /// STRICT booking: require exactly one matching lot.
-    /// Also allows "total match exception": if reduction equals total inventory, accept.
+    /// STRICT booking: require exactly one matching lot, or that all matched
+    /// lots are identical (same cost), in which case the choice between them
+    /// is irrelevant and we fall back to insertion order (FIFO).
+    ///
+    /// If multiple lots with *different* costs match — for example a wildcard
+    /// reduction `-5 AAPL {}` against an inventory holding both `{150 USD}`
+    /// and `{160 USD}` — the reduction is genuinely ambiguous and we return
+    /// `AmbiguousMatch`, matching Python beancount's `AmbiguousMatchError`.
     pub(super) fn reduce_strict(
         &mut self,
         units: &Amount,
@@ -369,12 +375,44 @@ impl Inventory {
                 let idx = matching_indices[0];
                 self.reduce_from_lot(idx, units)
             }
-            _n => {
-                // When multiple lots match the same cost spec, Python beancount falls back to FIFO
-                // order rather than erroring. This is consistent with how beancount handles
-                // identical lots - if the cost spec is specified, it's considered "matched"
-                // and we just pick by insertion order.
-                self.reduce_ordered(units, spec, false)
+            n => {
+                // Are the matched lots financially interchangeable? Two lots
+                // count as identical if they have the same cost number + cost
+                // currency — the user-visible monetary identity. Date and label
+                // differences don't make a reduction ambiguous because the user
+                // could not have observed a different outcome based on the cost
+                // spec they wrote. Beancount falls back to FIFO in that case.
+                let first_key = self.positions[matching_indices[0]]
+                    .cost
+                    .as_ref()
+                    .map(|c| (c.number, c.currency.clone()));
+                let all_same_value = matching_indices.iter().skip(1).all(|&i| {
+                    let key = self.positions[i]
+                        .cost
+                        .as_ref()
+                        .map(|c| (c.number, c.currency.clone()));
+                    key == first_key
+                });
+
+                if all_same_value {
+                    return self.reduce_ordered(units, spec, false);
+                }
+
+                // Total match exception: if the reduction equals the sum of all
+                // matching lots, the user is selling the entire matched
+                // inventory and the lot choice doesn't matter — accept it.
+                let total_units: Decimal = matching_indices
+                    .iter()
+                    .map(|&i| self.positions[i].units.number.abs())
+                    .sum();
+                if total_units == units.number.abs() {
+                    return self.reduce_ordered(units, spec, false);
+                }
+
+                Err(BookingError::AmbiguousMatch {
+                    num_matches: n,
+                    currency: units.currency.clone(),
+                })
             }
         }
     }

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -341,13 +341,33 @@ impl Inventory {
 
 impl Inventory {
     /// STRICT booking: require exactly one matching lot, or that all matched
-    /// lots are identical (same cost), in which case the choice between them
-    /// is irrelevant and we fall back to insertion order (FIFO).
+    /// lots are identical (same cost number + currency), in which case the
+    /// choice between them is irrelevant and we fall back to insertion order
+    /// (FIFO).
     ///
     /// If multiple lots with *different* costs match — for example a wildcard
     /// reduction `-5 AAPL {}` against an inventory holding both `{150 USD}`
     /// and `{160 USD}` — the reduction is genuinely ambiguous and we return
-    /// `AmbiguousMatch`, matching Python beancount's `AmbiguousMatchError`.
+    /// `AmbiguousMatch`, matching Python beancount's `AmbiguousMatchError`
+    /// and the formal `STRICTCorrect.tla` specification.
+    ///
+    /// # The "interchangeable lots" heuristic
+    ///
+    /// We treat two matched lots as interchangeable when their `(cost.number,
+    /// cost.currency)` agree — the user-visible monetary identity. We
+    /// deliberately ignore `cost.date` and `cost.label`: the user's cost spec
+    /// could not have constrained those fields without naming them, so two
+    /// lots that differ only on date/label could not have been distinguished
+    /// by the spec the user wrote, and FIFO is unambiguous within that
+    /// equivalence class.
+    ///
+    /// A stricter spec-derived check would compare each pair of matched lots
+    /// on every cost field the spec did *not* constrain. The simpler
+    /// number+currency check matches Python beancount's behavior for the
+    /// real-world cases we know about (see
+    /// `test_reduce_strict_multiple_match_with_identical_costs_uses_fifo` and
+    /// the `test_validate_multiple_lot_match_uses_fifo` integration test for
+    /// the same-cost-different-date case).
     pub(super) fn reduce_strict(
         &mut self,
         units: &Amount,

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -605,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reduce_strict_multiple_match_uses_fifo() {
+    fn test_reduce_strict_multiple_match_with_different_costs_is_ambiguous() {
         let mut inv = Inventory::new();
 
         let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
@@ -614,15 +614,59 @@ mod tests {
         inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
         inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
 
-        // Reducing without cost spec in STRICT mode falls back to FIFO
-        // (Python beancount behavior: when multiple lots match, use FIFO order)
+        // Per Python beancount: a wildcard reduction (`-3 AAPL` with no cost
+        // spec) against an inventory with lots at different costs is
+        // genuinely ambiguous and must error. Issue #737.
+        let result = inv.reduce(&Amount::new(dec!(-3), "AAPL"), None, BookingMethod::Strict);
+
+        assert!(
+            matches!(result, Err(BookingError::AmbiguousMatch { .. })),
+            "expected AmbiguousMatch, got {result:?}"
+        );
+        // Inventory unchanged after a failed reduction
+        assert_eq!(inv.units("AAPL"), dec!(15));
+    }
+
+    #[test]
+    fn test_reduce_strict_multiple_match_with_identical_costs_uses_fifo() {
+        let mut inv = Inventory::new();
+
+        // Two lots with identical cost — interchangeable, so FIFO is fine.
+        let cost = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
+
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            cost.clone(),
+        ));
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost));
+
         let result = inv
             .reduce(&Amount::new(dec!(-3), "AAPL"), None, BookingMethod::Strict)
-            .unwrap();
+            .expect("identical lots should fall back to FIFO without error");
 
-        assert_eq!(inv.units("AAPL"), dec!(12)); // 7 + 5 remaining
-        // Should reduce from first lot (cost1) at 150.00 USD
-        assert_eq!(result.cost_basis.unwrap().number, dec!(450.00)); // 3 * 150
+        assert_eq!(inv.units("AAPL"), dec!(12));
+        assert_eq!(result.cost_basis.unwrap().number, dec!(450.00));
+    }
+
+    #[test]
+    fn test_reduce_strict_multiple_match_total_match_exception() {
+        let mut inv = Inventory::new();
+
+        let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 1));
+        let cost2 = Cost::new(dec!(160.00), "USD").with_date(date(2024, 1, 15));
+
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
+        inv.add(Position::with_cost(Amount::new(dec!(5), "AAPL"), cost2));
+
+        // Selling exactly the entire inventory (10 + 5 = 15) is unambiguous
+        // even with mixed costs — the user is liquidating the position.
+        let result = inv
+            .reduce(&Amount::new(dec!(-15), "AAPL"), None, BookingMethod::Strict)
+            .expect("total-match exception should accept a full liquidation");
+
+        assert_eq!(inv.units("AAPL"), dec!(0));
+        // Cost basis = 10*150 + 5*160 = 1500 + 800 = 2300
+        assert_eq!(result.cost_basis.unwrap().number, dec!(2300.00));
     }
 
     #[test]

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -649,6 +649,28 @@ mod tests {
     }
 
     #[test]
+    fn test_reduce_strict_multiple_match_different_dates_same_cost_uses_fifo() {
+        let mut inv = Inventory::new();
+
+        // Two lots at the same cost number but different acquisition dates.
+        // The user's cost spec could not have constrained the date without
+        // naming it, so the lots are interchangeable for the spec — FIFO.
+        let cost1 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 1, 15));
+        let cost2 = Cost::new(dec!(150.00), "USD").with_date(date(2024, 2, 15));
+
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost1));
+        inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
+
+        let result = inv
+            .reduce(&Amount::new(dec!(-5), "AAPL"), None, BookingMethod::Strict)
+            .expect("same cost number, different dates should fall back to FIFO");
+
+        assert_eq!(inv.units("AAPL"), dec!(15));
+        // Reduced from the first (oldest) lot at 150.00 USD: 5 * 150 = 750.
+        assert_eq!(result.cost_basis.unwrap().number, dec!(750.00));
+    }
+
+    #[test]
     fn test_reduce_strict_multiple_match_total_match_exception() {
         let mut inv = Inventory::new();
 

--- a/crates/rustledger-core/tests/tla_proptest.rs
+++ b/crates/rustledger-core/tests/tla_proptest.rs
@@ -9,7 +9,7 @@ use chrono::NaiveDate;
 use proptest::prelude::*;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use rustledger_core::{Amount, BookingMethod, Cost, CostSpec, Inventory, Position};
+use rustledger_core::{Amount, BookingError, BookingMethod, Cost, CostSpec, Inventory, Position};
 
 // ============================================================================
 // Test Strategies
@@ -313,18 +313,18 @@ proptest! {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(50))]
 
-    /// TLA+ STRICTCorrect (Python-compatible):
-    /// STRICT booking falls back to FIFO when multiple lots match.
-    /// This matches Python beancount's behavior where ambiguous matches
-    /// use FIFO order rather than erroring.
+    /// TLA+ STRICTCorrect (Python-compatible, issue #737):
+    /// STRICT booking errors with `AmbiguousMatch` when a wildcard reduction
+    /// targets multiple lots with *different* costs. The user must
+    /// disambiguate by specifying a cost, date, or label.
     #[test]
-    fn prop_strict_uses_fifo_on_ambiguous(
+    fn prop_strict_errors_on_ambiguous_match(
         cost in 100i64..200,
     ) {
         let mut inv = Inventory::new();
         let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
 
-        // Add two lots with same currency (ambiguous match)
+        // Add two lots with the same currency at different costs.
         inv.add(Position::with_cost(
             Amount::new(dec!(10), "AAPL"),
             Cost::new(Decimal::from(cost), "USD").with_date(date),
@@ -334,30 +334,17 @@ proptest! {
             Cost::new(Decimal::from(cost + 10), "USD").with_date(date),
         ));
 
-        // STRICT falls back to FIFO when multiple lots match
         let result = inv.reduce(
             &Amount::new(dec!(-5), "AAPL"),
             None,
             BookingMethod::Strict,
         );
 
-        // Should succeed with FIFO behavior
         prop_assert!(
-            result.is_ok(),
-            "STRICT should fall back to FIFO with multiple matching lots, but got error: {:?}",
-            result.unwrap_err()
+            matches!(result, Err(BookingError::AmbiguousMatch { .. })),
+            "STRICT must error on ambiguous wildcard reduction, got: {:?}",
+            result
         );
-
-        // Should have reduced from the first lot (cost)
-        let booking_result = result.unwrap();
-        if let Some(cost_basis) = booking_result.cost_basis {
-            // 5 units at cost price = 5 * cost
-            prop_assert_eq!(
-                cost_basis.number,
-                Decimal::from(5 * cost),
-                "Cost basis should be from first lot"
-            );
-        }
     }
 
     /// TLA+ STRICTCorrect:

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -201,6 +201,7 @@ pub fn load_source(source: &str) -> LoadResult {
             .parse()
             .unwrap_or(rustledger_core::BookingMethod::Strict);
         let mut booking_engine = BookingEngine::with_method(booking_method);
+        booking_engine.register_account_methods(directives.iter());
 
         for (i, directive) in directives.iter_mut().enumerate() {
             if let Directive::Transaction(txn) = directive {

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -165,6 +165,7 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
         .parse()
         .unwrap_or(rustledger_core::BookingMethod::Strict);
     let mut booking_engine = BookingEngine::with_method(booking_method);
+    booking_engine.register_account_methods(directives.iter());
 
     for (i, directive) in directives.iter_mut().enumerate() {
         if let Directive::Transaction(txn) = directive {

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -249,6 +249,7 @@ fn run_booking(
     use rustledger_booking::BookingEngine;
 
     let mut engine = BookingEngine::with_method(options.booking_method);
+    engine.register_account_methods(directives.iter().map(|s| &s.value));
 
     for spanned in directives.iter_mut() {
         if let Directive::Transaction(txn) = &mut spanned.value {

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -234,6 +234,7 @@ fn calculate_balance_at_date(
 
     // Run booking/interpolation to fill in missing amounts
     let mut booking_engine = BookingEngine::with_method(BookingMethod::Strict);
+    booking_engine.register_account_methods(directives.iter().map(|s| &s.value));
     for spanned in &mut directives {
         if let Directive::Transaction(txn) = &mut spanned.value
             && let Ok(result) = booking_engine.book_and_interpolate(txn)

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -163,6 +163,7 @@ pub fn validation_errors_to_diagnostics(
     // This fills in missing amounts (auto-balancing) so validation sees the complete picture.
     // Use Strict booking method to match rledger check's default behavior.
     let mut booking_engine = BookingEngine::with_method(BookingMethod::Strict);
+    booking_engine.register_account_methods(booked_directives.iter().map(|s| &s.value));
     for spanned in &mut booked_directives {
         if let Directive::Transaction(txn) = &mut spanned.value
             && let Ok(result) = booking_engine.book_and_interpolate(txn)

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -667,6 +667,7 @@ include "accounts.beancount"
         // Extract directives and book transactions
         let mut directives: Vec<_> = result.directives.into_iter().map(|s| s.value).collect();
         let mut engine = BookingEngine::new();
+        engine.register_account_methods(directives.iter());
         for directive in &mut directives {
             if let Directive::Transaction(txn) = directive {
                 if let Ok(result) = engine.book_and_interpolate(txn) {

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -672,18 +672,10 @@ pub fn run(args: &Args) -> Result<ExitCode> {
         .parse()
         .unwrap_or(BookingMethod::Strict);
     let mut booking_engine = BookingEngine::with_method(booking_method);
-
     // Register per-account booking methods from Open directives so the
     // booking engine uses the right method for each account (FIFO/LIFO/NONE/
     // STRICT/etc.) instead of the engine-wide default for all accounts.
-    for spanned in &spanned_directives {
-        if let Directive::Open(open) = &spanned.value
-            && let Some(method_str) = &open.booking
-            && let Ok(method) = method_str.parse::<BookingMethod>()
-        {
-            booking_engine.set_account_method(open.account.clone(), method);
-        }
-    }
+    booking_engine.register_account_methods(spanned_directives.iter().map(|s| &s.value));
 
     let mut interpolation_errors: Vec<(NaiveDate, String, InterpolationError)> = Vec::new();
     // Lot-matching errors raised by the booking layer (ambiguous lot match,

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -672,9 +672,30 @@ pub fn run(args: &Args) -> Result<ExitCode> {
         .parse()
         .unwrap_or(BookingMethod::Strict);
     let mut booking_engine = BookingEngine::with_method(booking_method);
-    let mut interpolation_errors: Vec<(NaiveDate, String, InterpolationError)> = Vec::new();
 
-    for spanned in &mut spanned_directives {
+    // Register per-account booking methods from Open directives so the
+    // booking engine uses the right method for each account (FIFO/LIFO/NONE/
+    // STRICT/etc.) instead of the engine-wide default for all accounts.
+    for spanned in &spanned_directives {
+        if let Directive::Open(open) = &spanned.value
+            && let Some(method_str) = &open.booking
+            && let Ok(method) = method_str.parse::<BookingMethod>()
+        {
+            booking_engine.set_account_method(open.account.clone(), method);
+        }
+    }
+
+    let mut interpolation_errors: Vec<(NaiveDate, String, InterpolationError)> = Vec::new();
+    // Lot-matching errors raised by the booking layer (ambiguous lot match,
+    // no matching lot, insufficient units). Reported as E4xxx diagnostics.
+    let mut booking_errors: Vec<(NaiveDate, String, rustledger_booking::BookingError)> = Vec::new();
+    // Indices of transactions whose booking failed. These are filtered out of
+    // the validator's input below so that booking and the validator's own
+    // independent lot-matching pass don't double-report the same diagnostic.
+    let mut failed_booking_indices: std::collections::HashSet<usize> =
+        std::collections::HashSet::new();
+
+    for (idx, spanned) in spanned_directives.iter_mut().enumerate() {
         if let Directive::Transaction(txn) = &mut spanned.value {
             match booking_engine.book_and_interpolate(txn) {
                 Ok(result) => {
@@ -682,16 +703,35 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                     *txn = result.transaction;
                 }
                 Err(e) => {
-                    if let rustledger_booking::BookingError::Interpolation(interp_err) = e {
-                        interpolation_errors.push((
-                            txn.date,
-                            txn.narration.to_string(),
-                            interp_err,
-                        ));
+                    failed_booking_indices.insert(idx);
+                    match e {
+                        rustledger_booking::BookingError::Interpolation(interp_err) => {
+                            interpolation_errors.push((
+                                txn.date,
+                                txn.narration.to_string(),
+                                interp_err,
+                            ));
+                        }
+                        other => {
+                            booking_errors.push((txn.date, txn.narration.to_string(), other));
+                        }
                     }
                 }
             }
         }
+    }
+
+    // Drop failed-booking transactions from the validator's input. The
+    // validator runs its own lot-matching pass over the directives it
+    // receives, and we've already reported the booking failures above —
+    // including them in validation would emit a duplicate E4xxx diagnostic.
+    if !failed_booking_indices.is_empty() {
+        spanned_directives = spanned_directives
+            .into_iter()
+            .enumerate()
+            .filter(|(i, _)| !failed_booking_indices.contains(i))
+            .map(|(_, s)| s)
+            .collect();
     }
 
     // Extract directives and spans in a single pass for efficiency
@@ -1075,6 +1115,48 @@ pub fn run(args: &Args) -> Result<ExitCode> {
         }
     }
     error_count += interpolation_errors.len();
+
+    // Report booking errors (ambiguous lot match, no matching lot, insufficient
+    // units) propagated from the booking engine. These map to validation-phase
+    // E4xxx codes per spec/core/validation.md.
+    if !booking_errors.is_empty() {
+        let code_for = |err: &rustledger_booking::BookingError| -> &'static str {
+            match err {
+                rustledger_booking::BookingError::AmbiguousMatch { .. } => "E4003",
+                rustledger_booking::BookingError::NoMatchingLot { .. } => "E4001",
+                rustledger_booking::BookingError::InsufficientUnits { .. } => "E4002",
+                rustledger_booking::BookingError::Interpolation(_) => "INTERP",
+            }
+        };
+        if json_mode {
+            for (date, narration, err) in &booking_errors {
+                diagnostics.push(JsonDiagnostic {
+                    file: main_file_str.clone(),
+                    line: 1,
+                    column: 1,
+                    end_line: 1,
+                    end_column: 1,
+                    severity: "error".to_string(),
+                    phase: "validate".to_string(),
+                    code: code_for(err).to_string(),
+                    message: format!("{err}"),
+                    hint: None,
+                    context: Some(format!("{date}, \"{narration}\"")),
+                });
+            }
+            validate_error_count += booking_errors.len();
+        } else if !args.quiet {
+            for (date, narration, err) in &booking_errors {
+                writeln!(
+                    stdout,
+                    "error[{}]: {err} ({date}, \"{narration}\")",
+                    code_for(err)
+                )?;
+                writeln!(stdout)?;
+            }
+        }
+    }
+    error_count += booking_errors.len();
 
     // Validate the directives
     if args.verbose && !args.quiet {

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -206,6 +206,76 @@ fn test_check_invalid_account_root_is_parse_phase() {
     );
 }
 
+/// Regression for issue #737: a wildcard reduction `-5 AAPL {}` against an
+/// inventory holding lots at different costs must produce exactly one E4003
+/// "Ambiguous lot match" diagnostic — not zero (the original silent-accept
+/// bug) and not two (the validator/booking double-report).
+#[test]
+fn test_check_ambiguous_lot_match_reports_once() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(
+        tmp.path(),
+        "\
+2024-01-01 open Assets:Stock AAPL \"STRICT\"
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Income:Gains
+
+2024-01-15 * \"Buy lot 1\"
+  Assets:Stock 10 AAPL {150 USD}
+  Assets:Cash -1500 USD
+
+2024-01-20 * \"Buy lot 2\"
+  Assets:Stock 10 AAPL {160 USD}
+  Assets:Cash -1600 USD
+
+2024-02-15 * \"Sell - ambiguous\"
+  Assets:Stock -5 AAPL {}
+  Assets:Cash 800 USD
+  Income:Gains
+",
+    )
+    .expect("write");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--format", "json", "--no-cache"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to run rledger check");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("--no-cache") || stderr.contains("--format") {
+            eprintln!("Skipping: required flags not supported");
+            return;
+        }
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("check --format json should produce valid JSON");
+
+    let diagnostics = json["diagnostics"]
+        .as_array()
+        .expect("diagnostics array missing");
+    let e4003: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["code"] == "E4003")
+        .collect();
+
+    assert_eq!(
+        e4003.len(),
+        1,
+        "expected exactly one E4003 diagnostic, got {}: {json}",
+        e4003.len()
+    );
+    let msg = e4003[0]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.to_lowercase().contains("ambiguous"),
+        "E4003 message should mention 'ambiguous', got: {msg}"
+    );
+}
+
 // =============================================================================
 // rledger query tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Originally a one-line bug: STRICT booking silently accepted wildcard reductions (`-5 AAPL {}`) against inventories holding lots at different costs, instead of raising `AmbiguousMatchError`. Investigation surfaced a second latent bug in the same layer — the `BookingEngine` was using a single engine-wide booking method for every account, ignoring per-account `FIFO` / `LIFO` / `NONE` / `HIFO` / `STRICT_WITH_SIZE` / `AVERAGE` declarations on `open` directives. The silent swallow in `book.rs` was compensating for that by dropping the spurious errors it produced.

This PR fixes all three layers of the problem:

1. **`reduce_strict` detects real ambiguity** — aligning with the formal `spec/tla/STRICTCorrect.tla` model (which the previous implementation contradicted).
2. **`BookingEngine` respects per-account booking methods** — new `account_methods` map + `set_account_method` / `register_account_methods` APIs, wired into every consumer.
3. **`book.rs` propagates errors instead of swallowing them** — errors flow cleanly through `convert_core_booking_error` and are reported exactly once.

Closes #737.

## What changed

### Core fix: ambiguous lot match detection (`rustledger-core`)

`reduce_strict` previously fell back to FIFO whenever multiple lots matched the cost spec — even when the lots had different cost values. The intent of the fallback was to handle truly interchangeable lots, but the implementation didn't check identity.

New logic in the multi-match arm:

1. **Interchangeable lots fast path**: if all matched lots share the same `(cost.number, cost.currency)`, they're financially interchangeable from the user's perspective and FIFO is safe. Date and label differences alone do NOT make a reduction ambiguous because the user's cost spec could not have distinguished them without naming those fields. Matches Python beancount.
2. **Total-match exception**: if the reduction equals the sum of all matched units, the user is liquidating the entire matched inventory and lot order is irrelevant — accept (mirrors `reduce_strict_with_size`).
3. **Otherwise**: return `BookingError::AmbiguousMatch`.

Expanded doc comment on `reduce_strict` explains the interchangeable-lots heuristic and where a stricter spec-derived check would differ.

### Per-account booking methods (`rustledger-booking`)

- New `BookingEngine::account_methods: FxHashMap<InternedStr, BookingMethod>` override map.
- New `set_account_method(account, method)` and `method_for(&account)` APIs.
- New convenience `register_account_methods(iter)` that scans any directive iterator and registers methods from `open` directives in one call.
- Both `book()` and `apply()` use `method_for()` so per-account methods apply consistently.
- New `BookingError::AmbiguousMatch { account, currency, num_matches }` variant; `InsufficientUnits` gains an `account` field.
- New `convert_core_booking_error` helper to map `rustledger_core::BookingError` → `BookingError` with account context.

### Error propagation in `book.rs`

`book.rs` no longer silently swallows `inv.reduce` errors. Failures propagate via `?` through the new conversion helper. The previous comment claiming "intentionally not surfaced" is removed.

### All consumers updated to register account methods

Every place that creates a `BookingEngine` now registers per-account methods before booking:

- `rustledger/src/cmd/check.rs`
- `rustledger-loader/src/process.rs`
- `rustledger-lsp/src/handlers/diagnostics.rs`
- `rustledger-lsp/src/handlers/code_lens.rs`
- `rustledger-ffi-wasi/src/jsonrpc/router.rs`
- `rustledger-ffi-wasi/src/helpers.rs`
- `rustledger-wasm/src/lib.rs` (test)

Before this PR, LSP diagnostics and the FFI path would have booked every account against STRICT regardless of declared method.

### Deduplication in `rustledger check`

- New `booking_errors` bucket alongside `interpolation_errors`.
- Failed-booking transaction indices are tracked; `spanned_directives` is filtered before being passed to the validator so the validator's independent lot-matching pass doesn't double-report the same diagnostic.
- Booking errors emitted as E4xxx (`E4001` NoMatchingLot, `E4002` InsufficientUnits, `E4003` AmbiguousMatch) with `phase="validate"`.
- Library-level `validate()` entry point still reports these errors itself, so LSP/embedded consumers that call `validate()` directly without going through booking still get the diagnostics.

## Before / After

Issue input (`{}` cost spec against two lots at different costs):

```beancount
2024-01-01 open Assets:Stock AAPL "STRICT"
...
2024-01-15 * "Buy lot 1"
  Assets:Stock 10 AAPL {150 USD}
  Assets:Cash -1500 USD
2024-01-20 * "Buy lot 2"
  Assets:Stock 10 AAPL {160 USD}
  Assets:Cash -1600 USD
2024-02-15 * "Sell - ambiguous"
  Assets:Stock -5 AAPL {}
  Assets:Cash 800 USD
  Income:Gains
```

**Before**: `validate success` — silently picked the first lot via FIFO. Same behavior for the default-STRICT variant.

**After**: exactly one `error[E4003]: ambiguous lot match: 2 lots match for AAPL in account Assets:Stock`. Same for default STRICT.

## Tests

- **`test_reduce_strict_multiple_match_with_different_costs_is_ambiguous`** — inventory-level pin for the issue scenario (returns `AmbiguousMatch`, inventory unchanged).
- **`test_reduce_strict_multiple_match_with_identical_costs_uses_fifo`** — same date, same cost → FIFO (interchangeable lots fast path).
- **`test_reduce_strict_multiple_match_different_dates_same_cost_uses_fifo`** — *different* dates, same cost → FIFO. This was only tested indirectly via `test_validate_multiple_lot_match_uses_fifo`; now pinned directly at the inventory level.
- **`test_reduce_strict_multiple_match_total_match_exception`** — full liquidation across mixed-cost lots accepted.
- **`prop_strict_errors_on_ambiguous_match`** (renamed from `prop_strict_uses_fifo_on_ambiguous`) — proptest now asserts the spec-correct behavior. The previous proptest had inverted expectations with a misleading comment that claimed it matched Python beancount.
- **`test_check_ambiguous_lot_match_reports_once`** — end-to-end integration test against the exact #737 input. Asserts exactly ONE E4003 diagnostic, guarding against both the original silent-accept bug and any future regression that introduces double-reporting from booking + validator.
- Existing `booking-scenarios.beancount` fixture continues to pass — the FIFO/LIFO/NONE/STRICT_WITH_SIZE accounts now work for the *right* reason (per-account methods) instead of the wrong reason (silent-swallow + engine default).

## Verification

- [x] `cargo test --all-features` — 3,000+ tests pass, including all the new tests and the previously-failing `test_booking_scenarios_validates`.
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Issue input produces exactly one E4003 for both explicit-STRICT and default-STRICT variants.
- [x] `cargo check -p rustledger-wasm --target wasm32-unknown-unknown` clean.
- [x] `cargo check -p rustledger-ffi-wasi --all-features` clean.

## Commit history

1. `fix(booking): detect ambiguous lot match in STRICT mode` — original `reduce_strict` fix.
2. `fix(booking): propagate errors, track per-account booking methods` — silent swallow removed, per-account methods added, `rustledger check` wired up, double-report prevention.
3. `fix(booking): apply per-account methods across all consumers` — LSP, FFI, WASM, loader all updated via `register_account_methods`.

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
