### PR TITLE
fix: resolve document paths against option "documents" directories

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -694,41 +694,38 @@ fn run_validation(
 ) {
     use rustledger_validate::{ValidationOptions, validate_spanned_with_options};
 
-    let account_types: Vec<String> = file_options
-        .account_types()
-        .iter()
-        .map(|s| (*s).to_string())
-        .collect();
-
-    // Resolve document directories relative to the ledger's base directory
-    // so validation finds documents using the same path resolution as run_plugins.
+    // Resolve document directories relative to the main file's directory
     let base_dir = source_map
         .files()
         .first()
         .and_then(|f| f.path.parent())
         .unwrap_or_else(|| std::path::Path::new("."));
 
-    let resolved_document_dirs: Vec<String> = file_options
+    let resolved_document_dirs: Vec<std::path::PathBuf> = file_options
         .documents
         .iter()
         .map(|d| {
             let path = std::path::Path::new(d);
             if path.is_absolute() {
-                d.clone()
+                path.to_path_buf()
             } else {
-                base_dir.join(path).to_string_lossy().to_string()
+                base_dir.join(path)
             }
         })
         .collect();
 
-    let validation_options = ValidationOptions {
-        account_types,
-        document_dirs: resolved_document_dirs,
-        infer_tolerance_from_cost: file_options.infer_tolerance_from_cost,
-        tolerance_multiplier: file_options.inferred_tolerance_multiplier,
-        inferred_tolerance_default: file_options.inferred_tolerance_default.clone(),
-        ..Default::default()
-    };
+    let account_types: Vec<String> = file_options
+        .account_types()
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+
+    let validation_options = ValidationOptions::default()
+        .with_account_types(account_types)
+        .with_document_dirs(resolved_document_dirs)
+        .with_infer_tolerance_from_cost(file_options.infer_tolerance_from_cost)
+        .with_tolerance_multiplier(file_options.inferred_tolerance_multiplier)
+        .with_inferred_tolerance_default(file_options.inferred_tolerance_default.clone());
 
     let validation_errors = validate_spanned_with_options(directives, validation_options);
 

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -28,28 +28,28 @@ fn build_validation_options_from_loader(
     loader_options: &LoaderOptions,
     base_dir: &std::path::Path,
 ) -> ValidationOptions {
-    let resolved_documents: Vec<String> = loader_options
+    let document_dirs: Vec<std::path::PathBuf> = loader_options
         .documents
         .iter()
         .map(|d| {
             let path = std::path::Path::new(d);
             if path.is_absolute() {
-                d.clone()
+                path.to_path_buf()
             } else {
-                base_dir.join(path).to_string_lossy().to_string()
+                base_dir.join(path)
             }
         })
         .collect();
 
-    ValidationOptions {
-        account_types: loader_options
-            .account_types()
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect(),
-        document_dirs: resolved_documents,
-        ..Default::default()
-    }
+    ValidationOptions::default()
+        .with_account_types(
+            loader_options
+                .account_types()
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        )
+        .with_document_dirs(document_dirs)
 }
 
 /// Build `ValidationOptions` with custom account type names from parsed file options.
@@ -64,18 +64,16 @@ fn build_validation_options_from_loader(
 ///
 /// Used when no ledger is loaded (single-file validation).
 ///
-/// Note on `document_dirs`: In single-file mode, `documents` paths are stored
-/// as raw strings from the parsed options. The validator handles resolution
-/// internally using the file's parent directory as the base when needed.
-/// We intentionally pass the raw strings here rather than resolving them
-/// ourselves, to avoid duplicating the validator's resolution logic.
+/// When `base_dir` is `Some`, relative document directory paths are resolved
+/// against it; when `None`, they are kept as-is (tests and single-file
+/// buffers without an on-disk path rely on this fallback).
 ///
 /// See issue #572: <https://github.com/rustledger/rustledger/issues/572>
 fn build_validation_options_from_file(
     file_options: &[(String, String, Span)],
     base_dir: Option<&std::path::Path>,
 ) -> ValidationOptions {
-    let mut opts = ValidationOptions::default();
+    let opts = ValidationOptions::default();
 
     // Start with validator defaults, override with file options.
     // This avoids duplicating the canonical default account type names.
@@ -102,20 +100,19 @@ fn build_validation_options_from_file(
             "documents" => {
                 let path = std::path::Path::new(value);
                 if path.is_absolute() {
-                    document_dirs.push(value.clone());
+                    document_dirs.push(path.to_path_buf());
                 } else if let Some(base) = base_dir {
-                    document_dirs.push(base.join(path).to_string_lossy().to_string());
+                    document_dirs.push(base.join(path));
                 } else {
-                    document_dirs.push(value.clone());
+                    document_dirs.push(path.to_path_buf());
                 }
             }
             _ => {}
         }
     }
 
-    opts.account_types = account_types;
-    opts.document_dirs = document_dirs;
-    opts
+    opts.with_account_types(account_types)
+        .with_document_dirs(document_dirs)
 }
 
 /// Convert parse errors to LSP diagnostics.

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -30,7 +30,7 @@ rustc-hash.workspace = true
 rust_decimal_macros = "1.40"
 criterion.workspace = true
 proptest.workspace = true
-tempfile = "3"
+tempfile.workspace = true
 
 [[bench]]
 name = "validate_bench"

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -79,6 +79,7 @@ struct AccountState {
 }
 
 /// Validation options.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ValidationOptions {
     /// Whether to require commodity declarations.
@@ -91,7 +92,8 @@ pub struct ValidationOptions {
     pub document_base: Option<std::path::PathBuf>,
     /// Document directories from `option "documents"`.
     /// Relative document paths are resolved against these directories.
-    pub document_dirs: Vec<String>,
+    /// Paths are resolved against the ledger file's directory at load time.
+    pub document_dirs: Vec<std::path::PathBuf>,
     /// Valid account type prefixes (from options like `name_assets`, `name_liabilities`, etc.).
     /// Defaults to `["Assets", "Liabilities", "Equity", "Income", "Expenses"]`.
     pub account_types: Vec<String>,
@@ -126,6 +128,64 @@ impl Default for ValidationOptions {
             tolerance_multiplier: Decimal::new(5, 1), // 0.5
             inferred_tolerance_default: FxHashMap::default(),
         }
+    }
+}
+
+impl ValidationOptions {
+    /// Set account types.
+    #[must_use]
+    pub fn with_account_types(mut self, types: Vec<String>) -> Self {
+        self.account_types = types;
+        self
+    }
+
+    /// Set whether to require commodity declarations.
+    #[must_use]
+    pub const fn with_require_commodities(mut self, require: bool) -> Self {
+        self.require_commodities = require;
+        self
+    }
+
+    /// Set whether to check if document files exist.
+    #[must_use]
+    pub const fn with_check_documents(mut self, check: bool) -> Self {
+        self.check_documents = check;
+        self
+    }
+
+    /// Set whether to warn about future-dated entries.
+    #[must_use]
+    pub const fn with_warn_future_dates(mut self, warn: bool) -> Self {
+        self.warn_future_dates = warn;
+        self
+    }
+
+    /// Set document directories (resolved paths).
+    #[must_use]
+    pub fn with_document_dirs(mut self, dirs: Vec<std::path::PathBuf>) -> Self {
+        self.document_dirs = dirs;
+        self
+    }
+
+    /// Set whether to infer tolerance from cost.
+    #[must_use]
+    pub const fn with_infer_tolerance_from_cost(mut self, infer: bool) -> Self {
+        self.infer_tolerance_from_cost = infer;
+        self
+    }
+
+    /// Set tolerance multiplier.
+    #[must_use]
+    pub const fn with_tolerance_multiplier(mut self, multiplier: Decimal) -> Self {
+        self.tolerance_multiplier = multiplier;
+        self
+    }
+
+    /// Set per-currency default tolerances.
+    #[must_use]
+    pub fn with_inferred_tolerance_default(mut self, defaults: FxHashMap<String, Decimal>) -> Self {
+        self.inferred_tolerance_default = defaults;
+        self
     }
 }
 
@@ -759,10 +819,7 @@ mod tests {
         );
 
         // With warn_future_dates option, should warn
-        let options = ValidationOptions {
-            warn_future_dates: true,
-            ..Default::default()
-        };
+        let options = ValidationOptions::default().with_warn_future_dates(true);
         let errors = validate_with_options(&directives, options);
         assert!(
             errors.iter().any(|e| e.code == ErrorCode::FutureDate),
@@ -792,10 +849,7 @@ mod tests {
         );
 
         // With check_documents disabled, should not error
-        let options = ValidationOptions {
-            check_documents: false,
-            ..Default::default()
-        };
+        let options = ValidationOptions::default().with_check_documents(false);
         let errors = validate_with_options(&directives, options);
         assert!(
             !errors.iter().any(|e| e.code == ErrorCode::DocumentNotFound),
@@ -823,19 +877,21 @@ mod tests {
 
     #[test]
     fn test_validate_document_relative_path_in_document_dirs() {
+        // Use a unique filename so the CWD fallback (triggered when
+        // document_dirs is empty) doesn't pick up a same-named file that
+        // happens to exist in the test runner's working directory.
+        let filename = "rustledger_test_889_relative_receipt.pdf";
         let dir = tempfile::tempdir().unwrap();
         let doc_subdir = dir.path().join("documents");
         std::fs::create_dir_all(&doc_subdir).unwrap();
-        std::fs::write(doc_subdir.join("receipt.pdf"), "test").unwrap();
-
-        let doc_path = doc_subdir.to_string_lossy().to_string();
+        std::fs::write(doc_subdir.join(filename), "test").unwrap();
 
         let directives = vec![
             Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
             Directive::Document(Document {
                 date: date(2024, 1, 15),
                 account: "Assets:Bank".into(),
-                path: "receipt.pdf".to_string(),
+                path: filename.to_string(),
                 tags: vec![],
                 links: vec![],
                 meta: Default::default(),
@@ -850,10 +906,7 @@ mod tests {
         );
 
         // With document_dirs pointing to the directory, should pass
-        let options = ValidationOptions {
-            document_dirs: vec![doc_path],
-            ..Default::default()
-        };
+        let options = ValidationOptions::default().with_document_dirs(vec![doc_subdir]);
         let errors = validate_with_options(&directives, options);
         assert!(
             !errors.iter().any(|e| e.code == ErrorCode::DocumentNotFound),
@@ -863,28 +916,25 @@ mod tests {
 
     #[test]
     fn test_validate_document_relative_path_not_found_in_dirs() {
+        // Use a unique filename — see comment in the sibling test above.
+        let filename = "rustledger_test_889_nonexistent.pdf";
         let dir = tempfile::tempdir().unwrap();
         let doc_subdir = dir.path().join("documents");
         std::fs::create_dir_all(&doc_subdir).unwrap();
-
-        let doc_path = doc_subdir.to_string_lossy().to_string();
 
         let directives = vec![
             Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
             Directive::Document(Document {
                 date: date(2024, 1, 15),
                 account: "Assets:Bank".into(),
-                path: "nonexistent.pdf".to_string(),
+                path: filename.to_string(),
                 tags: vec![],
                 links: vec![],
                 meta: Default::default(),
             }),
         ];
 
-        let options = ValidationOptions {
-            document_dirs: vec![doc_path],
-            ..Default::default()
-        };
+        let options = ValidationOptions::default().with_document_dirs(vec![doc_subdir]);
         let errors = validate_with_options(&directives, options);
         assert!(
             errors.iter().any(|e| e.code == ErrorCode::DocumentNotFound),
@@ -894,19 +944,18 @@ mod tests {
 
     #[test]
     fn test_validate_document_absolute_path_ignores_document_dirs() {
+        let filename = "rustledger_test_889_absolute_receipt.pdf";
         let dir = tempfile::tempdir().unwrap();
         let doc_subdir = dir.path().join("documents");
         std::fs::create_dir_all(&doc_subdir).unwrap();
-        std::fs::write(doc_subdir.join("receipt.pdf"), "test").unwrap();
-
-        let doc_path_str = doc_subdir.to_string_lossy().to_string();
+        std::fs::write(doc_subdir.join(filename), "test").unwrap();
 
         let directives = vec![
             Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
             Directive::Document(Document {
                 date: date(2024, 1, 15),
                 account: "Assets:Bank".into(),
-                path: format!("{doc_path_str}/receipt.pdf"),
+                path: doc_subdir.join(filename).display().to_string(),
                 tags: vec![],
                 links: vec![],
                 meta: Default::default(),
@@ -914,10 +963,8 @@ mod tests {
         ];
 
         // Absolute path should work regardless of document_dirs
-        let options = ValidationOptions {
-            document_dirs: vec!["/nonexistent/path".to_string()],
-            ..Default::default()
-        };
+        let options = ValidationOptions::default()
+            .with_document_dirs(vec![std::path::PathBuf::from("/nonexistent/path")]);
         let errors = validate_with_options(&directives, options);
         assert!(
             !errors.iter().any(|e| e.code == ErrorCode::DocumentNotFound),
@@ -1605,10 +1652,7 @@ mod tests {
             ),
         ];
 
-        let options = ValidationOptions {
-            require_commodities: true,
-            ..Default::default()
-        };
+        let options = ValidationOptions::default().with_require_commodities(true);
         let errors = validate_with_options(&directives, options);
 
         assert!(
@@ -1642,10 +1686,7 @@ mod tests {
             ),
         ];
 
-        let options = ValidationOptions {
-            require_commodities: true,
-            ..Default::default()
-        };
+        let options = ValidationOptions::default().with_require_commodities(true);
         let errors = validate_with_options(&directives, options);
 
         assert!(

--- a/crates/rustledger-validate/src/validators/document.rs
+++ b/crates/rustledger-validate/src/validators/document.rs
@@ -60,7 +60,7 @@ pub fn validate_document(state: &LedgerState, doc: &Document, errors: &mut Vec<V
             // Try resolving relative path against each document directory
             let mut found = None;
             for dir in &state.options.document_dirs {
-                let candidate = Path::new(dir).join(doc_path);
+                let candidate = dir.join(doc_path);
                 if candidate.exists() {
                     found = Some(candidate);
                     break;
@@ -93,7 +93,7 @@ pub fn validate_document(state: &LedgerState, doc: &Document, errors: &mut Vec<V
                     .options
                     .document_dirs
                     .iter()
-                    .map(|d| Path::new(d).join(doc_path).display().to_string())
+                    .map(|d| d.join(doc_path).display().to_string())
                     .collect();
                 error = error.with_context(format!("searched: {}", searched.join(", ")));
             } else {


### PR DESCRIPTION
## Summary
Fix #889: `document` directives with relative paths (e.g. `"./credit-card-statement.pdf"`) now resolve against `option "documents"` directories before falling back to CWD.

This PR builds on main (which already has the basic `document_dirs` search) to:
- Store resolved absolute `PathBuf` instead of raw `String` so resolution is stable regardless of the process CWD
- Mark `ValidationOptions` `#[non_exhaustive]` + add builder methods so downstream crates don't break when new fields are added
- Use portable `Path::join` everywhere (no more OS-specific `"{}/{}"` concat)
- Make test filenames unique so the CWD fallback can't accidentally resolve to a collider

## Changes
- `rustledger-validate`:
  - `ValidationOptions.document_dirs: Vec<PathBuf>` (was `Vec<String>`)
  - `#[non_exhaustive]` on `ValidationOptions`
  - New builder methods: `with_account_types`, `with_require_commodities`, `with_check_documents`, `with_warn_future_dates`, `with_document_dirs`, `with_infer_tolerance_from_cost`, `with_tolerance_multiplier`, `with_inferred_tolerance_default`
  - `validate_document` doc comment describes resolution precedence (absolute → `document_base` → `document_dirs` → CWD fallback)
  - Tests use unique filenames (`rustledger_test_889_*.pdf`) to avoid CWD collisions
  - `tempfile` now uses `tempfile.workspace = true` for consistency with the rest of the workspace
- `rustledger-loader`: `run_validation` builds `ValidationOptions` via builder chain, passes resolved `Vec<PathBuf>` document dirs
- `rustledger-lsp`: `build_validation_options_from_loader` and `build_validation_options_from_file` return `Vec<PathBuf>` and use builder methods; signatures preserve the `base_dir: Option<&Path>` threading added by #900

## Known CI failures
- **Semver**: `ValidationOptions.document_dirs` type change (`Vec<String>` → `Vec<PathBuf>`) is a breaking change requiring a major version bump. Addressed separately at release time.

## Copilot review comments addressed
All 7 original + 4 re-review comments addressed:
- document_dirs resolved to absolute paths at load time
- `#[non_exhaustive]` + builder methods eliminate struct-literal breakage
- Tests use `PathBuf::join` instead of `format!` with path separators
- Error context uses `Path::join` for portable paths
- Unique test filenames avoid CWD non-determinism
- `tempfile` now uses workspace dependency
- README scope creep dropped on rebase (already on main via PR #898)
- Stale doc comment on `build_validation_options_from_file` replaced