### PR TITLE
docs: update architecture docs to reflect current state

### DIFF
--- a/docs/reference/adr/0001-crate-organization.md
+++ b/docs/reference/adr/0001-crate-organization.md
@@ -19,18 +19,19 @@ Key considerations:
 
 Organize the codebase as a workspace with multiple focused crates:
 
-- **rustledger-core**: Core types (Directive, Transaction, Amount, etc.) with no dependencies beyond std
+- **rustledger-core**: Core types (Directive, Transaction, Amount, etc.) with no internal dependencies
 - **rustledger-parser**: Beancount file parser, depends only on core
-- **rustledger-loader**: File loading with include resolution, depends on parser
-- **rustledger-validate**: Validation rules, depends on core
+- **rustledger-loader**: File loading, includes, caching, and processing pipeline (sort → book → plugins → validate)
+- **rustledger-validate**: Validation rules, depends on core, parser, booking
 - **rustledger-booking**: Balance booking algorithms, depends on core
-- **rustledger-query**: BQL query language, depends on core
-- **rustledger-plugin**: Plugin infrastructure, depends on core
+- **rustledger-query**: BQL query language, depends on core, parser, loader
+- **rustledger-plugin**: Native + WASM + Python plugin system (30+ plugins), depends on core
+- **rustledger-plugin-types**: Shared WASM plugin interface types (minimal, no internal deps)
 - **rustledger-importer**: Bank statement import framework (CSV, OFX)
 - **rustledger**: CLI binary (`rledger`, `bean-*` commands)
 - **rustledger-wasm**: WebAssembly bindings for JS/TS
 - **rustledger-lsp**: Language Server Protocol for editor integration
-- **rustledger-ffi-wasi**: FFI via WASI for embedding in any language
+- **rustledger-ffi-wasi**: FFI via WASI JSON-RPC for embedding in any language
 
 ## Consequences
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -43,12 +43,13 @@ This document describes rustledger's crate structure and data flow.
                                   └─────────────────┘
 
 
-    ┌─────────────────┐           ┌───────────────────┐
-    │ rustledger-wasm │           │rustledger-importer│
-    │ (JS/TS bindings)│           │      (CSV)        │
-    └────────┬────────┘           └───────────────────┘
-              │
-              └─────────────────► rustledger-core, parser, query
+    ┌─────────────────┐   ┌───────────────────┐   ┌───────────────────┐
+    │ rustledger-wasm │   │rustledger-ffi-wasi│   │rustledger-importer│
+    │ (JS/TS bindings)│   │ (JSON-RPC/WASI)   │   │    (CSV/OFX)      │
+    └────────┬────────┘   └────────┬──────────┘   └───────────────────┘
+              │                     │
+              └─────────┬──────────┘
+                        └──────────► rustledger-core, parser, loader, query
 ```
 
 ## Crate Descriptions
@@ -73,7 +74,8 @@ This document describes rustledger's crate structure and data flow.
 | Crate | Purpose | Key Types |
 |-------|---------|-----------|
 | `rustledger-query` | BQL query engine | `Query`, `Executor`, `Table`, `Row` |
-| `rustledger-plugin` | Native + Python plugins | `NativePlugin`, `PluginRegistry` |
+| `rustledger-plugin` | Native + WASM + Python plugins | `NativePlugin`, `NativePluginRegistry`, `PluginManager` |
+| `rustledger-plugin-types` | WASM plugin interface types | `PluginInput`, `PluginOutput`, `DirectiveWrapper` |
 | `rustledger-lsp` | Language Server Protocol | LSP handlers for all standard features |
 | `rustledger-importer` | Bank statement import | `CsvImporter`, `OfxImporter` |
 
@@ -83,7 +85,7 @@ This document describes rustledger's crate structure and data flow.
 |-------|---------|
 | `rustledger` | CLI binary (`rledger`, `bean-*` commands) |
 | `rustledger-wasm` | WebAssembly bindings for JS/TS |
-| `rustledger-ffi-wasi` | FFI via WASI for embedding in any language |
+| `rustledger-ffi-wasi` | FFI via WASI JSON-RPC for embedding |
 
 ## Data Flow
 
@@ -110,18 +112,20 @@ Input File
     │
     ▼
 ┌─────────────────────────────────────┐
-│ 3. PLUGINS (rustledger-plugin)      │
-│    - Run native plugins             │
-│    - Run Python plugins (WASI)      │
-│    - Transform directives           │
+│ 3. SORT + BOOK (rustledger-booking) │
+│    - Sort by date/type/cost-reduce  │
+│    - Interpolate missing amounts    │
+│    - Match lots (FIFO/LIFO/etc)     │
+│    - Compute cost basis             │
 └─────────────────────────────────────┘
     │
     ▼
 ┌─────────────────────────────────────┐
-│ 4. BOOKING (rustledger-booking)     │
-│    - Interpolate missing amounts    │
-│    - Match lots (FIFO/LIFO/etc)     │
-│    - Compute cost basis             │
+│ 4. PLUGINS (rustledger-plugin)      │
+│    - Run native plugins (30+)       │
+│    - Run WASM plugins (sandboxed)   │
+│    - Run Python plugins (via WASI)  │
+│    - Transform directives           │
 └─────────────────────────────────────┘
     │
     ▼
@@ -192,13 +196,15 @@ Each crate defines its own error type. The CLI crate uses `anyhow` to unify them
 
 See: [ADR-0002: Error Handling](adr/0002-error-handling.md)
 
-### 4. Python Plugin Sandbox
+### 4. Plugin System
 
-Python plugins run in a WebAssembly sandbox (CPython compiled to WASI). This provides:
+Plugins are executed by `run_plugins()` in `rustledger-loader`, the single source of truth for all file-declared plugin execution. Three plugin backends:
 
-- Security: Plugins can't access filesystem or network
-- Portability: No system Python needed
-- Compatibility: Runs existing Python plugins
+- **Native plugins** (30+): Rust implementations, zero serialization overhead
+- **WASM plugins**: Any language compiled to WASM, sandboxed via wasmtime
+- **Python plugins**: CPython compiled to WASI, runs existing beancount plugins
+
+Plugin execution order within the pipeline: after booking, before validation. This ensures plugins see fully-interpolated directives and validation checks plugin output.
 
 ### 5. Binary Cache
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -46,10 +46,11 @@ This document describes rustledger's crate structure and data flow.
     ┌─────────────────┐   ┌───────────────────┐   ┌───────────────────┐
     │ rustledger-wasm │   │rustledger-ffi-wasi│   │rustledger-importer│
     │ (JS/TS bindings)│   │ (JSON-RPC/WASI)   │   │    (CSV/OFX)      │
-    └────────┬────────┘   └────────┬──────────┘   └───────────────────┘
-              │                     │
-              └─────────┬──────────┘
-                        └──────────► rustledger-core, parser, loader, query
+    └────────┬────────┘   └────────┬──────────┘   └────────┬──────────┘
+              │                     │                       │
+              │                     └──► core, booking, validate, plugin, query
+              └────────────────────────► core, parser, booking, validate, loader, query
+                                                            └──► core only
 ```
 
 ## Crate Descriptions
@@ -112,11 +113,14 @@ Input File
     │
     ▼
 ┌─────────────────────────────────────┐
-│ 3. SORT + BOOK (rustledger-booking) │
-│    - Sort by date/type/cost-reduce  │
-│    - Interpolate missing amounts    │
-│    - Match lots (FIFO/LIFO/etc)     │
-│    - Compute cost basis             │
+│ 3. SORT (rustledger-loader) +       │
+│    BOOK (rustledger-booking)        │
+│    - Loader sorts by                │
+│      date/type/cost-reduce          │
+│    - Booking interpolates amounts   │
+│    - Booking matches lots           │
+│      (FIFO/LIFO/etc)                │
+│    - Booking computes cost basis    │
 └─────────────────────────────────────┘
     │
     ▼
@@ -198,7 +202,7 @@ See: [ADR-0002: Error Handling](adr/0002-error-handling.md)
 
 ### 4. Plugin System
 
-Plugins are executed by `run_plugins()` in `rustledger-loader`, the single source of truth for all file-declared plugin execution. Three plugin backends:
+Plugins are executed by `run_plugins()` in `rustledger-loader`, the single source of truth for all file-declared plugin execution (native, WASM, and Python). The CLI additionally supports `--plugin` flags for CLI-specified WASM plugins that run as post-processing. Three plugin backends:
 
 - **Native plugins** (30+): Rust implementations, zero serialization overhead
 - **WASM plugins**: Any language compiled to WASM, sandboxed via wasmtime

--- a/spec/impl/architecture.md
+++ b/spec/impl/architecture.md
@@ -57,7 +57,8 @@ rustledger/
 │   ├── rustledger-ffi-wasi/     # FFI via WASI JSON-RPC
 │   └── rustledger/              # CLI tools (rledger, bean-* commands)
 ├── packages/
-│   └── vscode/                  # VS Code extension (LSP client)
+│   ├── vscode/                  # VS Code extension (LSP client)
+│   └── mcp-server/              # MCP server (Model Context Protocol)
 ├── Cargo.toml                   # Workspace definition
 └── spec/                        # Specifications (this folder)
 ```

--- a/spec/impl/architecture.md
+++ b/spec/impl/architecture.md
@@ -43,16 +43,23 @@ This document describes the high-level architecture of rustledger.
 ```
 rustledger/
 ├── crates/
-│   ├── rustledger-core/       # Core types and traits
-│   ├── rustledger-parser/     # Lexer and parser
-│   ├── rustledger-loader/     # File loading and includes
-│   ├── rustledger-booking/    # Interpolation and booking engine
-│   ├── rustledger-validate/   # Validation rules
-│   ├── rustledger-query/      # BQL query engine
-│   ├── rustledger-plugin/     # WASM plugin runtime
-│   └── rustledger/            # CLI tools
-├── Cargo.toml                # Workspace definition
-└── spec/                     # Specifications (this folder)
+│   ├── rustledger-core/         # Core types (Amount, Directive, Inventory)
+│   ├── rustledger-parser/       # Logos lexer + Winnow parser
+│   ├── rustledger-loader/       # File loading, includes, processing pipeline
+│   ├── rustledger-booking/      # Interpolation and booking engine (7 methods)
+│   ├── rustledger-validate/     # Validation rules (28 error codes)
+│   ├── rustledger-query/        # BQL query engine
+│   ├── rustledger-plugin/       # Native + WASM + Python plugin system
+│   ├── rustledger-plugin-types/ # WASM plugin interface types
+│   ├── rustledger-importer/     # CSV/OFX bank statement import
+│   ├── rustledger-lsp/          # Language Server Protocol
+│   ├── rustledger-wasm/         # WebAssembly bindings for JS/TS
+│   ├── rustledger-ffi-wasi/     # FFI via WASI JSON-RPC
+│   └── rustledger/              # CLI tools (rledger, bean-* commands)
+├── packages/
+│   └── vscode/                  # VS Code extension (LSP client)
+├── Cargo.toml                   # Workspace definition
+└── spec/                        # Specifications (this folder)
 ```
 
 ## Crate Dependencies
@@ -94,7 +101,7 @@ rustledger/
                ▼
     ┌─────────────────────┐
     │    rust_decimal     │
-    │    chrono           │
+    │    jiff             │
     └─────────────────────┘
 ```
 
@@ -115,20 +122,20 @@ rustledger/
 │                                                          │              │
 │                                                          ▼              │
 │  ┌────────┐   ┌────────┐   ┌────────┐   ┌────────┐   ┌────────┐        │
-│  │ Apply  │◀──│ Plugin │◀──│Validate│◀──│  Book  │◀──│Interpolate     │
-│  │ Plugins│   │  Host  │   │  Accts │   │  Lots  │   │ Amounts│        │
-│  └───┬────┘   └────────┘   └────────┘   └────────┘   └────────┘        │
-│      │                                                                  │
-│  Phase 2: BOOKING & VALIDATION                                          │
+│  │  Sort  │──▶│Interpol│──▶│  Book  │──▶│ Plugins│──▶│Validate│        │
+│  │by date │   │amounts │   │  Lots  │   │(native,│   │accounts│        │
+│  └────────┘   └────────┘   └────────┘   │WASM,Py)│   │balance │        │
+│                                          └────────┘   └───┬────┘        │
+│  Phase 2: SORT → BOOK → PLUGINS → VALIDATE                │              │
 │  ─────────────────────────────────────────────────────────              │
-│      │                                                                  │
-│      ▼                                                                  │
-│  ┌────────┐   ┌────────┐   ┌────────┐                                  │
-│  │Validate│──▶│ Collect│──▶│ Ledger │                                  │
-│  │Balance │   │ Errors │   │(final) │                                  │
-│  └────────┘   └────────┘   └────────┘                                  │
+│                                                          │              │
+│                                                          ▼              │
+│                                          ┌────────┐   ┌────────┐        │
+│                                          │ Collect│──▶│ Ledger │        │
+│                                          │ Errors │   │(final) │        │
+│                                          └────────┘   └────────┘        │
 │                                                                          │
-│  Phase 3: FINAL VALIDATION                                              │
+│  Phase 3: OUTPUT                                                         │
 │  ─────────────────────────────────────────────────────────              │
 │                                                                          │
 └──────────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
## Summary

- Fix processing pipeline order: Sort → Book → Plugins → Validate (was showing plugins before booking)
- Update `chrono` → `jiff` in dependency diagram
- Add missing crates to all architecture docs (plugin-types, lsp, wasm, ffi-wasi, importer)
- Update plugin system description to cover all 3 backends (native, WASM, Python)
- Update ADR-0001 crate list to match current 13-crate workspace

## Files changed

- `docs/reference/architecture.md` — main user-facing architecture doc
- `spec/impl/architecture.md` — internal spec architecture doc
- `docs/reference/adr/0001-crate-organization.md` — crate organization ADR

## Test plan

- [ ] Docs render correctly on website
- [ ] No broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)