### PR TITLE
fix(ci): remove bean-check test steps from release channel tests

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -155,8 +155,6 @@ jobs:
         run: echo '${{ env.TEST_BEANCOUNT }}' > /tmp/test.beancount
       - name: Test rledger check
         run: rledger check /tmp/test.beancount
-      - name: Test bean-check compatibility
-        run: bean-check /tmp/test.beancount
   test-homebrew-macos:
     name: Test Homebrew (macOS)
     needs: prepare
@@ -184,8 +182,6 @@ jobs:
         run: echo '${{ env.TEST_BEANCOUNT }}' > /tmp/test.beancount
       - name: Test rledger check
         run: rledger check /tmp/test.beancount
-      - name: Test bean-check compatibility
-        run: bean-check /tmp/test.beancount
   test-scoop:
     name: Test Scoop (Windows)
     needs: prepare


### PR DESCRIPTION
## Summary

- Remove `bean-check` test steps from Homebrew Linux and macOS release channel tests
- `bean-check` is no longer installed by default after #872 made `bean-compat` opt-in
- The `rledger check` step immediately above already covers the same functionality

## Test plan

- [x] Verify no other workflows reference bean-* as rustledger binaries (compat.yml and bench.yml reference Python beancount's bean-check, which is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)