### PR TITLE
fix: restore "not enough" phrasing for InsufficientUnits booking error

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -36,7 +36,16 @@ pub enum BookingError {
     },
 
     /// Insufficient units in matching lots.
-    #[error("insufficient units: need {requested} but only {available} available")]
+    ///
+    /// Display string deliberately includes the phrase "not enough" and the
+    /// account name to match Python beancount's `BookingError` message and the
+    /// validator's pre-existing phrasing. The pta-standards
+    /// `reduction-exceeds-inventory` conformance test asserts on
+    /// `error_contains: ["not enough"]`, and downstream user tooling (CI
+    /// filters, scripts) matches on this phrasing — see #748.
+    #[error(
+        "Not enough units in {account}: requested {requested}, available {available}; not enough to reduce"
+    )]
     InsufficientUnits {
         /// The account being reduced.
         account: InternedStr,
@@ -1177,6 +1186,38 @@ mod tests {
         assert_eq!(
             result.transaction.postings[0].units,
             Some(IncompleteAmount::Complete(Amount::new(dec!(50), "USD")))
+        );
+    }
+
+    /// Regression test for #748.
+    ///
+    /// The pta-standards `reduction-exceeds-inventory` conformance test
+    /// asserts on `error_contains: ["not enough"]`. PR #745 made the booking
+    /// layer propagate `InsufficientUnits` directly to the user instead of
+    /// letting the validator's "Not enough units in ..." message win, which
+    /// dropped the "not enough" phrasing. This test pins the booking layer's
+    /// Display string so the conformance assertion (and any downstream user
+    /// tooling that greps the message) cannot regress silently again.
+    #[test]
+    fn test_insufficient_units_display_contains_not_enough() {
+        let err = BookingError::InsufficientUnits {
+            account: "Assets:Stock".into(),
+            requested: dec!(15),
+            available: dec!(10),
+        };
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("not enough"),
+            "InsufficientUnits Display must contain 'not enough' for beancount \
+             compatibility (#748). Got: {rendered}"
+        );
+        assert!(
+            rendered.contains("Assets:Stock"),
+            "InsufficientUnits Display must include the account name. Got: {rendered}"
+        );
+        assert!(
+            rendered.contains("15") && rendered.contains("10"),
+            "InsufficientUnits Display must include requested and available amounts. Got: {rendered}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the pta-standards `reduction-exceeds-inventory` conformance regression introduced by #745.

PR #745 made the booking layer propagate `BookingError::InsufficientUnits` directly to the user instead of letting the validator's "Not enough units in ..." message win. The booking variant's Display string ("insufficient units: need X but only Y available") didn't contain "not enough", and the conformance test asserts on `error_contains: ["not enough"]`. The error itself is still correctly detected — only the wording diverged.

This PR aligns the booking layer's `#[error(...)]` to the validator's pre-existing phrasing verbatim. The `account` field is already on the variant (added in #745 for exactly this purpose), so no struct change is needed.

**Before:**
```
error[E4002]: insufficient units: need 15 but only 10 available
```

**After:**
```
error[E4002]: Not enough units in Assets:Stock: requested 15, available 10; not enough to reduce
```

## Why option 1, not the bigger refactor

#748 outlined two fixes:
1. Align the Display string (this PR).
2. Standardize on a single shared `InsufficientUnits` type between `rustledger-booking` and `rustledger-validate`.

Option 2 is the right longer-term cleanup, but it's invasive and out of scope for a regression fix. Option 1 is one-line and pins behavior with a regression test. Option 2 should get its own tracking issue once this lands.

## Regression test

Added `test_insufficient_units_display_contains_not_enough` in `crates/rustledger-booking/src/book.rs`. Asserts the rendered Display string contains:
- the literal phrase `"not enough"` (the conformance assertion)
- the account name
- both the requested and available numbers

The test docstring references #748 so the next person to touch the variant understands why the exact phrasing is load-bearing. A doc comment on the `InsufficientUnits` variant itself also explains the constraint.

## Test plan

- [x] `cargo test -p rustledger-booking` — all 76 tests pass (75 existing + 1 new)
- [x] `cargo test --workspace --all-features` — full suite green
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] pta-standards conformance run — verify `reduction-exceeds-inventory` flips back to passing once this lands

Closes #748