### PR TITLE
fix: rewrite currency_accounts plugin to match Python beancount semantics

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -6,10 +6,26 @@ use super::super::NativePlugin;
 
 /// Plugin that auto-generates currency trading account postings.
 ///
-/// For multi-currency transactions, this plugin adds neutralizing postings
-/// to equity accounts like `Equity:CurrencyAccounts:USD` to track currency
-/// conversion gains/losses. This enables proper reporting of currency
-/// trading activity.
+/// Implements the currency trading accounts method as in Python beancount's
+/// `beancount.plugins.currency_accounts`. For transactions that mix multiple
+/// currencies and use price annotations, this plugin:
+///
+/// 1. Groups postings by `cost.currency` (if the posting has a cost) or
+///    `units.currency` (otherwise). **Price currency is never used as the
+///    group key** — this matches Python's `group_postings_by_weight_currency`.
+/// 2. If there is at least one price annotation in the transaction and
+///    there are two or more distinct group keys, inserts a neutralizing
+///    posting for each group. The neutralizing posting goes to
+///    `<base>:<group_key>` and carries the negated weight inventory of
+///    that group (denominated in the weight/cost currency, which may
+///    differ from the group key).
+/// 3. Unlike Python's plugin, does NOT strip `price` annotations from
+///    the original postings. Python strips them because its pipeline
+///    runs plugins before booking; rustledger runs booking first, so
+///    stripping prices would cause balance-check failures (E3001) in
+///    the post-plugin validator.
+/// 4. Emits `open` directives at the earliest transaction date for all
+///    newly created currency trading accounts.
 pub struct CurrencyAccountsPlugin {
     /// Base account for currency tracking (default: "Equity:CurrencyAccounts").
     base_account: String,
@@ -47,24 +63,23 @@ impl NativePlugin for CurrencyAccountsPlugin {
     fn process(&self, input: PluginInput) -> PluginOutput {
         use crate::types::{AmountData, OpenData, PostingData};
         use rust_decimal::Decimal;
-        use std::collections::{HashMap, HashSet};
+        use std::collections::{BTreeMap, HashSet};
         use std::str::FromStr;
 
-        // Get base account from config if provided
+        // Get base account from config if provided, validating that it's
+        // non-empty. Python's plugin falls back to the default when the
+        // config isn't a valid account string.
         let base_account = input
             .config
             .as_ref()
-            .map_or_else(|| self.base_account.clone(), |c| c.trim().to_string());
+            .map(|c| c.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.base_account.clone());
 
-        // Pre-allocate with expected capacity
-        let mut new_directives: Vec<DirectiveWrapper> = Vec::with_capacity(input.directives.len());
-        let mut created_accounts: HashSet<String> = HashSet::new();
-
-        // Single pass: collect existing opens AND find earliest date
+        // Find earliest date and collect existing Open accounts in one pass.
         let mut existing_opens: HashSet<String> = HashSet::new();
         let mut earliest_date: Option<&str> = None;
         for wrapper in &input.directives {
-            // Track earliest date
             match earliest_date {
                 None => earliest_date = Some(&wrapper.date),
                 Some(current) if wrapper.date.as_str() < current => {
@@ -72,125 +87,172 @@ impl NativePlugin for CurrencyAccountsPlugin {
                 }
                 _ => {}
             }
-            // Collect existing Open accounts
             if let DirectiveData::Open(open) = &wrapper.data {
                 existing_opens.insert(open.account.clone());
             }
         }
         let earliest_date = earliest_date.unwrap_or("1970-01-01").to_string();
 
+        let mut new_directives: Vec<DirectiveWrapper> = Vec::with_capacity(input.directives.len());
+        let mut created_accounts: HashSet<String> = HashSet::new();
+
         for wrapper in &input.directives {
-            if let DirectiveData::Transaction(txn) = &wrapper.data {
-                // Calculate currency totals for this transaction
-                // Map from currency -> total amount in that currency
-                // Like Python beancount, we use the WEIGHT currency (cost currency if present)
-                let mut currency_totals: HashMap<String, Decimal> = HashMap::new();
-
-                for posting in &txn.postings {
-                    if let Some(units) = &posting.units {
-                        let units_amount = Decimal::from_str(&units.number).unwrap_or_default();
-
-                        // Determine the weight currency and amount
-                        // If posting has a cost, use cost currency and calculate cost amount
-                        // Otherwise use units currency and amount
-                        let (currency, amount) = if let Some(cost) = &posting.cost {
-                            if let Some(cost_currency) = &cost.currency {
-                                // Calculate cost amount
-                                let cost_amount = if let Some(num_per) = &cost.number_per {
-                                    // Per-unit cost: units * cost_per_unit
-                                    let per_unit =
-                                        Decimal::from_str(num_per).unwrap_or(Decimal::ONE);
-                                    units_amount * per_unit
-                                } else if let Some(num_total) = &cost.number_total {
-                                    // Total cost specified directly
-                                    Decimal::from_str(num_total).unwrap_or_default()
-                                } else {
-                                    // No cost number, fall back to units
-                                    units_amount
-                                };
-                                (cost_currency.clone(), cost_amount)
-                            } else {
-                                // Cost exists but no currency - fall back to units
-                                (units.currency.clone(), units_amount)
-                            }
-                        } else if let Some(price) = &posting.price {
-                            // Price annotation (@) - use price currency for weight
-                            if let Some(price_amount) = &price.amount {
-                                let price_currency = price_amount.currency.clone();
-                                let price_num =
-                                    Decimal::from_str(&price_amount.number).unwrap_or(Decimal::ONE);
-                                let weight = if price.is_total {
-                                    // Total price (@@): weight is the price amount directly
-                                    // But sign follows units
-                                    if units_amount < Decimal::ZERO {
-                                        -price_num
-                                    } else {
-                                        price_num
-                                    }
-                                } else {
-                                    // Per-unit price (@): weight = units * price
-                                    units_amount * price_num
-                                };
-                                (price_currency, weight)
-                            } else {
-                                // Incomplete price - fall back to units
-                                (units.currency.clone(), units_amount)
-                            }
-                        } else {
-                            // No cost or price - use units directly
-                            (units.currency.clone(), units_amount)
-                        };
-
-                        *currency_totals.entry(currency).or_default() += amount;
-                    }
-                }
-
-                // If we have multiple currencies with non-zero totals, add balancing postings
-                let non_zero_currencies: Vec<_> = currency_totals
-                    .iter()
-                    .filter(|&(_, total)| *total != Decimal::ZERO)
-                    .collect();
-
-                if non_zero_currencies.len() > 1 {
-                    // Clone the transaction and add currency account postings
-                    let mut modified_txn = txn.clone();
-
-                    for &(currency, total) in &non_zero_currencies {
-                        let account_name = format!("{base_account}:{currency}");
-                        // Track the account for Open directive generation
-                        created_accounts.insert(account_name.clone());
-
-                        // Add posting to currency account to neutralize
-                        modified_txn.postings.push(PostingData {
-                            account: account_name,
-                            units: Some(AmountData {
-                                number: (-*total).to_string(),
-                                currency: (*currency).clone(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        });
-                    }
-
-                    new_directives.push(DirectiveWrapper {
-                        directive_type: wrapper.directive_type.clone(),
-                        date: wrapper.date.clone(),
-                        filename: wrapper.filename.clone(), // Preserve original location
-                        lineno: wrapper.lineno,
-                        data: DirectiveData::Transaction(modified_txn),
-                    });
-                } else {
-                    // Single currency or balanced - pass through
-                    new_directives.push(wrapper.clone());
-                }
-            } else {
+            let DirectiveData::Transaction(txn) = &wrapper.data else {
                 new_directives.push(wrapper.clone());
+                continue;
+            };
+
+            // Group postings by key and track whether any posting has a price.
+            //
+            // Use BTreeMap for deterministic iteration so the order in which
+            // neutralizing postings are appended is stable across runs.
+            let mut curmap: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+            let mut has_price = false;
+
+            for (i, posting) in txn.postings.iter().enumerate() {
+                let Some(units) = &posting.units else {
+                    continue;
+                };
+
+                // Group key: cost.currency if the posting has a cost,
+                // otherwise units.currency. Matches Python's
+                // `group_postings_by_weight_currency` at
+                // currency_accounts.py:93-104.
+                let key = if let Some(cost) = &posting.cost {
+                    cost.currency
+                        .clone()
+                        .unwrap_or_else(|| units.currency.clone())
+                } else {
+                    units.currency.clone()
+                };
+
+                if posting.price.is_some() {
+                    has_price = true;
+                }
+
+                curmap.entry(key).or_default().push(i);
             }
+
+            // Only neutralize when there's at least one price AND more than
+            // one currency group. This is Python's gating condition.
+            if !has_price || curmap.len() < 2 {
+                new_directives.push(wrapper.clone());
+                continue;
+            }
+
+            // `weight(posting)` returns (amount, currency):
+            //   - Cost: (units * number_per, cost.currency), or total cost
+            //     with sign following units.
+            //   - Price: (units * price, price.currency). For @@ (is_total),
+            //     weight magnitude is the total price, sign follows units.
+            //   - Else: (units.amount, units.currency)
+            let weight_of = |posting: &PostingData| -> Option<(Decimal, String)> {
+                let units = posting.units.as_ref()?;
+                let units_num = Decimal::from_str(&units.number).unwrap_or_default();
+                if let Some(cost) = &posting.cost {
+                    let currency = cost
+                        .currency
+                        .clone()
+                        .unwrap_or_else(|| units.currency.clone());
+                    let amount = if let Some(per) = &cost.number_per {
+                        let per = Decimal::from_str(per).unwrap_or_default();
+                        units_num * per
+                    } else if let Some(total) = &cost.number_total {
+                        let total = Decimal::from_str(total).unwrap_or_default();
+                        // Total cost magnitude with sign following units
+                        // (matches beancount.core.convert.get_cost).
+                        if units_num.is_sign_negative() {
+                            -total.abs()
+                        } else {
+                            total.abs()
+                        }
+                    } else {
+                        units_num
+                    };
+                    Some((amount, currency))
+                } else if let Some(price) = &posting.price {
+                    let price_amount = price.amount.as_ref()?;
+                    let price_num = Decimal::from_str(&price_amount.number).unwrap_or_default();
+                    let currency = price_amount.currency.clone();
+                    let amount = if price.is_total {
+                        if units_num.is_sign_negative() {
+                            -price_num.abs()
+                        } else {
+                            price_num.abs()
+                        }
+                    } else {
+                        units_num * price_num
+                    };
+                    Some((amount, currency))
+                } else {
+                    Some((units_num, units.currency.clone()))
+                }
+            };
+
+            let mut new_postings: Vec<PostingData> =
+                Vec::with_capacity(txn.postings.len() + curmap.len());
+
+            for (group_key, posting_indices) in &curmap {
+                // Accumulate the group's weight inventory.
+                let mut inv: BTreeMap<String, Decimal> = BTreeMap::new();
+                for &idx in posting_indices {
+                    if let Some((amount, currency)) = weight_of(&txn.postings[idx]) {
+                        *inv.entry(currency).or_default() += amount;
+                    }
+                }
+
+                // Re-insert original postings for this group.
+                //
+                // Python's plugin strips price annotations here
+                // (currency_accounts.py:145) because its pipeline runs
+                // plugins BEFORE booking. In rustledger, booking runs
+                // first and the validator re-checks afterwards, so we
+                // must keep prices to preserve the weight-based balance.
+                for &idx in posting_indices {
+                    new_postings.push(txn.postings[idx].clone());
+                }
+
+                // Drop zero-sum entries.
+                inv.retain(|_, amount| !amount.is_zero());
+
+                // Python calls `inv.get_only_position()` and errors on
+                // multi-currency groups. We skip neutralization in that
+                // case rather than failing — it indicates a transaction
+                // shape the prototype plugin never handled.
+                if inv.len() != 1 {
+                    continue;
+                }
+
+                let (weight_currency, weight_amount) = inv.into_iter().next().unwrap();
+                let account_name = format!("{base_account}:{group_key}");
+                created_accounts.insert(account_name.clone());
+
+                new_postings.push(PostingData {
+                    account: account_name,
+                    units: Some(AmountData {
+                        number: (-weight_amount).to_string(),
+                        currency: weight_currency,
+                    }),
+                    cost: None,
+                    price: None,
+                    flag: None,
+                    metadata: vec![],
+                });
+            }
+
+            let mut modified_txn = txn.clone();
+            modified_txn.postings = new_postings;
+
+            new_directives.push(DirectiveWrapper {
+                directive_type: wrapper.directive_type.clone(),
+                date: wrapper.date.clone(),
+                filename: wrapper.filename.clone(),
+                lineno: wrapper.lineno,
+                data: DirectiveData::Transaction(modified_txn),
+            });
         }
 
-        // Generate Open directives for created currency accounts (skip existing ones)
+        // Generate Open directives for created currency accounts (skip existing).
         let mut open_directives: Vec<DirectiveWrapper> = created_accounts
             .into_iter()
             .filter(|account| !existing_opens.contains(account))
@@ -208,7 +270,7 @@ impl NativePlugin for CurrencyAccountsPlugin {
             })
             .collect();
 
-        // Sort for deterministic output
+        // Sort for deterministic output.
         open_directives.sort_by(|a, b| {
             if let (DirectiveData::Open(oa), DirectiveData::Open(ob)) = (&a.data, &b.data) {
                 oa.account.cmp(&ob.account)
@@ -217,7 +279,8 @@ impl NativePlugin for CurrencyAccountsPlugin {
             }
         });
 
-        // Prepend Open directives to the output
+        // Prepend Open directives to the output (matches Python which does
+        // `open_entries + new_entries`).
         open_directives.extend(new_directives);
 
         PluginOutput {
@@ -232,530 +295,300 @@ mod currency_accounts_tests {
     use super::*;
     use crate::types::*;
 
+    fn txn_wrapper(date: &str, narration: &str, postings: Vec<PostingData>) -> DirectiveWrapper {
+        DirectiveWrapper {
+            directive_type: "transaction".to_string(),
+            date: date.to_string(),
+            filename: None,
+            lineno: None,
+            data: DirectiveData::Transaction(TransactionData {
+                flag: "*".to_string(),
+                payee: None,
+                narration: narration.to_string(),
+                tags: vec![],
+                links: vec![],
+                metadata: vec![],
+                postings,
+            }),
+        }
+    }
+
+    fn posting(account: &str, number: &str, currency: &str) -> PostingData {
+        PostingData {
+            account: account.to_string(),
+            units: Some(AmountData {
+                number: number.to_string(),
+                currency: currency.to_string(),
+            }),
+            cost: None,
+            price: None,
+            flag: None,
+            metadata: vec![],
+        }
+    }
+
+    fn price_usd(number: &str) -> PriceAnnotationData {
+        PriceAnnotationData {
+            is_total: false,
+            amount: Some(AmountData {
+                number: number.to_string(),
+                currency: "USD".to_string(),
+            }),
+            number: None,
+            currency: None,
+        }
+    }
+
+    fn default_options() -> PluginOptions {
+        PluginOptions {
+            operating_currencies: vec!["USD".to_string()],
+            title: None,
+        }
+    }
+
+    /// Regression test for #776. The canonical reproducer: a currency
+    /// exchange with a price annotation on one side. Python groups by
+    /// units currency, yielding EUR and USD groups, and emits two
+    /// neutralizing postings and two Open directives.
     #[test]
-    fn test_currency_accounts_adds_balancing_postings() {
-        let plugin = CurrencyAccountsPlugin::new();
+    fn test_issue_776_currency_exchange_with_price() {
+        let plugin = CurrencyAccountsPlugin::with_base_account("Equity:Currency".to_string());
+
+        let mut p1 = posting("Assets:Bank:EUR", "-100", "EUR");
+        p1.price = Some(price_usd("1.10"));
 
         let input = PluginInput {
-            directives: vec![DirectiveWrapper {
-                directive_type: "transaction".to_string(),
-                date: "2024-01-15".to_string(),
-                filename: None,
-                lineno: None,
-                data: DirectiveData::Transaction(TransactionData {
-                    flag: "*".to_string(),
-                    payee: None,
-                    narration: "Currency exchange".to_string(),
-                    tags: vec![],
-                    links: vec![],
-                    metadata: vec![],
-                    postings: vec![
-                        PostingData {
-                            account: "Assets:Bank:USD".to_string(),
-                            units: Some(AmountData {
-                                number: "-100".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                        PostingData {
-                            account: "Assets:Bank:EUR".to_string(),
-                            units: Some(AmountData {
-                                number: "85".to_string(),
-                                currency: "EUR".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                    ],
-                }),
-            }],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
+            directives: vec![txn_wrapper(
+                "2026-03-17",
+                "Currency exchange",
+                vec![p1, posting("Assets:Bank:USD", "110", "USD")],
+            )],
+            options: default_options(),
             config: None,
         };
 
         let output = plugin.process(input);
         assert_eq!(output.errors.len(), 0);
-        // Should have 2 Open directives + 1 Transaction
+
+        // 2 opens + 1 modified txn
         assert_eq!(output.directives.len(), 3);
 
-        // First two should be Open directives (sorted alphabetically)
-        if let DirectiveData::Open(open) = &output.directives[0].data {
-            assert_eq!(open.account, "Equity:CurrencyAccounts:EUR");
-            assert_eq!(output.directives[0].date, "2024-01-15");
-        } else {
-            panic!("Expected Open directive at index 0");
-        }
+        let opens: Vec<&str> = output
+            .directives
+            .iter()
+            .filter_map(|d| {
+                if let DirectiveData::Open(o) = &d.data {
+                    Some(o.account.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(opens, vec!["Equity:Currency:EUR", "Equity:Currency:USD"]);
 
-        if let DirectiveData::Open(open) = &output.directives[1].data {
-            assert_eq!(open.account, "Equity:CurrencyAccounts:USD");
-            assert_eq!(output.directives[1].date, "2024-01-15");
-        } else {
-            panic!("Expected Open directive at index 1");
-        }
+        let DirectiveData::Transaction(txn) = &output.directives[2].data else {
+            panic!("expected transaction at index 2");
+        };
+        // 2 originals + 2 neutralizers
+        assert_eq!(txn.postings.len(), 4);
+        // Original postings keep their price annotations (rustledger
+        // runs booking before plugins, so stripping prices would cause
+        // E3001 in the validator).
+        assert!(txn.postings[0].price.is_some()); // EUR posting has price
+        assert!(txn.postings[1].price.is_none()); // USD posting never had price
 
-        // Last should be the transaction
-        if let DirectiveData::Transaction(txn) = &output.directives[2].data {
-            // Should have original 2 postings + 2 currency account postings
-            assert_eq!(txn.postings.len(), 4);
+        // EUR group weight is -110 USD → neutralizer +110 USD on Equity:Currency:EUR.
+        // Note the counter-intuitive currency mismatch — this is what Python emits.
+        let eur_neut = txn
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Currency:EUR")
+            .expect("missing EUR neutralizer");
+        // rust_decimal preserves precision of operands: -100 * 1.10 = -110.00,
+        // so the negated weight string is "110.00" (two trailing zeros from
+        // the 1.10 factor). Python prints the same Decimal as "110.00".
+        assert_eq!(eur_neut.units.as_ref().unwrap().number, "110.00");
+        assert_eq!(eur_neut.units.as_ref().unwrap().currency, "USD");
 
-            // Check for currency account postings
-            let usd_posting = txn
-                .postings
-                .iter()
-                .find(|p| p.account == "Equity:CurrencyAccounts:USD");
-            assert!(usd_posting.is_some());
-            let usd_posting = usd_posting.unwrap();
-            // Should neutralize the -100 USD
-            assert_eq!(usd_posting.units.as_ref().unwrap().number, "100");
-
-            let eur_posting = txn
-                .postings
-                .iter()
-                .find(|p| p.account == "Equity:CurrencyAccounts:EUR");
-            assert!(eur_posting.is_some());
-            let eur_posting = eur_posting.unwrap();
-            // Should neutralize the 85 EUR
-            assert_eq!(eur_posting.units.as_ref().unwrap().number, "-85");
-        } else {
-            panic!("Expected Transaction directive at index 2");
-        }
+        // USD group weight is +110 USD → neutralizer -110 USD on Equity:Currency:USD.
+        let usd_neut = txn
+            .postings
+            .iter()
+            .find(|p| p.account == "Equity:Currency:USD")
+            .expect("missing USD neutralizer");
+        assert_eq!(usd_neut.units.as_ref().unwrap().number, "-110");
+        assert_eq!(usd_neut.units.as_ref().unwrap().currency, "USD");
     }
 
+    /// Cost-only transaction: grouping key is cost.currency, and the plugin
+    /// only neutralizes when `has_price` is true. Without a price annotation,
+    /// the transaction passes through unchanged (no currency accounts created).
     #[test]
-    fn test_currency_accounts_single_currency_unchanged() {
+    fn test_cost_only_no_price_skipped() {
         let plugin = CurrencyAccountsPlugin::new();
 
+        let mut p1 = posting("Assets:Shares:RING", "9", "RING");
+        p1.cost = Some(CostData {
+            number_per: Some("68.55".to_string()),
+            number_total: None,
+            currency: Some("USD".to_string()),
+            date: None,
+            label: None,
+            merge: false,
+        });
+
         let input = PluginInput {
-            directives: vec![DirectiveWrapper {
-                directive_type: "transaction".to_string(),
-                date: "2024-01-15".to_string(),
-                filename: None,
-                lineno: None,
-                data: DirectiveData::Transaction(TransactionData {
-                    flag: "*".to_string(),
-                    payee: None,
-                    narration: "Simple transfer".to_string(),
-                    tags: vec![],
-                    links: vec![],
-                    metadata: vec![],
-                    postings: vec![
-                        PostingData {
-                            account: "Assets:Bank".to_string(),
-                            units: Some(AmountData {
-                                number: "-100".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                        PostingData {
-                            account: "Expenses:Food".to_string(),
-                            units: Some(AmountData {
-                                number: "100".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                    ],
-                }),
-            }],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
+            directives: vec![txn_wrapper(
+                "2026-03-21",
+                "Buy RING",
+                vec![
+                    p1,
+                    posting("Expenses:Financial", "0.35", "USD"),
+                    posting("Assets:Cash:USD", "-617.30", "USD"),
+                ],
+            )],
+            options: default_options(),
             config: None,
         };
 
         let output = plugin.process(input);
         assert_eq!(output.errors.len(), 0);
-
-        // Single currency balanced - should not add any postings
-        if let DirectiveData::Transaction(txn) = &output.directives[0].data {
-            assert_eq!(txn.postings.len(), 2);
-        }
+        assert_eq!(output.directives.len(), 1);
+        let DirectiveData::Transaction(txn) = &output.directives[0].data else {
+            panic!("expected transaction");
+        };
+        assert_eq!(txn.postings.len(), 3);
     }
 
+    /// Single-currency transaction (no price, no cost): passed through.
     #[test]
-    fn test_currency_accounts_custom_base_account() {
+    fn test_single_currency_unchanged() {
+        let plugin = CurrencyAccountsPlugin::new();
+        let input = PluginInput {
+            directives: vec![txn_wrapper(
+                "2024-01-15",
+                "Simple transfer",
+                vec![
+                    posting("Assets:Bank", "-100", "USD"),
+                    posting("Expenses:Food", "100", "USD"),
+                ],
+            )],
+            options: default_options(),
+            config: None,
+        };
+
+        let output = plugin.process(input);
+        assert_eq!(output.directives.len(), 1);
+        let DirectiveData::Transaction(txn) = &output.directives[0].data else {
+            panic!("expected transaction");
+        };
+        assert_eq!(txn.postings.len(), 2);
+    }
+
+    /// Custom base account via config string.
+    #[test]
+    fn test_custom_base_account() {
         let plugin = CurrencyAccountsPlugin::new();
 
+        let mut p1 = posting("Assets:Bank:EUR", "-100", "EUR");
+        p1.price = Some(price_usd("1.10"));
+
         let input = PluginInput {
-            directives: vec![DirectiveWrapper {
-                directive_type: "transaction".to_string(),
-                date: "2024-01-15".to_string(),
-                filename: None,
-                lineno: None,
-                data: DirectiveData::Transaction(TransactionData {
-                    flag: "*".to_string(),
-                    payee: None,
-                    narration: "Exchange".to_string(),
-                    tags: vec![],
-                    links: vec![],
-                    metadata: vec![],
-                    postings: vec![
-                        PostingData {
-                            account: "Assets:USD".to_string(),
-                            units: Some(AmountData {
-                                number: "-50".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                        PostingData {
-                            account: "Assets:EUR".to_string(),
-                            units: Some(AmountData {
-                                number: "42".to_string(),
-                                currency: "EUR".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                    ],
-                }),
-            }],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
+            directives: vec![txn_wrapper(
+                "2024-01-15",
+                "Exchange",
+                vec![p1, posting("Assets:Bank:USD", "110", "USD")],
+            )],
+            options: default_options(),
             config: Some("Income:Trading".to_string()),
         };
 
         let output = plugin.process(input);
-        // Should have 2 Open directives + 1 Transaction
         assert_eq!(output.directives.len(), 3);
-
-        // Check Open directives use custom base account
         assert!(output.directives.iter().any(|d| {
-            if let DirectiveData::Open(open) = &d.data {
-                open.account.starts_with("Income:Trading:")
+            if let DirectiveData::Open(o) = &d.data {
+                o.account == "Income:Trading:EUR"
             } else {
                 false
             }
         }));
-
-        // Transaction is at index 2
-        if let DirectiveData::Transaction(txn) = &output.directives[2].data {
-            // Check for custom base account in postings
-            assert!(
-                txn.postings
-                    .iter()
-                    .any(|p| p.account.starts_with("Income:Trading:"))
-            );
-        } else {
-            panic!("Expected Transaction directive at index 2");
-        }
-    }
-
-    #[test]
-    fn test_currency_accounts_open_directives_use_earliest_date() {
-        let plugin = CurrencyAccountsPlugin::new();
-
-        let input = PluginInput {
-            directives: vec![
-                DirectiveWrapper {
-                    directive_type: "transaction".to_string(),
-                    date: "2024-03-15".to_string(),
-                    filename: None,
-                    lineno: None,
-                    data: DirectiveData::Transaction(TransactionData {
-                        flag: "*".to_string(),
-                        payee: None,
-                        narration: "Later exchange".to_string(),
-                        tags: vec![],
-                        links: vec![],
-                        metadata: vec![],
-                        postings: vec![
-                            PostingData {
-                                account: "Assets:USD".to_string(),
-                                units: Some(AmountData {
-                                    number: "-100".to_string(),
-                                    currency: "USD".to_string(),
-                                }),
-                                cost: None,
-                                price: None,
-                                flag: None,
-                                metadata: vec![],
-                            },
-                            PostingData {
-                                account: "Assets:EUR".to_string(),
-                                units: Some(AmountData {
-                                    number: "85".to_string(),
-                                    currency: "EUR".to_string(),
-                                }),
-                                cost: None,
-                                price: None,
-                                flag: None,
-                                metadata: vec![],
-                            },
-                        ],
-                    }),
-                },
-                DirectiveWrapper {
-                    directive_type: "transaction".to_string(),
-                    date: "2024-01-01".to_string(), // Earlier date
-                    filename: None,
-                    lineno: None,
-                    data: DirectiveData::Transaction(TransactionData {
-                        flag: "*".to_string(),
-                        payee: None,
-                        narration: "Earlier exchange".to_string(),
-                        tags: vec![],
-                        links: vec![],
-                        metadata: vec![],
-                        postings: vec![
-                            PostingData {
-                                account: "Assets:GBP".to_string(),
-                                units: Some(AmountData {
-                                    number: "-50".to_string(),
-                                    currency: "GBP".to_string(),
-                                }),
-                                cost: None,
-                                price: None,
-                                flag: None,
-                                metadata: vec![],
-                            },
-                            PostingData {
-                                account: "Assets:JPY".to_string(),
-                                units: Some(AmountData {
-                                    number: "7500".to_string(),
-                                    currency: "JPY".to_string(),
-                                }),
-                                cost: None,
-                                price: None,
-                                flag: None,
-                                metadata: vec![],
-                            },
-                        ],
-                    }),
-                },
-            ],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
-            config: None,
-        };
-
-        let output = plugin.process(input);
-        // Should have 4 Open directives (EUR, GBP, JPY, USD) + 2 Transactions
-        assert_eq!(output.directives.len(), 6);
-
-        // All Open directives should use the earliest date (2024-01-01)
-        for wrapper in &output.directives[..4] {
-            if let DirectiveData::Open(_) = &wrapper.data {
-                assert_eq!(
-                    wrapper.date, "2024-01-01",
-                    "Open directive should use earliest date"
-                );
+        assert!(output.directives.iter().any(|d| {
+            if let DirectiveData::Open(o) = &d.data {
+                o.account == "Income:Trading:USD"
+            } else {
+                false
             }
-        }
+        }));
     }
 
+    /// Pre-existing Open for a currency account should not be duplicated
+    /// by the plugin (would cause E1002 in the validator).
     #[test]
-    fn test_currency_accounts_uses_cost_currency() {
-        // Issue #521/#531: When a posting has a cost, use the cost currency
-        // for grouping, not the units currency
+    fn test_skips_existing_open() {
         let plugin = CurrencyAccountsPlugin::new();
 
-        // Transaction: Buy 9 RING at 68.55 USD each
-        // All postings should be grouped under USD (the cost currency)
-        let input = PluginInput {
-            directives: vec![DirectiveWrapper {
-                directive_type: "transaction".to_string(),
-                date: "2026-03-21".to_string(),
-                filename: None,
-                lineno: None,
-                data: DirectiveData::Transaction(TransactionData {
-                    flag: "*".to_string(),
-                    payee: Some("Buy RING".to_string()),
-                    narration: String::new(),
-                    tags: vec![],
-                    links: vec![],
-                    metadata: vec![],
-                    postings: vec![
-                        PostingData {
-                            account: "Assets:Shares:RING".to_string(),
-                            units: Some(AmountData {
-                                number: "9".to_string(),
-                                currency: "RING".to_string(),
-                            }),
-                            cost: Some(CostData {
-                                number_per: Some("68.55".to_string()),
-                                number_total: None,
-                                currency: Some("USD".to_string()),
-                                date: None,
-                                label: None,
-                                merge: false,
-                            }),
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                        PostingData {
-                            account: "Expenses:Financial".to_string(),
-                            units: Some(AmountData {
-                                number: "0.35".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                        PostingData {
-                            account: "Assets:Cash:USD".to_string(),
-                            units: Some(AmountData {
-                                number: "-617.30".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                    ],
-                }),
-            }],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
-            config: None,
+        let existing_open = DirectiveWrapper {
+            directive_type: "open".to_string(),
+            date: "2024-01-01".to_string(),
+            filename: None,
+            lineno: None,
+            data: DirectiveData::Open(OpenData {
+                account: "Equity:CurrencyAccounts:USD".to_string(),
+                currencies: vec![],
+                booking: None,
+                metadata: vec![],
+            }),
         };
 
-        let output = plugin.process(input);
-        assert_eq!(output.errors.len(), 0);
-
-        // All postings have cost/units in USD, so NO currency account postings should be added
-        // The transaction should pass through unchanged (just 1 directive)
-        assert_eq!(output.directives.len(), 1);
-
-        if let DirectiveData::Transaction(txn) = &output.directives[0].data {
-            // Should have the original 3 postings only
-            assert_eq!(txn.postings.len(), 3);
-        } else {
-            panic!("Expected Transaction directive");
-        }
-    }
-
-    #[test]
-    fn test_currency_accounts_uses_price_currency() {
-        // When a posting has a price (@), use the price currency for grouping
-        let plugin = CurrencyAccountsPlugin::new();
-
-        // Transaction: -100 EUR @ 1.10 USD, +110 USD
-        // Both should be grouped under USD (price currency for first, units for second)
-        let input = PluginInput {
-            directives: vec![DirectiveWrapper {
-                directive_type: "transaction".to_string(),
-                date: "2026-03-17".to_string(),
-                filename: None,
-                lineno: None,
-                data: DirectiveData::Transaction(TransactionData {
-                    flag: "*".to_string(),
-                    payee: None,
-                    narration: "Currency exchange".to_string(),
-                    tags: vec![],
-                    links: vec![],
-                    metadata: vec![],
-                    postings: vec![
-                        PostingData {
-                            account: "Assets:Bank:EUR".to_string(),
-                            units: Some(AmountData {
-                                number: "-100".to_string(),
-                                currency: "EUR".to_string(),
-                            }),
-                            cost: None,
-                            price: Some(PriceAnnotationData {
-                                is_total: false,
-                                amount: Some(AmountData {
-                                    number: "1.10".to_string(),
-                                    currency: "USD".to_string(),
-                                }),
-                                number: None,
-                                currency: None,
-                            }),
-                            flag: None,
-                            metadata: vec![],
-                        },
-                        PostingData {
-                            account: "Assets:Bank:USD".to_string(),
-                            units: Some(AmountData {
-                                number: "110".to_string(),
-                                currency: "USD".to_string(),
-                            }),
-                            cost: None,
-                            price: None,
-                            flag: None,
-                            metadata: vec![],
-                        },
-                    ],
-                }),
-            }],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
-            config: None,
-        };
-
-        let output = plugin.process(input);
-        assert_eq!(output.errors.len(), 0);
-
-        // Both postings have weight in USD:
-        // -100 EUR @ 1.10 USD = -110 USD weight
-        // +110 USD = +110 USD weight
-        // Total: 0 USD - balanced, NO currency account postings needed
-        assert_eq!(output.directives.len(), 1);
-
-        if let DirectiveData::Transaction(txn) = &output.directives[0].data {
-            // Should have the original 2 postings only
-            assert_eq!(txn.postings.len(), 2);
-        } else {
-            panic!("Expected Transaction directive");
-        }
-    }
-
-    #[test]
-    fn test_currency_accounts_skips_existing_open() {
-        // When user already has Open directive for currency account,
-        // plugin should NOT create a duplicate (would cause E1002)
-        let plugin = CurrencyAccountsPlugin::new();
+        let mut p1 = posting("Assets:Bank:EUR", "-100", "EUR");
+        p1.price = Some(price_usd("1.10"));
 
         let input = PluginInput {
             directives: vec![
-                // Pre-existing Open for the currency account
-                DirectiveWrapper {
-                    directive_type: "open".to_string(),
-                    date: "2024-01-01".to_string(),
-                    filename: None,
-                    lineno: None,
-                    data: DirectiveData::Open(OpenData {
-                        account: "Equity:CurrencyAccounts:USD".to_string(),
-                        currencies: vec![],
-                        booking: None,
-                        metadata: vec![],
-                    }),
-                },
+                existing_open,
+                txn_wrapper(
+                    "2024-01-15",
+                    "Exchange",
+                    vec![p1, posting("Assets:Bank:USD", "110", "USD")],
+                ),
+            ],
+            options: default_options(),
+            config: None,
+        };
+
+        let output = plugin.process(input);
+
+        // Only Equity:CurrencyAccounts:EUR should be a newly-created open
+        // (filename marker <currency_accounts>). The USD open passed
+        // through from the input.
+        let new_currency_opens: Vec<&str> = output
+            .directives
+            .iter()
+            .filter_map(|d| {
+                if let DirectiveData::Open(o) = &d.data
+                    && d.filename.as_deref() == Some("<currency_accounts>")
+                {
+                    Some(o.account.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(new_currency_opens, vec!["Equity:CurrencyAccounts:EUR"]);
+    }
+
+    /// Open directives for plugin-created accounts use the earliest date
+    /// observed in the input (matches Python `earliest_date = entries[0].date`
+    /// when entries are date-sorted upstream).
+    #[test]
+    fn test_open_uses_earliest_date() {
+        let plugin = CurrencyAccountsPlugin::new();
+
+        let mut p_later = posting("Assets:Bank:EUR", "-100", "EUR");
+        p_later.price = Some(price_usd("1.10"));
+
+        let input = PluginInput {
+            directives: vec![
                 DirectiveWrapper {
                     directive_type: "open".to_string(),
                     date: "2024-01-01".to_string(),
@@ -768,94 +601,27 @@ mod currency_accounts_tests {
                         metadata: vec![],
                     }),
                 },
-                DirectiveWrapper {
-                    directive_type: "open".to_string(),
-                    date: "2024-01-01".to_string(),
-                    filename: None,
-                    lineno: None,
-                    data: DirectiveData::Open(OpenData {
-                        account: "Assets:Bank:USD".to_string(),
-                        currencies: vec![],
-                        booking: None,
-                        metadata: vec![],
-                    }),
-                },
-                // Multi-currency transaction
-                DirectiveWrapper {
-                    directive_type: "transaction".to_string(),
-                    date: "2024-01-15".to_string(),
-                    filename: None,
-                    lineno: None,
-                    data: DirectiveData::Transaction(TransactionData {
-                        flag: "*".to_string(),
-                        payee: None,
-                        narration: "Currency exchange".to_string(),
-                        tags: vec![],
-                        links: vec![],
-                        metadata: vec![],
-                        postings: vec![
-                            PostingData {
-                                account: "Assets:Bank:USD".to_string(),
-                                units: Some(AmountData {
-                                    number: "-100".to_string(),
-                                    currency: "USD".to_string(),
-                                }),
-                                cost: None,
-                                price: None,
-                                flag: None,
-                                metadata: vec![],
-                            },
-                            PostingData {
-                                account: "Assets:Bank:EUR".to_string(),
-                                units: Some(AmountData {
-                                    number: "85".to_string(),
-                                    currency: "EUR".to_string(),
-                                }),
-                                cost: None,
-                                price: None,
-                                flag: None,
-                                metadata: vec![],
-                            },
-                        ],
-                    }),
-                },
+                txn_wrapper(
+                    "2026-03-17",
+                    "Exchange",
+                    vec![p_later, posting("Assets:Bank:USD", "110", "USD")],
+                ),
             ],
-            options: PluginOptions {
-                operating_currencies: vec!["USD".to_string()],
-                title: None,
-            },
+            options: default_options(),
             config: None,
         };
 
         let output = plugin.process(input);
-        assert_eq!(output.errors.len(), 0);
-
-        // Should have:
-        // - 1 new Open for Equity:CurrencyAccounts:EUR (USD already exists)
-        // - 3 original Open directives
-        // - 1 modified Transaction
-        assert_eq!(output.directives.len(), 5);
-
-        // Count Open directives for currency accounts
-        let currency_account_opens: Vec<_> = output
-            .directives
-            .iter()
-            .filter_map(|d| {
-                if let DirectiveData::Open(open) = &d.data {
-                    if open.account.starts_with("Equity:CurrencyAccounts:") {
-                        Some(open.account.clone())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        // Should have exactly 2 currency account Opens (USD from input, EUR generated)
-        assert_eq!(currency_account_opens.len(), 2);
-        assert!(currency_account_opens.contains(&"Equity:CurrencyAccounts:USD".to_string()));
-        assert!(currency_account_opens.contains(&"Equity:CurrencyAccounts:EUR".to_string()));
+        for wrapper in &output.directives {
+            if let DirectiveData::Open(o) = &wrapper.data
+                && o.account.starts_with("Equity:CurrencyAccounts:")
+                && wrapper.filename.as_deref() == Some("<currency_accounts>")
+            {
+                assert_eq!(
+                    wrapper.date, "2024-01-01",
+                    "plugin-created open should use earliest date"
+                );
+            }
+        }
     }
 }

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -66,9 +66,10 @@ impl NativePlugin for CurrencyAccountsPlugin {
         use std::collections::{BTreeMap, HashSet};
         use std::str::FromStr;
 
-        // Get base account from config if provided, validating that it's
-        // non-empty. Python's plugin falls back to the default when the
-        // config isn't a valid account string.
+        // Get base account from config if provided. We only check for
+        // non-empty (Python's plugin additionally validates that it is a
+        // well-formed account name and falls back to the default when
+        // it isn't, but we skip that check for simplicity).
         let base_account = input
             .config
             .as_ref()
@@ -189,32 +190,36 @@ impl NativePlugin for CurrencyAccountsPlugin {
                 }
             };
 
-            let mut new_postings: Vec<PostingData> =
-                Vec::with_capacity(txn.postings.len() + curmap.len());
-
+            // Compute each group's weight inventory for neutralization.
+            let mut group_inv: BTreeMap<&String, BTreeMap<String, Decimal>> = BTreeMap::new();
             for (group_key, posting_indices) in &curmap {
-                // Accumulate the group's weight inventory.
-                let mut inv: BTreeMap<String, Decimal> = BTreeMap::new();
+                let inv = group_inv.entry(group_key).or_default();
                 for &idx in posting_indices {
                     if let Some((amount, currency)) = weight_of(&txn.postings[idx]) {
                         *inv.entry(currency).or_default() += amount;
                     }
                 }
-
-                // Re-insert original postings for this group.
-                //
-                // Python's plugin strips price annotations here
-                // (currency_accounts.py:145) because its pipeline runs
-                // plugins BEFORE booking. In rustledger, booking runs
-                // first and the validator re-checks afterwards, so we
-                // must keep prices to preserve the weight-based balance.
-                for &idx in posting_indices {
-                    new_postings.push(txn.postings[idx].clone());
-                }
-
-                // Drop zero-sum entries.
                 inv.retain(|_, amount| !amount.is_zero());
+            }
 
+            // Re-insert ALL original postings in their original order
+            // (including any with units == None, which are auto-balanced
+            // postings that must not be dropped).
+            //
+            // Python's plugin strips price annotations here
+            // (currency_accounts.py:145) because its pipeline runs
+            // plugins BEFORE booking. In rustledger, booking runs
+            // first and the validator re-checks afterwards, so we
+            // must keep prices to preserve the weight-based balance.
+            let mut new_postings: Vec<PostingData> =
+                Vec::with_capacity(txn.postings.len() + curmap.len());
+            for posting in &txn.postings {
+                new_postings.push(posting.clone());
+            }
+
+            // Append neutralizing postings (sorted by group key for
+            // deterministic output).
+            for (group_key, inv) in &group_inv {
                 // Python calls `inv.get_only_position()` and errors on
                 // multi-currency groups. We skip neutralization in that
                 // case rather than failing — it indicates a transaction
@@ -223,15 +228,15 @@ impl NativePlugin for CurrencyAccountsPlugin {
                     continue;
                 }
 
-                let (weight_currency, weight_amount) = inv.into_iter().next().unwrap();
+                let (weight_currency, weight_amount) = inv.iter().next().unwrap();
                 let account_name = format!("{base_account}:{group_key}");
                 created_accounts.insert(account_name.clone());
 
                 new_postings.push(PostingData {
                     account: account_name,
                     units: Some(AmountData {
-                        number: (-weight_amount).to_string(),
-                        currency: weight_currency,
+                        number: (-*weight_amount).to_string(),
+                        currency: weight_currency.clone(),
                     }),
                     cost: None,
                     price: None,


### PR DESCRIPTION
## Summary

- Rewrote the `currency_accounts` plugin's posting grouping logic to match Python beancount's `beancount.plugins.currency_accounts` semantics
- **Root cause**: the plugin grouped postings by *weight currency* (price currency for `@`-annotated postings), which collapsed multi-currency exchange transactions into a single group with net-zero weight — producing zero output
- **Fix**: group by *units currency* (or cost currency if cost spec exists), matching Python's `group_postings_by_weight_currency` function
- Keep price annotations on re-inserted postings (unlike Python) because rustledger runs booking before plugins; stripping prices would cause E3001 balance failures in the post-plugin validator

## Before/After

**Before** (`rledger query` on `issue-520.beancount`):
```
Assets:Bank:EUR
Assets:Bank:USD
```

**After**:
```
Assets:Bank:EUR
Assets:Bank:USD
Equity:Currency:EUR
Equity:Currency:USD
```

Matches Python beancount output exactly.

## Test plan

- [x] All 6 unit tests pass (rewrote test suite to match new semantics)
- [x] Integration test `test_currency_accounts_single_currency_no_change` passes
- [x] `cargo test --all-features` — zero failures
- [x] `cargo clippy -p rustledger-plugin --all-features -- -D warnings` — clean
- [x] `rledger check --no-cache tests/regressions/issue-520.beancount` — no errors
- [x] `rledger query` returns 4 accounts and `COUNT(*)=4`

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)