### PR TITLE
fix: fix release channel testing failures

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -298,7 +298,7 @@ jobs:
           echo "Timeout waiting for @rustledger/wasm@${VERSION}"
           exit 1
       - name: Install @rustledger/wasm
-        run: npm install @rustledger/wasm
+        run: npm install "@rustledger/wasm@${VERSION}"
       - name: Test import
         run: |
           node -e "
@@ -328,7 +328,7 @@ jobs:
           echo "Timeout waiting for @rustledger/mcp-server@${VERSION}"
           exit 1
       - name: Install @rustledger/mcp-server
-        run: npm install @rustledger/mcp-server
+        run: npm install "@rustledger/mcp-server@${VERSION}"
       - name: Test MCP server package
         run: |
           # Verify the package has a valid entry point

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -286,18 +286,16 @@ jobs:
     steps:
       - name: Wait for npm propagation
         run: |
-          echo "Waiting for @rustledger/wasm on npm..."
+          echo "Waiting for @rustledger/wasm@$VERSION on npm..."
           for i in $(seq 1 30); do
-            NPM_VERSION=$(npm view @rustledger/wasm version 2>/dev/null || echo "not found")
-            echo "npm version: $NPM_VERSION"
-            if [ "$NPM_VERSION" = "$VERSION" ]; then
-              echo "npm is up to date"
+            if npm view "@rustledger/wasm@${VERSION}" version >/dev/null 2>&1; then
+              echo "@rustledger/wasm@${VERSION} is available"
               exit 0
             fi
             echo "Attempt $i/30: Not yet available, waiting 20s..."
             sleep 20
           done
-          echo "Timeout waiting for npm"
+          echo "Timeout waiting for @rustledger/wasm@${VERSION}"
           exit 1
       - name: Install @rustledger/wasm
         run: npm install @rustledger/wasm
@@ -318,18 +316,16 @@ jobs:
     steps:
       - name: Wait for npm propagation
         run: |
-          echo "Waiting for @rustledger/mcp-server on npm..."
+          echo "Waiting for @rustledger/mcp-server@$VERSION on npm..."
           for i in $(seq 1 30); do
-            NPM_VERSION=$(npm view @rustledger/mcp-server version 2>/dev/null || echo "not found")
-            echo "npm version: $NPM_VERSION"
-            if [ "$NPM_VERSION" = "$VERSION" ]; then
-              echo "npm is up to date"
+            if npm view "@rustledger/mcp-server@${VERSION}" version >/dev/null 2>&1; then
+              echo "@rustledger/mcp-server@${VERSION} is available"
               exit 0
             fi
             echo "Attempt $i/30: Not yet available, waiting 20s..."
             sleep 20
           done
-          echo "Timeout waiting for npm"
+          echo "Timeout waiting for @rustledger/mcp-server@${VERSION}"
           exit 1
       - name: Install @rustledger/mcp-server
         run: npm install @rustledger/mcp-server

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,7 @@
             commonArgs
             // {
               inherit cargoArtifacts;
+              meta.mainProgram = "rledger";
             }
           );
 


### PR DESCRIPTION
## Summary
Fixes three release channel test failures:

1. **Nix flake**: `nix run` failed with `No such file or directory` because it looked for a binary named `rustledger` but the actual binary is `rledger`. Added `meta.mainProgram = "rledger"` to the Crane build.

2. **npm propagation checks**: The wait loop checked `npm view @rustledger/wasm version` (the `latest` dist-tag) which can return the wrong version when multiple versions publish in quick succession. Changed to check the specific version: `npm view @rustledger/wasm@$VERSION`.

Tested locally: `nix run . -- --version` → `rledger 0.13.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)