### PR TITLE
fix: accept date as VALUE() second argument (closes #892)

### DIFF
--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -261,13 +261,25 @@ impl Executor<'_> {
 
     /// Evaluate VALUE function (market value conversion).
     ///
-    /// Converts positions/amounts/inventories to their market value using the latest
-    /// available price. This matches Python beancount's behavior where `value(position)`
-    /// uses the most recent price, not the transaction date.
+    /// Python beancount-compatible signatures:
+    /// - `VALUE(position)` / `VALUE(inventory)`: convert to market value using
+    ///   the latest available price. The target currency is inferred from the
+    ///   position's cost currency (or the executor's `target_currency`). A
+    ///   future-dated price may be used — this matches Python's
+    ///   `value(position)` with `date=None`.
+    /// - `VALUE(position, DATE)` / `VALUE(inventory, DATE)`: convert using the
+    ///   most recent price on or before `DATE`. For a `position` with no such
+    ///   price, the raw units are returned (matches Python's
+    ///   `convert.get_value()` fallback). For an `inventory`, see the caveat
+    ///   in [`Executor::convert_to_market_value`] — unpriced positions are
+    ///   silently dropped from the target-currency sum, which is a known
+    ///   divergence from Python that is orthogonal to this fix.
     ///
-    /// If no target currency is specified, it is inferred from the position's cost
-    /// currency (for positions with cost basis) or falls back to the executor's
-    /// target currency setting.
+    /// Rustledger extension (not in Python beancount):
+    /// - `VALUE(x, 'CURRENCY')`: override the target currency, still using the
+    ///   latest price. For explicit-currency behavior in Python, use
+    ///   `CONVERT(x, 'USD', [date])` instead — that signature is also
+    ///   supported here.
     pub(crate) fn eval_value(
         &self,
         func: &FunctionCall,
@@ -283,22 +295,25 @@ impl Executor<'_> {
         // Evaluate the first argument (position/amount/inventory)
         let val = self.evaluate_expr(&func.args[0], ctx)?;
 
-        // Get explicit target currency if provided
-        let explicit_currency = if func.args.len() == 2 {
+        // Dispatch on the optional second argument:
+        //   DATE   -> price at-or-before DATE (Python beancount compatible)
+        //   STRING -> override target currency (rustledger extension; use CONVERT
+        //             for the Python-idiomatic spelling with a historical date)
+        let (explicit_currency, at_date) = if func.args.len() == 2 {
             match self.evaluate_expr(&func.args[1], ctx)? {
-                Value::String(s) => Some(s),
+                Value::Date(d) => (None, Some(d)),
+                Value::String(s) => (Some(s), None),
                 _ => {
                     return Err(QueryError::Type(
-                        "VALUE second argument must be a currency string".to_string(),
+                        "VALUE second argument must be a date or currency string".to_string(),
                     ));
                 }
             }
         } else {
-            None
+            (None, None)
         };
 
-        // Use shared implementation for consistent behavior
-        self.convert_to_market_value(&val, explicit_currency.as_deref())
+        self.convert_to_market_value(&val, explicit_currency.as_deref(), at_date)
     }
 
     /// Evaluate GETPRICE function.

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -17,9 +17,9 @@ use rustc_hash::FxHashMap;
 
 use regex::{Regex, RegexBuilder};
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, Directive, InternedStr, Inventory, Metadata, Position};
+use rustledger_core::{Amount, Directive, InternedStr, Inventory, Metadata, NaiveDate, Position};
 #[cfg(test)]
-use rustledger_core::{MetaValue, NaiveDate, Transaction};
+use rustledger_core::{MetaValue, Transaction};
 use rustledger_loader::SourceMap;
 use rustledger_parser::Spanned;
 
@@ -649,22 +649,30 @@ impl<'a> Executor<'a> {
                 }
             }
             "VALUE" => {
-                // Use shared VALUE implementation for consistent behavior
+                // Use shared VALUE implementation for consistent behavior.
+                // See `eval_value` on PositionFunctions for the full signature
+                // contract (DATE vs. currency-string dispatch).
                 if args.is_empty() || args.len() > 2 {
                     return Err(QueryError::InvalidArguments(
                         "VALUE".to_string(),
                         "expected 1-2 arguments".to_string(),
                     ));
                 }
-                let explicit_currency = if args.len() == 2 {
+                let (explicit_currency, at_date) = if args.len() == 2 {
                     match &args[1] {
-                        Value::String(s) => Some(s.as_str()),
-                        _ => None,
+                        Value::Date(d) => (None, Some(*d)),
+                        Value::String(s) => (Some(s.as_str()), None),
+                        _ => {
+                            return Err(QueryError::Type(
+                                "VALUE second argument must be a date or currency string"
+                                    .to_string(),
+                            ));
+                        }
                     }
                 } else {
-                    None
+                    (None, None)
                 };
-                self.convert_to_market_value(&args[0], explicit_currency)
+                self.convert_to_market_value(&args[0], explicit_currency, at_date)
             }
             // Math functions
             "SAFEDIV" => {
@@ -1422,30 +1430,45 @@ impl<'a> Executor<'a> {
         Ok(())
     }
 
-    /// Convert a value to its market value using the latest available price.
+    /// Convert a value to its market value.
     ///
-    /// This is the core `VALUE()` implementation shared by both expression evaluation
-    /// and aggregate/subquery contexts. It matches Python beancount's behavior:
-    /// - Uses the latest available price (not a specific date)
-    /// - Infers target currency from position's cost basis if not provided
+    /// Shared `VALUE()` implementation used by both expression evaluation and
+    /// the aggregate/subquery path in `evaluate_function_on_values`.
     ///
     /// # Arguments
-    /// * `val` - The value to convert (Position, Amount, or Inventory)
-    /// * `explicit_currency` - Optional explicit target currency
+    /// * `val` - The value to convert (`Position`, `Amount`, `Inventory`, or `Null`).
+    /// * `explicit_currency` - Optional explicit target currency. When `None`,
+    ///   the currency is inferred from the position's cost basis (Python
+    ///   beancount compatibility) or falls back to the executor's
+    ///   `target_currency` setting.
+    /// * `at_date` - Optional valuation date. When `Some`, prices are looked up
+    ///   with "on or before" semantics via [`price::PriceDatabase::convert`];
+    ///   when `None`, the latest available price is used via
+    ///   [`price::PriceDatabase::convert_latest`] (matches Python's
+    ///   `value(position)` with `date=None`, which may use a future-dated price).
     ///
     /// # Returns
-    /// - `Value::Amount` when conversion succeeds or the input is a single amount/position
-    /// - `Value::Inventory` when no target currency can be determined and the input is an inventory
-    /// - `Value::Null` when the input is null
+    /// - `Value::Amount` when conversion succeeds, or when the input is a
+    ///   single `Position`/`Amount` that can't be priced (raw units returned).
+    /// - `Value::Inventory` when no target currency can be determined and the
+    ///   input is an `Inventory`.
+    /// - `Value::Null` when the input is null.
     ///
-    /// When no explicit currency is provided and none can be inferred from the
-    /// cost basis or executor settings, the input value is returned as-is rather
-    /// than producing an error. This matches Python beancount behavior for
-    /// positions without cost.
+    /// # Inventory caveat
+    ///
+    /// For `Value::Inventory` inputs with a determined target currency, this
+    /// function returns a single `Value::Amount` summed in the target currency.
+    /// Positions within the inventory that cannot be priced at `at_date` (or
+    /// have no latest price) are silently dropped from the sum. This differs
+    /// from Python beancount's `inventory.reduce(get_value, ...)`, which
+    /// preserves unpriced positions as raw units in the resulting inventory.
+    /// Reconciling this is tracked as a separate follow-up and is out of scope
+    /// for #892.
     pub(crate) fn convert_to_market_value(
         &self,
         val: &Value,
         explicit_currency: Option<&str>,
+        at_date: Option<NaiveDate>,
     ) -> Result<Value, QueryError> {
         // Determine target currency:
         // 1. Explicit argument takes precedence
@@ -1468,7 +1491,9 @@ impl<'a> Executor<'a> {
                 Some(c) => c,
                 None => {
                     // No currency can be determined — return value as-is
-                    // (matches Python beancount behavior for positions without cost)
+                    // (matches Python beancount behavior for positions without cost).
+                    // Note: `at_date` is ignored here because there is nothing to
+                    // convert without a target currency.
                     return match val {
                         Value::Position(p) => Ok(Value::Amount(p.units.clone())),
                         Value::Amount(a) => Ok(Value::Amount(a.clone())),
@@ -1482,15 +1507,22 @@ impl<'a> Executor<'a> {
             }
         };
 
-        // Use latest available price for conversion (beancount compatibility).
-        // Python beancount's value() passes None as the date, which means "use latest price".
+        // Price lookup matches Python beancount's semantics:
+        // - When `at_date` is None, use the latest price (which may be future-dated).
+        // - When `at_date` is Some, use the most recent price on or before that date;
+        //   if no such price exists, the conversion silently returns the raw units.
+        let convert_one = |amount: &Amount| -> Option<Amount> {
+            match at_date {
+                Some(d) => self.price_db.convert(amount, &target_currency, d),
+                None => self.price_db.convert_latest(amount, &target_currency),
+            }
+        };
+
         match val {
             Value::Position(p) => {
                 if p.units.currency == target_currency {
                     Ok(Value::Amount(p.units.clone()))
-                } else if let Some(converted) =
-                    self.price_db.convert_latest(&p.units, &target_currency)
-                {
+                } else if let Some(converted) = convert_one(&p.units) {
                     Ok(Value::Amount(converted))
                 } else {
                     Ok(Value::Amount(p.units.clone()))
@@ -1499,7 +1531,7 @@ impl<'a> Executor<'a> {
             Value::Amount(a) => {
                 if a.currency == target_currency {
                     Ok(Value::Amount(a.clone()))
-                } else if let Some(converted) = self.price_db.convert_latest(a, &target_currency) {
+                } else if let Some(converted) = convert_one(a) {
                     Ok(Value::Amount(converted))
                 } else {
                     Ok(Value::Amount(a.clone()))
@@ -1510,9 +1542,7 @@ impl<'a> Executor<'a> {
                 for pos in inv.positions() {
                     if pos.units.currency == target_currency {
                         total += pos.units.number;
-                    } else if let Some(converted) =
-                        self.price_db.convert_latest(&pos.units, &target_currency)
-                    {
+                    } else if let Some(converted) = convert_one(&pos.units) {
                         total += converted.number;
                     }
                 }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -4014,6 +4014,181 @@ fn test_value_no_currency_aggregated_returns_as_is() {
 }
 
 // ============================================================================
+// VALUE(position, DATE) Python-beancount compat tests (issue #892)
+// ============================================================================
+
+/// Mirrors the fixture used to empirically validate Python bean-query behavior:
+/// one position of 4 SP purchased at 250 USD cost, with four price points
+/// spanning before and after the relevant dates (including a far-future price).
+fn make_issue_892_directives() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2020, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2020, 1, 1), "Equity:Opening")),
+        Directive::Price(Price::new(
+            date(2020, 1, 1),
+            "SP",
+            Amount::new(dec!(250), "USD"),
+        )),
+        Directive::Price(Price::new(
+            date(2020, 6, 1),
+            "SP",
+            Amount::new(dec!(300), "USD"),
+        )),
+        Directive::Price(Price::new(
+            date(2021, 1, 1),
+            "SP",
+            Amount::new(dec!(500), "USD"),
+        )),
+        // Far-future price to prove that `value(pos)` with no date argument
+        // uses the latest price (which matches Python's date=None behavior)
+        // rather than today's date.
+        Directive::Price(Price::new(
+            date(2099, 1, 1),
+            "SP",
+            Amount::new(dec!(9999), "USD"),
+        )),
+        Directive::Transaction(
+            Transaction::new(date(2020, 1, 1), "Buy stock").with_posting(
+                Posting::new("Assets:Brokerage", Amount::new(dec!(4), "SP")).with_cost(
+                    CostSpec::empty()
+                        .with_number_per(dec!(250))
+                        .with_currency("USD")
+                        .with_date(date(2020, 1, 1)),
+                ),
+            ),
+        ),
+    ]
+}
+
+#[test]
+fn test_value_date_arg_returns_price_at_or_before() {
+    // value(position, 2020-06-01) should use the price on-or-before 2020-06-01.
+    // The fixture has a 300 USD price dated 2020-06-01, so 4 SP * 300 = 1200 USD.
+    let directives = make_issue_892_directives();
+    let result = execute_query(
+        r"SELECT number(value(position, 2020-06-01)) AS v
+          WHERE account ~ 'Brokerage'",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows[0][0], Value::Number(dec!(1200)));
+}
+
+#[test]
+fn test_value_date_arg_uses_earlier_price_when_no_match_on_date() {
+    // value(position, 2020-02-15): no price directive on that exact date,
+    // so use the most recent price before it — the 250 USD price from 2020-01-01.
+    // 4 SP * 250 = 1000 USD (this matches the result the issue reporter got from
+    // Python bean-query with their own simpler fixture).
+    let directives = make_issue_892_directives();
+    let result = execute_query(
+        r"SELECT number(value(position, 2020-02-15)) AS v
+          WHERE account ~ 'Brokerage'",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows[0][0], Value::Number(dec!(1000)));
+}
+
+#[test]
+fn test_value_date_arg_returns_raw_units_when_no_price_available() {
+    // value(position, 2019-01-01): no price exists on or before that date,
+    // so the position is returned as-is (raw units). Python beancount does
+    // the same — its convert.get_value() falls through to `return units`.
+    let directives = make_issue_892_directives();
+    let result = execute_query(
+        r"SELECT number(value(position, 2019-01-01)) AS v
+          WHERE account ~ 'Brokerage'",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows[0][0], Value::Number(dec!(4)));
+}
+
+#[test]
+fn test_value_no_date_arg_still_uses_latest_price() {
+    // Regression: value(position) without a date continues to use the latest
+    // price (4 * 9999 = 39996), including future-dated prices. Matches Python.
+    let directives = make_issue_892_directives();
+    let result = execute_query(
+        r"SELECT number(value(position)) AS v
+          WHERE account ~ 'Brokerage'",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows[0][0], Value::Number(dec!(39996)));
+}
+
+#[test]
+fn test_value_date_arg_in_aggregate_context() {
+    // Issue #892 fix must cover the aggregate-evaluation path too —
+    // see executor/mod.rs `evaluate_function_on_values` for "VALUE".
+    let directives = make_issue_892_directives();
+    let result = execute_query(
+        r"SELECT account, number(value(sum(position), 2020-06-01)) AS v
+          WHERE account ~ 'Brokerage'
+          GROUP BY account",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows[0][1], Value::Number(dec!(1200)));
+}
+
+#[test]
+fn test_value_currency_string_is_rustledger_extension() {
+    // Regression: the existing `value(x, 'USD')` extension (not in Python
+    // beancount — Python uses CONVERT for this) continues to work and uses
+    // the latest price. A caller wanting an explicit currency AND a historical
+    // price should use CONVERT(x, 'USD', date).
+    let directives = make_issue_892_directives();
+    let result = execute_query(
+        r"SELECT number(value(position, 'USD')) AS v
+          WHERE account ~ 'Brokerage'",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows[0][0], Value::Number(dec!(39996)));
+}
+
+#[test]
+fn test_value_rejects_invalid_second_argument_type() {
+    // The error message should mention both accepted types (date and currency).
+    let directives = make_issue_892_directives();
+    let query = parse(r"SELECT value(position, 42) AS v WHERE account ~ 'Brokerage'")
+        .expect("query should parse");
+    let mut executor = Executor::new(&directives);
+    let err = executor.execute(&query).expect_err("should reject integer");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("date") && msg.contains("currency"),
+        "error should mention both accepted types, got: {msg}"
+    );
+}
+
+#[test]
+fn test_value_rejects_invalid_second_argument_in_aggregate_context() {
+    // Parallel coverage to the non-aggregate test above: the aggregate-evaluation
+    // path (evaluate_function_on_values) has its own dispatch and should reject
+    // non-date/non-string second arguments with the same error message.
+    let directives = make_issue_892_directives();
+    let query = parse(
+        r"SELECT account, value(sum(position), 42) AS v
+          WHERE account ~ 'Brokerage'
+          GROUP BY account",
+    )
+    .expect("query should parse");
+    let mut executor = Executor::new(&directives);
+    let err = executor
+        .execute(&query)
+        .expect_err("aggregate-context should reject integer too");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("date") && msg.contains("currency"),
+        "aggregate error should mention both accepted types, got: {msg}"
+    );
+}
+
+// ============================================================================
 // #prices System Table Tests (Issue #562)
 // ============================================================================
 


### PR DESCRIPTION
## Summary
Fixes #892. Python beancount's `value(position, DATE)` returns the market value using the most recent price on or before `DATE`; rustledger was rejecting the date argument outright with `VALUE second argument must be a currency string`.

## Changes
- `eval_value` (and the aggregate-context `evaluate_function_on_values` path) dispatches the 2nd argument on type:
  - `Date`   → look up price at-or-before date (Python beancount compatible)
  - `String` → override target currency (rustledger extension; use `CONVERT` for the Python-idiomatic spelling with a historical date)
  - `Null`   → treat as 1-arg form
- `convert_to_market_value` takes an `Option<NaiveDate>`, routing to the existing `price_db.convert(_, _, date)` (historical) or `convert_latest` (no date).
- 7 new integration tests covering: date at-or-before matching, earlier-price fallback, no-price-available fallback (returns raw units), aggregate-context date arg, currency-string extension regression, and invalid-type error.

## Semantics verified empirically against Python bean-query 0.2.0 / beancount 3.2.0
| Query | rustledger (this PR) | Python |
|---|---|---|
| `value(pos, 2020-06-01)` with price on that date | 1200 | 1200 |
| `value(pos, 2020-02-15)` (falls back to 2020-01-01 price) | 1000 | 1000 |
| `value(pos, 2019-01-01)` (no price available) | 4 (raw units) | 4 |
| `value(pos)` with future-dated price in DB | 39996 | 39996 |

## Intentionally unchanged
- `value(position)` with no date argument continues to use the **latest** price in the database (including future-dated), matching Python's `date=None` semantics.
- `FROM CLOSE ON DATE` filters transactions but does not affect `VALUE()`'s default price date, matching Python.
- `value(x, 'USD')` remains a rustledger extension; the doc comment now documents this explicitly and directs users to `CONVERT` for Python parity.

## Test plan
- [x] `cargo test -p rustledger-query --all-features` — 470 tests pass
- [x] `cargo clippy -p rustledger-query -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified against Python bean-query with matching fixtures

Closes #892