### PR TITLE
fix(mcp-server): add amount and date to ToolArguments

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustledger/mcp-server",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@rustledger/wasm": "^0.13.0"
+        "@rustledger/wasm": "^0.14.0"
       },
       "bin": {
         "rustledger-mcp": "dist/index.js"
@@ -876,9 +876,9 @@
       ]
     },
     "node_modules/@rustledger/wasm": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@rustledger/wasm/-/wasm-0.13.0.tgz",
-      "integrity": "sha512-Opcn6GlD8qcmbV2FxXB3cbAmRIh1g1fCkNWTrw6d+rAcaiEDLbtOuIbLyPoKBSRAoDJTOGjfh76H7R1VKj9b9Q==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@rustledger/wasm/-/wasm-0.14.0.tgz",
+      "integrity": "sha512-qusAblPffHTr4fQiC36T12H/d3aoz7aFZ7/JhVzBqtCQwAd5Ctmcpz4ZfMZsyRQZ86ntql9ViK05PE42WtH/+w==",
       "license": "GPL-3.0-only"
     },
     "node_modules/@standard-schema/spec": {

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -170,4 +170,7 @@ export interface ToolArguments {
   currency?: string;
   file_path?: string;
   write?: boolean;
+  // Used by handleImportCategorize (src/handlers.ts:107).
+  amount?: string;
+  date?: string;
 }


### PR DESCRIPTION
## Why

The `Publish MCP server to npm` step in `Release Publish` failed for **both v0.13.0 and v0.14.0** with the same three TS errors:

```
src/handlers.ts(109,65): error TS2322: Type '"date"' is not assignable to type 'keyof ToolArguments'.
src/handlers.ts(145,27): error TS2339: Property 'amount' does not exist on type 'ToolArguments'.
src/handlers.ts(147,24): error TS2339: Property 'date' does not exist on type 'ToolArguments'.
```

`handleImportCategorize` references `args.amount`, `args.date`, and passes `"date"` to `validateArgs` (which is typed as `(keyof ToolArguments)[]`), but the `ToolArguments` interface in `src/types.ts` was missing those two fields.

That's why `npm view @rustledger/mcp-server version` still returns `0.12.0` — neither subsequent release ever published.

## Fix

Add the two missing optional fields to the interface.

Also refreshes `package-lock.json` to pick up `@rustledger/wasm@0.14.0` (now on npm).

## Test plan

- [x] `npm install` resolves cleanly with the now-available wasm@0.14.0
- [x] `npm run build` (`tsc && cp -r src/docs dist/`) completes without TS errors
- [ ] After merge, re-trigger `Release Publish` via workflow_dispatch with `tag: v0.14.0` to publish `@rustledger/mcp-server@0.14.0`

## Related

Last remaining real failure from today's v0.14.0 release flow. Other failures resolved:
- crates.io publish-order (fixed in #924, all 14 crates now at 0.14.0)
- Docker / AUR-bin race with release-build (resolved on re-run)
- Homebrew "Whoops" — was a misleading exit-1 from the bump action; homebrew-core's rustledger.rb is at v0.14.0 already

🤖 Generated with [Claude Code](https://claude.com/claude-code)