### PR TITLE
docs: fix Liberapay README badge to show receives instead of gives

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Parse and validate your ledger faster than Python beancount.
 [![Compatibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/rustledger/rustledger/compatibility/.github/badges/compat-badge.json)](https://github.com/rustledger/rustledger/actions/workflows/compat.yml)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Liberapay](https://img.shields.io/liberapay/gives/rustledger.svg?logo=liberapay)](https://liberapay.com/rustledger)
+[![Liberapay](https://img.shields.io/liberapay/receives/rustledger.svg?logo=liberapay)](https://liberapay.com/rustledger)
 
 </div>
 


### PR DESCRIPTION
## Summary
- The README badge used `/liberapay/gives/rustledger.svg` (donations rustledger *sends*, which is $0), so it rendered as `gives 0.00 USD/week`.
- rustledger actually *receives* ~$1.09/week from 2 patrons. Switched the badge URL to `/liberapay/receives/rustledger.svg` so it reflects income.

## Test plan
- [x] Badge URL resolves: https://img.shields.io/liberapay/receives/rustledger.svg

🤖 Generated with [Claude Code](https://claude.com/claude-code)