### PR TITLE
chore(deps): bump hono from 4.12.12 to 4.12.14 in /packages/mcp-server

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustledger/mcp-server",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -1657,9 +1657,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Bumps [hono](https://github.com/honojs/hono) from 4.12.12 to 4.12.14 in `/packages/mcp-server`.

### Security fix (v4.12.14)
- **Improper handling of JSX attribute names in hono/jsx SSR** (GHSA-458j-xx4x-4375): Fixes missing validation of JSX attribute names during server-side rendering, which could allow malformed attribute keys to corrupt the generated HTML output and inject unintended attributes or elements.

### Other changes (v4.12.13)
- fix(types): infer response type from last handler in app.on 9-/10-handler overloads
- feat(trailing-slash): add `skip` option
- feat(cache): add `onCacheNotAvailable` option
- fix(aws-lambda): handle invalid header names in request processing

Supersedes #821 (dependabot PR).