### PR TITLE
fix(query): accept single-element IN without trailing comma (closes #916)

### DIFF
--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -79,9 +79,9 @@ impl Executor<'_> {
                         let found = values.iter().any(|v| self.values_equal(&left, v));
                         Ok(Value::Boolean(found))
                     }
-                    _ => Err(QueryError::Type(
-                        "IN requires set right operand".to_string(),
-                    )),
+                    // Fall back to scalar equality so `x IN ('a')` ≡ `x = 'a'`,
+                    // matching SQL/bean-query semantics (issue #916).
+                    _ => Ok(Value::Boolean(self.values_equal(&left, &right))),
                 }
             }
             BinaryOperator::NotRegex => {
@@ -125,9 +125,9 @@ impl Executor<'_> {
                         let found = values.iter().any(|v| self.values_equal(&left, v));
                         Ok(Value::Boolean(!found))
                     }
-                    _ => Err(QueryError::Type(
-                        "NOT IN requires set right operand".to_string(),
-                    )),
+                    // Fall back to scalar inequality so `x NOT IN ('a')` ≡ `x != 'a'`,
+                    // matching SQL/bean-query semantics (issue #916).
+                    _ => Ok(Value::Boolean(!self.values_equal(&left, &right))),
                 }
             }
             BinaryOperator::Add => {
@@ -372,9 +372,9 @@ impl Executor<'_> {
                         let found = values.iter().any(|v| self.values_equal(left, v));
                         Ok(Value::Boolean(found))
                     }
-                    _ => Err(QueryError::Type(
-                        "IN requires set right operand".to_string(),
-                    )),
+                    // Fall back to scalar equality so `x IN ('a')` ≡ `x = 'a'`,
+                    // matching SQL/bean-query semantics (issue #916).
+                    _ => Ok(Value::Boolean(self.values_equal(left, right))),
                 }
             }
             BinaryOperator::NotRegex => {
@@ -418,9 +418,9 @@ impl Executor<'_> {
                         let found = values.iter().any(|v| self.values_equal(left, v));
                         Ok(Value::Boolean(!found))
                     }
-                    _ => Err(QueryError::Type(
-                        "NOT IN requires set right operand".to_string(),
-                    )),
+                    // Fall back to scalar inequality so `x NOT IN ('a')` ≡ `x != 'a'`,
+                    // matching SQL/bean-query semantics (issue #916).
+                    _ => Ok(Value::Boolean(!self.values_equal(left, right))),
                 }
             }
             BinaryOperator::Add => {

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -81,7 +81,7 @@ impl Executor<'_> {
                     }
                     // Fall back to scalar equality so `x IN ('a')` ≡ `x = 'a'`,
                     // matching SQL/bean-query semantics (issue #916).
-                    _ => Ok(Value::Boolean(self.values_equal(&left, &right))),
+                    other => Ok(Value::Boolean(self.values_equal(&left, &other))),
                 }
             }
             BinaryOperator::NotRegex => {
@@ -127,7 +127,7 @@ impl Executor<'_> {
                     }
                     // Fall back to scalar inequality so `x NOT IN ('a')` ≡ `x != 'a'`,
                     // matching SQL/bean-query semantics (issue #916).
-                    _ => Ok(Value::Boolean(!self.values_equal(&left, &right))),
+                    other => Ok(Value::Boolean(!self.values_equal(&left, &other))),
                 }
             }
             BinaryOperator::Add => {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -2519,7 +2519,7 @@ fn test_in_operator_single_element_set() {
         ),
     ];
 
-    // Single element set requires trailing comma to distinguish from parenthesized expression
+    // Single element set with trailing comma parses as Expr::Set([..])
     let result = execute_query(r"SELECT currency WHERE currency IN ('EUR',)", &directives);
 
     assert_eq!(result.rows.len(), 2, "Expected 2 EUR postings");
@@ -2529,6 +2529,52 @@ fn test_in_operator_single_element_set() {
             other => panic!("Expected String for currency, got {other:?}"),
         };
         assert_eq!(currency, "EUR");
+    }
+}
+
+/// Regression test for issue #916: `IN ('one_value')` (no trailing comma)
+/// should match `'one_value'`, behaving like `= 'one_value'`. The parser
+/// resolves this to a parenthesized scalar; the executor falls back to
+/// scalar equality, matching SQL/Python bean-query semantics.
+#[test]
+fn test_in_operator_single_element_no_trailing_comma() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 15), "EUR expense")
+                .with_posting(Posting::new("Expenses:Food", Amount::new(dec!(100), "EUR")))
+                .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-100), "EUR"))),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 16), "USD expense")
+                .with_posting(Posting::new("Expenses:Food", Amount::new(dec!(50), "USD")))
+                .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-50), "USD"))),
+        ),
+    ];
+
+    let result = execute_query(r"SELECT currency WHERE currency IN ('EUR')", &directives);
+    assert_eq!(result.rows.len(), 2, "Expected 2 EUR postings");
+    for row in &result.rows {
+        let currency = match &row[0] {
+            Value::String(s) => s.as_str(),
+            other => panic!("Expected String for currency, got {other:?}"),
+        };
+        assert_eq!(currency, "EUR");
+    }
+
+    // NOT IN ('EUR') should select non-EUR rows
+    let result = execute_query(
+        r"SELECT currency WHERE currency NOT IN ('EUR')",
+        &directives,
+    );
+    assert_eq!(result.rows.len(), 2, "Expected 2 non-EUR postings");
+    for row in &result.rows {
+        let currency = match &row[0] {
+            Value::String(s) => s.as_str(),
+            other => panic!("Expected String for currency, got {other:?}"),
+        };
+        assert_eq!(currency, "USD");
     }
 }
 

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -2576,6 +2576,21 @@ fn test_in_operator_single_element_no_trailing_comma() {
         };
         assert_eq!(currency, "USD");
     }
+
+    // HAVING uses the borrowed `binary_op_on_values` path; exercise the same
+    // single-element fallback there so both code paths are covered.
+    let result = execute_query(
+        r"SELECT currency, sum(number) AS total
+          GROUP BY currency
+          HAVING currency IN ('EUR')",
+        &directives,
+    );
+    assert_eq!(result.rows.len(), 1, "Expected 1 EUR group");
+    let currency = match &result.rows[0][0] {
+        Value::String(s) => s.as_str(),
+        other => panic!("Expected String for currency, got {other:?}"),
+    };
+    assert_eq!(currency, "EUR");
 }
 
 /// Test IN with parenthesized column (not a set literal).


### PR DESCRIPTION
## Summary

`WHERE x IN ('value')` errored with `IN requires set right operand`. The parser intentionally requires either ≥2 elements or a trailing comma `('value',)` to disambiguate from `IN (column_name)` (the `'x' IN (tags)` StringSet form), so `('value')` parses as a parenthesized scalar and the runtime then rejects non-Set right operands.

Python `bean-query` accepts the single-element form (verified). SQL treats `x IN (a)` as `x = a`.

## Fix

In the executor `In`/`NotIn` arms (two locations each — owned and borrowed values), fall back to scalar (in)equality via the existing `values_equal` helper when `right` is neither `Set` nor `StringSet`. Preferred over a parser change because:

- The parser's trailing-comma rule still has a real purpose (disambiguating `'x' IN (tags)` for `StringSet` columns like `tags`/`links`).
- The executor fallback also handles `IN <function_call>`, `IN <subexpression>`, and other scalar-yielding right operands.

`values_equal` already returns `false` on cross-type comparisons (no error), so the fallback is well-defined for any scalar.

## Test plan

- [x] New regression test `test_in_operator_single_element_no_trailing_comma` covers `IN ('x')` and `NOT IN ('x')`.
- [x] All 6 existing IN tests still pass (single-element-with-comma, multi-element, parenthesized column, numeric set, NOT IN variants).
- [x] Full `rustledger-query` suite: 464 tests green.
- [x] CLI smoke against a real ledger: `rledger query ... "WHERE account IN ('Assets:Bank')"` returns the row.
- [x] Verified Python `bean-query` parity on the same query.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)