### PR TITLE
fix: support full Unicode in account names (Cyrillic, CJK, Arabic, etc.)

### DIFF
--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -575,8 +575,9 @@ impl Options {
 
     /// Check if a value looks like a valid account name.
     ///
-    /// Valid accounts have format "Type:Subaccount:..." where Type starts with
-    /// uppercase letter and subaccounts are colon-separated.
+    /// Valid accounts have format "Type:Subaccount:..." where each component
+    /// starts with an uppercase letter (any script) or a non-ASCII letter
+    /// without case (CJK, etc.), and components are colon-separated.
     fn is_valid_account(value: &str) -> bool {
         // Must contain at least one colon
         if !value.contains(':') {
@@ -585,9 +586,10 @@ impl Options {
 
         // Check each component
         for part in value.split(':') {
-            // First char of each component should be uppercase letter
             if let Some(first) = part.chars().next() {
-                if !first.is_ascii_uppercase() {
+                // Accept: uppercase (any script), non-ASCII alphabetic (CJK, etc.)
+                let valid = first.is_uppercase() || (!first.is_ascii() && first.is_alphabetic());
+                if !valid {
                     return false;
                 }
             } else {
@@ -831,13 +833,17 @@ mod tests {
 
     #[test]
     fn test_is_valid_account() {
-        // Valid accounts
+        // Valid accounts — ASCII
         assert!(Options::is_valid_account("Assets:Bank"));
         assert!(Options::is_valid_account("Equity:Rounding:Precision"));
 
+        // Valid accounts — Unicode
+        assert!(Options::is_valid_account("Капитал:Retained"));
+        assert!(Options::is_valid_account("资产:银行:支票"));
+
         // Invalid accounts
         assert!(!Options::is_valid_account("invalid")); // No colon
-        assert!(!Options::is_valid_account("assets:bank")); // Lowercase
+        assert!(!Options::is_valid_account("assets:bank")); // Lowercase ASCII
         assert!(!Options::is_valid_account("Assets:")); // Empty component
         assert!(!Options::is_valid_account(":Bank")); // Empty first component
     }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -902,8 +902,8 @@ mod tests {
     /// previous behavior where Unicode was accepted.
     #[test]
     fn test_unicode_account_names_issue_572() {
-        // File with Russian account type names — these now produce parse errors
-        // because beancount v3 restricts account names to ASCII characters only.
+        // File with Russian account type names — Unicode account names are
+        // fully supported (Cyrillic, CJK, etc.). See issue #816.
         let source = r#"option "name_assets" "Активы"
 option "name_liabilities" "Обязательства"
 option "name_income" "Доходы"
@@ -917,23 +917,21 @@ option "name_equity" "Капитал"
 "#;
 
         let result = parse(source);
-        // Per beancount v3, Unicode account names are rejected at parse time.
         assert!(
-            !result.errors.is_empty(),
-            "Unicode account names should produce parse errors per the beancount v3 spec"
+            result.errors.is_empty(),
+            "Unicode account names should parse without errors: {:?}",
+            result
+                .errors
+                .iter()
+                .map(|e| e.message())
+                .collect::<Vec<_>>()
         );
 
-        // Verify the diagnostics layer produces ERROR diagnostics (not just parse errors).
+        // No parse errors means no diagnostics from this layer.
         let diagnostics = parse_errors_to_diagnostics(&result, source);
         assert!(
-            !diagnostics.is_empty(),
-            "Unicode account name errors should produce LSP diagnostics"
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|d| d.severity == Some(DiagnosticSeverity::ERROR)),
-            "At least one diagnostic should be ERROR severity"
+            diagnostics.is_empty(),
+            "Valid Unicode accounts should produce no diagnostics"
         );
     }
 

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -55,23 +55,23 @@ pub enum Token<'src> {
     #[regex(r#""([^"\\]|\\.)*""#)]
     String(&'src str),
 
-    /// An account name like Assets:Bank:Checking, Aktiva:Banque-Épargne, or Assets:Müller.
-    /// Must start with a capitalized word (account type prefix) and have at least one sub-account.
+    /// An account name like Assets:Bank:Checking, Капитал:Retained-Earnings,
+    /// or 资产:银行:支票.
     ///
-    /// Per the beancount v3 spec (`formats/beancount/v3/spec/lexical.md`):
+    /// Each component starts with an uppercase letter (Unicode `\p{Lu}`) or
+    /// digit, followed by letters, digits, or hyphens. Full Unicode is
+    /// supported in all positions — Cyrillic, CJK, Arabic, etc.
     ///
-    /// ```text
-    /// component = ascii_start (alphanumeric_dash | utf8_char)*
-    /// ```
-    ///
-    /// Each segment must START with an ASCII uppercase letter (or digit, for
-    /// sub-segments), but subsequent characters may include Unicode letters —
-    /// e.g. `Banque-Épargne` (French), `Müller` (German), `CorpJP日本` after an
-    /// ASCII start. Symbols, emoji, and non-letter Unicode are not allowed, and
-    /// segments starting with non-ASCII are still rejected (matching beancount).
+    /// Note: The beancount v3 spec restricts the first character to ASCII
+    /// `[A-Z]`, but this is an artifact of the C flex lexer's poor Unicode
+    /// support, not a meaningful language design choice. Every non-Latin
+    /// user is affected (see beancount/beancount#161, #398, #733). Python
+    /// beancount v2 partially supports `\p{Lu}` but is inconsistent
+    /// (beancount/beancount#377). Rustledger uses `\p{Lu}` throughout for
+    /// correct Unicode uppercase handling.
     ///
     /// The account type prefix is validated later against options (`name_assets`, etc.).
-    #[regex(r"[A-Z][\p{L}0-9-]*(:([A-Z0-9][\p{L}0-9-]*)+)+")]
+    #[regex(r"[\p{Lu}\p{Lo}\p{Lt}][\p{L}0-9-]*(:([\p{Lu}\p{Lo}\p{Lt}0-9][\p{L}0-9-]*)+)+")]
     Account(&'src str),
 
     /// A currency/commodity code like USD, EUR, AAPL, BTC, or single-char tickers like T, V, F.
@@ -561,12 +561,10 @@ mod tests {
 
     #[test]
     fn test_tokenize_account_unicode() {
-        // Per the beancount v3 spec, account name segments must START with an
-        // ASCII uppercase letter (or digit for sub-segments), but subsequent
-        // characters may include Unicode letters. Symbols/emoji and segments
-        // that start with non-ASCII remain invalid.
+        // Unicode uppercase letters and CJK characters are valid at the
+        // start of account components. Emoji and symbols are not.
 
-        // Non-letter (emoji) after valid ASCII start - tokenizes as partial Account + Error
+        // Non-letter (emoji) after valid ASCII start — still invalid
         let tokens = tokenize("Assets:CORP✨");
         assert!(
             !matches!(tokens[0].0, Token::Account("Assets:CORP✨")),
@@ -577,26 +575,32 @@ mod tests {
             "Unicode emoji should produce at least one Error token"
         );
 
-        // Sub-component starts with non-ASCII (CJK) — should be rejected
+        // CJK sub-component start — now valid (CJK ideographs are \p{Lo})
         let tokens = tokenize("Assets:沪深300");
         assert!(
-            !matches!(tokens[0].0, Token::Account("Assets:沪深300")),
-            "CJK characters at the start of a sub-component should not tokenize as a valid Account"
-        );
-        assert!(
-            tokens.iter().any(|(t, _)| matches!(t, Token::Error(_))),
-            "CJK start should produce at least one Error token"
+            matches!(tokens[0].0, Token::Account("Assets:沪深300")),
+            "CJK characters at the start of a sub-component should tokenize as Account"
         );
 
-        // Full CJK component - sub-component starts with non-ASCII, should be rejected
+        // Full CJK sub-component — valid
         let tokens = tokenize("Assets:日本銀行");
         assert!(
-            !matches!(tokens[0].0, Token::Account("Assets:日本銀行")),
-            "CJK sub-component start should not tokenize as a valid Account"
+            matches!(tokens[0].0, Token::Account("Assets:日本銀行")),
+            "CJK sub-component should tokenize as Account"
         );
+
+        // Cyrillic account type — valid (Cyrillic uppercase is \p{Lu})
+        let tokens = tokenize("Капитал:Retained");
         assert!(
-            tokens.iter().any(|(t, _)| matches!(t, Token::Error(_))),
-            "CJK sub-component start should produce at least one Error token"
+            matches!(tokens[0].0, Token::Account("Капитал:Retained")),
+            "Cyrillic-starting account should tokenize as Account"
+        );
+
+        // Fully CJK account — valid
+        let tokens = tokenize("资产:银行:支票");
+        assert!(
+            matches!(tokens[0].0, Token::Account("资产:银行:支票")),
+            "Fully CJK account should tokenize as Account"
         );
     }
 

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -58,17 +58,15 @@ pub enum Token<'src> {
     /// An account name like Assets:Bank:Checking, Капитал:Retained-Earnings,
     /// or 资产:银行:支票.
     ///
-    /// Each component starts with an uppercase letter (Unicode `\p{Lu}`) or
-    /// digit, followed by letters, digits, or hyphens. Full Unicode is
-    /// supported in all positions — Cyrillic, CJK, Arabic, etc.
+    /// The first component starts with an uppercase letter (`\p{Lu}`), a
+    /// letter without case like CJK ideographs (`\p{Lo}`), or a titlecase
+    /// letter (`\p{Lt}`). Sub-components may also start with a digit.
+    /// Subsequent characters can be any Unicode letter, digit, or hyphen.
     ///
     /// Note: The beancount v3 spec restricts the first character to ASCII
     /// `[A-Z]`, but this is an artifact of the C flex lexer's poor Unicode
-    /// support, not a meaningful language design choice. Every non-Latin
-    /// user is affected (see beancount/beancount#161, #398, #733). Python
-    /// beancount v2 partially supports `\p{Lu}` but is inconsistent
-    /// (beancount/beancount#377). Rustledger uses `\p{Lu}` throughout for
-    /// correct Unicode uppercase handling.
+    /// support, not a meaningful language design choice (see
+    /// beancount/beancount#161, #398, #733).
     ///
     /// The account type prefix is validated later against options (`name_assets`, etc.).
     #[regex(r"[\p{Lu}\p{Lo}\p{Lt}][\p{L}0-9-]*(:([\p{Lu}\p{Lo}\p{Lt}0-9][\p{L}0-9-]*)+)+")]

--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -2180,18 +2180,21 @@ mod tests {
     }
 
     #[test]
-    fn test_unicode_account_produces_invalid_account_error() {
+    fn test_unicode_account_parses_successfully() {
+        // Cyrillic accounts are valid — Unicode uppercase letters (\p{Lu})
+        // and CJK ideographs (\p{Lo}) are accepted at component start.
         let source = "2024-01-01 open Активы:Банк\n";
         let result = parse(source);
         assert!(
-            !result.errors.is_empty(),
-            "Unicode account should produce a parse error"
+            result.errors.is_empty(),
+            "Cyrillic account should parse without errors, got: {:?}",
+            result
+                .errors
+                .iter()
+                .map(ParseError::message)
+                .collect::<Vec<_>>()
         );
-        let msg = result.errors[0].message();
-        assert!(
-            msg.contains("Invalid account"),
-            "Unicode account error should contain 'Invalid account', got: {msg}"
-        );
+        assert_eq!(result.directives.len(), 1, "Should have 1 directive");
     }
 
     // ============================================================================

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -844,15 +844,21 @@ fn test_reject_pad_without_source_account() {
 }
 
 /// Case: unicode-account-name
-/// Account name segments must use only ASCII letters, digits, and hyphens
-/// per the beancount v3 spec. Unicode characters are rejected.
+/// Unicode letters (CJK, Cyrillic, etc.) are valid in account names.
+/// This extends beyond the beancount v3 spec's ASCII restriction, which
+/// was an artifact of the C flex lexer's poor Unicode support.
 #[test]
-fn test_reject_unicode_account_name() {
+fn test_accept_unicode_account_name() {
     let source = "2024-01-01 open Assets:銀行口座\n";
     let result = parse(source);
     assert!(
-        !result.errors.is_empty(),
-        "expected parse error for Unicode characters in account name"
+        result.errors.is_empty(),
+        "Unicode account names should parse successfully, got: {:?}",
+        result
+            .errors
+            .iter()
+            .map(rustledger_parser::ParseError::message)
+            .collect::<Vec<_>>()
     );
 }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -1334,13 +1334,11 @@ mod tests {
             "Equity:Opening-Balances",
             "Income:Salary2024",
             "Expenses:Food:Restaurant",
-            "Assets:401k",          // Component starting with digit
-            "Assets:CORP✨",        // Emoji in component (beancount UTF-8-ONLY support)
-            "Assets:沪深300",       // CJK characters
-            "Assets:Café",          // Non-ASCII letter (é)
-            "Assets:日本銀行",      // Full non-ASCII component
-            "Assets:Test💰Account", // Emoji in middle
-            "Assets:€uro",          // Currency symbol at start of component
+            "Assets:401k",     // Component starting with digit
+            "Assets:沪深300",  // CJK characters
+            "Assets:Café",     // Non-ASCII letter (é)
+            "Assets:日本銀行", // Full non-ASCII component
+            "Assets:Капитал",  // Cyrillic sub-account
         ];
 
         for name in valid_names {

--- a/crates/rustledger-validate/src/validators/helpers.rs
+++ b/crates/rustledger-validate/src/validators/helpers.rs
@@ -49,8 +49,7 @@ pub fn validate_account_name(account: &str, account_types: &[String]) -> Option<
             ));
         }
 
-        // Remaining characters: ASCII letters, ASCII digits, hyphens, or any non-ASCII character.
-        // This matches beancount's lexer.l: `([A-Za-z0-9-]|UTF-8-ONLY)*`
+        // Remaining characters: letters (any script), digits, or hyphens.
         for c in part.chars().skip(1) {
             if !c.is_ascii_alphanumeric() && c != '-' && c.is_ascii() {
                 return Some(format!(

--- a/crates/rustledger-validate/src/validators/helpers.rs
+++ b/crates/rustledger-validate/src/validators/helpers.rs
@@ -31,20 +31,18 @@ pub fn validate_account_name(account: &str, account_types: &[String]) -> Option<
             return Some(format!("component {} is empty", i + 1));
         }
 
-        // First character must be uppercase ASCII letter, ASCII digit, or any non-ASCII character.
-        // This matches beancount's lexer.l: `([A-Z]|UTF-8-ONLY)` for account type start,
-        // and `([A-Z0-9]|UTF-8-ONLY)` for sub-account start.
-        // Non-ASCII includes CJK, emojis, symbols, and any other Unicode character.
-        // Safety: we just checked part.is_empty() above, so this is guaranteed to succeed
+        // First character must be an uppercase letter (any script) or digit.
+        // Unicode uppercase (\p{Lu}) covers Latin A-Z, Cyrillic А-Я, etc.
+        // Non-ASCII non-letter characters (CJK ideographs, etc.) are also
+        // accepted as they have no case distinction.
         let Some(first_char) = part.chars().next() else {
-            // This branch is unreachable due to the is_empty check above,
-            // but we handle it defensively to avoid unwrap
             return Some(format!("component {} is empty", i + 1));
         };
-        // Accept: uppercase ASCII letters, ASCII digits, or any non-ASCII character
-        let is_valid_start = first_char.is_ascii_uppercase()
+        // Accept: uppercase letters (any script), digits, or non-ASCII
+        // characters without case (CJK, Arabic, etc.)
+        let is_valid_start = first_char.is_uppercase()
             || first_char.is_ascii_digit()
-            || !first_char.is_ascii();
+            || (!first_char.is_ascii() && !first_char.is_lowercase());
         if !is_valid_start {
             return Some(format!(
                 "component '{part}' must start with uppercase letter or digit"

--- a/crates/rustledger-validate/src/validators/helpers.rs
+++ b/crates/rustledger-validate/src/validators/helpers.rs
@@ -41,10 +41,11 @@ pub fn validate_account_name(account: &str, account_types: &[String]) -> Option<
             return Some(format!("component {} is empty", i + 1));
         };
         // Accept: uppercase letters (any script), digits, or non-ASCII
-        // characters without case (CJK, Arabic, etc.)
+        // letters without case (CJK ideographs, etc.). Matches the lexer
+        // regex [\p{Lu}\p{Lo}\p{Lt}0-9].
         let is_valid_start = first_char.is_uppercase()
             || first_char.is_ascii_digit()
-            || (!first_char.is_ascii() && !first_char.is_lowercase());
+            || (!first_char.is_ascii() && first_char.is_alphabetic());
         if !is_valid_start {
             return Some(format!(
                 "component '{part}' must start with uppercase letter or digit"

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -301,6 +301,8 @@ Type:Category:Subcategory:Detail
 
 ### Root Types
 
+The defaults are English, but can be customized to any language via options:
+
 | Type | Purpose |
 |------|---------|
 | `Assets` | What you own (positive = good) |
@@ -308,6 +310,16 @@ Type:Category:Subcategory:Detail
 | `Equity` | Net worth adjustments |
 | `Income` | Money coming in (negative in ledger) |
 | `Expenses` | Money going out (positive in ledger) |
+
+Account names support full Unicode — Cyrillic, CJK, Arabic, etc.:
+
+```beancount
+option "name_equity" "Капитал"
+option "name_assets" "资产"
+
+2024-01-01 open Капитал:Opening-Balances
+2024-01-01 open 资产:银行:支票 CNY
+```
 
 ### Naming Conventions
 


### PR DESCRIPTION
## Summary

Allow account name components to start with any Unicode uppercase letter or CJK ideograph, not just ASCII `[A-Z]`.

## Before / After

```beancount
; BEFORE: parse error
option "name_equity" "Капитал"
2024-01-01 open Капитал:Retained-Earnings  ; ❌ "Invalid account"

; AFTER: works
option "name_equity" "Капитал"
2024-01-01 open Капитал:Retained-Earnings  ; ✓

; Also works:
option "name_assets" "资产"
2024-01-01 open 资产:银行:支票  ; ✓ CJK
```

## Why

The beancount v3 spec restricts account components to start with ASCII `[A-Z]`. This is an artifact of the C flex lexer's poor Unicode support, not a meaningful language design choice. It has been a longstanding pain point for non-Latin users:

- [beancount#161](https://github.com/beancount/beancount/issues/161) (2015) — Russian user, Blais said "will come after 1.0". Never came.
- [beancount#398](https://github.com/beancount/beancount/issues/398) (2017) — CJK users requesting logogram support. Still open.
- [beancount#733](https://github.com/beancount/beancount/issues/733) (2023) — Chinese user. Still open.
- [beancount#377](https://github.com/beancount/beancount/issues/377) — Python beancount v2's regex uses `\p{Lu}` but `is_root_account()` still uses `[A-Z]`. Inconsistent.

Python beancount v2 partially supports Unicode uppercase via `\p{Lu}` in the account regex, but internal functions are inconsistent. Rustledger now fully supports it throughout.

## Change

Lexer regex: `[A-Z]` → `[\p{Lu}\p{Lo}\p{Lt}]`

- `\p{Lu}` — Unicode uppercase letters (Latin A-Z, Cyrillic А-Я, Greek Α-Ω, etc.)
- `\p{Lo}` — Letters without case (CJK ideographs, Arabic, Hebrew, etc.)
- `\p{Lt}` — Titlecase letters

Emoji and symbols remain rejected (not letters).

## Test plan

- [x] Cyrillic accounts: `Капитал:Retained-Earnings` ✓
- [x] CJK accounts: `资产:银行:支票` ✓
- [x] Mixed: `Assets:銀行口座` ✓
- [x] Emoji still rejected: `Assets:CORP✨` ✗
- [x] All existing tests pass (parser, validator, loader)
- [x] Clippy clean

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)