### PR TITLE
chore: add compatibility testing scripts

### DIFF
--- a/scripts/analyze-compat-results.py
+++ b/scripts/analyze-compat-results.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Analyze Compatibility Test Results
+
+Generates a detailed root cause analysis of mismatches between
+Python beancount and rustledger.
+
+Usage:
+    python scripts/analyze-compat-results.py [results_dir]
+"""
+
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    """Load a JSONL file, skipping malformed lines."""
+    results = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    results.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # Skip malformed JSON lines (may occur from truncated output or encoding issues)
+                    continue
+    return results
+
+
+def analyze_check_results(results: list[dict]) -> dict:
+    """Analyze bean-check vs rledger check results."""
+    analysis = {
+        "total": len(results),
+        "matching": 0,
+        "mismatching": 0,
+        "categories": Counter(),
+        "mismatch_patterns": defaultdict(list),
+    }
+
+    for r in results:
+        if r.get("match"):
+            analysis["matching"] += 1
+        else:
+            analysis["mismatching"] += 1
+
+            # Categorize the mismatch
+            py = r.get("python", {})
+            rs = r.get("rust", {})
+            py_exit = py.get("exit", -1)
+            rs_exit = rs.get("exit", -1)
+            py_parse_err = py.get("parse_error", False)
+            rs_parse_err = rs.get("parse_error", False)
+
+            if py_exit == 0 and rs_exit != 0:
+                category = "python_pass_rust_fail"
+            elif py_exit != 0 and rs_exit == 0:
+                category = "python_fail_rust_pass"
+            elif py_parse_err and not rs_parse_err:
+                category = "python_parse_error_only"
+            elif rs_parse_err and not py_parse_err:
+                category = "rust_parse_error_only"
+            else:
+                category = "different_errors"
+
+            analysis["categories"][category] += 1
+            analysis["mismatch_patterns"][category].append(r.get("file", "unknown"))
+
+    return analysis
+
+
+def analyze_bql_results(results: list[dict]) -> dict:
+    """Analyze BQL query results."""
+    analysis = {
+        "total": len(results),
+        "matching": 0,
+        "mismatching": 0,
+        "categories": Counter(),
+        "by_query": defaultdict(lambda: {"match": 0, "mismatch": 0}),
+        "sample_failures": defaultdict(list),
+    }
+
+    for r in results:
+        query = r.get("query", "unknown")[:40]  # Truncate for display
+        category = r.get("category", "unknown")
+
+        if r.get("match"):
+            analysis["matching"] += 1
+            analysis["by_query"][query]["match"] += 1
+        else:
+            analysis["mismatching"] += 1
+            analysis["by_query"][query]["mismatch"] += 1
+            analysis["categories"][category] += 1
+
+            if len(analysis["sample_failures"][category]) < 3:
+                analysis["sample_failures"][category].append({
+                    "file": r.get("file", "unknown"),
+                    "query": query,
+                    "py_rows": r.get("py_rows", "?"),
+                    "rs_rows": r.get("rs_rows", "?"),
+                })
+
+    return analysis
+
+
+def analyze_ast_results(results: list[dict]) -> dict:
+    """Analyze AST/directive comparison results."""
+    analysis = {
+        "total": len(results),
+        "full_match": 0,
+        "partial_match": 0,
+        "mismatch": 0,
+        "issues": Counter(),
+        "sample_issues": [],
+    }
+
+    for r in results:
+        if r.get("full_match"):
+            analysis["full_match"] += 1
+        else:
+            if r.get("accounts_match") and r.get("posting_count_match"):
+                analysis["partial_match"] += 1
+            else:
+                analysis["mismatch"] += 1
+
+            # Track specific issues
+            if not r.get("accounts_match"):
+                analysis["issues"]["accounts_differ"] += 1
+            if not r.get("posting_count_match"):
+                analysis["issues"]["posting_count_differs"] += 1
+            if not r.get("error_count_match"):
+                analysis["issues"]["error_presence_differs"] += 1
+
+            # Sample issues
+            if len(analysis["sample_issues"]) < 5:
+                sample = {"file": r.get("file", "unknown")}
+                if r.get("accounts_only_python"):
+                    sample["py_only_accounts"] = r["accounts_only_python"][:3]
+                if r.get("accounts_only_rust"):
+                    sample["rs_only_accounts"] = r["accounts_only_rust"][:3]
+                if r.get("posting_count_diff"):
+                    sample["posting_diff"] = r["posting_count_diff"]
+                analysis["sample_issues"].append(sample)
+
+    return analysis
+
+
+def print_report(results_dir: Path):
+    """Print a comprehensive analysis report."""
+    print("=" * 70)
+    print("COMPATIBILITY ROOT CAUSE ANALYSIS")
+    print("=" * 70)
+    print()
+
+    # Find most recent results
+    check_files = sorted(results_dir.glob("results_*.jsonl"), reverse=True)
+    bql_files = sorted(results_dir.glob("bql_results_*.jsonl"), reverse=True)
+    ast_files = sorted(results_dir.glob("ast_results_*.jsonl"), reverse=True)
+
+    # Analyze check results
+    if check_files:
+        print("## Check Results (bean-check vs rledger check)")
+        print("-" * 50)
+        data = load_jsonl(check_files[0])
+        analysis = analyze_check_results(data)
+
+        match_pct = analysis["matching"] * 100 // analysis["total"] if analysis["total"] else 0
+        print(f"Files tested:  {analysis['total']}")
+        print(f"Matching:      {analysis['matching']} ({match_pct}%)")
+        print(f"Mismatching:   {analysis['mismatching']}")
+        print()
+
+        if analysis["categories"]:
+            print("Mismatch breakdown:")
+            for cat, count in analysis["categories"].most_common():
+                print(f"  {cat}: {count}")
+                # Show sample files
+                samples = analysis["mismatch_patterns"][cat][:3]
+                for f in samples:
+                    print(f"    - {f}")
+        print()
+
+    # Analyze BQL results
+    if bql_files:
+        print("## BQL Query Results")
+        print("-" * 50)
+        data = load_jsonl(bql_files[0])
+        analysis = analyze_bql_results(data)
+
+        match_pct = analysis["matching"] * 100 // analysis["total"] if analysis["total"] else 0
+        print(f"Queries tested: {analysis['total']}")
+        print(f"Matching:       {analysis['matching']} ({match_pct}%)")
+        print(f"Mismatching:    {analysis['mismatching']}")
+        print()
+
+        if analysis["categories"]:
+            print("Mismatch categories:")
+            for cat, count in analysis["categories"].most_common():
+                print(f"  {cat}: {count}")
+
+            print()
+            print("Sample failures by category:")
+            for cat, samples in analysis["sample_failures"].items():
+                print(f"  [{cat}]")
+                for s in samples:
+                    print(f"    {s['file']}: {s['query']} (py={s['py_rows']}, rs={s['rs_rows']})")
+        print()
+
+        print("Match rate by query type:")
+        for query, stats in sorted(analysis["by_query"].items()):
+            total = stats["match"] + stats["mismatch"]
+            pct = stats["match"] * 100 // total if total else 0
+            status = "OK" if pct >= 80 else "WARN" if pct >= 50 else "FAIL"
+            print(f"  [{status}] {query}... {stats['match']}/{total} ({pct}%)")
+        print()
+
+    # Analyze AST results
+    if ast_files:
+        print("## AST/Directive Results")
+        print("-" * 50)
+        data = load_jsonl(ast_files[0])
+        analysis = analyze_ast_results(data)
+
+        match_pct = analysis["full_match"] * 100 // analysis["total"] if analysis["total"] else 0
+        print(f"Files tested:  {analysis['total']}")
+        print(f"Full match:    {analysis['full_match']} ({match_pct}%)")
+        print(f"Partial match: {analysis['partial_match']}")
+        print(f"Mismatch:      {analysis['mismatch']}")
+        print()
+
+        if analysis["issues"]:
+            print("Issue types:")
+            for issue, count in analysis["issues"].most_common():
+                print(f"  {issue}: {count}")
+
+        if analysis["sample_issues"]:
+            print()
+            print("Sample issues:")
+            for s in analysis["sample_issues"]:
+                print(f"  {s['file']}:")
+                if "py_only_accounts" in s:
+                    print(f"    Python-only accounts: {s['py_only_accounts']}")
+                if "rs_only_accounts" in s:
+                    print(f"    Rust-only accounts: {s['rs_only_accounts']}")
+                if "posting_diff" in s:
+                    print(f"    Posting count diff: {s['posting_diff']:+d}")
+        print()
+
+    # Summary recommendations
+    print("=" * 70)
+    print("RECOMMENDATIONS")
+    print("=" * 70)
+    print()
+    print("1. rust_empty issues: Investigate why Rust returns no data for some queries")
+    print("   - Check if certain directives are not being parsed")
+    print("   - Verify BQL FROM clause is processing all entries")
+    print()
+    print("2. python_empty issues: May indicate Rust parsing additional entries")
+    print("   - Could be auto-generated entries (prices, opens)")
+    print("   - Check plugin behavior differences")
+    print()
+    print("3. data_diff issues: Row counts match but values differ")
+    print("   - Check sorting/ordering differences")
+    print("   - Verify numeric formatting (decimal places)")
+    print()
+    print("4. accounts_differ: Account extraction differences")
+    print("   - Check implicit account generation (auto_accounts plugin)")
+    print("   - Verify Open directive parsing")
+    print()
+
+
+def main():
+    if len(sys.argv) > 1:
+        results_dir = Path(sys.argv[1])
+    else:
+        results_dir = Path("tests/compatibility-results")
+
+    if not results_dir.exists():
+        print(f"Error: Results directory not found: {results_dir}")
+        sys.exit(1)
+
+    print_report(results_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compat-ast-test.py
+++ b/scripts/compat-ast-test.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""
+AST/Directive Comparison Test (Parallel)
+
+Compares the parsed output between Python beancount and rustledger,
+going beyond exit codes to compare:
+- Directive counts by type
+- Extracted accounts
+- Transaction counts
+- Error counts
+
+Usage:
+    python scripts/compat-ast-test.py [directory]
+    python scripts/compat-ast-test.py tests/compatibility/files
+
+Environment variables:
+    PARALLEL_JOBS: Number of parallel workers (default: CPU count, max 8)
+"""
+
+import json
+import subprocess
+import sys
+import os
+import multiprocessing
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Try to import beancount
+try:
+    from beancount import loader
+    from beancount.core import data
+    BEANCOUNT_AVAILABLE = True
+except ImportError:
+    BEANCOUNT_AVAILABLE = False
+    print("Warning: beancount not installed, Python comparison disabled")
+
+# Parallel settings
+MAX_WORKERS = min(int(os.environ.get('PARALLEL_JOBS', multiprocessing.cpu_count())), 16)
+
+
+@dataclass
+class ParseResult:
+    """Result of parsing a beancount file."""
+    accounts: set = field(default_factory=set)
+    directive_counts: dict = field(default_factory=dict)
+    total_directives: int = 0
+    error_count: int = 0
+    transaction_count: int = 0
+    posting_count: int = 0  # COUNT(*) in BQL counts postings
+    balance_count: int = 0
+    open_count: int = 0
+    price_count: int = 0
+    raw_errors: list = field(default_factory=list)
+
+
+@dataclass
+class ComparisonResult:
+    """Result of comparing Python vs Rust parsing."""
+    file: str
+    python: Optional[ParseResult]
+    rust: Optional[ParseResult]
+
+    # Comparison flags
+    accounts_match: bool = False
+    posting_count_match: bool = False
+    error_count_match: bool = False
+
+    # Differences
+    accounts_only_python: set = field(default_factory=set)
+    accounts_only_rust: set = field(default_factory=set)
+    posting_count_diff: int = 0  # rust - python
+
+    @property
+    def full_match(self) -> bool:
+        return (self.accounts_match and
+                self.posting_count_match and
+                self.error_count_match)
+
+
+def parse_with_python(file_path: Path) -> Optional[ParseResult]:
+    """Parse a file with Python beancount and extract structured data."""
+    if not BEANCOUNT_AVAILABLE:
+        return None
+
+    try:
+        entries, errors, options = loader.load_file(str(file_path))
+    except Exception as e:
+        return ParseResult(error_count=1, raw_errors=[str(e)])
+
+    result = ParseResult()
+    result.error_count = len(errors)
+    result.raw_errors = [str(e) for e in errors[:5]]  # Keep first 5
+    result.total_directives = len(entries)
+
+    type_counts = Counter()
+    for entry in entries:
+        type_name = type(entry).__name__
+        type_counts[type_name] += 1
+
+        if isinstance(entry, data.Open):
+            result.open_count += 1
+        elif isinstance(entry, data.Transaction):
+            result.transaction_count += 1
+            result.posting_count += len(entry.postings)
+        elif isinstance(entry, data.Balance):
+            result.balance_count += 1
+        elif isinstance(entry, data.Price):
+            result.price_count += 1
+
+    result.directive_counts = dict(type_counts)
+
+    # Get accounts via BQL (fair comparison with Rust side)
+    try:
+        proc = subprocess.run(
+            ["bean-query", str(file_path), "SELECT DISTINCT account ORDER BY account"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if proc.returncode == 0:
+            for line in proc.stdout.strip().split('\n')[2:]:
+                line = line.strip()
+                if line and not line.startswith('-') and 'row(s)' not in line:
+                    result.accounts.add(line)
+    except Exception as e:
+        result.raw_errors.append(f"accounts query: {e}")
+
+    return result
+
+
+def parse_with_rust(file_path: Path, rledger: str) -> Optional[ParseResult]:
+    """Parse a file with rustledger and extract structured data."""
+    result = ParseResult()
+
+    # Get error count from rledger check --format json
+    try:
+        proc = subprocess.run(
+            [rledger, "check", "--format", "json", str(file_path)],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if proc.stdout.strip():
+            data = json.loads(proc.stdout)
+            result.error_count = data.get("error_count", 0)
+            result.raw_errors = [d.get("message", "") for d in data.get("diagnostics", [])[:5]]
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, Exception) as e:
+        result.raw_errors = [str(e)]
+        return result
+
+    # Get accounts via BQL
+    try:
+        proc = subprocess.run(
+            [rledger, "query", str(file_path), "SELECT DISTINCT account ORDER BY account"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if proc.returncode == 0:
+            # Parse the table output
+            lines = proc.stdout.strip().split('\n')
+            for line in lines[2:]:  # Skip header and separator
+                if line.strip() and not line.startswith('-') and 'row(s)' not in line:
+                    result.accounts.add(line.strip())
+    except Exception as e:
+        # BQL query failure is non-fatal; record error and continue with empty accounts set
+        result.raw_errors.append(f"accounts query: {e}")
+
+    # Get posting count via BQL (COUNT(*) counts postings)
+    try:
+        proc = subprocess.run(
+            [rledger, "query", str(file_path), "SELECT COUNT(*)"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if proc.returncode == 0:
+            lines = proc.stdout.strip().split('\n')
+            for line in lines[2:]:  # Skip header and separator
+                line = line.strip()
+                if line and not line.startswith('-') and 'row(s)' not in line:
+                    try:
+                        result.posting_count = int(line)
+                    except ValueError:
+                        # Non-integer lines (headers/footers) are expected; ignore them
+                        pass
+                    break
+    except Exception as e:
+        # BQL query failure is non-fatal; record error and continue with posting_count=0
+        result.raw_errors.append(f"posting count query: {e}")
+
+    return result
+
+
+def compare_results(file_path: str, python: Optional[ParseResult], rust: Optional[ParseResult]) -> ComparisonResult:
+    """Compare Python and Rust parsing results."""
+    result = ComparisonResult(file=file_path, python=python, rust=rust)
+
+    if python is None or rust is None:
+        return result
+
+    # Compare accounts
+    result.accounts_only_python = python.accounts - rust.accounts
+    result.accounts_only_rust = rust.accounts - python.accounts
+    # Only compare accounts when both tools report no errors.
+    # On error files, BQL results differ because Rust has better error recovery
+    # and interpolation (handles "too many missing numbers" cases Python rejects).
+    if python.error_count == 0 and rust.error_count == 0:
+        result.accounts_match = (python.accounts == rust.accounts)
+    else:
+        result.accounts_match = True
+
+    # Compare posting counts (what BQL COUNT(*) returns)
+    result.posting_count_diff = rust.posting_count - python.posting_count
+    result.posting_count_match = (python.posting_count == rust.posting_count)
+
+    # Compare error counts (both have errors or both don't)
+    result.error_count_match = (
+        (python.error_count > 0) == (rust.error_count > 0)
+    )
+
+    return result
+
+
+def test_single_file(args) -> ComparisonResult:
+    """Test a single file - designed to run in parallel."""
+    file_path, rledger = args
+    python_result = parse_with_python(file_path)
+    rust_result = parse_with_rust(file_path, rledger)
+    return compare_results(str(file_path), python_result, rust_result)
+
+
+def run_comparison(directory: Path, rledger: str) -> list[ComparisonResult]:
+    """Run comparison on all beancount files in directory (parallel)."""
+    files = list(directory.rglob("*.beancount"))
+
+    print(f"Comparing {len(files)} files with {MAX_WORKERS} parallel workers...")
+    print()
+
+    results = []
+    completed = 0
+
+    # Build args for parallel execution
+    test_args = [(f, rledger) for f in files]
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = [executor.submit(test_single_file, args) for args in test_args]
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                results.append(result)
+                completed += 1
+                if completed % 20 == 0:
+                    print(f"  Progress: {completed}/{len(files)}", end='\r')
+            except Exception as e:
+                print(f"Error: {e}")
+
+    print(f"  Completed: {len(results)}/{len(files)}    ")
+    print()
+    return results
+
+
+def print_summary(results: list[ComparisonResult]):
+    """Print summary of comparison results."""
+    total = len(results)
+    accounts_match = sum(1 for r in results if r.accounts_match)
+    posting_match = sum(1 for r in results if r.posting_count_match)
+    error_match = sum(1 for r in results if r.error_count_match)
+    full_match = sum(1 for r in results if r.full_match)
+
+    print("=" * 60)
+    print("AST/Directive Comparison Results")
+    print("=" * 60)
+    print()
+    print(f"Files tested:           {total}")
+    print()
+    print("Match Rates:")
+    print(f"  Accounts match:       {accounts_match}/{total} ({100*accounts_match//total}%)")
+    print(f"  Posting count:        {posting_match}/{total} ({100*posting_match//total}%)")
+    print(f"  Error presence:       {error_match}/{total} ({100*error_match//total}%)")
+    print(f"  Full match:           {full_match}/{total} ({100*full_match//total}%)")
+    print()
+
+    # Show mismatches
+    mismatches = [r for r in results if not r.full_match]
+    if mismatches:
+        print("=" * 60)
+        print(f"Mismatches ({len(mismatches)} files)")
+        print("=" * 60)
+
+        # Group by type
+        account_mismatches = [r for r in mismatches if not r.accounts_match]
+        posting_mismatches = [r for r in mismatches if not r.posting_count_match]
+        error_mismatches = [r for r in mismatches if not r.error_count_match]
+
+        if account_mismatches:
+            print()
+            print(f"Account Mismatches ({len(account_mismatches)}):")
+            for r in account_mismatches[:5]:
+                print(f"  {Path(r.file).name}")
+                if r.accounts_only_python:
+                    print(f"    Python only: {', '.join(sorted(r.accounts_only_python)[:3])}")
+                if r.accounts_only_rust:
+                    print(f"    Rust only:   {', '.join(sorted(r.accounts_only_rust)[:3])}")
+            if len(account_mismatches) > 5:
+                print(f"  ... and {len(account_mismatches) - 5} more")
+
+        if posting_mismatches:
+            print()
+            print(f"Posting Count Mismatches ({len(posting_mismatches)}):")
+            for r in posting_mismatches[:5]:
+                py_count = r.python.posting_count if r.python else "?"
+                rs_count = r.rust.posting_count if r.rust else "?"
+                diff = r.posting_count_diff
+                print(f"  {Path(r.file).name}: Python={py_count}, Rust={rs_count} (diff={diff:+d})")
+            if len(posting_mismatches) > 5:
+                print(f"  ... and {len(posting_mismatches) - 5} more")
+
+        if error_mismatches:
+            print()
+            print(f"Error Presence Mismatches ({len(error_mismatches)}):")
+            for r in error_mismatches[:5]:
+                py_err = r.python.error_count if r.python else "?"
+                rs_err = r.rust.error_count if r.rust else "?"
+                print(f"  {Path(r.file).name}: Python errors={py_err}, Rust errors={rs_err}")
+            if len(error_mismatches) > 5:
+                print(f"  ... and {len(error_mismatches) - 5} more")
+
+
+def save_results(results: list[ComparisonResult], output_file: Path):
+    """Save results to JSON file."""
+    data = []
+    for r in results:
+        entry = {
+            "file": r.file,
+            "accounts_match": r.accounts_match,
+            "posting_count_match": r.posting_count_match,
+            "error_count_match": r.error_count_match,
+            "full_match": r.full_match,
+        }
+        if r.python:
+            entry["python"] = {
+                "accounts": sorted(r.python.accounts),
+                "posting_count": r.python.posting_count,
+                "transaction_count": r.python.transaction_count,
+                "error_count": r.python.error_count,
+            }
+        if r.rust:
+            entry["rust"] = {
+                "accounts": sorted(r.rust.accounts),
+                "posting_count": r.rust.posting_count,
+                "error_count": r.rust.error_count,
+            }
+        if r.accounts_only_python:
+            entry["accounts_only_python"] = sorted(r.accounts_only_python)
+        if r.accounts_only_rust:
+            entry["accounts_only_rust"] = sorted(r.accounts_only_rust)
+        if r.posting_count_diff != 0:
+            entry["posting_count_diff"] = r.posting_count_diff
+        data.append(entry)
+
+    with open(output_file, 'w') as f:
+        for entry in data:
+            f.write(json.dumps(entry) + '\n')
+
+    print(f"\nResults saved to: {output_file}")
+
+
+def main():
+    # Determine directory to test
+    if len(sys.argv) > 1:
+        test_dir = Path(sys.argv[1])
+    else:
+        # Default to curated files, then full suite
+        test_dir = Path("tests/compatibility/files")
+        if not test_dir.exists():
+            test_dir = Path("tests/compatibility-full")
+
+    if not test_dir.exists():
+        print(f"Error: Directory not found: {test_dir}")
+        sys.exit(1)
+
+    # Find rustledger binary
+    rledger = "./target/release/rledger"
+
+    if not Path(rledger).exists():
+        print("Building rustledger...")
+        subprocess.run(["cargo", "build", "--release", "-p", "rustledger"], check=True)
+
+    print(f"Testing directory: {test_dir}")
+    print()
+
+    # Run comparison
+    results = run_comparison(test_dir, rledger)
+
+    # Print summary
+    print_summary(results)
+
+    # Save results
+    output_dir = Path("tests/compatibility-results")
+    output_dir.mkdir(exist_ok=True)
+
+    from datetime import datetime
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_file = output_dir / f"ast_results_{timestamp}.jsonl"
+    save_results(results, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compat-bql-test.sh
+++ b/scripts/compat-bql-test.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+set -e
+
+# BQL Compatibility Test (Parallel)
+# Compares bean-query (Python) vs rledger query (Rust) on valid beancount files
+# Run inside: nix develop --command ./scripts/compat-bql-test.sh
+#
+# Environment variables:
+#   PARALLEL_JOBS: Number of parallel workers (default: CPU count, max 8)
+
+FIXTURES_DIR="${1:-tests/compatibility/files}"
+RESULTS_DIR="tests/compatibility-results"
+
+# Check if test files exist
+if [ ! -d "$FIXTURES_DIR" ] || [ -z "$(ls -A "$FIXTURES_DIR" 2>/dev/null)" ]; then
+    echo "Test files not found at $FIXTURES_DIR"
+    echo "Run ./scripts/fetch-compat-test-files.sh to download test files"
+    exit 1
+fi
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS_FILE="$RESULTS_DIR/bql_results_$TIMESTAMP.jsonl"
+
+# Clean cache files to ensure fresh test results
+find "$FIXTURES_DIR" -name "*.cache" -delete 2>/dev/null || true
+
+# Parallel settings
+PARALLEL_JOBS="${PARALLEL_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+[ "$PARALLEL_JOBS" -gt 16 ] && PARALLEL_JOBS=16
+
+echo "=== BQL Compatibility Test (Parallel) ==="
+echo ""
+
+mkdir -p "$RESULTS_DIR"
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Build rustledger
+echo "Building rustledger..."
+cargo build --release --quiet
+RLEDGER="./target/release/rledger"
+
+if [ ! -x "$RLEDGER" ]; then
+    echo "Error: rledger not found"
+    exit 1
+fi
+
+# Check bean-query is available
+if ! command -v bean-query &> /dev/null; then
+    echo "Error: bean-query not found. Run inside nix develop."
+    exit 1
+fi
+
+echo "Using $PARALLEL_JOBS parallel workers"
+echo ""
+
+# Find files that passed both check tests (use most recent results)
+COMPAT_RESULTS=$(ls -t "$RESULTS_DIR"/results_*.jsonl 2>/dev/null | head -1)
+if [ -z "$COMPAT_RESULTS" ]; then
+    echo "No compat-test results found. Run ./scripts/compat-test.sh first."
+    exit 1
+fi
+
+# Get files where both implementations passed (match=true and both exit=0)
+# BQL_FILE_LIMIT controls max files (default: 100, use 0 for unlimited)
+BQL_FILE_LIMIT="${BQL_FILE_LIMIT:-100}"
+if [ "$BQL_FILE_LIMIT" -eq 0 ]; then
+    mapfile -t valid_files < <(jq -r 'select(.match == true and .python.exit == 0 and .rust.exit == 0) | .file' "$COMPAT_RESULTS")
+else
+    mapfile -t valid_files < <(jq -r 'select(.match == true and .python.exit == 0 and .rust.exit == 0) | .file' "$COMPAT_RESULTS" | head -"$BQL_FILE_LIMIT")
+fi
+
+# Standard queries to test - expanded coverage (50+ queries)
+# Note: All queries with LIMIT must have ORDER BY for deterministic results
+# Without ORDER BY, LIMIT selects different rows depending on processing order
+QUERIES_FILE="$TEMP_DIR/queries.txt"
+cat > "$QUERIES_FILE" << 'EOF'
+SELECT DISTINCT account ORDER BY account LIMIT 20
+SELECT COUNT(*) AS total
+SELECT currency, COUNT(*) AS cnt GROUP BY currency ORDER BY cnt DESC LIMIT 10
+SELECT YEAR(date) AS year, COUNT(*) AS cnt GROUP BY year ORDER BY year
+SELECT DISTINCT ROOT(account) AS root ORDER BY root
+SELECT DISTINCT LEAF(account) AS leaf ORDER BY leaf LIMIT 20
+SELECT account, SUM(position) GROUP BY account ORDER BY account LIMIT 10
+SELECT MONTH(date) AS month, COUNT(*) AS cnt GROUP BY month ORDER BY month
+SELECT date, narration ORDER BY date, narration LIMIT 10
+SELECT account, FIRST(date) AS first_date GROUP BY account ORDER BY account LIMIT 10
+SELECT MIN(date) AS min_date, MAX(date) AS max_date
+SELECT DAY(date) AS day, COUNT(*) AS cnt GROUP BY day ORDER BY day
+SELECT WEEKDAY(date) AS weekday, COUNT(*) AS cnt GROUP BY weekday ORDER BY weekday
+SELECT QUARTER(date) AS quarter, COUNT(*) AS cnt GROUP BY quarter ORDER BY quarter
+SELECT account, LAST(date) AS last_date GROUP BY account ORDER BY account LIMIT 10
+SELECT account, COUNT(*) AS cnt GROUP BY account ORDER BY cnt DESC LIMIT 10
+SELECT PARENT(account) AS parent, COUNT(*) AS cnt GROUP BY parent ORDER BY parent LIMIT 10
+SELECT LENGTH(narration) AS len, COUNT(*) AS cnt GROUP BY len ORDER BY len LIMIT 20
+SELECT DISTINCT flag ORDER BY flag
+SELECT flag, COUNT(*) AS cnt GROUP BY flag ORDER BY flag
+SELECT account, SUM(NUMBER(position)) AS total GROUP BY account ORDER BY total DESC LIMIT 10
+SELECT DISTINCT tags ORDER BY tags LIMIT 20
+SELECT DISTINCT links ORDER BY links LIMIT 20
+SELECT account WHERE account ~ "Assets:" ORDER BY account LIMIT 20
+SELECT account WHERE account ~ "Expenses:" ORDER BY account LIMIT 20
+SELECT account WHERE account ~ "Income:" ORDER BY account LIMIT 20
+SELECT account WHERE account ~ "Liabilities:" ORDER BY account LIMIT 20
+SELECT date, account, position WHERE NUMBER(position) > 100 ORDER BY date, account LIMIT 20
+SELECT date, account, position WHERE NUMBER(position) < 0 ORDER BY date, account LIMIT 20
+SELECT account, AVG(NUMBER(position)) AS avg_amt GROUP BY account ORDER BY avg_amt DESC LIMIT 10
+SELECT YEAR(date) AS year, SUM(NUMBER(position)) AS total GROUP BY year ORDER BY year
+SELECT date, account, narration WHERE narration ~ ".*" ORDER BY date LIMIT 10
+SELECT account, MIN(NUMBER(position)) AS min_amt, MAX(NUMBER(position)) AS max_amt GROUP BY account ORDER BY account LIMIT 10
+SELECT DISTINCT CURRENCY(position) AS curr ORDER BY curr
+SELECT account, CURRENCY(position) AS curr, SUM(NUMBER(position)) AS total GROUP BY account, curr ORDER BY account, curr LIMIT 20
+SELECT convert(sum(position),\'USD\') WHERE account \~\'^Income\'
+SELECT convert(sum(position),\'USD\') WHERE account \~\'^Assets\'
+SELECT convert(sum(position),\'USD\') WHERE account ~\'^Expenses\'
+SELECT convert(sum(position),\'USD\') WHERE account ~\'^Liabilities\'
+SELECT id, date, flag, payee, narration, tags, links, filename, lineno, account, number, currency, cost_number, cost_currency, cost_date, price, entry.meta as entry_meta FROM postings ORDER BY date DESC, id, account
+SELECT lineno, date FROM accounts
+BALANCES
+BALANCES AT cost
+BALANCES WHERE account ~ "Assets:"
+BALANCES WHERE account ~ "Liabilities:"
+JOURNAL "Assets:*"
+EOF
+
+QUERY_COUNT=$(wc -l < "$QUERIES_FILE" | tr -d ' ')
+echo "Found ${#valid_files[@]} files that passed both implementations"
+echo "Testing with $QUERY_COUNT queries each..."
+echo ""
+
+# Create test script for parallel execution
+cat > "$TEMP_DIR/test_bql.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+file="$1"
+query="$2"
+FIXTURES_DIR="$3"
+RLEDGER="$4"
+
+full_path="$FIXTURES_DIR/$file"
+[ ! -f "$full_path" ] && exit 0
+
+# Run Python bean-query
+py_out=$(bean-query "$full_path" "$query" 2>/dev/null)
+py_exit=$?
+[[ $py_exit -ne 0 ]] && py_out="ERROR" || py_out=$(echo "$py_out" | head -50)
+
+# Run Rust rledger query
+rs_out=$("$RLEDGER" query "$full_path" "$query" 2>/dev/null) 
+rs_exit=$?
+[[ $rs_exit -ne 0 ]] && rs_out="ERROR" || rs_out=$(echo "$rs_out" | head -50)
+
+# Normalize function: extract just the data values
+# - Skip header row (first line)
+# - Skip separator lines (----)
+# - Skip row count lines (N row(s))
+# - Trim whitespace, normalize spaces
+# - Normalize whitespace inside braces (lot costs): { 5.16 -> {5.16
+# - Sort for comparison (handles undefined ORDER BY)
+normalize_output() {
+    echo "$1" | \
+        grep -v "^-" | \
+        grep -v "row(s)" | \
+        grep -v "^$" | \
+        tail -n +2 | \
+        tr -s ' \t' ' ' | \
+        sed 's/{ /{/g' | \
+        sed 's/ }/}/g' | \
+        sed 's/^ *//; s/ *$//' | \
+        sort
+}
+
+py_data=$(normalize_output "$py_out")
+rs_data=$(normalize_output "$rs_out")
+
+# Count data rows (needed for categorization)
+py_rows=$(echo "$py_data" | grep -c . 2>/dev/null || echo 0)
+rs_rows=$(echo "$rs_data" | grep -c . 2>/dev/null || echo 0)
+py_rows=$(echo "$py_rows" | tr -d '\n')
+rs_rows=$(echo "$rs_rows" | tr -d '\n')
+
+# Normalize numbers for comparison
+# Handles:
+# - Python's display context truncation (e.g., "111 USD" vs "111.11 USD")
+# - Zero balance display differences (Python shows empty, Rust shows "0 USD")
+# - Empty currency rows (Rust may show rows for empty/null currencies)
+normalize_numbers() {
+    echo "$1" | \
+        sed -E 's/([0-9]+)\.[0-9]+/\1/g' | \
+        sed -E 's/\b0 [A-Z]+\b//g' | \
+        grep -v '^[[:space:]]*[0-9]*[[:space:]]*$' | \
+        sed 's/^ *//; s/ *$//'
+}
+
+# Categorize the result
+if [ "$py_exit" -ne 0 ] || [ "$rs_exit" -ne 0 ]; then
+    match="false"
+    category="error"
+elif [ -z "$py_data" ] && [ -z "$rs_data" ]; then
+    match="true"
+    category="both_empty"
+elif [ -z "$py_data" ]; then
+    match="false"
+    category="python_empty"
+elif [ -z "$rs_data" ]; then
+    match="false"
+    category="rust_empty"
+elif [ "$py_data" = "$rs_data" ]; then
+    match="true"
+    category="match"
+else
+    # Check if difference is only in decimal precision or zero values
+    py_normalized=$(normalize_numbers "$py_data")
+    rs_normalized=$(normalize_numbers "$rs_data")
+    if [ "$py_normalized" = "$rs_normalized" ]; then
+        # Values match when decimals/zeros are normalized - acceptable
+        match="true"
+        category="precision_diff"
+    else
+        # Data differs after normalization - this is a real difference
+        match="false"
+        category="data_diff"
+    fi
+fi
+
+# Output JSON result with more detail
+query_escaped=$(echo "$query" | head -c 50 | sed 's/"/\\"/g')
+echo "{\"file\":\"$file\",\"query\":\"$query_escaped\",\"match\":$match,\"category\":\"$category\",\"py_rows\":$py_rows,\"rs_rows\":$rs_rows}"
+SCRIPT
+chmod +x "$TEMP_DIR/test_bql.sh"
+
+# Build list of all (file, query) pairs
+TEST_CASES_FILE="$TEMP_DIR/test_cases.txt"
+> "$TEST_CASES_FILE"
+for file in "${valid_files[@]}"; do
+    while IFS= read -r query; do
+        echo "$file	$query" >> "$TEST_CASES_FILE"
+    done < "$QUERIES_FILE"
+done
+
+total_cases=$(wc -l < "$TEST_CASES_FILE" | tr -d ' ')
+echo "Running $total_cases BQL tests..."
+echo ""
+
+start_time=$(date +%s)
+
+# Run tests in parallel
+while IFS=$'\t' read -r file query; do
+    echo "$file"$'\t'"$query"
+done < "$TEST_CASES_FILE" | \
+    xargs -P "$PARALLEL_JOBS" -I {} bash -c '
+        IFS=$'"'"'\t'"'"' read -r file query <<< "{}"
+        '"$TEMP_DIR"'/test_bql.sh "$file" "$query" "'"$FIXTURES_DIR"'" "'"$RLEDGER"'"
+    ' > "$RESULTS_FILE"
+
+end_time=$(date +%s)
+elapsed=$((end_time - start_time))
+
+echo ""
+echo "=== BQL Results Summary ==="
+echo ""
+
+total_queries=$(wc -l < "$RESULTS_FILE" | tr -d ' ')
+matching_queries=$(grep -c '"match":true' "$RESULTS_FILE" || echo 0)
+failed_queries=$((total_queries - matching_queries))
+
+if [ "$total_queries" -gt 0 ]; then
+    match_pct=$((matching_queries * 100 / total_queries))
+else
+    match_pct=0
+fi
+
+echo "Total queries:    $total_queries"
+echo "Matching:         $matching_queries ($match_pct%)"
+echo "Different:        $failed_queries"
+echo "Execution time:   ${elapsed}s"
+echo ""
+
+# Show breakdown by category (grep -c exits 1 when 0 matches, so use || true)
+cat_match=$(grep -c '"category":"match"' "$RESULTS_FILE" 2>/dev/null) || cat_match=0
+cat_both_empty=$(grep -c '"py_rows":00,"rs_rows":00' "$RESULTS_FILE" 2>/dev/null) || cat_both_empty=0
+cat_precision_diff=$(grep -c '"category":"precision_diff"' "$RESULTS_FILE" 2>/dev/null) || cat_precision_diff=0
+cat_python_empty=$(grep -c '"category":"python_empty"' "$RESULTS_FILE" 2>/dev/null) || cat_python_empty=0
+cat_rust_empty=$(grep -c '"category":"rust_empty"' "$RESULTS_FILE" 2>/dev/null) || cat_rust_empty=0
+cat_data_diff=$(grep -c '"category":"data_diff"' "$RESULTS_FILE" 2>/dev/null) || cat_data_diff=0
+cat_error=$(grep -c '"category":"error"' "$RESULTS_FILE" 2>/dev/null) || cat_error=0
+
+echo "Breakdown by category:"
+echo "  Passing:"
+echo "    match:          $cat_match"
+echo "    both_empty:     $cat_both_empty"
+echo "    precision_diff: $cat_precision_diff  (display precision only)"
+echo "  Failing:"
+echo "    python_empty:   $cat_python_empty"
+echo "    rust_empty:     $cat_rust_empty"
+echo "    data_diff:      $cat_data_diff"
+echo "    error:          $cat_error"
+echo ""
+
+# Show sample data_diff cases for debugging
+data_diffs=$(jq -r 'select(.category == "data_diff") | "\(.file) | \(.query) | py=\(.py_rows) rs=\(.rs_rows)"' "$RESULTS_FILE" 2>/dev/null | head -5)
+if [ -n "$data_diffs" ]; then
+    echo "Sample data differences (py vs rs row counts):"
+    echo "$data_diffs" | while read line; do echo "  $line"; done
+    echo ""
+fi
+
+echo "Results in: $RESULTS_FILE"

--- a/scripts/compat-error-quality.py
+++ b/scripts/compat-error-quality.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""
+Error Message Quality Testing
+
+Compares error messages between bean-check (Python) and rledger check (Rust)
+to ensure Rust provides equally helpful diagnostics.
+
+This script tests:
+1. Error message presence for known-bad inputs
+2. Error location accuracy (line/column)
+3. Error type consistency
+4. Helpfulness of error messages
+
+Usage:
+    python scripts/compat-error-quality.py [--verbose]
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class ErrorInfo:
+    """Parsed error information from compiler output."""
+    line: Optional[int]
+    column: Optional[int]
+    error_type: str
+    message: str
+    raw: str
+
+
+@dataclass
+class TestCase:
+    """A test case with known-bad input."""
+    name: str
+    content: str
+    expected_error_pattern: str
+    description: str
+
+
+# Known-bad inputs that should produce helpful errors
+TEST_CASES = [
+    TestCase(
+        name="invalid_date",
+        content='2024-13-01 open Assets:Bank\n',
+        expected_error_pattern=r"(invalid|date|month)",
+        description="Invalid month in date",
+    ),
+    TestCase(
+        name="invalid_date_day",
+        content='2024-02-30 open Assets:Bank\n',
+        expected_error_pattern=r"(invalid|date|day)",
+        description="Invalid day in date",
+    ),
+    TestCase(
+        name="unclosed_string",
+        content='2024-01-01 * "Unclosed string\n  Assets:Bank  100 USD\n',
+        expected_error_pattern=r"(unterminated|unclosed|string|quote)",
+        description="Unterminated string literal",
+    ),
+    TestCase(
+        name="invalid_account_segment",
+        content='2024-01-01 open Assets:123Invalid\n',
+        expected_error_pattern=r"(invalid|account|segment|name)",
+        description="Account segment starting with number",
+    ),
+    TestCase(
+        name="missing_account_type",
+        content='2024-01-01 open MyAccount:Bank\n',
+        expected_error_pattern=r"(invalid|account|type|root)",
+        description="Account without valid root type",
+    ),
+    TestCase(
+        name="duplicate_open",
+        content='2024-01-01 open Assets:Bank\n2024-01-02 open Assets:Bank\n',
+        expected_error_pattern=r"(duplicate|already|open)",
+        description="Opening an already open account",
+    ),
+    TestCase(
+        name="unbalanced_transaction",
+        content='2024-01-01 open Assets:Bank\n2024-01-01 open Expenses:Food\n2024-01-02 * "Test"\n  Assets:Bank  -100 USD\n  Expenses:Food  50 USD\n',
+        expected_error_pattern=r"(balance|unbalanced|sum|residual)",
+        description="Transaction that doesn't balance",
+    ),
+    TestCase(
+        name="invalid_currency",
+        content='2024-01-01 open Assets:Bank\n2024-01-02 * "Test"\n  Assets:Bank  100 123\n',
+        expected_error_pattern=r"(invalid|currency|symbol)",
+        description="Invalid currency symbol",
+    ),
+    TestCase(
+        name="posting_without_account",
+        content='2024-01-01 * "Test"\n  100 USD\n',
+        expected_error_pattern=r"(account|expected|syntax|posting)",
+        description="Posting without account name",
+    ),
+    TestCase(
+        name="invalid_metadata_key",
+        content='2024-01-01 open Assets:Bank\n  123key: "value"\n',
+        expected_error_pattern=r"(metadata|key|invalid|syntax)",
+        description="Metadata key starting with number",
+    ),
+    TestCase(
+        name="balance_wrong_currency",
+        content='2024-01-01 open Assets:Bank USD\n2024-01-02 balance Assets:Bank  100 EUR\n',
+        expected_error_pattern=r"(currency|mismatch|constraint)",
+        description="Balance assertion with wrong currency",
+    ),
+    TestCase(
+        name="close_unopened",
+        content='2024-01-01 close Assets:Bank\n',
+        expected_error_pattern=r"(close|unopened|not open|never)",
+        description="Closing an account that was never opened",
+    ),
+    TestCase(
+        name="use_before_open",
+        content='2024-01-01 * "Test"\n  Assets:Bank  100 USD\n  Expenses:Food  -100 USD\n2024-01-02 open Assets:Bank\n2024-01-02 open Expenses:Food\n',
+        expected_error_pattern=r"(open|before|used|not open)",
+        description="Using account before it's opened",
+    ),
+    TestCase(
+        name="use_after_close",
+        content='2024-01-01 open Assets:Bank\n2024-01-02 close Assets:Bank\n2024-01-03 * "Test"\n  Assets:Bank  100 USD\n  Equity:Opening  -100 USD\n2024-01-01 open Equity:Opening\n',
+        expected_error_pattern=r"(close|after|closed)",
+        description="Using account after it's closed",
+    ),
+    TestCase(
+        name="invalid_flag",
+        content='2024-01-01 X "Invalid flag"\n  Assets:Bank  100 USD\n',
+        expected_error_pattern=r"(flag|invalid|syntax|expected)",
+        description="Invalid transaction flag",
+    ),
+]
+
+
+def parse_python_error(stderr: str) -> list[ErrorInfo]:
+    """Parse error information from bean-check output."""
+    errors = []
+    # Python beancount format: "file:line: message" or "file:line:col: message"
+    pattern = r'(?:.*?):(\d+)(?::(\d+))?:\s*(.+)'
+
+    for line in stderr.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+        match = re.match(pattern, line)
+        if match:
+            line_no = int(match.group(1)) if match.group(1) else None
+            col_no = int(match.group(2)) if match.group(2) else None
+            message = match.group(3)
+
+            # Try to extract error type
+            error_type = "unknown"
+            if "syntax" in message.lower():
+                error_type = "syntax"
+            elif "balance" in message.lower():
+                error_type = "balance"
+            elif "invalid" in message.lower():
+                error_type = "invalid"
+            elif "duplicate" in message.lower():
+                error_type = "duplicate"
+
+            errors.append(ErrorInfo(
+                line=line_no,
+                column=col_no,
+                error_type=error_type,
+                message=message,
+                raw=line,
+            ))
+        elif line and not line.startswith(' '):
+            # Capture lines that might be errors but don't match pattern
+            errors.append(ErrorInfo(
+                line=None,
+                column=None,
+                error_type="unknown",
+                message=line,
+                raw=line,
+            ))
+
+    return errors
+
+
+def parse_rust_error(stderr: str) -> list[ErrorInfo]:
+    """Parse error information from rledger check output."""
+    errors = []
+    # Rust format varies, try common patterns
+    # Format 1: "error[E001]: message\n  --> file:line:col"
+    # Format 2: "file:line:col: error: message"
+
+    current_message = None
+    current_line = None
+    current_col = None
+
+    for line in stderr.split('\n'):
+        line_stripped = line.strip()
+        if not line_stripped:
+            continue
+
+        # Check for error line
+        if line_stripped.startswith('error'):
+            if current_message:
+                errors.append(ErrorInfo(
+                    line=current_line,
+                    column=current_col,
+                    error_type="error",
+                    message=current_message,
+                    raw=current_message,
+                ))
+            current_message = line_stripped
+            current_line = None
+            current_col = None
+
+        # Check for location line
+        elif '-->' in line_stripped:
+            match = re.search(r':(\d+):(\d+)', line_stripped)
+            if match:
+                current_line = int(match.group(1))
+                current_col = int(match.group(2))
+
+        # Alternative format: "file:line:col: error: message"
+        elif ':' in line_stripped:
+            match = re.match(r'.*?:(\d+):(\d+):\s*(?:error:\s*)?(.+)', line_stripped)
+            if match:
+                errors.append(ErrorInfo(
+                    line=int(match.group(1)),
+                    column=int(match.group(2)),
+                    error_type="error",
+                    message=match.group(3),
+                    raw=line_stripped,
+                ))
+
+    # Don't forget the last error
+    if current_message:
+        errors.append(ErrorInfo(
+            line=current_line,
+            column=current_col,
+            error_type="error",
+            message=current_message,
+            raw=current_message,
+        ))
+
+    return errors
+
+
+def run_checker(cmd: list[str], input_file: str) -> tuple[int, str, str]:
+    """Run a checker command and return exit code, stdout, stderr."""
+    try:
+        result = subprocess.run(
+            cmd + [input_file],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return -1, "", "timeout"
+    except Exception as e:
+        return -1, "", str(e)
+
+
+def test_error_quality(test: TestCase, verbose: bool = False) -> dict:
+    """Run a single error quality test."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.beancount', delete=False) as f:
+        f.write(test.content)
+        temp_file = f.name
+
+    try:
+        # Run Python bean-check
+        py_exit, py_stdout, py_stderr = run_checker(['bean-check'], temp_file)
+        py_errors = parse_python_error(py_stderr + py_stdout)
+
+        # Run Rust rledger check
+        rs_exit, rs_stdout, rs_stderr = run_checker(['./target/release/rledger', 'check'], temp_file)
+        rs_errors = parse_rust_error(rs_stderr + rs_stdout)
+
+        # Check if expected error pattern is found
+        py_has_expected = any(
+            re.search(test.expected_error_pattern, e.message, re.IGNORECASE)
+            for e in py_errors
+        )
+        rs_has_expected = any(
+            re.search(test.expected_error_pattern, e.message, re.IGNORECASE)
+            for e in rs_errors
+        )
+
+        # Check location accuracy (if Python provides location, Rust should too)
+        py_has_location = any(e.line is not None for e in py_errors)
+        rs_has_location = any(e.line is not None for e in rs_errors)
+
+        # Determine overall result
+        if py_exit != 0 and rs_exit == 0:
+            status = "rust_missed"
+        elif py_exit == 0 and rs_exit != 0:
+            status = "rust_extra"
+        elif py_exit == 0:
+            # Both pass (rs_exit == 0 implied by previous conditions)
+            status = "both_pass"  # Unexpected - test case should fail
+        elif not rs_has_expected and py_has_expected:
+            status = "rust_unhelpful"
+        elif py_has_location and not rs_has_location:
+            status = "rust_no_location"
+        else:
+            status = "pass"
+
+        result = {
+            "name": test.name,
+            "description": test.description,
+            "status": status,
+            "python": {
+                "exit": py_exit,
+                "error_count": len(py_errors),
+                "has_expected_pattern": py_has_expected,
+                "has_location": py_has_location,
+                "errors": [e.raw for e in py_errors[:3]],
+            },
+            "rust": {
+                "exit": rs_exit,
+                "error_count": len(rs_errors),
+                "has_expected_pattern": rs_has_expected,
+                "has_location": rs_has_location,
+                "errors": [e.raw for e in rs_errors[:3]],
+            },
+        }
+
+        if verbose:
+            print(f"\n{'='*60}")
+            print(f"Test: {test.name}")
+            print(f"Description: {test.description}")
+            print(f"Status: {status}")
+            print(f"\nPython errors ({len(py_errors)}):")
+            for e in py_errors[:3]:
+                print(f"  {e.raw}")
+            print(f"\nRust errors ({len(rs_errors)}):")
+            for e in rs_errors[:3]:
+                print(f"  {e.raw}")
+
+        return result
+
+    finally:
+        os.unlink(temp_file)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Error message quality testing")
+    parser.add_argument('--verbose', '-v', action='store_true', help="Show detailed output")
+    parser.add_argument('--json', action='store_true', help="Output JSON results")
+    args = parser.parse_args()
+
+    # Build rustledger first
+    print("Building rustledger...")
+    result = subprocess.run(
+        ['cargo', 'build', '--release', '--quiet'],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        print("Failed to build rustledger")
+        sys.exit(1)
+
+    # Check bean-check is available
+    try:
+        subprocess.run(['bean-check', '--version'], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("bean-check not found. Run inside nix develop.")
+        sys.exit(1)
+
+    print(f"\nRunning {len(TEST_CASES)} error quality tests...\n")
+
+    results = []
+    for test in TEST_CASES:
+        result = test_error_quality(test, verbose=args.verbose)
+        results.append(result)
+
+        if not args.verbose:
+            status_icon = "✓" if result["status"] == "pass" else "✗"
+            print(f"  {status_icon} {test.name}: {result['status']}")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print('='*60)
+
+    passed = sum(1 for r in results if r["status"] == "pass")
+    rust_missed = sum(1 for r in results if r["status"] == "rust_missed")
+    rust_unhelpful = sum(1 for r in results if r["status"] == "rust_unhelpful")
+    rust_no_location = sum(1 for r in results if r["status"] == "rust_no_location")
+    rust_extra = sum(1 for r in results if r["status"] == "rust_extra")
+    both_pass = sum(1 for r in results if r["status"] == "both_pass")
+
+    print(f"Total tests:        {len(results)}")
+    print(f"Passed:             {passed}")
+    print(f"Rust missed error:  {rust_missed}")
+    print(f"Rust unhelpful:     {rust_unhelpful}")
+    print(f"Rust no location:   {rust_no_location}")
+    print(f"Rust extra error:   {rust_extra}")
+    print(f"Both pass (bad):    {both_pass}")
+
+    if args.json:
+        print(f"\n{json.dumps(results, indent=2)}")
+
+    # Save results
+    results_dir = Path("tests/compatibility-results")
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    from datetime import datetime
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    results_file = results_dir / f"error_quality_{timestamp}.json"
+
+    with open(results_file, 'w') as f:
+        json.dump(results, f, indent=2)
+
+    print(f"\nResults saved to: {results_file}")
+
+    # Exit with error if any tests failed
+    if passed < len(results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compat-test.sh
+++ b/scripts/compat-test.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -e
+
+# Beancount Compatibility Test Harness (Parallel)
+# Compares bean-check (Python) vs rledger check (Rust) on all .beancount files
+# Run inside: nix develop --command ./scripts/compat-test.sh [directory]
+#
+# Examples:
+#   ./scripts/fetch-compat-test-files.sh       # Download test files first
+#   ./scripts/compat-test.sh                   # Run tests on downloaded files
+
+# Default to tests/compatibility/files/, allow override via argument
+FIXTURES_DIR="${1:-tests/compatibility/files}"
+RESULTS_DIR="tests/compatibility-results"
+EXCLUSIONS_FILE="tests/compatibility/exclusions.toml"
+
+# Check if test files exist
+if [ ! -d "$FIXTURES_DIR" ] || [ -z "$(ls -A "$FIXTURES_DIR" 2>/dev/null)" ]; then
+    echo "Test files not found at $FIXTURES_DIR"
+    echo "Run ./scripts/fetch-compat-test-files.sh to download test files"
+    exit 1
+fi
+
+# Load exclusions from TOML file
+declare -a EXCLUDED_PATTERNS=()
+declare -a EXCLUDED_REASONS=()
+if [ -f "$EXCLUSIONS_FILE" ]; then
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^pattern\ *=\ *\"(.*)\"$ ]]; then
+            EXCLUDED_PATTERNS+=("${BASH_REMATCH[1]}")
+        elif [[ "$line" =~ ^reason\ *=\ *\"(.*)\"$ ]]; then
+            EXCLUDED_REASONS+=("${BASH_REMATCH[1]}")
+        fi
+    done < "$EXCLUSIONS_FILE"
+fi
+
+# Function to check if a file should be excluded
+is_excluded() {
+    local file="$1"
+    local relpath="${file#$FIXTURES_DIR/}"
+    for pattern in "${EXCLUDED_PATTERNS[@]}"; do
+        if [[ "$relpath" == "$pattern" ]] || [[ "$relpath" == *"$pattern"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS_FILE="$RESULTS_DIR/results_$TIMESTAMP.jsonl"
+SUMMARY_FILE="$RESULTS_DIR/summary_$TIMESTAMP.md"
+
+# Clean cache files to ensure fresh test results
+find "$FIXTURES_DIR" -name "*.cache" -delete 2>/dev/null || true
+
+# Parallel settings
+PARALLEL_JOBS="${PARALLEL_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+# Cap at 16 for stability
+[ "$PARALLEL_JOBS" -gt 16 ] && PARALLEL_JOBS=16
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=== Beancount Compatibility Test Harness (Parallel) ==="
+echo ""
+
+# Create results directory and temp directory
+mkdir -p "$RESULTS_DIR"
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Build rustledger in release mode
+echo "Building rustledger..."
+cargo build --release --quiet
+RLEDGER="./target/release/rledger"
+
+if [ ! -x "$RLEDGER" ]; then
+    echo "Error: rledger not found at $RLEDGER"
+    exit 1
+fi
+
+# Activate plugin venv if available (provides third-party plugins)
+VENV_DIR=".venv-plugins"
+if [ -d "$VENV_DIR" ] && [ -f "$VENV_DIR/bin/activate" ]; then
+    source "$VENV_DIR/bin/activate"
+fi
+
+# Check that bean-check is available
+if ! command -v bean-check &> /dev/null; then
+    echo "Error: bean-check not found. Run inside nix develop."
+    exit 1
+fi
+
+echo "Using:"
+echo "  Python: $(bean-check --version 2>&1 | head -1 || echo 'bean-check available')"
+echo "  Rust:   $($RLEDGER --version 2>&1 || echo 'rledger available')"
+echo "  Parallel jobs: $PARALLEL_JOBS"
+echo ""
+
+# Find all beancount files, filtering out exclusions
+mapfile -t all_files < <(find "$FIXTURES_DIR" -name "*.beancount" -type f | sort)
+files=()
+excluded_files=()
+for f in "${all_files[@]}"; do
+    if is_excluded "$f"; then
+        excluded_files+=("$f")
+    else
+        files+=("$f")
+    fi
+done
+total_files=${#files[@]}
+total_excluded=${#excluded_files[@]}
+
+echo "Found $((total_files + total_excluded)) .beancount files"
+if [ "$total_excluded" -gt 0 ]; then
+    echo "  - Testing: $total_files"
+    echo "  - Excluded (known limitations): $total_excluded"
+fi
+echo "Results will be written to: $RESULTS_FILE"
+echo ""
+
+# Export variables and functions for parallel execution
+export FIXTURES_DIR RLEDGER TEMP_DIR
+
+# Create a test script that can be run in parallel
+cat > "$TEMP_DIR/test_one.sh" << 'SCRIPT'
+#!/usr/bin/env bash
+file="$1"
+FIXTURES_DIR="$2"
+RLEDGER_CHECK="$3"
+TEMP_DIR="$4"
+
+relpath="${file#$FIXTURES_DIR/}"
+
+# Escape string for safe JSON embedding (limit to 200 chars)
+escape_json() {
+    echo "$1" | head -c 200 | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | tr '\n' ' '
+}
+
+# Run Python bean-check
+py_stderr=$(mktemp)
+bean-check "$file" >/dev/null 2>"$py_stderr" && py_exit=0 || py_exit=$?
+py_err=$(cat "$py_stderr" | head -c 500)
+rm -f "$py_stderr"
+
+# Run Rust rledger check (capture both stdout and stderr since errors go to stdout)
+# Always use --no-cache for reproducible results during testing
+# Strip ANSI codes to avoid breaking JSON
+rs_output=$(mktemp)
+"$RLEDGER" check --no-cache "$file" >"$rs_output" 2>&1 && rs_exit=0 || rs_exit=$?
+rs_err=$(cat "$rs_output" | sed 's/\x1b\[[0-9;]*m//g' | head -c 500)
+rm -f "$rs_output"
+
+# Determine parse errors
+py_parse_error=false
+rs_parse_error=false
+echo "$py_err" | grep -qi "syntax error\|parse error\|unexpected\|invalid token" && py_parse_error=true
+echo "$rs_err" | grep -qi "syntax error\|parse error\|unexpected\|invalid token" && rs_parse_error=true
+
+# Check if exits match
+exit_match=false
+if [ "$py_exit" -eq 0 ] && [ "$rs_exit" -eq 0 ]; then
+    exit_match=true
+elif [ "$py_exit" -ne 0 ] && [ "$rs_exit" -ne 0 ]; then
+    exit_match=true
+fi
+
+# Count errors
+py_error_count=$(echo "$py_err" | grep -c "error\|Error" || echo 0)
+rs_error_count=$(echo "$rs_err" | grep -c "error\|Error" || echo 0)
+[[ "$py_error_count" =~ ^[0-9]+$ ]] || py_error_count=0
+[[ "$rs_error_count" =~ ^[0-9]+$ ]] || rs_error_count=0
+
+# Escape special chars for JSON using helper function
+py_err_escaped=$(escape_json "$py_err")
+rs_err_escaped=$(escape_json "$rs_err")
+
+# Output JSON result
+echo "{\"file\":\"$relpath\",\"python\":{\"exit\":$py_exit,\"parse_error\":$py_parse_error,\"error_count\":$py_error_count,\"stderr\":\"$py_err_escaped\"},\"rust\":{\"exit\":$rs_exit,\"parse_error\":$rs_parse_error,\"error_count\":$rs_error_count,\"stderr\":\"$rs_err_escaped\"},\"match\":$exit_match}"
+SCRIPT
+chmod +x "$TEMP_DIR/test_one.sh"
+
+echo "Running tests with $PARALLEL_JOBS parallel jobs..."
+echo ""
+
+start_time=$(date +%s)
+
+# Run tests in parallel using xargs
+# Each job outputs one JSON line to stdout
+printf '%s\n' "${files[@]}" | \
+    xargs -P "$PARALLEL_JOBS" -I {} "$TEMP_DIR/test_one.sh" {} "$FIXTURES_DIR" "$RLEDGER_CHECK" "$TEMP_DIR" \
+    > "$RESULTS_FILE" 2>/dev/null
+
+end_time=$(date +%s)
+elapsed=$((end_time - start_time))
+
+echo "Completed in ${elapsed}s"
+echo ""
+echo "=== Results Summary ==="
+echo ""
+
+# Calculate statistics from results
+total=$(wc -l < "$RESULTS_FILE" | tr -d ' ')
+check_match=$(grep -c '"match":true' "$RESULTS_FILE" || echo 0)
+check_mismatch=$((total - check_match))
+
+# Parse match (both have parse error or both don't)
+# Use -c (compact) to ensure one line per match for accurate counting
+parse_match=$(jq -c 'select(.python.parse_error == .rust.parse_error)' "$RESULTS_FILE" 2>/dev/null | wc -l | tr -d ' ')
+parse_fail_python=$(jq -c 'select(.python.parse_error == true and .rust.parse_error == false)' "$RESULTS_FILE" 2>/dev/null | wc -l | tr -d ' ')
+parse_fail_rust=$(jq -c 'select(.rust.parse_error == true and .python.parse_error == false)' "$RESULTS_FILE" 2>/dev/null | wc -l | tr -d ' ')
+
+# Ensure numeric
+[ -z "$parse_match" ] && parse_match=0
+[ -z "$parse_fail_python" ] && parse_fail_python=0
+[ -z "$parse_fail_rust" ] && parse_fail_rust=0
+
+# Calculate percentages
+parse_pct=$((parse_match * 100 / total))
+check_pct=$((check_match * 100 / total))
+
+# Display summary
+echo "Files tested:       $total"
+if [ "$total_excluded" -gt 0 ]; then
+    echo "Files excluded:     $total_excluded (known limitations)"
+fi
+echo "Execution time:     ${elapsed}s ($((total / (elapsed + 1))) files/sec)"
+echo ""
+echo "Parse behavior match: $parse_match/$total ($parse_pct%)"
+echo "  - Python parse error only: $parse_fail_python"
+echo "  - Rust parse error only:   $parse_fail_rust"
+echo ""
+echo "Check exit match:     $check_match/$total ($check_pct%)"
+echo "  - Mismatches: $check_mismatch"
+echo ""
+
+# Generate markdown summary
+cat > "$SUMMARY_FILE" << EOF
+# Beancount Compatibility Report
+
+Generated: $(date)
+
+## Summary
+
+| Metric | Count | Percentage |
+|--------|-------|------------|
+| Files tested | $total | 100% |
+| Files excluded | $total_excluded | (known limitations) |
+| Parse match | $parse_match | $parse_pct% |
+| Check exit match | $check_match | $check_pct% |
+
+## Performance
+
+- **Execution time:** ${elapsed}s
+- **Parallel jobs:** $PARALLEL_JOBS
+- **Rate:** $((total / (elapsed + 1))) files/sec
+
+## Parse Behavior
+
+- **Python-only parse errors:** $parse_fail_python
+- **Rust-only parse errors:** $parse_fail_rust
+
+## Check Mismatches
+
+Total: $check_mismatch files
+
+EOF
+
+# Add exclusions section if any
+if [ "$total_excluded" -gt 0 ]; then
+    cat >> "$SUMMARY_FILE" << EOF
+
+## Excluded Files (Known Limitations)
+
+These files are excluded from testing due to known limitations that are not practical issues.
+See \`tests/compatibility/exclusions.toml\` for details.
+
+EOF
+    for i in "${!excluded_files[@]}"; do
+        relpath="${excluded_files[$i]#$FIXTURES_DIR/}"
+        reason="${EXCLUDED_REASONS[$i]:-No reason provided}"
+        echo "- \`$relpath\`: $reason" >> "$SUMMARY_FILE"
+    done
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# Find and list mismatches
+echo "### Files with exit code mismatch:" >> "$SUMMARY_FILE"
+echo "" >> "$SUMMARY_FILE"
+
+jq -r 'select(.match == false) | "- \(.file): Python=\(.python.exit), Rust=\(.rust.exit)"' "$RESULTS_FILE" 2>/dev/null | head -50 >> "$SUMMARY_FILE" || true
+
+echo "" >> "$SUMMARY_FILE"
+echo "## Details" >> "$SUMMARY_FILE"
+echo "" >> "$SUMMARY_FILE"
+echo "Full results in: \`$RESULTS_FILE\`" >> "$SUMMARY_FILE"
+
+echo "Summary written to: $SUMMARY_FILE"
+echo "Full results in:    $RESULTS_FILE"
+echo ""
+
+# Exit with error if match rate is too low
+if [ "$check_pct" -lt 80 ]; then
+    echo -e "${YELLOW}Warning: Check match rate below 80%${NC}"
+fi

--- a/scripts/fetch-compat-test-files.sh
+++ b/scripts/fetch-compat-test-files.sh
@@ -10,13 +10,13 @@ set -e
 # Target: 800+ unique beancount files from 70+ diverse sources (after deduplication)
 
 DEST="tests/compatibility/files"
-TMPDIR="/tmp/beancount-fetch-$$"
+mkdir -p "$DEST"
+
+TMPDIR=$(mktemp -d /tmp/beancount-fetch-XXX)
 
 echo "=== Fetching Beancount Test Files ==="
 echo ""
 
-mkdir -p "$TMPDIR"
-mkdir -p "$DEST"
 
 cleanup() {
     rm -rf "$TMPDIR"
@@ -33,12 +33,12 @@ fetch_repo() {
     mkdir -p "$subdir"
     echo "Fetching $name..."
 
-    local clone_args=(-- --depth=1)
+    local clone_args="--depth 1"
     if [ -n "$branch" ]; then
-        clone_args+=(--branch="$branch")
+        clone_args+=" -b $branch"
     fi
 
-    gh repo clone "$repo" "$TMPDIR/$name" "${clone_args[@]}" 2>/dev/null || {
+    git clone ${clone_args} git@github.com:$repo.git $TMPDIR/$name 2>/dev/null || {
         echo "  Warning: Failed to clone $name"
         return 0
     }

--- a/scripts/generate-synthetic-compat-test-files.sh
+++ b/scripts/generate-synthetic-compat-test-files.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+echo "Generating synthetic test files..."
+    
+mkdir -p tests/compatibility/files/synthetic
+
+# Use rledger doctor to generate synthetic files with manifest
+./target/release/rledger doctor generate-synthetic \
+    --output tests/compatibility/files/synthetic \
+    --count 50 \
+    --seed 12345 \
+    --manifest \
+    --skip-validation
+echo "Generated $(find tests/compatibility/synthetic -name '*.beancount' 2>/dev/null | wc -l) synthetic files"
+
+# Also generate bean-example files if available
+if command -v bean-example &> /dev/null; then
+    echo "Generating bean-example files..."
+    for seed in 1 42 123; do
+        end_date=$(date +%Y-%m-%d)
+        start_date=$(date -d "$end_date - 1 year" +%Y-%m-%d 2>/dev/null || date -v-1y +%Y-%m-%d)
+        output="tests/compatibility/files/synthetic/bean-example_seed${seed}.beancount"
+        bean-example --seed "$seed" --date-begin "$start_date" --date-end "$end_date" --output "$output" 2>/dev/null || true
+    done
+    echo "Generated $(find tests/compatibility/synthetic/bean-example -name '*.beancount' 2>/dev/null | wc -l) bean-example files"
+fi


### PR DESCRIPTION
## Summary

- Add scripts for comparing rustledger against Python beancount (compat-test, compat-bql-test, compat-ast-test, compat-error-quality, analyze-compat-results)
- Add synthetic test file generation script
- Fix fetch-compat-test-files.sh clone method

Towards #820.

Split from #823 — based on work by @brunotvs.

## Test plan

- [ ] Run `./scripts/compat-test.sh` inside `nix develop`
- [ ] Run `./scripts/compat-bql-test.sh` inside `nix develop`
- [ ] Verify scripts are executable and have correct shebangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)