### PR TITLE
fix: route plugin errors into JSON diagnostics in --format json mode

### DIFF
--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -579,7 +579,6 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                     python_plugins_to_run.push(plugin.clone());
                 } else {
                     // Module-based plugin - we can't resolve it without system Python
-                    // Provide helpful error message with suggestion
                     let (line, file_path) =
                         if let Some(source_file) = load_result.source_map.get(plugin.file_id) {
                             let (l, _) = source_file.line_col(plugin.span.start);
@@ -595,27 +594,55 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                         None
                     };
 
-                    if let Some(module_path) = suggestion {
-                        if !args.quiet {
-                            let plugin_name = &plugin.name;
+                    let (code, message) = if let Some(module_path) = &suggestion {
+                        (
+                            "E8004".to_string(),
+                            format!(
+                                "Cannot resolve Python module '{}'. Replace with: plugin \"{}\"",
+                                plugin.name, module_path
+                            ),
+                        )
+                    } else {
+                        (
+                            "E8001".to_string(),
+                            format!("Plugin not found: \"{}\"", plugin.name),
+                        )
+                    };
+
+                    if json_mode {
+                        diagnostics.push(JsonDiagnostic {
+                            file: file_path.display().to_string(),
+                            line,
+                            column: 1,
+                            end_line: line,
+                            end_column: 1,
+                            severity: "error".to_string(),
+                            phase: "plugin".to_string(),
+                            code,
+                            message,
+                            hint: suggestion.map(|m| format!("plugin \"{m}\"")),
+                            context: None,
+                        });
+                        parse_error_count += 1;
+                    } else if !args.quiet {
+                        let path_str = file_path.display();
+                        let plugin_name = &plugin.name;
+                        if let Some(module_path) = &suggestion {
                             writeln!(
                                 stdout,
-                                "{}:{line}: error[E8004]: Cannot resolve Python module '{plugin_name}'",
-                                file_path.display(),
+                                "{path_str}:{line}: error[E8004]: Cannot resolve Python module '{plugin_name}'",
                             )?;
                             writeln!(stdout)?;
                             writeln!(stdout, "Replace line {line}:")?;
                             writeln!(stdout, "  plugin \"{plugin_name}\"")?;
                             writeln!(stdout, "with:")?;
                             writeln!(stdout, "  plugin \"{module_path}\"")?;
+                        } else {
+                            writeln!(
+                                stdout,
+                                "{path_str}:{line}: error[E8001]: Plugin not found: \"{plugin_name}\"",
+                            )?;
                         }
-                    } else if !args.quiet {
-                        let plugin_name = &plugin.name;
-                        writeln!(
-                            stdout,
-                            "{}:{line}: error[E8001]: Plugin not found: \"{plugin_name}\"",
-                            file_path.display(),
-                        )?;
                     }
                     error_count += 1;
                 }
@@ -631,7 +658,25 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                         (1, 1, file.clone())
                     };
 
-                if !args.quiet {
+                if json_mode {
+                    diagnostics.push(JsonDiagnostic {
+                        file: file_path.display().to_string(),
+                        line,
+                        column: 1,
+                        end_line: line,
+                        end_column: 1,
+                        severity: "error".to_string(),
+                        phase: "plugin".to_string(),
+                        code: "E8005".to_string(),
+                        message: format!(
+                            "Python plugin \"{}\" requires python-plugin-wasm feature",
+                            plugin.name
+                        ),
+                        hint: None,
+                        context: None,
+                    });
+                    parse_error_count += 1;
+                } else if !args.quiet {
                     writeln!(
                         stdout,
                         "{}:{}: error[E8005]: Python plugin \"{}\" requires python-plugin-wasm feature",
@@ -844,7 +889,28 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                 let output = plugin.process(plugin_input);
 
                 for err in &output.errors {
-                    if !args.quiet {
+                    if json_mode {
+                        let severity = match err.severity {
+                            rustledger_plugin::PluginErrorSeverity::Error => "error",
+                            rustledger_plugin::PluginErrorSeverity::Warning => "warning",
+                        };
+                        diagnostics.push(JsonDiagnostic {
+                            file: main_file_str.clone(),
+                            line: 1,
+                            column: 1,
+                            end_line: 1,
+                            end_column: 1,
+                            severity: severity.to_string(),
+                            phase: "plugin".to_string(),
+                            code: "PLUGIN".to_string(),
+                            message: err.message.clone(),
+                            hint: None,
+                            context: Some(format!("plugin: {}", plugin.name())),
+                        });
+                        if matches!(err.severity, rustledger_plugin::PluginErrorSeverity::Error) {
+                            validate_error_count += 1;
+                        }
+                    } else if !args.quiet {
                         writeln!(stdout, "{:?}: {}", err.severity, err.message)?;
                     }
                     error_count += 1;
@@ -881,15 +947,27 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                         match runtime.execute_module(&plugin.name, &plugin_input, file.parent()) {
                             Ok(output) => {
                                 for err in &output.errors {
-                                    if !args.quiet {
-                                        let severity = match err.severity {
-                                            rustledger_plugin::PluginErrorSeverity::Error => {
-                                                "error"
-                                            }
-                                            rustledger_plugin::PluginErrorSeverity::Warning => {
-                                                "warning"
-                                            }
-                                        };
+                                    let severity = match err.severity {
+                                        rustledger_plugin::PluginErrorSeverity::Error => "error",
+                                        rustledger_plugin::PluginErrorSeverity::Warning => {
+                                            "warning"
+                                        }
+                                    };
+                                    if json_mode {
+                                        diagnostics.push(JsonDiagnostic {
+                                            file: main_file_str.clone(),
+                                            line: 1,
+                                            column: 1,
+                                            end_line: 1,
+                                            end_column: 1,
+                                            severity: severity.to_string(),
+                                            phase: "plugin".to_string(),
+                                            code: "PLUGIN".to_string(),
+                                            message: err.message.clone(),
+                                            hint: None,
+                                            context: Some(format!("plugin: {}", plugin.name)),
+                                        });
+                                    } else if !args.quiet {
                                         writeln!(stdout, "{severity}: {}", err.message)?;
                                     }
                                     error_count += 1;
@@ -901,7 +979,22 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                                 };
                             }
                             Err(e) => {
-                                if !args.quiet {
+                                if json_mode {
+                                    diagnostics.push(JsonDiagnostic {
+                                        file: main_file_str.clone(),
+                                        line: 1,
+                                        column: 1,
+                                        end_line: 1,
+                                        end_column: 1,
+                                        severity: "error".to_string(),
+                                        phase: "plugin".to_string(),
+                                        code: "E8002".to_string(),
+                                        message: format!("Python plugin execution failed: {e}"),
+                                        hint: None,
+                                        context: Some(format!("plugin: {}", plugin.name)),
+                                    });
+                                    parse_error_count += 1;
+                                } else if !args.quiet {
                                     writeln!(
                                         stdout,
                                         "error[E8002]: Python plugin execution failed: {e}"
@@ -914,7 +1007,22 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                 }
                 Err(e) => {
                     // E8003: Python runtime unavailable
-                    if !args.quiet {
+                    if json_mode {
+                        diagnostics.push(JsonDiagnostic {
+                            file: main_file_str.clone(),
+                            line: 1,
+                            column: 1,
+                            end_line: 1,
+                            end_column: 1,
+                            severity: "error".to_string(),
+                            phase: "plugin".to_string(),
+                            code: "E8003".to_string(),
+                            message: format!("Python runtime unavailable: {e}"),
+                            hint: None,
+                            context: None,
+                        });
+                        parse_error_count += python_plugins_to_run.len();
+                    } else if !args.quiet {
                         writeln!(stdout, "error[E8003]: Python runtime unavailable: {e}")?;
                     }
                     error_count += python_plugins_to_run.len();

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -49,7 +49,7 @@ pub struct JsonDiagnostic {
     pub end_column: usize,
     /// Severity: "error" or "warning"
     pub severity: String,
-    /// Processing phase: "parse" or "validate"
+    /// Processing phase: "parse", "validate", or "plugin"
     pub phase: String,
     /// Error code (e.g., "P0012", "E1001")
     pub code: String,
@@ -623,7 +623,6 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                             hint: suggestion.map(|m| format!("plugin \"{m}\"")),
                             context: None,
                         });
-                        parse_error_count += 1;
                     } else if !args.quiet {
                         let path_str = file_path.display();
                         let plugin_name = &plugin.name;
@@ -675,7 +674,6 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                         hint: None,
                         context: None,
                     });
-                    parse_error_count += 1;
                 } else if !args.quiet {
                     writeln!(
                         stdout,
@@ -907,13 +905,17 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                             hint: None,
                             context: Some(format!("plugin: {}", plugin.name())),
                         });
-                        if matches!(err.severity, rustledger_plugin::PluginErrorSeverity::Error) {
-                            validate_error_count += 1;
-                        }
                     } else if !args.quiet {
                         writeln!(stdout, "{:?}: {}", err.severity, err.message)?;
                     }
-                    error_count += 1;
+                    match err.severity {
+                        rustledger_plugin::PluginErrorSeverity::Error => {
+                            error_count += 1;
+                        }
+                        rustledger_plugin::PluginErrorSeverity::Warning => {
+                            // Warnings don't increment error_count
+                        }
+                    }
                 }
 
                 current_input = PluginInput {
@@ -970,7 +972,14 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                                     } else if !args.quiet {
                                         writeln!(stdout, "{severity}: {}", err.message)?;
                                     }
-                                    error_count += 1;
+                                    match err.severity {
+                                        rustledger_plugin::PluginErrorSeverity::Error => {
+                                            error_count += 1;
+                                        }
+                                        rustledger_plugin::PluginErrorSeverity::Warning => {
+                                            // Warnings don't increment error_count
+                                        }
+                                    }
                                 }
                                 current_input = PluginInput {
                                     directives: output.directives,
@@ -993,7 +1002,6 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                                         hint: None,
                                         context: Some(format!("plugin: {}", plugin.name)),
                                     });
-                                    parse_error_count += 1;
                                 } else if !args.quiet {
                                     writeln!(
                                         stdout,
@@ -1021,10 +1029,13 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                             hint: None,
                             context: None,
                         });
-                        parse_error_count += python_plugins_to_run.len();
                     } else if !args.quiet {
                         writeln!(stdout, "error[E8003]: Python runtime unavailable: {e}")?;
                     }
+                    // Count all affected plugins as errors (the single
+                    // diagnostic represents them collectively, but the
+                    // error count reflects the number of plugins that
+                    // couldn't run).
                     error_count += python_plugins_to_run.len();
                 }
             }


### PR DESCRIPTION
## Summary

- Plugin errors (E8001, E8004, E8005, E8002, E8003, and native plugin output errors) were written as plain text to stdout before the JSON document when using `--format json`, breaking `json.loads()` on the captured output
- Now all plugin errors are routed into the `diagnostics` array with `phase: "plugin"` and the appropriate error code
- No plain text is written to stdout in JSON mode

## Before/After

**Before** (`rledger check --format json` on file with unknown plugins):
```
tests/file.beancount:11: error[E8001]: Plugin not found: "a_mythical_plugin"
{
  "diagnostics": [...]
}
```
(`json.loads()` fails)

**After**:
```json
{
  "diagnostics": [
    {"code": "E8001", "phase": "plugin", "message": "Plugin not found: \"a_mythical_plugin\"", ...},
    ...
  ]
}
```
(`json.loads()` succeeds, `error_count=35` correctly reported)

## Impact on compat suite

Fixes ~8 false negatives where `json.JSONDecodeError` was silently swallowed, causing `rust_error_count` to be reported as 0. This should reduce Full AST Match failures by ~1%.

## Test plan

- [x] Verified `rledger check --format json` on `examples_data_full.beancount` produces valid JSON
- [x] Verified `json.loads()` succeeds and `error_count=35` matches expected
- [x] Verified E8001 plugin diagnostics appear in JSON with `phase: "plugin"`
- [x] `cargo test --all-features` — zero failures
- [x] `cargo clippy -p rustledger --all-features -- -D warnings` — clean

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)