### PR TITLE
chore: remove dead code in rustledger-wasm

### DIFF
--- a/crates/rustledger-wasm/src/editor/symbols.rs
+++ b/crates/rustledger-wasm/src/editor/symbols.rs
@@ -27,6 +27,7 @@ pub fn get_document_symbols_cached(
 }
 
 /// Get all document symbols (for outline view, non-cached, used by tests).
+#[cfg(test)]
 pub fn get_document_symbols(source: &str, parse_result: &ParseResult) -> Vec<EditorDocumentSymbol> {
     let line_index = LineIndex::new(source);
     parse_result

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -473,24 +473,6 @@ pub struct Ledger {
     editor_cache: editor::EditorCache,
 }
 
-#[cfg(test)]
-impl Ledger {
-    /// Test-only constructor from pre-processed parts.
-    pub(crate) fn new_from_parts(
-        directives: Vec<Directive>,
-        options: LedgerOptions,
-        errors: Vec<Error>,
-        editor_cache: editor::EditorCache,
-    ) -> Self {
-        Self {
-            directives,
-            options,
-            errors,
-            editor_cache,
-        }
-    }
-}
-
 #[wasm_bindgen]
 impl Ledger {
     /// Create a `Ledger` from multiple files with include resolution.


### PR DESCRIPTION
## Summary

- Remove unused `Ledger::new_from_parts` test constructor — never called from any test
- Gate `get_document_symbols` with `#[cfg(test)]` — only used in unit tests, not part of the WASM API surface (the WASM API uses `get_document_symbols_cached` instead)

Closes #862

## Test plan

- [x] `cargo check -p rustledger-wasm` — both warnings eliminated
- [x] `cargo test -p rustledger-wasm -- document_symbols` — 2 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)