### PR TITLE
fix(fuzz): widen i32→i64 in format_price_amount + enable pipefail in Fuzz CI (closes #911)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,6 +37,15 @@ permissions:
   contents: read
 env:
   CARGO_TERM_COLOR: always
+# Use `bash` explicitly so GitHub runs every `run:` step with
+# `bash --noprofile --norc -eo pipefail`. The default `bash -e` only
+# sets errexit, not pipefail — which meant that a failing
+# `cargo fuzz run ... | tee fuzz-output.txt` returned tee's exit code
+# (0) and silently masked compile failures in the fuzz targets
+# (see #911).
+defaults:
+  run:
+    shell: bash
 jobs:
   fuzz-parser:
     name: Fuzz Parser (${{ matrix.target }})

--- a/crates/rustledger-parser/fuzz/Cargo.lock
+++ b/crates/rustledger-parser/fuzz/Cargo.lock
@@ -29,15 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ar_archive_writer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,16 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
-]
-
-[[package]]
-name = "ariadne"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
-dependencies = [
- "unicode-width",
- "yansi",
 ]
 
 [[package]]
@@ -217,20 +198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "chumsky"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,12 +230,6 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "derive_arbitrary"
@@ -409,30 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +384,47 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -666,6 +644,21 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -917,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -929,6 +922,7 @@ dependencies = [
  "rkyv 0.7.46",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -958,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.8.5"
+version = "0.13.0"
 dependencies = [
- "chrono",
+ "jiff",
  "rkyv 0.8.14",
  "rust_decimal",
  "rust_decimal_macros",
@@ -972,10 +966,8 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.8.5"
+version = "0.13.0"
 dependencies = [
- "ariadne",
- "chrono",
  "chumsky 1.0.0-alpha.8",
  "logos 0.16.0",
  "logosky",
@@ -984,7 +976,7 @@ dependencies = [
  "rustledger-core",
  "serde",
  "thiserror",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1193,7 +1185,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -1202,7 +1194,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -1267,12 +1259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1310,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -1361,41 +1348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,15 +1358,6 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -1511,6 +1454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,12 +1476,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_parse_line.rs
+++ b/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_parse_line.rs
@@ -161,7 +161,12 @@ impl FuzzInput {
 
     /// Format a price amount with 2 decimal places in range 0.00-99.99
     fn format_price_amount(&self) -> f64 {
-        (self.price_amount.abs() % MAX_AMOUNT_CENTS) as f64 / CENTS_DIVISOR
+        // Widen to i64 *before* taking the absolute value so that
+        // `price_amount == i32::MIN` can't panic / wrap. `i32::MIN` widened
+        // to i64 is well within i64's range, so `.abs()` on it is safe.
+        // The result is then reduced mod MAX_AMOUNT_CENTS (also i64), and
+        // only reaches `f64` after the math is done.
+        (i64::from(self.price_amount).abs() % MAX_AMOUNT_CENTS) as f64 / CENTS_DIVISOR
     }
 
     fn format_account(&self, account_type: u8, sub: &str) -> String {
@@ -206,10 +211,11 @@ impl FuzzInput {
     fn format_amount(&self) -> String {
         let sign = if self.amount_negative { "-" } else { "" };
         let decimal = self.amount_decimal % 100;
+        // Widen before abs — see comment on format_price_amount for why.
         format!(
             "{}{}.{:02}",
             sign,
-            self.amount_integer.abs() % 1_000_000,
+            i64::from(self.amount_integer).abs() % 1_000_000,
             decimal
         )
     }
@@ -350,14 +356,20 @@ impl FuzzInput {
                 s.push_str(&self.format_metadata());
 
                 for i in 0..num {
-                    let acc =
-                        self.format_account((self.account_type + i) % 5, &format!("Sub{}", i));
+                    // `wrapping_add` because both operands are `u8` and the
+                    // fuzzer can legally produce `account_type` near 255 with
+                    // `i` up to 3; we only care about the value mod 5 anyway.
+                    let acc = self.format_account(
+                        self.account_type.wrapping_add(i) % 5,
+                        &format!("Sub{}", i),
+                    );
                     if i == num - 1 {
                         // Last posting auto-balanced
                         s.push_str(&format!("\n  {}", acc));
                     } else {
-                        let amt =
-                            (self.amount_integer.abs() as i64 / (num as i64)) % MAX_AMOUNT_CENTS;
+                        // Widen before abs — see comment on format_price_amount.
+                        let amt = (i64::from(self.amount_integer).abs() / i64::from(num))
+                            % MAX_AMOUNT_CENTS;
                         s.push_str(&format!("\n  {}  {}.00 {}", acc, amt, currency));
                     }
                 }


### PR DESCRIPTION
Closes #911.

## 1. Compile error in `fuzz_parse_line`

`crates/rustledger-parser/fuzz/fuzz_targets/fuzz_parse_line.rs:164` computed `i32 % i64`:
```rust
(self.price_amount.abs() % MAX_AMOUNT_CENTS) as f64 / CENTS_DIVISOR
//  ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^
//  i32                      i64
```

`cargo check` inside the fuzz crate produces:
```
error[E0277]: cannot calculate the remainder of `i32` divided by `i64`
```

Introduced between `4ad5aa6b` (added `price_amount: i32`) and `ec4ae792` (added `MAX_AMOUNT_CENTS: i64`). Broken since late January 2026.

**Fix**: widen via `i64::from(...)`, matching the cast at line 360 that already handles this the same way.

## 2. Why Fuzz CI was green all along

The compile error WAS emitted on every nightly Fuzz CI run — but the job reported success anyway. The culprit is this workflow pattern:

```yaml
- name: Run fuzzer
  run: |
    cd crates/rustledger-parser
    cargo +nightly fuzz run ${{ matrix.target }} -- ... 2>&1 | tee fuzz-output.txt
```

GitHub's default `run:` shell on Linux is `bash -e {0}` — errexit only, **no pipefail**. So `cmd | tee file` returns `tee`'s exit code (0), discarding `cargo-fuzz`'s non-zero exit. The subsequent "Check for crashes" step then finds nothing in `fuzz/artifacts/` (because nothing ran) and reports success.

Evidence from the 2026-04-24 scheduled run (job `72824418709`), `fuzz_parse_line`:

```
05:10:27  Running fuzz_parse_line for 1800 seconds...      ← start
05:11:28  error[E0308]: mismatched types                    ← rustc
05:11:28  error: could not compile `rustledger-parser-fuzz` ← cargo
05:11:28  Error: failed to build fuzz script                ← cargo-fuzz
05:11:28  Run cd crates/rustledger-parser                   ← next step (!)
05:11:28  No crashes found                                  ← "success"
```

The job completed in 1m46s instead of the nightly-scheduled 30 minutes — a dead giveaway that nothing actually fuzzed.

**Fix**: add `defaults.run.shell: bash` at the workflow level. GitHub runs explicit `shell: bash` with `bash --noprofile --norc -eo pipefail`, so pipe failures now propagate. Affects all three jobs (`fuzz-parser`, `fuzz-query`, `fuzz-booking`) uniformly.

## Verification

- [x] `cargo check` inside `crates/rustledger-parser/fuzz` → clean
- [x] `cargo fmt --check` clean
- [x] Workflow YAML sanity-checked locally (shell directive placement matches GitHub Actions docs)

## Note on Cargo.lock diff

The PR also refreshes `crates/rustledger-parser/fuzz/Cargo.lock` — the lock had stale entries for sibling workspace crates (rustledger-parser 0.8.5 vs. current 0.13.0) which `cargo check` updated. Same refresh also lands in #910; whichever merges first trivially shrinks the other's diff.

Closes #911