### PR TITLE
ci(release): publish rustledger-ops before rustledger-plugin

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -74,13 +74,18 @@ jobs:
           # To determine the correct order, run: cargo metadata --format-version=1 | jq -r '.packages[].name'
           # and arrange so that each crate's dependencies appear before it.
           # Current dependency tree (simplified):
-          #   core -> parser -> booking -> plugin-types -> plugin -> validate -> loader -> query -> importer -> rustledger
+          #   core -> parser -> booking -> plugin-types -> ops -> plugin -> validate -> loader -> query -> importer -> rustledger
           #   wasm and ffi-wasi depend on most crates; lsp depends on query
+          # rustledger-ops MUST come before rustledger-plugin: the plugin
+          # crate path-depends on ops, so cargo publish refuses to push
+          # a plugin version whose `ops` requirement isn't on crates.io
+          # yet.
           CRATES=(
             rustledger-core
             rustledger-parser
             rustledger-booking
             rustledger-plugin-types
+            rustledger-ops
             rustledger-plugin
             rustledger-validate
             rustledger-loader


### PR DESCRIPTION
## What

Adds `rustledger-ops` to the `CRATES` publish order in `release-publish.yml`, between `rustledger-plugin-types` and `rustledger-plugin` (which path-depends on it).

## Why

The ops crate was added as a workspace member in #890 but never wired into the publish job. Effect:

**v0.13.0 release (April 21–23):** dependent crate publishes succeeded because `rustledger-ops = "^0.13.0"` was satisfiable — except *only* because someone manually `cargo publish -p rustledger-ops`'d it on April 23 outside the workflow. Trusted publishing has since been configured for the crate.

**v0.14.0 release (today, just now):** the `Publish to crates.io` job in `Release Publish` failed mid-chain at `rustledger-plugin`:

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `rustledger-ops = "^0.14.0"`
```

The five crates ahead of `plugin` in the order published cleanly (`core`, `parser`, `booking`, `plugin-types`, `validate`). The eight after it cascaded.

## Fix

```diff
 CRATES=(
   rustledger-core
   rustledger-parser
   rustledger-booking
   rustledger-plugin-types
+  rustledger-ops
   rustledger-plugin
   rustledger-validate
   ...
 )
```

## After this lands

I'll re-trigger Release Publish via workflow_dispatch with `tag: v0.14.0`. The job will:
- Skip `core`/`parser`/`booking`/`plugin-types`/`validate` (already on crates.io at 0.14.0).
- Publish `rustledger-ops@0.14.0` (trusted publishing is set up for it).
- Publish the remaining 8 crates that cascaded last time.

The MCP server TS errors and Homebrew bump conflict are separate issues, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)