### PR TITLE
chore: add benchmark comparison and chart generation scripts

### DIFF
--- a/scripts/bench-compare.py
+++ b/scripts/bench-compare.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Benchmark comparison and regression detection tool.
+
+This script compares benchmark results from hyperfine JSON output against
+historical baselines stored in the benchmarks branch.
+
+Usage:
+    # Compare latest local benchmark against history
+    ./scripts/bench-compare.py bench-validation.json
+
+    # Compare against specific baseline
+    ./scripts/bench-compare.py bench-validation.json --baseline 30.0
+
+    # Check for regressions (exit 1 if regression detected)
+    ./scripts/bench-compare.py bench-validation.json --fail-on-regression
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+# Default regression threshold (percentage)
+DEFAULT_THRESHOLD = 15.0
+
+
+def load_hyperfine_results(filepath: Path) -> dict[str, float]:
+    """Load results from hyperfine JSON output."""
+    with open(filepath) as f:
+        data = json.load(f)
+
+    results = {}
+    for r in data.get("results", []):
+        name = r.get("command", "unknown")
+        mean_ms = r.get("mean", 0) * 1000  # Convert to milliseconds
+        results[name] = round(mean_ms, 2)
+
+    return results
+
+
+def load_baseline_from_history(history_file: Path) -> Optional[float]:
+    """Load the most recent rustledger result from history."""
+    if not history_file.exists():
+        return None
+
+    try:
+        with open(history_file) as f:
+            history = json.load(f)
+        if history:
+            return history[-1].get("rustledger_ms")
+    except (json.JSONDecodeError, KeyError):
+        # History file may be malformed or missing expected fields - safe to ignore
+        # and fall through to return None (no baseline available)
+        pass
+
+    return None
+
+
+def compare_results(
+    current: float,
+    baseline: float,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> tuple[float, str]:
+    """Compare current vs baseline, return (change_percent, status)."""
+    if baseline <= 0:
+        return 0.0, "no_baseline"
+
+    change = ((current - baseline) / baseline) * 100
+
+    if change > threshold:
+        status = "regression"
+    elif change > 5:
+        status = "warning"
+    elif change < -5:
+        status = "improvement"
+    else:
+        status = "stable"
+
+    return change, status
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare benchmark results and detect regressions"
+    )
+    parser.add_argument(
+        "results_file",
+        type=Path,
+        help="Hyperfine JSON results file",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=float,
+        default=None,
+        help="Baseline time in ms (overrides history lookup)",
+    )
+    parser.add_argument(
+        "--history",
+        type=Path,
+        default=None,
+        help="Path to history JSON file for baseline lookup",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"Regression threshold percentage (default: {DEFAULT_THRESHOLD}%%)",
+    )
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit with code 1 if regression detected",
+    )
+    parser.add_argument(
+        "--tool",
+        default="rustledger",
+        help="Tool name to check for regression (default: rustledger)",
+    )
+
+    args = parser.parse_args()
+
+    # Load current results
+    if not args.results_file.exists():
+        print(f"Error: Results file not found: {args.results_file}")
+        sys.exit(1)
+
+    results = load_hyperfine_results(args.results_file)
+
+    if args.tool not in results:
+        print(f"Error: Tool '{args.tool}' not found in results")
+        print(f"Available tools: {list(results.keys())}")
+        sys.exit(1)
+
+    current = results[args.tool]
+
+    # Get baseline
+    baseline = args.baseline
+    if baseline is None and args.history:
+        baseline = load_baseline_from_history(args.history)
+
+    # Print all results
+    print("=" * 60)
+    print("Benchmark Results")
+    print("=" * 60)
+    for tool, time_ms in sorted(results.items(), key=lambda x: x[1]):
+        marker = " <--" if tool == args.tool else ""
+        print(f"  {tool:20} {time_ms:8.1f} ms{marker}")
+    print()
+
+    # Compare against baseline if available
+    if baseline is not None:
+        change, status = compare_results(current, baseline, args.threshold)
+
+        print("=" * 60)
+        print("Regression Check")
+        print("=" * 60)
+        print(f"  Tool:      {args.tool}")
+        print(f"  Current:   {current:.1f} ms")
+        print(f"  Baseline:  {baseline:.1f} ms")
+        print(f"  Change:    {change:+.1f}%")
+        print(f"  Threshold: {args.threshold}%")
+        print(f"  Status:    {status.upper()}")
+        print()
+
+        # Status symbols
+        status_symbols = {
+            "regression": "[FAIL] Regression detected",
+            "warning": "[WARN] Performance degradation",
+            "improvement": "[GOOD] Performance improved",
+            "stable": "[OK] Stable performance",
+            "no_baseline": "[SKIP] No baseline available",
+        }
+        print(status_symbols.get(status, status))
+
+        if status == "regression" and args.fail_on_regression:
+            sys.exit(1)
+    else:
+        print("No baseline available for comparison.")
+        print("Run benchmarks with --history to compare against historical data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-bench-charts.py
+++ b/scripts/generate-bench-charts.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Generate Vega benchmark charts from history JSON files.
+
+This script loads the Vega spec template from .github/badges/validation-spec.json
+and populates it with benchmark data.
+
+Usage:
+    # Generate specs from history files
+    ./scripts/generate-bench-charts.py
+
+    # Generate with custom values (for testing)
+    ./scripts/generate-bench-charts.py --rustledger 32 --ledger 65 --hledger 540 --beancount 880
+
+    # Render to SVG (requires: npm install -g vega vega-cli)
+    vg2svg .github/badges/validation-chart.vega.json validation-chart.svg
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def load_spec_template(template_path: Path) -> dict:
+    """Load a Vega spec template from file."""
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template not found: {template_path}")
+    return json.loads(template_path.read_text())
+
+
+def populate_spec(
+    spec: dict,
+    title: str,
+    subtitle: str,
+    rustledger_ms: float,
+    ledger_ms: float,
+    hledger_ms: float,
+    beancount_ms: float,
+    bench_date: str,
+) -> dict:
+    """Populate a Vega spec template with benchmark data."""
+    max_ms = max(rustledger_ms, ledger_ms, hledger_ms, beancount_ms)
+
+    # Update signals
+    signal_updates = {
+        "rustledger_ms": rustledger_ms,
+        "max_ms": max_ms,
+        "bench_date": bench_date,
+    }
+    for signal in spec.get("signals", []):
+        if signal["name"] in signal_updates:
+            signal["value"] = signal_updates[signal["name"]]
+
+    # Update data values
+    benchmark_values = [
+        {"tool": "rustledger", "label": "rustledger", "time_ms": rustledger_ms, "baseline_ms": beancount_ms, "color": "#00d4aa"},
+        {"tool": "ledger", "label": "ledger (C++)", "time_ms": ledger_ms, "baseline_ms": beancount_ms, "color": "#9b59b6"},
+        {"tool": "hledger", "label": "hledger (Haskell)", "time_ms": hledger_ms, "baseline_ms": beancount_ms, "color": "#e74c3c"},
+        {"tool": "beancount", "label": "beancount (Python)", "time_ms": beancount_ms, "baseline_ms": beancount_ms, "color": "#f4b942"},
+    ]
+    for data_item in spec.get("data", []):
+        if data_item.get("name") == "benchmarks":
+            data_item["values"] = benchmark_values
+
+    # Update title
+    if "title" in spec:
+        spec["title"]["text"] = title
+        spec["title"]["subtitle"] = subtitle
+
+    return spec
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Vega benchmark charts")
+    parser.add_argument("--rustledger", type=float, help="rustledger time in ms")
+    parser.add_argument("--ledger", type=float, help="ledger time in ms")
+    parser.add_argument("--hledger", type=float, help="hledger time in ms")
+    parser.add_argument("--beancount", type=float, help="beancount time in ms")
+    parser.add_argument("--output-dir", type=Path, default=Path(".github/badges"))
+    parser.add_argument("--render", action="store_true", help="Render to SVG using vg2svg")
+
+    args = parser.parse_args()
+
+    # Determine script location to find templates
+    script_dir = Path(__file__).parent
+    repo_root = script_dir.parent
+    template_dir = repo_root / ".github" / "badges"
+
+    # Use provided values or load from history
+    if all([args.rustledger, args.ledger, args.hledger, args.beancount]):
+        val_data = {
+            "rustledger_ms": args.rustledger,
+            "ledger_ms": args.ledger,
+            "hledger_ms": args.hledger,
+            "beancount_ms": args.beancount,
+        }
+        bal_data = val_data.copy()
+        bench_date = datetime.now().strftime("%Y-%m-%d")
+    else:
+        # Load from history files
+        val_history_file = args.output_dir / "validation-history.json"
+        bal_history_file = args.output_dir / "balance-history.json"
+
+        if not val_history_file.exists():
+            print(f"Error: {val_history_file} not found")
+            print("Provide values with --rustledger, --ledger, --hledger, --beancount")
+            sys.exit(1)
+
+        val_history = json.loads(val_history_file.read_text())
+        bal_history = json.loads(bal_history_file.read_text())
+
+        if not val_history:
+            print("Error: validation history is empty")
+            sys.exit(1)
+
+        val_data = val_history[-1]
+        bal_data = bal_history[-1] if bal_history else val_data
+        bench_date = val_data.get("date", datetime.now().strftime("%Y-%m-%d"))
+
+    # Load spec template
+    template_path = template_dir / "validation-spec.json"
+    try:
+        spec_template = load_spec_template(template_path)
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    # Generate validation chart
+    import copy
+    val_spec = populate_spec(
+        copy.deepcopy(spec_template),
+        title="Validation: Parse + Check (10K transactions)",
+        subtitle="rustledger vs other plain-text accounting tools",
+        rustledger_ms=val_data["rustledger_ms"],
+        ledger_ms=val_data["ledger_ms"],
+        hledger_ms=val_data["hledger_ms"],
+        beancount_ms=val_data["beancount_ms"],
+        bench_date=bench_date,
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    val_spec_path = args.output_dir / "validation-chart.vega.json"
+    val_spec_path.write_text(json.dumps(val_spec, indent=2))
+    print(f"Generated: {val_spec_path}")
+
+    # Generate balance chart
+    bal_spec = populate_spec(
+        copy.deepcopy(spec_template),
+        title="Balance Report: Parse + Compute (10K transactions)",
+        subtitle="rustledger vs other plain-text accounting tools",
+        rustledger_ms=bal_data.get("rustledger_ms", val_data["rustledger_ms"]),
+        ledger_ms=bal_data.get("ledger_ms", val_data["ledger_ms"]),
+        hledger_ms=bal_data.get("hledger_ms", val_data["hledger_ms"]),
+        beancount_ms=bal_data.get("beancount_ms", val_data["beancount_ms"]),
+        bench_date=bench_date,
+    )
+
+    bal_spec_path = args.output_dir / "balance-chart.vega.json"
+    bal_spec_path.write_text(json.dumps(bal_spec, indent=2))
+    print(f"Generated: {bal_spec_path}")
+
+    # Render to SVG if requested
+    if args.render:
+        try:
+            for name in ["validation-chart", "balance-chart"]:
+                spec_path = args.output_dir / f"{name}.vega.json"
+                svg_path = args.output_dir / f"{name}.svg"
+                subprocess.run(["vg2svg", str(spec_path), str(svg_path)], check=True)
+                print(f"Rendered: {svg_path}")
+        except FileNotFoundError:
+            print("\nError: vg2svg not found. Install with: npm install -g vega vega-cli")
+            sys.exit(1)
+        except subprocess.CalledProcessError as e:
+            print(f"\nError rendering: {e}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add bench-compare.py for comparing hyperfine benchmark results against baselines and detecting regressions
- Add generate-bench-charts.py for generating Vega benchmark visualization charts

Split from #823 — based on work by @brunotvs.

## Test plan

- [ ] Run `./scripts/bench-compare.py --help` and verify usage output
- [ ] Run `./scripts/generate-bench-charts.py --help` and verify usage output

🤖 Generated with [Claude Code](https://claude.com/claude-code)