### PR TITLE
fix(query): respect -o/--output flag in batch mode

### DIFF
--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -161,7 +161,13 @@ pub fn run(args: &Args) -> Result<()> {
     // Batch query: no pager (matching Python bean-query behavior).
     // Pager is only used in interactive REPL mode.
     let settings = ShellSettings::from_args(args, display_context);
-    output::execute_query(&query_str, &directives, &settings, &mut io::stdout())
+    if let Some(ref output_path) = settings.output_file {
+        let mut file = fs::File::create(output_path)
+            .with_context(|| format!("failed to create output file {}", output_path.display()))?;
+        output::execute_query(&query_str, &directives, &settings, &mut file)
+    } else {
+        output::execute_query(&query_str, &directives, &settings, &mut io::stdout())
+    }
 }
 
 /// Shell settings for query output and interactive mode.


### PR DESCRIPTION
## Summary
- Fixes #888: `rledger query` now respects the `-o`/`--output` flag in batch (non-interactive) mode
- Previously, batch queries always wrote to stdout, ignoring the output file setting
- Now checks `settings.output_file` and writes to the specified file when provided

## Changes
- Modified `crates/rustledger/src/cmd/query/mod.rs` to handle output file in batch query path
- All 12 existing query tests pass
- Manually verified output file creation and empty stdout when `-o` is used