### PR TITLE
chore: document pre-push hook tradeoffs and add just test-changed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,25 @@ cargo fmt --all -- --check                 # Format check
 cargo deny check                           # Security audit
 ```
 
+## Pre-push Hooks & Fast Testing
+
+The pre-push hook runs `cargo check` (2-30s) but intentionally **does not** run `cargo test` (full workspace takes 10-30 min). This means compilation-correct but semantically-wrong changes can be pushed and only caught in CI.
+
+**Before pushing, test the crates you changed:**
+
+```bash
+# Test only the crate(s) you modified (5-30s typically)
+cargo test -p rustledger-parser
+cargo test -p rustledger-lsp --all-features
+
+# Or use the just recipe to auto-detect changed crates:
+just test-changed
+```
+
+The `just test-changed` recipe detects which crates have uncommitted or staged changes and runs tests only for those. This is the recommended workflow before pushing.
+
+**Bypass the pre-push hook** (for WIP commits): `git push --no-verify`
+
 ## Headless / Automated Issue Resolution
 
 When running in headless mode (`claude -p`) or via Agent Orchestrator (`ao`), follow this exact workflow:

--- a/justfile
+++ b/justfile
@@ -55,6 +55,7 @@ test-changed:
         echo "No crate changes detected."
         exit 0
     fi
+    failed=0
     for crate in $changed_crates; do
         pkg="rustledger-${crate#rustledger-}"
         # Normalize: if crate dir is already "rustledger-foo", don't double-prefix
@@ -63,9 +64,21 @@ test-changed:
         elif [[ "$crate" == "rustledger" ]]; then
             pkg="rustledger"
         fi
+        # Check if the package exists before trying to test it
+        if ! cargo pkgid -p "$pkg" > /dev/null 2>&1; then
+            echo "  (skipped: $pkg not a cargo package)"
+            continue
+        fi
         echo "==> Testing $pkg"
-        cargo test -p "$pkg" --all-features 2>/dev/null || echo "  (skipped: $pkg not found)"
+        if ! cargo test -p "$pkg" --all-features; then
+            failed=1
+        fi
     done
+    if [ "$failed" -ne 0 ]; then
+        echo ""
+        echo "Some tests failed!"
+        exit 1
+    fi
 
 # Run specific test
 test-one name:

--- a/justfile
+++ b/justfile
@@ -46,6 +46,27 @@ test-cov:
 test-prop iterations="10000":
     PROPTEST_CASES={{iterations}} cargo test --features proptest
 
+# Run tests only for crates with uncommitted changes (fast pre-push check)
+test-changed:
+    #!/usr/bin/env bash
+    set -eo pipefail
+    changed_crates=$(git diff --name-only HEAD 2>/dev/null | grep '^crates/' | cut -d/ -f2 | sort -u || true)
+    if [ -z "$changed_crates" ]; then
+        echo "No crate changes detected."
+        exit 0
+    fi
+    for crate in $changed_crates; do
+        pkg="rustledger-${crate#rustledger-}"
+        # Normalize: if crate dir is already "rustledger-foo", don't double-prefix
+        if [[ "$crate" == rustledger-* ]]; then
+            pkg="$crate"
+        elif [[ "$crate" == "rustledger" ]]; then
+            pkg="rustledger"
+        fi
+        echo "==> Testing $pkg"
+        cargo test -p "$pkg" --all-features 2>/dev/null || echo "  (skipped: $pkg not found)"
+    done
+
 # Run specific test
 test-one name:
     cargo nextest run {{name}}


### PR DESCRIPTION
## Summary

- Document pre-push hook tradeoffs in CLAUDE.md (cargo check runs, cargo test doesn't)
- Add `just test-changed` recipe that auto-detects modified crates and tests only those
- Recommended workflow: run `just test-changed` before pushing to catch semantic errors

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | New "Pre-push Hooks & Fast Testing" section after Build Commands |
| `justfile` | New `test-changed` recipe using `git diff` to detect modified crates |

## Test plan

- [x] `just test-changed` with no crate changes → "No crate changes detected."
- [x] `just test-changed` with crate changes → runs tests for affected crates only

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)