### PR TITLE
chore: release v0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "criterion",
  "jiff",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "rustc-hash",
  "rustledger-booking",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "glob",
  "jiff",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "crossbeam-channel",
  "jiff",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "blake3",
  "jiff",
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chumsky 1.0.0-alpha.8",
  "criterion",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chumsky 1.0.0-alpha.8",
  "criterion",
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.94"
 license = "GPL-3.0-only"
@@ -139,16 +139,16 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.14.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.14.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.14.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.14.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.14.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.14.0", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.14.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.14.0", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.14.0", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.14.0", path = "crates/rustledger-ops" }
+rustledger-core = { version = "0.14.1", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.14.1", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.14.1", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.14.1", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.14.1", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.14.1", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.14.1", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.14.1", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.14.1", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.14.1", path = "crates/rustledger-ops" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Rustledger FFI via WASI - JSON API for embedding in any language"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 20 native plugins and WASM support"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 27 error codes for ledger correctness"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.14.0"
+    "@rustledger/wasm": "^0.14.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.14.0
+Version:        0.14.1
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.14.0.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.14.1.tar.gz
 
 BuildRequires:  rust >= 1.75
 BuildRequires:  cargo
@@ -21,7 +21,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.14.0
+%setup -q -n rustledger-0.14.1
 
 %build
 cargo build --release

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -9,7 +9,10 @@ License:        GPL-3.0-only
 URL:            https://rustledger.github.io
 Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.14.1.tar.gz
 
-BuildRequires:  rust >= 1.75
+# Must match `workspace.package.rust-version` in Cargo.toml.
+# Edition 2024 stabilized in 1.85, so older toolchains fail at parse
+# time regardless of MSRV.
+BuildRequires:  rust >= 1.94
 BuildRequires:  cargo
 BuildRequires:  gcc
 


### PR DESCRIPTION
Patch release to redrive the v0.14.0 publish flow with the mcp-server TypeScript fix from #926 included in the tagged source tree.

## Why a patch

The v0.14.0 tag at `d655dbb8` pre-dates the type-fix from #926. `release-publish.yml`'s mcp job checks out the tag, so re-triggering against `tag=v0.14.0` kept hitting the same `tsc` errors. v0.14.1 captures all the fixes and lets the publish flow run end-to-end.

## What's in the bump

Standard surfaces from RELEASING.md:

- Workspace `[workspace.package].version` + 10 `[workspace.dependencies]` pins
- 14 crate `Cargo.toml`s
- `packages/mcp-server/package.json` (`version` + `@rustledger/wasm` dep)
- `packaging/rpm/rustledger.spec` (`Version`, `Source0`, `%setup`)
- `Cargo.lock` (auto-regenerated)

No code changes beyond version strings — the actual fixes (#924 ops publish order, #926 mcp-server TS types) already landed on main as part of unblocking v0.14.0.

## Expected publish state after merge + `gh release create v0.14.1`

| Channel | Expected |
|---|---|
| crates.io (all 14) | 0.14.1 (skip-if-published guard now honors trusted publishing for ops) |
| `@rustledger/wasm` | 0.14.1 (monotonicity guard from #918 will accept it) |
| `@rustledger/mcp-server` | **0.14.1** ← the actual goal of this release |
| Docker, AUR, Scoop, COPR, Homebrew | 0.14.1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)