### PR TITLE
fix: remove error-swallowing || true from npm publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Publish to npm (trusted publishing)
         run: |
           cd crates/rustledger-wasm/pkg
-          npm publish --access public --provenance || true
+          npm publish --access public --provenance
   # Trigger website rebuild to use new WASM package
   trigger-website:
     name: Trigger website rebuild
@@ -219,7 +219,7 @@ jobs:
       - name: Publish to npm (trusted publishing)
         run: |
           cd packages/mcp-server
-          npm publish --access public --provenance || true
+          npm publish --access public --provenance
   # Build and push Docker images
   publish-docker:
     name: Build Docker images

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -156,7 +156,12 @@ jobs:
       - name: Publish to npm (trusted publishing)
         run: |
           cd crates/rustledger-wasm/pkg
-          npm publish --access public --provenance
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@rustledger/wasm@${VERSION}" version >/dev/null 2>&1; then
+            echo "@rustledger/wasm@${VERSION} already published, skipping."
+          else
+            npm publish --access public --provenance
+          fi
   # Trigger website rebuild to use new WASM package
   trigger-website:
     name: Trigger website rebuild
@@ -219,7 +224,13 @@ jobs:
       - name: Publish to npm (trusted publishing)
         run: |
           cd packages/mcp-server
-          npm publish --access public --provenance
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "${PACKAGE_NAME}@${PACKAGE_VERSION} already published, skipping."
+          else
+            npm publish --access public --provenance
+          fi
   # Build and push Docker images
   publish-docker:
     name: Build Docker images


### PR DESCRIPTION
## Summary
Three fixes for npm OIDC trusted publishing:

1. **Remove `|| true` from `npm publish`** — was silently swallowing failures, causing v0.12.0 and v0.13.0 to never publish while CI reported success
2. **Add idempotent publish guard** — `npm view` pre-check skips publish if version already exists, so workflow re-runs don't fail with 409
3. **Upgrade to Node 24** — Node 22 ships with npm 10 which doesn't fully support OIDC trusted publishing. npm 11.5.1+ (bundled with Node 24) is required. This was the root cause of E404 on `npm publish` with provenance.

## What broke
- `@rustledger/wasm` on npm is stuck at 0.11.0 — versions 0.12.0 and 0.13.0 never published
- The MCP server also failed to publish (depends on WASM package)
- Two separate bugs: `npm install -g npm@latest` corruption (fixed in #883) and npm 10 lacking OIDC support (fixed here)

## After merge
Re-run Release Publish for v0.12.0 and v0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)