### PR TITLE
fix: only consider cost-bearing positions for reduction matching

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -212,8 +212,9 @@ impl BookingEngine {
                 // - Selling long positions (negative units, positive inventory)
                 // - Closing short positions (positive units, negative inventory)
                 if let Some(inv) = working_inventories.get_mut(&posting.account) {
-                    // Check if inventory is_reduced_by these units
-                    // (signs differ for the same currency)
+                    // Check if these units reduce existing cost-bearing inventory lots.
+                    // Only positions with a cost basis are considered; simple (no-cost)
+                    // positions are ignored to avoid misclassifying augmentations.
                     let is_reduction = inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
                     if is_reduction {
@@ -439,8 +440,10 @@ impl BookingEngine {
                 let method = self.method_for(&posting.account);
                 let inv = self.inventories.entry(posting.account.clone()).or_default();
 
-                // Determine if this is a reduction using is_reduced_by logic:
-                // Units reduce inventory when signs differ for the same currency
+                // Determine if this is a reduction: units reduce inventory when
+                // signs differ for the same currency. Only cost-bearing positions
+                // are considered, so simple (no-cost) positions don't trigger
+                // false reduction detection.
                 let is_reduction = posting.cost.is_some()
                     && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -214,7 +214,7 @@ impl BookingEngine {
                 if let Some(inv) = working_inventories.get_mut(&posting.account) {
                     // Check if inventory is_reduced_by these units
                     // (signs differ for the same currency)
-                    let is_reduction = inv.is_reduced_by(units);
+                    let is_reduction = inv.is_reduced_by(units, true);
 
                     if is_reduction {
                         // Use reduce (not try_reduce) to actually update the working inventory.
@@ -369,7 +369,7 @@ impl BookingEngine {
                     let is_reduction = self
                         .inventories
                         .get(&posting.account)
-                        .is_some_and(|inv| inv.is_reduced_by(units));
+                        .is_some_and(|inv| inv.is_reduced_by(units, true));
 
                     // Fill in date for augmentations only (not reductions)
                     let inferred_date = if is_reduction {
@@ -442,7 +442,7 @@ impl BookingEngine {
 
                 // Determine if this is a reduction using is_reduced_by logic:
                 // Units reduce inventory when signs differ for the same currency
-                let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units);
+                let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units, true);
 
                 if is_reduction {
                     // Reduce from inventory
@@ -1163,6 +1163,77 @@ mod tests {
     /// [`rustledger_core::AccountedBookingError`] and `BookingError::Inventory`
     /// delegates to it transparently — so this test exercises the same path
     /// the validator and `cmd/check.rs` use.
+    // =========================================================================
+    // Regression test for issue #875 / beancount#889
+    //
+    // Scenario: buy stock with cost, sell without cost spec (leaves a simple
+    // negative position), then buy more with cost spec. The third transaction
+    // must succeed as an augmentation, not fail as a reduction.
+    // =========================================================================
+
+    #[test]
+    fn test_augmentation_after_sell_without_cost_spec() {
+        // Regression test for issue #875 / beancount#889.
+        //
+        // Before the fix, the sell-without-cost-spec left a -25 HOOG simple
+        // position, causing the subsequent buy-with-cost-spec to be
+        // misclassified as a reduction (because is_reduced_by saw opposite
+        // signs without distinguishing cost-bearing vs simple positions).
+        let mut engine = BookingEngine::new();
+
+        // 2024-01-10: Buy 100 HOOG {1.50 EUR}
+        let buy1 = Transaction::new(date(2024, 1, 10), "Buy 100 HOOG")
+            .with_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(100), "HOOG")).with_cost(
+                    CostSpec::empty()
+                        .with_number_per(dec!(1.50))
+                        .with_currency("EUR"),
+                ),
+            )
+            .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-150), "EUR")));
+
+        engine.apply(&buy1);
+
+        // 2024-01-15: Sell 25 HOOG without cost spec (price-only)
+        let sell = Transaction::new(date(2024, 1, 15), "Sell 25 HOOG without cost spec")
+            .with_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(-25), "HOOG"))
+                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.60), "EUR"))),
+            )
+            .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(40), "EUR")));
+
+        engine.apply(&sell);
+
+        // 2024-01-20: Buy 50 more HOOG {1.70 EUR} - this MUST succeed
+        let buy2 = Transaction::new(date(2024, 1, 20), "Buy 50 more HOOG - should succeed")
+            .with_posting(
+                Posting::new("Assets:Stocks", Amount::new(dec!(50), "HOOG")).with_cost(
+                    CostSpec::empty()
+                        .with_number_per(dec!(1.70))
+                        .with_currency("EUR"),
+                ),
+            )
+            .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-85), "EUR")));
+
+        // This should NOT fail. Before the fix, the engine would see the
+        // -25 HOOG simple position and try to reduce, which would fail
+        // because the cost spec wouldn't match any existing lot.
+        let result = engine.book(&buy2);
+        assert!(
+            result.is_ok(),
+            "Buy with cost spec after sell without cost spec should succeed as augmentation, \
+             but got error: {:?}",
+            result.err()
+        );
+
+        engine.apply(&buy2);
+
+        // Verify final inventory state
+        let inv = engine.inventory(&"Assets:Stocks".into()).unwrap();
+        // 100 (original) - 25 (sold simple) + 50 (new lot) = 125 HOOG total
+        assert_eq!(inv.units("HOOG"), dec!(125));
+    }
+
     #[test]
     fn test_insufficient_units_display_contains_not_enough() {
         let err = BookingError::Inventory(

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -9,7 +9,7 @@
 use rustc_hash::FxHashMap;
 use rustledger_core::{
     AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, IncompleteAmount, InternedStr,
-    Inventory, Position, Posting, Transaction,
+    Inventory, Position, Posting, ReductionScope, Transaction,
 };
 use thiserror::Error;
 
@@ -214,7 +214,7 @@ impl BookingEngine {
                 if let Some(inv) = working_inventories.get_mut(&posting.account) {
                     // Check if inventory is_reduced_by these units
                     // (signs differ for the same currency)
-                    let is_reduction = inv.is_reduced_by(units, true);
+                    let is_reduction = inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
                     if is_reduction {
                         // Use reduce (not try_reduce) to actually update the working inventory.
@@ -366,10 +366,9 @@ impl BookingEngine {
 
                     // Check if this is a reduction (opposite sign exists in inventory)
                     // Reductions get their date from matched lot, augmentations get txn date
-                    let is_reduction = self
-                        .inventories
-                        .get(&posting.account)
-                        .is_some_and(|inv| inv.is_reduced_by(units, true));
+                    let is_reduction = self.inventories.get(&posting.account).is_some_and(|inv| {
+                        inv.is_reduced_by(units, ReductionScope::CostBearingOnly)
+                    });
 
                     // Fill in date for augmentations only (not reductions)
                     let inferred_date = if is_reduction {
@@ -442,7 +441,8 @@ impl BookingEngine {
 
                 // Determine if this is a reduction using is_reduced_by logic:
                 // Units reduce inventory when signs differ for the same currency
-                let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units, true);
+                let is_reduction = posting.cost.is_some()
+                    && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
                 if is_reduction {
                     // Reduce from inventory
@@ -1163,6 +1163,7 @@ mod tests {
     /// [`rustledger_core::AccountedBookingError`] and `BookingError::Inventory`
     /// delegates to it transparently — so this test exercises the same path
     /// the validator and `cmd/check.rs` use.
+
     // =========================================================================
     // Regression test for issue #875 / beancount#889
     //
@@ -1226,7 +1227,8 @@ mod tests {
             result.err()
         );
 
-        engine.apply(&buy2);
+        let booked = result.unwrap();
+        engine.apply(&booked.transaction);
 
         // Verify final inventory state
         let inv = engine.inventory(&"Assets:Stocks".into()).unwrap();

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -351,13 +351,21 @@ impl Inventory {
     /// Returns `true` if there's a position with the same currency but opposite
     /// sign, meaning these units would reduce the inventory rather than add to it.
     ///
+    /// When `has_cost_spec` is `true`, only positions **with** a cost basis are
+    /// considered for reduction matching.  Simple (no-cost) positions are ignored
+    /// because they live in a different "cost layer" — a sell-without-cost-spec
+    /// that left a negative simple position should not cause a subsequent
+    /// cost-bearing augmentation to be misclassified as a reduction.
+    /// See: issue #875, beancount#889.
+    ///
     /// This is used to determine whether a posting is a sale/reduction or a
     /// purchase/augmentation.
     #[must_use]
-    pub fn is_reduced_by(&self, units: &Amount) -> bool {
+    pub fn is_reduced_by(&self, units: &Amount, has_cost_spec: bool) -> bool {
         self.positions.iter().any(|pos| {
             pos.units.currency == units.currency
                 && pos.units.number.is_sign_positive() != units.number.is_sign_positive()
+                && (!has_cost_spec || pos.cost.is_some())
         })
     }
 
@@ -2121,6 +2129,56 @@ mod tests {
     // produced #748. Any change to the Display strings below will break
     // these tests, forcing the author to consciously re-check pta-standards
     // conformance assertions and downstream user tooling.
+
+    // =========================================================================
+    // Regression test for issue #875 / beancount#889
+    //
+    // When a sell-without-cost-spec leaves a negative simple position in the
+    // inventory, a subsequent augmentation WITH a cost spec should NOT be
+    // misclassified as a reduction. `is_reduced_by` must only consider
+    // cost-bearing positions when the incoming posting has a cost spec.
+    // =========================================================================
+
+    #[test]
+    fn test_is_reduced_by_ignores_simple_positions_when_has_cost_spec() {
+        // Regression test for issue #875 / beancount#889.
+        //
+        // Scenario:
+        //   1. Buy 100 HOOG {1.50 EUR}  -> inventory: [100 HOOG {1.50 EUR}]
+        //   2. Sell 25 HOOG @ 1.60 EUR   -> inventory: [100 HOOG {1.50 EUR}, -25 HOOG (simple)]
+        //   3. Buy 50 HOOG {1.70 EUR}    -> should be augmentation, NOT reduction
+        //
+        // Before fix: is_reduced_by saw the -25 HOOG simple position and
+        // incorrectly reported that +50 HOOG would reduce the inventory.
+        let mut inv = Inventory::new();
+
+        // Step 1: buy 100 HOOG with cost
+        let cost = Cost::new(dec!(1.50), "EUR").with_date(date(2024, 1, 10));
+        inv.add(Position::with_cost(Amount::new(dec!(100), "HOOG"), cost));
+
+        // Step 2: sell 25 HOOG without cost spec (simple position)
+        inv.add(Position::simple(Amount::new(dec!(-25), "HOOG")));
+
+        // Step 3: check if buying 50 HOOG with cost spec would be a reduction
+        let buy_units = Amount::new(dec!(50), "HOOG");
+
+        // With has_cost_spec=true, only cost-bearing positions should be
+        // considered. The 100 HOOG {1.50 EUR} is positive and so is the
+        // incoming 50 HOOG -> same sign -> NOT a reduction.
+        assert!(
+            !inv.is_reduced_by(&buy_units, true),
+            "augmentation with cost spec should NOT be treated as reduction \
+             when only a simple (no-cost) position has opposite sign"
+        );
+
+        // With has_cost_spec=false, all positions are considered,
+        // including the -25 HOOG simple position -> IS a reduction.
+        assert!(
+            inv.is_reduced_by(&buy_units, false),
+            "without cost spec filter, the -25 HOOG simple position \
+             should cause is_reduced_by to return true"
+        );
+    }
 
     #[test]
     fn test_accounted_error_display_insufficient_units() {

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -72,6 +72,24 @@ impl fmt::Display for BookingMethod {
     }
 }
 
+/// Controls which positions are considered when checking whether incoming
+/// units reduce (i.e. have the opposite sign of) an existing inventory.
+///
+/// - [`AllPositions`](ReductionScope::AllPositions): every position is
+///   considered, regardless of whether it carries a cost.
+/// - [`CostBearingOnly`](ReductionScope::CostBearingOnly): only positions
+///   with a cost are considered.  This prevents a negative simple (no-cost)
+///   position — left behind by a sell-without-cost-spec — from causing a
+///   subsequent cost-bearing augmentation to be misclassified as a reduction.
+///   See: issue #875, beancount#889.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReductionScope {
+    /// Consider all positions (cost-bearing and simple).
+    AllPositions,
+    /// Consider only positions that carry a cost.
+    CostBearingOnly,
+}
+
 /// Result of a booking operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BookingResult {
@@ -361,11 +379,14 @@ impl Inventory {
     /// This is used to determine whether a posting is a sale/reduction or a
     /// purchase/augmentation.
     #[must_use]
-    pub fn is_reduced_by(&self, units: &Amount, has_cost_spec: bool) -> bool {
+    pub fn is_reduced_by(&self, units: &Amount, scope: ReductionScope) -> bool {
         self.positions.iter().any(|pos| {
             pos.units.currency == units.currency
                 && pos.units.number.is_sign_positive() != units.number.is_sign_positive()
-                && (!has_cost_spec || pos.cost.is_some())
+                && match scope {
+                    ReductionScope::AllPositions => true,
+                    ReductionScope::CostBearingOnly => pos.cost.is_some(),
+                }
         })
     }
 
@@ -2166,15 +2187,15 @@ mod tests {
         // considered. The 100 HOOG {1.50 EUR} is positive and so is the
         // incoming 50 HOOG -> same sign -> NOT a reduction.
         assert!(
-            !inv.is_reduced_by(&buy_units, true),
+            !inv.is_reduced_by(&buy_units, ReductionScope::CostBearingOnly),
             "augmentation with cost spec should NOT be treated as reduction \
              when only a simple (no-cost) position has opposite sign"
         );
 
-        // With has_cost_spec=false, all positions are considered,
+        // With AllPositions, all positions are considered,
         // including the -25 HOOG simple position -> IS a reduction.
         assert!(
-            inv.is_reduced_by(&buy_units, false),
+            inv.is_reduced_by(&buy_units, ReductionScope::AllPositions),
             "without cost spec filter, the -25 HOOG simple position \
              should cause is_reduced_by to return true"
         );

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -70,7 +70,9 @@ pub use extract::{
 };
 pub use format::{FormatConfig, format_directive};
 pub use intern::{InternedStr, StringInterner};
-pub use inventory::{AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory};
+pub use inventory::{
+    AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,
+};
 pub use position::Position;
 
 // Re-export commonly used external types

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -2,7 +2,9 @@
 
 use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;
-use rustledger_core::{Amount, BookingMethod, InternedStr, Inventory, Posting, Transaction};
+use rustledger_core::{
+    Amount, BookingMethod, InternedStr, Inventory, Posting, ReductionScope, Transaction,
+};
 use std::collections::HashMap;
 
 use crate::error::{ErrorCode, ValidationError};
@@ -453,7 +455,8 @@ pub fn update_inventories(
         // reduces inventory when the inventory has positions with the opposite
         // sign for the same currency. This correctly handles sell-to-open
         // (selling into empty inventory) as an augmentation, not a reduction.
-        let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units, true);
+        let is_reduction =
+            posting.cost.is_some() && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
         if is_reduction {
             process_inventory_reduction(inv, posting, units, booking_method, txn, errors);

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -452,9 +452,10 @@ pub fn update_inventories(
             .unwrap_or_default();
 
         // Use the same reduction detection as the booking engine: a posting
-        // reduces inventory when the inventory has positions with the opposite
-        // sign for the same currency. This correctly handles sell-to-open
-        // (selling into empty inventory) as an augmentation, not a reduction.
+        // reduces inventory when the inventory has cost-bearing positions with
+        // the opposite sign for the same currency. Simple (no-cost) positions
+        // are ignored. This correctly handles sell-to-open (selling into empty
+        // inventory) as an augmentation, not a reduction.
         let is_reduction =
             posting.cost.is_some() && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -453,7 +453,7 @@ pub fn update_inventories(
         // reduces inventory when the inventory has positions with the opposite
         // sign for the same currency. This correctly handles sell-to-open
         // (selling into empty inventory) as an augmentation, not a reduction.
-        let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units);
+        let is_reduction = posting.cost.is_some() && inv.is_reduced_by(units, true);
 
         if is_reduction {
             process_inventory_reduction(inv, posting, units, booking_method, txn, errors);


### PR DESCRIPTION
## Summary

- Modified `Inventory::is_reduced_by()` in `rustledger-core` to accept a `has_cost_spec` parameter. When `true`, only positions **with** a cost basis are considered for reduction matching, ignoring simple (no-cost) positions.
- Updated all three call sites in `rustledger-booking` and `rustledger-validate` to pass `has_cost_spec: true`, since they are already gated on `posting.cost.is_some()`.
- Added regression tests in both `rustledger-core` (unit test on `is_reduced_by`) and `rustledger-booking` (integration test with `BookingEngine`).

Closes #875

## Context

When a sell-without-cost-spec (e.g., `-25 HOOG @ 1.60 EUR`) leaves a negative simple position in the inventory, a subsequent augmentation WITH a cost spec (e.g., `50 HOOG {1.70 EUR}`) was incorrectly classified as a reduction. This happened because `is_reduced_by()` checked all positions for opposite signs without distinguishing cost-bearing from simple positions.

See also: beancount#889.

## Test plan

- [x] `cargo test -p rustledger-core` -- 228 tests pass including new `test_is_reduced_by_ignores_simple_positions_when_has_cost_spec`
- [x] `cargo test -p rustledger-booking` -- 77 tests pass including new `test_augmentation_after_sell_without_cost_spec`
- [x] `cargo check -p rustledger-validate` -- compiles cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)