### PR TITLE
feat: add Nushell shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,7 +1146,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1232,7 +1242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1893,7 +1903,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2321,7 +2331,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3156,7 +3166,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3176,6 +3186,7 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "criterion",
  "dirs",
  "edit",
@@ -3912,7 +3923,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3931,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5068,7 +5079,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ toml = "1.0"
 # CLI
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+clap_complete_nushell = "4"
 rustyline = { version = "18", features = ["derive"] }
 dirs = "6"
 edit = "0.1"

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -77,6 +77,7 @@ rustledger-plugin.workspace = true
 rustledger-importer.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
+clap_complete_nushell.workspace = true
 rustyline.workspace = true
 dirs.workspace = true
 edit.workspace = true

--- a/crates/rustledger/src/cmd/completions.rs
+++ b/crates/rustledger/src/cmd/completions.rs
@@ -19,6 +19,8 @@ pub enum ShellType {
     Powershell,
     /// Elvish shell completions
     Elvish,
+    /// Nushell completions
+    Nushell,
 }
 
 impl Generator for ShellType {
@@ -29,6 +31,7 @@ impl Generator for ShellType {
             Self::Fish => Shell::Fish.file_name(name),
             Self::Powershell => Shell::PowerShell.file_name(name),
             Self::Elvish => Shell::Elvish.file_name(name),
+            Self::Nushell => clap_complete_nushell::Nushell.file_name(name),
         }
     }
 
@@ -39,6 +42,7 @@ impl Generator for ShellType {
             Self::Fish => Shell::Fish.generate(cmd, buf),
             Self::Powershell => Shell::PowerShell.generate(cmd, buf),
             Self::Elvish => Shell::Elvish.generate(cmd, buf),
+            Self::Nushell => clap_complete_nushell::Nushell.generate(cmd, buf),
         }
     }
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -160,6 +160,10 @@ criteria = "safe-to-deploy"
 version = "4.6.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.clap_complete_nushell]]
+version = "4.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.clap_derive]]
 version = "4.6.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

Add Nushell as a supported shell for completion generation via `clap_complete_nushell`.

```bash
rledger --generate-completions nushell > ~/.config/nushell/completions/rledger.nu
```

All `bean-*` compatibility commands also support it:
```bash
bean-check --generate-completions nushell
bean-query --generate-completions nushell
```

Closes #853

## Test plan

- [ ] `cargo clippy -p rustledger --all-features --all-targets -- -D warnings`
- [ ] `rledger --generate-completions nushell` produces valid Nushell completions
- [ ] Cargo vet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)