### PR TITLE
fix: use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -148,11 +148,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      # Node 22 includes an npm version that supports OIDC trusted publishing.
-      # Do NOT run `npm install -g npm@latest` — it can corrupt the bundled
-      # npm installation on this runner setup (MODULE_NOT_FOUND: promise-retry).
       - name: Publish to npm (trusted publishing)
         run: |
           cd crates/rustledger-wasm/pkg
@@ -194,11 +191,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      # Node 22 includes an npm version that supports OIDC trusted publishing.
-      # Do NOT run `npm install -g npm@latest` — it can corrupt the bundled
-      # npm installation on this runner setup (MODULE_NOT_FOUND: promise-retry).
       - name: Wait for npm registry propagation
         run: |
           VERSION=${RELEASE_TAG#v}


### PR DESCRIPTION
## Summary
- Upgrades Node 22 → Node 24 in both npm publish jobs
- Node 22 ships with npm 10 which lacks full OIDC trusted publishing support
- npm 11.5.1+ (bundled with Node 24) is required for OIDC token exchange to work
- This is the root cause of the E404 on `npm publish --provenance` that has prevented all npm publishes since v0.11.0

## After merge
Re-run Release Publish for v0.12.0 and v0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)