### PR TITLE
fix: remove npm self-upgrade that breaks OIDC publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -150,8 +150,9 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+      # Node 22 ships with npm 10.9+ which supports OIDC natively.
+      # Do NOT run `npm install -g npm@latest` — it corrupts the npm
+      # installation on Node 22 (MODULE_NOT_FOUND: promise-retry).
       - name: Publish to npm (trusted publishing)
         run: |
           cd crates/rustledger-wasm/pkg
@@ -190,8 +191,9 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+      # Node 22 ships with npm 10.9+ which supports OIDC natively.
+      # Do NOT run `npm install -g npm@latest` — it corrupts the npm
+      # installation on Node 22 (MODULE_NOT_FOUND: promise-retry).
       - name: Wait for npm registry propagation
         run: |
           VERSION=${RELEASE_TAG#v}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -150,9 +150,9 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      # Node 22 ships with npm 10.9+ which supports OIDC natively.
-      # Do NOT run `npm install -g npm@latest` — it corrupts the npm
-      # installation on Node 22 (MODULE_NOT_FOUND: promise-retry).
+      # Node 22 includes an npm version that supports OIDC trusted publishing.
+      # Do NOT run `npm install -g npm@latest` — it can corrupt the bundled
+      # npm installation on this runner setup (MODULE_NOT_FOUND: promise-retry).
       - name: Publish to npm (trusted publishing)
         run: |
           cd crates/rustledger-wasm/pkg
@@ -191,9 +191,9 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      # Node 22 ships with npm 10.9+ which supports OIDC natively.
-      # Do NOT run `npm install -g npm@latest` — it corrupts the npm
-      # installation on Node 22 (MODULE_NOT_FOUND: promise-retry).
+      # Node 22 includes an npm version that supports OIDC trusted publishing.
+      # Do NOT run `npm install -g npm@latest` — it can corrupt the bundled
+      # npm installation on this runner setup (MODULE_NOT_FOUND: promise-retry).
       - name: Wait for npm registry propagation
         run: |
           VERSION=${RELEASE_TAG#v}


### PR DESCRIPTION
## Summary
- Removes `npm install -g npm@latest` from both npm publish jobs in `release-publish.yml`
- This command corrupts npm on Node 22 by replacing itself mid-execution (`MODULE_NOT_FOUND: promise-retry`)
- Node 22 ships with npm 10.9+ which supports OIDC trusted publishing natively — the upgrade is unnecessary

## What broke
The v0.13.0 Release Publish workflow failed at the "Update npm for OIDC support" step:
```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

## How to re-publish v0.13.0
After merging this fix, re-run the Release Publish workflow manually targeting v0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)