### PR TITLE
fix: implement cost merge operator {*}

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -332,10 +332,8 @@ impl Inventory {
             });
         }
 
-        let cost_basis = match average_cost_from_positions(&matching, total_units)? {
-            Some((avg_cost, currency)) => Some(Amount::new(reduction * avg_cost, currency)),
-            None => None,
-        };
+        let cost_basis = average_cost_from_positions(&matching, total_units)?
+            .map(|(avg_cost, currency)| Amount::new(reduction * avg_cost, currency));
 
         let matched: Vec<Position> = matching.into_iter().cloned().collect();
 
@@ -770,10 +768,8 @@ impl Inventory {
             });
         }
 
-        let cost_basis = match average_cost_from_positions(&matching, total_units)? {
-            Some((avg_cost, currency)) => Some(Amount::new(reduction * avg_cost, currency)),
-            None => None,
-        };
+        let cost_basis = average_cost_from_positions(&matching, total_units)?
+            .map(|(avg_cost, currency)| Amount::new(reduction * avg_cost, currency));
 
         let matched: Vec<Position> = matching.into_iter().cloned().collect();
         let new_units = total_units + units.number;
@@ -849,15 +845,16 @@ impl Inventory {
         // Return a single synthetic matched position representing the merged lot.
         // This prevents the booking engine from expanding the posting into multiple
         // postings (one per original lot), which would be incorrect for {*}.
-        let avg_cost_obj = Cost {
+        let make_avg_cost = || Cost {
             number: avg_cost,
             currency: cost_currency.clone(),
             date: None,
             label: None,
         };
+
         let matched = vec![Position::with_cost(
             Amount::new(units.number.abs(), units.currency.clone()),
-            avg_cost_obj.clone(),
+            make_avg_cost(),
         )];
 
         // Remove all matching lots of this currency
@@ -875,7 +872,7 @@ impl Inventory {
         if !remaining.is_zero() {
             self.positions.push(Position::with_cost(
                 Amount::new(remaining, units.currency.clone()),
-                avg_cost_obj,
+                make_avg_cost(),
             ));
         }
 

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -820,15 +820,35 @@ impl Inventory {
             });
         }
 
-        // Compute weighted-average cost across matching lots
-        let book_values = self.book_value(&units.currency);
-        let (avg_cost, cost_currency) = if let Some((curr, &total_cost)) = book_values.iter().next()
-        {
-            (total_cost / total_units, curr.clone())
-        } else {
-            // No cost info — fall back to simple reduction
-            return self.reduce_average(units);
+        // Compute weighted-average cost directly from matching lots.
+        // Only count lots that have cost info; if any lot lacks cost, error
+        // rather than silently computing an incorrect average.
+        let mut total_cost = Decimal::ZERO;
+        let mut cost_currency: Option<crate::InternedStr> = None;
+        for (_, pos) in &matching {
+            if let Some(cost) = &pos.cost {
+                if let Some(ref cc) = cost_currency {
+                    if *cc != cost.currency {
+                        // Multiple cost currencies — cannot merge
+                        return Err(BookingError::CurrencyMismatch {
+                            expected: cc.clone(),
+                            got: cost.currency.clone(),
+                        });
+                    }
+                } else {
+                    cost_currency = Some(cost.currency.clone());
+                }
+                total_cost += pos.units.number * cost.number;
+            } else {
+                // Lot without cost — cannot compute meaningful average
+                return self.reduce_average(units);
+            }
+        }
+        let cost_currency = match cost_currency {
+            Some(c) => c,
+            None => return self.reduce_average(units),
         };
+        let avg_cost = total_cost / total_units;
 
         let cost_basis = Some(Amount::new(reduction * avg_cost, cost_currency.clone()));
 

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -7,7 +7,43 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
 
 use super::{BookingError, BookingMethod, BookingResult, Inventory};
-use crate::{Amount, Cost, CostSpec, Position};
+use crate::{Amount, Cost, CostSpec, InternedStr, Position};
+
+/// Compute weighted-average cost from a set of positions.
+///
+/// Returns `(avg_cost_per_unit, cost_currency)` or `None` if no positions have cost info.
+/// Returns `Err(CurrencyMismatch)` if positions have costs in different currencies.
+fn average_cost_from_positions(
+    positions: &[&Position],
+    total_units: Decimal,
+) -> Result<Option<(Decimal, InternedStr)>, BookingError> {
+    let mut total_cost = Decimal::ZERO;
+    let mut cost_currency: Option<InternedStr> = None;
+    let mut has_any_cost = false;
+
+    for pos in positions {
+        if let Some(cost) = &pos.cost {
+            has_any_cost = true;
+            if let Some(ref cc) = cost_currency {
+                if *cc != cost.currency {
+                    return Err(BookingError::CurrencyMismatch {
+                        expected: cc.clone(),
+                        got: cost.currency.clone(),
+                    });
+                }
+            } else {
+                cost_currency = Some(cost.currency.clone());
+            }
+            total_cost += pos.units.number * cost.number;
+        }
+    }
+
+    if !has_any_cost || cost_currency.is_none() {
+        return Ok(None);
+    }
+
+    Ok(Some((total_cost / total_units, cost_currency.unwrap())))
+}
 
 impl Inventory {
     /// Try reducing positions without modifying the inventory.
@@ -271,12 +307,13 @@ impl Inventory {
 
     /// Try AVERAGE booking without modifying inventory.
     fn try_reduce_average(&self, units: &Amount) -> Result<BookingResult, BookingError> {
-        let total_units: Decimal = self
+        let matching: Vec<&Position> = self
             .positions
             .iter()
             .filter(|p| p.units.currency == units.currency && !p.is_empty())
-            .map(|p| p.units.number)
-            .sum();
+            .collect();
+
+        let total_units: Decimal = matching.iter().map(|p| p.units.number).sum();
 
         if total_units.is_zero() {
             return Err(BookingError::InsufficientUnits {
@@ -295,20 +332,12 @@ impl Inventory {
             });
         }
 
-        let book_values = self.book_value(&units.currency);
-        let cost_basis = if let Some((curr, &total)) = book_values.iter().next() {
-            let per_unit_cost = total / total_units;
-            Some(Amount::new(reduction * per_unit_cost, curr.clone()))
-        } else {
-            None
+        let cost_basis = match average_cost_from_positions(&matching, total_units)? {
+            Some((avg_cost, currency)) => Some(Amount::new(reduction * avg_cost, currency)),
+            None => None,
         };
 
-        let matched: Vec<Position> = self
-            .positions
-            .iter()
-            .filter(|p| p.units.currency == units.currency && !p.is_empty())
-            .cloned()
-            .collect();
+        let matched: Vec<Position> = matching.into_iter().cloned().collect();
 
         Ok(BookingResult {
             matched,
@@ -716,13 +745,13 @@ impl Inventory {
 
     /// AVERAGE booking: merge all lots of the currency.
     pub(super) fn reduce_average(&mut self, units: &Amount) -> Result<BookingResult, BookingError> {
-        // Calculate average cost
-        let total_units: Decimal = self
+        let matching: Vec<&Position> = self
             .positions
             .iter()
             .filter(|p| p.units.currency == units.currency && !p.is_empty())
-            .map(|p| p.units.number)
-            .sum();
+            .collect();
+
+        let total_units: Decimal = matching.iter().map(|p| p.units.number).sum();
 
         if total_units.is_zero() {
             return Err(BookingError::InsufficientUnits {
@@ -732,7 +761,6 @@ impl Inventory {
             });
         }
 
-        // Check sufficient units
         let reduction = units.number.abs();
         if reduction > total_units.abs() {
             return Err(BookingError::InsufficientUnits {
@@ -742,26 +770,15 @@ impl Inventory {
             });
         }
 
-        // Calculate total cost basis
-        let book_values = self.book_value(&units.currency);
-        let cost_basis = if let Some((curr, &total)) = book_values.iter().next() {
-            let per_unit_cost = total / total_units;
-            Some(Amount::new(reduction * per_unit_cost, curr.clone()))
-        } else {
-            None
+        let cost_basis = match average_cost_from_positions(&matching, total_units)? {
+            Some((avg_cost, currency)) => Some(Amount::new(reduction * avg_cost, currency)),
+            None => None,
         };
 
-        // Create merged position
+        let matched: Vec<Position> = matching.into_iter().cloned().collect();
         let new_units = total_units + units.number;
 
         // Remove all positions of this currency
-        let matched: Vec<Position> = self
-            .positions
-            .iter()
-            .filter(|p| p.units.currency == units.currency && !p.is_empty())
-            .cloned()
-            .collect();
-
         self.positions
             .retain(|p| p.units.currency != units.currency);
 
@@ -773,7 +790,6 @@ impl Inventory {
             )));
         }
 
-        // Rebuild index after modifications
         self.rebuild_index();
 
         Ok(BookingResult {
@@ -820,35 +836,13 @@ impl Inventory {
             });
         }
 
-        // Compute weighted-average cost directly from matching lots.
-        // Only count lots that have cost info; if any lot lacks cost, error
-        // rather than silently computing an incorrect average.
-        let mut total_cost = Decimal::ZERO;
-        let mut cost_currency: Option<crate::InternedStr> = None;
-        for (_, pos) in &matching {
-            if let Some(cost) = &pos.cost {
-                if let Some(ref cc) = cost_currency {
-                    if *cc != cost.currency {
-                        // Multiple cost currencies — cannot merge
-                        return Err(BookingError::CurrencyMismatch {
-                            expected: cc.clone(),
-                            got: cost.currency.clone(),
-                        });
-                    }
-                } else {
-                    cost_currency = Some(cost.currency.clone());
-                }
-                total_cost += pos.units.number * cost.number;
-            } else {
-                // Lot without cost — cannot compute meaningful average
-                return self.reduce_average(units);
-            }
-        }
-        let cost_currency = match cost_currency {
-            Some(c) => c,
-            None => return self.reduce_average(units),
-        };
-        let avg_cost = total_cost / total_units;
+        // Compute weighted-average cost from matching lots.
+        let matching_refs: Vec<&Position> = matching.iter().map(|(_, p)| *p).collect();
+        let (avg_cost, cost_currency) =
+            match average_cost_from_positions(&matching_refs, total_units)? {
+                Some(result) => result,
+                None => return self.reduce_average(units),
+            };
 
         let cost_basis = Some(Amount::new(reduction * avg_cost, cost_currency.clone()));
 

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -788,11 +788,17 @@ impl Inventory {
     /// Example: 10 AAPL {150 USD} + 10 AAPL {160 USD} merged = 20 AAPL {155 USD}.
     /// Reducing 5 AAPL {*} takes 5 from the merged 20 AAPL {155 USD} lot.
     pub(super) fn reduce_merge(&mut self, units: &Amount) -> Result<BookingResult, BookingError> {
+        // Only merge lots with opposite sign (same as other reduce methods).
+        // This prevents accidentally netting long and short positions.
         let matching: Vec<(usize, &Position)> = self
             .positions
             .iter()
             .enumerate()
-            .filter(|(_, p)| p.units.currency == units.currency && !p.is_empty())
+            .filter(|(_, p)| {
+                p.units.currency == units.currency
+                    && !p.is_empty()
+                    && p.units.number.is_sign_positive() != units.number.is_sign_positive()
+            })
             .collect();
 
         if matching.is_empty() {
@@ -814,7 +820,7 @@ impl Inventory {
             });
         }
 
-        // Compute weighted-average cost across all lots
+        // Compute weighted-average cost across matching lots
         let book_values = self.book_value(&units.currency);
         let (avg_cost, cost_currency) = if let Some((curr, &total_cost)) = book_values.iter().next()
         {
@@ -826,25 +832,36 @@ impl Inventory {
 
         let cost_basis = Some(Amount::new(reduction * avg_cost, cost_currency.clone()));
 
-        // Collect matched positions before mutation
-        let matched: Vec<Position> = matching.iter().map(|(_, p)| (*p).clone()).collect();
+        // Return a single synthetic matched position representing the merged lot.
+        // This prevents the booking engine from expanding the posting into multiple
+        // postings (one per original lot), which would be incorrect for {*}.
+        let avg_cost_obj = Cost {
+            number: avg_cost,
+            currency: cost_currency.clone(),
+            date: None,
+            label: None,
+        };
+        let matched = vec![Position::with_cost(
+            Amount::new(units.number.abs(), units.currency.clone()),
+            avg_cost_obj.clone(),
+        )];
 
-        // Remove all lots of this currency
-        self.positions
-            .retain(|p| p.units.currency != units.currency);
+        // Remove all matching lots of this currency
+        let matching_indices: std::collections::HashSet<usize> =
+            matching.iter().map(|(i, _)| *i).collect();
+        let mut idx = 0;
+        self.positions.retain(|_| {
+            let keep = !matching_indices.contains(&idx);
+            idx += 1;
+            keep
+        });
 
         // Add back a single merged lot with the remainder
         let remaining = total_units + units.number; // units.number is negative for reductions
         if !remaining.is_zero() {
-            let merged_cost = Cost {
-                number: avg_cost,
-                currency: cost_currency,
-                date: None,
-                label: None,
-            };
             self.positions.push(Position::with_cost(
                 Amount::new(remaining, units.currency.clone()),
-                merged_cost,
+                avg_cost_obj,
             ));
         }
 

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -7,7 +7,7 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
 
 use super::{BookingError, BookingMethod, BookingResult, Inventory};
-use crate::{Amount, CostSpec, Position};
+use crate::{Amount, Cost, CostSpec, Position};
 
 impl Inventory {
     /// Try reducing positions without modifying the inventory.
@@ -33,6 +33,11 @@ impl Inventory {
         method: BookingMethod,
     ) -> Result<BookingResult, BookingError> {
         let spec = cost_spec.cloned().unwrap_or_default();
+
+        // {*} merge operator: use average-cost semantics (read-only preview)
+        if spec.merge {
+            return self.try_reduce_average(units);
+        }
 
         match method {
             BookingMethod::Strict | BookingMethod::StrictWithSize => {
@@ -769,6 +774,80 @@ impl Inventory {
         }
 
         // Rebuild index after modifications
+        self.rebuild_index();
+
+        Ok(BookingResult {
+            matched,
+            cost_basis,
+        })
+    }
+
+    /// Cost merge `{*}`: merge all lots of the currency into a single
+    /// weighted-average-cost lot, then reduce from it.
+    ///
+    /// Example: 10 AAPL {150 USD} + 10 AAPL {160 USD} merged = 20 AAPL {155 USD}.
+    /// Reducing 5 AAPL {*} takes 5 from the merged 20 AAPL {155 USD} lot.
+    pub(super) fn reduce_merge(&mut self, units: &Amount) -> Result<BookingResult, BookingError> {
+        let matching: Vec<(usize, &Position)> = self
+            .positions
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p.units.currency == units.currency && !p.is_empty())
+            .collect();
+
+        if matching.is_empty() {
+            return Err(BookingError::InsufficientUnits {
+                currency: units.currency.clone(),
+                requested: units.number.abs(),
+                available: Decimal::ZERO,
+            });
+        }
+
+        let total_units: Decimal = matching.iter().map(|(_, p)| p.units.number).sum();
+        let reduction = units.number.abs();
+
+        if reduction > total_units.abs() {
+            return Err(BookingError::InsufficientUnits {
+                currency: units.currency.clone(),
+                requested: reduction,
+                available: total_units.abs(),
+            });
+        }
+
+        // Compute weighted-average cost across all lots
+        let book_values = self.book_value(&units.currency);
+        let (avg_cost, cost_currency) = if let Some((curr, &total_cost)) = book_values.iter().next()
+        {
+            (total_cost / total_units, curr.clone())
+        } else {
+            // No cost info — fall back to simple reduction
+            return self.reduce_average(units);
+        };
+
+        let cost_basis = Some(Amount::new(reduction * avg_cost, cost_currency.clone()));
+
+        // Collect matched positions before mutation
+        let matched: Vec<Position> = matching.iter().map(|(_, p)| (*p).clone()).collect();
+
+        // Remove all lots of this currency
+        self.positions
+            .retain(|p| p.units.currency != units.currency);
+
+        // Add back a single merged lot with the remainder
+        let remaining = total_units + units.number; // units.number is negative for reductions
+        if !remaining.is_zero() {
+            let merged_cost = Cost {
+                number: avg_cost,
+                currency: cost_currency,
+                date: None,
+                label: None,
+            };
+            self.positions.push(Position::with_cost(
+                Amount::new(remaining, units.currency.clone()),
+                merged_cost,
+            ));
+        }
+
         self.rebuild_index();
 
         Ok(BookingResult {

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -462,6 +462,12 @@ impl Inventory {
     ) -> Result<BookingResult, BookingError> {
         let spec = cost_spec.cloned().unwrap_or_default();
 
+        // {*} merge operator: merge all lots into a single weighted-average-cost
+        // lot before reducing, regardless of the account's booking method.
+        if spec.merge {
+            return self.reduce_merge(units);
+        }
+
         match method {
             BookingMethod::Strict => self.reduce_strict(units, &spec),
             BookingMethod::StrictWithSize => self.reduce_strict_with_size(units, &spec),
@@ -1464,6 +1470,88 @@ mod tests {
             result,
             Err(BookingError::InsufficientUnits { .. })
         ));
+    }
+
+    #[test]
+    fn test_reduce_merge_operator() {
+        // {*} merge: two lots merged into weighted-average, then reduced
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD"),
+        ));
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(160), "USD"),
+        ));
+
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv
+            .reduce(
+                &Amount::new(dec!(-5), "AAPL"),
+                Some(&merge_spec),
+                BookingMethod::Strict,
+            )
+            .expect("merge reduction should succeed");
+
+        // Cost basis: 5 units * 155 USD average = 775 USD
+        assert_eq!(result.cost_basis, Some(Amount::new(dec!(775), "USD")));
+
+        // Inventory should have a single merged lot with 15 remaining @ 155
+        assert_eq!(inv.positions.len(), 1);
+        assert_eq!(inv.positions[0].units.number, dec!(15));
+        let cost = inv.positions[0].cost.as_ref().expect("should have cost");
+        assert_eq!(cost.number, dec!(155));
+    }
+
+    #[test]
+    fn test_reduce_merge_insufficient_units() {
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD"),
+        ));
+
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv.reduce(
+            &Amount::new(dec!(-20), "AAPL"),
+            Some(&merge_spec),
+            BookingMethod::Strict,
+        );
+
+        assert!(matches!(
+            result,
+            Err(BookingError::InsufficientUnits { .. })
+        ));
+    }
+
+    #[test]
+    fn test_reduce_merge_sells_all() {
+        // Merge and sell entire position
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD"),
+        ));
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(160), "USD"),
+        ));
+
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv
+            .reduce(
+                &Amount::new(dec!(-20), "AAPL"),
+                Some(&merge_spec),
+                BookingMethod::Strict,
+            )
+            .expect("merge reduction should succeed");
+
+        // Cost basis: 20 * 155 = 3100 USD
+        assert_eq!(result.cost_basis, Some(Amount::new(dec!(3100), "USD")));
+
+        // Inventory should be empty
+        assert!(inv.positions.is_empty() || inv.positions.iter().all(|p| p.is_empty()));
     }
 
     #[test]

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1612,6 +1612,32 @@ mod tests {
     }
 
     #[test]
+    fn test_reduce_merge_mixed_cost_currencies_errors() {
+        // Lots with different cost currencies cannot be merged
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD"),
+        ));
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(130), "EUR"),
+        ));
+
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv.reduce(
+            &Amount::new(dec!(-5), "AAPL"),
+            Some(&merge_spec),
+            BookingMethod::Strict,
+        );
+
+        assert!(
+            matches!(result, Err(BookingError::CurrencyMismatch { .. })),
+            "expected CurrencyMismatch, got {result:?}"
+        );
+    }
+
+    #[test]
     fn test_reduce_merge_empty_inventory() {
         let mut inv = Inventory::new();
 

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1551,7 +1551,7 @@ mod tests {
         assert_eq!(result.cost_basis, Some(Amount::new(dec!(3100), "USD")));
 
         // Inventory should be empty
-        assert!(inv.positions.is_empty() || inv.positions.iter().all(|p| p.is_empty()));
+        assert!(inv.positions.is_empty() || inv.positions.iter().all(Position::is_empty));
     }
 
     #[test]

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1555,6 +1555,80 @@ mod tests {
     }
 
     #[test]
+    fn test_reduce_merge_single_lot() {
+        // {*} with a single lot should work trivially
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD"),
+        ));
+
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv
+            .reduce(
+                &Amount::new(dec!(-3), "AAPL"),
+                Some(&merge_spec),
+                BookingMethod::Strict,
+            )
+            .expect("single-lot merge should succeed");
+
+        assert_eq!(result.cost_basis, Some(Amount::new(dec!(450), "USD")));
+        assert_eq!(inv.positions.len(), 1);
+        assert_eq!(inv.positions[0].units.number, dec!(7));
+    }
+
+    #[test]
+    fn test_reduce_merge_three_lots() {
+        // {*} with three lots at different costs
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(100), "USD"),
+        ));
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD"),
+        ));
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(200), "USD"),
+        ));
+
+        // Average cost: (1000 + 1500 + 2000) / 30 = 150 USD
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv
+            .reduce(
+                &Amount::new(dec!(-6), "AAPL"),
+                Some(&merge_spec),
+                BookingMethod::Strict,
+            )
+            .expect("three-lot merge should succeed");
+
+        assert_eq!(result.cost_basis, Some(Amount::new(dec!(900), "USD")));
+        assert_eq!(inv.positions.len(), 1);
+        assert_eq!(inv.positions[0].units.number, dec!(24));
+        let cost = inv.positions[0].cost.as_ref().expect("should have cost");
+        assert_eq!(cost.number, dec!(150));
+    }
+
+    #[test]
+    fn test_reduce_merge_empty_inventory() {
+        let mut inv = Inventory::new();
+
+        let merge_spec = CostSpec::empty().with_merge();
+        let result = inv.reduce(
+            &Amount::new(dec!(-5), "AAPL"),
+            Some(&merge_spec),
+            BookingMethod::Strict,
+        );
+
+        assert!(matches!(
+            result,
+            Err(BookingError::InsufficientUnits { .. })
+        ));
+    }
+
+    #[test]
     fn test_inventory_display_sorted() {
         let mut inv = Inventory::new();
 

--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -649,6 +649,15 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
             return Err(());
         }
 
+        // Check for merge operator {*}
+        if let Some(t) = stream.peek()
+            && matches!(t.token, Token::Star)
+        {
+            stream.advance();
+            spec.merge = true;
+            continue;
+        }
+
         // Try to parse different component types
         if let Ok(date) = parse_date(stream) {
             spec.date = Some(date);
@@ -2670,6 +2679,27 @@ mod tests {
 "#;
         let result = parse(source);
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    }
+
+    #[test]
+    fn test_parse_cost_spec_merge() {
+        let source = r#"
+2024-01-15 * "Test"
+  Assets:Stock  -10 AAPL {*}
+  Assets:Cash
+"#;
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let txn = result.directives.iter().find_map(|d| {
+            if let Directive::Transaction(t) = &d.value {
+                Some(t)
+            } else {
+                None
+            }
+        });
+        let posting = &txn.unwrap().postings[0];
+        let cost = posting.cost.as_ref().expect("should have cost spec");
+        assert!(cost.merge, "merge flag should be true for {{*}}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement the `{*}` cost merge operator as defined in the [PTA spec](https://github.com/rustledger/pta-standards/blob/main/formats/beancount/v3/spec/costs.md#cost-merge). Previously, `{*}` was accepted by the parser but the merge semantics were not implemented — it fell back to partial-cost matching and reported an ambiguous match when multiple lots existed.

### What `{*}` does

```beancount
Assets:Stock -5 AAPL {*}
```

Merges all existing AAPL lots into a single weighted-average-cost lot, then reduces 5 units from it. For example, 10 AAPL {150 USD} + 10 AAPL {160 USD} → 20 AAPL {155 USD avg}, then sell 5 from the merged lot.

### Changes

- **Parser** (`winnow_parser.rs`): Handle `Token::Star` inside cost spec to set `merge: true`
- **Inventory** (`booking.rs`): New `reduce_merge()` method that computes weighted-average cost, merges all lots, and reduces from the merged lot. Check `spec.merge` in both `reduce()` and `try_reduce()` before dispatching by booking method.

### Conformance

This was the only failing PTA conformance test (`cost-asterisk-merge`): **269/270 → 270/270** (100%).

Note: Python beancount 3.x also doesn't implement this feature yet.

Closes #773.

## Test plan

- [x] 3 new unit tests: merge reduction, insufficient units, sell-all
- [x] 1 new parser test: `{*}` sets merge flag
- [x] Manual test with issue reproduction case (`rledger check --no-cache`)
- [x] All 482 existing tests pass across core, booking, and parser crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)