### PR TITLE
fix(query): make `from close on D` exclusive (closes #935)

### DIFF
--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -99,9 +99,14 @@ pub struct Target {
 /// FROM clause with transaction-level modifiers.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FromClause {
-    /// OPEN ON date - summarize entries before this date.
+    /// OPEN ON date - inclusive lower bound. Entries before `date` are
+    /// summarized into the running balance and excluded from results;
+    /// entries on or after `date` are included.
     pub open_on: Option<NaiveDate>,
-    /// CLOSE ON date - truncate entries after this date.
+    /// CLOSE ON date - exclusive upper bound (matches bean-query). Entries
+    /// strictly before `date` are kept; entries on or after `date` are
+    /// excluded. Combined with `open_on`, the resulting period is
+    /// `[open_on, close_on)`.
     pub close_on: Option<NaiveDate>,
     /// CLEAR - transfer income/expense to equity.
     pub clear: bool,

--- a/crates/rustledger-query/src/completions.rs
+++ b/crates/rustledger-query/src/completions.rs
@@ -353,8 +353,14 @@ fn get_completions_for_context(context: &BqlContext) -> Vec<Completion> {
         ],
 
         BqlContext::AfterFrom => vec![
-            keyword("OPEN ON", Some("Summarize entries before date")),
-            keyword("CLOSE ON", Some("Truncate entries after date")),
+            keyword(
+                "OPEN ON",
+                Some("Inclusive lower bound: summarize entries before, include from"),
+            ),
+            keyword(
+                "CLOSE ON",
+                Some("Exclusive upper bound: include entries strictly before"),
+            ),
             keyword("CLEAR", Some("Transfer income/expense to equity")),
             keyword("WHERE", Some("Filter results")),
             keyword("GROUP BY", Some("Group results")),

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -337,8 +337,12 @@ impl<'a> Executor<'a> {
                         }
                         continue;
                     }
+                    // `close on D` is exclusive (matches bean-query): the books
+                    // are closed AT D, so a transaction stamped exactly on D is
+                    // not part of the closing period. Combined with `open on D`
+                    // being inclusive, the resulting range is `[open, close)`.
                     if let Some(close_date) = from.close_on
-                        && txn.date > close_date
+                        && txn.date >= close_date
                     {
                         continue;
                     }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -511,11 +511,12 @@ fn test_close_on_is_exclusive() {
     );
     let boundary = date(2024, 1, 22);
     for row in &result.rows {
-        if let Value::Date(d) = &row[0] {
-            assert!(
+        match &row[0] {
+            Value::Date(d) => assert!(
                 *d < boundary,
                 "row at {d} violates exclusive close: should be < {boundary}"
-            );
+            ),
+            other => panic!("expected Value::Date in column 0, got {other:?}"),
         }
     }
 }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -494,6 +494,46 @@ fn test_execute_balances_with_from() {
 }
 
 #[test]
+fn test_close_on_is_exclusive() {
+    // `FROM CLOSE ON D` matches bean-query semantics: the books are closed AT D,
+    // so a transaction stamped exactly on D is NOT included. See issue #935.
+    //
+    // Test fixture txns: 2024-01-15, 2024-01-20, 2024-01-22, 2024-01-25, 2024-01-27.
+    // With CLOSE ON 2024-01-22, only the 2024-01-15 and 2024-01-20 txns remain
+    // (2 postings each = 4 rows). The 2024-01-22 txn must be excluded.
+    let directives = make_test_directives();
+    let result = execute_query("SELECT date FROM CLOSE ON 2024-01-22", &directives);
+    assert_eq!(
+        result.len(),
+        4,
+        "expected 4 rows (txns before 2024-01-22, 2 postings each); got {}",
+        result.len()
+    );
+    let boundary = date(2024, 1, 22);
+    for row in &result.rows {
+        if let Value::Date(d) = &row[0] {
+            assert!(
+                *d < boundary,
+                "row at {d} violates exclusive close: should be < {boundary}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_close_on_first_txn_date_yields_empty() {
+    // Boundary case from issue #935: CLOSE ON the very first transaction date
+    // should return zero rows (everything is >= the close date and thus excluded).
+    let directives = make_test_directives();
+    let result = execute_query("SELECT date FROM CLOSE ON 2024-01-15", &directives);
+    assert!(
+        result.is_empty(),
+        "expected no rows for CLOSE ON the earliest txn date; got {}",
+        result.len()
+    );
+}
+
+#[test]
 fn test_execute_balances_with_where() {
     let directives = make_test_directives();
     let query = parse("BALANCES WHERE account ~ 'Assets:'").expect("should parse");


### PR DESCRIPTION
## Summary

`bean-query` treats `FROM CLOSE ON D` as **exclusive** — the books are closed AT D, so a transaction stamped exactly on D is not part of the closing period. rustledger was off by one (used `>` instead of `>=` in `executor/mod.rs`), leaving `txn.date == close_date` rows in the result. That produced the inclusive (≤ D) behavior reported in #935.

Combined with `OPEN ON D`, which is already inclusive of D, the intended period bound is now `[open, close)`, matching bean-query.

## Reproducing

From #935:
```text
2020-01-01 open Assets:Checking USD
2020-06-01 * "On the close date"
  Assets:Checking  -10 USD
  Expenses:Food     10 USD
```
- **Before:** `SELECT date FROM CLOSE ON 2020-06-01` returned the 2020-06-01 row.
- **After:** returns zero rows (matches `bean-query`).

## Changes

- `crates/rustledger-query/src/executor/mod.rs` — flip `>` to `>=` in the close-on filter, plus a comment explaining the `[open, close)` convention.
- `crates/rustledger-query/tests/bql_integration_test.rs` — add two boundary tests:
  1. `test_close_on_is_exclusive` — asserts no row in the result has `date == close_date`.
  2. `test_close_on_first_txn_date_yields_empty` — asserts `CLOSE ON` the earliest transaction date returns zero rows (the case from the bug report).

## Test plan

- [x] `cargo test -p rustledger-query --test bql_integration_test test_close_on` — both new tests pass on this branch
- [ ] Verify CI compatibility-test against bean-query Check/BQL gets a higher score (or stays the same with no regressions)

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)