### PR TITLE
chore(loader): silence three rustc 1.95 clippy errors

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -509,6 +509,15 @@ pub fn run_plugins(
                     .unwrap_or("")
                     .to_lowercase();
 
+                // The closure is only invoked from inside the wasm-plugins /
+                // python-plugins cfg blocks below. When neither feature is
+                // enabled, `cargo clippy --no-default-features` flags it as
+                // unused; allow that without underscore-prefixing (which would
+                // trip `no_effect_underscore_binding` since we DO call it).
+                #[cfg_attr(
+                    not(any(feature = "wasm-plugins", feature = "python-plugins")),
+                    allow(unused_variables)
+                )]
                 let resolve_path = |name: &str| -> Result<std::path::PathBuf, String> {
                     let p = std::path::Path::new(name);
                     let resolved = if p.is_absolute() {
@@ -567,8 +576,7 @@ pub fn run_plugins(
                             LedgerError::error(
                                 "PLUGIN",
                                 format!(
-                                    "WASM plugin '{}' requires the wasm-plugins feature",
-                                    raw_name
+                                    "WASM plugin '{raw_name}' requires the wasm-plugins feature",
                                 ),
                             )
                             .with_phase("plugin"),
@@ -614,8 +622,7 @@ pub fn run_plugins(
                             LedgerError::error(
                                 "E8005",
                                 format!(
-                                    "Python plugin \"{}\" requires python-plugin-wasm feature",
-                                    raw_name
+                                    "Python plugin \"{raw_name}\" requires python-plugin-wasm feature",
                                 ),
                             )
                             .with_phase("plugin"),

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -510,10 +510,14 @@ pub fn run_plugins(
                     .to_lowercase();
 
                 // The closure is only invoked from inside the wasm-plugins /
-                // python-plugins cfg blocks below. When neither feature is
-                // enabled, `cargo clippy --no-default-features` flags it as
-                // unused; allow that without underscore-prefixing (which would
-                // trip `no_effect_underscore_binding` since we DO call it).
+                // python-plugins cfg blocks below. The whole function is
+                // already `#[cfg(feature = "plugins")]`, so this only matters
+                // when `plugins` is enabled but neither child feature is
+                // (e.g. `--features native-plugins`). Allow `unused_variables`
+                // for exactly that configuration. Underscore-prefixing the
+                // binding would have been the wrong fix because we DO call
+                // the closure in builds with one of the features enabled,
+                // which would trip `no_effect_underscore_binding` instead.
                 #[cfg_attr(
                     not(any(feature = "wasm-plugins", feature = "python-plugins")),
                     allow(unused_variables)
@@ -622,7 +626,7 @@ pub fn run_plugins(
                             LedgerError::error(
                                 "E8005",
                                 format!(
-                                    "Python plugin \"{raw_name}\" requires python-plugin-wasm feature",
+                                    "Python plugin \"{raw_name}\" requires the python-plugins feature",
                                 ),
                             )
                             .with_phase("plugin"),


### PR DESCRIPTION
## Summary

Fix three clippy errors in `crates/rustledger-loader/src/process.rs` that the rustc 1.95 toolchain bump promoted from warnings into hard errors. CI's `cargo clippy --all-features --all-targets -- -D warnings` step has been red on every PR since.

## Changes

| Line | Lint | Fix |
|---|---|---|
| 569 | `uninlined_format_args` | Inline `raw_name` into format string |
| 616 | `uninlined_format_args` | Inline `raw_name` into format string |
| 512 | `unused_variables` | `#[cfg_attr(not(any(feature = "wasm-plugins", feature = "python-plugins")), allow(unused_variables))]` on the `resolve_path` closure binding. Underscore-prefix would have tripped `no_effect_underscore_binding` because the closure IS called from inside the gated blocks. |

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` (the exact CI invocation): clean
- `cargo clippy -p rustledger-loader --all-targets -- -D warnings`: clean

Once this lands, the open PRs (#937, #940, #942) should stop seeing red Clippy checks unrelated to their content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)