### PR TITLE
ci: fix dependabot auto-merge pipeline

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -86,15 +86,15 @@ jobs:
             BASE_TREE=$(gh api "repos/$REPO/git/commits/$CURRENT_SHA" --jq '.tree.sha')
             echo "Base tree: $BASE_TREE"
 
-            # Create blobs for all changed files in supply-chain/
+            # Create blobs for all changed files in supply-chain/.
+            # Pipe the JSON body through stdin (`--input -`) instead of `-f content="$CONTENT"`
+            # so a large base64 blob can't blow past ARG_MAX and crash gh with E2BIG.
             TREE_ENTRIES="[]"
             for file in $(git diff --staged --name-only); do
               if [ -f "$file" ]; then
-                CONTENT=$(base64 -w 0 "$file")
-                BLOB_SHA=$(gh api "repos/$REPO/git/blobs" \
-                  -f encoding=base64 \
-                  -f content="$CONTENT" \
-                  --jq '.sha')
+                BLOB_SHA=$(jq -n --rawfile content "$file" \
+                  '{encoding: "base64", content: ($content | @base64)}' \
+                  | gh api "repos/$REPO/git/blobs" --input - --jq '.sha')
                 echo "Created blob for $file: $BLOB_SHA"
                 TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq --arg path "$file" --arg sha "$BLOB_SHA" \
                   '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+# Auto-merge Dependabot PRs once required checks pass.
+#
+# Triggers `gh pr merge --auto --squash`, which queues the merge but waits
+# for branch protection's required checks. Major version bumps are skipped —
+# those usually need a human because of API breakage.
+name: Dependabot Auto-Merge
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for non-major bumps
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Two ci-only changes that unblock the rust-deps Dependabot batch:

1. **`cargo-vet-auto.yml`: pipe blob content through stdin, not CLI args.**
   When `supply-chain/config.toml` grew large enough, base64-encoding it into
   a CLI argument (`gh api ... -f content="$CONTENT"`) exceeded `ARG_MAX` and
   crashed with `Argument list too long` / exit 126. Causing every rust-deps
   Dependabot PR to leave `Cargo Vet` failing because the autofix workflow
   couldn't commit regenerated exemptions. The fix uses `--input -` so the
   payload is sent on stdin and size doesn't matter.

   Reproduced on PR #933 (rust-dependencies group with 4 updates).

2. **New `dependabot-auto-merge.yml`.** Calls `gh pr merge --auto --squash`
   on any Dependabot PR that isn't a `version-update:semver-major`. Branch
   protection still gates the actual merge until required checks pass. Major
   bumps (e.g., #934 ndarray 0.16→0.17) still need a human because they
   typically include API breakage.

## Test plan

- [x] cargo-vet-auto.yml diff is minimal — only the blob-creation step
- [x] No code changes outside `.github/workflows/`
- [ ] After merge, rerun `Update Exemptions` on PR #933 to confirm the fix
- [ ] After merge, verify auto-merge workflow runs on the next Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)