### PR TITLE
perf: parallel file loading for multi-file ledgers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,6 +3220,7 @@ version = "0.12.0"
 dependencies = [
  "chrono",
  "glob",
+ "rayon",
  "rkyv 0.8.15",
  "rust_decimal",
  "rust_decimal_macros",

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -41,6 +41,7 @@ glob.workspace = true
 rkyv = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 rustc-hash.workspace = true
+rayon.workspace = true
 
 # Optional processing dependencies
 rustledger-booking = { workspace = true, optional = true }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -574,48 +574,43 @@ impl Loader {
             if valid_paths.len() > 1 && self.fs.supports_parallel_read() {
                 use rayon::prelude::*;
 
-                // Filter out encrypted files — they need sequential decryption.
-                let (encrypted, plaintext): (Vec<_>, Vec<_>) = valid_paths
-                    .into_iter()
-                    .partition(|p| self.fs.is_encrypted(p));
+                // Read + parse non-encrypted files in parallel, preserving
+                // original include order. Each entry becomes either
+                // Some((source, parsed)) for successful reads, or None for
+                // encrypted/failed files (which fall back to sequential).
+                //
+                // We keep the original index to merge results in order,
+                // ensuring option/directive precedence matches the declared
+                // include sequence.
+                let pre_parsed: Vec<Option<(std::sync::Arc<str>, rustledger_parser::ParseResult)>> =
+                    valid_paths
+                        .par_iter()
+                        .map(|p| {
+                            // Skip encrypted files — they need sequential GPG decryption
+                            if p.extension()
+                                .and_then(|e| e.to_str())
+                                .is_some_and(|e| e == "gpg" || e == "asc")
+                            {
+                                return None;
+                            }
+                            let bytes = std::fs::read(p).ok()?;
+                            let content = match String::from_utf8(bytes) {
+                                Ok(s) => s,
+                                Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
+                            };
+                            let source: std::sync::Arc<str> = content.into();
+                            let parsed = rustledger_parser::parse(&source);
+                            Some((source, parsed))
+                        })
+                        .collect();
 
-                // Read + parse plaintext files in parallel.
-                // Uses DiskFileSystem::read logic (UTF-8 with lossy fallback).
-                let parse_results: Vec<_> = plaintext
-                    .par_iter()
-                    .filter_map(|p| {
-                        let source: std::sync::Arc<str> = match std::fs::read(p) {
-                            Ok(bytes) => match String::from_utf8(bytes) {
-                                Ok(s) => s.into(),
-                                Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned().into(),
-                            },
-                            Err(_) => return None, // I/O error — will be caught by load_recursive
-                        };
-                        let parsed = rustledger_parser::parse(&source);
-                        Some((p.clone(), source, parsed))
-                    })
-                    .collect();
-
-                // Merge parallel results sequentially (preserves include
-                // order, handles nested includes, updates shared state).
-                for (canonical, source, result) in parse_results {
+                // Merge in original include order. Files that were
+                // pre-parsed pass their data to load_recursive; files
+                // that weren't (encrypted or I/O error) are loaded
+                // sequentially as a fallback.
+                for (canonical, pre) in valid_paths.iter().zip(pre_parsed) {
                     if let Err(e) = self.load_recursive(
-                        &canonical,
-                        Some((source, result)),
-                        directives,
-                        options,
-                        plugins,
-                        source_map,
-                        errors,
-                    ) {
-                        errors.push(e);
-                    }
-                }
-
-                // Process encrypted files sequentially.
-                for canonical in encrypted {
-                    if let Err(e) = self.load_recursive(
-                        &canonical, None, directives, options, plugins, source_map, errors,
+                        canonical, pre, directives, options, plugins, source_map, errors,
                     ) {
                         errors.push(e);
                     }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -330,10 +330,177 @@ impl Loader {
         self
     }
 
+    /// Merge a pre-parsed file into the loading state.
+    #[allow(clippy::too_many_arguments)]
+    ///
+    /// Used by the parallel loading path: files are read + parsed in parallel,
+    /// then merged sequentially to preserve include order and handle nested
+    /// includes via recursive calls.
+    fn merge_parsed_file(
+        &mut self,
+        path: &Path,
+        source: &std::sync::Arc<str>,
+        result: rustledger_parser::ParseResult,
+        directives: &mut Vec<Spanned<Directive>>,
+        options: &mut Options,
+        plugins: &mut Vec<Plugin>,
+        source_map: &mut SourceMap,
+        errors: &mut Vec<LoadError>,
+    ) -> Result<(), LoadError> {
+        let path_buf = path.to_path_buf();
+
+        // Cycle and duplicate detection
+        if self.include_stack_set.contains(&path_buf) {
+            let cycle: Vec<String> = self
+                .include_stack
+                .iter()
+                .map(|p| p.display().to_string())
+                .chain(std::iter::once(path.display().to_string()))
+                .collect();
+            return Err(LoadError::IncludeCycle { cycle });
+        }
+        if self.loaded_files.contains(&path_buf) {
+            return Ok(());
+        }
+
+        // Register in source map and tracking sets
+        let file_id = source_map.add_file(path_buf.clone(), source.clone());
+        self.include_stack_set.insert(path_buf.clone());
+        self.include_stack.push(path_buf.clone());
+        self.loaded_files.insert(path_buf);
+
+        // Collect parse errors
+        if !result.errors.is_empty() {
+            errors.push(LoadError::ParseErrors {
+                path: path.to_path_buf(),
+                errors: result.errors,
+            });
+        }
+
+        // Process options
+        for (key, value, _span) in &result.options {
+            options.set(key, value);
+        }
+
+        // Process plugins
+        for (name, config, span) in &result.plugins {
+            let (actual_name, force_python) = if let Some(stripped) = name.strip_prefix("python:") {
+                (stripped.to_string(), true)
+            } else {
+                (name.clone(), false)
+            };
+            plugins.push(Plugin {
+                name: actual_name,
+                config: config.clone(),
+                span: *span,
+                file_id,
+                force_python,
+            });
+        }
+
+        // Process includes recursively (nested includes are handled here)
+        let base_dir = path.parent().unwrap_or(Path::new("."));
+        for (include_path, _span) in &result.includes {
+            let has_glob = include_path.contains('*')
+                || include_path.contains('?')
+                || include_path.contains('[');
+            let full_path = base_dir.join(include_path);
+
+            // Path traversal protection
+            if self.enforce_path_security
+                && let Some(ref root) = self.root_dir
+            {
+                let path_to_check = if has_glob {
+                    let glob_start = include_path
+                        .find(['*', '?', '['])
+                        .unwrap_or(include_path.len());
+                    let prefix = &include_path[..glob_start];
+                    let prefix_path = if let Some(last_sep) = prefix.rfind('/') {
+                        base_dir.join(&include_path[..=last_sep])
+                    } else {
+                        base_dir.to_path_buf()
+                    };
+                    normalize_path(&prefix_path)
+                } else {
+                    normalize_path(&full_path)
+                };
+
+                if !path_to_check.starts_with(root) {
+                    errors.push(LoadError::PathTraversal {
+                        include_path: include_path.clone(),
+                        base_dir: root.clone(),
+                    });
+                    continue;
+                }
+            }
+
+            let full_path_str = full_path.to_string_lossy();
+            let paths_to_load: Vec<PathBuf> = if has_glob {
+                match self.fs.glob(&full_path_str) {
+                    Ok(matched) => matched,
+                    Err(e) => {
+                        errors.push(LoadError::GlobError {
+                            pattern: include_path.clone(),
+                            message: e,
+                        });
+                        continue;
+                    }
+                }
+            } else {
+                vec![full_path.clone()]
+            };
+
+            if has_glob && paths_to_load.is_empty() {
+                errors.push(LoadError::GlobNoMatch {
+                    pattern: include_path.clone(),
+                });
+                continue;
+            }
+
+            // Recurse into nested includes (sequential — they may have
+            // their own nested includes)
+            for matched_path in paths_to_load {
+                let canonical = self.fs.normalize(&matched_path);
+                if self.enforce_path_security
+                    && let Some(ref root) = self.root_dir
+                    && !canonical.starts_with(root)
+                {
+                    errors.push(LoadError::PathTraversal {
+                        include_path: matched_path.to_string_lossy().into_owned(),
+                        base_dir: root.clone(),
+                    });
+                    continue;
+                }
+                if let Err(e) = self
+                    .load_recursive(&canonical, directives, options, plugins, source_map, errors)
+                {
+                    errors.push(e);
+                }
+            }
+        }
+
+        // Add directives from this file
+        directives.extend(
+            result
+                .directives
+                .into_iter()
+                .map(|d| d.with_file_id(file_id)),
+        );
+
+        // Pop from stack
+        if let Some(popped) = self.include_stack.pop() {
+            self.include_stack_set.remove(&popped);
+        }
+
+        Ok(())
+    }
+
     /// Load a beancount file and all its includes.
     ///
-    /// Parses the file, processes options and plugin directives, and recursively
-    /// loads any included files.
+    /// Uses parallel file parsing when multiple files are discovered via
+    /// include directives. The root file is parsed first to resolve the
+    /// include tree, then all included files are read and parsed in
+    /// parallel using rayon.
     ///
     /// # Errors
     ///
@@ -360,6 +527,8 @@ impl Loader {
             self.root_dir = canonical.parent().map(Path::to_path_buf);
         }
 
+        // Phase 1: Parse the root file to discover includes.
+        // The root file is typically small (just includes + options).
         self.load_recursive(
             &canonical,
             &mut directives,
@@ -533,13 +702,12 @@ impl Loader {
                 continue;
             }
 
-            // Load each matched file
+            // Normalize and security-check all matched paths first.
+            let mut valid_paths = Vec::with_capacity(paths_to_load.len());
             for matched_path in paths_to_load {
-                // Use filesystem-specific normalization (VFS vs disk)
                 let canonical = self.fs.normalize(&matched_path);
 
-                // Additional security check for each matched file
-                // (glob could still match files outside root via symlinks)
+                // Security check: glob could match files outside root via symlinks
                 if self.enforce_path_security
                     && let Some(ref root) = self.root_dir
                     && !canonical.starts_with(root)
@@ -551,10 +719,47 @@ impl Loader {
                     continue;
                 }
 
-                if let Err(e) = self
-                    .load_recursive(&canonical, directives, options, plugins, source_map, errors)
-                {
-                    errors.push(e);
+                valid_paths.push(canonical);
+            }
+
+            // Parallel optimization: when loading multiple sibling includes
+            // from disk, read and parse them in parallel. The expensive work
+            // (I/O + tokenize + parse) runs on rayon's thread pool while the
+            // main thread coordinates the include tree walk.
+            //
+            // Each file is read and parsed independently. Results are then
+            // merged sequentially to preserve include order and process any
+            // nested includes via recursive calls.
+            if valid_paths.len() > 1 && self.fs.supports_parallel_read() {
+                use rayon::prelude::*;
+
+                // Read + parse all sibling includes in parallel.
+                let parse_results: Vec<_> = valid_paths
+                    .par_iter()
+                    .map(|p| {
+                        let source: std::sync::Arc<str> =
+                            std::fs::read_to_string(p).unwrap_or_default().into();
+                        let parsed = rustledger_parser::parse(&source);
+                        (p.clone(), source, parsed)
+                    })
+                    .collect();
+
+                // Merge results sequentially (preserves include order,
+                // handles nested includes, updates shared state).
+                for (canonical, source, result) in parse_results {
+                    self.merge_parsed_file(
+                        &canonical, &source, result, directives, options, plugins, source_map,
+                        errors,
+                    )?;
+                }
+            } else {
+                // Sequential fallback: single file, VFS, or encrypted files.
+                for canonical in valid_paths {
+                    if let Err(e) = self.load_recursive(
+                        &canonical, directives, options, plugins, source_map, errors,
+                    ) {
+                        errors.push(e);
+                    }
                 }
             }
         }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -330,171 +330,6 @@ impl Loader {
         self
     }
 
-    /// Merge a pre-parsed file into the loading state.
-    #[allow(clippy::too_many_arguments)]
-    ///
-    /// Used by the parallel loading path: files are read + parsed in parallel,
-    /// then merged sequentially to preserve include order and handle nested
-    /// includes via recursive calls.
-    fn merge_parsed_file(
-        &mut self,
-        path: &Path,
-        source: &std::sync::Arc<str>,
-        result: rustledger_parser::ParseResult,
-        directives: &mut Vec<Spanned<Directive>>,
-        options: &mut Options,
-        plugins: &mut Vec<Plugin>,
-        source_map: &mut SourceMap,
-        errors: &mut Vec<LoadError>,
-    ) -> Result<(), LoadError> {
-        let path_buf = path.to_path_buf();
-
-        // Cycle and duplicate detection
-        if self.include_stack_set.contains(&path_buf) {
-            let cycle: Vec<String> = self
-                .include_stack
-                .iter()
-                .map(|p| p.display().to_string())
-                .chain(std::iter::once(path.display().to_string()))
-                .collect();
-            return Err(LoadError::IncludeCycle { cycle });
-        }
-        if self.loaded_files.contains(&path_buf) {
-            return Ok(());
-        }
-
-        // Register in source map and tracking sets
-        let file_id = source_map.add_file(path_buf.clone(), source.clone());
-        self.include_stack_set.insert(path_buf.clone());
-        self.include_stack.push(path_buf.clone());
-        self.loaded_files.insert(path_buf);
-
-        // Collect parse errors
-        if !result.errors.is_empty() {
-            errors.push(LoadError::ParseErrors {
-                path: path.to_path_buf(),
-                errors: result.errors,
-            });
-        }
-
-        // Process options
-        for (key, value, _span) in &result.options {
-            options.set(key, value);
-        }
-
-        // Process plugins
-        for (name, config, span) in &result.plugins {
-            let (actual_name, force_python) = if let Some(stripped) = name.strip_prefix("python:") {
-                (stripped.to_string(), true)
-            } else {
-                (name.clone(), false)
-            };
-            plugins.push(Plugin {
-                name: actual_name,
-                config: config.clone(),
-                span: *span,
-                file_id,
-                force_python,
-            });
-        }
-
-        // Process includes recursively (nested includes are handled here)
-        let base_dir = path.parent().unwrap_or(Path::new("."));
-        for (include_path, _span) in &result.includes {
-            let has_glob = include_path.contains('*')
-                || include_path.contains('?')
-                || include_path.contains('[');
-            let full_path = base_dir.join(include_path);
-
-            // Path traversal protection
-            if self.enforce_path_security
-                && let Some(ref root) = self.root_dir
-            {
-                let path_to_check = if has_glob {
-                    let glob_start = include_path
-                        .find(['*', '?', '['])
-                        .unwrap_or(include_path.len());
-                    let prefix = &include_path[..glob_start];
-                    let prefix_path = if let Some(last_sep) = prefix.rfind('/') {
-                        base_dir.join(&include_path[..=last_sep])
-                    } else {
-                        base_dir.to_path_buf()
-                    };
-                    normalize_path(&prefix_path)
-                } else {
-                    normalize_path(&full_path)
-                };
-
-                if !path_to_check.starts_with(root) {
-                    errors.push(LoadError::PathTraversal {
-                        include_path: include_path.clone(),
-                        base_dir: root.clone(),
-                    });
-                    continue;
-                }
-            }
-
-            let full_path_str = full_path.to_string_lossy();
-            let paths_to_load: Vec<PathBuf> = if has_glob {
-                match self.fs.glob(&full_path_str) {
-                    Ok(matched) => matched,
-                    Err(e) => {
-                        errors.push(LoadError::GlobError {
-                            pattern: include_path.clone(),
-                            message: e,
-                        });
-                        continue;
-                    }
-                }
-            } else {
-                vec![full_path.clone()]
-            };
-
-            if has_glob && paths_to_load.is_empty() {
-                errors.push(LoadError::GlobNoMatch {
-                    pattern: include_path.clone(),
-                });
-                continue;
-            }
-
-            // Recurse into nested includes (sequential — they may have
-            // their own nested includes)
-            for matched_path in paths_to_load {
-                let canonical = self.fs.normalize(&matched_path);
-                if self.enforce_path_security
-                    && let Some(ref root) = self.root_dir
-                    && !canonical.starts_with(root)
-                {
-                    errors.push(LoadError::PathTraversal {
-                        include_path: matched_path.to_string_lossy().into_owned(),
-                        base_dir: root.clone(),
-                    });
-                    continue;
-                }
-                if let Err(e) = self
-                    .load_recursive(&canonical, directives, options, plugins, source_map, errors)
-                {
-                    errors.push(e);
-                }
-            }
-        }
-
-        // Add directives from this file
-        directives.extend(
-            result
-                .directives
-                .into_iter()
-                .map(|d| d.with_file_id(file_id)),
-        );
-
-        // Pop from stack
-        if let Some(popped) = self.include_stack.pop() {
-            self.include_stack_set.remove(&popped);
-        }
-
-        Ok(())
-    }
-
     /// Load a beancount file and all its includes.
     ///
     /// Uses parallel file parsing when multiple files are discovered via
@@ -531,6 +366,7 @@ impl Loader {
         // The root file is typically small (just includes + options).
         self.load_recursive(
             &canonical,
+            None,
             &mut directives,
             &mut options,
             &mut plugins,
@@ -551,9 +387,11 @@ impl Loader {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn load_recursive(
         &mut self,
         path: &Path,
+        pre_parsed: Option<(std::sync::Arc<str>, rustledger_parser::ParseResult)>,
         directives: &mut Vec<Spanned<Directive>>,
         options: &mut Options,
         plugins: &mut Vec<Plugin>,
@@ -584,12 +422,18 @@ impl Loader {
             return Ok(());
         }
 
-        // Read file (decrypting if necessary)
-        // Try fast UTF-8 conversion first, fall back to lossy for non-UTF-8 files
-        let source: std::sync::Arc<str> = if self.fs.is_encrypted(path) {
-            decrypt_gpg_file(path)?.into()
+        // Use pre-parsed data if available (from parallel loading path),
+        // otherwise read and parse the file.
+        let (source, result) = if let Some(pre) = pre_parsed {
+            pre
         } else {
-            self.fs.read(path)?
+            let src: std::sync::Arc<str> = if self.fs.is_encrypted(path) {
+                decrypt_gpg_file(path)?.into()
+            } else {
+                self.fs.read(path)?
+            };
+            let parsed = rustledger_parser::parse(&src);
+            (src, parsed)
         };
 
         // Add to source map (Arc::clone is cheap - just increments refcount)
@@ -599,9 +443,6 @@ impl Loader {
         self.include_stack_set.insert(path_buf.clone());
         self.include_stack.push(path_buf.clone());
         self.loaded_files.insert(path_buf);
-
-        // Parse (borrows from Arc, no allocation)
-        let result = rustledger_parser::parse(&source);
 
         // Collect parse errors
         if !result.errors.is_empty() {
@@ -733,30 +574,57 @@ impl Loader {
             if valid_paths.len() > 1 && self.fs.supports_parallel_read() {
                 use rayon::prelude::*;
 
-                // Read + parse all sibling includes in parallel.
-                let parse_results: Vec<_> = valid_paths
+                // Filter out encrypted files — they need sequential decryption.
+                let (encrypted, plaintext): (Vec<_>, Vec<_>) = valid_paths
+                    .into_iter()
+                    .partition(|p| self.fs.is_encrypted(p));
+
+                // Read + parse plaintext files in parallel.
+                // Uses DiskFileSystem::read logic (UTF-8 with lossy fallback).
+                let parse_results: Vec<_> = plaintext
                     .par_iter()
-                    .map(|p| {
-                        let source: std::sync::Arc<str> =
-                            std::fs::read_to_string(p).unwrap_or_default().into();
+                    .filter_map(|p| {
+                        let source: std::sync::Arc<str> = match std::fs::read(p) {
+                            Ok(bytes) => match String::from_utf8(bytes) {
+                                Ok(s) => s.into(),
+                                Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned().into(),
+                            },
+                            Err(_) => return None, // I/O error — will be caught by load_recursive
+                        };
                         let parsed = rustledger_parser::parse(&source);
-                        (p.clone(), source, parsed)
+                        Some((p.clone(), source, parsed))
                     })
                     .collect();
 
-                // Merge results sequentially (preserves include order,
-                // handles nested includes, updates shared state).
+                // Merge parallel results sequentially (preserves include
+                // order, handles nested includes, updates shared state).
                 for (canonical, source, result) in parse_results {
-                    self.merge_parsed_file(
-                        &canonical, &source, result, directives, options, plugins, source_map,
+                    if let Err(e) = self.load_recursive(
+                        &canonical,
+                        Some((source, result)),
+                        directives,
+                        options,
+                        plugins,
+                        source_map,
                         errors,
-                    )?;
+                    ) {
+                        errors.push(e);
+                    }
+                }
+
+                // Process encrypted files sequentially.
+                for canonical in encrypted {
+                    if let Err(e) = self.load_recursive(
+                        &canonical, None, directives, options, plugins, source_map, errors,
+                    ) {
+                        errors.push(e);
+                    }
                 }
             } else {
-                // Sequential fallback: single file, VFS, or encrypted files.
+                // Sequential fallback: single file or VFS.
                 for canonical in valid_paths {
                     if let Err(e) = self.load_recursive(
-                        &canonical, directives, options, plugins, source_map, errors,
+                        &canonical, None, directives, options, plugins, source_map, errors,
                     ) {
                         errors.push(e);
                     }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -582,23 +582,18 @@ impl Loader {
                 // We keep the original index to merge results in order,
                 // ensuring option/directive precedence matches the declared
                 // include sequence.
+                let fs = &*self.fs;
                 let pre_parsed: Vec<Option<(std::sync::Arc<str>, rustledger_parser::ParseResult)>> =
                     valid_paths
                         .par_iter()
                         .map(|p| {
                             // Skip encrypted files — they need sequential GPG decryption
-                            if p.extension()
-                                .and_then(|e| e.to_str())
-                                .is_some_and(|e| e == "gpg" || e == "asc")
-                            {
+                            if fs.is_encrypted(p) {
                                 return None;
                             }
-                            let bytes = std::fs::read(p).ok()?;
-                            let content = match String::from_utf8(bytes) {
-                                Ok(s) => s,
-                                Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
-                            };
-                            let source: std::sync::Arc<str> = content.into();
+                            // Read through the FileSystem trait so all I/O goes
+                            // through one code path (UTF-8 handling, error types, etc.)
+                            let source = fs.read(p).ok()?;
                             let parsed = rustledger_parser::parse(&source);
                             Some((source, parsed))
                         })

--- a/crates/rustledger-loader/src/vfs.rs
+++ b/crates/rustledger-loader/src/vfs.rs
@@ -89,13 +89,16 @@ impl FileSystem for DiskFileSystem {
         match path.extension().and_then(|e| e.to_str()) {
             Some("gpg") => true,
             Some("asc") => {
-                // Check for PGP header in first 1024 bytes
-                if let Ok(content) = fs::read_to_string(path) {
-                    let check_len = 1024.min(content.len());
-                    content[..check_len].contains("-----BEGIN PGP MESSAGE-----")
-                } else {
-                    false
-                }
+                // Check for PGP header in the first 1024 bytes.
+                // Only read what we need instead of the entire file.
+                use std::io::Read;
+                let Ok(file) = std::fs::File::open(path) else {
+                    return false;
+                };
+                let mut buf = [0u8; 1024];
+                let n = file.take(1024).read(&mut buf).unwrap_or(0);
+                let header = String::from_utf8_lossy(&buf[..n]);
+                header.contains("-----BEGIN PGP MESSAGE-----")
             }
             _ => false,
         }

--- a/crates/rustledger-loader/src/vfs.rs
+++ b/crates/rustledger-loader/src/vfs.rs
@@ -38,6 +38,15 @@ pub trait FileSystem: Send + Sync + std::fmt::Debug {
     /// For virtual filesystems, this just cleans up the path.
     fn normalize(&self, path: &Path) -> PathBuf;
 
+    /// Whether this filesystem supports parallel file reads.
+    ///
+    /// Disk filesystems return `true` — multiple files can be read
+    /// concurrently from different threads. Virtual filesystems return
+    /// `false` since they may use shared mutable state.
+    fn supports_parallel_read(&self) -> bool {
+        false
+    }
+
     /// Expand a glob pattern and return matching paths.
     ///
     /// # Errors
@@ -136,6 +145,10 @@ impl FileSystem for DiskFileSystem {
         let mut matched: Vec<PathBuf> = entries.filter_map(Result::ok).collect();
         matched.sort();
         Ok(matched)
+    }
+
+    fn supports_parallel_read(&self) -> bool {
+        true
     }
 }
 

--- a/crates/rustledger-loader/tests/fixtures/parallel_a.beancount
+++ b/crates/rustledger-loader/tests/fixtures/parallel_a.beancount
@@ -1,0 +1,6 @@
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Expenses:Food USD
+
+2024-01-15 * "Groceries"
+  Expenses:Food  50 USD
+  Assets:Bank   -50 USD

--- a/crates/rustledger-loader/tests/fixtures/parallel_b.beancount
+++ b/crates/rustledger-loader/tests/fixtures/parallel_b.beancount
@@ -1,0 +1,5 @@
+2024-01-01 open Income:Salary USD
+
+2024-02-01 * "Salary"
+  Assets:Bank    3000 USD
+  Income:Salary -3000 USD

--- a/crates/rustledger-loader/tests/fixtures/parallel_c.beancount
+++ b/crates/rustledger-loader/tests/fixtures/parallel_c.beancount
@@ -1,0 +1,1 @@
+2024-03-01 balance Assets:Bank 2950 USD

--- a/crates/rustledger-loader/tests/fixtures/parallel_main.beancount
+++ b/crates/rustledger-loader/tests/fixtures/parallel_main.beancount
@@ -1,0 +1,7 @@
+; Root file with multiple includes to exercise parallel loading.
+option "title" "Parallel Test Ledger"
+option "operating_currency" "USD"
+
+include "parallel_a.beancount"
+include "parallel_b.beancount"
+include "parallel_c.beancount"

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -959,3 +959,82 @@ fn test_plugin_output_directives_visible_in_ledger() {
         "Total directives should be at least 5 (2 txn + 3 opens). Got {total}"
     );
 }
+
+/// Test that parallel loading of multiple sibling includes produces
+/// the same results as sequential loading. The fixture has a root file
+/// with 3 includes (triggering the parallel path on `DiskFileSystem`).
+#[test]
+fn test_parallel_loading_multiple_includes() {
+    use rustledger_loader::{LoadOptions, load};
+
+    let path = fixtures_path("parallel_main.beancount");
+    let ledger = load(&path, &LoadOptions::default()).expect("should load parallel fixture");
+
+    // All 3 accounts should be opened (from parallel_a and parallel_b)
+    let opens: Vec<_> = ledger
+        .directives
+        .iter()
+        .filter_map(|d| {
+            if let rustledger_core::Directive::Open(o) = &d.value {
+                Some(o.account.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        opens.iter().any(|a| a == "Assets:Bank"),
+        "Should have Assets:Bank from parallel_a. Opens: {opens:?}"
+    );
+    assert!(
+        opens.iter().any(|a| a == "Expenses:Food"),
+        "Should have Expenses:Food from parallel_a. Opens: {opens:?}"
+    );
+    assert!(
+        opens.iter().any(|a| a == "Income:Salary"),
+        "Should have Income:Salary from parallel_b. Opens: {opens:?}"
+    );
+
+    // 2 transactions (from parallel_a and parallel_b)
+    let txn_count = ledger
+        .directives
+        .iter()
+        .filter(|d| matches!(d.value, rustledger_core::Directive::Transaction(_)))
+        .count();
+    assert_eq!(
+        txn_count, 2,
+        "Should have 2 transactions from included files"
+    );
+
+    // 1 balance assertion (from parallel_c)
+    let balance_count = ledger
+        .directives
+        .iter()
+        .filter(|d| matches!(d.value, rustledger_core::Directive::Balance(_)))
+        .count();
+    assert_eq!(
+        balance_count, 1,
+        "Should have 1 balance assertion from parallel_c"
+    );
+
+    // Options from root file should be preserved
+    assert_eq!(
+        ledger.options.title,
+        Some("Parallel Test Ledger".to_string())
+    );
+
+    // No errors expected
+    assert!(
+        ledger.errors.is_empty(),
+        "Parallel loading should produce no errors. Got: {:?}",
+        ledger.errors
+    );
+
+    // Source map should have 4 files (root + 3 includes)
+    assert_eq!(
+        ledger.source_map.files().len(),
+        4,
+        "Source map should have 4 files"
+    );
+}


### PR DESCRIPTION
## Summary

Parallelize reading and parsing of sibling include files using rayon. When a beancount file includes multiple files (e.g., `include "2024/*.beancount"`), they are now loaded concurrently instead of sequentially.

## How It Works

```
Sequential (before):
  parse root → read+parse child1 → read+parse child2 → read+parse child3

Parallel (after):
  parse root → [read+parse child1, child2, child3] in parallel → merge
```

When `load_recursive` encounters N > 1 sibling includes:
1. Normalize and security-check all paths (sequential, fast)
2. Read + parse all N files in parallel via `rayon::par_iter`
3. Merge results sequentially via `merge_parsed_file` — preserves include order, processes nested includes recursively

## Design Decisions

- **Only for DiskFileSystem**: Virtual filesystems (VFS) may use shared mutable state. Added `supports_parallel_read()` trait method.
- **Nested includes supported**: If a parallelly-loaded file contains its own includes, those are handled via recursive `load_recursive` calls during the merge phase.
- **Single-file fallback**: When only one include is found, uses the existing sequential path (no rayon overhead).
- **Encrypted file fallback**: GPG-encrypted files use the sequential path since decryption isn't parallelized.

## Expected Impact

For a typical multi-file ledger (15+ year files + prices):
- **Before**: 15 sequential read+parse operations
- **After**: 1 root parse + 15 parallel read+parse + sequential merge
- **Estimated speedup**: 2-4x on the file loading stage (depends on core count and I/O)

Single-file ledgers see no change (no parallel overhead).

## Test plan

- [x] `cargo test -p rustledger-loader --all-features` — 96 tests pass
- [x] `cargo clippy -p rustledger-loader --all-features --all-targets -- -D warnings` — clean
- [x] Existing multi-file test fixtures (includes, globs, cycles) pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)