### PR TITLE
fix: lowercase type column values for beancount compatibility

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -449,7 +449,7 @@ impl Executor<'_> {
             }
             // type - directive type (matches Python beancount's type column)
             // For SELECT FROM (default), this is always "Transaction"
-            "type" => Ok(Value::String("Transaction".to_string())),
+            "type" => Ok(Value::String("transaction".to_string())),
             _ => Err(QueryError::UnknownColumn(name.to_string())),
         }
     }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2128,18 +2128,18 @@ impl<'a> Executor<'a> {
         source_loc: Option<&SourceLocation>,
     ) -> Vec<Value> {
         let type_name = match directive {
-            Directive::Transaction(_) => "Transaction",
-            Directive::Balance(_) => "Balance",
-            Directive::Open(_) => "Open",
-            Directive::Close(_) => "Close",
-            Directive::Commodity(_) => "Commodity",
-            Directive::Pad(_) => "Pad",
-            Directive::Event(_) => "Event",
-            Directive::Query(_) => "Query",
-            Directive::Note(_) => "Note",
-            Directive::Document(_) => "Document",
-            Directive::Price(_) => "Price",
-            Directive::Custom(_) => "Custom",
+            Directive::Transaction(_) => "transaction",
+            Directive::Balance(_) => "balance",
+            Directive::Open(_) => "open",
+            Directive::Close(_) => "close",
+            Directive::Commodity(_) => "commodity",
+            Directive::Pad(_) => "pad",
+            Directive::Event(_) => "event",
+            Directive::Query(_) => "query",
+            Directive::Note(_) => "note",
+            Directive::Document(_) => "document",
+            Directive::Price(_) => "price",
+            Directive::Custom(_) => "custom",
         };
 
         let date = match directive {
@@ -2693,7 +2693,7 @@ mod tests {
         let result = executor.execute(&query).unwrap();
         // Only transactions in the sample data
         assert_eq!(result.len(), 1);
-        assert_eq!(result.rows[0][0], Value::String("Transaction".to_string()));
+        assert_eq!(result.rows[0][0], Value::String("transaction".to_string()));
         assert_eq!(result.rows[0][1], Value::Integer(2));
     }
 

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -4921,18 +4921,18 @@ fn test_entries_table_type_column() {
     let result = execute_query("SELECT type FROM #entries", &directives);
 
     let types: Vec<&Value> = result.rows.iter().map(|r| &r[0]).collect();
-    assert!(types.contains(&&Value::String("Open".to_string())));
-    assert!(types.contains(&&Value::String("Commodity".to_string())));
-    assert!(types.contains(&&Value::String("Transaction".to_string())));
-    assert!(types.contains(&&Value::String("Note".to_string())));
-    assert!(types.contains(&&Value::String("Event".to_string())));
+    assert!(types.contains(&&Value::String("open".to_string())));
+    assert!(types.contains(&&Value::String("commodity".to_string())));
+    assert!(types.contains(&&Value::String("transaction".to_string())));
+    assert!(types.contains(&&Value::String("note".to_string())));
+    assert!(types.contains(&&Value::String("event".to_string())));
 }
 
 #[test]
 fn test_entries_table_with_where_clause() {
     let directives = make_entries_test_directives();
     let result = execute_query(
-        "SELECT * FROM #entries WHERE type = 'Transaction'",
+        "SELECT * FROM #entries WHERE type = 'transaction'",
         &directives,
     );
 
@@ -4943,7 +4943,7 @@ fn test_entries_table_with_where_clause() {
 fn test_entries_table_transaction_fields() {
     let directives = make_entries_test_directives();
     let result = execute_query(
-        "SELECT flag, payee, narration, tags, accounts FROM #entries WHERE type = 'Transaction'",
+        "SELECT flag, payee, narration, tags, accounts FROM #entries WHERE type = 'transaction'",
         &directives,
     );
 
@@ -4963,7 +4963,7 @@ fn test_entries_table_transaction_fields() {
 fn test_entries_table_non_transaction_nulls() {
     let directives = make_entries_test_directives();
     let result = execute_query(
-        "SELECT flag, payee, narration FROM #entries WHERE type = 'Open'",
+        "SELECT flag, payee, narration FROM #entries WHERE type = 'open'",
         &directives,
     );
 
@@ -6916,7 +6916,7 @@ fn test_entry_meta_from_entries_table() {
     ];
 
     let result = execute_query(
-        "SELECT type, entry_meta('source') FROM #entries WHERE type = 'Transaction'",
+        "SELECT type, entry_meta('source') FROM #entries WHERE type = 'transaction'",
         &directives,
     );
 


### PR DESCRIPTION
## Summary
- Lowercase all type column string values (e.g., `"Transaction"` -> `"transaction"`, `"Balance"` -> `"balance"`) in `directive_to_entry_row()`, `build_postings_table()`, and `evaluate_column()` to match Python beancount behavior.
- Updated all tests that assert on or filter by capitalized type values.

## Test plan
- [x] All existing `rustledger-query` tests pass with the new lowercase values
- [x] Verified `#entries` table, postings evaluation, and WHERE clause filtering all use lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)