### PR TITLE
fix: honor file-level booking_method option in process pipeline

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -206,21 +206,25 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     //
     // The booking method comes from two sources: the API-level
     // `LoadOptions.booking_method` and the file-level `option
-    // "booking_method"`. The file-level option takes precedence when
-    // the caller hasn't explicitly overridden it (i.e., when
-    // `LoadOptions` still has the default `Strict`). This matches
-    // Python beancount, where `option "booking_method" "FIFO"` sets the
-    // default for all accounts without an explicit method on their
-    // `open` directive.
+    // "booking_method"`. The file-level option takes precedence only
+    // when the file explicitly set it AND the caller hasn't overridden
+    // the API-level default. This matches Python beancount, where
+    // `option "booking_method" "FIFO"` sets the default for all accounts
+    // without an explicit method on their `open` directive.
+    //
+    // We check `set_options` (not `booking_method.is_empty()`) because
+    // `Options::new()` defaults `booking_method` to "STRICT", so the
+    // string is never empty.
     #[cfg(feature = "booking")]
     {
-        let effective_method = if raw.options.booking_method.is_empty() {
-            options.booking_method
-        } else {
+        let file_set_booking = raw.options.set_options.contains("booking_method");
+        let effective_method = if file_set_booking {
             raw.options
                 .booking_method
                 .parse()
                 .unwrap_or(options.booking_method)
+        } else {
+            options.booking_method
         };
         run_booking(&mut directives, effective_method, &mut errors);
     }

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -203,9 +203,26 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     });
 
     // 2. Booking/interpolation
+    //
+    // The booking method comes from two sources: the API-level
+    // `LoadOptions.booking_method` and the file-level `option
+    // "booking_method"`. The file-level option takes precedence when
+    // the caller hasn't explicitly overridden it (i.e., when
+    // `LoadOptions` still has the default `Strict`). This matches
+    // Python beancount, where `option "booking_method" "FIFO"` sets the
+    // default for all accounts without an explicit method on their
+    // `open` directive.
     #[cfg(feature = "booking")]
     {
-        run_booking(&mut directives, options, &mut errors);
+        let effective_method = if raw.options.booking_method.is_empty() {
+            options.booking_method
+        } else {
+            raw.options
+                .booking_method
+                .parse()
+                .unwrap_or(options.booking_method)
+        };
+        run_booking(&mut directives, effective_method, &mut errors);
     }
 
     // 3. Run plugins (including document discovery when run_plugins is enabled)
@@ -243,12 +260,12 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
 #[cfg(feature = "booking")]
 fn run_booking(
     directives: &mut Vec<Spanned<Directive>>,
-    options: &LoadOptions,
+    booking_method: BookingMethod,
     errors: &mut Vec<LedgerError>,
 ) {
     use rustledger_booking::BookingEngine;
 
-    let mut engine = BookingEngine::with_method(options.booking_method);
+    let mut engine = BookingEngine::with_method(booking_method);
     engine.register_account_methods(directives.iter().map(|s| &s.value));
 
     for spanned in directives.iter_mut() {

--- a/crates/rustledger-loader/tests/fixtures/booking_method_fifo.beancount
+++ b/crates/rustledger-loader/tests/fixtures/booking_method_fifo.beancount
@@ -1,0 +1,18 @@
+option "operating_currency" "USD"
+option "booking_method" "FIFO"
+
+2020-01-01 open Assets:Stock
+2020-01-01 open Assets:Cash    USD
+
+2020-02-01 * "Buy lot 1"
+  Assets:Stock    10 CORP {1 USD}
+  Assets:Cash    -10 USD
+
+2020-03-01 * "Buy lot 2"
+  Assets:Stock    10 CORP {2 USD}
+  Assets:Cash    -20 USD
+
+; Sell 5 - FIFO should match lot 1 without ambiguity
+2020-04-01 * "Sell"
+  Assets:Stock    -5 CORP {}
+  Assets:Cash      10 USD

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -631,6 +631,28 @@ fn test_process_preserves_display_context() {
 }
 
 // ============================================================================
+// Booking Method Default Tests (Issue #775)
+// ============================================================================
+
+#[test]
+fn test_file_level_booking_method_applied() {
+    // The file has `option "booking_method" "FIFO"` and a sell posting
+    // that matches 2 lots. Under STRICT this would be an ambiguous lot
+    // match error. Under FIFO the oldest lot is selected.
+    let path = fixtures_path("booking_method_fifo.beancount");
+    let options = LoadOptions::default(); // default = Strict, but file says FIFO
+
+    let ledger = load(&path, &options).expect("should load and process");
+
+    // No booking errors — FIFO resolves the ambiguity.
+    let booking_errors: Vec<_> = ledger.errors.iter().filter(|e| e.code == "BOOK").collect();
+    assert!(
+        booking_errors.is_empty(),
+        "expected no BOOK errors under file-level FIFO, got: {booking_errors:?}"
+    );
+}
+
+// ============================================================================
 // Document Discovery Tests (Issue #466)
 // ============================================================================
 

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -652,6 +652,29 @@ fn test_file_level_booking_method_applied() {
     );
 }
 
+#[test]
+fn test_api_booking_method_used_when_file_does_not_set_option() {
+    // simple.beancount does NOT set `option "booking_method"`. The
+    // API-level LoadOptions.booking_method should be used as-is.
+    let path = fixtures_path("simple.beancount");
+    let options = LoadOptions {
+        booking_method: rustledger_core::BookingMethod::Fifo,
+        ..Default::default()
+    };
+
+    let ledger = load(&path, &options).expect("should load and process");
+
+    // No errors — simple.beancount has no cost-based transactions, so
+    // the booking method doesn't matter. But the important thing is
+    // that the API-level override is accepted (not overridden by the
+    // file's default "STRICT").
+    assert!(
+        ledger.errors.is_empty(),
+        "unexpected errors: {:?}",
+        ledger.errors
+    );
+}
+
 // ============================================================================
 // Document Discovery Tests (Issue #466)
 // ============================================================================

--- a/tests/regressions/issue-775.beancount
+++ b/tests/regressions/issue-775.beancount
@@ -1,0 +1,31 @@
+; Issue: https://github.com/rustledger/rustledger/issues/775
+; Description: File-level `option "booking_method" "FIFO"` should be applied
+;              as the default for accounts opened without an explicit method.
+; Expected: No errors - FIFO resolves the ambiguous lot match.
+
+option "operating_currency" "USD"
+option "booking_method" "FIFO"
+
+2020-01-01 open Assets:Stock
+2020-01-01 open Assets:Cash       USD
+2020-01-01 open Expenses:Gains    USD
+
+; Build up 3 lots
+2020-02-01 * "Buy lot 1"
+  Assets:Stock    100 CORP {1 USD}
+  Assets:Cash    -100 USD
+
+2020-03-01 * "Buy lot 2"
+  Assets:Stock    100 CORP {2 USD}
+  Assets:Cash    -200 USD
+
+2020-04-01 * "Buy lot 3"
+  Assets:Stock    100 CORP {3 USD}
+  Assets:Cash    -300 USD
+
+; Sell 50 shares - under FIFO should match lot 1 (oldest)
+; Under STRICT this would be "ambiguous lot match"
+2020-05-01 * "Sell 50"
+  Assets:Stock    -50 CORP {}
+  Assets:Cash     100 USD
+  Expenses:Gains


### PR DESCRIPTION
## Summary

- `process::run_booking()` was using `LoadOptions.booking_method` (default: `STRICT`) without reading the file-level `option "booking_method"` from `LedgerOptions`
- Any code path through `process::load()` — `rledger query`, LSP, MCP server, WASM — ignored the file's booking method setting
- Fix: read `raw.options.booking_method` and use it as the effective method when the file specifies one

`rledger check` was unaffected (it has its own booking setup that reads `LedgerOptions` directly).

## Before/After

**Before** (`rledger query` on file with `option "booking_method" "FIFO"`):
```
BOOK: Ambiguous lot match for CORP: 3 lots match in Assets:CORP (2020-06-01)
BOOK: Ambiguous lot match for CORP: 3 lots match in Assets:CORP (2020-08-01)
COUNT = 22
```

**After**:
```
COUNT = 24
```
(matches Python beancount)

## Test plan

- [x] New integration test `test_file_level_booking_method_applied` in `loader_test.rs`
- [x] Regression fixture `booking_method_fifo.beancount`
- [x] Regression file `tests/regressions/issue-775.beancount`
- [x] `cargo test --all-features` — zero failures
- [x] `cargo clippy -p rustledger-loader --all-features -- -D warnings` — clean
- [x] Verified on real compat file (`example_stock.beancount`): count=24, no warnings

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)