### PR TITLE
refactor: deduplicate booking logic between validator and booking engine

### DIFF
--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -445,11 +445,14 @@ pub fn process_inventory_reduction(
     txn: &Transaction,
     errors: &mut Vec<ValidationError>,
 ) {
-    // Skip reductions with empty cost specs — these are unbooked transactions
-    // where the booking engine already failed and reported an error. Re-running
-    // lot matching here would double-report errors or (worse) make different
-    // decisions than the booking engine. This mirrors validate_transaction_balance
-    // which also skips transactions with empty cost specs (line 216-224).
+    // Skip reductions with no numeric cost (e.g., `{}`, `{2024-01-15}`, `{"lot1"}`).
+    // These are unbooked postings where either:
+    //   - Booking wasn't run (standalone validation), or
+    //   - Booking failed and already reported the error (normal pipeline).
+    // If booking succeeded, it would have filled in number_per from the matched
+    // lot. Re-running lot matching here would double-report or diverge from the
+    // booking engine's decisions. This mirrors validate_transaction_balance which
+    // also skips transactions with empty cost specs.
     if let Some(cost) = &posting.cost
         && cost.number_per.is_none()
         && cost.number_total.is_none()

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -433,10 +433,10 @@ pub fn update_inventories(
 /// On pre-booked directives (the normal pipeline), every reduction posting has
 /// a fully-resolved cost spec, so `inv.reduce()` is a trivial exact match.
 ///
-/// If the cost spec is empty (booking failed or wasn't run), we skip inventory
-/// processing entirely — booking already reported the error, and re-running
-/// lot matching here would either double-report or diverge from the booking
-/// engine's decisions.
+/// If the cost spec has no cost amount (booking failed or wasn't run), we skip
+/// inventory processing entirely — booking already reported the error, and
+/// re-running lot matching here would either double-report or diverge from the
+/// booking engine's decisions.
 pub fn process_inventory_reduction(
     inv: &mut Inventory,
     posting: &Posting,
@@ -445,14 +445,14 @@ pub fn process_inventory_reduction(
     txn: &Transaction,
     errors: &mut Vec<ValidationError>,
 ) {
-    // Skip reductions with no numeric cost (e.g., `{}`, `{2024-01-15}`, `{"lot1"}`).
-    // These are unbooked postings where either:
+    // Skip reductions whose cost spec has no cost amount (e.g., `{}`, `{2024-01-15}`,
+    // `{"lot1"}`). These are unbooked postings where either:
     //   - Booking wasn't run (standalone validation), or
     //   - Booking failed and already reported the error (normal pipeline).
     // If booking succeeded, it would have filled in number_per from the matched
     // lot. Re-running lot matching here would double-report or diverge from the
-    // booking engine's decisions. This mirrors validate_transaction_balance which
-    // also skips transactions with empty cost specs.
+    // booking engine's decisions. This mirrors `validate_transaction_balance`,
+    // which also skips balance checking when a posting has an unresolved cost.
     if let Some(cost) = &posting.cost
         && cost.number_per.is_none()
         && cost.number_total.is_none()

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -429,6 +429,14 @@ pub fn update_inventories(
 }
 
 /// Process an inventory reduction (selling/removing units).
+///
+/// On pre-booked directives (the normal pipeline), every reduction posting has
+/// a fully-resolved cost spec, so `inv.reduce()` is a trivial exact match.
+///
+/// If the cost spec is empty (booking failed or wasn't run), we skip inventory
+/// processing entirely — booking already reported the error, and re-running
+/// lot matching here would either double-report or diverge from the booking
+/// engine's decisions.
 pub fn process_inventory_reduction(
     inv: &mut Inventory,
     posting: &Posting,
@@ -437,102 +445,46 @@ pub fn process_inventory_reduction(
     txn: &Transaction,
     errors: &mut Vec<ValidationError>,
 ) {
+    // Skip reductions with empty cost specs — these are unbooked transactions
+    // where the booking engine already failed and reported an error. Re-running
+    // lot matching here would double-report errors or (worse) make different
+    // decisions than the booking engine. This mirrors validate_transaction_balance
+    // which also skips transactions with empty cost specs (line 216-224).
+    if let Some(cost) = &posting.cost
+        && cost.number_per.is_none()
+        && cost.number_total.is_none()
+    {
+        return;
+    }
+
     match inv.reduce(units, posting.cost.as_ref(), booking_method) {
         Ok(_) => {}
-        Err(err @ rustledger_core::BookingError::InsufficientUnits { .. }) => {
-            errors.push(
-                ValidationError::new(
+        Err(err) => {
+            // On pre-booked directives, reduce() with a fully-specified cost
+            // should not fail. If it does, report the error — this catches
+            // bugs in the booking engine or standalone validation without booking.
+            let (code, context) = match &err {
+                rustledger_core::BookingError::InsufficientUnits { .. } => (
                     ErrorCode::InsufficientUnits,
-                    format!("{}", err.with_account(posting.account.clone())),
-                    txn.date,
-                )
-                .with_context(format!("currency: {}", units.currency)),
-            );
-        }
-        Err(err @ rustledger_core::BookingError::NoMatchingLot { .. }) => {
-            // In STRICT mode, when no lot matches AND the inventory has no POSITIVE
-            // positions for this commodity, Python beancount allows "sell to open"
-            // by creating a new lot with negative units. This is common in options trading.
-            // However, if there ARE positive lots that just don't match the cost spec,
-            // that's an error (you're trying to sell from a lot that doesn't exist).
-            // We only check for positive lots because negative lots are short positions
-            // from previous sell-to-open operations.
-            let has_positive_lots = inv
-                .positions()
-                .iter()
-                .any(|p| p.units.currency == units.currency && p.units.number > Decimal::ZERO);
-
-            if booking_method == BookingMethod::Strict
-                && !has_positive_lots
-                && let Some(cost_spec) = &posting.cost
-            {
-                // Need cost per unit (or total) and currency to create a new lot
-                let cost_number = cost_spec
-                    .number_per
-                    .or_else(|| cost_spec.number_total.map(|t| t / units.number.abs()));
-
-                // Infer currency from cost spec, price annotation, or fall back
-                let cost_currency = cost_spec.currency.clone().or_else(|| {
-                    // Try to get currency from price annotation
-                    posting.price.as_ref().and_then(|p| match p {
-                        rustledger_core::PriceAnnotation::Unit(a)
-                        | rustledger_core::PriceAnnotation::Total(a) => Some(a.currency.clone()),
-                        rustledger_core::PriceAnnotation::UnitIncomplete(inc)
-                        | rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                            inc.as_amount().map(|a| a.currency.clone())
-                        }
-                        _ => None,
-                    })
-                });
-
-                if let (Some(number), Some(curr)) = (cost_number, cost_currency) {
-                    // Create a new position with negative units (sell to open)
-                    let cost = rustledger_core::Cost::new(number, curr)
-                        .with_date(cost_spec.date.unwrap_or(txn.date));
-                    let cost = if let Some(label) = &cost_spec.label {
-                        cost.with_label(label.clone())
-                    } else {
-                        cost
-                    };
-                    let position = rustledger_core::Position::with_cost(units.clone(), cost);
-                    inv.add(position);
-                    return; // Successfully created sell-to-open position
-                }
-            }
-            // Couldn't create sell-to-open (or has existing lots that don't match), report error
-            errors.push(
-                ValidationError::new(
-                    ErrorCode::NoMatchingLot,
-                    format!("{}", err.with_account(posting.account.clone())),
-                    txn.date,
-                )
-                .with_context(format!("cost spec: {:?}", posting.cost)),
-            );
-        }
-        Err(err @ rustledger_core::BookingError::AmbiguousMatch { .. }) => {
-            errors.push(
-                ValidationError::new(
+                    format!("currency: {}", units.currency),
+                ),
+                rustledger_core::BookingError::AmbiguousMatch { .. } => (
                     ErrorCode::AmbiguousLotMatch,
-                    format!("{}", err.with_account(posting.account.clone())),
-                    txn.date,
-                )
-                .with_context("Specify cost, date, or label to disambiguate".to_string()),
-            );
-        }
-        Err(err @ rustledger_core::BookingError::CurrencyMismatch { .. }) => {
-            // Defensive: no `Inventory::reduce` path in `rustledger-core`
-            // currently emits this variant, but if a future one does we
-            // surface it consistently with the booking engine's path in
-            // `cmd/check.rs`. CurrencyMismatch is rendered and classified as
-            // a specialization of NoMatchingLot — see the canonical
-            // `AccountedBookingError::Display` impl in `rustledger-core`.
+                    "Specify cost, date, or label to disambiguate".to_string(),
+                ),
+                rustledger_core::BookingError::NoMatchingLot { .. }
+                | rustledger_core::BookingError::CurrencyMismatch { .. } => (
+                    ErrorCode::NoMatchingLot,
+                    format!("cost spec: {:?}", posting.cost),
+                ),
+            };
             errors.push(
                 ValidationError::new(
-                    ErrorCode::NoMatchingLot,
+                    code,
                     format!("{}", err.with_account(posting.account.clone())),
                     txn.date,
                 )
-                .with_context(format!("currency: {}", units.currency)),
+                .with_context(context),
             );
         }
     }

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -418,7 +418,11 @@ pub fn update_inventories(
             .map(|a| a.booking)
             .unwrap_or_default();
 
-        let is_reduction = units.number.is_sign_negative() && posting.cost.is_some();
+        // Use the same reduction detection as the booking engine: a posting
+        // reduces inventory when the inventory has positions with the opposite
+        // sign for the same currency. This correctly handles sell-to-open
+        // (selling into empty inventory) as an augmentation, not a reduction.
+        let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units);
 
         if is_reduction {
             process_inventory_reduction(inv, posting, units, booking_method, txn, errors);

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -163,9 +163,12 @@ fn test_check_invalid_account_root_is_parse_phase() {
 }
 
 /// Regression for issue #737: a wildcard reduction `-5 AAPL {}` against an
-/// inventory holding lots at different costs must produce exactly one E4003
-/// "Ambiguous lot match" diagnostic — not zero (the original silent-accept
-/// bug) and not two (the validator/booking double-report).
+/// inventory holding lots at different costs must produce exactly one
+/// "Ambiguous" diagnostic from the booking engine — not zero (the original
+/// silent-accept bug) and not two (the old validator/booking double-report).
+///
+/// Since #859, the validator no longer re-runs lot matching on pre-booked
+/// directives, so the sole reporter is the booking engine (code "BOOK").
 #[test]
 fn test_check_ambiguous_lot_match_reports_once() {
     let rledger = require_rledger!();
@@ -214,21 +217,29 @@ fn test_check_ambiguous_lot_match_reports_once() {
     let diagnostics = json["diagnostics"]
         .as_array()
         .expect("diagnostics array missing");
-    let e4003: Vec<_> = diagnostics
+    // The booking engine reports this as a "BOOK" error. The validator no longer
+    // re-reports it (see #859), so we look for any diagnostic mentioning "ambiguous".
+    let ambiguous: Vec<_> = diagnostics
         .iter()
-        .filter(|d| d["code"] == "E4003")
+        .filter(|d| {
+            d["message"]
+                .as_str()
+                .unwrap_or("")
+                .to_lowercase()
+                .contains("ambiguous")
+        })
         .collect();
 
     assert_eq!(
-        e4003.len(),
+        ambiguous.len(),
         1,
-        "expected exactly one E4003 diagnostic, got {}: {json}",
-        e4003.len()
+        "expected exactly one ambiguous-lot diagnostic, got {}: {json}",
+        ambiguous.len()
     );
-    let msg = e4003[0]["message"].as_str().unwrap_or("");
-    assert!(
-        msg.to_lowercase().contains("ambiguous"),
-        "E4003 message should mention 'ambiguous', got: {msg}"
+    assert_eq!(
+        ambiguous[0]["code"].as_str().unwrap_or(""),
+        "BOOK",
+        "ambiguous lot error should come from the booking engine, not the validator"
     );
 }
 

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -217,29 +217,31 @@ fn test_check_ambiguous_lot_match_reports_once() {
     let diagnostics = json["diagnostics"]
         .as_array()
         .expect("diagnostics array missing");
-    // The booking engine reports this as a "BOOK" error. The validator no longer
-    // re-reports it (see #859), so we look for any diagnostic mentioning "ambiguous".
-    let ambiguous: Vec<_> = diagnostics
-        .iter()
-        .filter(|d| {
-            d["message"]
-                .as_str()
-                .unwrap_or("")
-                .to_lowercase()
-                .contains("ambiguous")
-        })
-        .collect();
+    // The booking engine is the sole reporter of lot-matching errors (#859).
+    // The validator no longer re-runs lot matching on unbooked postings.
+    let book_errors: Vec<_> = diagnostics.iter().filter(|d| d["code"] == "BOOK").collect();
 
     assert_eq!(
-        ambiguous.len(),
+        book_errors.len(),
         1,
-        "expected exactly one ambiguous-lot diagnostic, got {}: {json}",
-        ambiguous.len()
+        "expected exactly one BOOK diagnostic, got {}: {json}",
+        book_errors.len()
     );
-    assert_eq!(
-        ambiguous[0]["code"].as_str().unwrap_or(""),
-        "BOOK",
-        "ambiguous lot error should come from the booking engine, not the validator"
+    let msg = book_errors[0]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.to_lowercase().contains("ambiguous"),
+        "BOOK diagnostic should mention 'ambiguous', got: {msg}"
+    );
+
+    // Confirm the validator does NOT double-report as E4003.
+    let e4003: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d["code"] == "E4003")
+        .collect();
+    assert!(
+        e4003.is_empty(),
+        "validator should not re-report booking errors, but found {} E4003 diagnostics",
+        e4003.len()
     );
 }
 


### PR DESCRIPTION
## Summary

The validator's `process_inventory_reduction()` contained ~50 lines of sell-to-open logic and booking error handling that duplicated — and diverged from — the booking engine.

**The divergence:** The validator created sell-to-open (short) positions in STRICT mode when no matching lot existed. The booking engine would reject these transactions entirely. Since the normal pipeline runs booking first, this validator code was unreachable — but if anyone called `validate()` standalone, they'd get different behavior than the full pipeline.

**What changed:**

- **Skip reductions with empty cost specs** — if a posting has an unresolved cost (`{}`), booking already failed and reported the error. The validator no longer re-runs lot matching on these, avoiding double-reporting. This mirrors `validate_transaction_balance` which already skips transactions with empty cost specs.

- **Remove sell-to-open from validator** — this booking decision doesn't belong in the validator. If sell-to-open is desired, it should be implemented in `rustledger-booking` or `rustledger-core::Inventory::reduce()`.

- **Simplify error handling** — collapsed 4 separate error match arms into one, since the special-case handling (ambiguity resolution, cost currency inference) can't arise on pre-booked directives.

- **Update regression test** — `test_check_ambiguous_lot_match_reports_once` now checks for the booking engine's `BOOK` error instead of the validator's `E4003`, confirming no double-reporting.

Net result: -37 lines, cleaner separation of concerns.

Closes #859

## Test plan

- [x] `cargo test -p rustledger-validate` — 26 passed
- [x] `cargo test -p rustledger --test cli_commands_test` — 43 passed (including updated regression test)
- [x] `cargo test -p rustledger-loader -p rustledger-booking` — all passed
- [x] `cargo clippy -p rustledger-validate -- -D warnings` — clean
- [ ] CI (compatibility tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)