### PR TITLE
chore: release v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "jiff",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "rustc-hash",
  "rustledger-booking",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glob",
  "jiff",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "crossbeam-channel",
  "jiff",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chumsky 1.0.0-alpha.8",
  "criterion",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chumsky 1.0.0-alpha.8",
  "criterion",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.94"
 license = "GPL-3.0-only"
@@ -133,16 +133,16 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.13.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.13.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.13.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.13.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.13.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.13.0", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.13.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.13.0", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.13.0", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.13.0", path = "crates/rustledger-ops" }
+rustledger-core = { version = "0.14.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.14.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.14.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.14.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.14.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.14.0", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.14.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.14.0", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.14.0", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.14.0", path = "crates/rustledger-ops" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,13 +33,15 @@ cargo semver-checks check-release --feature-group all-features
 
 The version surface is:
 
-- Workspace `Cargo.toml`: `[workspace.package].version`.
-- All 14 crate `Cargo.toml` files (each currently hardcodes `version = "X.Y.Z"` rather than inheriting from the workspace).
-- `packages/mcp-server/package.json`: both `version` and the `@rustledger/wasm` entry under `dependencies`.
+- Workspace `Cargo.toml`:
+  - `[workspace.package].version`.
+  - All 10 entries under `[workspace.dependencies]` that path-depend on a sibling crate (`rustledger-core`, `rustledger-parser`, `rustledger-loader`, `rustledger-booking`, `rustledger-validate`, `rustledger-query`, `rustledger-plugin`, `rustledger-plugin-types`, `rustledger-importer`, `rustledger-ops`). Their pinned `version = "X.Y.Z"` must match — `cargo publish` rejects a crate whose dep version doesn't match what's on crates.io.
+- All 14 crate `Cargo.toml` files under `crates/` (each currently hardcodes its own `version = "X.Y.Z"` rather than inheriting from the workspace).
+- `packages/mcp-server/package.json`: both `version` and the `@rustledger/wasm` entry under `dependencies`. **Don't try to update `package-lock.json`** — `@rustledger/wasm@X.Y.Z` doesn't exist on npm yet during the bump PR, so `npm install` fails with `ETARGET`. The publish workflow regenerates the lockfile after wasm is published.
 - `packaging/rpm/rustledger.spec`: `Version`, `Source0` URL, and the `%setup -n rustledger-X.Y.Z` directory all hardcode the version. COPR pulls this file from the release tag via SCM integration, so missing this means COPR keeps building the old version.
 - `Cargo.lock`: refreshed by `cargo check` after the Cargo.toml edits.
 
-`packages/vscode/package.json` is *not* bumped here — the VS Code extension version is synced from the release tag at build time. The AUR `PKGBUILD`s under `packaging/arch/` also don't need manual edits — `release-publish.yml` `sed`-bumps them at release time.
+`packages/vscode/package.json` is *not* bumped here — the VS Code extension version is synced from the release tag at build time. The AUR `PKGBUILD`s under `packaging/arch/` also don't need manual edits — `release-publish.yml` `sed`-bumps them at release time. The Homebrew formula at `packaging/homebrew/rustledger.rb` is bumped automatically by `dawidd6/action-homebrew-bump-formula` during release-publish.
 
 ### 3. Open a release PR
 

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Rustledger FFI via WASI - JSON API for embedding in any language"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 20 native plugins and WASM support"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 27 error codes for ledger correctness"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.13.0"
+    "@rustledger/wasm": "^0.14.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packaging/homebrew/rustledger.rb
+++ b/packaging/homebrew/rustledger.rb
@@ -51,9 +51,6 @@ class Rustledger < Formula
     # Validate the ledger with rledger
     system bin/"rledger", "check", testpath/"test.beancount"
 
-    # Test bean-check compatibility binary
-    system bin/"bean-check", testpath/"test.beancount"
-
     # Test query functionality
     output = shell_output("#{bin}/rledger query #{testpath/"test.beancount"} \"SELECT account, sum(position)\"")
     assert_match "Assets:Bank:Checking", output

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.13.0
+Version:        0.14.0
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.13.0.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.14.0.tar.gz
 
 BuildRequires:  rust >= 1.75
 BuildRequires:  cargo
@@ -21,7 +21,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.13.0
+%setup -q -n rustledger-0.14.0
 
 %build
 cargo build --release
@@ -29,22 +29,16 @@ cargo build --release
 %install
 install -d %{buildroot}%{_bindir}
 
-# Main unified binary
+# Main unified binary + LSP server.
+# Bean-* compatibility wrappers were removed as compiled binaries; users
+# opt in post-install via `rledger compat install --prefix /usr/bin`.
 install -m 755 target/release/rledger %{buildroot}%{_bindir}/
-
-# Bean-* compatibility binaries
-install -m 755 target/release/bean-check %{buildroot}%{_bindir}/
-install -m 755 target/release/bean-format %{buildroot}%{_bindir}/
-install -m 755 target/release/bean-query %{buildroot}%{_bindir}/
-install -m 755 target/release/bean-report %{buildroot}%{_bindir}/
-install -m 755 target/release/bean-doctor %{buildroot}%{_bindir}/
-install -m 755 target/release/bean-extract %{buildroot}%{_bindir}/
-install -m 755 target/release/bean-price %{buildroot}%{_bindir}/
+install -m 755 target/release/rledger-lsp %{buildroot}%{_bindir}/
 
 %files
 %license LICENSE
 %{_bindir}/rledger
-%{_bindir}/bean-*
+%{_bindir}/rledger-lsp
 
 %changelog
 * Sat Jan 25 2026 rustledger <rustledger@users.noreply.github.com> - 0.7.3-1


### PR DESCRIPTION
## Summary

Bumps every version surface from 0.13.0 → 0.14.0 and fixes two stale `bean-*` references that would have broken the release.

## Bumps (per RELEASING.md, with one omission corrected — see "Doc updates" below)

| Surface | Files | Notes |
|---------|-------|-------|
| Workspace package version | `Cargo.toml:36` | `[workspace.package].version` |
| Inter-crate dep pins | `Cargo.toml:136-145` | 10 entries under `[workspace.dependencies]` |
| Crate versions | 14× `crates/*/Cargo.toml` | each hardcodes its own version |
| MCP server | `packages/mcp-server/package.json` | `version` + `@rustledger/wasm` dep |
| RPM spec | `packaging/rpm/rustledger.spec` | `Version`, `Source0`, `%setup` |
| Cargo.lock | regenerated by `cargo check` | not hand-edited |

`packages/mcp-server/package-lock.json` intentionally **not** touched: `@rustledger/wasm@0.14.0` doesn't exist on npm yet during the bump PR, so `npm install` ETARGETs. The publish workflow regenerates the lockfile after wasm is published. Same approach used for v0.13.0 (commit `d2f79cd4`).

## Bean-* fixes (release blockers)

| File | Issue | Fix |
|------|-------|-----|
| `packaging/rpm/rustledger.spec` | Installed 7 `bean-*` binaries (`bean-check`, `bean-format`, `bean-query`, `bean-report`, `bean-doctor`, `bean-extract`, `bean-price`) that don't exist anymore — the compiled bean-compat wrappers were removed in v0.10.0 (`8e3c0635`) in favor of opt-in `rledger compat install --prefix /usr/bin`. COPR build would have failed at install step. | Removed all bean-* installs; added missing `rledger-lsp` install. |
| `packaging/homebrew/rustledger.rb` | `test` block invoked `bin/"bean-check"` — same dead-binary root cause; Homebrew formula bump would have published a tap whose `brew test rustledger` failed. | Removed the bean-check test step. |

The AUR PKGBUILDs (`packaging/arch/rustledger`, `packaging/arch/rustledger-bin`) were already correct on this front — they only ship `rledger` + `rledger-lsp` with a comment about post-install bean-compat opt-in.

## RELEASING.md updates

While running through the doc, found three things missing:

1. **`[workspace.dependencies]` step was missing** from the bump checklist. Without bumping those 10 inter-crate version pins, `cargo publish` rejects each crate (its deps' versions don't match crates.io). Added.
2. Documented the `npm install` ETARGET issue so the next person doesn't lose time on it.
3. Noted that the Homebrew formula bumps automatically via `dawidd6/action-homebrew-bump-formula`.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets` (pre-push hook) passes — all crates build at 0.14.0
- [x] No remaining `0.13.0` references except `itertools` (third-party dep) and `Cargo.lock` regeneration entries
- [x] `packaging/rpm/rustledger.spec` no longer references non-existent binaries
- [x] `packaging/homebrew/rustledger.rb` test block no longer references bean-check
- [ ] CI on this PR exercises `release/*` branch handling (ci.yml + aur.yml — both updated to use `release/*` in #920)
- [ ] After merge: `gh release create v0.14.0 --target $(git rev-parse HEAD) --generate-notes` will trigger:
  - `release-build.yml` — 8 platforms + WASM + FFI-WASI + VS Code .vsix
  - `release-publish.yml` — crates.io (all 14 crates including new `rustledger-ops`), npm (`@rustledger/wasm`, `@rustledger/mcp-server`), Docker, Homebrew, Scoop, COPR, AUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)