### PR TITLE
chore: combined dependency bumps (CI actions + Rust deps)

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -173,7 +173,7 @@ jobs:
           fi
 
       - name: Post PR comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const rustledger_ms = parseFloat('${{ steps.benchmark.outputs.rustledger_ms }}');

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -696,7 +696,7 @@ jobs:
           EOF
 
       - name: Upload results artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scaling-${{ matrix.size }}
           path: bench-scaling-${{ matrix.size }}.json

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1083,7 +1083,7 @@ jobs:
 
       - name: Post PR comment (release PRs only)
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -121,14 +121,14 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: crashes-${{ matrix.target }}
           path: crates/rustledger-parser/fuzz/artifacts/${{ matrix.target }}/
 
       - name: Upload corpus
         if: steps.check.outputs.should_run == 'true' && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: corpus-${{ matrix.target }}
           path: crates/rustledger-parser/fuzz/corpus/${{ matrix.target }}/
@@ -220,14 +220,14 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: crashes-fuzz_query_parse
           path: crates/rustledger-query/fuzz/artifacts/fuzz_query_parse/
 
       - name: Upload corpus
         if: steps.check.outputs.should_run == 'true' && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: corpus-fuzz_query_parse
           path: crates/rustledger-query/fuzz/corpus/fuzz_query_parse/
@@ -319,14 +319,14 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: crashes-fuzz_booking
           path: crates/rustledger-booking/fuzz/artifacts/fuzz_booking/
 
       - name: Upload corpus
         if: steps.check.outputs.should_run == 'true' && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: corpus-fuzz_booking
           path: crates/rustledger-booking/fuzz/corpus/fuzz_booking/

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Kani output
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: kani-results
           path: crates/*/kani-*-output.txt

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -169,7 +169,7 @@ jobs:
           fi
 
       - name: Upload mutation results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutation-results
           path: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@9f3c2bd861691e2415c027f87e23302b57026a6e # latest as of 2026-03-30
+        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab # latest as of 2026-03-30
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode (review and fix)
-        uses: anomalyco/opencode/github@9f3c2bd861691e2415c027f87e23302b57026a6e
+        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode (review only)
-        uses: anomalyco/opencode/github@9f3c2bd861691e2415c027f87e23302b57026a6e
+        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -155,7 +155,7 @@ jobs:
 
       - name: Run opencode (review and fix)
         if: inputs.action == 'review-and-fix'
-        uses: anomalyco/opencode/github@9f3c2bd861691e2415c027f87e23302b57026a6e
+        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -180,7 +180,7 @@ jobs:
 
       - name: Run opencode (review only)
         if: inputs.action == 'review-only'
-        uses: anomalyco/opencode/github@9f3c2bd861691e2415c027f87e23302b57026a6e
+        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -236,7 +236,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode on issue #${{ matrix.issue }}
-        uses: anomalyco/opencode/github@9f3c2bd861691e2415c027f87e23302b57026a6e
+        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -299,7 +299,7 @@ jobs:
           cd ../../..
           (Get-FileHash -Algorithm SHA256 $ARCHIVE).Hash.ToLower() + "  " + $ARCHIVE | Out-File -Encoding utf8 "${ARCHIVE}.sha256"
       - name: Upload artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
         with:
           name: rustledger-${{ matrix.target }}
           path: |
@@ -333,7 +333,7 @@ jobs:
           sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" package.json
           sed -i 's/"name": "rustledger-wasm"/"name": "@rustledger\/wasm"/' package.json
       - name: Upload WASM artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
         with:
           name: wasm-package
           path: crates/rustledger-wasm/pkg/
@@ -359,7 +359,7 @@ jobs:
           cp target/wasm32-wasip1/release/rustledger-ffi-wasi.wasm "rustledger-ffi-wasi-${VERSION}.wasm"
           shasum -a 256 "rustledger-ffi-wasi-${VERSION}.wasm" > "rustledger-ffi-wasi-${VERSION}.wasm.sha256"
       - name: Upload FFI-WASI artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
         with:
           name: ffi-wasi-package
           path: |
@@ -392,7 +392,7 @@ jobs:
         working-directory: packages/vscode
         run: shasum -a 256 rustledger-vscode.vsix > rustledger-vscode.vsix.sha256
       - name: Upload VS Code extension artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
         with:
           name: vscode-extension
           path: |
@@ -445,7 +445,7 @@ jobs:
       - name: List artifacts
         run: ls -la artifacts/
       - name: Create Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           draft: false

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -299,7 +299,7 @@ jobs:
           cd ../../..
           (Get-FileHash -Algorithm SHA256 $ARCHIVE).Hash.ToLower() + "  " + $ARCHIVE | Out-File -Encoding utf8 "${ARCHIVE}.sha256"
       - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rustledger-${{ matrix.target }}
           path: |
@@ -333,7 +333,7 @@ jobs:
           sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" package.json
           sed -i 's/"name": "rustledger-wasm"/"name": "@rustledger\/wasm"/' package.json
       - name: Upload WASM artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wasm-package
           path: crates/rustledger-wasm/pkg/
@@ -359,7 +359,7 @@ jobs:
           cp target/wasm32-wasip1/release/rustledger-ffi-wasi.wasm "rustledger-ffi-wasi-${VERSION}.wasm"
           shasum -a 256 "rustledger-ffi-wasi-${VERSION}.wasm" > "rustledger-ffi-wasi-${VERSION}.wasm.sha256"
       - name: Upload FFI-WASI artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ffi-wasi-package
           path: |
@@ -392,7 +392,7 @@ jobs:
         working-directory: packages/vscode
         run: shasum -a 256 rustledger-vscode.vsix > rustledger-vscode.vsix.sha256
       - name: Upload VS Code extension artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vscode-extension
           path: |

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -440,7 +440,7 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31.10.3
+        uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo cyclonedx --format json > sbom.cdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-cyclonedx
           path: sbom.cdx.json

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo cyclonedx --format json > sbom.cdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6
         with:
           name: sbom-cyclonedx
           path: sbom.cdx.json

--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload counterexample traces
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: tla-traces
           path: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -148,7 +148,7 @@ jobs:
           fi
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: wasm-packages
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -1136,7 +1136,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1232,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2280,7 +2280,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3100,7 +3100,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3854,7 +3854,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3873,7 +3873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4004,9 +4004,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5010,7 +5010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5452,9 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.5.0"
+version = "8.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
  "aes",
  "bzip2",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -805,7 +805,7 @@ version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.51.0"
+version = "1.51.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-stream]]
@@ -997,7 +997,7 @@ version = "0.11.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zip]]
-version = "8.5.0"
+version = "8.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zopfli]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -128,8 +128,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_complete]]
-version = "4.6.0"
-when = "2026-03-12"
+version = "4.6.2"
+when = "2026-04-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"


### PR DESCRIPTION
## Summary

Combines 6 dependabot PRs into a single update with cargo vet fixes.

### CI Actions
| Dependency | From | To | PR |
|-----------|------|----|----|
| anomalyco/opencode | 9f3c2bd | 21d7a85 | #804 |
| cachix/install-nix-action | 31.10.3 | 31.10.4 | #805 |
| actions/upload-artifact | 7.0.0 | 7.0.1 | #806 |
| actions/github-script | 8.0.0 | 9.0.0 | #807 |
| softprops/action-gh-release | 2.6.1 | 3.0.0 | #808 |

### Rust Dependencies
| Dependency | From | To | PR |
|-----------|------|----|----|
| clap_complete | 4.6.0 | 4.6.2 | #809 |
| zip | 8.5.0 | 8.5.1 | #809 |
| tokio | 1.51.0 | 1.51.1 | #809 |

### Supply Chain
- Regenerated cargo vet exemptions for tokio and zip updates

## Test plan

- [x] `cargo vet` — passes
- [x] `cargo check --all-features --all-targets` — passes

Supersedes #804, #805, #806, #807, #808, #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)