### PR TITLE
fix(ci): handle new crates.io "already exists" error message

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -101,7 +101,7 @@ jobs:
               # Wait for crates.io to index the crate before publishing dependents
               echo "Waiting 30s for crates.io indexing..."
               sleep 30
-            elif grep -q "already been uploaded" /tmp/publish.log; then
+            elif grep -qE "already (been uploaded|exists on)" /tmp/publish.log; then
               echo "✓ $crate already published (skipping)"
             elif grep -q "Trusted Publishing tokens do not support creating new crates" /tmp/publish.log; then
               echo "⚠ $crate is a new crate - must be published manually first"


### PR DESCRIPTION
## Problem

The v0.12.0 release-publish workflow failed because `cargo publish` now returns `"already exists on crates.io index"` instead of the previous `"already been uploaded"` message. The grep pattern in the publish script didn't match, causing already-published crates to be treated as failures.

This left 5 crates unpublished on crates.io:
- `rustledger-query`, `rustledger-importer`, `rustledger-lsp`, `rustledger-wasm`, `rustledger`

## Fix

Update the grep pattern to match both message variants:
```bash
# Before
grep -q "already been uploaded"

# After  
grep -qE "already (been uploaded|exists on)"
```

## After merging

Re-run the release-publish workflow to publish the remaining crates:
```bash
gh workflow run release-publish.yml -f tag=v0.12.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)