### PR TITLE
fix(wasm): enable jiff js feature for browser builds (closes #925)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,10 +1917,12 @@ checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "wasm-bindgen",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,13 @@ name = "rustledger"
 [workspace.dependencies]
 # Core
 rust_decimal = { version = "1.41", features = ["serde"] }
-jiff = { version = "0.2", features = ["serde"] }
+# `js` feature is wasm32-only (cfg-gated inside jiff) and pulls in
+# js-sys so jiff::Zoned::now() / Timestamp::now() work in browsers
+# instead of panicking with "getting the current time in
+# wasm32-unknown-unknown is not possible with just the standard library".
+# No effect on native builds. Required by @rustledger/wasm consumers
+# (see #925).
+jiff = { version = "0.2", features = ["serde", "js"] }
 glob = "0.3"
 thiserror = "2"
 anyhow = "1"


### PR DESCRIPTION
## Bug

`@rustledger/wasm@0.13.0` and `@0.14.0` panic at `ParsedLedger` construction in browser environments:

```
panicked at jiff-0.2.x/src/now.rs:33:13:
  getting the current time in wasm32-unknown-unknown is not possible
  with just the standard library, enable Jiff's `js` feature if you
  are targeting a browser environment
```

Reported in #925.

## Root cause

#840 (refactor: replace chrono with jiff for date handling) swapped `chrono` for `jiff` but missed that jiff requires an opt-in `js` feature on `wasm32-unknown-unknown`. `jiff::Timestamp::now()` / `Zoned::now()` panic in browsers without it.

(`chrono`, the previous library, exposes wasm time without an opt-in.)

## Fix

```diff
-jiff = { version = "0.2", features = ["serde"] }
+jiff = { version = "0.2", features = ["serde", "js"] }
```

The `js` feature is `cfg(target_arch = "wasm32")` inside jiff itself, so enabling it workspace-wide has no effect on native builds — it just adds a `js-sys` dep that's only linked into wasm32 builds and lets jiff call `Date.now()`.

## Test plan

- [x] `wasm-pack build --target web --release` against `crates/rustledger-wasm` completes cleanly with the fix
- [ ] After merge + v0.14.1 release, smoke-test a Svelte/Vite consumer (mirrors the failing setup from #925) to confirm `new ParsedLedger(...)` doesn't panic

## Sequencing with v0.14.1

`#927` (the v0.14.1 release PR) needs this to land first — otherwise v0.14.1's WASM is still broken in browsers. Plan: merge this → rebase #927 onto updated main → merge #927 → tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #925


