### PR TITLE
test: add inline assertion support to regression test script

### DIFF
--- a/scripts/test-regressions.sh
+++ b/scripts/test-regressions.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 # Run regression tests against rledger
+#
+# Supports inline assertions in beancount files via ; ASSERT: comments:
+#
+#   ; ASSERT: no_errors
+#   ; ASSERT: error_count == 0
+#   ; ASSERT: check_stderr !contains "ambiguous"
+#   ; ASSERT: check_stderr contains "warning"
+#   ; ASSERT: query "SELECT DISTINCT account" contains "Equity:Currency:USD"
+#   ; ASSERT: query "SELECT DISTINCT account" row_count == 4
+#
+# Files without ASSERT comments fall back to exit-code-only checking (exit 0 = pass).
+#
 # Usage: ./scripts/test-regressions.sh [rledger-binary]
 
 set -e
@@ -8,6 +20,7 @@ RLEDGER="${1:-./target/release/rledger}"
 TESTS_DIR="tests/regressions"
 PASSED=0
 FAILED=0
+SKIPPED=0
 FAILED_TESTS=""
 
 # Build if binary doesn't exist
@@ -21,6 +34,115 @@ echo "Binary: $RLEDGER"
 echo "Tests:  $TESTS_DIR"
 echo ""
 
+# Run a single assertion. Returns 0 on success, 1 on failure.
+# Globals: RLEDGER, check_stdout, check_stderr, check_exit
+run_assertion() {
+    local file="$1"
+    local assertion="$2"
+    local issue_num="$3"
+
+    # no_errors: exit code must be 0
+    if [[ "$assertion" == "no_errors" ]]; then
+        if [ "$check_exit" -ne 0 ]; then
+            echo "    FAIL: expected no errors, got exit $check_exit"
+            echo "    stderr: $(head -5 <<< "$check_stderr")"
+            return 1
+        fi
+        return 0
+    fi
+
+    # error_count == N
+    if [[ "$assertion" =~ ^error_count\ *==\ *([0-9]+)$ ]]; then
+        local expected="${BASH_REMATCH[1]}"
+        # Try JSON output first for precise count
+        local json_out
+        json_out=$("$RLEDGER" check --format json --no-cache "$file" 2>/dev/null || true)
+        local actual
+        actual=$(echo "$json_out" | grep -o '"error_count":[0-9]*' | cut -d: -f2 || echo "")
+        if [ -z "$actual" ]; then
+            # Fallback: count error lines in text output
+            actual=$(echo "$check_stdout" | grep -c "^error\[" || echo "0")
+        fi
+        if [ "$actual" != "$expected" ]; then
+            echo "    FAIL: error_count == $expected, got $actual"
+            return 1
+        fi
+        return 0
+    fi
+
+    # check_stderr contains "TEXT"
+    if [[ "$assertion" =~ ^check_stderr\ +contains\ +\"(.+)\"$ ]]; then
+        local pattern="${BASH_REMATCH[1]}"
+        if ! echo "$check_stderr" | grep -qF "$pattern"; then
+            echo "    FAIL: stderr should contain \"$pattern\""
+            return 1
+        fi
+        return 0
+    fi
+
+    # check_stderr !contains "TEXT"
+    if [[ "$assertion" =~ ^check_stderr\ +\!contains\ +\"(.+)\"$ ]]; then
+        local pattern="${BASH_REMATCH[1]}"
+        if echo "$check_stderr" | grep -qF "$pattern"; then
+            echo "    FAIL: stderr should NOT contain \"$pattern\""
+            echo "    found: $(grep -F "$pattern" <<< "$check_stderr" | head -3)"
+            return 1
+        fi
+        return 0
+    fi
+
+    # query "BQL" contains "TEXT"
+    if [[ "$assertion" =~ ^query\ +\"(.+)\"\ +contains\ +\"(.+)\"$ ]]; then
+        local bql="${BASH_REMATCH[1]}"
+        local pattern="${BASH_REMATCH[2]}"
+        local query_out
+        query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
+        if ! echo "$query_out" | grep -qF "$pattern"; then
+            echo "    FAIL: query output should contain \"$pattern\""
+            echo "    query: $bql"
+            echo "    output: $(head -10 <<< "$query_out")"
+            return 1
+        fi
+        return 0
+    fi
+
+    # query "BQL" !contains "TEXT"
+    if [[ "$assertion" =~ ^query\ +\"(.+)\"\ +\!contains\ +\"(.+)\"$ ]]; then
+        local bql="${BASH_REMATCH[1]}"
+        local pattern="${BASH_REMATCH[2]}"
+        local query_out
+        query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
+        if echo "$query_out" | grep -qF "$pattern"; then
+            echo "    FAIL: query output should NOT contain \"$pattern\""
+            echo "    query: $bql"
+            echo "    found: $(grep -F "$pattern" <<< "$query_out" | head -3)"
+            return 1
+        fi
+        return 0
+    fi
+
+    # query "BQL" row_count == N
+    if [[ "$assertion" =~ ^query\ +\"(.+)\"\ +row_count\ *==\ *([0-9]+)$ ]]; then
+        local bql="${BASH_REMATCH[1]}"
+        local expected="${BASH_REMATCH[2]}"
+        local query_out
+        query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
+        # Count non-empty, non-header lines (skip first 2 lines: header + separator)
+        local actual
+        actual=$(echo "$query_out" | tail -n +3 | grep -c '.' || echo "0")
+        if [ "$actual" != "$expected" ]; then
+            echo "    FAIL: query row_count == $expected, got $actual"
+            echo "    query: $bql"
+            echo "    output: $(head -10 <<< "$query_out")"
+            return 1
+        fi
+        return 0
+    fi
+
+    echo "    WARN: unknown assertion syntax: $assertion"
+    return 0
+}
+
 for f in "$TESTS_DIR"/issue-*.beancount; do
     if [ ! -f "$f" ]; then
         echo "No regression tests found in $TESTS_DIR"
@@ -30,15 +152,51 @@ for f in "$TESTS_DIR"/issue-*.beancount; do
     BASENAME=$(basename "$f")
     ISSUE_NUM=$(echo "$BASENAME" | sed 's/issue-\([0-9]*\).*/\1/')
 
-    if "$RLEDGER" check "$f" > /dev/null 2>&1; then
-        echo "✓ #$ISSUE_NUM passed"
-        PASSED=$((PASSED + 1))
+    # Extract ASSERT lines from the file
+    assertions=()
+    while IFS= read -r line; do
+        assertions+=("$line")
+    done < <(grep '^; ASSERT: ' "$f" | sed 's/^; ASSERT: //')
+
+    # Run rledger check and capture output
+    check_stdout=""
+    check_stderr=""
+    check_exit=0
+    check_stdout=$("$RLEDGER" check --no-cache "$f" 2>/tmp/rledger-regression-stderr) || check_exit=$?
+    check_stderr=$(cat /tmp/rledger-regression-stderr 2>/dev/null || true)
+
+    if [ ${#assertions[@]} -eq 0 ]; then
+        # No assertions — fall back to exit-code-only
+        if [ "$check_exit" -eq 0 ]; then
+            echo "✓ #$ISSUE_NUM passed (exit-code only)"
+            PASSED=$((PASSED + 1))
+        else
+            echo "✗ #$ISSUE_NUM FAILED (exit $check_exit)"
+            FAILED=$((FAILED + 1))
+            FAILED_TESTS="$FAILED_TESTS #$ISSUE_NUM"
+        fi
     else
-        echo "✗ #$ISSUE_NUM FAILED"
-        FAILED=$((FAILED + 1))
-        FAILED_TESTS="$FAILED_TESTS #$ISSUE_NUM"
+        # Run each assertion
+        test_failed=0
+        for assertion in "${assertions[@]}"; do
+            if ! run_assertion "$f" "$assertion" "$ISSUE_NUM"; then
+                test_failed=1
+            fi
+        done
+
+        if [ "$test_failed" -eq 0 ]; then
+            echo "✓ #$ISSUE_NUM passed (${#assertions[@]} assertions)"
+            PASSED=$((PASSED + 1))
+        else
+            echo "✗ #$ISSUE_NUM FAILED"
+            FAILED=$((FAILED + 1))
+            FAILED_TESTS="$FAILED_TESTS #$ISSUE_NUM"
+        fi
     fi
 done
+
+# Cleanup
+rm -f /tmp/rledger-regression-stderr
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/scripts/test-regressions.sh
+++ b/scripts/test-regressions.sh
@@ -23,6 +23,10 @@ FAILED=0
 SKIPPED=0
 FAILED_TESTS=""
 
+# Create a temp file for stderr capture; clean up on exit
+STDERR_TMP=$(mktemp)
+trap 'rm -f "$STDERR_TMP"' EXIT
+
 # Build if binary doesn't exist
 if [ ! -f "$RLEDGER" ]; then
     echo "Building rledger..."
@@ -54,14 +58,14 @@ run_assertion() {
     # error_count == N
     if [[ "$assertion" =~ ^error_count\ *==\ *([0-9]+)$ ]]; then
         local expected="${BASH_REMATCH[1]}"
-        # Try JSON output first for precise count
+        # Try JSON output first for precise count (handles pretty-printed JSON)
         local json_out
         json_out=$("$RLEDGER" check --format json --no-cache "$file" 2>/dev/null || true)
         local actual
-        actual=$(echo "$json_out" | grep -o '"error_count":[0-9]*' | cut -d: -f2 || echo "")
+        actual=$(echo "$json_out" | grep -oE '"error_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -n1 || echo "")
         if [ -z "$actual" ]; then
             # Fallback: count error lines in text output
-            actual=$(echo "$check_stdout" | grep -c "^error\[" || echo "0")
+            actual=$(echo "$check_stdout" | grep -cE '(^error\[|: error\[)' || echo "0")
         fi
         if [ "$actual" != "$expected" ]; then
             echo "    FAIL: error_count == $expected, got $actual"
@@ -73,7 +77,7 @@ run_assertion() {
     # check_stderr contains "TEXT"
     if [[ "$assertion" =~ ^check_stderr\ +contains\ +\"(.+)\"$ ]]; then
         local pattern="${BASH_REMATCH[1]}"
-        if ! echo "$check_stderr" | grep -qF "$pattern"; then
+        if ! echo "$check_stderr" | grep -qF -- "$pattern"; then
             echo "    FAIL: stderr should contain \"$pattern\""
             return 1
         fi
@@ -83,9 +87,9 @@ run_assertion() {
     # check_stderr !contains "TEXT"
     if [[ "$assertion" =~ ^check_stderr\ +\!contains\ +\"(.+)\"$ ]]; then
         local pattern="${BASH_REMATCH[1]}"
-        if echo "$check_stderr" | grep -qF "$pattern"; then
+        if echo "$check_stderr" | grep -qF -- "$pattern"; then
             echo "    FAIL: stderr should NOT contain \"$pattern\""
-            echo "    found: $(grep -F "$pattern" <<< "$check_stderr" | head -3)"
+            echo "    found: $(grep -F -- "$pattern" <<< "$check_stderr" | head -3)"
             return 1
         fi
         return 0
@@ -97,7 +101,7 @@ run_assertion() {
         local pattern="${BASH_REMATCH[2]}"
         local query_out
         query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
-        if ! echo "$query_out" | grep -qF "$pattern"; then
+        if ! echo "$query_out" | grep -qF -- "$pattern"; then
             echo "    FAIL: query output should contain \"$pattern\""
             echo "    query: $bql"
             echo "    output: $(head -10 <<< "$query_out")"
@@ -112,10 +116,10 @@ run_assertion() {
         local pattern="${BASH_REMATCH[2]}"
         local query_out
         query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
-        if echo "$query_out" | grep -qF "$pattern"; then
+        if echo "$query_out" | grep -qF -- "$pattern"; then
             echo "    FAIL: query output should NOT contain \"$pattern\""
             echo "    query: $bql"
-            echo "    found: $(grep -F "$pattern" <<< "$query_out" | head -3)"
+            echo "    found: $(grep -F -- "$pattern" <<< "$query_out" | head -3)"
             return 1
         fi
         return 0
@@ -127,9 +131,13 @@ run_assertion() {
         local expected="${BASH_REMATCH[2]}"
         local query_out
         query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
-        # Count non-empty, non-header lines (skip first 2 lines: header + separator)
+        # Parse the trailing "N row(s)" summary line for the actual count
         local actual
-        actual=$(echo "$query_out" | tail -n +3 | grep -c '.' || echo "0")
+        actual=$(echo "$query_out" | grep -oE '^[0-9]+ row' | grep -oE '^[0-9]+' | tail -1 || echo "")
+        if [ -z "$actual" ]; then
+            # Fallback: count non-empty lines after header+separator (skip first 2)
+            actual=$(echo "$query_out" | tail -n +3 | grep -cE '.+' || echo "0")
+        fi
         if [ "$actual" != "$expected" ]; then
             echo "    FAIL: query row_count == $expected, got $actual"
             echo "    query: $bql"
@@ -139,8 +147,8 @@ run_assertion() {
         return 0
     fi
 
-    echo "    WARN: unknown assertion syntax: $assertion"
-    return 0
+    echo "    FAIL: unknown assertion syntax: $assertion"
+    return 1
 }
 
 for f in "$TESTS_DIR"/issue-*.beancount; do
@@ -162,8 +170,8 @@ for f in "$TESTS_DIR"/issue-*.beancount; do
     check_stdout=""
     check_stderr=""
     check_exit=0
-    check_stdout=$("$RLEDGER" check --no-cache "$f" 2>/tmp/rledger-regression-stderr) || check_exit=$?
-    check_stderr=$(cat /tmp/rledger-regression-stderr 2>/dev/null || true)
+    check_stdout=$("$RLEDGER" check --no-cache "$f" 2>"$STDERR_TMP") || check_exit=$?
+    check_stderr=$(cat "$STDERR_TMP" 2>/dev/null || true)
 
     if [ ${#assertions[@]} -eq 0 ]; then
         # No assertions — fall back to exit-code-only
@@ -194,9 +202,6 @@ for f in "$TESTS_DIR"/issue-*.beancount; do
         fi
     fi
 done
-
-# Cleanup
-rm -f /tmp/rledger-regression-stderr
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/scripts/test-regressions.sh
+++ b/scripts/test-regressions.sh
@@ -20,12 +20,12 @@ RLEDGER="${1:-./target/release/rledger}"
 TESTS_DIR="tests/regressions"
 PASSED=0
 FAILED=0
-SKIPPED=0
 FAILED_TESTS=""
 
-# Create a temp file for stderr capture; clean up on exit
+# Create temp files for output capture; clean up on exit
 STDERR_TMP=$(mktemp)
-trap 'rm -f "$STDERR_TMP"' EXIT
+QUERY_STDERR_TMP=$(mktemp)
+trap 'rm -f "$STDERR_TMP" "$QUERY_STDERR_TMP"' EXIT
 
 # Build if binary doesn't exist
 if [ ! -f "$RLEDGER" ]; then
@@ -38,12 +38,31 @@ echo "Binary: $RLEDGER"
 echo "Tests:  $TESTS_DIR"
 echo ""
 
+# Run a query and validate it succeeded. Sets query_out on success.
+# Returns 1 if the query command itself failed.
+run_query() {
+    local file="$1"
+    local bql="$2"
+    local query_exit=0
+    query_out=$("$RLEDGER" query "$file" "$bql" 2>"$QUERY_STDERR_TMP") || query_exit=$?
+    local query_stderr
+    query_stderr=$(cat "$QUERY_STDERR_TMP" 2>/dev/null || true)
+    if [ "$query_exit" -ne 0 ]; then
+        echo "    FAIL: query command failed (exit $query_exit)"
+        echo "    query: $bql"
+        if [ -n "$query_stderr" ]; then
+            echo "    stderr: $(head -3 <<< "$query_stderr")"
+        fi
+        return 1
+    fi
+    return 0
+}
+
 # Run a single assertion. Returns 0 on success, 1 on failure.
-# Globals: RLEDGER, check_stdout, check_stderr, check_exit
+# Globals: RLEDGER, check_stdout, check_stderr, check_exit, check_json
 run_assertion() {
     local file="$1"
     local assertion="$2"
-    local issue_num="$3"
 
     # no_errors: exit code must be 0
     if [[ "$assertion" == "no_errors" ]]; then
@@ -55,14 +74,11 @@ run_assertion() {
         return 0
     fi
 
-    # error_count == N
+    # error_count == N (uses cached JSON output from the main check run)
     if [[ "$assertion" =~ ^error_count\ *==\ *([0-9]+)$ ]]; then
         local expected="${BASH_REMATCH[1]}"
-        # Try JSON output first for precise count (handles pretty-printed JSON)
-        local json_out
-        json_out=$("$RLEDGER" check --format json --no-cache "$file" 2>/dev/null || true)
         local actual
-        actual=$(echo "$json_out" | grep -oE '"error_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -n1 || echo "")
+        actual=$(echo "$check_json" | grep -oE '"error_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -n1 || echo "")
         if [ -z "$actual" ]; then
             # Fallback: count error lines in text output
             actual=$(echo "$check_stdout" | grep -cE '(^error\[|: error\[)' || echo "0")
@@ -99,8 +115,9 @@ run_assertion() {
     if [[ "$assertion" =~ ^query\ +\"(.+)\"\ +contains\ +\"(.+)\"$ ]]; then
         local bql="${BASH_REMATCH[1]}"
         local pattern="${BASH_REMATCH[2]}"
-        local query_out
-        query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
+        if ! run_query "$file" "$bql"; then
+            return 1
+        fi
         if ! echo "$query_out" | grep -qF -- "$pattern"; then
             echo "    FAIL: query output should contain \"$pattern\""
             echo "    query: $bql"
@@ -114,8 +131,9 @@ run_assertion() {
     if [[ "$assertion" =~ ^query\ +\"(.+)\"\ +\!contains\ +\"(.+)\"$ ]]; then
         local bql="${BASH_REMATCH[1]}"
         local pattern="${BASH_REMATCH[2]}"
-        local query_out
-        query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
+        if ! run_query "$file" "$bql"; then
+            return 1
+        fi
         if echo "$query_out" | grep -qF -- "$pattern"; then
             echo "    FAIL: query output should NOT contain \"$pattern\""
             echo "    query: $bql"
@@ -129,8 +147,9 @@ run_assertion() {
     if [[ "$assertion" =~ ^query\ +\"(.+)\"\ +row_count\ *==\ *([0-9]+)$ ]]; then
         local bql="${BASH_REMATCH[1]}"
         local expected="${BASH_REMATCH[2]}"
-        local query_out
-        query_out=$("$RLEDGER" query -q "$file" "$bql" 2>/dev/null || true)
+        if ! run_query "$file" "$bql"; then
+            return 1
+        fi
         # Parse the trailing "N row(s)" summary line for the actual count
         local actual
         actual=$(echo "$query_out" | grep -oE '^[0-9]+ row' | grep -oE '^[0-9]+' | tail -1 || echo "")
@@ -166,12 +185,15 @@ for f in "$TESTS_DIR"/issue-*.beancount; do
         assertions+=("$line")
     done < <(grep '^; ASSERT: ' "$f" | sed 's/^; ASSERT: //')
 
-    # Run rledger check and capture output
+    # Run rledger check and capture output (text mode)
     check_stdout=""
     check_stderr=""
     check_exit=0
     check_stdout=$("$RLEDGER" check --no-cache "$f" 2>"$STDERR_TMP") || check_exit=$?
     check_stderr=$(cat "$STDERR_TMP" 2>/dev/null || true)
+
+    # Also run in JSON mode once (cached for error_count assertions)
+    check_json=$("$RLEDGER" check --format json --no-cache "$f" 2>/dev/null || true)
 
     if [ ${#assertions[@]} -eq 0 ]; then
         # No assertions — fall back to exit-code-only
@@ -187,7 +209,7 @@ for f in "$TESTS_DIR"/issue-*.beancount; do
         # Run each assertion
         test_failed=0
         for assertion in "${assertions[@]}"; do
-            if ! run_assertion "$f" "$assertion" "$ISSUE_NUM"; then
+            if ! run_assertion "$f" "$assertion"; then
                 test_failed=1
             fi
         done

--- a/tests/regressions/README.md
+++ b/tests/regressions/README.md
@@ -28,18 +28,29 @@ Example:
 ...
 ```
 
+## Inline Assertions
+
+Files can include `; ASSERT:` comments for content-based verification (not just exit codes):
+
+```beancount
+; ASSERT: no_errors
+; ASSERT: error_count == 0
+; ASSERT: check_stderr !contains "ambiguous"
+; ASSERT: check_stderr contains "warning"
+; ASSERT: query "SELECT DISTINCT account" contains "Equity:Currency:USD"
+; ASSERT: query "SELECT DISTINCT account" row_count == 4
+```
+
+Files without assertions fall back to exit-code-only checking (exit 0 = pass).
+
 ## Running Tests
 
-These files are tested by:
-1. `rledger check` - should exit 0 (no errors)
-2. Compatibility test suite - compares output with Python beancount
-
 ```bash
-# Run all regression tests
-for f in tests/regressions/issue-*.beancount; do
-  echo "Testing $f..."
-  cargo run --release -p rustledger -- check "$f"
-done
+# Run all regression tests (with assertions)
+./scripts/test-regressions.sh
+
+# Run with a specific binary
+./scripts/test-regressions.sh ./target/debug/rledger
 ```
 
 ## Adding New Tests

--- a/tests/regressions/README.md
+++ b/tests/regressions/README.md
@@ -53,6 +53,10 @@ Files without assertions fall back to exit-code-only checking (exit 0 = pass).
 ./scripts/test-regressions.sh ./target/debug/rledger
 ```
 
+These regression files are also exercised by the nightly compatibility workflow,
+which includes `tests/regressions` in its `TEST_DIRS` configuration in
+`.github/workflows/compat.yml`.
+
 ## Adding New Tests
 
 When adding a test from a new issue:

--- a/tests/regressions/issue-520.beancount
+++ b/tests/regressions/issue-520.beancount
@@ -2,6 +2,8 @@
 ; Description: currency_accounts plugin should generate Open directives for
 ;              the currency tracking accounts it creates (e.g., Equity:Currency:USD)
 ; Expected: No errors - plugin generates Open directives like Python beancount
+; ASSERT: no_errors
+; ASSERT: query "SELECT DISTINCT account ORDER BY account" contains "Equity:Currency:USD"
 
 option "operating_currency" "EUR"
 

--- a/tests/regressions/issue-593.beancount
+++ b/tests/regressions/issue-593.beancount
@@ -17,6 +17,9 @@
 ;     - Should use latest price (1.40 EUR from last @ annotation)
 ;     - SUM(value(position)) should equal 4 ABC * 1.40 = 5.60 EUR
 
+; ASSERT: no_errors
+; ASSERT: query "SELECT SUM(cost(position)) WHERE account = 'Equity:Stocks'" contains "5.20 EUR"
+
 plugin "beancount.plugins.implicit_prices"
 
 1900-01-01 open Equity:Stocks

--- a/tests/regressions/issue-775.beancount
+++ b/tests/regressions/issue-775.beancount
@@ -2,6 +2,8 @@
 ; Description: File-level `option "booking_method" "FIFO"` should be applied
 ;              as the default for accounts opened without an explicit method.
 ; Expected: No errors - FIFO resolves the ambiguous lot match.
+; ASSERT: no_errors
+; ASSERT: check_stderr !contains "ambiguous"
 
 option "operating_currency" "USD"
 option "booking_method" "FIFO"


### PR DESCRIPTION
## Summary

- Enhance `scripts/test-regressions.sh` to support `; ASSERT:` inline comments for content-based verification
- Add assertions to 3 regression files that previously relied on exit-code-only checking
- Files without assertions continue to work as before (exit-code only)

## Assertion Syntax

```beancount
; ASSERT: no_errors
; ASSERT: error_count == 0
; ASSERT: check_stderr !contains "ambiguous"
; ASSERT: check_stderr contains "warning"
; ASSERT: query "SELECT DISTINCT account" contains "Equity:Currency:USD"
; ASSERT: query "SELECT DISTINCT account" row_count == 4
```

## Files with Assertions Added

| File | Assertions | What they verify |
|------|-----------|-----------------|
| `issue-520.beancount` | `no_errors` + query contains | currency_accounts plugin generates `Equity:Currency:USD` |
| `issue-593.beancount` | `no_errors` + query contains | BQL `cost()` returns correct sum (5.20 EUR) |
| `issue-775.beancount` | `no_errors` + stderr !contains | FIFO booking resolves without "ambiguous" warning |

## Test plan

- [x] `./scripts/test-regressions.sh` — all 21 tests pass (18 exit-code only, 3 with assertions)
- [x] Verified assertion failures are reported correctly (manually tested with wrong expected values)

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)