### PR TITLE
feat: expose option warnings (E7001–E7006) in LSP and WASM

### DIFF
--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -628,6 +628,33 @@ pub fn all_diagnostics(
         }
     }
 
+    // Emit option warnings (E7001–E7006) from the loaded ledger.
+    // These are only shown in the main file (file_id 0) to avoid duplication
+    // across open documents in multi-file mode.
+    let show_option_warnings = current_file_id.is_none() || current_file_id == Some(0);
+    if show_option_warnings {
+        if let Some(ls) = ledger_state
+            && let Some(ledger) = ls.ledger()
+        {
+            for warning in &ledger.options.warnings {
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position::new(0, 0),
+                        end: Position::new(0, 0),
+                    },
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(lsp_types::NumberOrString::String(warning.code.to_string())),
+                    source: Some("rustledger".to_string()),
+                    message: warning.message.clone(),
+                    related_information: None,
+                    tags: None,
+                    code_description: None,
+                    data: None,
+                });
+            }
+        }
+    }
+
     diagnostics
 }
 

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -628,30 +628,43 @@ pub fn all_diagnostics(
         }
     }
 
-    // Emit option warnings (E7001–E7006) from the loaded ledger.
-    // These are only shown in the main file (file_id 0) to avoid duplication
-    // across open documents in multi-file mode.
+    // Emit option warnings (E7001–E7006).
+    // In multi-file mode, use warnings from the loaded ledger (shown only in
+    // the main file to avoid duplication). In single-file mode (no ledger),
+    // validate options from the parse result so diagnostics still appear
+    // before the workspace ledger has loaded.
     let show_option_warnings = current_file_id.is_none() || current_file_id == Some(0);
     if show_option_warnings {
-        if let Some(ls) = ledger_state
+        let single_file_options;
+        let option_warnings = if let Some(ls) = ledger_state
             && let Some(ledger) = ls.ledger()
         {
-            for warning in &ledger.options.warnings {
-                diagnostics.push(Diagnostic {
-                    range: Range {
-                        start: Position::new(0, 0),
-                        end: Position::new(0, 0),
-                    },
-                    severity: Some(DiagnosticSeverity::ERROR),
-                    code: Some(lsp_types::NumberOrString::String(warning.code.to_string())),
-                    source: Some("rustledger".to_string()),
-                    message: warning.message.clone(),
-                    related_information: None,
-                    tags: None,
-                    code_description: None,
-                    data: None,
-                });
+            ledger.options.warnings.as_slice()
+        } else {
+            // Single-file fallback: validate parsed options to generate warnings.
+            let mut opts = LoaderOptions::default();
+            for (key, value, _span) in &result.options {
+                opts.set(key, value);
             }
+            single_file_options = opts;
+            single_file_options.warnings.as_slice()
+        };
+
+        for warning in option_warnings {
+            diagnostics.push(Diagnostic {
+                range: Range {
+                    start: Position::new(0, 0),
+                    end: Position::new(0, 0),
+                },
+                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(lsp_types::NumberOrString::String(warning.code.to_string())),
+                source: Some("rustledger".to_string()),
+                message: warning.message.clone(),
+                related_information: None,
+                tags: None,
+                code_description: None,
+                data: None,
+            });
         }
     }
 

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -549,7 +549,12 @@ impl Ledger {
             Ok(ledger) => {
                 let directives: Vec<Directive> =
                     ledger.directives.into_iter().map(|s| s.value).collect();
-                let errors: Vec<Error> = ledger.errors.into_iter().map(Error::from).collect();
+                let mut errors: Vec<Error> = ledger.errors.into_iter().map(Error::from).collect();
+                // Include option warnings (E7001–E7006) so WASM consumers
+                // see the same diagnostics as `rledger check` and the LSP.
+                for w in &ledger.options.warnings {
+                    errors.push(Error::new(format!("[{}] {}", w.code, w.message)));
+                }
                 let editor_cache = editor::EditorCache::from_directives(&directives);
 
                 Ok(Self {


### PR DESCRIPTION
## Summary

Option warnings (E7001–E7006) were already collected during parsing in `rustledger-loader` but only surfaced by the CLI's `rledger check`. The LSP and WASM interfaces silently dropped them, so tools using those APIs never reported invalid options like unknown option names, invalid values, or deprecated options.

- **LSP**: Convert `options.warnings` to diagnostics in `all_diagnostics()`, shown only in the main file (file_id 0) to avoid duplication across open documents
- **WASM**: Include option warnings in `Ledger.errors` so JS consumers see them alongside other diagnostics

No architectural changes needed — just plumbing existing data through existing APIs.

Closes #858

## Test plan

- [x] `cargo test -p rustledger-lsp` — 114 passed
- [x] `cargo test -p rustledger-wasm` — 67 passed
- [x] `cargo check -p rustledger-lsp -p rustledger-wasm` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)