### PR TITLE
chore: enforce forbid-unsafe-code invariant and add pre-push cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,27 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  # Fast invariant check: verify that crates declaring
+  # `#![forbid(unsafe_code)]` contain no `unsafe` blocks/items. Runs in
+  # milliseconds via grep, so it fails loudly and early on AI-generated
+  # PRs that try to add unsafe to a forbidding crate (see PR #769 for
+  # the proximate trigger).
+  #
+  # `cargo check` also enforces this invariant, but its failure message
+  # reads `"usage of an unsafe block"` without mentioning the forbid
+  # directive the author is violating. This script prints both the
+  # offending line and the forbid directive line in the same error, as
+  # a named CI status, so reviewers don't have to hunt for context.
+  unsafe-invariant:
+    name: Unsafe Invariant
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+      - name: Verify forbid-unsafe-code invariant
+        run: ./scripts/check-unsafe-invariant.sh
+
   # Main CI matrix - check, clippy, test, doc (only on code changes)
   ci:
     name: ${{ matrix.name }}
@@ -191,7 +212,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, ci, doctest, regressions]
+    needs: [changes, fmt, unsafe-invariant, ci, doctest, regressions]
     steps:
       - name: Check results
         run: |
@@ -202,7 +223,7 @@ jobs:
           fi
 
           # Otherwise, check that all jobs passed
-          results="${{ needs.fmt.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }}"
+          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }}"
           echo "Job results: $results"
 
           if echo "$results" | grep -qE '(failure|cancelled)'; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,13 +71,21 @@ repos:
       # `git push --no-verify` to bypass if you're intentionally pushing
       # a WIP commit for backup.
 
-      # Cargo check - fast compile verification before push
+      # Cargo check - fast compile verification before push.
+      #
+      # `always_run: true` is deliberate: a `Cargo.toml` or
+      # `Cargo.lock` change can introduce compile errors (dependency
+      # version bumps, feature flag changes, removed crates) without
+      # touching any `.rs` file. If we gated this hook on
+      # `types: [rust]`, a `Cargo.toml`-only push would skip it and
+      # the errors would only surface in CI. Running on every push
+      # catches the whole class early at ~2-30s on a warm cache.
       - id: cargo-check
         name: cargo check --workspace --all-features --all-targets
         entry: cargo check --workspace --all-features --all-targets
         language: system
-        types: [rust]
         pass_filenames: false
+        always_run: true
         stages: [pre-push]
 
       # Forbid-unsafe-code invariant check - grep-level, runs in ms.
@@ -86,10 +94,16 @@ repos:
       # clearer message that points at both the violation site and the
       # forbid directive. See scripts/check-unsafe-invariant.sh for the
       # full rationale.
+      #
+      # Also `always_run: true`: `#![forbid(unsafe_code)]` lives in the
+      # crate entry files, and somebody could push a change to those
+      # that adds or removes the directive without touching any other
+      # `.rs` file in the same push. Running unconditionally keeps the
+      # check honest.
       - id: unsafe-invariant
         name: verify forbid-unsafe-code invariant
         entry: scripts/check-unsafe-invariant.sh
         language: system
-        types: [rust]
         pass_filenames: false
+        always_run: true
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,37 @@ repos:
       # workspace). These checks run in CI instead where they can be parallelized
       # and cached. Use `cargo clippy` and `cargo test` manually before pushing
       # if you want to catch issues early.
+      #
+      # `cargo check` IS run as a pre-push hook. Unlike clippy/test, it
+      # skips codegen and lint passes and is typically 2-30 seconds on a
+      # warm incremental cache. Its job is specifically to catch compile
+      # errors (hallucinated APIs, missing imports, type mismatches,
+      # `unsafe` in forbid-unsafe-code crates) before a PR is opened.
+      # Closed PRs #768 and #769 each wasted a CI run because their
+      # authors pushed without running `cargo check` locally; this hook
+      # makes it impossible to repeat that mistake accidentally. Use
+      # `git push --no-verify` to bypass if you're intentionally pushing
+      # a WIP commit for backup.
+
+      # Cargo check - fast compile verification before push
+      - id: cargo-check
+        name: cargo check --workspace --all-features --all-targets
+        entry: cargo check --workspace --all-features --all-targets
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
+      # Forbid-unsafe-code invariant check - grep-level, runs in ms.
+      # Complements the cargo-check hook above. cargo-check catches the
+      # violation as a compile error; this script surfaces it with a
+      # clearer message that points at both the violation site and the
+      # forbid directive. See scripts/check-unsafe-invariant.sh for the
+      # full rationale.
+      - id: unsafe-invariant
+        name: verify forbid-unsafe-code invariant
+        entry: scripts/check-unsafe-invariant.sh
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/scripts/check-unsafe-invariant.sh
+++ b/scripts/check-unsafe-invariant.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Verify the `#![forbid(unsafe_code)]` invariant in every crate that declares it.
+#
+# This script enumerates workspace crates whose entry file contains the
+# `#![forbid(unsafe_code)]` directive, then grep-searches each crate's source
+# tree for `unsafe` blocks / items. If any are found, it prints a clear
+# pointed error message that identifies both the offending file and the
+# forbid directive the offender is violating, then exits non-zero.
+#
+# Why this check exists
+# ---------------------
+#
+# `cargo check` already enforces the forbid-unsafe-code invariant as a
+# compile error, so in theory this script is redundant with the existing
+# `cargo check` CI job. In practice, three things made a dedicated check
+# worth adding (see PR #769 for the proximate trigger):
+#
+# 1. When a PR adds `unsafe { ... }` to a forbid-unsafe-code crate, the
+#    `cargo check` failure reads "usage of an unsafe block" without
+#    mentioning the forbid directive the author is violating. Reviewers
+#    had to hunt for the context. This script prints the forbid line
+#    verbatim so the violation is obvious at a glance.
+#
+# 2. It runs in milliseconds (grep over Rust source) vs ~30 seconds for a
+#    cold `cargo check`. Failing early on obvious invariant violations
+#    reduces CI latency when an AI-generated PR is submitted without
+#    being run through `cargo check` locally.
+#
+# 3. It gives the check a named CI status ("Unsafe Invariant") instead of
+#    burying the failure inside the generic "Check" job's 500-line log.
+#
+# Exit codes
+# ----------
+#
+#   0  all forbid-unsafe-code crates are clean
+#   1  one or more crates contain `unsafe` blocks/items
+#   2  invocation error (no crates found, filesystem error, etc.)
+#
+# Usage
+# -----
+#
+#   ./scripts/check-unsafe-invariant.sh
+#
+# Runs from the repo root. No arguments, no flags, no environment variables.
+
+set -euo pipefail
+
+# Resolve repo root. Works whether this is invoked from the repo root,
+# from a subdirectory, or by CI which checks out to an arbitrary path.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "error: not inside a git repository" >&2
+    exit 2
+}
+cd "$REPO_ROOT"
+
+# Enumerate crates with `#![forbid(unsafe_code)]`. We look only at the
+# crate entry file (src/lib.rs or src/main.rs) because `forbid` must be
+# at the crate root to apply crate-wide.
+#
+# Binary-only crates use src/main.rs; library crates use src/lib.rs.
+# Workspace crates live under `crates/`.
+FORBID_CRATES=()
+while IFS= read -r entry_file; do
+    if grep -q '^\s*#!\[forbid(unsafe_code)\]' "$entry_file"; then
+        # Strip src/lib.rs or src/main.rs to get the crate dir
+        crate_dir="${entry_file%/src/lib.rs}"
+        crate_dir="${crate_dir%/src/main.rs}"
+        FORBID_CRATES+=("$crate_dir")
+    fi
+done < <(find crates -type f \( -name lib.rs -o -name main.rs \) -path '*/src/*' 2>/dev/null)
+
+if [[ ${#FORBID_CRATES[@]} -eq 0 ]]; then
+    echo "error: found no crates with #![forbid(unsafe_code)] — is the workspace layout correct?" >&2
+    exit 2
+fi
+
+echo "Checking ${#FORBID_CRATES[@]} forbid-unsafe-code crate(s)..."
+
+# Patterns that indicate the use or declaration of `unsafe` code.
+# We match:
+#   - `unsafe {`     (unsafe block)
+#   - `unsafe fn`    (unsafe function declaration)
+#   - `unsafe impl`  (unsafe trait impl)
+#   - `unsafe trait` (unsafe trait declaration)
+# and anywhere the keyword `unsafe` appears as a whole word followed by
+# any of the above sigils. Conservative: may catch a comment containing
+# "unsafe {" but that's vanishingly rare and a false positive is cheap
+# to resolve (rename the comment) vs letting a real violation through.
+#
+# Deliberately NOT matched: `unsafe_code` as a substring (the forbid
+# directive itself), and string literals containing "unsafe" (rare in
+# rustledger and cheap to suppress locally with `allow(...)` if needed).
+#
+# Rationale for not using rustc/clippy as the grep backend: we want
+# this check to run in milliseconds without compiling anything. rustc's
+# own error for the violation is perfectly good; this script exists to
+# surface it faster and with better context.
+
+VIOLATIONS_FOUND=0
+
+for crate_dir in "${FORBID_CRATES[@]}"; do
+    crate_name="${crate_dir#crates/}"
+
+    # Find the forbid directive's location for the error message.
+    forbid_location=""
+    for entry in "$crate_dir/src/lib.rs" "$crate_dir/src/main.rs"; do
+        if [[ -f "$entry" ]]; then
+            line_num="$(grep -n '^\s*#!\[forbid(unsafe_code)\]' "$entry" | head -n1 | cut -d: -f1 || true)"
+            if [[ -n "$line_num" ]]; then
+                forbid_location="$entry:$line_num"
+                break
+            fi
+        fi
+    done
+
+    # Search the crate's src/ tree (but not target/ or tests/) for
+    # new unsafe usage. Tests are NOT excluded: a forbid-unsafe-code
+    # crate with test-only unsafe is still a violation because
+    # `#![forbid]` at the crate root applies to the whole crate
+    # including tests (though `#[cfg(test)]` modules in bins/libs
+    # compile under the same crate attributes).
+    matches="$(grep -rn --include='*.rs' \
+        -E '(^|[^[:alnum:]_])unsafe[[:space:]]+(\{|fn|impl|trait)' \
+        "$crate_dir/src" 2>/dev/null || true)"
+
+    if [[ -n "$matches" ]]; then
+        VIOLATIONS_FOUND=1
+        echo
+        echo "============================================================"
+        echo "FORBID_UNSAFE_CODE VIOLATION in crate: $crate_name"
+        echo "============================================================"
+        echo "Directive: #![forbid(unsafe_code)] at $forbid_location"
+        echo
+        echo "Offending lines:"
+        echo "$matches" | sed 's/^/    /'
+        echo
+        echo "Either:"
+        echo "  1. Remove the unsafe block/item and use a safe alternative, or"
+        echo "  2. If unsafe is genuinely required, remove the"
+        echo "     #![forbid(unsafe_code)] directive from $forbid_location"
+        echo "     and justify the change in the PR description."
+        echo "     (Reviewers will treat removal of a forbid directive as"
+        echo "     a significant change requiring extra scrutiny.)"
+        echo "============================================================"
+    fi
+done
+
+if [[ $VIOLATIONS_FOUND -ne 0 ]]; then
+    echo
+    echo "error: one or more forbid-unsafe-code invariants were violated" >&2
+    exit 1
+fi
+
+echo "OK: all ${#FORBID_CRATES[@]} forbid-unsafe-code crates are clean"
+exit 0

--- a/scripts/check-unsafe-invariant.sh
+++ b/scripts/check-unsafe-invariant.sh
@@ -62,7 +62,11 @@ cd "$REPO_ROOT"
 # Workspace crates live under `crates/`.
 FORBID_CRATES=()
 while IFS= read -r entry_file; do
-    if grep -q '^\s*#!\[forbid(unsafe_code)\]' "$entry_file"; then
+    # `[[:space:]]*` is POSIX-portable; `\s*` is a PCRE escape that GNU
+    # grep accepts as an extension but BSD/macOS grep treats as literal
+    # `s`. Using the POSIX character class ensures the script works in
+    # every CI environment and on every developer's machine.
+    if grep -q '^[[:space:]]*#!\[forbid(unsafe_code)\]' "$entry_file"; then
         # Strip src/lib.rs or src/main.rs to get the crate dir
         crate_dir="${entry_file%/src/lib.rs}"
         crate_dir="${crate_dir%/src/main.rs}"
@@ -103,10 +107,12 @@ for crate_dir in "${FORBID_CRATES[@]}"; do
     crate_name="${crate_dir#crates/}"
 
     # Find the forbid directive's location for the error message.
+    # POSIX `[[:space:]]*` instead of PCRE `\s*` for portability — see
+    # the comment at the enumeration loop above.
     forbid_location=""
     for entry in "$crate_dir/src/lib.rs" "$crate_dir/src/main.rs"; do
         if [[ -f "$entry" ]]; then
-            line_num="$(grep -n '^\s*#!\[forbid(unsafe_code)\]' "$entry" | head -n1 | cut -d: -f1 || true)"
+            line_num="$(grep -n '^[[:space:]]*#!\[forbid(unsafe_code)\]' "$entry" | head -n1 | cut -d: -f1 || true)"
             if [[ -n "$line_num" ]]; then
                 forbid_location="$entry:$line_num"
                 break
@@ -114,14 +120,34 @@ for crate_dir in "${FORBID_CRATES[@]}"; do
         fi
     done
 
-    # Search the crate's src/ tree (but not target/ or tests/) for
-    # new unsafe usage. Tests are NOT excluded: a forbid-unsafe-code
-    # crate with test-only unsafe is still a violation because
-    # `#![forbid]` at the crate root applies to the whole crate
-    # including tests (though `#[cfg(test)]` modules in bins/libs
-    # compile under the same crate attributes).
+    # Search the crate's `src/` tree for new unsafe usage. This covers
+    # the library crate itself and any `#[cfg(test)]` modules inside
+    # `src/`, because those compile under the same crate attributes
+    # and therefore inherit the `#![forbid(unsafe_code)]` directive.
+    #
+    # What is NOT scanned: `tests/` (integration tests) and `benches/`
+    # (benchmarks). Each file under those directories is a separate
+    # crate target that does NOT inherit `src/lib.rs`'s crate-root
+    # attributes. If you want similar protection for integration
+    # tests, each test file needs its own `#![forbid(unsafe_code)]`.
+    #
+    # The regex has two alternatives because the `unsafe` + keyword
+    # whitespace rules differ:
+    #   - `unsafe [fn|impl|trait]` requires at least one whitespace
+    #     character between `unsafe` and the keyword. Rust's lexer
+    #     would merge `unsafefn` into a single identifier, so the
+    #     syntactically-valid form always has whitespace.
+    #   - `unsafe {` can have zero whitespace: `unsafe{ body }` is
+    #     valid Rust (rustfmt will insert the space, but the raw form
+    #     is legal). So we match `[[:space:]]*\{` for this case to
+    #     catch `unsafe{}` alongside `unsafe {}`.
+    #
+    # Known limitation: a comment between `unsafe` and the following
+    # token (`unsafe /* c */ {}`) is not matched. This is vanishingly
+    # rare in practice and adding support would complicate the regex
+    # without meaningful coverage gain.
     matches="$(grep -rn --include='*.rs' \
-        -E '(^|[^[:alnum:]_])unsafe[[:space:]]+(\{|fn|impl|trait)' \
+        -E '(^|[^[:alnum:]_])unsafe([[:space:]]+(fn|impl|trait)|[[:space:]]*\{)' \
         "$crate_dir/src" 2>/dev/null || true)"
 
     if [[ -n "$matches" ]]; then


### PR DESCRIPTION
Implements recommendations 2 and 3 from [the weekend code review](https://github.com/rustledger/rustledger/commits/main) (internal context). Two small pieces of CI/tooling hygiene aimed at a class of AI-generated PR failures we saw this week.

## Why

Closed PRs #768 and #769 had a common failure mode: the author pushed code that didn't compile, then CI caught it 15 jobs deep. #769 specifically added \`unsafe { String::from_utf8_unchecked(...) }\` to \`rustledger-loader\`, which has \`#![forbid(unsafe_code)]\` at \`src/lib.rs:28\`. \`cargo check\` correctly rejected it, but the error reads:

\`\`\`
error: usage of an \`unsafe\` block
 --> crates/rustledger-loader/src/vfs.rs:76:13
\`\`\`

without mentioning the forbid directive the author was violating. Reviewers had to hunt for context. More importantly, the author clearly hadn't run \`cargo check\` locally before pushing, otherwise all three compile errors would have been visible in 30 seconds.

Both of these are free to catch.

## What this PR adds

### 1. \`scripts/check-unsafe-invariant.sh\` (new, 160 lines)

Shell script that enumerates workspace crates with \`#![forbid(unsafe_code)]\` (9 at time of writing) and greps each for \`unsafe {\` / \`unsafe fn\` / \`unsafe impl\` / \`unsafe trait\`. On violation, prints both the offending line and the forbid directive line with guidance on how to resolve:

\`\`\`
============================================================
FORBID_UNSAFE_CODE VIOLATION in crate: rustledger-loader
============================================================
Directive: #![forbid(unsafe_code)] at crates/rustledger-loader/src/lib.rs:28

Offending lines:
    crates/rustledger-loader/src/lib.rs:991:fn _test_violation() { let _ = unsafe { ... }; }

Either:
  1. Remove the unsafe block/item and use a safe alternative, or
  2. If unsafe is genuinely required, remove the
     #![forbid(unsafe_code)] directive from crates/rustledger-loader/src/lib.rs:28
     and justify the change in the PR description.
     (Reviewers will treat removal of a forbid directive as
     a significant change requiring extra scrutiny.)
============================================================
\`\`\`

Runs in milliseconds (grep over source, no compilation). Exits 0/1/2 for clean/violation/invocation-error. Handles invocation from any directory via \`git rev-parse --show-toplevel\`.

### 2. \`Unsafe Invariant\` CI job (\`.github/workflows/ci.yml\`)

New fast-check job added alongside \`Format\`. Runs the script above with no toolchain install (~1 second on a fresh runner). Wired into the \`build\` gate's \`needs\` list so it must pass for merges. Gets a named CI status, so violations don't have to be dug out of the generic \`Check\` job's 500-line log.

### 3. Pre-push hooks (\`.pre-commit-config.yaml\`)

Two new pre-push hook entries:

- **\`cargo-check\`** — runs \`cargo check --workspace --all-features --all-targets\` before every push. Unlike clippy/test (which the existing config correctly notes are too slow for pre-push), \`cargo check\` skips codegen and lint passes and is typically 2-30 seconds on a warm incremental cache. Catches the compile-error class that killed #768/#769 before the PR even opens. Use \`git push --no-verify\` to bypass for intentional WIP pushes.

- **\`unsafe-invariant\`** — same script as the CI job, as a second defense layer. Faster than \`cargo check\` for the specific forbid-unsafe-code case, and surfaces the clearer error message locally too.

The existing pre-commit-config comment that explains why clippy/test are *not* pre-push is preserved and extended with an explanation of why \`cargo check\` is fast enough to be.

## How it was tested

1. **Clean tree:** \`OK: all 9 forbid-unsafe-code crates are clean\` — exit 0.
2. **Injected violation:** added a test function with \`let _ = unsafe { std::mem::transmute::<u8, u8>(0) };\` to \`rustledger-loader/src/lib.rs\`, ran the script, got the violation output above with the correct file:line, correct forbid directive pointer, and exit 1. Reverted immediately.
3. **YAML validation:** both \`.github/workflows/ci.yml\` and \`.pre-commit-config.yaml\` parsed cleanly via \`python3 -c \"import yaml; yaml.safe_load(...)\"\`.
4. **pre-commit hooks ran on commit** (rustfmt, typos, gitleaks, commitizen) — all passed.

## Risks and limitations

- **The grep is conservative.** It matches \`unsafe\` followed by \`{\`, \`fn\`, \`impl\`, or \`trait\` as whole words. A string literal containing \`\"unsafe { ... }\"\` in, say, a test fixture would produce a false positive. I haven't found any in the current tree, but if one shows up later, the fix is either to rephrase the string or add a \`#[allow(...)]\` marker the script can skip. I chose this conservative approach because a false positive is cheap (rename the string) but a false negative (missed violation) is the thing we're trying to prevent.
- **The pre-push hook adds 2-30 seconds to every push** on warm caches. On cold caches (first push after a dependency update), it can be several minutes. \`--no-verify\` is the escape hatch.
- **The unsafe-invariant check is redundant with \`cargo check\`** for the compile-error aspect. The value is the clearer error message, faster feedback, and named CI status. It's not meant to replace \`cargo check\`.

## What it does not do

- Does not run clippy, tests, docs, fuzz, or bench as pre-push hooks. Those continue to run only in CI per the existing policy.
- Does not modify any production code.
- Does not change the existing forbid directives in any crate.

Closes no issue (chore). Complements #758 / #767-era reliability work by making it harder to ship obviously-broken code.