### PR TITLE
fix: support WHERE clause in BALANCES queries

### DIFF
--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -150,6 +150,8 @@ pub struct BalancesQuery {
     pub at_function: Option<String>,
     /// Optional FROM clause.
     pub from: Option<FromClause>,
+    /// Optional WHERE clause.
+    pub where_clause: Option<Expr>,
 }
 
 /// PRINT shorthand query.

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -863,11 +863,12 @@ impl Executor<'_> {
         let columns = vec!["account".to_string(), "balance".to_string()];
         let mut result = QueryResult::new(columns.clone());
 
-        // Build column map for WHERE clause evaluation
+        // Build column map for WHERE clause evaluation (lowercase keys for
+        // consistent lookup with evaluate_subquery_filter)
         let column_map: FxHashMap<String, usize> = columns
             .iter()
             .enumerate()
-            .map(|(i, c)| (c.clone(), i))
+            .map(|(i, c)| (c.to_lowercase(), i))
             .collect();
 
         // Sort accounts for consistent output
@@ -902,10 +903,10 @@ impl Executor<'_> {
             let row = vec![Value::String(account.to_string()), balance_value];
 
             // Apply WHERE clause filter if present
-            if let Some(where_expr) = &query.where_clause {
-                if !self.evaluate_subquery_filter(where_expr, &row, &column_map)? {
-                    continue;
-                }
+            if let Some(where_expr) = &query.where_clause
+                && !self.evaluate_subquery_filter(where_expr, &row, &column_map)?
+            {
+                continue;
             }
 
             result.add_row(row);

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -861,7 +861,14 @@ impl Executor<'_> {
         self.build_balances_with_filter(query.from.as_ref())?;
 
         let columns = vec!["account".to_string(), "balance".to_string()];
-        let mut result = QueryResult::new(columns);
+        let mut result = QueryResult::new(columns.clone());
+
+        // Build column map for WHERE clause evaluation
+        let column_map: FxHashMap<String, usize> = columns
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.clone(), i))
+            .collect();
 
         // Sort accounts for consistent output
         let mut accounts: Vec<_> = self.balances.keys().collect();
@@ -893,6 +900,14 @@ impl Executor<'_> {
             };
 
             let row = vec![Value::String(account.to_string()), balance_value];
+
+            // Apply WHERE clause filter if present
+            if let Some(where_expr) = &query.where_clause {
+                if !self.evaluate_subquery_filter(where_expr, &row, &column_map)? {
+                    continue;
+                }
+            }
+
             result.add_row(row);
         }
 

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -374,16 +374,27 @@ fn journal_query<'a>() -> impl Parser<'a, ParserInput<'a>, JournalQuery, ParserE
 /// Parse BALANCES query.
 fn balances_query<'a>() -> impl Parser<'a, ParserInput<'a>, BalancesQuery, ParserExtra<'a>> + Clone
 {
+    // Use rewind-based lookahead so optional clauses don't consume whitespace
+    // that subsequent clauses need. Without this, `BALANCES WHERE ...` fails
+    // because at_function() consumes whitespace before failing on "WHERE" != "AT".
+    let at_fn = ws1().then(kw("AT")).rewind().ignore_then(at_function());
+
+    let from = ws1().then(kw("FROM")).rewind().ignore_then(
+        ws1()
+            .ignore_then(kw("FROM"))
+            .ignore_then(ws1())
+            .ignore_then(from_modifiers()),
+    );
+
     kw("BALANCES")
-        .ignore_then(at_function().or_not())
-        .then(
-            ws1()
-                .ignore_then(kw("FROM"))
-                .ignore_then(ws1())
-                .ignore_then(from_modifiers())
-                .or_not(),
-        )
-        .map(|(at_function, from)| BalancesQuery { at_function, from })
+        .ignore_then(at_fn.or_not())
+        .then(from.or_not())
+        .then(where_clause().or_not())
+        .map(|((at_function, from), where_clause)| BalancesQuery {
+            at_function,
+            from,
+            where_clause,
+        })
 }
 
 /// Parse PRINT query.

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -164,6 +164,8 @@ fn test_execute_balances_where() {
     for row in &result.rows {
         if let Value::String(account) = &row[0] {
             assert!(account.starts_with("Expenses:"), "got {account}");
+        } else {
+            panic!("expected Value::String, got {:?}", row[0]);
         }
     }
 }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -135,6 +135,40 @@ fn test_parse_balances_query() {
 }
 
 #[test]
+fn test_parse_balances_where_query() {
+    let query = parse(r#"BALANCES WHERE account ~ "Assets:""#).expect("should parse");
+    if let rustledger_query::Query::Balances(b) = query {
+        assert!(b.where_clause.is_some());
+    } else {
+        panic!("Expected BALANCES query");
+    }
+}
+
+#[test]
+fn test_parse_balances_at_cost_where_query() {
+    let query = parse(r#"BALANCES AT cost WHERE account ~ "Assets:""#).expect("should parse");
+    if let rustledger_query::Query::Balances(b) = query {
+        assert_eq!(b.at_function, Some("cost".to_string()));
+        assert!(b.where_clause.is_some());
+    } else {
+        panic!("Expected BALANCES query");
+    }
+}
+
+#[test]
+fn test_execute_balances_where() {
+    let directives = make_test_directives();
+    let result = execute_query(r#"BALANCES WHERE account ~ "Expenses:""#, &directives);
+    assert!(!result.is_empty());
+    // All accounts should match the filter
+    for row in &result.rows {
+        if let Value::String(account) = &row[0] {
+            assert!(account.starts_with("Expenses:"), "got {account}");
+        }
+    }
+}
+
+#[test]
 fn test_parse_print_query() {
     let query = parse("PRINT").expect("should parse");
     assert!(matches!(query, rustledger_query::Query::Print(_)));
@@ -409,6 +443,27 @@ fn test_execute_balances_with_from() {
 
     // Should have balances
     assert!(!result.is_empty());
+}
+
+#[test]
+fn test_execute_balances_with_where() {
+    let directives = make_test_directives();
+    let query = parse("BALANCES WHERE account ~ 'Assets:'").expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    // Should only have Assets: accounts (Checking and Savings)
+    assert_eq!(result.len(), 2);
+    for row in &result.rows {
+        if let Value::String(acct) = &row[0] {
+            assert!(
+                acct.starts_with("Assets:"),
+                "Expected Assets: account, got {acct}"
+            );
+        } else {
+            panic!("Expected string account");
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix `BALANCES WHERE account ~ "Assets:"` which previously failed with a parse error
- Root cause: optional `AT` and `FROM` clause parsers consumed whitespace before failing, preventing the `WHERE` parser from matching
- Fix: use `rewind`-based lookahead for optional clauses so they don't consume input on failure

## Test plan

- [x] 3 new tests: parse BALANCES WHERE, parse BALANCES AT cost WHERE, execute BALANCES WHERE
- [x] All 444 existing tests pass
- [x] Existing BALANCES and BALANCES AT tests still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)