### PR TITLE
perf(booking): Optimize inventory cloning and capacity hints

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -203,12 +203,21 @@ impl BookingEngine {
         // Create working copies of inventories for this transaction.
         // This allows us to track inventory changes across multiple postings
         // within the same transaction (e.g., main sale + fee posting).
-        // Clone only the inventories we actually need for this transaction's accounts
+        //
+        // Clone only the inventories we actually need for this transaction's
+        // accounts. Use `entry().or_insert_with(...)` so that a posting list
+        // with repeated accounts (e.g., two postings on `Assets:Stock`) only
+        // triggers one clone per unique account instead of cloning the same
+        // inventory every time it appears. Without deduping, the optimization
+        // would be silently undone by transactions that list the same
+        // account more than once.
         let mut working_inventories: FxHashMap<InternedStr, Inventory> =
             FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
         for posting in &txn.postings {
             if let Some(inv) = self.inventories.get(&posting.account) {
-                working_inventories.insert(posting.account.clone(), inv.clone());
+                working_inventories
+                    .entry(posting.account.clone())
+                    .or_insert_with(|| inv.clone());
             }
         }
 

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -203,10 +203,13 @@ impl BookingEngine {
         // Create working copies of inventories for this transaction.
         // This allows us to track inventory changes across multiple postings
         // within the same transaction (e.g., main sale + fee posting).
+        // Clone only the inventories we actually need for this transaction's accounts
         let mut working_inventories: FxHashMap<InternedStr, Inventory> =
-            FxHashMap::with_capacity_and_hasher(self.inventories.len(), Default::default());
-        for (k, v) in &self.inventories {
-            working_inventories.insert(k.clone(), v.clone());
+            FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
+        for posting in &txn.postings {
+            if let Some(inv) = self.inventories.get(&posting.account) {
+                working_inventories.insert(posting.account.clone(), inv.clone());
+            }
         }
 
         // First pass: identify postings that need lot matching (reductions)

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -117,7 +117,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     let num_postings = transaction.postings.len();
     let mut residuals: HashMap<InternedStr, Decimal> = HashMap::with_capacity(num_postings.min(4));
     let mut missing_by_currency: HashMap<InternedStr, Vec<usize>> = HashMap::with_capacity(2);
-    let mut unassigned_missing: Vec<usize> = Vec::new();
+    let mut unassigned_missing: Vec<usize> = Vec::with_capacity(2);
 
     // Track maximum scale (decimal places) per currency for rounding interpolated amounts.
     // Python beancount rounds interpolated amounts to match the precision of other amounts

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -66,6 +66,7 @@ pub fn calculate_tolerance(amounts: &[&Amount]) -> HashMap<InternedStr, Decimal>
 /// 2. A price annotation on a simple posting (the price currency takes precedence).
 /// 3. The currency of other simple postings (units or currency-only amounts).
 /// 4. The currency from a cost spec (e.g., `{0 USD}` for zero-cost items).
+#[must_use]
 pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Option<InternedStr> {
     // First pass: look for simple postings (no cost spec) - these take priority
     for posting in &transaction.postings {

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -99,10 +99,12 @@ struct PendingPad {
 /// - Synthetic padding transactions
 /// - Any errors encountered
 pub fn process_pads(directives: &[Directive]) -> PadResult {
-    let mut inventories: HashMap<InternedStr, Inventory> = HashMap::new();
-    let mut pending_pads: HashMap<InternedStr, PendingPad> = HashMap::new();
-    let mut padding_transactions = Vec::new();
-    let mut errors = Vec::new();
+    let num_directives = directives.len();
+    let mut inventories: HashMap<InternedStr, Inventory> =
+        HashMap::with_capacity(num_directives.min(16));
+    let mut pending_pads: HashMap<InternedStr, PendingPad> = HashMap::with_capacity(4);
+    let mut padding_transactions = Vec::with_capacity(num_directives.min(16));
+    let mut errors = Vec::with_capacity(4);
 
     // Sort directives by date for processing
     let mut sorted: Vec<&Directive> = directives.iter().collect();


### PR DESCRIPTION
## Summary

Optimizes inventory cloning in booking engine and adds capacity hints to reduce heap allocations.

## Changes

| File | Change | Impact |
|------|--------|--------|
| book.rs:203-211 | Clone only needed inventories | O(txn accounts) vs O(all accounts) |
| interpolate.rs:120 | Vec::with_capacity(2) | Saves 1 alloc per interpolation |
| pad.rs:102-106 | 4 capacity hints | Saves allocs in pad processing |
| lib.rs:69 | #[must_use] attribute | API clarity |

## Impact

- **Memory reduction**: Clones only inventories for accounts in transaction (typically 2-4) instead of all accounts (could be 100+)
- **Performance**: Reduces heap allocations for large ledgers with many accounts
- All 83 tests pass ✅ (75 unit + 8 prop)

## rust-skills Rules Addressed

- `mem-vec-with-capacity` ✅ Fixed
- `own-clone-excessive` ✅ Fixed (inventory cloning)
- `api-must-use` ✅ Fixed