### PR TITLE
test: add insta snapshot tests for CLI output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "edit",
  "format_num_pattern",
  "glob",
+ "insta",
  "miette",
  "rayon",
  "rust_decimal",

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -100,6 +100,7 @@ sha2.workspace = true
 rust_decimal_macros.workspace = true
 criterion.workspace = true
 tempfile.workspace = true
+insta.workspace = true
 
 [[bench]]
 name = "pipeline_bench"

--- a/crates/rustledger/tests/cli_snapshot_test.rs
+++ b/crates/rustledger/tests/cli_snapshot_test.rs
@@ -1,0 +1,224 @@
+//! Snapshot tests for CLI output formatting.
+//!
+//! These tests capture the exact output of `rledger check` and `rledger query`
+//! to detect unintentional formatting regressions. When formatting changes
+//! intentionally, update snapshots with `cargo insta review`.
+//!
+//! See issue #786: <https://github.com/rustledger/rustledger/issues/786>
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn test_fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn rledger_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rledger") {
+        return Some(PathBuf::from(path));
+    }
+    let release_path = project_root().join("target/release/rledger");
+    if release_path.exists() {
+        return Some(release_path);
+    }
+    let debug_path = project_root().join("target/debug/rledger");
+    if debug_path.exists() {
+        return Some(debug_path);
+    }
+    None
+}
+
+macro_rules! require_rledger {
+    () => {
+        match rledger_binary() {
+            Some(path) => path,
+            None => {
+                eprintln!("Skipping: rledger binary not found");
+                return;
+            }
+        }
+    };
+}
+
+/// Normalize output for snapshot stability: strip the file path prefix
+/// so snapshots don't depend on the absolute path of the test machine.
+fn normalize_output(output: &str, fixture_dir: &str) -> String {
+    output.replace(fixture_dir, "<fixtures>")
+}
+
+// ============================================================================
+// rledger check — text output
+// ============================================================================
+
+/// Snapshot: `rledger check` on a clean file (text mode, no errors).
+#[test]
+fn test_snapshot_check_clean_file_text() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("valid-ledger.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--no-cache"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run rledger check");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout, &test_fixtures_dir().display().to_string());
+
+    insta::assert_snapshot!("check_clean_text", normalized.trim());
+}
+
+/// Snapshot: `rledger check` on a file with validation errors (text mode).
+#[test]
+fn test_snapshot_check_validation_errors_text() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("validation-errors.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--no-cache"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run rledger check");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout, &test_fixtures_dir().display().to_string());
+
+    insta::assert_snapshot!("check_validation_errors_text", normalized.trim());
+}
+
+// ============================================================================
+// rledger check — JSON output
+// ============================================================================
+
+/// Snapshot: `rledger check --format json` on a clean file.
+#[test]
+fn test_snapshot_check_clean_file_json() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("valid-ledger.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--format", "json", "--no-cache"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run rledger check");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("--format") {
+            eprintln!("Skipping: --format json not supported");
+            return;
+        }
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Parse and re-serialize to normalize field ordering, then snapshot
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("should produce valid JSON");
+
+    // Snapshot the structure — redact file paths for portability
+    let normalized_json = normalize_json_paths(&json, &test_fixtures_dir().display().to_string());
+    let pretty = serde_json::to_string_pretty(&normalized_json).unwrap();
+
+    insta::assert_snapshot!("check_clean_json", pretty);
+}
+
+/// Snapshot: `rledger check --format json` on a file with validation errors.
+#[test]
+fn test_snapshot_check_validation_errors_json() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("validation-errors.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--format", "json", "--no-cache"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run rledger check");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("--format") {
+            eprintln!("Skipping: --format json not supported");
+            return;
+        }
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("should produce valid JSON");
+    let normalized_json = normalize_json_paths(&json, &test_fixtures_dir().display().to_string());
+    let pretty = serde_json::to_string_pretty(&normalized_json).unwrap();
+
+    insta::assert_snapshot!("check_validation_errors_json", pretty);
+}
+
+// ============================================================================
+// rledger query — table output
+// ============================================================================
+
+/// Snapshot: `rledger query` table output for a simple SELECT.
+#[test]
+fn test_snapshot_query_table_output() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("query-test.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["query", "-q"])
+        .arg(&fixture)
+        .arg("SELECT date, narration, account, position WHERE account ~ 'Expenses' ORDER BY date")
+        .output()
+        .expect("failed to run rledger query");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    insta::assert_snapshot!("query_table_output", stdout.trim());
+}
+
+/// Snapshot: `rledger query` aggregate output.
+#[test]
+fn test_snapshot_query_aggregate_output() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("query-test.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["query", "-q"])
+        .arg(&fixture)
+        .arg("SELECT account, SUM(position) GROUP BY account ORDER BY account")
+        .output()
+        .expect("failed to run rledger query");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    insta::assert_snapshot!("query_aggregate_output", stdout.trim());
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Replace absolute file paths in JSON values with `<fixtures>/filename`.
+fn normalize_json_paths(value: &serde_json::Value, fixture_dir: &str) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => {
+            serde_json::Value::String(s.replace(fixture_dir, "<fixtures>"))
+        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.iter()
+                .map(|v| normalize_json_paths(v, fixture_dir))
+                .collect(),
+        ),
+        serde_json::Value::Object(obj) => serde_json::Value::Object(
+            obj.iter()
+                .map(|(k, v)| (k.clone(), normalize_json_paths(v, fixture_dir)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}

--- a/crates/rustledger/tests/cli_snapshot_test.rs
+++ b/crates/rustledger/tests/cli_snapshot_test.rs
@@ -59,7 +59,8 @@ fn normalize_output(output: &str, fixture_dir: &str) -> String {
 // rledger check — text output
 // ============================================================================
 
-/// Snapshot: `rledger check` on a clean file (text mode, no errors).
+/// Snapshot: `rledger check` on a valid file (text mode).
+/// The file triggers a warning (E1004: close with non-zero balance) but no errors.
 #[test]
 fn test_snapshot_check_clean_file_text() {
     let rledger = require_rledger!();
@@ -71,10 +72,39 @@ fn test_snapshot_check_clean_file_text() {
         .output()
         .expect("failed to run rledger check");
 
+    assert!(
+        output.status.success(),
+        "rledger check should succeed on valid file: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     let normalized = normalize_output(&stdout, &test_fixtures_dir().display().to_string());
 
     insta::assert_snapshot!("check_clean_text", normalized.trim());
+}
+
+/// Snapshot: `rledger check` on a file with parse errors (text mode).
+#[test]
+fn test_snapshot_check_parse_errors_text() {
+    let rledger = require_rledger!();
+    let fixture = test_fixtures_dir().join("parse-errors.beancount");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--no-cache"])
+        .arg(&fixture)
+        .output()
+        .expect("failed to run rledger check");
+
+    assert!(
+        !output.status.success(),
+        "rledger check should fail on file with parse errors"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout, &test_fixtures_dir().display().to_string());
+
+    insta::assert_snapshot!("check_parse_errors_text", normalized.trim());
 }
 
 /// Snapshot: `rledger check` on a file with validation errors (text mode).
@@ -88,6 +118,11 @@ fn test_snapshot_check_validation_errors_text() {
         .arg(&fixture)
         .output()
         .expect("failed to run rledger check");
+
+    assert!(
+        !output.status.success(),
+        "rledger check should fail on file with validation errors"
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let normalized = normalize_output(&stdout, &test_fixtures_dir().display().to_string());
@@ -176,6 +211,12 @@ fn test_snapshot_query_table_output() {
         .output()
         .expect("failed to run rledger query");
 
+    assert!(
+        output.status.success(),
+        "rledger query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     insta::assert_snapshot!("query_table_output", stdout.trim());
@@ -193,6 +234,12 @@ fn test_snapshot_query_aggregate_output() {
         .arg("SELECT account, SUM(position) GROUP BY account ORDER BY account")
         .output()
         .expect("failed to run rledger query");
+
+    assert!(
+        output.status.success(),
+        "rledger query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 

--- a/crates/rustledger/tests/fixtures/parse-errors.beancount
+++ b/crates/rustledger/tests/fixtures/parse-errors.beancount
@@ -1,0 +1,9 @@
+; File with intentional parse errors for snapshot testing
+
+2024-01-01 open Assets:Cash USD
+
+this is not valid beancount {{{ }}
+
+2024-01-15 * "Valid transaction"
+  Assets:Cash   100 USD
+  Income:Salary

--- a/crates/rustledger/tests/fixtures/query-test.beancount
+++ b/crates/rustledger/tests/fixtures/query-test.beancount
@@ -1,0 +1,17 @@
+option "operating_currency" "USD"
+
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Expenses:Food
+2024-01-01 open Income:Salary
+
+2024-01-15 * "Acme Corp" "January salary"
+  Assets:Cash    3000 USD
+  Income:Salary
+
+2024-01-20 * "Grocery Store" "Weekly groceries"
+  Expenses:Food   50 USD
+  Assets:Cash
+
+2024-01-25 * "Restaurant" "Dinner"
+  Expenses:Food   30 USD
+  Assets:Cash

--- a/crates/rustledger/tests/fixtures/validation-errors.beancount
+++ b/crates/rustledger/tests/fixtures/validation-errors.beancount
@@ -1,0 +1,10 @@
+; File with intentional validation errors for snapshot testing
+option "operating_currency" "USD"
+
+; Transaction referencing accounts that were never opened
+2024-01-15 * "Lunch"
+  Expenses:Food   10 USD
+  Assets:Cash    -10 USD
+
+; Balance assertion that will fail (no opens, so balance is 0)
+2024-01-16 balance Assets:Cash 100 USD

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_json.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_json.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: pretty
+---
+{
+  "diagnostics": [
+    {
+      "code": "E1004",
+      "column": 1,
+      "end_column": 1,
+      "end_line": 1,
+      "file": "<fixtures>/valid-ledger.beancount",
+      "line": 1,
+      "message": "[E1004] Cannot close account Assets:Bank:Savings with non-zero balance",
+      "phase": "validate",
+      "severity": "warning"
+    }
+  ],
+  "error_count": 0,
+  "parse_error_count": 0,
+  "validate_error_count": 0,
+  "warning_count": 1
+}

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_text.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_text.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: normalized.trim()
+---
+<fixtures>/valid-ledger.beancount: error[E1004]: [E1004] Cannot close account Assets:Bank:Savings with non-zero balance
+⚠ 1 warning

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_parse_errors_text.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_parse_errors_text.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: normalized.trim()
+---
+P0012
+
+  x parse error: unexpected input
+   ,-[<fixtures>/parse-errors.beancount:5:1]
+ 4 | 
+ 5 | this is not valid beancount {{{ }}
+   : ^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^
+   :                  `-- parse error
+ 6 | 
+ 7 | 2024-01-15 * "Valid transaction"
+   `----
+<fixtures>/parse-errors.beancount: error[E1001]: [E1001] Account Income:Salary was never opened
+✗ 2 errors

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_json.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_json.snap
@@ -1,0 +1,45 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: pretty
+---
+{
+  "diagnostics": [
+    {
+      "code": "E1001",
+      "column": 1,
+      "end_column": 1,
+      "end_line": 1,
+      "file": "<fixtures>/validation-errors.beancount",
+      "line": 1,
+      "message": "[E1001] Account Expenses:Food was never opened",
+      "phase": "validate",
+      "severity": "error"
+    },
+    {
+      "code": "E1001",
+      "column": 1,
+      "end_column": 1,
+      "end_line": 1,
+      "file": "<fixtures>/validation-errors.beancount",
+      "line": 1,
+      "message": "[E1001] Account Assets:Cash was never opened",
+      "phase": "validate",
+      "severity": "error"
+    },
+    {
+      "code": "E1001",
+      "column": 1,
+      "end_column": 1,
+      "end_line": 1,
+      "file": "<fixtures>/validation-errors.beancount",
+      "line": 1,
+      "message": "[E1001] Account Assets:Cash was never opened",
+      "phase": "validate",
+      "severity": "error"
+    }
+  ],
+  "error_count": 3,
+  "parse_error_count": 0,
+  "validate_error_count": 3,
+  "warning_count": 0
+}

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_text.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_text.snap
@@ -1,0 +1,8 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: normalized.trim()
+---
+<fixtures>/validation-errors.beancount: error[E1001]: [E1001] Account Expenses:Food was never opened
+<fixtures>/validation-errors.beancount: error[E1001]: [E1001] Account Assets:Cash was never opened
+<fixtures>/validation-errors.beancount: error[E1001]: [E1001] Account Assets:Cash was never opened
+✗ 3 errors

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__query_aggregate_output.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__query_aggregate_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: stdout.trim()
+---
+account        SUM      
+-------------  ---------
+Assets:Cash    2920 USD 
+Expenses:Food  80 USD   
+Income:Salary  -3000 USD
+
+3 row(s)

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__query_table_output.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__query_table_output.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rustledger/tests/cli_snapshot_test.rs
+expression: stdout.trim()
+---
+date        narration         account        position
+----------  ----------------  -------------  --------
+2024-01-20  Weekly groceries  Expenses:Food  50 USD  
+2024-01-25  Dinner            Expenses:Food  30 USD  
+
+2 row(s)


### PR DESCRIPTION
## Summary

- Add 6 `insta` snapshot tests capturing exact CLI output for `rledger check` and `rledger query`
- Add 3 test fixture beancount files (parse errors, validation errors, query data)
- File paths normalized to `<fixtures>` for snapshot portability across machines

## Snapshots

| Snapshot | What it captures |
|----------|-----------------|
| `check_clean_text` | `rledger check` on a valid file (text mode) |
| `check_validation_errors_text` | `rledger check` with validation errors (text mode) |
| `check_clean_json` | `rledger check --format json` on a valid file |
| `check_validation_errors_json` | `rledger check --format json` with validation errors |
| `query_table_output` | `rledger query` SELECT with WHERE/ORDER BY |
| `query_aggregate_output` | `rledger query` with GROUP BY/SUM |

## Updating Snapshots

When formatting intentionally changes:
```bash
INSTA_UPDATE=always cargo test -p rustledger --test cli_snapshot_test
```

## Test plan

- [x] `cargo test -p rustledger --test cli_snapshot_test` — all 6 pass
- [x] `cargo clippy -p rustledger --all-features --all-targets -- -D warnings` — clean

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)