### PR TITLE
perf(query): Fix rust-skills CRITICAL and HIGH issues

### DIFF
--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -331,48 +331,56 @@ impl SelectQuery {
     }
 
     /// Set the DISTINCT flag.
+    #[must_use]
     pub const fn distinct(mut self) -> Self {
         self.distinct = true;
         self
     }
 
     /// Set the FROM clause.
+    #[must_use]
     pub fn from(mut self, from: FromClause) -> Self {
         self.from = Some(from);
         self
     }
 
     /// Set the WHERE clause.
+    #[must_use]
     pub fn where_clause(mut self, expr: Expr) -> Self {
         self.where_clause = Some(expr);
         self
     }
 
     /// Set the GROUP BY clause.
+    #[must_use]
     pub fn group_by(mut self, exprs: Vec<Expr>) -> Self {
         self.group_by = Some(exprs);
         self
     }
 
     /// Set the HAVING clause.
+    #[must_use]
     pub fn having(mut self, expr: Expr) -> Self {
         self.having = Some(expr);
         self
     }
 
     /// Set the PIVOT BY clause.
+    #[must_use]
     pub fn pivot_by(mut self, exprs: Vec<Expr>) -> Self {
         self.pivot_by = Some(exprs);
         self
     }
 
     /// Set the ORDER BY clause.
+    #[must_use]
     pub fn order_by(mut self, specs: Vec<OrderSpec>) -> Self {
         self.order_by = Some(specs);
         self
     }
 
     /// Set the LIMIT.
+    #[must_use]
     pub const fn limit(mut self, n: u64) -> Self {
         self.limit = Some(n);
         self

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -694,7 +694,8 @@ fn set_literal<'a>(
                     ),
                 )
                 .map(|(first, rest)| {
-                    let mut elements = vec![first];
+                    let mut elements = Vec::with_capacity(1 + rest.len());
+                    elements.push(first);
                     elements.extend(rest);
                     elements
                 }),


### PR DESCRIPTION
## Summary

Fixes rust-skills violations in the query crate related to memory allocation and API safety.

## Changes

| File | Change | Impact |
|------|--------|--------|
| parser.rs:697-699 | Vec::with_capacity before extend | Saves 1 alloc per set parse |
| ast.rs:334-388 | Add #[must_use] to 8 SelectQuery builder methods | API safety |

The 8 builder methods: `distinct`, `from`, `where_clause`, `group_by`, `having`, `pivot_by`, `order_by`, `limit`.

## Impact

- **Memory**: Reduces allocations during query parsing
- **API Safety**: `#[must_use]` prevents accidentally discarding builder results
- Query crate compiles successfully

## Potential breaking change

Adding `#[must_use]` to public builder methods can break downstream crates that compile with `#![deny(warnings)]` (or `#![deny(unused_must_use)]`) and previously ignored the return value of these methods. In practice this is uncommon because builder methods are almost always chained and the return value is used. The case of `query.distinct();` followed by a discard is a latent bug that the new attribute will catch.

Downstream consumers pinning an earlier version of `rustledger-query` can continue to do so; this only affects code that upgrades.

## rust-skills Rules Addressed

- `mem-vec-with-capacity` ✅ Fixed
- `api-must-use` ✅ Fixed (8 methods)