### PR TITLE
fix: overlay in-memory buffer on stale ledger snapshot for LSP diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,6 +3250,7 @@ dependencies = [
  "rustledger-validate",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -42,6 +42,7 @@ chrono.workspace = true
 
 [dev-dependencies]
 tokio-test = "0.4"
+tempfile.workspace = true
 
 [[bin]]
 name = "rledger-lsp"

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -251,6 +251,53 @@ pub fn validation_error_to_diagnostic(
 /// 500KB is a generous limit - most beancount files are much smaller.
 const MAX_VALIDATION_FILE_SIZE: usize = 500 * 1024;
 
+/// Build the effective directive list for validation by overlaying a fresh
+/// in-memory parse onto a potentially-stale ledger snapshot.
+///
+/// # Why this exists (issue #685)
+///
+/// The LSP's `LedgerState` is loaded from disk at startup and refreshed only
+/// by file-watcher events, which fire on save. In-memory buffer edits do not
+/// touch it. Without an overlay, `all_diagnostics` would validate the current
+/// file against the stale on-disk directives and produce two bad behaviors:
+///
+/// 1. A new error the user introduces in the buffer is not reported until
+///    after the next save.
+/// 2. After the user saves (at which point the file-watcher pushes the bad
+///    content into `LedgerState`) and then fixes the error in the buffer,
+///    the error is still reported against the now-stale `LedgerState` until
+///    the user saves again.
+///
+/// The overlay solves both: for the file currently being edited we drop the
+/// stale directives (matched by `file_id`) and append the fresh directives
+/// from the latest in-memory parse, remapped to the same `file_id` so the
+/// per-file filter in [`validation_errors_to_diagnostics`] still works.
+/// Validation then sees the live buffer state for this file plus the
+/// on-disk state for every other file in the ledger.
+///
+/// Returns `None` when there is nothing to overlay (no ledger state or no
+/// `current_file_id`). Callers should fall back to the original
+/// `full_directives` in that case.
+fn build_live_directive_overlay(
+    fresh_directives: &[Spanned<Directive>],
+    full_directives: Option<&[Spanned<Directive>]>,
+    current_file_id: Option<u16>,
+) -> Option<Vec<Spanned<Directive>>> {
+    match (full_directives, current_file_id) {
+        (Some(full), Some(fid)) => {
+            let mut merged: Vec<Spanned<Directive>> =
+                full.iter().filter(|d| d.file_id != fid).cloned().collect();
+            for d in fresh_directives {
+                let mut d = d.clone();
+                d.file_id = fid;
+                merged.push(d);
+            }
+            Some(merged)
+        }
+        _ => None,
+    }
+}
+
 /// Get all diagnostics (parse errors + validation errors) for a parse result.
 ///
 /// Validation is skipped for files larger than `MAX_VALIDATION_FILE_SIZE` to
@@ -278,8 +325,21 @@ pub fn all_diagnostics(
     // 2. File is not too large (to keep LSP responsive)
     if result.errors.is_empty() {
         if source.len() <= MAX_VALIDATION_FILE_SIZE {
-            // Get full directives from ledger state if available
-            let full_directives = ledger_state.and_then(|ls| ls.directives());
+            // Get full directives from ledger state if available, then
+            // apply a live overlay of the fresh in-memory parse.
+            //
+            // See `build_live_directive_overlay` for why the overlay is
+            // necessary (it's the fix for issue #685: without it,
+            // diagnostics lag behind in-memory buffer edits because the
+            // ledger state is only refreshed on file-watcher save events).
+            let full_directives_raw = ledger_state.and_then(|ls| ls.directives());
+            let overlay = build_live_directive_overlay(
+                &result.directives,
+                full_directives_raw,
+                current_file_id,
+            );
+            let full_directives: Option<&[Spanned<Directive>]> =
+                overlay.as_deref().or(full_directives_raw);
 
             // Build validation options with custom account type names.
             // Use ledger-wide options when a ledger is loaded (handles multi-file
@@ -624,6 +684,206 @@ option "name_equity" "Капитал"
                 .iter()
                 .any(|d| d.severity == Some(DiagnosticSeverity::ERROR)),
             "At least one diagnostic should be ERROR severity"
+        );
+    }
+
+    /// Regression test for issue #685.
+    ///
+    /// When the LSP is started against a journal file, `ledger_state` is
+    /// loaded from disk at startup and refreshed only by file-watcher events
+    /// on save. In-memory buffer edits don't touch it, so without a live
+    /// overlay the validation pass sees stale directives and diagnostics lag
+    /// behind the buffer until the next save.
+    ///
+    /// This test exercises `build_live_directive_overlay` directly, plus the
+    /// downstream `validation_errors_to_diagnostics` path, to confirm both of
+    /// the bad behaviors that motivated the bug are fixed:
+    ///
+    /// 1. A new error introduced in the buffer is reported before any save.
+    /// 2. After the buffer is fixed, the error is cleared, even if the
+    ///    stale `full_directives` still hold the broken version.
+    #[test]
+    fn test_live_overlay_reflects_buffer_edits_issue_685() {
+        // Helper for reading an LSP diagnostic's string code.
+        fn get_code(d: &Diagnostic) -> String {
+            match d.code.as_ref().unwrap() {
+                lsp_types::NumberOrString::String(s) => s.clone(),
+                lsp_types::NumberOrString::Number(n) => panic!("Unexpected number code: {n}"),
+            }
+        }
+
+        // The on-disk version of the file is balanced.
+        let on_disk_source = r#"2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary
+
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5000 USD
+"#;
+
+        // The buffer version has been edited to be unbalanced (5000 vs 5001).
+        let buffer_unbalanced_source = r#"2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary
+
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5001 USD
+"#;
+
+        // And a later state where the user has fixed the imbalance back to
+        // its original value while `ledger_state` still holds the broken
+        // saved version (simulating: user saved while broken, then fixed in
+        // the buffer).
+        let buffer_fixed_source = on_disk_source;
+        let on_disk_stale_broken_source = buffer_unbalanced_source;
+
+        // ===== Scenario 1: buffer is edited, ledger_state still clean =====
+
+        let fresh_unbalanced = parse(buffer_unbalanced_source);
+        assert!(
+            fresh_unbalanced.errors.is_empty(),
+            "buffer should parse cleanly"
+        );
+
+        // Simulate what `LedgerState::load` would have given us: parsed
+        // directives from the on-disk content, with a specific file_id.
+        // file_id=1 matches how multi-file tests in this module assign IDs.
+        let on_disk_clean = parse(on_disk_source);
+        let stale_full_directives: Vec<Spanned<Directive>> = on_disk_clean
+            .directives
+            .iter()
+            .map(|d| {
+                let mut d = d.clone();
+                d.file_id = 1;
+                d
+            })
+            .collect();
+
+        // Without the overlay: validation would use the stale clean
+        // directives and report no error, which is the bug.
+        let no_overlay = validation_errors_to_diagnostics(
+            &fresh_unbalanced.directives,
+            buffer_unbalanced_source,
+            ValidationOptions::default(),
+            Some(&stale_full_directives),
+            Some(1),
+        );
+        let no_overlay_codes: Vec<_> = no_overlay.iter().map(get_code).collect();
+        assert!(
+            !no_overlay_codes.iter().any(|c| c == "E3001"),
+            "Bug reproduction: without overlay, stale ledger_state hides \
+             the buffer's new imbalance. Got: {no_overlay_codes:?}"
+        );
+
+        // With the overlay: fresh directives replace stale ones for this
+        // file, and the new imbalance is reported.
+        let overlay = build_live_directive_overlay(
+            &fresh_unbalanced.directives,
+            Some(&stale_full_directives),
+            Some(1),
+        )
+        .expect("overlay must be built when both full_directives and file_id are present");
+
+        let with_overlay = validation_errors_to_diagnostics(
+            &fresh_unbalanced.directives,
+            buffer_unbalanced_source,
+            ValidationOptions::default(),
+            Some(&overlay),
+            Some(1),
+        );
+        let with_overlay_codes: Vec<_> = with_overlay.iter().map(get_code).collect();
+        assert!(
+            with_overlay_codes.iter().any(|c| c == "E3001"),
+            "Fix verification: with overlay, buffer's imbalance should be \
+             reported as E3001. Got: {with_overlay_codes:?}"
+        );
+
+        // ===== Scenario 2: buffer is fixed, ledger_state still broken =====
+
+        let fresh_fixed = parse(buffer_fixed_source);
+        assert!(
+            fresh_fixed.errors.is_empty(),
+            "fixed buffer should parse cleanly"
+        );
+
+        // Simulate: user saved the broken version at some point, so
+        // `ledger_state` now holds the broken directives.
+        let stale_broken = parse(on_disk_stale_broken_source);
+        let stale_broken_full: Vec<Spanned<Directive>> = stale_broken
+            .directives
+            .iter()
+            .map(|d| {
+                let mut d = d.clone();
+                d.file_id = 1;
+                d
+            })
+            .collect();
+
+        // Without the overlay: validation uses the stale broken ledger and
+        // the old error persists even though the buffer is fixed.
+        let no_overlay_persist = validation_errors_to_diagnostics(
+            &fresh_fixed.directives,
+            buffer_fixed_source,
+            ValidationOptions::default(),
+            Some(&stale_broken_full),
+            Some(1),
+        );
+        let no_overlay_persist_codes: Vec<_> = no_overlay_persist.iter().map(get_code).collect();
+        assert!(
+            no_overlay_persist_codes.iter().any(|c| c == "E3001"),
+            "Bug reproduction: without overlay, stale broken ledger_state \
+             makes a now-fixed buffer still appear broken. \
+             Got: {no_overlay_persist_codes:?}"
+        );
+
+        // With the overlay: fresh fixed directives replace the stale broken
+        // ones, and the error is cleared.
+        let overlay_fixed = build_live_directive_overlay(
+            &fresh_fixed.directives,
+            Some(&stale_broken_full),
+            Some(1),
+        )
+        .expect("overlay must be built when both full_directives and file_id are present");
+
+        let with_overlay_fixed = validation_errors_to_diagnostics(
+            &fresh_fixed.directives,
+            buffer_fixed_source,
+            ValidationOptions::default(),
+            Some(&overlay_fixed),
+            Some(1),
+        );
+        let with_overlay_fixed_codes: Vec<_> = with_overlay_fixed.iter().map(get_code).collect();
+        assert!(
+            !with_overlay_fixed_codes.iter().any(|c| c == "E3001"),
+            "Fix verification: with overlay, fixed buffer should clear the \
+             stale error. Got: {with_overlay_fixed_codes:?}"
+        );
+    }
+
+    #[test]
+    fn test_live_overlay_returns_none_without_file_id() {
+        let parsed = parse("2024-01-01 open Assets:Bank:Checking USD\n");
+        let result = build_live_directive_overlay(&parsed.directives, None, None);
+        assert!(
+            result.is_none(),
+            "no ledger, no file_id: overlay should be None"
+        );
+
+        let other_parsed = parse("2024-01-01 open Income:Salary\n");
+        let other_dirs: Vec<Spanned<Directive>> = other_parsed
+            .directives
+            .iter()
+            .map(|d| {
+                let mut d = d.clone();
+                d.file_id = 2;
+                d
+            })
+            .collect();
+        let result = build_live_directive_overlay(&parsed.directives, Some(&other_dirs), None);
+        assert!(
+            result.is_none(),
+            "full_directives present but no file_id: overlay should be None \
+             (caller will fall back to full_directives as-is)"
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -126,10 +126,10 @@ pub fn parse_error_to_diagnostic(error: &ParseError, line_index: &LineIndex) -> 
 /// # Arguments
 /// * `directives` - Owned directive list to validate. The caller is
 ///   responsible for constructing it (e.g., cloning from `LedgerState`
-///   directives, or moving from an overlay produced by
-///   [`build_live_directive_overlay`]). Taking ownership here lets
-///   callers that already produced an owned Vec (the overlay path) avoid
-///   a second clone on every diagnostics run.
+///   directives, or moving from an overlay produced by the
+///   crate-internal `build_live_directive_overlay` helper). Taking
+///   ownership here lets callers that already produced an owned Vec
+///   (the overlay path) avoid a second clone on every diagnostics run.
 /// * `source` - Source text of the current file
 /// * `validation_options` - Validation options (including custom account type names)
 /// * `current_file_id` - Optional: File ID of the current file (to filter errors)

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -124,34 +124,28 @@ pub fn parse_error_to_diagnostic(error: &ParseError, line_index: &LineIndex) -> 
 /// flagged as unbalanced.
 ///
 /// # Arguments
-/// * `directives` - Directives from the current file (used for line number mapping)
+/// * `directives` - Owned directive list to validate. The caller is
+///   responsible for constructing it (e.g., cloning from `LedgerState`
+///   directives, or moving from an overlay produced by
+///   [`build_live_directive_overlay`]). Taking ownership here lets
+///   callers that already produced an owned Vec (the overlay path) avoid
+///   a second clone on every diagnostics run.
 /// * `source` - Source text of the current file
 /// * `validation_options` - Validation options (including custom account type names)
-/// * `full_directives` - Optional: All directives from all files (for multi-file validation)
 /// * `current_file_id` - Optional: File ID of the current file (to filter errors)
 ///
-/// When `full_directives` is provided, validation runs on the complete ledger
-/// but only returns errors for the current file.
+/// When `current_file_id` is set, errors are filtered to those whose
+/// `file_id` matches (or is `None`, for global errors like duplicate
+/// account opens across files).
 pub fn validation_errors_to_diagnostics(
-    directives: &[Spanned<Directive>],
+    mut booked_directives: Vec<Spanned<Directive>>,
     source: &str,
     validation_options: ValidationOptions,
-    full_directives: Option<&[Spanned<Directive>]>,
     current_file_id: Option<u16>,
 ) -> Vec<Diagnostic> {
     let line_index = LineIndex::new(source);
 
-    // Only use full directives if we can identify this file in the ledger.
-    // If current_file_id is None, we can't filter errors properly and would
-    // produce diagnostics with incorrect line numbers (wrong file's LineIndex).
-    let directives_to_validate = if current_file_id.is_some() {
-        full_directives.unwrap_or(directives)
-    } else {
-        directives
-    };
-
-    // Clone and sort directives by date (required for correct lot matching during booking)
-    let mut booked_directives: Vec<Spanned<Directive>> = directives_to_validate.to_vec();
+    // Sort directives by date (required for correct lot matching during booking).
     booked_directives.sort_by(|a, b| {
         a.value
             .date()
@@ -349,8 +343,24 @@ pub fn all_diagnostics(
                 full_directives_raw,
                 current_file_id,
             );
-            let full_directives: Option<&[Spanned<Directive>]> =
-                overlay.as_deref().or(full_directives_raw);
+
+            // Construct the owned directive list for validation. This used
+            // to be done by `validation_errors_to_diagnostics.to_vec()`
+            // internally, which on the multi-file overlay path meant two
+            // full-ledger clones per keystroke (one for the overlay, one
+            // for `booked_directives`). Moving the overlay in by value
+            // saves the second clone. Other paths (single-file, or
+            // multi-file without overlay) still pay one clone, same as
+            // before.
+            let booked_directives: Vec<Spanned<Directive>> = if let Some(owned) = overlay {
+                owned
+            } else if let Some(full) = full_directives_raw
+                && current_file_id.is_some()
+            {
+                full.to_vec()
+            } else {
+                result.directives.clone()
+            };
 
             // Build validation options with custom account type names.
             // Use ledger-wide options when a ledger is loaded (handles multi-file
@@ -365,10 +375,9 @@ pub fn all_diagnostics(
             };
 
             let validation_diagnostics = validation_errors_to_diagnostics(
-                &result.directives,
+                booked_directives,
                 source,
                 validation_options,
-                full_directives,
                 current_file_id,
             );
             diagnostics.extend(validation_diagnostics);
@@ -604,10 +613,9 @@ mod tests {
         // Test 1: Validate bank.bean in ISOLATION (old broken behavior)
         // This should show E2001 for the second balance assertion
         let isolated_diagnostics = validation_errors_to_diagnostics(
-            &bank_result.directives,
+            bank_result.directives.clone(),
             bank_source,
             ValidationOptions::default(),
-            None,
             None,
         );
 
@@ -624,10 +632,9 @@ mod tests {
         // Test 2: Validate bank.bean with FULL LEDGER (fixed behavior)
         // This should NOT show E2001 because it sees the transaction from credit_card.bean
         let full_ledger_diagnostics = validation_errors_to_diagnostics(
-            &bank_result.directives,
+            all_directives.clone(),
             bank_source,
             ValidationOptions::default(),
-            Some(&all_directives),
             Some(1), // file_id=1 for bank.bean
         );
 
@@ -773,10 +780,9 @@ option "name_equity" "Капитал"
         // Without the overlay: validation would use the stale clean
         // directives and report no error, which is the bug.
         let no_overlay = validation_errors_to_diagnostics(
-            &fresh_unbalanced.directives,
+            stale_full_directives.clone(),
             buffer_unbalanced_source,
             ValidationOptions::default(),
-            Some(&stale_full_directives),
             Some(1),
         );
         let no_overlay_codes: Vec<_> = no_overlay.iter().map(get_code).collect();
@@ -796,10 +802,9 @@ option "name_equity" "Капитал"
         .expect("overlay must be built when both full_directives and file_id are present");
 
         let with_overlay = validation_errors_to_diagnostics(
-            &fresh_unbalanced.directives,
+            overlay,
             buffer_unbalanced_source,
             ValidationOptions::default(),
-            Some(&overlay),
             Some(1),
         );
         let with_overlay_codes: Vec<_> = with_overlay.iter().map(get_code).collect();
@@ -833,10 +838,9 @@ option "name_equity" "Капитал"
         // Without the overlay: validation uses the stale broken ledger and
         // the old error persists even though the buffer is fixed.
         let no_overlay_persist = validation_errors_to_diagnostics(
-            &fresh_fixed.directives,
+            stale_broken_full.clone(),
             buffer_fixed_source,
             ValidationOptions::default(),
-            Some(&stale_broken_full),
             Some(1),
         );
         let no_overlay_persist_codes: Vec<_> = no_overlay_persist.iter().map(get_code).collect();
@@ -857,10 +861,9 @@ option "name_equity" "Капитал"
         .expect("overlay must be built when both full_directives and file_id are present");
 
         let with_overlay_fixed = validation_errors_to_diagnostics(
-            &fresh_fixed.directives,
+            overlay_fixed,
             buffer_fixed_source,
             ValidationOptions::default(),
-            Some(&overlay_fixed),
             Some(1),
         );
         let with_overlay_fixed_codes: Vec<_> = with_overlay_fixed.iter().map(get_code).collect();

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -288,6 +288,17 @@ fn build_live_directive_overlay(
             let mut merged: Vec<Spanned<Directive>> =
                 full.iter().filter(|d| d.file_id != fid).cloned().collect();
             for d in fresh_directives {
+                // The per-file parse produces directives with file_id=0 by
+                // default. Anything else would mean a caller pre-tagged
+                // them, which would silently get overwritten here and
+                // likely indicate a bug upstream. Assert in debug builds
+                // so we catch it early.
+                debug_assert!(
+                    d.file_id == 0 || d.file_id == fid,
+                    "fresh directive for file_id={fid} was pre-tagged with \
+                     unexpected file_id={} — caller bug?",
+                    d.file_id
+                );
                 let mut d = d.clone();
                 d.file_id = fid;
                 merged.push(d);
@@ -884,6 +895,119 @@ option "name_equity" "Капитал"
             result.is_none(),
             "full_directives present but no file_id: overlay should be None \
              (caller will fall back to full_directives as-is)"
+        );
+    }
+
+    /// End-to-end regression test for #685 through `all_diagnostics`.
+    ///
+    /// The other #685 regression test exercises
+    /// `build_live_directive_overlay` and `validation_errors_to_diagnostics`
+    /// directly, which pins the helper logic but does not pin the wiring
+    /// inside `all_diagnostics`. A future refactor that moves or renames
+    /// the overlay call (or adds a new caller that forgets it) could break
+    /// the fix without tripping the direct tests. This test uses a real
+    /// `LedgerState` backed by a tempdir file so the full
+    /// `all_diagnostics` code path runs, catching integration-level
+    /// regressions.
+    #[test]
+    fn test_all_diagnostics_applies_live_overlay_issue_685() {
+        use std::fs;
+
+        fn get_code(d: &Diagnostic) -> String {
+            match d.code.as_ref().unwrap() {
+                lsp_types::NumberOrString::String(s) => s.clone(),
+                lsp_types::NumberOrString::Number(n) => panic!("Unexpected number code: {n}"),
+            }
+        }
+
+        let on_disk = r#"2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary
+
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5000 USD
+"#;
+        let buffer_unbalanced = r#"2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary
+
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5001 USD
+"#;
+
+        // Write the balanced version to disk and build a real LedgerState
+        // from it. This is the state the LSP would have at startup, before
+        // any in-memory edits.
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let journal_path = tempdir.path().join("ledger.beancount");
+        fs::write(&journal_path, on_disk).expect("write journal");
+
+        let mut ledger_state = LedgerState::new();
+        ledger_state
+            .load(&journal_path)
+            .expect("LedgerState::load should succeed on well-formed journal");
+
+        // Find the file_id the loader assigned to this file. Mirrors the
+        // logic in `main_loop::publish_diagnostics` at the call site.
+        let canonical = journal_path.canonicalize().expect("canonicalize");
+        let file_id = ledger_state
+            .ledger()
+            .expect("ledger loaded")
+            .source_map
+            .files()
+            .iter()
+            .find_map(|f| {
+                f.path
+                    .canonicalize()
+                    .ok()
+                    .filter(|p| *p == canonical)
+                    .map(|_| f.id as u16)
+            })
+            .expect("file_id for loaded file");
+
+        // Simulate a `didChange` with the unbalanced buffer content.
+        // `all_diagnostics` parses the fresh text and should report E3001
+        // because the overlay brings the buffer edits into the validation
+        // directive list.
+        let result = parse(buffer_unbalanced);
+        assert!(
+            result.errors.is_empty(),
+            "buffer content should parse cleanly"
+        );
+
+        let diagnostics = all_diagnostics(
+            &result,
+            buffer_unbalanced,
+            Some(&ledger_state),
+            Some(file_id),
+        );
+        let codes: Vec<_> = diagnostics.iter().map(get_code).collect();
+
+        assert!(
+            codes.iter().any(|c| c == "E3001"),
+            "all_diagnostics should report the buffer's new imbalance (E3001) \
+             even though LedgerState still holds the balanced on-disk \
+             version. Got: {codes:?}"
+        );
+
+        // And the inverse: re-parsing the now-balanced buffer should clear
+        // diagnostics, regardless of LedgerState's contents. (LedgerState
+        // here still holds the balanced on-disk version, so this path is
+        // symmetric with the unbalanced case — we're mainly asserting the
+        // happy path still works after the overlay merge.)
+        let result_clean = parse(on_disk);
+        assert!(result_clean.errors.is_empty());
+        let clean_diagnostics =
+            all_diagnostics(&result_clean, on_disk, Some(&ledger_state), Some(file_id));
+        let clean_error_count = clean_diagnostics
+            .iter()
+            .filter(|d| matches!(d.severity, Some(DiagnosticSeverity::ERROR)))
+            .count();
+        assert_eq!(
+            clean_error_count,
+            0,
+            "balanced buffer should produce no ERROR diagnostics. Got: {:?}",
+            clean_diagnostics.iter().map(get_code).collect::<Vec<_>>()
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -245,15 +245,16 @@ pub fn validation_error_to_diagnostic(
 /// 500KB is a generous limit - most beancount files are much smaller.
 const MAX_VALIDATION_FILE_SIZE: usize = 500 * 1024;
 
-/// Build the effective directive list for validation by overlaying a fresh
-/// in-memory parse onto a potentially-stale ledger snapshot.
+/// Build the effective directive list for validation by overlaying one or
+/// more fresh in-memory parses onto a potentially-stale ledger snapshot.
 ///
-/// # Why this exists (issue #685)
+/// # Why this exists (issues #685 and #760)
 ///
 /// The LSP's `LedgerState` is loaded from disk at startup and refreshed only
 /// by file-watcher events, which fire on save. In-memory buffer edits do not
-/// touch it. Without an overlay, `all_diagnostics` would validate the current
-/// file against the stale on-disk directives and produce two bad behaviors:
+/// touch it. Without an overlay, `all_diagnostics` would validate the
+/// current file against the stale on-disk directives and produce two bad
+/// behaviors:
 ///
 /// 1. A new error the user introduces in the buffer is not reported until
 ///    after the next save.
@@ -262,45 +263,64 @@ const MAX_VALIDATION_FILE_SIZE: usize = 500 * 1024;
 ///    the error is still reported against the now-stale `LedgerState` until
 ///    the user saves again.
 ///
-/// The overlay solves both: for the file currently being edited we drop the
-/// stale directives (matched by `file_id`) and append the fresh directives
-/// from the latest in-memory parse, remapped to the same `file_id` so the
-/// per-file filter in [`validation_errors_to_diagnostics`] still works.
-/// Validation then sees the live buffer state for this file plus the
-/// on-disk state for every other file in the ledger.
+/// #685 fixed the single-file case by overlaying just the file being
+/// edited. #760 generalized the helper to accept overlays for multiple
+/// files at once so that a multi-file ledger with several open buffers
+/// gets a coherent view: the validator sees the in-memory buffer state
+/// for every open file, plus the on-disk state for every file in the
+/// ledger that is not currently open. That matters when a balance
+/// assertion in file A depends on a transaction in file B and both have
+/// unsaved changes.
 ///
-/// Returns `None` when there is nothing to overlay (no ledger state or no
-/// `current_file_id`). Callers should fall back to the original
+/// For each `(file_id, fresh)` pair in `fresh_overlays`, stale directives
+/// with that `file_id` are dropped from `full_directives` and replaced by
+/// `fresh`, remapped to the same `file_id` so the per-file filter in
+/// [`validation_errors_to_diagnostics`] still works.
+///
+/// Returns `None` when there is nothing to overlay (no ledger state, or
+/// no fresh overlays). Callers should fall back to the original
 /// `full_directives` in that case.
 fn build_live_directive_overlay(
-    fresh_directives: &[Spanned<Directive>],
+    fresh_overlays: &[(u16, &[Spanned<Directive>])],
     full_directives: Option<&[Spanned<Directive>]>,
-    current_file_id: Option<u16>,
 ) -> Option<Vec<Spanned<Directive>>> {
-    match (full_directives, current_file_id) {
-        (Some(full), Some(fid)) => {
-            let mut merged: Vec<Spanned<Directive>> =
-                full.iter().filter(|d| d.file_id != fid).cloned().collect();
-            for d in fresh_directives {
-                // The per-file parse produces directives with file_id=0 by
-                // default. Anything else would mean a caller pre-tagged
-                // them, which would silently get overwritten here and
-                // likely indicate a bug upstream. Assert in debug builds
-                // so we catch it early.
-                debug_assert!(
-                    d.file_id == 0 || d.file_id == fid,
-                    "fresh directive for file_id={fid} was pre-tagged with \
-                     unexpected file_id={} — caller bug?",
-                    d.file_id
-                );
-                let mut d = d.clone();
-                d.file_id = fid;
-                merged.push(d);
-            }
-            Some(merged)
-        }
-        _ => None,
+    let full = full_directives?;
+    if fresh_overlays.is_empty() {
+        return None;
     }
+
+    // Collect the file_ids being replaced so the filter below is O(1) per
+    // directive instead of O(n) over a slice scan. For typical small
+    // overlay sets (1-5 open buffers) the HashSet overhead is negligible
+    // but the code reads more clearly than a `contains` on a slice.
+    let replaced: std::collections::HashSet<u16> =
+        fresh_overlays.iter().map(|(fid, _)| *fid).collect();
+
+    let mut merged: Vec<Spanned<Directive>> = full
+        .iter()
+        .filter(|d| !replaced.contains(&d.file_id))
+        .cloned()
+        .collect();
+
+    for (fid, fresh) in fresh_overlays {
+        for d in *fresh {
+            // The per-file parse produces directives with file_id=0 by
+            // default. Anything else would mean a caller pre-tagged them,
+            // which would silently get overwritten here and likely indicate
+            // a bug upstream. Assert in debug builds so we catch it early.
+            debug_assert!(
+                d.file_id == 0 || d.file_id == *fid,
+                "fresh directive for file_id={fid} was pre-tagged with \
+                 unexpected file_id={} (caller bug?)",
+                d.file_id
+            );
+            let mut d = d.clone();
+            d.file_id = *fid;
+            merged.push(d);
+        }
+    }
+
+    Some(merged)
 }
 
 /// Get all diagnostics (parse errors + validation errors) for a parse result.
@@ -313,15 +333,23 @@ fn build_live_directive_overlay(
 /// * `source` - Source text of the current file
 /// * `ledger_state` - Optional: Full ledger state for multi-file validation
 /// * `current_file_id` - Optional: File ID of the current file (to filter errors)
+/// * `other_buffer_overlays` - Fresh parses for every **other** open buffer
+///   that is part of the ledger, keyed by file_id. Pass `&[]` in single-file
+///   mode or for tests that don't care about cross-buffer consistency.
+///   See `build_live_directive_overlay` for why this exists (#760).
 ///
 /// When `ledger_state` is provided, validation considers all files in the ledger,
 /// providing accurate diagnostics for balance assertions that depend on transactions
-/// in other files.
+/// in other files. Fresh overlays for the current file (from `result`) and for
+/// every entry in `other_buffer_overlays` replace the on-disk snapshot of
+/// those files in the validation input, so in-memory edits are seen before
+/// the buffer is saved.
 pub fn all_diagnostics(
     result: &ParseResult,
     source: &str,
     ledger_state: Option<&LedgerState>,
     current_file_id: Option<u16>,
+    other_buffer_overlays: &[(u16, &[Spanned<Directive>])],
 ) -> Vec<Diagnostic> {
     let mut diagnostics = parse_errors_to_diagnostics(result, source);
 
@@ -331,27 +359,39 @@ pub fn all_diagnostics(
     if result.errors.is_empty() {
         if source.len() <= MAX_VALIDATION_FILE_SIZE {
             // Get full directives from ledger state if available, then
-            // apply a live overlay of the fresh in-memory parse.
+            // apply a live overlay of every fresh in-memory parse we have.
             //
             // See `build_live_directive_overlay` for why the overlay is
-            // necessary (it's the fix for issue #685: without it,
-            // diagnostics lag behind in-memory buffer edits because the
-            // ledger state is only refreshed on file-watcher save events).
+            // necessary (#685 / #760: without it, diagnostics lag behind
+            // in-memory buffer edits because the ledger state is only
+            // refreshed on file-watcher save events).
+            //
+            // We build the overlay list inline from the current file's
+            // fresh parse plus any other open buffers the caller handed
+            // in. The current file is always first so that a caller
+            // passing duplicate entries in `other_buffer_overlays`
+            // (shouldn't happen, but is harmless) doesn't shadow it.
             let full_directives_raw = ledger_state.and_then(|ls| ls.directives());
-            let overlay = build_live_directive_overlay(
-                &result.directives,
-                full_directives_raw,
-                current_file_id,
-            );
 
-            // Construct the owned directive list for validation. This used
-            // to be done by `validation_errors_to_diagnostics.to_vec()`
-            // internally, which on the multi-file overlay path meant two
-            // full-ledger clones per keystroke (one for the overlay, one
-            // for `booked_directives`). Moving the overlay in by value
-            // saves the second clone. Other paths (single-file, or
-            // multi-file without overlay) still pay one clone, same as
-            // before.
+            // Build the list of overlays to apply to the ledger snapshot.
+            // Always include the current file's fresh parse first, then
+            // append any other open buffers the caller handed in (#760).
+            let mut overlay_entries: Vec<(u16, &[Spanned<Directive>])> =
+                Vec::with_capacity(1 + other_buffer_overlays.len());
+            if let Some(fid) = current_file_id {
+                overlay_entries.push((fid, result.directives.as_slice()));
+            }
+            overlay_entries.extend_from_slice(other_buffer_overlays);
+            let overlay = build_live_directive_overlay(&overlay_entries, full_directives_raw);
+
+            // Construct the owned directive list for validation. Moving
+            // the overlay in by value saves a second clone on the
+            // multi-file overlay path (the overlay is already an owned
+            // Vec; handing it to `validation_errors_to_diagnostics` by
+            // value avoids the `.to_vec()` that used to happen inside
+            // that function). Other paths still pay one clone, same as
+            // before. See #758 for the single-file version of this
+            // optimization.
             let booked_directives: Vec<Spanned<Directive>> = if let Some(owned) = overlay {
                 owned
             } else if let Some(full) = full_directives_raw
@@ -430,7 +470,7 @@ mod tests {
         assert!(result.errors.is_empty(), "Should have no parse errors");
 
         // Single-file validation (no ledger state)
-        let diagnostics = all_diagnostics(&result, source, None, None);
+        let diagnostics = all_diagnostics(&result, source, None, None, &[]);
 
         // Should have at least these validation errors:
         // - E1001: Account Income:Typo was never opened
@@ -503,7 +543,7 @@ mod tests {
         assert!(result.errors.is_empty(), "Should have no parse errors");
 
         // Single-file validation (no ledger state)
-        let diagnostics = all_diagnostics(&result, source, None, None);
+        let diagnostics = all_diagnostics(&result, source, None, None, &[]);
 
         // Helper to get code string from a diagnostic
         fn get_code(d: &Diagnostic) -> String {
@@ -795,11 +835,10 @@ option "name_equity" "Капитал"
         // With the overlay: fresh directives replace stale ones for this
         // file, and the new imbalance is reported.
         let overlay = build_live_directive_overlay(
-            &fresh_unbalanced.directives,
+            &[(1, fresh_unbalanced.directives.as_slice())],
             Some(&stale_full_directives),
-            Some(1),
         )
-        .expect("overlay must be built when both full_directives and file_id are present");
+        .expect("overlay must be built when both full_directives and overlays are present");
 
         let with_overlay = validation_errors_to_diagnostics(
             overlay,
@@ -854,11 +893,10 @@ option "name_equity" "Капитал"
         // With the overlay: fresh fixed directives replace the stale broken
         // ones, and the error is cleared.
         let overlay_fixed = build_live_directive_overlay(
-            &fresh_fixed.directives,
+            &[(1, fresh_fixed.directives.as_slice())],
             Some(&stale_broken_full),
-            Some(1),
         )
-        .expect("overlay must be built when both full_directives and file_id are present");
+        .expect("overlay must be built when both full_directives and overlays are present");
 
         let with_overlay_fixed = validation_errors_to_diagnostics(
             overlay_fixed,
@@ -875,14 +913,18 @@ option "name_equity" "Капитал"
     }
 
     #[test]
-    fn test_live_overlay_returns_none_without_file_id() {
+    fn test_live_overlay_returns_none_when_nothing_to_overlay() {
         let parsed = parse("2024-01-01 open Assets:Bank:Checking USD\n");
-        let result = build_live_directive_overlay(&parsed.directives, None, None);
+
+        // No ledger state at all: nothing to overlay onto.
+        let result = build_live_directive_overlay(&[(1, parsed.directives.as_slice())], None);
         assert!(
             result.is_none(),
-            "no ledger, no file_id: overlay should be None"
+            "no full_directives: overlay should be None (caller falls back \
+             to the single-file validation path)"
         );
 
+        // Ledger state present but no fresh overlays: nothing to apply.
         let other_parsed = parse("2024-01-01 open Income:Salary\n");
         let other_dirs: Vec<Spanned<Directive>> = other_parsed
             .directives
@@ -893,11 +935,167 @@ option "name_equity" "Капитал"
                 d
             })
             .collect();
-        let result = build_live_directive_overlay(&parsed.directives, Some(&other_dirs), None);
+        let result = build_live_directive_overlay(&[], Some(&other_dirs));
         assert!(
             result.is_none(),
-            "full_directives present but no file_id: overlay should be None \
-             (caller will fall back to full_directives as-is)"
+            "full_directives present but no overlays: overlay should be None \
+             (caller falls back to full_directives as-is)"
+        );
+    }
+
+    /// Regression test for issue #760: multi-file live overlay.
+    ///
+    /// The #685 fix only overlays the file currently being validated. In a
+    /// multi-file ledger with several open buffers, edits in files other
+    /// than the one being validated were still ignored by the validator. A
+    /// balance assertion in file A that depends on an edited transaction in
+    /// file B would be validated against B's on-disk version, producing a
+    /// diagnostic that disagrees with what the user sees on screen.
+    ///
+    /// This test directly exercises `build_live_directive_overlay` with
+    /// two overlays at once and verifies that both files' stale entries
+    /// are replaced atomically, so validation sees a coherent snapshot of
+    /// every open buffer in the ledger.
+    #[test]
+    fn test_multi_buffer_overlay_replaces_multiple_files_issue_760() {
+        fn get_code(d: &Diagnostic) -> String {
+            match d.code.as_ref().unwrap() {
+                lsp_types::NumberOrString::String(s) => s.clone(),
+                lsp_types::NumberOrString::Number(n) => panic!("Unexpected number code: {n}"),
+            }
+        }
+
+        // Bank file: has a balance assertion (4950) that depends on the
+        // credit-card file's transaction amount (-50). If the credit-card
+        // file's transaction is edited in the buffer to -75, the assertion
+        // should start failing with an expected of 4925, not 4950.
+        let bank_on_disk = r#"2024-01-01 open Assets:Bank:Checking USD
+
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary
+
+2024-01-21 balance Assets:Bank:Checking 4950 USD
+"#;
+
+        // Credit card file: currently on disk has -50 USD, so the bank
+        // balance assertion holds.
+        let credit_card_on_disk = r#"2024-01-01 open Liabilities:Credit-Card
+
+2024-01-20 * "Pay off credit card"
+  Assets:Bank:Checking -50 USD
+  Liabilities:Credit-Card
+"#;
+
+        // User edits the credit-card file in-buffer to -75 USD without
+        // saving. Nothing else changes.
+        let credit_card_buffer = r#"2024-01-01 open Liabilities:Credit-Card
+
+2024-01-20 * "Pay off credit card"
+  Assets:Bank:Checking -75 USD
+  Liabilities:Credit-Card
+"#;
+
+        // Main file: root with account opens.
+        let main_on_disk = r#"2024-01-01 open Income:Salary USD
+2024-01-01 open Expenses:Food USD
+"#;
+
+        let main_parsed = parse(main_on_disk);
+        let bank_parsed = parse(bank_on_disk);
+        let credit_card_parsed_disk = parse(credit_card_on_disk);
+        let credit_card_parsed_buffer = parse(credit_card_buffer);
+        assert!(main_parsed.errors.is_empty());
+        assert!(bank_parsed.errors.is_empty());
+        assert!(credit_card_parsed_disk.errors.is_empty());
+        assert!(credit_card_parsed_buffer.errors.is_empty());
+
+        // Simulate the ledger snapshot the LSP would have at startup:
+        // main=0, bank=1, credit_card=2, all loaded from disk.
+        let mut stale_full: Vec<Spanned<Directive>> = Vec::new();
+        for mut d in main_parsed.directives.clone() {
+            d.file_id = 0;
+            stale_full.push(d);
+        }
+        for mut d in bank_parsed.directives.clone() {
+            d.file_id = 1;
+            stale_full.push(d);
+        }
+        for mut d in credit_card_parsed_disk.directives {
+            d.file_id = 2;
+            stale_full.push(d);
+        }
+
+        // Baseline sanity check: with both files as they are on disk, the
+        // bank balance assertion holds (4950 expected, 4950 actual). No
+        // E2001 diagnostic for bank.
+        let baseline = validation_errors_to_diagnostics(
+            stale_full.clone(),
+            bank_on_disk,
+            ValidationOptions::default(),
+            Some(1),
+        );
+        let baseline_codes: Vec<_> = baseline.iter().map(get_code).collect();
+        assert!(
+            !baseline_codes.iter().any(|c| c == "E2001"),
+            "baseline: bank balance should hold with disk state. Got: {baseline_codes:?}"
+        );
+
+        // The bug we're fixing: user edits credit_card.bean in a second
+        // buffer, but bank.bean is the one being validated. Without an
+        // overlay for credit_card, the bank balance assertion is validated
+        // against the stale credit_card directives and appears to hold,
+        // even though the user's actual edited state makes it wrong
+        // (4950 expected, 4925 actual after the -75 edit).
+        //
+        // Scenario 1: overlay only bank (simulating #685's fix). Bank's
+        // balance assertion still appears to hold because credit_card is
+        // stale.
+        let single_buffer_overlay = build_live_directive_overlay(
+            &[(1, bank_parsed.directives.as_slice())],
+            Some(&stale_full),
+        )
+        .expect("overlay should be built");
+
+        let single_overlay_diagnostics = validation_errors_to_diagnostics(
+            single_buffer_overlay,
+            bank_on_disk,
+            ValidationOptions::default(),
+            Some(1),
+        );
+        let single_codes: Vec<_> = single_overlay_diagnostics.iter().map(get_code).collect();
+        assert!(
+            !single_codes.iter().any(|c| c == "E2001"),
+            "Bug reproduction: with only the current file overlaid, the \
+             credit_card buffer edit is invisible and the bank balance \
+             appears to still hold. Got: {single_codes:?}"
+        );
+
+        // Scenario 2: overlay both buffers (the #760 fix). Now validation
+        // sees the edited credit_card content, the balance assertion in
+        // bank is checked against the actual in-buffer state of the whole
+        // ledger, and E2001 is reported as expected.
+        let multi_buffer_overlay = build_live_directive_overlay(
+            &[
+                (1, bank_parsed.directives.as_slice()),
+                (2, credit_card_parsed_buffer.directives.as_slice()),
+            ],
+            Some(&stale_full),
+        )
+        .expect("overlay should be built");
+
+        let multi_overlay_diagnostics = validation_errors_to_diagnostics(
+            multi_buffer_overlay,
+            bank_on_disk,
+            ValidationOptions::default(),
+            Some(1),
+        );
+        let multi_codes: Vec<_> = multi_overlay_diagnostics.iter().map(get_code).collect();
+        assert!(
+            multi_codes.iter().any(|c| c == "E2001"),
+            "Fix verification: with both files overlaid, bank balance \
+             assertion (4950) should fail because credit_card was edited to \
+             -75 in the buffer, making actual 4925. Got: {multi_codes:?}"
         );
     }
 
@@ -983,6 +1181,7 @@ option "name_equity" "Капитал"
             buffer_unbalanced,
             Some(&ledger_state),
             Some(file_id),
+            &[],
         );
         let codes: Vec<_> = diagnostics.iter().map(get_code).collect();
 
@@ -1000,8 +1199,13 @@ option "name_equity" "Капитал"
         // happy path still works after the overlay merge.)
         let result_clean = parse(on_disk);
         assert!(result_clean.errors.is_empty());
-        let clean_diagnostics =
-            all_diagnostics(&result_clean, on_disk, Some(&ledger_state), Some(file_id));
+        let clean_diagnostics = all_diagnostics(
+            &result_clean,
+            on_disk,
+            Some(&ledger_state),
+            Some(file_id),
+            &[],
+        );
         let clean_error_count = clean_diagnostics
             .iter()
             .filter(|d| matches!(d.severity, Some(DiagnosticSeverity::ERROR)))
@@ -1011,6 +1215,150 @@ option "name_equity" "Капитал"
             0,
             "balanced buffer should produce no ERROR diagnostics. Got: {:?}",
             clean_diagnostics.iter().map(get_code).collect::<Vec<_>>()
+        );
+    }
+
+    /// End-to-end regression test for #760 through `all_diagnostics`.
+    ///
+    /// The direct helper test `test_multi_buffer_overlay_replaces_multiple_files_issue_760`
+    /// exercises `build_live_directive_overlay` + `validation_errors_to_diagnostics`,
+    /// but doesn't pin the integration point in `all_diagnostics` that
+    /// consumes `other_buffer_overlays` and feeds them into the helper.
+    /// This test uses a real `LedgerState` backed by a tempdir with two
+    /// files (a main journal and an included credit-card file), verifies
+    /// the baseline (no overlays → no error), then passes a fresh parse
+    /// of an edited credit-card buffer as an `other_buffer_overlays` entry
+    /// and confirms the edit is visible to validation of the main file.
+    #[test]
+    fn test_all_diagnostics_multi_buffer_overlay_issue_760() {
+        use std::fs;
+
+        fn get_code(d: &Diagnostic) -> String {
+            match d.code.as_ref().unwrap() {
+                lsp_types::NumberOrString::String(s) => s.clone(),
+                lsp_types::NumberOrString::Number(n) => panic!("Unexpected number code: {n}"),
+            }
+        }
+
+        // Main journal: opens, a paycheck, a balance assertion that depends
+        // on the credit-card file, and an include directive.
+        let main_content = r#"2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary USD
+2024-01-01 open Liabilities:Credit-Card USD
+
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary
+
+2024-01-21 balance Assets:Bank:Checking 4950 USD
+
+include "credit_card.beancount"
+"#;
+
+        // Credit-card file on disk: -50 USD, which makes the main balance
+        // assertion (4950) hold.
+        let credit_card_disk = r#"2024-01-20 * "Pay off credit card"
+  Assets:Bank:Checking -50 USD
+  Liabilities:Credit-Card
+"#;
+
+        // Credit-card file after the user edits the buffer to -75 USD
+        // without saving. The main balance assertion should now fail
+        // (expected 4950, actual 4925), but only if validation sees the
+        // buffer edit.
+        let credit_card_buffer = r#"2024-01-20 * "Pay off credit card"
+  Assets:Bank:Checking -75 USD
+  Liabilities:Credit-Card
+"#;
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let main_path = tempdir.path().join("main.beancount");
+        let credit_card_path = tempdir.path().join("credit_card.beancount");
+        fs::write(&main_path, main_content).expect("write main");
+        fs::write(&credit_card_path, credit_card_disk).expect("write credit_card");
+
+        let mut ledger_state = LedgerState::new();
+        ledger_state
+            .load(&main_path)
+            .expect("LedgerState::load should succeed");
+
+        // Resolve file_ids for both files.
+        let ledger = ledger_state.ledger().expect("ledger loaded");
+        let main_canonical = main_path.canonicalize().expect("canonicalize main");
+        let credit_card_canonical = credit_card_path
+            .canonicalize()
+            .expect("canonicalize credit_card");
+
+        let main_file_id = ledger
+            .source_map
+            .files()
+            .iter()
+            .find_map(|f| {
+                f.path
+                    .canonicalize()
+                    .ok()
+                    .filter(|p| *p == main_canonical)
+                    .map(|_| f.id as u16)
+            })
+            .expect("main file_id");
+        let credit_card_file_id = ledger
+            .source_map
+            .files()
+            .iter()
+            .find_map(|f| {
+                f.path
+                    .canonicalize()
+                    .ok()
+                    .filter(|p| *p == credit_card_canonical)
+                    .map(|_| f.id as u16)
+            })
+            .expect("credit_card file_id");
+
+        // Simulate a didChange on the main file (unchanged). Without any
+        // overlays for other buffers, validation uses the on-disk
+        // credit-card content and the balance assertion holds.
+        let main_result = parse(main_content);
+        assert!(main_result.errors.is_empty(), "main should parse cleanly");
+
+        let baseline = all_diagnostics(
+            &main_result,
+            main_content,
+            Some(&ledger_state),
+            Some(main_file_id),
+            &[],
+        );
+        let baseline_codes: Vec<_> = baseline.iter().map(get_code).collect();
+        assert!(
+            !baseline_codes.iter().any(|c| c == "E2001"),
+            "baseline: bank balance should hold with disk credit_card. Got: {baseline_codes:?}"
+        );
+
+        // Now simulate having the credit_card buffer open with the edited
+        // content. Parse it and pass it as an other_buffer_overlays entry.
+        // all_diagnostics should now report E2001 because the balance
+        // assertion (4950) doesn't match the buffer-state actual (4925).
+        let credit_card_buffer_parse = parse(credit_card_buffer);
+        assert!(
+            credit_card_buffer_parse.errors.is_empty(),
+            "credit_card buffer should parse cleanly"
+        );
+
+        let with_overlay = all_diagnostics(
+            &main_result,
+            main_content,
+            Some(&ledger_state),
+            Some(main_file_id),
+            &[(
+                credit_card_file_id,
+                credit_card_buffer_parse.directives.as_slice(),
+            )],
+        );
+        let with_overlay_codes: Vec<_> = with_overlay.iter().map(get_code).collect();
+        assert!(
+            with_overlay_codes.iter().any(|c| c == "E2001"),
+            "Fix verification: with credit_card buffer overlaid, main's \
+             balance assertion should fail (4950 expected, 4925 actual \
+             after the -75 edit). Got: {with_overlay_codes:?}"
         );
     }
 }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -75,7 +75,8 @@ use lsp_types::{
     WorkspaceSymbolParams,
 };
 use parking_lot::RwLock;
-use rustledger_parser::{ParseResult, parse};
+use rustledger_core::Directive;
+use rustledger_parser::{ParseResult, Spanned, parse};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1209,26 +1210,64 @@ impl MainLoopState {
     /// When a full ledger is loaded (multi-file mode), validation considers all
     /// files in the ledger, providing accurate diagnostics for balance assertions
     /// that depend on transactions in other files.
+    ///
+    /// To handle unsaved edits in multiple open buffers (#685 / #760), this
+    /// collects fresh parses from the VFS for every open document that is
+    /// part of the ledger and hands them to `all_diagnostics` as overlays.
+    /// The VFS caches parses per document and invalidates on update, so
+    /// this is usually a cache hit (O(1) per open buffer) except immediately
+    /// after an edit to that buffer.
     fn publish_diagnostics(&mut self, uri: &Uri, text: &str) {
-        // Parse the document
+        // Parse the current document.
         let result = parse(text);
 
-        // Get ledger state and file_id for multi-file validation
+        // Canonicalize the current URI's path so we can both skip it when
+        // collecting "other" buffer overlays and look up its file_id in
+        // the ledger source map.
+        let current_canonical_path = uri_to_path(uri).and_then(|p| p.canonicalize().ok());
+
+        // Collect fresh parses for every OTHER open buffer via the VFS.
+        // Done before grabbing the ledger-state read lock so the VFS
+        // write lock (needed by the cache-aware iterator) is released
+        // before we start the file_id lookups.
+        //
+        // We skip:
+        //   - the current file (its fresh parse is already in `result`)
+        //   - any buffer whose fresh parse has errors (keeping the stale
+        //     ledger directives is better than overlaying a partial parse)
+        //
+        // Each entry returns the canonicalized path + the cached Arc of
+        // the parse result, which owns the directives we hand into
+        // `all_diagnostics`. The Arc keeps them alive for the call.
+        let other_buffer_parses: Vec<(PathBuf, Arc<ParseResult>)> = {
+            let mut vfs = self.vfs.write();
+            vfs.iter_with_parse()
+                .filter_map(|(path, _text, parsed)| {
+                    let canonical = path.canonicalize().ok()?;
+                    if Some(&canonical) == current_canonical_path.as_ref() {
+                        return None;
+                    }
+                    if !parsed.errors.is_empty() {
+                        return None;
+                    }
+                    Some((canonical, parsed))
+                })
+                .collect()
+        };
+
+        // Get ledger state and the current file's file_id.
         let ledger_guard = self.ledger_state.read();
         let (ledger_state, current_file_id) = if ledger_guard.ledger().is_some() {
             // Find the file_id for this URI by matching against included files.
-            // We canonicalize the URI path to handle path normalization differences
-            // (e.g., /a/b/../c vs /a/c, or symlinks).
-            let file_id = uri_to_path(uri).and_then(|uri_path| {
-                // Canonicalize to resolve symlinks and normalize path components
-                let canonical_uri_path = uri_path.canonicalize().ok()?;
+            // Canonicalized comparison handles path normalization (e.g.,
+            // /a/b/../c vs /a/c, or symlinks).
+            let file_id = current_canonical_path.as_ref().and_then(|canonical| {
                 ledger_guard.ledger().and_then(|ledger| {
-                    // Search the source map for this file using canonical path comparison
                     ledger.source_map.files().iter().find_map(|f| {
                         f.path
                             .canonicalize()
                             .ok()
-                            .filter(|canonical_f| *canonical_f == canonical_uri_path)
+                            .filter(|canonical_f| canonical_f == canonical)
                             .map(|_| f.id as u16)
                     })
                 })
@@ -1238,8 +1277,37 @@ impl MainLoopState {
             (None, None)
         };
 
+        // Resolve each other buffer's file_id against the ledger source
+        // map. Buffers that aren't part of the ledger get dropped (they
+        // can't affect validation anyway).
+        let other_buffer_overlays: Vec<(u16, &[Spanned<Directive>])> =
+            if let Some(ls) = ledger_state {
+                let ledger = ls.ledger().expect("ledger_state.ledger() checked above");
+                other_buffer_parses
+                    .iter()
+                    .filter_map(|(canonical, parsed)| {
+                        let fid = ledger.source_map.files().iter().find_map(|f| {
+                            f.path
+                                .canonicalize()
+                                .ok()
+                                .filter(|canonical_f| canonical_f == canonical)
+                                .map(|_| f.id as u16)
+                        })?;
+                        Some((fid, parsed.directives.as_slice()))
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
         // Convert parse errors and validation errors to LSP diagnostics
-        let diagnostics = all_diagnostics(&result, text, ledger_state, current_file_id);
+        let diagnostics = all_diagnostics(
+            &result,
+            text,
+            ledger_state,
+            current_file_id,
+            &other_buffer_overlays,
+        );
         drop(ledger_guard); // Release lock before sending
 
         tracing::debug!(


### PR DESCRIPTION
Closes #685.

## Summary

When the LSP is started against a journal file, `LedgerState` is loaded from disk at startup and refreshed only by file-watcher events (which fire on save). In-memory buffer edits never touch it, so `all_diagnostics` was validating the current file against the stale on-disk directives instead of the fresh parse of the buffer. That produced exactly the two symptoms in the asciicast:

1. A new error introduced in the buffer did not appear until the next save.
2. After saving a broken version and then fixing it in the buffer, the error still appeared until the next save.

## My earlier diagnosis was wrong

I previously closed the issue after testing via raw JSON-RPC `didOpen` / `didChange` against an LSP instance with no journal file loaded. That path takes the `ledger_state.ledger().is_none()` branch in `publish_diagnostics`, which correctly uses fresh directives from the current parse. The buggy path is the one your nvim setup actually hits when the LSP is started against a real journal. Apologies to @lutzky for the runaround.

## Fix

Live overlay at the `all_diagnostics` layer. When both `ledger_state` and `current_file_id` are present, build a merged directive list that:

- takes `full_directives` from `ledger_state`,
- drops the stale entries whose `file_id == current_file_id`,
- appends the fresh directives from the buffer's current parse, remapped to `current_file_id` so the existing per-file filter in `validation_errors_to_diagnostics` still works.

Validation then sees the in-memory buffer state for the current file plus the on-disk state for every other file in the ledger. Other files in a multi-file ledger behave exactly as before.

The overlay construction is extracted into a `build_live_directive_overlay` helper so it can be unit-tested without having to stand up a full `LedgerState` over a tempdir.

## Regression tests

Two new tests in `crates/rustledger-lsp/src/handlers/diagnostics.rs`:

1. **`test_live_overlay_reflects_buffer_edits_issue_685`** exercises both scenarios end-to-end through `validation_errors_to_diagnostics`:
   - **Scenario 1 (new error in buffer):** fresh parse is unbalanced, `full_directives` still holds the clean on-disk version. Without the overlay the E3001 is missing (bug reproduction). With the overlay applied, E3001 appears.
   - **Scenario 2 (buffer fixed, ledger still broken):** fresh parse is balanced, `full_directives` holds the broken post-save version. Without the overlay, E3001 persists (bug reproduction). With the overlay applied, diagnostics are clean.
2. **`test_live_overlay_returns_none_without_file_id`** pins the fallback semantics (no `current_file_id` means no overlay, caller falls back to the original `full_directives`) so a future refactor that eagerly clones an empty list or silently fails is caught.

## Test plan

- [x] `cargo test -p rustledger-lsp --lib handlers::diagnostics` — 7/7 pass (5 existing + 2 new)
- [x] `cargo test --workspace --all-features` — all suites green, 0 failures
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual verification in nvim with a real journal (worth trying once this lands to confirm the end-to-end asciicast scenario is fixed; the unit test simulates the exact data flow but doesn't exercise the transport layer)

## Files touched

- `crates/rustledger-lsp/src/handlers/diagnostics.rs` — overlay helper, call site, two regression tests

Net: 1 file, 262 insertions, 2 deletions.

## Notes for reviewers

- The overlay clones full_directives on every `publishDiagnostics` call. For a 10K-directive multi-file ledger this is a `Vec::clone` on each keystroke while editing. If that turns out to be a bottleneck in practice, the obvious optimization is to wrap `LedgerState::directives()` in an `Arc<[Spanned<Directive>]>` so the overlay can share memory with the ledger snapshot and only pay for the slice filter + append. I held off on that because (a) the current `LedgerState` API returns `&[Spanned<Directive>]` and changing it would ripple, and (b) I haven't measured that this is actually a hot path yet. Happy to follow up as a separate PR if benchmarks show it matters.
- The helper deliberately returns `Option<Vec<…>>` rather than always cloning, so in the single-file case (`current_file_id` is `None`) we pay zero allocations and fall back to the existing `full_directives` path unchanged.