### PR TITLE
fix: resolve SELECT aliases in GROUP BY clauses

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -61,6 +61,32 @@ impl<'a> Executor<'a> {
         }
         non_aggregate_exprs
     }
+    /// Resolve GROUP BY expressions by substituting SELECT aliases.
+    ///
+    /// If a GROUP BY expression is a column name that matches a SELECT alias,
+    /// replace it with the aliased expression. For example, in:
+    ///   `SELECT month(date) AS m, COUNT(*) GROUP BY m`
+    /// the GROUP BY `m` is resolved to `month(date)`.
+    pub(super) fn resolve_group_by_aliases(group_exprs: &[Expr], targets: &[Target]) -> Vec<Expr> {
+        let alias_map: HashMap<String, Expr> = targets
+            .iter()
+            .filter_map(|t| t.alias.as_ref().map(|a| (a.to_uppercase(), t.expr.clone())))
+            .collect();
+
+        group_exprs
+            .iter()
+            .map(|expr| {
+                if let Expr::Column(name) = expr
+                    && let Some(target_expr) = alias_map.get(&name.to_uppercase())
+                {
+                    target_expr.clone()
+                } else {
+                    expr.clone()
+                }
+            })
+            .collect()
+    }
+
     pub(super) fn make_group_key(values: &[Value]) -> String {
         use std::fmt::Write;
         let mut key = String::new();

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -64,8 +64,27 @@ impl Executor<'_> {
             // - If explicit GROUP BY is provided, use it
             // - Otherwise, implicitly group by non-aggregate columns in SELECT
             //   (matches Python beancount behavior)
-            let group_by_exprs: Option<Vec<Expr>> = if query.group_by.is_some() {
-                query.group_by.clone()
+            let group_by_exprs: Option<Vec<Expr>> = if let Some(ref group_exprs) = query.group_by {
+                // Resolve alias references: if a GROUP BY expr is a column name
+                // matching a SELECT alias, replace it with the aliased expression.
+                let alias_expr_map: std::collections::HashMap<String, Expr> = query
+                    .targets
+                    .iter()
+                    .filter_map(|t| t.alias.as_ref().map(|a| (a.to_uppercase(), t.expr.clone())))
+                    .collect();
+                let resolved = group_exprs
+                    .iter()
+                    .map(|expr| {
+                        if let Expr::Column(name) = expr
+                            && let Some(target_expr) = alias_expr_map.get(&name.to_uppercase())
+                        {
+                            target_expr.clone()
+                        } else {
+                            expr.clone()
+                        }
+                    })
+                    .collect();
+                Some(resolved)
             } else {
                 let implicit = Self::extract_implicit_group_by_exprs(&query.targets);
                 if implicit.is_empty() {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -65,26 +65,7 @@ impl Executor<'_> {
             // - Otherwise, implicitly group by non-aggregate columns in SELECT
             //   (matches Python beancount behavior)
             let group_by_exprs: Option<Vec<Expr>> = if let Some(ref group_exprs) = query.group_by {
-                // Resolve alias references: if a GROUP BY expr is a column name
-                // matching a SELECT alias, replace it with the aliased expression.
-                let alias_expr_map: std::collections::HashMap<String, Expr> = query
-                    .targets
-                    .iter()
-                    .filter_map(|t| t.alias.as_ref().map(|a| (a.to_uppercase(), t.expr.clone())))
-                    .collect();
-                let resolved = group_exprs
-                    .iter()
-                    .map(|expr| {
-                        if let Expr::Column(name) = expr
-                            && let Some(target_expr) = alias_expr_map.get(&name.to_uppercase())
-                        {
-                            target_expr.clone()
-                        } else {
-                            expr.clone()
-                        }
-                    })
-                    .collect();
-                Some(resolved)
+                Some(Self::resolve_group_by_aliases(group_exprs, &query.targets))
             } else {
                 let implicit = Self::extract_implicit_group_by_exprs(&query.targets);
                 if implicit.is_empty() {
@@ -475,29 +456,8 @@ impl Executor<'_> {
 
         // Determine GROUP BY expressions.
         // If no explicit GROUP BY, implicitly group by non-aggregate columns (beancount compat).
-        // Build alias -> expression map so GROUP BY can reference SELECT aliases.
-        let alias_expr_map: std::collections::HashMap<String, Expr> = query
-            .targets
-            .iter()
-            .filter_map(|t| t.alias.as_ref().map(|a| (a.to_uppercase(), t.expr.clone())))
-            .collect();
-
         let group_by_exprs: Option<Vec<Expr>> = if let Some(ref exprs) = query.group_by {
-            // Resolve alias references: if a GROUP BY expr is a column name matching
-            // a SELECT alias, replace it with the aliased expression.
-            let resolved = exprs
-                .iter()
-                .map(|expr| {
-                    if let Expr::Column(name) = expr
-                        && let Some(target_expr) = alias_expr_map.get(&name.to_uppercase())
-                    {
-                        target_expr.clone()
-                    } else {
-                        expr.clone()
-                    }
-                })
-                .collect();
-            Some(resolved)
+            Some(Self::resolve_group_by_aliases(exprs, &query.targets))
         } else {
             let implicit = Self::extract_implicit_group_by_exprs(&query.targets);
             if implicit.is_empty() {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -299,8 +299,8 @@ fn test_group_by_month_alias() {
     assert!(!result.is_empty());
     // Month values should be 1-12
     for row in &result.rows {
-        if let Value::Integer(m) = row[0] {
-            assert!((1..=12).contains(&m));
+        if let Value::Integer(m) = &row[0] {
+            assert!((1..=12).contains(m));
         } else {
             panic!("Expected integer month");
         }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -272,6 +272,52 @@ fn test_execute_group_by_account() {
     assert_eq!(accounts.len(), unique_accounts.len());
 }
 
+#[test]
+fn test_group_by_function_alias() {
+    // GROUP BY should resolve SELECT aliases to the original expression
+    let directives = make_test_directives();
+    let result = execute_query(
+        "SELECT year(date) AS y, COUNT(*) AS cnt GROUP BY y ORDER BY y",
+        &directives,
+    );
+    assert!(!result.is_empty());
+    assert_eq!(result.columns[0], "y");
+    assert_eq!(result.columns[1], "cnt");
+    // All rows should have integer year values
+    for row in &result.rows {
+        assert!(matches!(row[0], Value::Integer(_)));
+    }
+}
+
+#[test]
+fn test_group_by_month_alias() {
+    let directives = make_test_directives();
+    let result = execute_query(
+        "SELECT month(date) AS m, COUNT(*) AS cnt GROUP BY m ORDER BY m",
+        &directives,
+    );
+    assert!(!result.is_empty());
+    // Month values should be 1-12
+    for row in &result.rows {
+        if let Value::Integer(m) = row[0] {
+            assert!((1..=12).contains(&m));
+        } else {
+            panic!("Expected integer month");
+        }
+    }
+}
+
+#[test]
+fn test_group_by_parent_alias() {
+    let directives = make_test_directives();
+    let result = execute_query(
+        "SELECT PARENT(account) AS parent, COUNT(*) AS cnt GROUP BY parent ORDER BY parent",
+        &directives,
+    );
+    assert!(!result.is_empty());
+    assert_eq!(result.columns[0], "parent");
+}
+
 // ============================================================================
 // Ordering Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix GROUP BY to resolve SELECT aliases back to their original expressions
- `SELECT month(date) AS m, COUNT(*) GROUP BY m` now works correctly
- `SELECT PARENT(account) AS parent, COUNT(*) GROUP BY parent` now works correctly

The alias resolution logic already existed for table-based aggregate queries but was missing from the posting-based path.

## Test plan

- [x] 3 new integration tests (year, month, parent aliases)
- [x] All 443 existing tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)