### PR TITLE
fix(validate): attribute plugin-synthesized directives in errors (closes #896)

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -657,7 +657,9 @@ pub fn run_plugins(
         let directive = wrapper_to_directive(wrapper)
             .map_err(|e| ProcessError::PluginConversion(e.to_string()))?;
 
-        // Reconstruct span from filename/lineno if available
+        // Reconstruct span from filename/lineno if available, falling back to
+        // the plugin-synthesized sentinel when no source location is recoverable.
+        // See `rustledger_parser::SYNTHESIZED_FILE_ID` and issue #896.
         let (span, file_id) =
             if let (Some(filename), Some(lineno)) = (&wrapper.filename, wrapper.lineno) {
                 if let Some(&fid) = filename_to_file_id.get(filename) {
@@ -666,15 +668,24 @@ pub fn run_plugins(
                         let span_start = file.line_start(lineno as usize).unwrap_or(0);
                         (rustledger_parser::Span::new(span_start, span_start), fid)
                     } else {
-                        (rustledger_parser::Span::new(0, 0), 0)
+                        (
+                            rustledger_parser::Span::new(0, 0),
+                            rustledger_parser::SYNTHESIZED_FILE_ID,
+                        )
                     }
                 } else {
-                    // Unknown file (plugin-generated) - use zero span
-                    (rustledger_parser::Span::new(0, 0), 0)
+                    // Plugin-generated directive with an unknown/synthetic filename.
+                    (
+                        rustledger_parser::Span::new(0, 0),
+                        rustledger_parser::SYNTHESIZED_FILE_ID,
+                    )
                 }
             } else {
-                // No location info - use zero span
-                (rustledger_parser::Span::new(0, 0), 0)
+                // Plugin-generated directive with no source location at all.
+                (
+                    rustledger_parser::Span::new(0, 0),
+                    rustledger_parser::SYNTHESIZED_FILE_ID,
+                )
             };
 
         new_directives.push(Spanned::new(directive, span).with_file_id(file_id as usize));
@@ -743,10 +754,17 @@ fn run_validation(
         } else {
             ErrorSeverity::Error
         };
+        // Fold the advisory note (if any) into the message so it propagates
+        // through every downstream format (LedgerError, JSON diagnostic, CLI
+        // report, LSP diagnostic) without each one needing a dedicated field.
+        let message = match &err.note {
+            Some(note) => format!("{err}\n  note: {note}"),
+            None => err.to_string(),
+        };
         errors.push(LedgerError {
             severity: severity_level,
             code: err.code.code().to_string(),
-            message: err.to_string(),
+            message,
             location: None,
             phase: phase.to_string(),
         });

--- a/crates/rustledger-loader/src/source_map.rs
+++ b/crates/rustledger-loader/src/source_map.rs
@@ -103,8 +103,21 @@ impl SourceMap {
     /// Add a file to the source map.
     ///
     /// Returns the file ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if adding this file would produce an ID that collides with
+    /// [`rustledger_parser::SYNTHESIZED_FILE_ID`] (i.e., with more than
+    /// `u16::MAX - 1` = 65,534 loaded files). Directives stored in
+    /// `Spanned<T>` use a `u16` for `file_id`, and the topmost value is
+    /// reserved as a sentinel for plugin-synthesized directives.
     pub fn add_file(&mut self, path: PathBuf, source: Arc<str>) -> usize {
         let id = self.files.len();
+        assert!(
+            id < rustledger_parser::SYNTHESIZED_FILE_ID as usize,
+            "SourceMap exceeded {} files; file_id {id} collides with SYNTHESIZED_FILE_ID sentinel",
+            rustledger_parser::SYNTHESIZED_FILE_ID,
+        );
         self.files.push(SourceFile::new(id, path, source));
         id
     }

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -35,7 +35,7 @@ mod span;
 mod winnow_parser;
 
 pub use error::{ParseError, ParseErrorKind};
-pub use span::{Span, Spanned};
+pub use span::{SYNTHESIZED_FILE_ID, Span, Spanned};
 
 use rustledger_core::Directive;
 

--- a/crates/rustledger-parser/src/span.rs
+++ b/crates/rustledger-parser/src/span.rs
@@ -85,6 +85,18 @@ impl fmt::Display for Span {
     }
 }
 
+/// Sentinel `file_id` indicating a directive was synthesized by a plugin
+/// rather than parsed from a source file.
+///
+/// Regular source files get sequential IDs starting at 0 (see
+/// `rustledger_loader::SourceMap::add_file`), so this sentinel is safely out
+/// of the normal range. Code that formats error locations or looks up files
+/// in a `SourceMap` should treat this as "no source location" and, where
+/// appropriate, hint to the user that a plugin generated the directive.
+///
+/// See issue #896.
+pub const SYNTHESIZED_FILE_ID: u16 = u16::MAX;
+
 /// A value with an associated source location (span and file).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -182,6 +182,7 @@ impl std::fmt::Display for ErrorCode {
 /// A validation error.
 #[derive(Debug, Clone, Error)]
 #[error("[{code}] {message}")]
+#[non_exhaustive]
 pub struct ValidationError {
     /// Error code.
     pub code: ErrorCode,
@@ -191,6 +192,11 @@ pub struct ValidationError {
     pub date: NaiveDate,
     /// Additional context.
     pub context: Option<String>,
+    /// Advisory note attached to the error — typically used to help users
+    /// diagnose the underlying cause (e.g. "this directive was synthesized
+    /// by a plugin"). Unlike [`Self::context`], which describes data tied
+    /// to the error, the note describes something about its *origin*.
+    pub note: Option<String>,
     /// Source span (byte offsets within the file).
     pub span: Option<Span>,
     /// Source file ID (index into `SourceMap`).
@@ -207,6 +213,7 @@ impl ValidationError {
             message: message.into(),
             date,
             context: None,
+            note: None,
             span: None,
             file_id: None,
         }
@@ -225,6 +232,7 @@ impl ValidationError {
             message: message.into(),
             date,
             context: None,
+            note: None,
             span: Some(spanned.span),
             file_id: Some(spanned.file_id),
         }
@@ -234,6 +242,13 @@ impl ValidationError {
     #[must_use]
     pub fn with_context(mut self, context: impl Into<String>) -> Self {
         self.context = Some(context.into());
+        self
+    }
+
+    /// Attach an advisory note to this error (builder pattern).
+    #[must_use]
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
         self
     }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -62,7 +62,7 @@ const PARALLEL_SORT_THRESHOLD: usize = 5000;
 use rust_decimal::Decimal;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustledger_core::{BookingMethod, Directive, InternedStr, Inventory};
-use rustledger_parser::Spanned;
+use rustledger_parser::{SYNTHESIZED_FILE_ID, Spanned};
 
 /// Account state for tracking lifecycle.
 #[derive(Debug, Clone)]
@@ -389,6 +389,12 @@ pub fn validate_spanned_with_options(
         let directive = &spanned.value;
         let date = directive.date();
 
+        // Snapshot before ANY errors are pushed for this directive so the
+        // downstream patching loop can enrich every error tied to this
+        // directive — including the ordering / future-date checks below,
+        // not just the ones produced by the per-kind validators (issue #896).
+        let error_count_before = errors.len();
+
         // Check for date ordering (info only - we sort anyway)
         if let Some(last) = state.last_date
             && date < last
@@ -411,9 +417,6 @@ pub fn validate_spanned_with_options(
                 spanned,
             ));
         }
-
-        // Track error count before helper function so we can patch new errors with location
-        let error_count_before = errors.len();
 
         match directive {
             Directive::Open(open) => {
@@ -443,11 +446,21 @@ pub fn validate_spanned_with_options(
             _ => {}
         }
 
-        // Patch any new errors with location info from the current directive
+        // Patch any new errors with location info from the current directive,
+        // and tag plugin-synthesized directives with an advisory note so users
+        // can trace errors that don't correspond to anything in their source
+        // files back to a plugin (see issue #896).
         for error in errors.iter_mut().skip(error_count_before) {
             if error.span.is_none() {
                 error.span = Some(spanned.span);
                 error.file_id = Some(spanned.file_id);
+            }
+            if error.note.is_none() && spanned.file_id == SYNTHESIZED_FILE_ID {
+                error.note = Some(
+                    "directive was synthesized by a plugin (no source location); \
+                     check your `plugin \"…\"` declarations for the responsible plugin"
+                        .to_string(),
+                );
             }
         }
     }

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -875,3 +875,67 @@ fn test_spanned_validation_out_of_order_dates_have_location() {
         );
     }
 }
+
+// ============================================================================
+// Plugin-synthesized directive attribution (issue #896)
+// ============================================================================
+
+#[test]
+fn test_plugin_synthesized_directive_gets_attribution_note() {
+    // A validator error raised on a directive whose file_id is the synthesized
+    // sentinel must carry an advisory note telling the user a plugin generated
+    // the directive. Without this, errors from plugin-generated Opens look
+    // like they came from nowhere.
+    let directives = vec![spanned_directive(
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Currency:FSS_AUSFIX")),
+        0,
+        0,
+        rustledger_parser::SYNTHESIZED_FILE_ID,
+    )];
+
+    let errors = validate_spanned_with_options(&directives, ValidationOptions::default());
+
+    let account_error = errors
+        .iter()
+        .find(|e| e.code == ErrorCode::InvalidAccountName)
+        .expect("expected E1005 for the '_'-containing account name");
+
+    let note = account_error
+        .note
+        .as_deref()
+        .expect("plugin-synthesized directive must have an attribution note");
+    assert!(
+        note.contains("synthesized by a plugin"),
+        "note should clearly identify the directive as plugin-generated, got: {note}",
+    );
+    assert!(
+        note.contains("plugin"),
+        "note should point users at their `plugin` declarations, got: {note}",
+    );
+}
+
+#[test]
+fn test_source_directive_does_not_get_attribution_note() {
+    // Complement to the test above: errors on directives with a real file_id
+    // (i.e. directly parsed from source) must NOT get the plugin attribution
+    // note, or we would confuse users whose accounts ARE in their files.
+    let directives = vec![spanned_directive(
+        Directive::Open(Open::new(date(2024, 1, 1), "Invalid:Root")),
+        10,
+        40,
+        0, // real source file_id
+    )];
+
+    let errors = validate_spanned_with_options(&directives, ValidationOptions::default());
+
+    let account_error = errors
+        .iter()
+        .find(|e| e.code == ErrorCode::InvalidAccountName)
+        .expect("expected E1005 for bad root account type");
+
+    assert!(
+        account_error.note.is_none(),
+        "source-parsed directive must not be tagged as plugin-synthesized, got note: {:?}",
+        account_error.note,
+    );
+}

--- a/crates/rustledger/src/report.rs
+++ b/crates/rustledger/src/report.rs
@@ -156,6 +156,9 @@ pub fn report_validation_errors<W: Write>(
         if let Some(ctx) = &error.context {
             writeln!(writer, "  context: {ctx}")?;
         }
+        if let Some(note) = &error.note {
+            writeln!(writer, "  note: {note}")?;
+        }
         writeln!(writer)?;
     }
 


### PR DESCRIPTION
## Summary
Fixes the error-attribution half of #896. When a plugin synthesizes a directive whose account name the parser would reject (e.g. `Equity:Currency:FSS_AUSFIX`), validation still (correctly) fires E1005 — but now the error tells the user where it came from instead of looking like a ghost account.

Before:
```
error[E1005]: Invalid account name "Equity:Currency:FSS_AUSFIX": component 'FSS_AUSFIX' contains invalid character '_' (2020-01-01)
  context: Equity:Currency:FSS_AUSFIX
```

After:
```
error[E1005]: Invalid account name "Equity:Currency:FSS_AUSFIX": component 'FSS_AUSFIX' contains invalid character '_' (2020-01-01)
  context: Equity:Currency:FSS_AUSFIX
  note: directive was synthesized by a plugin (no source location); check your `plugin "…"` declarations for the responsible plugin
```

## Why not just relax the validator?
Python beancount silently accepts plugin-generated account names that its own lexer would reject — that's a latent corruption (the ledger contains directives that can't round-trip back to text). Rustledger's stricter validation catches this. The original complaint in #896 wasn't really about the validation firing — it was about not being able to trace the error to a plugin. This PR fixes the UX without weakening the check.

## Changes
- `rustledger-parser`: new public constant `SYNTHESIZED_FILE_ID` (`u16::MAX`). Real source files get IDs starting at 0, so the sentinel is safely out of range.
- `rustledger-loader`: in `run_plugins`'s directive-reconstruction path, stamp synthesized directives with the sentinel instead of the previous `0` (which collided with the first source file).
- `rustledger-validate`:
  - New `note: Option<String>` field on `ValidationError` for advisory text separate from `context` (which describes data) and the error `message` (which describes the problem).
  - In the spanned-validation patching loop, detect `file_id == SYNTHESIZED_FILE_ID` and attach the attribution note to any errors raised on that directive.
- `rustledger-loader::run_validation`: fold the `note` into the `LedgerError.message` so it propagates through every downstream consumer (CLI report, JSON, LSP) without each one needing a dedicated field.
- `rustledger`: CLI report prints the note after context.
- 2 new integration tests:
  - Plugin-synthesized directive (file_id = SENTINEL) → error carries the note.
  - Source-parsed directive → error has no note.

## Stage 2 (filed as follow-up)
Naming the *specific* plugin in the error requires threading plugin identity through `DirectiveWrapper` and the run_plugins loop — a plugin ABI change. Tracked in #905.

## Test plan
- [x] `cargo test -p rustledger-validate -p rustledger-loader -p rustledger-parser -p rustledger` — 715 tests pass
- [x] `cargo fmt --check` clean
- [x] Validated empirically: produced a minimal Python plugin that emits an Open with `_` in the name, confirmed Python accepts it (bug), confirmed rustledger's new error message with attribution note.

Closes #896