### PR TITLE
fix: include snapshot files in nix source filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,9 @@
           srcFilter = path: type:
             (craneLib.filterCargoSources path type) ||
             (builtins.match ".*\\.beancount$" path != null) ||
-            (builtins.match ".*/tests/fixtures(/.*)?$" path != null);
+            (builtins.match ".*\\.snap$" path != null) ||
+            (builtins.match ".*/tests/fixtures(/.*)?$" path != null) ||
+            (builtins.match ".*/tests/snapshots(/.*)?$" path != null);
 
           src = lib.cleanSourceWith {
             src = ./.;


### PR DESCRIPTION
## Summary

- Include `*.snap` files and `tests/snapshots/` directories in the nix flake's source filter
- Without this, `nix run github:rustledger/rustledger` fails because insta snapshot tests can't find their snapshot files

Closes #830.

## Test plan

- [ ] `nix run github:rustledger/rustledger` builds and tests pass
- [ ] `nix build` succeeds
- [ ] Snapshot files are present in the nix store source

🤖 Generated with [Claude Code](https://claude.com/claude-code)