### PR TITLE
fix(plugin): hash links/tags/flag/cost/price in noduplicates

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
@@ -148,19 +148,34 @@ impl NativePlugin for NoDuplicatesPlugin {
             payee.hash(&mut hasher);
             narration.hash(&mut hasher);
 
-            // Tags and links are unordered sets in beancount; sort so the
-            // hash is stable regardless of the order the parser emitted them.
+            // Tags and links are unordered sets in beancount (`frozenset`),
+            // so:
+            //   1. Sort + dedup so the hash is stable regardless of parser
+            //      order and collapses any accidental duplicates the parser
+            //      might emit (matching beancount set semantics).
+            //   2. Each collection is prefixed with its length so the two
+            //      streams can't be merged or swapped without changing the
+            //      resulting hash — e.g. `tags={a,b}, links={}` no longer
+            //      collides with `tags={a}, links={b}`.
             let mut sorted_tags: Vec<&String> = tags.iter().collect();
             sorted_tags.sort();
+            sorted_tags.dedup();
+            sorted_tags.len().hash(&mut hasher);
             for tag in sorted_tags {
                 tag.hash(&mut hasher);
             }
+
             let mut sorted_links: Vec<&String> = links.iter().collect();
             sorted_links.sort();
+            sorted_links.dedup();
+            sorted_links.len().hash(&mut hasher);
             for link in sorted_links {
                 link.hash(&mut hasher);
             }
 
+            // Prefix postings with their count so the posting stream can't
+            // collide with trailing fields of the set streams above.
+            postings.len().hash(&mut hasher);
             for posting in postings {
                 hash_posting(posting, &mut hasher);
             }

--- a/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
@@ -1,6 +1,16 @@
 //! Hash-based duplicate transaction detection.
+//!
+//! Mirrors Python beancount's `beancount.plugins.noduplicates`, which uses
+//! `beancount.core.compare.hash_entry` to identify structurally identical
+//! transactions. `hash_entry` hashes every field that contributes to a
+//! transaction's structural identity: flag, payee, narration, tags, links,
+//! and each posting's account, units, cost, price, and flag. Metadata is
+//! deliberately excluded (beancount's `hash_entry` passes `exclude_meta=True`).
 
-use crate::types::{DirectiveData, PluginError, PluginInput, PluginOutput, TransactionData};
+use crate::types::{
+    CostData, DirectiveData, PluginError, PluginInput, PluginOutput, PostingData,
+    PriceAnnotationData, TransactionData,
+};
 
 use super::super::NativePlugin;
 
@@ -21,18 +31,80 @@ impl NativePlugin for NoDuplicatesPlugin {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
 
+        // Hash a cost spec field-by-field so two cost specs with identical
+        // contents but independently allocated `Option`s hash to the same
+        // value.
+        fn hash_cost<H: Hasher>(cost: &CostData, hasher: &mut H) {
+            cost.number_per.hash(hasher);
+            cost.number_total.hash(hasher);
+            cost.currency.hash(hasher);
+            cost.date.hash(hasher);
+            cost.label.hash(hasher);
+            cost.merge.hash(hasher);
+        }
+
+        fn hash_price<H: Hasher>(price: &PriceAnnotationData, hasher: &mut H) {
+            price.is_total.hash(hasher);
+            if let Some(amount) = &price.amount {
+                amount.number.hash(hasher);
+                amount.currency.hash(hasher);
+            }
+            price.number.hash(hasher);
+            price.currency.hash(hasher);
+        }
+
+        fn hash_posting<H: Hasher>(posting: &PostingData, hasher: &mut H) {
+            posting.account.hash(hasher);
+            if let Some(units) = &posting.units {
+                units.number.hash(hasher);
+                units.currency.hash(hasher);
+            }
+            // Discriminate None from Some by hashing a sentinel before each
+            // optional component — otherwise `None, Some(x)` and `Some(x), None`
+            // would collide with each other for adjacent fields.
+            match &posting.cost {
+                Some(cost) => {
+                    1u8.hash(hasher);
+                    hash_cost(cost, hasher);
+                }
+                None => 0u8.hash(hasher),
+            }
+            match &posting.price {
+                Some(price) => {
+                    1u8.hash(hasher);
+                    hash_price(price, hasher);
+                }
+                None => 0u8.hash(hasher),
+            }
+            posting.flag.hash(hasher);
+        }
+
         fn hash_transaction(date: &str, txn: &TransactionData) -> u64 {
             let mut hasher = DefaultHasher::new();
             date.hash(&mut hasher);
-            txn.narration.hash(&mut hasher);
+            txn.flag.hash(&mut hasher);
             txn.payee.hash(&mut hasher);
-            for posting in &txn.postings {
-                posting.account.hash(&mut hasher);
-                if let Some(units) = &posting.units {
-                    units.number.hash(&mut hasher);
-                    units.currency.hash(&mut hasher);
-                }
+            txn.narration.hash(&mut hasher);
+
+            // Tags and links are unordered sets in beancount; sort so the
+            // hash is stable regardless of the order the parser emitted them.
+            let mut tags: Vec<&String> = txn.tags.iter().collect();
+            tags.sort();
+            for tag in tags {
+                tag.hash(&mut hasher);
             }
+            let mut links: Vec<&String> = txn.links.iter().collect();
+            links.sort();
+            for link in links {
+                link.hash(&mut hasher);
+            }
+
+            for posting in &txn.postings {
+                hash_posting(posting, &mut hasher);
+            }
+
+            // Metadata is intentionally NOT hashed: beancount's hash_entry
+            // defaults to exclude_meta=True for the noduplicates plugin.
             hasher.finish()
         }
 

--- a/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
@@ -55,13 +55,18 @@ impl NativePlugin for NoDuplicatesPlugin {
 
         fn hash_posting<H: Hasher>(posting: &PostingData, hasher: &mut H) {
             posting.account.hash(hasher);
-            if let Some(units) = &posting.units {
-                units.number.hash(hasher);
-                units.currency.hash(hasher);
-            }
             // Discriminate None from Some by hashing a sentinel before each
-            // optional component — otherwise `None, Some(x)` and `Some(x), None`
-            // would collide with each other for adjacent fields.
+            // optional component — otherwise `(None, Some(x))` and
+            // `(Some(x), None)` could collide for adjacent fields. Python's
+            // tuple hash naturally does the equivalent via `hash(None)`.
+            match &posting.units {
+                Some(units) => {
+                    1u8.hash(hasher);
+                    units.number.hash(hasher);
+                    units.currency.hash(hasher);
+                }
+                None => 0u8.hash(hasher),
+            }
             match &posting.cost {
                 Some(cost) => {
                     1u8.hash(hasher);

--- a/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
@@ -6,9 +6,15 @@
 //! transaction's structural identity: flag, payee, narration, tags, links,
 //! and each posting's account, units, cost, price, and flag. Metadata is
 //! deliberately excluded (beancount's `hash_entry` passes `exclude_meta=True`).
+//!
+//! The hash helpers below use exhaustive struct destructuring so that adding
+//! a field to `TransactionData`, `PostingData`, `CostData`, `AmountData`, or
+//! `PriceAnnotationData` causes a compile error here — forcing whoever adds
+//! the field to explicitly decide whether it contributes to structural
+//! identity (add to the hash) or not (bind with `_` and document why).
 
 use crate::types::{
-    CostData, DirectiveData, PluginError, PluginInput, PluginOutput, PostingData,
+    AmountData, CostData, DirectiveData, PluginError, PluginInput, PluginOutput, PostingData,
     PriceAnnotationData, TransactionData,
 };
 
@@ -31,85 +37,134 @@ impl NativePlugin for NoDuplicatesPlugin {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
 
-        // Hash a cost spec field-by-field so two cost specs with identical
-        // contents but independently allocated `Option`s hash to the same
-        // value.
+        // Sentinel bytes used to discriminate `None` from `Some` before each
+        // optional component. Otherwise `(None, Some(x))` and `(Some(x), None)`
+        // could collide for adjacent fields. Python's tuple hash achieves the
+        // equivalent via `hash(None)` being a distinct fixed value.
+        const ABSENT: u8 = 0;
+        const PRESENT: u8 = 1;
+
+        fn hash_amount<H: Hasher>(amount: &AmountData, hasher: &mut H) {
+            let AmountData { number, currency } = amount;
+            number.hash(hasher);
+            currency.hash(hasher);
+        }
+
         fn hash_cost<H: Hasher>(cost: &CostData, hasher: &mut H) {
-            cost.number_per.hash(hasher);
-            cost.number_total.hash(hasher);
-            cost.currency.hash(hasher);
-            cost.date.hash(hasher);
-            cost.label.hash(hasher);
-            cost.merge.hash(hasher);
+            let CostData {
+                number_per,
+                number_total,
+                currency,
+                date,
+                label,
+                merge,
+            } = cost;
+            number_per.hash(hasher);
+            number_total.hash(hasher);
+            currency.hash(hasher);
+            date.hash(hasher);
+            label.hash(hasher);
+            merge.hash(hasher);
         }
 
         fn hash_price<H: Hasher>(price: &PriceAnnotationData, hasher: &mut H) {
-            price.is_total.hash(hasher);
-            if let Some(amount) = &price.amount {
-                amount.number.hash(hasher);
-                amount.currency.hash(hasher);
+            let PriceAnnotationData {
+                is_total,
+                amount,
+                number,
+                currency,
+            } = price;
+            is_total.hash(hasher);
+            match amount {
+                Some(a) => {
+                    PRESENT.hash(hasher);
+                    hash_amount(a, hasher);
+                }
+                None => ABSENT.hash(hasher),
             }
-            price.number.hash(hasher);
-            price.currency.hash(hasher);
+            number.hash(hasher);
+            currency.hash(hasher);
         }
 
         fn hash_posting<H: Hasher>(posting: &PostingData, hasher: &mut H) {
-            posting.account.hash(hasher);
-            // Discriminate None from Some by hashing a sentinel before each
-            // optional component — otherwise `(None, Some(x))` and
-            // `(Some(x), None)` could collide for adjacent fields. Python's
-            // tuple hash naturally does the equivalent via `hash(None)`.
-            match &posting.units {
-                Some(units) => {
-                    1u8.hash(hasher);
-                    units.number.hash(hasher);
-                    units.currency.hash(hasher);
+            // Destructure so any future field added to `PostingData` causes a
+            // compile error here and the maintainer must explicitly decide
+            // whether it's part of structural identity.
+            let PostingData {
+                account,
+                units,
+                cost,
+                price,
+                flag,
+                // Metadata is intentionally NOT hashed — matches beancount's
+                // hash_entry(exclude_meta=True) default. Bind to `_` so adding
+                // a new field in the future is still a compile error.
+                metadata: _,
+            } = posting;
+
+            account.hash(hasher);
+            match units {
+                Some(u) => {
+                    PRESENT.hash(hasher);
+                    hash_amount(u, hasher);
                 }
-                None => 0u8.hash(hasher),
+                None => ABSENT.hash(hasher),
             }
-            match &posting.cost {
-                Some(cost) => {
-                    1u8.hash(hasher);
-                    hash_cost(cost, hasher);
+            match cost {
+                Some(c) => {
+                    PRESENT.hash(hasher);
+                    hash_cost(c, hasher);
                 }
-                None => 0u8.hash(hasher),
+                None => ABSENT.hash(hasher),
             }
-            match &posting.price {
-                Some(price) => {
-                    1u8.hash(hasher);
-                    hash_price(price, hasher);
+            match price {
+                Some(p) => {
+                    PRESENT.hash(hasher);
+                    hash_price(p, hasher);
                 }
-                None => 0u8.hash(hasher),
+                None => ABSENT.hash(hasher),
             }
-            posting.flag.hash(hasher);
+            flag.hash(hasher);
         }
 
         fn hash_transaction(date: &str, txn: &TransactionData) -> u64 {
+            // Destructure so any future field added to `TransactionData`
+            // causes a compile error here.
+            let TransactionData {
+                flag,
+                payee,
+                narration,
+                tags,
+                links,
+                // Metadata is intentionally NOT hashed — matches beancount's
+                // hash_entry(exclude_meta=True) default.
+                metadata: _,
+                postings,
+            } = txn;
+
             let mut hasher = DefaultHasher::new();
             date.hash(&mut hasher);
-            txn.flag.hash(&mut hasher);
-            txn.payee.hash(&mut hasher);
-            txn.narration.hash(&mut hasher);
+            flag.hash(&mut hasher);
+            payee.hash(&mut hasher);
+            narration.hash(&mut hasher);
 
             // Tags and links are unordered sets in beancount; sort so the
             // hash is stable regardless of the order the parser emitted them.
-            let mut tags: Vec<&String> = txn.tags.iter().collect();
-            tags.sort();
-            for tag in tags {
+            let mut sorted_tags: Vec<&String> = tags.iter().collect();
+            sorted_tags.sort();
+            for tag in sorted_tags {
                 tag.hash(&mut hasher);
             }
-            let mut links: Vec<&String> = txn.links.iter().collect();
-            links.sort();
-            for link in links {
+            let mut sorted_links: Vec<&String> = links.iter().collect();
+            sorted_links.sort();
+            for link in sorted_links {
                 link.hash(&mut hasher);
             }
 
-            for posting in &txn.postings {
+            for posting in postings {
                 hash_posting(posting, &mut hasher);
             }
 
-            // Metadata is intentionally NOT hashed: beancount's hash_entry
-            // defaults to exclude_meta=True for the noduplicates plugin.
             hasher.finish()
         }
 

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -463,6 +463,105 @@ fn test_noduplicates_distinct_tags_are_not_duplicates() {
     );
 }
 
+/// Tags and links are beancount `frozenset`s, so a tag that appears twice
+/// in a `Vec<String>` (which the parser could emit) must collapse to a
+/// single member for hashing purposes.
+#[test]
+fn test_noduplicates_duplicate_tags_collapse_to_set() {
+    let plugin = NoDuplicatesPlugin;
+
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.tags = vec!["morning".to_string(), "morning".to_string()];
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.tags = vec!["morning".to_string()];
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "a tag repeated in the Vec must collapse to a set member and hash \
+         equal to a single occurrence, got: {:?}",
+        output.errors
+    );
+}
+
+/// Regression: the tag and link hash streams are separated by length
+/// prefixes so `tags={a,b}, links={}` must NOT collide with
+/// `tags={a}, links={b}`. Without the boundary the concatenated
+/// sort-and-hash approach silently folded these two distinct inputs
+/// together.
+#[test]
+fn test_noduplicates_tag_link_boundary_no_collision() {
+    let plugin = NoDuplicatesPlugin;
+
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.tags = vec!["a".to_string(), "b".to_string()];
+        t.links = vec![];
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.tags = vec!["a".to_string()];
+        t.links = vec!["b".to_string()];
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "tags=[a,b] with no links must NOT collide with tags=[a] links=[b], \
+         got: {:?}",
+        output.errors
+    );
+}
+
 /// Tags and links are beancount sets — the order the parser emits them
 /// must not influence the duplicate hash.
 #[test]

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -368,6 +368,193 @@ fn test_noduplicates_ok_different_amounts() {
     assert!(output.errors.is_empty(), "expected no errors");
 }
 
+/// Regression for issue #746: transactions that share date, narration, and
+/// postings but have **distinct `^link` values** must not be flagged as
+/// duplicates. This mirrors Python beancount's `hash_entry`, which folds
+/// `links` into the transaction hash, and is the idiomatic beancount way
+/// to disambiguate legitimate identical postings (e.g. two $100 ATM
+/// withdrawals on the same day imported from a bank statement).
+#[test]
+fn test_noduplicates_distinct_links_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+
+    let mut txn_a = make_transaction(
+        "2024-06-11",
+        "ATM Withdrawal",
+        vec![
+            ("Assets:Checking:Test", "-100.00", "USD"),
+            ("Expenses:ATM", "100.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.links = vec!["stmt-2024-06-seq1".to_string()];
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-06-11",
+        "ATM Withdrawal",
+        vec![
+            ("Assets:Checking:Test", "-100.00", "USD"),
+            ("Expenses:ATM", "100.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.links = vec!["stmt-2024-06-seq2".to_string()];
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Checking:Test"),
+        make_open("2024-01-01", "Expenses:ATM"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "distinct ^link values should disambiguate otherwise-identical transactions, got: {:?}",
+        output.errors
+    );
+}
+
+/// Regression for issue #746: tags are also part of structural identity
+/// per beancount's `hash_entry`, so distinct tags on otherwise-identical
+/// transactions must disambiguate them.
+#[test]
+fn test_noduplicates_distinct_tags_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.tags = vec!["morning".to_string()];
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.tags = vec!["afternoon".to_string()];
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "distinct tags should disambiguate otherwise-identical transactions, got: {:?}",
+        output.errors
+    );
+}
+
+/// Tags and links are beancount sets — the order the parser emits them
+/// must not influence the duplicate hash.
+#[test]
+fn test_noduplicates_tag_order_independent() {
+    let plugin = NoDuplicatesPlugin;
+
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.tags = vec!["morning".to_string(), "caffeine".to_string()];
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        // Same tags, reversed order.
+        t.tags = vec!["caffeine".to_string(), "morning".to_string()];
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "reordered but identical tag sets should hash equal and be flagged as duplicate, got: {:?}",
+        output.errors
+    );
+}
+
+/// Transactions differing only in flag (`*` vs `!`) are structurally
+/// different and must not collide in the duplicate hash.
+#[test]
+fn test_noduplicates_distinct_flags_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.flag = "*".to_string();
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Assets:Bank", "-5.00", "USD"),
+            ("Expenses:Food", "5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.flag = "!".to_string();
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "distinct flags should disambiguate otherwise-identical transactions, got: {:?}",
+        output.errors
+    );
+}
+
 // ============================================================================
 // OneCommodityPlugin Tests (from onecommodity_test.py)
 // ============================================================================

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -692,8 +692,9 @@ fn test_noduplicates_distinct_prices_are_not_duplicates() {
 /// must still be flagged as duplicates.
 #[test]
 fn test_noduplicates_metadata_differences_are_still_duplicates() {
-    let plugin = NoDuplicatesPlugin;
     use rustledger_plugin_types::MetaValueData;
+
+    let plugin = NoDuplicatesPlugin;
 
     let mut txn_a = make_transaction(
         "2024-01-15",
@@ -948,7 +949,7 @@ fn test_noduplicates_link_order_independent() {
 }
 
 /// Empty tags/links vectors should be indistinguishable from absent
-/// tags/links. Matches beancount frozenset() == frozenset([]).
+/// tags/links. Matches beancount `frozenset()` == `frozenset([])`.
 #[test]
 fn test_noduplicates_empty_vs_absent_tags_are_duplicates() {
     let plugin = NoDuplicatesPlugin;
@@ -1396,8 +1397,9 @@ fn test_noduplicates_distinct_posting_flags_differ() {
 /// `hash_entry(exclude_meta=True)`.
 #[test]
 fn test_noduplicates_posting_metadata_does_not_disambiguate() {
-    let plugin = NoDuplicatesPlugin;
     use rustledger_plugin_types::MetaValueData;
+
+    let plugin = NoDuplicatesPlugin;
 
     let txn_a = make_transaction(
         "2024-01-15",
@@ -1512,7 +1514,7 @@ fn test_noduplicates_empty_postings_edge_case() {
 }
 
 /// Duplicates separated by many unrelated transactions are still
-/// detected — the plugin's HashSet lookup is independent of position.
+/// detected — the plugin's `HashSet` lookup is independent of position.
 #[test]
 fn test_noduplicates_detects_duplicates_across_distance() {
     let plugin = NoDuplicatesPlugin;

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -788,6 +788,799 @@ fn test_noduplicates_distinct_flags_are_not_duplicates() {
 }
 
 // ============================================================================
+// NoDuplicatesPlugin — exhaustive edge-case coverage (issue #746)
+// ============================================================================
+//
+// The noduplicates plugin mirrors Python beancount's
+// `beancount.core.compare.hash_entry`. The tests below walk every field
+// that contributes to structural identity (or is deliberately excluded)
+// and pin the expected behavior, so any future change to the hash
+// function is caught immediately.
+
+/// Shorthand: build a simple 2-posting transaction, apply a per-field
+/// mutation via a closure, and return the wrapper. Lets each test
+/// express "identical to baseline except for X" in a single expression.
+fn make_txn_with<F: FnOnce(&mut TransactionData)>(
+    date: &str,
+    narration: &str,
+    postings: Vec<(&str, &str, &str)>,
+    mutate: F,
+) -> DirectiveWrapper {
+    let mut wrapper = make_transaction(date, narration, postings);
+    if let DirectiveData::Transaction(t) = &mut wrapper.data {
+        mutate(t);
+    }
+    wrapper
+}
+
+// ---------- Transaction-level identity ----------
+
+/// Different dates must never collide, even with otherwise-identical
+/// fields.
+#[test]
+fn test_noduplicates_distinct_dates_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction("2024-01-15", "Coffee", postings.clone()),
+        make_transaction("2024-01-16", "Coffee", postings),
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "different dates must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// Distinct narration text disambiguates duplicates.
+#[test]
+fn test_noduplicates_distinct_narration_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction("2024-01-15", "Coffee", postings.clone()),
+        make_transaction("2024-01-15", "Lunch", postings),
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "different narration must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// Distinct payees disambiguate duplicates.
+#[test]
+fn test_noduplicates_distinct_payees_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let txn_a = make_txn_with("2024-01-15", "Coffee", postings.clone(), |t| {
+        t.payee = Some("Starbucks".to_string());
+    });
+    let txn_b = make_txn_with("2024-01-15", "Coffee", postings, |t| {
+        t.payee = Some("Blue Bottle".to_string());
+    });
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "different payees must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// `None` payee is distinct from `Some("")` — Rust's derived
+/// `Option::hash` already discriminates them, but pin it so a future
+/// custom hash can't regress.
+#[test]
+fn test_noduplicates_none_vs_empty_payee_differ() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let txn_a = make_txn_with("2024-01-15", "Coffee", postings.clone(), |t| {
+        t.payee = None;
+    });
+    let txn_b = make_txn_with("2024-01-15", "Coffee", postings, |t| {
+        t.payee = Some(String::new());
+    });
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "None payee must not collide with Some(\"\"), got: {:?}",
+        output.errors
+    );
+}
+
+/// Links are a set, just like tags — order-independence test.
+#[test]
+fn test_noduplicates_link_order_independent() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let txn_a = make_txn_with("2024-01-15", "Coffee", postings.clone(), |t| {
+        t.links = vec!["stmt-a".to_string(), "stmt-b".to_string()];
+    });
+    let txn_b = make_txn_with("2024-01-15", "Coffee", postings, |t| {
+        t.links = vec!["stmt-b".to_string(), "stmt-a".to_string()];
+    });
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "reordered link sets should hash equal, got: {:?}",
+        output.errors
+    );
+}
+
+/// Empty tags/links vectors should be indistinguishable from absent
+/// tags/links. Matches beancount frozenset() == frozenset([]).
+#[test]
+fn test_noduplicates_empty_vs_absent_tags_are_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let txn_a = make_transaction("2024-01-15", "Coffee", postings.clone());
+    let txn_b = make_txn_with("2024-01-15", "Coffee", postings, |t| {
+        t.tags = vec![];
+        t.links = vec![];
+    });
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "empty tags/links must hash equal to absent tags/links, got: {:?}",
+        output.errors
+    );
+}
+
+// ---------- Posting-level identity ----------
+
+/// Different account on a posting must disambiguate.
+#[test]
+fn test_noduplicates_distinct_accounts_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Assets:Cash"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction(
+            "2024-01-15",
+            "Coffee",
+            vec![
+                ("Assets:Bank", "-5.00", "USD"),
+                ("Expenses:Food", "5.00", "USD"),
+            ],
+        ),
+        make_transaction(
+            "2024-01-15",
+            "Coffee",
+            vec![
+                ("Assets:Cash", "-5.00", "USD"), // different account
+                ("Expenses:Food", "5.00", "USD"),
+            ],
+        ),
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "different account must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// Different number of postings must disambiguate.
+#[test]
+fn test_noduplicates_distinct_posting_count_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_open("2024-01-01", "Expenses:Fee"),
+        make_transaction(
+            "2024-01-15",
+            "Coffee",
+            vec![
+                ("Assets:Bank", "-5.00", "USD"),
+                ("Expenses:Food", "5.00", "USD"),
+            ],
+        ),
+        make_transaction(
+            "2024-01-15",
+            "Coffee",
+            vec![
+                ("Assets:Bank", "-5.00", "USD"),
+                ("Expenses:Food", "4.50", "USD"),
+                ("Expenses:Fee", "0.50", "USD"),
+            ],
+        ),
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "different posting counts must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// Posting order IS part of structural identity per beancount — two
+/// transactions with the same postings in different orders hash
+/// differently. This matches the Python `Posting` tuple being ordered
+/// inside `Transaction.postings: List[Posting]`.
+#[test]
+fn test_noduplicates_reordered_postings_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction(
+            "2024-01-15",
+            "Coffee",
+            vec![
+                ("Assets:Bank", "-5.00", "USD"),
+                ("Expenses:Food", "5.00", "USD"),
+            ],
+        ),
+        make_transaction(
+            "2024-01-15",
+            "Coffee",
+            vec![
+                ("Expenses:Food", "5.00", "USD"),
+                ("Assets:Bank", "-5.00", "USD"),
+            ],
+        ),
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "reordered postings must not collide (postings are an ordered list in \
+         beancount), got: {:?}",
+        output.errors
+    );
+}
+
+/// A posting with `units: None` (auto-balancing) is structurally
+/// different from one with explicit units.
+#[test]
+fn test_noduplicates_none_vs_some_units_differ() {
+    let plugin = NoDuplicatesPlugin;
+    // txn_a: both postings have units
+    let txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Expenses:Food", "5.00", "USD"),
+            ("Assets:Bank", "-5.00", "USD"),
+        ],
+    );
+    // txn_b: auto-balancing second posting
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Expenses:Food", "5.00", "USD"),
+            ("Assets:Bank", "-5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.postings[1].units = None;
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "None units must not collide with Some units, got: {:?}",
+        output.errors
+    );
+}
+
+/// A cost with a lot date is structurally different from one without.
+#[test]
+fn test_noduplicates_cost_with_date_differs() {
+    let plugin = NoDuplicatesPlugin;
+    let mut txn_a = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"),
+        "Assets:Cash",
+    );
+    let mut txn_b = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"),
+        "Assets:Cash",
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data
+        && let Some(cost) = &mut t.postings[0].cost
+    {
+        cost.date = Some("2024-01-10".to_string());
+    }
+    // Keep the tests independent of any posting-level expansion logic.
+    let _ = &mut txn_a;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "cost with date must not collide with cost without date, got: {:?}",
+        output.errors
+    );
+}
+
+/// A cost with a lot label is structurally different from one without.
+#[test]
+fn test_noduplicates_cost_with_label_differs() {
+    let plugin = NoDuplicatesPlugin;
+    let txn_a = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"),
+        "Assets:Cash",
+    );
+    let mut txn_b = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"),
+        "Assets:Cash",
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data
+        && let Some(cost) = &mut t.postings[0].cost
+    {
+        cost.label = Some("lot-42".to_string());
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "cost with label must not collide with cost without label, got: {:?}",
+        output.errors
+    );
+}
+
+/// Total cost (`number_total`) vs per-unit cost (`number_per`) are
+/// structurally different even when the cost spec otherwise matches.
+#[test]
+fn test_noduplicates_total_vs_per_unit_cost_differ() {
+    let plugin = NoDuplicatesPlugin;
+    let txn_a = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"), // per-unit cost
+        "Assets:Cash",
+    );
+    let mut txn_b = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"),
+        "Assets:Cash",
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data
+        && let Some(cost) = &mut t.postings[0].cost
+    {
+        // Swap to total cost form
+        cost.number_per = None;
+        cost.number_total = Some("1500.00".to_string());
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "per-unit cost must not collide with total cost, got: {:?}",
+        output.errors
+    );
+}
+
+/// `@` (per-unit price) and `@@` (total price) are structurally
+/// different annotations.
+#[test]
+fn test_noduplicates_unit_vs_total_price_differ() {
+    let plugin = NoDuplicatesPlugin;
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Sell",
+        vec![
+            ("Assets:Stock", "-5", "AAPL"),
+            ("Assets:Cash", "875.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.postings[0].price = Some(PriceAnnotationData {
+            is_total: false,
+            amount: Some(AmountData {
+                number: "175.00".to_string(),
+                currency: "USD".to_string(),
+            }),
+            number: None,
+            currency: None,
+        });
+    }
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Sell",
+        vec![
+            ("Assets:Stock", "-5", "AAPL"),
+            ("Assets:Cash", "875.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.postings[0].price = Some(PriceAnnotationData {
+            is_total: true, // @@
+            amount: Some(AmountData {
+                number: "875.00".to_string(),
+                currency: "USD".to_string(),
+            }),
+            number: None,
+            currency: None,
+        });
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "`@` and `@@` prices must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// An incomplete price (currency only, no number) is structurally
+/// different from a complete one.
+#[test]
+fn test_noduplicates_incomplete_vs_complete_price_differ() {
+    let plugin = NoDuplicatesPlugin;
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Sell",
+        vec![
+            ("Assets:Stock", "-5", "AAPL"),
+            ("Assets:Cash", "0.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.postings[0].price = Some(PriceAnnotationData {
+            is_total: false,
+            amount: None,
+            number: None,
+            currency: Some("USD".to_string()),
+        });
+    }
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Sell",
+        vec![
+            ("Assets:Stock", "-5", "AAPL"),
+            ("Assets:Cash", "0.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.postings[0].price = Some(PriceAnnotationData {
+            is_total: false,
+            amount: Some(AmountData {
+                number: "175.00".to_string(),
+                currency: "USD".to_string(),
+            }),
+            number: None,
+            currency: None,
+        });
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "incomplete and complete prices must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// Posting-level flag (`!` on a single posting) is part of structural
+/// identity, matching `Posting.flag` in beancount.
+#[test]
+fn test_noduplicates_distinct_posting_flags_differ() {
+    let plugin = NoDuplicatesPlugin;
+    let txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Expenses:Food", "5.00", "USD"),
+            ("Assets:Bank", "-5.00", "USD"),
+        ],
+    );
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Expenses:Food", "5.00", "USD"),
+            ("Assets:Bank", "-5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.postings[0].flag = Some("!".to_string());
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "distinct posting flags must not collide, got: {:?}",
+        output.errors
+    );
+}
+
+/// Posting-level metadata is excluded from the hash, matching
+/// `hash_entry(exclude_meta=True)`.
+#[test]
+fn test_noduplicates_posting_metadata_does_not_disambiguate() {
+    let plugin = NoDuplicatesPlugin;
+    use rustledger_plugin_types::MetaValueData;
+
+    let txn_a = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Expenses:Food", "5.00", "USD"),
+            ("Assets:Bank", "-5.00", "USD"),
+        ],
+    );
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Coffee",
+        vec![
+            ("Expenses:Food", "5.00", "USD"),
+            ("Assets:Bank", "-5.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.postings[0].metadata =
+            vec![("ref".to_string(), MetaValueData::String("abc".to_string()))];
+    }
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "posting-level metadata must not disambiguate (exclude_meta=True), \
+         got: {:?}",
+        output.errors
+    );
+}
+
+// ---------- Multi-transaction & structural scenarios ----------
+
+/// Three identical transactions produce exactly two duplicate errors
+/// (one per extra occurrence).
+#[test]
+fn test_noduplicates_three_identical_reports_two_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction("2024-01-15", "Coffee", postings.clone()),
+        make_transaction("2024-01-15", "Coffee", postings.clone()),
+        make_transaction("2024-01-15", "Coffee", postings),
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        2,
+        "three identical transactions should produce two duplicate errors, got: {:?}",
+        output.errors
+    );
+}
+
+/// Non-transaction directives (Open, Close, etc.) are ignored by the
+/// plugin — they should never be flagged as duplicates, and their
+/// presence between transactions should not affect duplicate detection.
+#[test]
+fn test_noduplicates_ignores_non_transaction_directives() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let input = make_input(vec![
+        // Two identical opens — not a transaction, must be ignored by
+        // the plugin (validators handle duplicate opens separately).
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction("2024-01-15", "Coffee", postings.clone()),
+        // An Open directive between the two transactions shouldn't
+        // cause any hash collision with either.
+        make_open("2024-02-01", "Assets:Savings"),
+        make_transaction("2024-01-15", "Coffee", postings),
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "only the two real transaction duplicates should be flagged \
+         (non-transaction directives ignored), got: {:?}",
+        output.errors
+    );
+}
+
+/// A transaction with zero postings (edge case) must still be
+/// processed without panicking, and two such transactions hash equal.
+#[test]
+fn test_noduplicates_empty_postings_edge_case() {
+    let plugin = NoDuplicatesPlugin;
+    let txn_a = make_txn_with("2024-01-15", "placeholder", vec![], |_| {});
+    let txn_b = make_txn_with("2024-01-15", "placeholder", vec![], |_| {});
+    let input = make_input(vec![txn_a, txn_b]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "two empty-posting transactions should hash equal and be flagged, got: {:?}",
+        output.errors
+    );
+}
+
+/// Duplicates separated by many unrelated transactions are still
+/// detected — the plugin's HashSet lookup is independent of position.
+#[test]
+fn test_noduplicates_detects_duplicates_across_distance() {
+    let plugin = NoDuplicatesPlugin;
+    let target_postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let mut directives = vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        make_transaction("2024-01-15", "Coffee", target_postings.clone()),
+    ];
+    // Fill with 50 distinct transactions on different dates.
+    for day in 16..=65 {
+        directives.push(make_transaction(
+            &format!("2024-01-{day:02}"),
+            "Distinct",
+            vec![
+                ("Expenses:Food", &format!("{day}.00"), "USD"),
+                ("Assets:Bank", &format!("-{day}.00"), "USD"),
+            ],
+        ));
+    }
+    // Duplicate of the first Coffee transaction, 50 entries later.
+    directives.push(make_transaction("2024-01-15", "Coffee", target_postings));
+    let input = make_input(directives);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "duplicates should be detected regardless of distance in the \
+         directive stream, got: {:?}",
+        output.errors
+    );
+}
+
+/// Two transactions with identical content but different filename/
+/// lineno (source locations) are still duplicates — location is not
+/// part of structural identity.
+#[test]
+fn test_noduplicates_source_location_not_part_of_identity() {
+    let plugin = NoDuplicatesPlugin;
+    let postings = vec![
+        ("Expenses:Food", "5.00", "USD"),
+        ("Assets:Bank", "-5.00", "USD"),
+    ];
+    let mut txn_a = make_transaction("2024-01-15", "Coffee", postings.clone());
+    txn_a.filename = Some("a.beancount".to_string());
+    txn_a.lineno = Some(10);
+    let mut txn_b = make_transaction("2024-01-15", "Coffee", postings);
+    txn_b.filename = Some("b.beancount".to_string());
+    txn_b.lineno = Some(42);
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "source filename/lineno must not influence the hash, got: {:?}",
+        output.errors
+    );
+}
+
+// ============================================================================
 // OneCommodityPlugin Tests (from onecommodity_test.py)
 // ============================================================================
 

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -510,6 +510,139 @@ fn test_noduplicates_tag_order_independent() {
     );
 }
 
+/// Transactions differing only in cost spec must not collide in the
+/// duplicate hash. Cost is part of a posting's structural identity per
+/// beancount's `hash_entry`.
+#[test]
+fn test_noduplicates_distinct_costs_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+
+    let txn_a = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy stock",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("150.00", "USD"),
+        "Assets:Cash",
+    );
+    let txn_b = make_transaction_with_cost(
+        "2024-01-15",
+        "Buy stock",
+        "Assets:Stock",
+        ("10", "AAPL"),
+        ("160.00", "USD"), // different cost
+        "Assets:Cash",
+    );
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "distinct cost specs should disambiguate otherwise-identical transactions, got: {:?}",
+        output.errors
+    );
+}
+
+/// Transactions differing only in price annotation must not collide in
+/// the duplicate hash.
+#[test]
+fn test_noduplicates_distinct_prices_are_not_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+
+    let txn_a = make_transaction_with_price(
+        "2024-01-15",
+        "Sell stock",
+        "Assets:Stock",
+        ("-5", "AAPL"),
+        ("200.00", "USD"),
+        "Assets:Cash",
+    );
+    let txn_b = make_transaction_with_price(
+        "2024-01-15",
+        "Sell stock",
+        "Assets:Stock",
+        ("-5", "AAPL"),
+        ("210.00", "USD"), // different price
+        "Assets:Cash",
+    );
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Stock"),
+        make_open("2024-01-01", "Assets:Cash"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert!(
+        output.errors.is_empty(),
+        "distinct prices should disambiguate otherwise-identical transactions, got: {:?}",
+        output.errors
+    );
+}
+
+/// Metadata is intentionally NOT part of the duplicate hash — matches
+/// Python beancount's `hash_entry(exclude_meta=True)` default for the
+/// noduplicates plugin. Two transactions that differ only on metadata
+/// must still be flagged as duplicates.
+#[test]
+fn test_noduplicates_metadata_differences_are_still_duplicates() {
+    let plugin = NoDuplicatesPlugin;
+    use rustledger_plugin_types::MetaValueData;
+
+    let mut txn_a = make_transaction(
+        "2024-01-15",
+        "Grocery Store",
+        vec![
+            ("Expenses:Food", "50.00", "USD"),
+            ("Assets:Bank", "-50.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_a.data {
+        t.metadata = vec![(
+            "reference".to_string(),
+            MetaValueData::String("A".to_string()),
+        )];
+    }
+
+    let mut txn_b = make_transaction(
+        "2024-01-15",
+        "Grocery Store",
+        vec![
+            ("Expenses:Food", "50.00", "USD"),
+            ("Assets:Bank", "-50.00", "USD"),
+        ],
+    );
+    if let DirectiveData::Transaction(t) = &mut txn_b.data {
+        t.metadata = vec![(
+            "reference".to_string(),
+            MetaValueData::String("B".to_string()),
+        )];
+    }
+
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Bank"),
+        make_open("2024-01-01", "Expenses:Food"),
+        txn_a,
+        txn_b,
+    ]);
+
+    let output = plugin.process(input);
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "metadata-only differences must not disambiguate (matches beancount \
+         exclude_meta=True), got: {:?}",
+        output.errors
+    );
+}
+
 /// Transactions differing only in flag (`*` vs `!`) are structurally
 /// different and must not collide in the duplicate hash.
 #[test]


### PR DESCRIPTION
## Summary

The `noduplicates` native plugin was hashing only `(date, narration, payee, postings.account, postings.units)` for duplicate detection. Python beancount's reference implementation uses `beancount.core.compare.hash_entry`, which hashes every field that contributes to a transaction's structural identity: `flag`, `payee`, `narration`, `tags`, `links`, and every posting's `account`, `units`, `cost`, `price`, and `flag`.

The practical effect: the idiomatic beancount pattern for disambiguating legitimate same-day identical postings — attaching a unique `^link` to each — was broken. Real-world bank-statement importers hit this immediately when a day legitimately contains two `$100` ATM withdrawals or identical wire-transfer fees. On the reporter's ledger, `bean-check` passes but `rledger check` reported 16 false-positive "Duplicate transaction" errors, all of which were genuine distinct postings disambiguated by links.

Closes #746.

## Fix

`crates/rustledger-plugin/src/native/plugins/no_duplicates.rs`:

- `hash_transaction` now folds in `flag`, `tags`, and `links`. Tags and links are sorted before hashing because beancount models them as unordered sets (`frozenset`), so the hash must be stable regardless of the order the parser emitted them.
- New `hash_posting` helper hashes `cost`, `price`, and posting `flag` alongside account/units. Sentinel bytes (`0u8` / `1u8`) discriminate `None` from `Some` so adjacent optional fields can't collide across cases.
- New `hash_cost` and `hash_price` helpers walk the inner structures field-by-field.
- Metadata is intentionally still NOT hashed — this matches beancount's `hash_entry`, which passes `exclude_meta=True` from `hash_entries` (the function the plugin calls).

## Before / After

Exact reproducer from the issue:

```beancount
option "operating_currency" "USD"

plugin "beancount.plugins.noduplicates"

2024-01-01 open Assets:Checking:Test USD
2024-01-01 open Expenses:ATM          USD

2024-06-11 * "ATM Withdrawal" ^stmt-2024-06-seq1
  Assets:Checking:Test  -100.00 USD
  Expenses:ATM

2024-06-11 * "ATM Withdrawal" ^stmt-2024-06-seq2
  Assets:Checking:Test  -100.00 USD
  Expenses:ATM
```

**Before**: `Error: Duplicate transaction: 2024-06-11 "ATM Withdrawal"`, exit 1.
**After**: `✓ No errors found`, exit 0 — matches `bean-check`.

## Test plan

- [x] `test_noduplicates_distinct_links_are_not_duplicates` — exact issue reproducer at the plugin level.
- [x] `test_noduplicates_distinct_tags_are_not_duplicates` — tags also disambiguate.
- [x] `test_noduplicates_tag_order_independent` — reordered tag sets hash equal (verifies the canonical sort).
- [x] `test_noduplicates_distinct_flags_are_not_duplicates` — `*` vs `!` disambiguate.
- [x] Existing `test_noduplicates_transaction` and `test_noduplicates_ok_different_amounts` still pass.
- [x] End-to-end: `rledger check` on the exact issue reproducer returns exit 0.
- [x] Full `cargo test --all-features` — all tests pass.
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

## Reference

Python beancount's `beancount.core.compare.hash_entry` computes a stable hash from `flag`, `payee`, `narration`, `tags` (as `frozenset`), `links` (as `frozenset`), and every posting's `(account, units, cost, price, flag)` — and excludes `meta` by default for the noduplicates plugin path.

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
