### PR TITLE
chore: add rustledger and rustledger-lsp to code coverage reporting

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -92,7 +92,9 @@ jobs:
             --package rustledger-validate \
             --package rustledger-query \
             --package rustledger-plugin \
-            --package rustledger-importer
+            --package rustledger-importer \
+            --package rustledger \
+            --package rustledger-lsp
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:


### PR DESCRIPTION
## Summary

Add `rustledger` (CLI) and `rustledger-lsp` to the `cargo-llvm-cov` package list in `quality.yml`.

## Why

The CLI crate was excluded from coverage despite containing 1300+ lines of complex dispatch logic in `check.rs`. This was the source of #774 (JSON output corruption) going undetected. The LSP crate has 29 handler modules with their own test suites — also worth tracking.

## Test plan

- [x] CI should run coverage on all 10 crates instead of 8

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)