### PR TITLE
chore: add TLA+ model-based testing tooling

### DIFF
--- a/scripts/model_based_testing.py
+++ b/scripts/model_based_testing.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+Model-Based Testing Generator for rustledger
+
+Generates exhaustive Rust test cases directly from TLA+ state machine models.
+Unlike trace-to-test (which converts counterexamples), this generates tests
+for ALL transitions in the state machine.
+
+Usage:
+    python model_based_testing.py --spec BookingMethods --output tests/generated_mbt.rs
+    python model_based_testing.py --spec Inventory --depth 3 --output tests/inventory_mbt.rs
+"""
+
+import re
+import sys
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+from itertools import product
+
+
+@dataclass
+class StateVariable:
+    """Represents a TLA+ state variable."""
+    name: str
+    tla_type: str
+    rust_type: str
+    initial_value: Any
+
+
+@dataclass
+class Action:
+    """Represents a TLA+ action (state transition)."""
+    name: str
+    parameters: list[tuple[str, str, str]]  # (name, tla_type, rust_type)
+    precondition: str
+    effect: str
+    rust_implementation: str
+
+
+@dataclass
+class StateModel:
+    """Complete TLA+ state machine model."""
+    name: str
+    variables: list[StateVariable]
+    actions: list[Action]
+    invariants: list[str]
+
+
+# Predefined models based on TLA+ specs
+BOOKING_MODEL = StateModel(
+    name="BookingMethods",
+    variables=[
+        StateVariable("lots", "Set(Lot)", "Vec<Lot>", "vec![]"),
+        StateVariable("method", "BookingMethod", "BookingMethod", "BookingMethod::FIFO"),
+        StateVariable("total_reduced", "Nat", "u64", "0"),
+    ],
+    actions=[
+        Action(
+            name="AddLot",
+            parameters=[
+                ("units", "1..MaxUnits", "u32"),
+                ("cost", "1..MaxCost", "u32"),
+                ("date", "1..MaxDate", "u32"),
+            ],
+            precondition="lots.len() < MAX_LOTS",
+            effect="lots.push(Lot { units, cost, date })",
+            rust_implementation="""
+    let lot = Lot { units: {units}, cost_per_unit: dec!({cost}), date: make_date({date}) };
+    inventory.add_position(lot.into());
+""",
+        ),
+        Action(
+            name="ReduceFIFO",
+            parameters=[
+                ("units", "1..MaxUnits", "u32"),
+            ],
+            precondition="method == FIFO && total_units() >= units",
+            effect="reduce oldest lot by units",
+            rust_implementation="""
+    inventory.reduce(BookingMethod::FIFO, dec!({units}), &CostSpec::default()).unwrap();
+""",
+        ),
+        Action(
+            name="ReduceLIFO",
+            parameters=[
+                ("units", "1..MaxUnits", "u32"),
+            ],
+            precondition="method == LIFO && total_units() >= units",
+            effect="reduce newest lot by units",
+            rust_implementation="""
+    inventory.reduce(BookingMethod::LIFO, dec!({units}), &CostSpec::default()).unwrap();
+""",
+        ),
+        Action(
+            name="ReduceHIFO",
+            parameters=[
+                ("units", "1..MaxUnits", "u32"),
+            ],
+            precondition="method == HIFO && total_units() >= units",
+            effect="reduce highest cost lot by units",
+            rust_implementation="""
+    inventory.reduce(BookingMethod::HIFO, dec!({units}), &CostSpec::default()).unwrap();
+""",
+        ),
+        Action(
+            name="SetMethod",
+            parameters=[
+                ("method", "BookingMethod", "BookingMethod"),
+            ],
+            precondition="true",
+            effect="method = new_method",
+            rust_implementation="""
+    // Method is set per-reduction in Rust, not stored in inventory
+""",
+        ),
+    ],
+    invariants=[
+        "NonNegativeUnits: total_units() >= 0",
+        "ValidLots: all lots have positive units",
+        "FIFOProperty: FIFO selects oldest",
+        "LIFOProperty: LIFO selects newest",
+        "HIFOProperty: HIFO selects highest cost",
+    ],
+)
+
+INVENTORY_MODEL = StateModel(
+    name="Inventory",
+    variables=[
+        StateVariable("inventory", "Set(Position)", "Inventory", "Inventory::new()"),
+        StateVariable("operations", "Seq(Op)", "Vec<Op>", "vec![]"),
+    ],
+    actions=[
+        Action(
+            name="Augment",
+            parameters=[
+                ("units", "1..MaxUnits", "u32"),
+                ("currency", "Currencies", "&str"),
+                ("cost", "1..MaxCost", "u32"),
+            ],
+            precondition="units > 0",
+            effect="add position to inventory",
+            rust_implementation="""
+    let amount = Amount::new(dec!({units}), "{currency}".into());
+    let cost = Cost {{ amount: Some(Amount::new(dec!({cost}), "USD".into())), date: Some(make_date(1)), label: None }};
+    inventory.add_position(Position {{ units: amount, cost: Some(cost) }});
+""",
+        ),
+        Action(
+            name="ReduceStrict",
+            parameters=[
+                ("units", "1..MaxUnits", "u32"),
+                ("currency", "Currencies", "&str"),
+            ],
+            precondition="matching positions exist with sufficient units",
+            effect="reduce matching position",
+            rust_implementation="""
+    inventory.reduce(BookingMethod::STRICT, dec!({units}), &CostSpec::default()).unwrap();
+""",
+        ),
+    ],
+    invariants=[
+        "NonNegativeUnits: units never negative (except NONE)",
+        "ValidPositions: no zero-unit positions",
+    ],
+)
+
+MODELS = {
+    "BookingMethods": BOOKING_MODEL,
+    "Inventory": INVENTORY_MODEL,
+}
+
+
+def generate_test_sequences(model: StateModel, depth: int) -> Iterator[list[tuple[Action, dict]]]:
+    """Generate all possible action sequences up to given depth."""
+    def generate_params(action: Action) -> Iterator[dict]:
+        """Generate parameter combinations for an action."""
+        param_values = []
+        for name, tla_type, rust_type in action.parameters:
+            if "1.." in tla_type:
+                # Range type - sample a few values
+                match = re.match(r"(\d+)\.\.(\w+)", tla_type)
+                if match:
+                    start = int(match.group(1))
+                    param_values.append([(name, v) for v in [start, start + 1, start + 2]])
+                else:
+                    param_values.append([(name, 1)])
+            elif tla_type == "BookingMethod":
+                param_values.append([(name, m) for m in ["FIFO", "LIFO", "HIFO"]])
+            elif tla_type == "Currencies":
+                param_values.append([(name, c) for c in ["USD", "AAPL"]])
+            else:
+                param_values.append([(name, "default")])
+
+        for combo in product(*param_values):
+            yield dict(combo)
+
+    def generate_sequences(current_depth: int) -> Iterator[list[tuple[Action, dict]]]:
+        """Recursively generate action sequences."""
+        if current_depth == 0:
+            yield []
+            return
+
+        for shorter in generate_sequences(current_depth - 1):
+            yield shorter  # Include shorter sequences too
+
+            for action in model.actions:
+                for params in generate_params(action):
+                    yield shorter + [(action, params)]
+
+    yield from generate_sequences(depth)
+
+
+def generate_rust_test(model: StateModel, sequence: list[tuple[Action, dict]], test_num: int) -> str:
+    """Generate a Rust test from an action sequence."""
+    # Create test name from actions
+    action_names = "_".join(a.name.lower() for a, _ in sequence[:3])
+    if len(sequence) > 3:
+        action_names += f"_plus{len(sequence) - 3}"
+
+    test_name = f"mbt_{model.name.lower()}_{action_names}_{test_num}"
+
+    # Generate test body
+    setup = "\n".join(f"    let mut {v.name} = {v.initial_value};" for v in model.variables)
+
+    steps = []
+    for action, params in sequence:
+        impl = action.rust_implementation
+        for param_name, param_value in params.items():
+            impl = impl.replace(f"{{{param_name}}}", str(param_value))
+        steps.append(f"    // Action: {action.name}({', '.join(f'{k}={v}' for k, v in params.items())})")
+        steps.append(impl.strip())
+
+    # Generate invariant checks
+    invariant_checks = "\n".join(f"    // Check: {inv}" for inv in model.invariants)
+
+    return f"""
+/// MBT Generated Test #{test_num}
+/// Sequence: {' -> '.join(a.name for a, _ in sequence)}
+#[test]
+fn {test_name}() {{
+{setup}
+
+{chr(10).join(steps)}
+
+{invariant_checks}
+    // Invariants checked by construction
+}}
+"""
+
+
+def generate_test_module(model: StateModel, depth: int, max_tests: int) -> str:
+    """Generate a complete Rust test module."""
+    tests = []
+    test_num = 0
+
+    for sequence in generate_test_sequences(model, depth):
+        if not sequence:
+            continue  # Skip empty sequences
+
+        test = generate_rust_test(model, sequence, test_num)
+        tests.append(test)
+        test_num += 1
+
+        if test_num >= max_tests:
+            break
+
+    imports = """//! Model-Based Tests Generated from TLA+ Specification
+//!
+//! Spec: {name}
+//! Depth: {depth}
+//! Tests: {count}
+//!
+//! These tests exhaustively cover all action sequences up to the specified depth,
+//! verifying that TLA+ invariants hold in the Rust implementation.
+
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use rustledger_core::{{Amount, Inventory, Position, Cost, CostSpec}};
+use rustledger_core::inventory::BookingMethod;
+use chrono::NaiveDate;
+
+fn make_date(days: i32) -> NaiveDate {{
+    NaiveDate::from_ymd_opt(2024, 1, 1).unwrap() + chrono::Duration::days(days as i64)
+}}
+
+#[derive(Debug, Clone)]
+struct Lot {{
+    units: u32,
+    cost_per_unit: Decimal,
+    date: NaiveDate,
+}}
+
+impl From<Lot> for Position {{
+    fn from(lot: Lot) -> Self {{
+        Position {{
+            units: Amount::new(Decimal::from(lot.units), "AAPL".into()),
+            cost: Some(Cost {{
+                amount: Some(Amount::new(lot.cost_per_unit, "USD".into())),
+                date: Some(lot.date),
+                label: None,
+            }}),
+        }}
+    }}
+}}
+""".format(name=model.name, depth=depth, count=len(tests))
+
+    return imports + "\n".join(tests)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate model-based tests from TLA+ specifications"
+    )
+    parser.add_argument(
+        "--spec", "-s",
+        choices=list(MODELS.keys()),
+        required=True,
+        help="TLA+ specification to generate tests from"
+    )
+    parser.add_argument(
+        "--depth", "-d",
+        type=int,
+        default=2,
+        help="Maximum depth of action sequences (default: 2)"
+    )
+    parser.add_argument(
+        "--max-tests", "-m",
+        type=int,
+        default=100,
+        help="Maximum number of tests to generate (default: 100)"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output Rust file (default: stdout)"
+    )
+
+    args = parser.parse_args()
+
+    model = MODELS[args.spec]
+    rust_code = generate_test_module(model, args.depth, args.max_tests)
+
+    if args.output:
+        args.output.write_text(rust_code)
+        print(f"Generated {args.output}", file=sys.stderr)
+    else:
+        print(rust_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tla_coverage.py
+++ b/scripts/tla_coverage.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+TLA+ State Space Coverage Analysis Tool
+
+Analyzes TLC output to determine which states and transitions are covered
+by Rust tests, identifying potential gaps in test coverage.
+
+Usage:
+    python tla_coverage.py --tlc-output tlc.log --rust-traces traces/*.json --report coverage.html
+"""
+
+import json
+import re
+import sys
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from collections import defaultdict
+
+
+@dataclass
+class TLAState:
+    """Represents a TLA+ state."""
+    state_num: int
+    variables: dict[str, Any]
+    fingerprint: str = ""
+
+    def __post_init__(self):
+        # Create a fingerprint for state comparison
+        self.fingerprint = self._compute_fingerprint()
+
+    def _compute_fingerprint(self) -> str:
+        """Compute a hashable fingerprint of the state."""
+        def normalize(v):
+            if isinstance(v, dict):
+                return tuple(sorted((k, normalize(vv)) for k, vv in v.items()))
+            elif isinstance(v, (list, tuple)):
+                return tuple(normalize(x) for x in v)
+            elif isinstance(v, set):
+                return frozenset(normalize(x) for x in v)
+            return v
+        return str(normalize(self.variables))
+
+
+@dataclass
+class TLATransition:
+    """Represents a TLA+ state transition."""
+    from_state: int
+    to_state: int
+    action: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.from_state}->{self.to_state}:{self.action}"
+
+
+@dataclass
+class CoverageReport:
+    """Coverage analysis report."""
+    spec_name: str
+    total_states: int = 0
+    covered_states: int = 0
+    total_transitions: int = 0
+    covered_transitions: int = 0
+    uncovered_states: list = field(default_factory=list)
+    uncovered_transitions: list = field(default_factory=list)
+    state_coverage_by_var: dict = field(default_factory=dict)
+    action_coverage: dict = field(default_factory=dict)
+
+    @property
+    def state_coverage_pct(self) -> float:
+        return (self.covered_states / self.total_states * 100) if self.total_states else 0
+
+    @property
+    def transition_coverage_pct(self) -> float:
+        return (self.covered_transitions / self.total_transitions * 100) if self.total_transitions else 0
+
+
+def parse_tlc_states(tlc_output: str) -> tuple[list[TLAState], list[TLATransition]]:
+    """Parse TLC output to extract states and transitions."""
+    states = []
+    transitions = []
+
+    # Pattern for state output
+    state_pattern = re.compile(r'^State (\d+):.*$', re.MULTILINE)
+    var_pattern = re.compile(r'^/\\ (\w+) = (.+)$', re.MULTILINE)
+
+    current_state_num = None
+    current_vars = {}
+
+    for line in tlc_output.split('\n'):
+        state_match = state_pattern.match(line)
+        if state_match:
+            # Save previous state
+            if current_state_num is not None:
+                states.append(TLAState(current_state_num, current_vars))
+            current_state_num = int(state_match.group(1))
+            current_vars = {}
+
+            # Extract action if present
+            action_match = re.search(r'<(\w+)', line)
+            if action_match and len(states) > 0:
+                transitions.append(TLATransition(
+                    from_state=len(states),
+                    to_state=len(states) + 1,
+                    action=action_match.group(1)
+                ))
+            continue
+
+        var_match = var_pattern.match(line)
+        if var_match and current_state_num is not None:
+            var_name = var_match.group(1)
+            var_value = var_match.group(2)
+            current_vars[var_name] = var_value
+
+    # Save last state
+    if current_state_num is not None:
+        states.append(TLAState(current_state_num, current_vars))
+
+    return states, transitions
+
+
+def parse_rust_traces(trace_files: list[Path]) -> set[str]:
+    """Parse Rust test traces and extract covered state fingerprints."""
+    covered_fingerprints = set()
+
+    for trace_file in trace_files:
+        try:
+            with open(trace_file) as f:
+                trace = json.load(f)
+
+            for state in trace.get("states", []):
+                # Create fingerprint from Rust trace state
+                vars = state.get("variables", {})
+                fp = str(sorted(vars.items()))
+                covered_fingerprints.add(fp)
+
+        except (json.JSONDecodeError, KeyError) as e:
+            print(f"Warning: Could not parse {trace_file}: {e}", file=sys.stderr)
+
+    return covered_fingerprints
+
+
+def analyze_coverage(
+    states: list[TLAState],
+    transitions: list[TLATransition],
+    covered_fingerprints: set[str],
+    spec_name: str
+) -> CoverageReport:
+    """Analyze coverage of TLA+ states by Rust tests."""
+    report = CoverageReport(spec_name=spec_name)
+    report.total_states = len(states)
+    report.total_transitions = len(transitions)
+
+    # Analyze state coverage
+    for state in states:
+        if state.fingerprint in covered_fingerprints:
+            report.covered_states += 1
+        else:
+            report.uncovered_states.append(state)
+
+    # Analyze transition coverage
+    transition_actions = defaultdict(int)
+    covered_actions = defaultdict(int)
+
+    for trans in transitions:
+        transition_actions[trans.action] += 1
+        # Check if both states are covered
+        from_covered = any(s.state_num == trans.from_state and s.fingerprint in covered_fingerprints
+                          for s in states)
+        to_covered = any(s.state_num == trans.to_state and s.fingerprint in covered_fingerprints
+                        for s in states)
+
+        if from_covered and to_covered:
+            report.covered_transitions += 1
+            covered_actions[trans.action] += 1
+        else:
+            report.uncovered_transitions.append(trans)
+
+    # Calculate per-action coverage
+    for action, total in transition_actions.items():
+        covered = covered_actions.get(action, 0)
+        report.action_coverage[action] = {
+            "total": total,
+            "covered": covered,
+            "percentage": (covered / total * 100) if total else 0
+        }
+
+    # Analyze per-variable coverage
+    var_values = defaultdict(set)
+    covered_var_values = defaultdict(set)
+
+    for state in states:
+        for var_name, var_value in state.variables.items():
+            var_values[var_name].add(str(var_value))
+            if state.fingerprint in covered_fingerprints:
+                covered_var_values[var_name].add(str(var_value))
+
+    for var_name, values in var_values.items():
+        covered = covered_var_values.get(var_name, set())
+        report.state_coverage_by_var[var_name] = {
+            "total_values": len(values),
+            "covered_values": len(covered),
+            "percentage": (len(covered) / len(values) * 100) if values else 0,
+            "uncovered": list(values - covered)[:5]  # First 5 uncovered values
+        }
+
+    return report
+
+
+def generate_html_report(report: CoverageReport) -> str:
+    """Generate an HTML coverage report."""
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>TLA+ Coverage Report: {report.spec_name}</title>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 40px; }}
+        h1 {{ color: #333; }}
+        .summary {{ background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0; }}
+        .metric {{ display: inline-block; margin-right: 40px; }}
+        .metric-value {{ font-size: 2em; font-weight: bold; }}
+        .metric-label {{ color: #666; }}
+        .good {{ color: #28a745; }}
+        .medium {{ color: #ffc107; }}
+        .poor {{ color: #dc3545; }}
+        table {{ border-collapse: collapse; width: 100%; margin: 20px 0; }}
+        th, td {{ border: 1px solid #ddd; padding: 12px; text-align: left; }}
+        th {{ background: #f8f9fa; }}
+        .progress {{ background: #e9ecef; border-radius: 4px; overflow: hidden; }}
+        .progress-bar {{ height: 20px; background: #28a745; }}
+    </style>
+</head>
+<body>
+    <h1>TLA+ Coverage Report: {report.spec_name}</h1>
+
+    <div class="summary">
+        <div class="metric">
+            <div class="metric-value {_coverage_class(report.state_coverage_pct)}">{report.state_coverage_pct:.1f}%</div>
+            <div class="metric-label">State Coverage ({report.covered_states}/{report.total_states})</div>
+        </div>
+        <div class="metric">
+            <div class="metric-value {_coverage_class(report.transition_coverage_pct)}">{report.transition_coverage_pct:.1f}%</div>
+            <div class="metric-label">Transition Coverage ({report.covered_transitions}/{report.total_transitions})</div>
+        </div>
+    </div>
+
+    <h2>Action Coverage</h2>
+    <table>
+        <tr><th>Action</th><th>Coverage</th><th>Covered/Total</th></tr>
+        {"".join(f'''
+        <tr>
+            <td>{action}</td>
+            <td>
+                <div class="progress">
+                    <div class="progress-bar" style="width: {data['percentage']:.0f}%"></div>
+                </div>
+            </td>
+            <td>{data['covered']}/{data['total']} ({data['percentage']:.1f}%)</td>
+        </tr>''' for action, data in sorted(report.action_coverage.items()))}
+    </table>
+
+    <h2>Variable Coverage</h2>
+    <table>
+        <tr><th>Variable</th><th>Coverage</th><th>Uncovered Values</th></tr>
+        {"".join(f'''
+        <tr>
+            <td>{var}</td>
+            <td>{data['covered_values']}/{data['total_values']} ({data['percentage']:.1f}%)</td>
+            <td>{', '.join(data['uncovered'][:3]) if data['uncovered'] else '✓ All covered'}</td>
+        </tr>''' for var, data in sorted(report.state_coverage_by_var.items()))}
+    </table>
+
+    <h2>Uncovered States ({len(report.uncovered_states)})</h2>
+    <table>
+        <tr><th>State #</th><th>Variables (sample)</th></tr>
+        {"".join(f'''
+        <tr>
+            <td>{state.state_num}</td>
+            <td><code>{str(state.variables)[:200]}...</code></td>
+        </tr>''' for state in report.uncovered_states[:10])}
+    </table>
+    {f'<p>... and {len(report.uncovered_states) - 10} more</p>' if len(report.uncovered_states) > 10 else ''}
+
+</body>
+</html>"""
+    return html
+
+
+def _coverage_class(pct: float) -> str:
+    """Return CSS class based on coverage percentage."""
+    if pct >= 80:
+        return "good"
+    elif pct >= 50:
+        return "medium"
+    return "poor"
+
+
+def generate_json_report(report: CoverageReport) -> str:
+    """Generate a JSON coverage report."""
+    return json.dumps({
+        "spec_name": report.spec_name,
+        "state_coverage": {
+            "total": report.total_states,
+            "covered": report.covered_states,
+            "percentage": report.state_coverage_pct
+        },
+        "transition_coverage": {
+            "total": report.total_transitions,
+            "covered": report.covered_transitions,
+            "percentage": report.transition_coverage_pct
+        },
+        "action_coverage": report.action_coverage,
+        "variable_coverage": report.state_coverage_by_var,
+        "uncovered_state_count": len(report.uncovered_states),
+        "uncovered_transition_count": len(report.uncovered_transitions)
+    }, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze TLA+ state space coverage by Rust tests"
+    )
+    parser.add_argument(
+        "--tlc-output", "-t",
+        type=Path,
+        required=True,
+        help="TLC output file with state enumeration"
+    )
+    parser.add_argument(
+        "--rust-traces", "-r",
+        type=Path,
+        nargs="*",
+        default=[],
+        help="Rust test trace JSON files"
+    )
+    parser.add_argument(
+        "--spec-name", "-s",
+        default="Unknown",
+        help="Name of the TLA+ specification"
+    )
+    parser.add_argument(
+        "--report", "-o",
+        type=Path,
+        help="Output report file (HTML or JSON based on extension)"
+    )
+    parser.add_argument(
+        "--format", "-f",
+        choices=["html", "json", "text"],
+        default="text",
+        help="Output format"
+    )
+
+    args = parser.parse_args()
+
+    # Parse TLC output
+    tlc_output = args.tlc_output.read_text()
+    states, transitions = parse_tlc_states(tlc_output)
+
+    # Parse Rust traces
+    covered = parse_rust_traces(args.rust_traces) if args.rust_traces else set()
+
+    # Analyze coverage
+    report = analyze_coverage(states, transitions, covered, args.spec_name)
+
+    # Generate output
+    if args.format == "html" or (args.report and args.report.suffix == ".html"):
+        output = generate_html_report(report)
+    elif args.format == "json" or (args.report and args.report.suffix == ".json"):
+        output = generate_json_report(report)
+    else:
+        output = f"""TLA+ Coverage Report: {report.spec_name}
+{'=' * 50}
+
+State Coverage:      {report.covered_states}/{report.total_states} ({report.state_coverage_pct:.1f}%)
+Transition Coverage: {report.covered_transitions}/{report.total_transitions} ({report.transition_coverage_pct:.1f}%)
+
+Action Coverage:
+{chr(10).join(f"  {action}: {data['covered']}/{data['total']} ({data['percentage']:.1f}%)"
+              for action, data in sorted(report.action_coverage.items()))}
+
+Uncovered States: {len(report.uncovered_states)}
+Uncovered Transitions: {len(report.uncovered_transitions)}
+"""
+
+    if args.report:
+        args.report.write_text(output)
+        print(f"Report written to {args.report}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tla_trace_to_json.py
+++ b/scripts/tla_trace_to_json.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+TLA+ Trace to JSON Converter
+
+Parses TLC model checker output and extracts counterexample traces as JSON.
+These can then be converted to Rust test cases.
+
+Usage:
+    python tla_trace_to_json.py < tlc_output.txt > trace.json
+    python tla_trace_to_json.py --spec BookingMethods < tlc_output.txt > trace.json
+"""
+
+import json
+import re
+import sys
+import argparse
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class TLAValue:
+    """Represents a TLA+ value that can be converted to Rust."""
+    tla_type: str
+    value: Any
+
+    def to_dict(self) -> dict:
+        return {"type": self.tla_type, "value": self.value}
+
+
+@dataclass
+class TraceState:
+    """A single state in a TLA+ counterexample trace."""
+    state_num: int
+    action: str | None
+    variables: dict[str, Any]
+
+
+@dataclass
+class Trace:
+    """A complete TLA+ counterexample trace."""
+    spec_name: str
+    invariant_violated: str | None
+    property_violated: str | None
+    states: list[TraceState]
+
+    def to_dict(self) -> dict:
+        return {
+            "spec_name": self.spec_name,
+            "invariant_violated": self.invariant_violated,
+            "property_violated": self.property_violated,
+            "states": [
+                {
+                    "state_num": s.state_num,
+                    "action": s.action,
+                    "variables": s.variables
+                }
+                for s in self.states
+            ]
+        }
+
+
+def parse_tla_value(value_str: str) -> Any:
+    """Parse a TLA+ value string into a Python value."""
+    value_str = value_str.strip()
+
+    # Boolean
+    if value_str == "TRUE":
+        return True
+    if value_str == "FALSE":
+        return False
+
+    # Number (integer)
+    if re.match(r'^-?\d+$', value_str):
+        return int(value_str)
+
+    # String
+    if value_str.startswith('"') and value_str.endswith('"'):
+        return value_str[1:-1]
+
+    # Set: {a, b, c}
+    if value_str.startswith('{') and value_str.endswith('}'):
+        inner = value_str[1:-1].strip()
+        if not inner:
+            return {"type": "set", "elements": []}
+        # Handle nested structures by tracking depth
+        elements = split_tla_list(inner)
+        return {"type": "set", "elements": [parse_tla_value(e) for e in elements]}
+
+    # Sequence: <<a, b, c>>
+    if value_str.startswith('<<') and value_str.endswith('>>'):
+        inner = value_str[2:-2].strip()
+        if not inner:
+            return {"type": "sequence", "elements": []}
+        elements = split_tla_list(inner)
+        return {"type": "sequence", "elements": [parse_tla_value(e) for e in elements]}
+
+    # Record: [field1 |-> val1, field2 |-> val2]
+    if value_str.startswith('[') and value_str.endswith(']'):
+        inner = value_str[1:-1].strip()
+        if not inner:
+            return {"type": "record", "fields": {}}
+
+        fields = {}
+        # Parse field |-> value pairs
+        parts = split_tla_list(inner)
+        for part in parts:
+            if ' |-> ' in part:
+                field, val = part.split(' |-> ', 1)
+                fields[field.strip()] = parse_tla_value(val.strip())
+
+        return {"type": "record", "fields": fields}
+
+    # Function: (arg1 :> val1 @@ arg2 :> val2)
+    if value_str.startswith('(') and value_str.endswith(')') and ':>' in value_str:
+        inner = value_str[1:-1].strip()
+        mapping = {}
+        parts = inner.split('@@')
+        for part in parts:
+            part = part.strip()
+            if ':>' in part:
+                key, val = part.split(':>', 1)
+                mapping[parse_tla_value(key.strip())] = parse_tla_value(val.strip())
+        return {"type": "function", "mapping": mapping}
+
+    # Null/None
+    if value_str == "NULL" or value_str == "null":
+        return None
+
+    # Default: return as string
+    return value_str
+
+
+def split_tla_list(s: str) -> list[str]:
+    """Split a TLA+ comma-separated list, respecting nested structures."""
+    elements = []
+    current = []
+    depth = 0
+    in_string = False
+
+    i = 0
+    while i < len(s):
+        c = s[i]
+
+        if c == '"' and (i == 0 or s[i-1] != '\\'):
+            in_string = not in_string
+            current.append(c)
+        elif in_string:
+            current.append(c)
+        elif c in '{[(<':
+            depth += 1
+            current.append(c)
+        elif c in '}])>':
+            depth -= 1
+            current.append(c)
+        elif c == ',' and depth == 0:
+            elements.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(c)
+        i += 1
+
+    if current:
+        elements.append(''.join(current).strip())
+
+    return [e for e in elements if e]
+
+
+def parse_tlc_output(lines: list[str], spec_name: str = "Unknown") -> Trace | None:
+    """Parse TLC model checker output and extract counterexample trace."""
+    states = []
+    invariant_violated = None
+    property_violated = None
+    current_state_num = None
+    current_action = None
+    current_vars = {}
+    in_trace = False
+
+    for line in lines:
+        line = line.rstrip()
+
+        # Check for invariant violation
+        if "Invariant" in line and "is violated" in line:
+            match = re.search(r'Invariant (\w+) is violated', line)
+            if match:
+                invariant_violated = match.group(1)
+
+        # Check for property violation
+        if "Property" in line and "is violated" in line:
+            match = re.search(r'Property (\w+) is violated', line)
+            if match:
+                property_violated = match.group(1)
+
+        # Start of trace
+        if "Error: The behavior up to this point is:" in line:
+            in_trace = True
+            continue
+
+        # State line: "State 1: <Init line 50, col 1 to line 55, col 20 of module Foo>"
+        state_match = re.match(r'^State (\d+):', line)
+        if state_match:
+            # Save previous state if exists
+            if current_state_num is not None:
+                states.append(TraceState(
+                    state_num=current_state_num,
+                    action=current_action,
+                    variables=current_vars
+                ))
+
+            current_state_num = int(state_match.group(1))
+            # Try to extract action name
+            action_match = re.search(r'<(\w+)', line)
+            current_action = action_match.group(1) if action_match else None
+            current_vars = {}
+            in_trace = True
+            continue
+
+        # Variable assignment: "/\ varname = value"
+        if in_trace and line.startswith('/\\'):
+            var_match = re.match(r'^/\\ (\w+) = (.+)$', line)
+            if var_match:
+                var_name = var_match.group(1)
+                var_value = var_match.group(2)
+                current_vars[var_name] = parse_tla_value(var_value)
+
+        # Continuation of multi-line value
+        elif in_trace and current_vars and not line.startswith('State'):
+            # Could be continuation - skip for now (complex multi-line parsing)
+            pass
+
+    # Save last state
+    if current_state_num is not None:
+        states.append(TraceState(
+            state_num=current_state_num,
+            action=current_action,
+            variables=current_vars
+        ))
+
+    if not states:
+        return None
+
+    return Trace(
+        spec_name=spec_name,
+        invariant_violated=invariant_violated,
+        property_violated=property_violated,
+        states=states
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert TLC counterexample traces to JSON"
+    )
+    parser.add_argument(
+        "--spec", "-s",
+        default="Unknown",
+        help="Name of the TLA+ specification"
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        type=argparse.FileType('r'),
+        default=sys.stdin,
+        help="TLC output file (default: stdin)"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        help="Output JSON file (default: stdout)"
+    )
+
+    args = parser.parse_args()
+
+    lines = args.input.readlines()
+    trace = parse_tlc_output(lines, args.spec)
+
+    if trace:
+        json.dump(trace.to_dict(), args.output, indent=2)
+        args.output.write('\n')
+    else:
+        print("No counterexample trace found in input", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add model_based_testing.py for TLA+ model-based testing framework
- Add tla_coverage.py for TLA+ coverage analysis
- Add tla_trace_to_json.py for TLA+ trace to JSON conversion

Split from #823 — based on work by @brunotvs.

## Test plan

- [ ] Run scripts with `--help` flag and verify usage output
- [ ] Verify TLA+ tools are available in `nix develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)