### PR TITLE
perf: avoid cloning directive list for native plugin execution

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -407,7 +407,7 @@ pub fn run_plugins(
     if has_document_dirs {
         let doc_plugin = DocumentDiscoveryPlugin::new(resolved_documents, base_dir.to_path_buf());
         let input = PluginInput {
-            directives: wrappers.clone(),
+            directives: std::mem::take(&mut wrappers),
             options: plugin_options.clone(),
             config: None,
         };
@@ -453,8 +453,11 @@ pub fn run_plugins(
             if let Some(name) = resolved_name
                 && let Some(plugin) = registry.find(name)
             {
+                // Move wrappers into the plugin input instead of cloning.
+                // The plugin returns modified directives in its output,
+                // which we reassign to `wrappers` below.
                 let input = PluginInput {
-                    directives: wrappers.clone(),
+                    directives: std::mem::take(&mut wrappers),
                     options: plugin_options.clone(),
                     config: plugin_config.clone(),
                 };


### PR DESCRIPTION
## Summary

- Replace `wrappers.clone()` with `std::mem::take(&mut wrappers)` for native plugins and document discovery
- Eliminates O(n×m) directive copies where n=directives, m=plugins
- For a 10K-directive ledger with 5 native plugins: 50K directive copies → 0

## How it works

Native plugins take `PluginInput` by value (owned) and return `PluginOutput` with modified directives. Previously we cloned the entire wrappers vec for each plugin call and reassigned from output. Now we move ownership directly via `std::mem::take`, which is O(1) — just swaps a pointer.

WASM and Python plugins still use `.to_vec()` since they need MessagePack serialization (which copies anyway) and must preserve wrappers on error. Native plugins are the common case (30+ built-in, most users never use WASM/Python).

## Test plan

- [ ] `cargo clippy -p rustledger-loader --all-features -- -D warnings`
- [ ] `cargo test -p rustledger-loader --all-features`
- [ ] Compatibility tests pass
- [ ] Benchmark shows improvement (or no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)