### PR TITLE
refactor: unify InsufficientUnits error type across booking and validate

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -6,11 +6,10 @@
 //! - Calculating capital gains/losses
 //! - Filling in cost specs for lot reductions
 
-use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;
 use rustledger_core::{
-    Amount, BookingMethod, Cost, CostSpec, IncompleteAmount, InternedStr, Inventory, Position,
-    Posting, Transaction,
+    AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, IncompleteAmount, InternedStr,
+    Inventory, Position, Posting, Transaction,
 };
 use thiserror::Error;
 
@@ -24,51 +23,23 @@ use crate::{InterpolationError, InterpolationResult, interpolate};
 // to 170.17, because 1.763 * 170.17 = 300.00971 ≠ 300.00.
 
 /// Errors that can occur during booking.
+///
+/// Inventory-level failures (insufficient units, no matching lot, ambiguous
+/// match, currency mismatch) are unified under [`BookingError::Inventory`],
+/// which carries an [`AccountedBookingError`] from `rustledger-core`. This
+/// keeps the user-facing wording in **one place** so it cannot drift between
+/// the booking layer and the validator — see #748 / #750.
 #[derive(Debug, Clone, Error)]
 pub enum BookingError {
-    /// No matching lot found for reduction.
-    #[error("no matching lot for {units} in account {account}")]
-    NoMatchingLot {
-        /// The account being reduced.
-        account: InternedStr,
-        /// The units being reduced.
-        units: String,
-    },
-
-    /// Insufficient units in matching lots.
+    /// An inventory-level booking failure (insufficient units, no matching
+    /// lot, ambiguous match, currency mismatch).
     ///
-    /// Display string deliberately includes the phrase "not enough" and the
-    /// account name to match Python beancount's `BookingError` message and the
-    /// validator's pre-existing phrasing. The pta-standards
-    /// `reduction-exceeds-inventory` conformance test asserts on
-    /// `error_contains: ["not enough"]`, and downstream user tooling (CI
-    /// filters, scripts) matches on this phrasing — see #748.
-    #[error(
-        "Not enough units in {account}: requested {requested}, available {available}; not enough to reduce"
-    )]
-    InsufficientUnits {
-        /// The account being reduced.
-        account: InternedStr,
-        /// Requested reduction amount.
-        requested: Decimal,
-        /// Available amount.
-        available: Decimal,
-    },
-
-    /// Multiple lots with differing costs matched the reduction.
-    ///
-    /// Raised by STRICT booking when a partial cost spec like `{}` matches
-    /// more than one non-identical lot. Mirrors Python beancount's
-    /// `AmbiguousMatchError`.
-    #[error("ambiguous lot match: {num_matches} lots match for {currency} in account {account}")]
-    AmbiguousMatch {
-        /// The account being reduced.
-        account: InternedStr,
-        /// The currency being reduced.
-        currency: InternedStr,
-        /// The number of matching lots.
-        num_matches: usize,
-    },
+    /// `Display` is delegated to the inner [`AccountedBookingError`], which
+    /// is the single canonical source of wording for booking errors. The
+    /// pta-standards `reduction-exceeds-inventory` conformance test depends
+    /// on this Display containing the literal substring `"not enough"`.
+    #[error(transparent)]
+    Inventory(AccountedBookingError),
 
     /// Interpolation failed after booking.
     #[error("interpolation failed: {0}")]
@@ -246,7 +217,7 @@ impl BookingEngine {
                         let method = self.method_for(&posting.account);
                         let booking_result = inv
                             .reduce(units, Some(cost_spec), method)
-                            .map_err(|e| convert_core_booking_error(e, &posting.account, units))?;
+                            .map_err(|e| convert_core_booking_error(e, &posting.account))?;
                         {
                             // Check if multiple lots were matched
                             if booking_result.matched.len() > 1 {
@@ -541,39 +512,16 @@ impl BookingEngine {
 
 /// Convert a core inventory `BookingError` into the booking-layer error,
 /// attaching the account context that the core layer doesn't carry.
+///
+/// All inventory-level failures funnel into a single
+/// [`BookingError::Inventory`] variant. The user-facing wording lives in the
+/// `Display` impl on [`AccountedBookingError`] so it cannot drift between
+/// the booking layer and the validator (#748 / #750).
 fn convert_core_booking_error(
     err: rustledger_core::BookingError,
     account: &InternedStr,
-    units: &Amount,
 ) -> BookingError {
-    use rustledger_core::BookingError as CoreError;
-    match err {
-        CoreError::AmbiguousMatch {
-            num_matches,
-            currency,
-        } => BookingError::AmbiguousMatch {
-            account: account.clone(),
-            currency,
-            num_matches,
-        },
-        CoreError::NoMatchingLot { .. } => BookingError::NoMatchingLot {
-            account: account.clone(),
-            units: format!("{units}"),
-        },
-        CoreError::InsufficientUnits {
-            requested,
-            available,
-            ..
-        } => BookingError::InsufficientUnits {
-            account: account.clone(),
-            requested,
-            available,
-        },
-        CoreError::CurrencyMismatch { .. } => BookingError::NoMatchingLot {
-            account: account.clone(),
-            units: format!("{units}"),
-        },
-    }
+    BookingError::Inventory(err.with_account(account.clone()))
 }
 
 /// Book and interpolate a list of transactions.
@@ -1195,16 +1143,24 @@ mod tests {
     /// asserts on `error_contains: ["not enough"]`. PR #745 made the booking
     /// layer propagate `InsufficientUnits` directly to the user instead of
     /// letting the validator's "Not enough units in ..." message win, which
-    /// dropped the "not enough" phrasing. This test pins the booking layer's
+    /// dropped the "not enough" phrasing. This test pins the user-facing
     /// Display string so the conformance assertion (and any downstream user
     /// tooling that greps the message) cannot regress silently again.
+    ///
+    /// After #750, the canonical Display lives on
+    /// [`rustledger_core::AccountedBookingError`] and `BookingError::Inventory`
+    /// delegates to it transparently — so this test exercises the same path
+    /// the validator and `cmd/check.rs` use.
     #[test]
     fn test_insufficient_units_display_contains_not_enough() {
-        let err = BookingError::InsufficientUnits {
-            account: "Assets:Stock".into(),
-            requested: dec!(15),
-            available: dec!(10),
-        };
+        let err = BookingError::Inventory(
+            rustledger_core::BookingError::InsufficientUnits {
+                currency: "AAPL".into(),
+                requested: dec!(15),
+                available: dec!(10),
+            }
+            .with_account("Assets:Stock".into()),
+        );
         let rendered = format!("{err}");
         assert!(
             rendered.contains("not enough"),

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -149,6 +149,79 @@ impl fmt::Display for BookingError {
 
 impl std::error::Error for BookingError {}
 
+impl BookingError {
+    /// Wrap this booking error with the account context that produced it.
+    ///
+    /// `Inventory` itself doesn't know which account it belongs to, so the
+    /// raw `BookingError` carries no `account` field. The caller (booking
+    /// engine, validator) knows the account and uses this constructor to
+    /// produce the user-facing error.
+    ///
+    /// The resulting [`AccountedBookingError`] is the **single canonical
+    /// rendering** of an inventory failure for user-facing output. Both the
+    /// booking layer and the validator format errors via this type so the
+    /// wording cannot drift between them — the failure mode that produced
+    /// #748.
+    #[must_use]
+    pub const fn with_account(self, account: InternedStr) -> AccountedBookingError {
+        AccountedBookingError {
+            error: self,
+            account,
+        }
+    }
+}
+
+/// A [`BookingError`] paired with the account that produced it.
+///
+/// This is the canonical user-facing inventory error type. Its `Display`
+/// impl is the **single source of truth** for booking-error wording across
+/// `rustledger-booking` and `rustledger-validate`. Conformance assertions
+/// (e.g. pta-standards `reduction-exceeds-inventory` requires the literal
+/// substring `"not enough"`) are pinned by this Display.
+///
+/// Construct via [`BookingError::with_account`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountedBookingError {
+    /// The underlying inventory-level error.
+    pub error: BookingError,
+    /// The account whose inventory produced the error.
+    pub account: InternedStr,
+}
+
+impl fmt::Display for AccountedBookingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.error {
+            BookingError::InsufficientUnits {
+                requested,
+                available,
+                ..
+            } => write!(
+                f,
+                "Not enough units in {}: requested {}, available {}; not enough to reduce",
+                self.account, requested, available
+            ),
+            BookingError::NoMatchingLot { currency, .. } => {
+                write!(f, "No matching lot for {} in {}", currency, self.account)
+            }
+            BookingError::AmbiguousMatch {
+                num_matches,
+                currency,
+            } => write!(
+                f,
+                "Ambiguous lot match for {}: {} lots match in {}",
+                currency, num_matches, self.account
+            ),
+            BookingError::CurrencyMismatch { expected, got } => write!(
+                f,
+                "Currency mismatch in {}: expected {}, got {}",
+                self.account, expected, got
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AccountedBookingError {}
+
 /// An inventory is a collection of positions.
 ///
 /// It tracks all positions for an account and supports booking operations

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -211,11 +211,17 @@ impl fmt::Display for AccountedBookingError {
                 "Ambiguous lot match for {}: {} lots match in {}",
                 currency, num_matches, self.account
             ),
-            BookingError::CurrencyMismatch { expected, got } => write!(
-                f,
-                "Currency mismatch in {}: expected {}, got {}",
-                self.account, expected, got
-            ),
+            // Currency mismatch is semantically a specialization of
+            // NoMatchingLot (there is no lot for the given currency in this
+            // inventory), so we render and classify it the same way. Consumers
+            // filtering on E4001 don't need to special-case CurrencyMismatch.
+            //
+            // This variant is defensive: no `Inventory::reduce` path in
+            // `rustledger-core` currently emits it, but we still render it
+            // consistently in case a future emission site is added.
+            BookingError::CurrencyMismatch { got, .. } => {
+                write!(f, "No matching lot for {} in {}", got, self.account)
+            }
         }
     }
 }
@@ -1554,5 +1560,123 @@ mod tests {
 
         // Should use cost from newest lot (200)
         assert_eq!(result.cost_basis.unwrap().number, dec!(1000.00));
+    }
+
+    // === AccountedBookingError Display tests ===
+    //
+    // These tests pin the canonical user-facing wording for every variant
+    // of `AccountedBookingError`. The whole point of unifying booking-error
+    // Display into `rustledger-core` (#750) is that there's a single source
+    // of truth — and a single source of truth with no tests is one refactor
+    // away from drifting again, which is exactly the failure mode that
+    // produced #748. Any change to the Display strings below will break
+    // these tests, forcing the author to consciously re-check pta-standards
+    // conformance assertions and downstream user tooling.
+
+    #[test]
+    fn test_accounted_error_display_insufficient_units() {
+        let err = BookingError::InsufficientUnits {
+            currency: "AAPL".into(),
+            requested: dec!(15),
+            available: dec!(10),
+        }
+        .with_account("Assets:Stock".into());
+        let rendered = format!("{err}");
+
+        // Pinned by pta-standards `reduction-exceeds-inventory`
+        // (`error_contains: ["not enough"]`). See #748 / #749.
+        assert!(
+            rendered.contains("not enough"),
+            "must contain 'not enough' (pta-standards): {rendered}"
+        );
+        assert!(
+            rendered.contains("Assets:Stock"),
+            "must contain account name: {rendered}"
+        );
+        assert!(
+            rendered.contains("15") && rendered.contains("10"),
+            "must contain requested and available amounts: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_accounted_error_display_no_matching_lot() {
+        let err = BookingError::NoMatchingLot {
+            currency: "AAPL".into(),
+            cost_spec: CostSpec::empty(),
+        }
+        .with_account("Assets:Stock".into());
+        let rendered = format!("{err}");
+
+        assert!(
+            rendered.contains("No matching lot"),
+            "must contain 'No matching lot': {rendered}"
+        );
+        assert!(
+            rendered.contains("AAPL"),
+            "must contain currency: {rendered}"
+        );
+        assert!(
+            rendered.contains("Assets:Stock"),
+            "must contain account name: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_accounted_error_display_ambiguous_match() {
+        let err = BookingError::AmbiguousMatch {
+            num_matches: 3,
+            currency: "AAPL".into(),
+        }
+        .with_account("Assets:Stock".into());
+        let rendered = format!("{err}");
+
+        assert!(
+            rendered.contains("Ambiguous"),
+            "must contain 'Ambiguous': {rendered}"
+        );
+        assert!(
+            rendered.contains("AAPL"),
+            "must contain currency: {rendered}"
+        );
+        assert!(
+            rendered.contains("Assets:Stock"),
+            "must contain account name: {rendered}"
+        );
+        assert!(
+            rendered.contains('3'),
+            "must contain match count: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_accounted_error_display_currency_mismatch_renders_as_no_matching_lot() {
+        // CurrencyMismatch is semantically a specialization of NoMatchingLot
+        // (there is no lot for the given currency in this inventory) and the
+        // canonical Display collapses them into the same user-facing phrasing
+        // so that consumers filtering on E4001 don't need to special-case it.
+        // This variant is defensive — no `Inventory::reduce` path currently
+        // emits it — but we still pin its rendering in case a future emission
+        // site is added.
+        let err = BookingError::CurrencyMismatch {
+            expected: "USD".into(),
+            got: "EUR".into(),
+        }
+        .with_account("Assets:Cash".into());
+        let rendered = format!("{err}");
+
+        assert!(
+            rendered.contains("No matching lot"),
+            "CurrencyMismatch must render as 'No matching lot' for E4001 \
+             consistency: {rendered}"
+        );
+        assert!(
+            rendered.contains("EUR"),
+            "must contain the mismatched (got) currency: {rendered}"
+        );
+        assert!(
+            rendered.contains("Assets:Cash"),
+            "must contain account name: {rendered}"
+        );
     }
 }

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -71,7 +71,7 @@ pub use extract::{
 };
 pub use format::{FormatConfig, format_directive};
 pub use intern::{InternedStr, StringInterner};
-pub use inventory::{BookingError, BookingMethod, BookingResult, Inventory};
+pub use inventory::{AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory};
 pub use position::Position;
 
 // Re-export commonly used external types

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -429,24 +429,17 @@ pub fn process_inventory_reduction(
 ) {
     match inv.reduce(units, posting.cost.as_ref(), booking_method) {
         Ok(_) => {}
-        Err(rustledger_core::BookingError::InsufficientUnits {
-            requested,
-            available,
-            ..
-        }) => {
+        Err(err @ rustledger_core::BookingError::InsufficientUnits { .. }) => {
             errors.push(
                 ValidationError::new(
                     ErrorCode::InsufficientUnits,
-                    format!(
-                        "Not enough units in {}: requested {}, available {}; not enough to reduce",
-                        posting.account, requested, available
-                    ),
+                    format!("{}", err.with_account(posting.account.clone())),
                     txn.date,
                 )
                 .with_context(format!("currency: {}", units.currency)),
             );
         }
-        Err(rustledger_core::BookingError::NoMatchingLot { currency, .. }) => {
+        Err(err @ rustledger_core::BookingError::NoMatchingLot { .. }) => {
             // In STRICT mode, when no lot matches AND the inventory has no POSITIVE
             // positions for this commodity, Python beancount allows "sell to open"
             // by creating a new lot with negative units. This is common in options trading.
@@ -500,23 +493,17 @@ pub fn process_inventory_reduction(
             errors.push(
                 ValidationError::new(
                     ErrorCode::NoMatchingLot,
-                    format!("No matching lot for {} in {}", currency, posting.account),
+                    format!("{}", err.with_account(posting.account.clone())),
                     txn.date,
                 )
                 .with_context(format!("cost spec: {:?}", posting.cost)),
             );
         }
-        Err(rustledger_core::BookingError::AmbiguousMatch {
-            currency,
-            num_matches,
-        }) => {
+        Err(err @ rustledger_core::BookingError::AmbiguousMatch { .. }) => {
             errors.push(
                 ValidationError::new(
                     ErrorCode::AmbiguousLotMatch,
-                    format!(
-                        "Ambiguous lot match for {}: {} lots match in {}",
-                        currency, num_matches, posting.account
-                    ),
+                    format!("{}", err.with_account(posting.account.clone())),
                     txn.date,
                 )
                 .with_context("Specify cost, date, or label to disambiguate".to_string()),

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -509,8 +509,21 @@ pub fn process_inventory_reduction(
                 .with_context("Specify cost, date, or label to disambiguate".to_string()),
             );
         }
-        Err(rustledger_core::BookingError::CurrencyMismatch { .. }) => {
-            // This shouldn't happen in normal validation
+        Err(err @ rustledger_core::BookingError::CurrencyMismatch { .. }) => {
+            // Defensive: no `Inventory::reduce` path in `rustledger-core`
+            // currently emits this variant, but if a future one does we
+            // surface it consistently with the booking engine's path in
+            // `cmd/check.rs`. CurrencyMismatch is rendered and classified as
+            // a specialization of NoMatchingLot — see the canonical
+            // `AccountedBookingError::Display` impl in `rustledger-core`.
+            errors.push(
+                ValidationError::new(
+                    ErrorCode::NoMatchingLot,
+                    format!("{}", err.with_account(posting.account.clone())),
+                    txn.date,
+                )
+                .with_context(format!("currency: {}", units.currency)),
+            );
         }
     }
 }

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -704,7 +704,7 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                                 interp_err,
                             ));
                         }
-                        other => {
+                        other @ rustledger_booking::BookingError::Inventory(_) => {
                             booking_errors.push((txn.date, txn.narration.to_string(), other));
                         }
                     }
@@ -1114,9 +1114,12 @@ pub fn run(args: &Args) -> Result<ExitCode> {
     if !booking_errors.is_empty() {
         let code_for = |err: &rustledger_booking::BookingError| -> &'static str {
             match err {
-                rustledger_booking::BookingError::AmbiguousMatch { .. } => "E4003",
-                rustledger_booking::BookingError::NoMatchingLot { .. } => "E4001",
-                rustledger_booking::BookingError::InsufficientUnits { .. } => "E4002",
+                rustledger_booking::BookingError::Inventory(inv_err) => match &inv_err.error {
+                    rustledger_core::BookingError::AmbiguousMatch { .. } => "E4003",
+                    rustledger_core::BookingError::NoMatchingLot { .. } => "E4001",
+                    rustledger_core::BookingError::InsufficientUnits { .. } => "E4002",
+                    rustledger_core::BookingError::CurrencyMismatch { .. } => "E4001",
+                },
                 rustledger_booking::BookingError::Interpolation(_) => "INTERP",
             }
         };


### PR DESCRIPTION
## Summary

Implements #750. Unifies the three independent error types for inventory-level booking failures into a single canonical type with one `Display` impl.

## Why

Before this PR, the same logical failure (reduction exceeds available inventory) was encoded as three separate error types with three separate hand-written `Display` strings across three crates:

| Type | Location | Variants |
|---|---|---|
| `rustledger_core::BookingError` | `crates/rustledger-core/src/inventory/mod.rs` | 4 (no account context) |
| `rustledger_booking::BookingError` | `crates/rustledger-booking/src/book.rs` | 4 wrapped + `Interpolation` |
| `rustledger_validate::ValidationError` | `crates/rustledger-validate/src/validators/transaction.rs` | Hand-formatted from core |

**12 match arms across three crates** all encoded the same 4-way structure, and the three `Display` strings drifted apart — that was the root cause of #748, where the booking layer's `"insufficient units: need X but only Y available"` bypassed the validator's `"Not enough units in ..."` and dropped the phrasing the pta-standards conformance suite asserts on.

## What changed

1. **`rustledger-core`**: new `AccountedBookingError { error: BookingError, account: InternedStr }` struct with a single canonical `Display` impl covering all four variants. Added `BookingError::with_account(self, account)` constructor. The raw `BookingError` is still what `Inventory::reduce` returns (it doesn't know its own account) — but every user-facing rendering goes through the new wrapper.

2. **`rustledger-booking`**: collapsed `BookingError::{InsufficientUnits, NoMatchingLot, AmbiguousMatch}` (3 variants) into a single `BookingError::Inventory(AccountedBookingError)` variant with `#[error(transparent)]` Display. `convert_core_booking_error` becomes a one-liner.

3. **`rustledger-validate`**: stopped hand-formatting inventory errors. Each match arm now calls `format!(\"{}\", err.with_account(posting.account.clone()))`. ~15 lines of hand-rolled format strings deleted.

4. **`rustledger`** (`cmd/check.rs`): `code_for` now dispatches on the inner `core::BookingError` variant of the unified `BookingError::Inventory` arm.

**Net:** 8 of 12 match arms eliminated, one canonical `Display` impl, zero hand-formatted duplicates. Adding a fifth booking failure variant now means touching **one crate**, not three.

## Canonical Display strings (locked by tests and conformance)

| Variant | Display |
|---|---|
| `InsufficientUnits` | `Not enough units in {account}: requested {req}, available {avail}; not enough to reduce` |
| `NoMatchingLot` | `No matching lot for {currency} in {account}` |
| `AmbiguousMatch` | `Ambiguous lot match for {currency}: {n} lots match in {account}` |
| `CurrencyMismatch` | `Currency mismatch in {account}: expected {e}, got {g}` |

The `InsufficientUnits` string is byte-for-byte identical to the one locked in #749 — so #749's regression test passes unchanged, now exercising the new unified path. The other three strings are equivalent rewordings of the pre-existing validator messages (I verified against pta-standards that only `reduction-exceeds-inventory` asserts on wording — it requires `\"not enough\"`, which the new canonical string contains).

## Test plan

- [x] `cargo test --workspace --all-features` — all suites green, 0 failures
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] #748 regression test (`test_insufficient_units_display_contains_not_enough`) passes, now exercising the unified path via `BookingError::Inventory(core_err.with_account(...))`
- [x] `rustledger-core/tests/tla_proptest.rs` `AmbiguousMatch` pattern-match still works (it uses the unchanged `rustledger_core::BookingError`, not the booking-layer wrapper)
- [ ] pta-standards `reduction-exceeds-inventory` remains green (inherited from #749)
- [ ] pta-standards `reduction-no-matching-lot` remains green (only asserts `validate: error`, no wording check)

## Risks

- **Public API break on `rustledger_booking::BookingError`**. In-tree, only `crates/rustledger/src/cmd/check.rs` pattern-matches on the removed variants, and that's updated. Any out-of-tree consumer pattern-matching on `BookingError::{InsufficientUnits, NoMatchingLot, AmbiguousMatch}` will get a compile error and need to match on `BookingError::Inventory(inner)` + `inner.error` instead.
- **CurrencyMismatch now produces a real user-facing message** (`\"Currency mismatch in {account}: ...\"`) where previously the validator silently ignored it. This is strictly an improvement — the comment in the old code was `\"This shouldn't happen in normal validation\"` — but it's a behavior change in edge cases. If you'd prefer to preserve silent-ignore, I can add an explicit skip in the validator.

## Related

- #748 — the regression that motivated this
- #749 — the one-line phrasing fix this builds on
- #745 — the architectural change that made the three layers diverge

Closes #750