### PR TITLE
chore: add test vector and regression testing scripts

### DIFF
--- a/scripts/fetch-test-vectors.sh
+++ b/scripts/fetch-test-vectors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # fetch-test-vectors.sh
 # Downloads golden test vectors from upstream sources
 
@@ -7,6 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures"
+TMPDIR=$(mktemp -d)
+trap "rm -rf '$TMPDIR'" EXIT
 
 echo "=== Fetching Beancount Test Vectors ==="
 echo "Target: $FIXTURES_DIR"
@@ -19,33 +21,22 @@ mkdir -p "$FIXTURES_DIR/python-tests"
 
 # 1. Fetch beancount-parser-lima test cases (220 files)
 echo "[1/3] Fetching beancount-parser-lima test cases..."
-if [ -d "/tmp/beancount-parser-lima" ]; then
-    rm -rf /tmp/beancount-parser-lima
-fi
+git clone --depth 1 https://github.com/tesujimath/beancount-parser-lima.git "$TMPDIR/lima"
 
-git clone --depth 1 https://github.com/tesujimath/beancount-parser-lima.git /tmp/beancount-parser-lima
-
-cp -r /tmp/beancount-parser-lima/test-cases/* "$FIXTURES_DIR/lima-tests/"
-echo "  -> Copied $(ls -1 "$FIXTURES_DIR/lima-tests" | wc -l) test files"
+cp -r "$TMPDIR/lima/test-cases/"* "$FIXTURES_DIR/lima-tests/"
+echo "  -> Copied $(find "$FIXTURES_DIR/lima-tests" -name "*.beancount" | wc -l) test files"
 
 # 2. Fetch Python beancount examples
 echo "[2/3] Fetching Python beancount examples..."
-if [ -d "/tmp/beancount" ]; then
-    rm -rf /tmp/beancount
-fi
+git clone --depth 1 --branch v2 https://github.com/beancount/beancount.git "$TMPDIR/beancount"
 
-git clone --depth 1 --branch v2 https://github.com/beancount/beancount.git /tmp/beancount
-
-cp -r /tmp/beancount/examples/* "$FIXTURES_DIR/examples/"
+cp -r "$TMPDIR/beancount/examples/"* "$FIXTURES_DIR/examples/"
 echo "  -> Copied examples directory"
 
 # 3. Copy Python test files (for reference)
 echo "[3/3] Copying Python test references..."
-cp /tmp/beancount/beancount/parser/*_test.py "$FIXTURES_DIR/python-tests/" 2>/dev/null || true
+cp "$TMPDIR/beancount/beancount/parser/"*_test.py "$FIXTURES_DIR/python-tests/" 2>/dev/null || true
 echo "  -> Copied Python test files for reference"
-
-# Cleanup
-rm -rf /tmp/beancount-parser-lima /tmp/beancount
 
 echo
 echo "=== Summary ==="

--- a/scripts/fetch-test-vectors.sh
+++ b/scripts/fetch-test-vectors.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# fetch-test-vectors.sh
+# Downloads golden test vectors from upstream sources
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures"
+
+echo "=== Fetching Beancount Test Vectors ==="
+echo "Target: $FIXTURES_DIR"
+echo
+
+# Create directories
+mkdir -p "$FIXTURES_DIR/lima-tests"
+mkdir -p "$FIXTURES_DIR/examples"
+mkdir -p "$FIXTURES_DIR/python-tests"
+
+# 1. Fetch beancount-parser-lima test cases (220 files)
+echo "[1/3] Fetching beancount-parser-lima test cases..."
+if [ -d "/tmp/beancount-parser-lima" ]; then
+    rm -rf /tmp/beancount-parser-lima
+fi
+
+git clone --depth 1 https://github.com/tesujimath/beancount-parser-lima.git /tmp/beancount-parser-lima
+
+cp -r /tmp/beancount-parser-lima/test-cases/* "$FIXTURES_DIR/lima-tests/"
+echo "  -> Copied $(ls -1 "$FIXTURES_DIR/lima-tests" | wc -l) test files"
+
+# 2. Fetch Python beancount examples
+echo "[2/3] Fetching Python beancount examples..."
+if [ -d "/tmp/beancount" ]; then
+    rm -rf /tmp/beancount
+fi
+
+git clone --depth 1 --branch v2 https://github.com/beancount/beancount.git /tmp/beancount
+
+cp -r /tmp/beancount/examples/* "$FIXTURES_DIR/examples/"
+echo "  -> Copied examples directory"
+
+# 3. Copy Python test files (for reference)
+echo "[3/3] Copying Python test references..."
+cp /tmp/beancount/beancount/parser/*_test.py "$FIXTURES_DIR/python-tests/" 2>/dev/null || true
+echo "  -> Copied Python test files for reference"
+
+# Cleanup
+rm -rf /tmp/beancount-parser-lima /tmp/beancount
+
+echo
+echo "=== Summary ==="
+echo "Lima tests:     $(find "$FIXTURES_DIR/lima-tests" -name "*.beancount" | wc -l) files"
+echo "Examples:       $(find "$FIXTURES_DIR/examples" -name "*.beancount" | wc -l) files"
+echo "Python tests:   $(ls -1 "$FIXTURES_DIR/python-tests" | wc -l) files"
+echo
+echo "Done! Test vectors are in: $FIXTURES_DIR"

--- a/scripts/test-format-regressions.sh
+++ b/scripts/test-format-regressions.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Run format regression tests against rledger format
+# Usage: ./scripts/test-format-regressions.sh [rledger-binary]
+#
+# These tests verify that the formatter preserves comments, metadata, and whitespace.
+# A test passes if formatting twice produces the same output (idempotent).
+
+set -e
+
+RLEDGER="${1:-./target/release/rledger}"
+TESTS_DIR="tests/regressions/format"
+PASSED=0
+FAILED=0
+FAILED_TESTS=""
+
+# Build if binary doesn't exist
+if [ ! -f "$RLEDGER" ]; then
+    echo "Building rledger..."
+    cargo build --release --bin rledger
+fi
+
+echo "Running format regression tests..."
+echo "Binary: $RLEDGER"
+echo "Tests:  $TESTS_DIR"
+echo ""
+
+for f in "$TESTS_DIR"/issue-*.beancount; do
+    if [ ! -f "$f" ]; then
+        echo "No format regression tests found in $TESTS_DIR"
+        exit 0
+    fi
+
+    BASENAME=$(basename "$f")
+    ISSUE_NUM=$(echo "$BASENAME" | sed 's/issue-\([0-9]*\).*/\1/')
+
+    # Create temp files for comparison
+    FORMATTED1=$(mktemp)
+    FORMATTED2=$(mktemp)
+    trap "rm -f $FORMATTED1 $FORMATTED2" EXIT
+
+    # Format once
+    "$RLEDGER" format "$f" > "$FORMATTED1" 2>/dev/null
+
+    # Format the formatted output (should be idempotent)
+    "$RLEDGER" format "$FORMATTED1" > "$FORMATTED2" 2>/dev/null
+
+    # Check idempotency
+    if ! diff -q "$FORMATTED1" "$FORMATTED2" > /dev/null 2>&1; then
+        echo "✗ #$ISSUE_NUM FAILED (not idempotent)"
+        FAILED=$((FAILED + 1))
+        FAILED_TESTS="$FAILED_TESTS #$ISSUE_NUM"
+        continue
+    fi
+
+    # Check that comments are preserved
+    ORIG_COMMENTS=$(grep -c "^;" "$f" || true)
+    FMT_COMMENTS=$(grep -c "^;" "$FORMATTED1" || true)
+    if [ "$ORIG_COMMENTS" -ne "$FMT_COMMENTS" ]; then
+        echo "✗ #$ISSUE_NUM FAILED (comments lost: $ORIG_COMMENTS -> $FMT_COMMENTS)"
+        FAILED=$((FAILED + 1))
+        FAILED_TESTS="$FAILED_TESTS #$ISSUE_NUM"
+        continue
+    fi
+
+    # Check that metadata is preserved (lines with key: value pattern indented)
+    # Note: formatter uses 4-space indent for metadata by default
+    ORIG_META=$(grep -cE "^[[:space:]]+[a-z]+:" "$f" || true)
+    FMT_META=$(grep -cE "^[[:space:]]+[a-z]+:" "$FORMATTED1" || true)
+    if [ "$ORIG_META" -ne "$FMT_META" ]; then
+        echo "✗ #$ISSUE_NUM FAILED (metadata lost: $ORIG_META -> $FMT_META)"
+        FAILED=$((FAILED + 1))
+        FAILED_TESTS="$FAILED_TESTS #$ISSUE_NUM"
+        continue
+    fi
+
+    echo "✓ #$ISSUE_NUM passed (comments: $ORIG_COMMENTS, metadata: $ORIG_META)"
+    PASSED=$((PASSED + 1))
+done
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+
+if [ $FAILED -gt 0 ]; then
+    echo "Failed tests:$FAILED_TESTS"
+    exit 1
+fi

--- a/scripts/test-format-regressions.sh
+++ b/scripts/test-format-regressions.sh
@@ -24,6 +24,15 @@ echo "Binary: $RLEDGER"
 echo "Tests:  $TESTS_DIR"
 echo ""
 
+# Single trap for cleanup — collect all temp files
+TMPFILES=()
+cleanup() {
+    for f in "${TMPFILES[@]}"; do
+        rm -f "$f"
+    done
+}
+trap cleanup EXIT
+
 for f in "$TESTS_DIR"/issue-*.beancount; do
     if [ ! -f "$f" ]; then
         echo "No format regression tests found in $TESTS_DIR"
@@ -36,7 +45,7 @@ for f in "$TESTS_DIR"/issue-*.beancount; do
     # Create temp files for comparison
     FORMATTED1=$(mktemp)
     FORMATTED2=$(mktemp)
-    trap "rm -f $FORMATTED1 $FORMATTED2" EXIT
+    TMPFILES+=("$FORMATTED1" "$FORMATTED2")
 
     # Format once
     "$RLEDGER" format "$f" > "$FORMATTED1" 2>/dev/null

--- a/scripts/test-lima.sh
+++ b/scripts/test-lima.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Test parser against lima test vectors
+
+failed=0
+passed=0
+total=0
+
+for f in tests/fixtures/lima-tests/*.beancount; do
+    total=$((total+1))
+    basename=$(basename "$f")
+    out=$(cargo run --quiet --bin bean-check -- "$f" 2>&1)
+    has_syntax_error=false
+    if echo "$out" | grep -qi "syntax error"; then
+        has_syntax_error=true
+    fi
+
+    # SyntaxErrors.* files are expected to produce syntax errors
+    if [[ "$basename" == SyntaxErrors.* ]]; then
+        if $has_syntax_error; then
+            passed=$((passed+1))
+        else
+            echo "FAIL (expected syntax error): $basename"
+            failed=$((failed+1))
+        fi
+    else
+        if $has_syntax_error; then
+            echo "FAIL: $basename"
+            failed=$((failed+1))
+        else
+            passed=$((passed+1))
+        fi
+    fi
+done
+
+echo "---"
+echo "Total: $total"
+echo "Passed: $passed"
+echo "Failed: $failed"

--- a/scripts/test-lima.sh
+++ b/scripts/test-lima.sh
@@ -1,30 +1,55 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test parser against lima test vectors
+#
+# Usage: ./scripts/test-lima.sh [rledger-binary]
+#
+# Downloads test vectors first if not present (run fetch-test-vectors.sh).
+
+set -uo pipefail
+
+RLEDGER="${1:-./target/release/rledger}"
+
+# Build if binary doesn't exist
+if [ ! -f "$RLEDGER" ]; then
+    echo "Building rledger..."
+    cargo build --release -p rustledger --quiet
+    RLEDGER="./target/release/rledger"
+fi
+
+TESTS_DIR="tests/fixtures/lima-tests"
+if [ ! -d "$TESTS_DIR" ] || [ -z "$(ls -A "$TESTS_DIR" 2>/dev/null)" ]; then
+    echo "Lima test vectors not found. Run: ./scripts/fetch-test-vectors.sh"
+    exit 1
+fi
 
 failed=0
 passed=0
 total=0
 
-for f in tests/fixtures/lima-tests/*.beancount; do
+for f in "$TESTS_DIR"/*.beancount; do
     total=$((total+1))
     basename=$(basename "$f")
-    out=$(cargo run --quiet --bin bean-check -- "$f" 2>&1)
-    has_syntax_error=false
-    if echo "$out" | grep -qi "syntax error"; then
-        has_syntax_error=true
+
+    # Run rledger check and capture both exit code and output
+    out=$("$RLEDGER" check "$f" 2>&1) || true
+    exit_code=$?
+
+    has_error=false
+    if [ $exit_code -ne 0 ] || echo "$out" | grep -qi "syntax error\|parse error\|unexpected"; then
+        has_error=true
     fi
 
-    # SyntaxErrors.* files are expected to produce syntax errors
-    if [[ "$basename" == SyntaxErrors.* ]]; then
-        if $has_syntax_error; then
+    # Files matching these patterns are expected to produce errors
+    if [[ "$basename" == SyntaxErrors.* ]] || [[ "$basename" == LexerAndParserErrors.* ]]; then
+        if $has_error; then
             passed=$((passed+1))
         else
-            echo "FAIL (expected syntax error): $basename"
+            echo "FAIL (expected error): $basename"
             failed=$((failed+1))
         fi
     else
-        if $has_syntax_error; then
-            echo "FAIL: $basename"
+        if $has_error; then
+            echo "FAIL (unexpected error): $basename"
             failed=$((failed+1))
         else
             passed=$((passed+1))
@@ -36,3 +61,7 @@ echo "---"
 echo "Total: $total"
 echo "Passed: $passed"
 echo "Failed: $failed"
+
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Add fetch-test-vectors.sh for downloading lima and Python beancount test cases
- Add test-lima.sh for running beancount-parser-lima test suite
- Add test-format-regressions.sh for format regression testing

Split from #823 — based on work by @brunotvs.

## Test plan

- [ ] Run `./scripts/fetch-test-vectors.sh` and verify test files are downloaded
- [ ] Run `./scripts/test-lima.sh` and verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)