### PR TITLE
fix: align include-cycle error wording with Python beancount

### DIFF
--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -116,9 +116,23 @@ pub enum LoadError {
     },
 
     /// Include cycle detected.
-    #[error("include cycle detected: {}", .cycle.join(" -> "))]
+    ///
+    /// The Display string intentionally begins with `Duplicate filename
+    /// parsed:` to match Python beancount's wording for the same
+    /// condition. The pta-standards `include-cycle-detection`
+    /// conformance test asserts on the substring `"Duplicate filename"`,
+    /// so this wording is load-bearing (#765). The full cycle path is
+    /// preserved in a trailing parenthetical for debuggability.
+    #[error(
+        "Duplicate filename parsed: \"{}\" (include cycle: {})",
+        .cycle.last().map_or("", String::as_str),
+        .cycle.join(" -> ")
+    )]
     IncludeCycle {
-        /// The cycle of file paths.
+        /// The cycle of file paths. The last element is the
+        /// re-encountered filename (equal to one of the earlier
+        /// entries), and it's the one quoted in the `"Duplicate
+        /// filename parsed:"` prefix.
         cycle: Vec<String>,
     },
 

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -106,6 +106,51 @@ fn test_load_include_cycle_detection() {
     }
 }
 
+/// Regression test for issue #765.
+///
+/// The pta-standards `include-cycle-detection` conformance test
+/// asserts on `error_contains: ["Duplicate filename"]`, matching Python
+/// beancount's wording for the same condition. rustledger previously
+/// said `"include cycle detected: ..."` which was more informative but
+/// didn't match the substring. We now lead with `"Duplicate filename
+/// parsed: \"<file>\""` and preserve the cycle path in a trailing
+/// parenthetical. This test pins the exact phrasing so a refactor
+/// can't silently drop the conformance-required substring.
+#[test]
+fn test_include_cycle_display_contains_duplicate_filename_issue_765() {
+    let path = fixtures_path("cycle_a.beancount");
+    let result = Loader::new().load(&path);
+
+    // Find the IncludeCycle error in either the Err path or the
+    // load_result.errors collection (the loader supports partial
+    // results).
+    let err: LoadError = match result {
+        Err(e @ LoadError::IncludeCycle { .. }) => e,
+        Ok(result) => result
+            .errors
+            .into_iter()
+            .find(|e| matches!(e, LoadError::IncludeCycle { .. }))
+            .expect("expected IncludeCycle error in load_result.errors"),
+        Err(other) => panic!("expected IncludeCycle error, got: {other}"),
+    };
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("Duplicate filename"),
+        "IncludeCycle Display must contain 'Duplicate filename' for \
+         beancount conformance (#765). Got: {rendered}"
+    );
+    assert!(
+        rendered.contains("cycle_a.beancount"),
+        "IncludeCycle Display must mention the cycle file. Got: {rendered}"
+    );
+    assert!(
+        rendered.contains("include cycle:"),
+        "IncludeCycle Display should still preserve the cycle path \
+         for debuggability. Got: {rendered}"
+    );
+}
+
 #[test]
 fn test_load_missing_include() {
     let path = fixtures_path("missing_include.beancount");

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -350,6 +350,15 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                 error_count += 1;
             }
             LoadError::IncludeCycle { cycle } => {
+                // Delegate to the canonical Display impl on
+                // `LoadError::IncludeCycle` so the wording lives in
+                // exactly one place (the `#[error(...)]` attribute on
+                // the variant). This is load-bearing for pta-standards
+                // conformance (#765): the substring `"Duplicate
+                // filename"` must appear, and centralizing the format
+                // string prevents it from drifting out of sync with the
+                // library-level error.
+                let message = load_error.to_string();
                 if json_mode {
                     diagnostics.push(JsonDiagnostic {
                         file: cycle.first().cloned().unwrap_or_default(),
@@ -360,17 +369,13 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                         severity: "error".to_string(),
                         phase: "parse".to_string(),
                         code: "E0002".to_string(),
-                        message: format!("include cycle detected: {}", cycle.join(" -> ")),
+                        message,
                         hint: Some("break the cycle by removing one of the includes".to_string()),
                         context: None,
                     });
                     parse_error_count += 1;
                 } else if !args.quiet {
-                    writeln!(
-                        stdout,
-                        "error: include cycle detected: {}",
-                        cycle.join(" -> ")
-                    )?;
+                    writeln!(stdout, "error: {message}")?;
                 }
                 error_count += 1;
             }


### PR DESCRIPTION
Closes #765.

## Summary

rustledger reported circular includes as `"include cycle detected: a -> b -> a"`. Python beancount reports the same condition as `"Duplicate filename parsed: \"a\""`. The pta-standards `include-cycle-detection` conformance test asserts on the substring `"Duplicate filename"`, so rustledger's wording didn't match even though both tools correctly detect the cycle.

**Before:**
```
error: include cycle detected: /path/a.beancount -> /path/b.beancount -> /path/a.beancount
```

**After:**
```
error: Duplicate filename parsed: "/path/a.beancount" (include cycle: /path/a.beancount -> /path/b.beancount -> /path/a.beancount)
```

The new wording leads with beancount's substring (satisfying conformance) and keeps the cycle path in a trailing parenthetical (preserving rustledger's debugging advantage).

## What changed

1. **`LoadError::IncludeCycle` `#[error(...)]`** in `crates/rustledger-loader/src/lib.rs` — updated to the new format. The duplicate filename comes from `cycle.last()`, which is always equal to one of the earlier entries in the cycle (that's how it got detected). Docstring explains why the wording is load-bearing.

2. **`crates/rustledger/src/cmd/check.rs` `LoadError::IncludeCycle` handling** — collapsed two hardcoded strings (JSON output and stdout output) to use `load_error.to_string()`. This makes the `#[error(...)]` attribute the single source of truth and prevents the library error and the CLI output from drifting apart again. Pattern matches what #749 did for `InsufficientUnits`.

## Regression test

`test_include_cycle_display_contains_duplicate_filename_issue_765` in `crates/rustledger-loader/tests/loader_test.rs` pins three substrings that matter:

- `"Duplicate filename"` — the conformance assertion
- `cycle_a.beancount` — the file name is still shown
- `"include cycle:"` — the debuggability guarantee is preserved

If a future refactor drops any of these, the test fails loudly with the actual rendered string. Same pattern as #749's `test_insufficient_units_display_contains_not_enough`.

## Test plan

- [x] `cargo test -p rustledger-loader` — 57 + 31 + 2 pass, including the new regression test
- [x] `cargo test --workspace --all-features` — all suites green, 0 failures
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] pta-standards `include-cycle-detection` should flip from failing to passing once this lands

## Note for reviewers

The existing `test_load_include_cycle_detection` test only inspects the `cycle` vec, not the Display string, so it continues to pass unchanged. The new test is additive and specifically targets the wording.