### PR TITLE
build(nix): silence x86_64-darwin deprecation warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -214,6 +214,14 @@
 
         in
         {
+          # Acknowledge the upstream x86_64-darwin deprecation (Nixpkgs 26.11+).
+          # Silences the evaluation warning while we continue to ship Intel macOS
+          # binaries; revisit when Nixpkgs fully drops the platform.
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            config.allowDeprecatedx86_64Darwin = true;
+          };
+
           # Formatters
           treefmt = {
             projectRootFile = "flake.nix";


### PR DESCRIPTION
## Summary

`nix flake check` and `nix develop` were emitting:

```
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin;
see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
```

This is upstream nixpkgs telling us it'll stop building Intel macOS in 26.11. flake-parts evaluates nixpkgs per-system, so the warning fires on every CI run — even from Linux.

## Why not just drop `x86_64-darwin` from `systems`?

We still ship `x86_64-apple-darwin` release binaries (`release-build.yml:98`, `release-test.yml:556`) and document that install path (`docs/getting-started/installation.md:71`). Removing it from the flake would regress Intel Mac developers before we drop those artifacts.

## Fix

The [Nixpkgs release notes](https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05) document the exact migration: import nixpkgs with `config.allowDeprecatedx86_64Darwin = true`. With flake-parts, that means overriding `_module.args.pkgs` per-system.

Verified that derivation paths are unchanged before/after:
- `packages.x86_64-linux.default`: `hx0x8gdf...` (same)
- `devShells.x86_64-linux.default`: `zn74dcg7...` (same)
- `formatter.x86_64-linux`: `9xb7kphx...` (same)

So this is purely a warning-suppression with no functional effect.

## Test plan

- [x] `nix flake check` no longer emits the deprecation warning
- [x] `nix develop` enters the shell cleanly
- [x] Derivation hashes for packages, devShells, and formatter are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)