### PR TITLE
fix(query): parse whole-number literals as Integer (closes #938)

### DIFF
--- a/crates/rustledger-query/src/executor/functions/account.rs
+++ b/crates/rustledger-query/src/executor/functions/account.rs
@@ -161,14 +161,22 @@ impl Executor<'_> {
 
         let val = self.evaluate_expr(&func.args[0], ctx)?;
         let n = if func.args.len() == 2 {
-            match self.evaluate_expr(&func.args[1], ctx)? {
-                Value::Integer(i) => i as usize,
+            let raw = match self.evaluate_expr(&func.args[1], ctx)? {
+                Value::Integer(i) => i,
                 _ => {
                     return Err(QueryError::Type(
                         "ROOT second arg must be integer".to_string(),
                     ));
                 }
-            }
+            };
+            // Reject negatives explicitly — without this guard, `i as usize`
+            // would silently turn -1 into `usize::MAX` and the slice below
+            // would always return the whole account string.
+            usize::try_from(raw).map_err(|_| {
+                QueryError::Type(format!(
+                    "ROOT second arg must be a non-negative integer, got {raw}"
+                ))
+            })?
         } else {
             1
         };

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -126,6 +126,11 @@ impl Executor<'_> {
                         let adjusted = if is_credit_normal { -n } else { n };
                         Ok(Value::Number(adjusted))
                     }
+                    Value::Integer(i) => {
+                        let n = Decimal::from(i);
+                        let adjusted = if is_credit_normal { -n } else { n };
+                        Ok(Value::Number(adjusted))
+                    }
                     Value::Null => Ok(Value::Null),
                     _ => Err(QueryError::Type(
                         "POSSIGN expects (amount, account_string)".to_string(),

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -208,7 +208,8 @@ impl Executor<'_> {
                 }
             }
             Expr::Literal(Literal::Number(n)) => {
-                // Numbers are parsed as Decimal - convert to integer index
+                // Defensive: literal whole numbers parse as Integer (issue #938),
+                // so this arm is only reachable for fractional literals like `1.0`.
                 use rust_decimal::prelude::ToPrimitive;
                 let idx = n.to_usize().unwrap_or(0).saturating_sub(1);
                 if idx < result.columns.len() {

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -860,8 +860,8 @@ fn literal<'a>() -> impl Parser<'a, ParserInput<'a>, Literal, ParserExtra<'a>> +
         kw("NULL").to(Literal::Null),
         // Date literal (must be before number to avoid parsing year as number)
         date_literal().map(Literal::Date),
-        // Number
-        decimal().map(Literal::Number),
+        // Number — Integer if no decimal point, Number otherwise
+        number_literal(),
         // String
         string_literal().map(Literal::String),
     ))
@@ -930,8 +930,14 @@ fn date_literal<'a>() -> impl Parser<'a, ParserInput<'a>, NaiveDate, ParserExtra
         })
 }
 
-/// Parse a decimal number.
-fn decimal<'a>() -> impl Parser<'a, ParserInput<'a>, Decimal, ParserExtra<'a>> + Clone {
+/// Parse a numeric literal as either `Literal::Integer` (no decimal point) or
+/// `Literal::Number` (has a decimal point, or whole-number value exceeds i64).
+///
+/// Distinguishing integer from decimal at the parser level matches BQL/SQL
+/// semantics and lets functions that strictly require integer arguments
+/// (e.g. `ROOT(account, n)`, `SUBSTR(s, start, len)`) work with literal
+/// arguments. See issue #938.
+fn number_literal<'a>() -> impl Parser<'a, ParserInput<'a>, Literal, ParserExtra<'a>> + Clone {
     just('-')
         .or_not()
         .then(digits())
@@ -943,11 +949,22 @@ fn decimal<'a>() -> impl Parser<'a, ParserInput<'a>, Decimal, ParserExtra<'a>> +
                     s.push('-');
                 }
                 s.push_str(int_part);
-                if let Some((_, frac)) = frac_part {
-                    s.push('.');
-                    s.push_str(frac);
+                match frac_part {
+                    None => match s.parse::<i64>() {
+                        Ok(i) => Ok(Literal::Integer(i)),
+                        // Whole-number value out of i64 range — fall back to Decimal.
+                        Err(_) => Decimal::from_str(&s)
+                            .map(Literal::Number)
+                            .map_err(|_| Rich::custom(span, "invalid number")),
+                    },
+                    Some((_, frac)) => {
+                        s.push('.');
+                        s.push_str(frac);
+                        Decimal::from_str(&s)
+                            .map(Literal::Number)
+                            .map_err(|_| Rich::custom(span, "invalid number"))
+                    }
                 }
-                Decimal::from_str(&s).map_err(|_| Rich::custom(span, "invalid number"))
             },
         )
 }
@@ -1198,8 +1215,8 @@ mod tests {
         match query {
             Query::Select(sel) => match sel.where_clause.unwrap() {
                 Expr::BinaryOp(op) => match op.right {
-                    Expr::Literal(Literal::Number(n)) => {
-                        assert_eq!(n, dec!(2024));
+                    Expr::Literal(Literal::Integer(n)) => {
+                        assert_eq!(n, 2024);
                     }
                     _ => panic!("Expected number literal"),
                 },
@@ -1207,6 +1224,45 @@ mod tests {
             },
             _ => panic!("Expected SELECT query"),
         }
+    }
+
+    #[test]
+    fn test_integer_vs_decimal_literal() {
+        // Whole-number literal → Integer
+        let q = parse("SELECT * WHERE x = 42").unwrap();
+        let Query::Select(sel) = q else {
+            panic!("expected SELECT");
+        };
+        let Expr::BinaryOp(op) = sel.where_clause.unwrap() else {
+            panic!("expected binary op");
+        };
+        assert!(matches!(op.right, Expr::Literal(Literal::Integer(42))));
+
+        // Literal with decimal point → Number, even when whole-valued
+        let q = parse("SELECT * WHERE x = 42.0").unwrap();
+        let Query::Select(sel) = q else {
+            panic!("expected SELECT");
+        };
+        let Expr::BinaryOp(op) = sel.where_clause.unwrap() else {
+            panic!("expected binary op");
+        };
+        match op.right {
+            Expr::Literal(Literal::Number(n)) => assert_eq!(n, dec!(42.0)),
+            other => panic!("expected Number literal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_integer_overflow_falls_back_to_number() {
+        // i64::MAX is 9_223_372_036_854_775_807 — this exceeds it
+        let q = parse("SELECT * WHERE x = 99999999999999999999").unwrap();
+        let Query::Select(sel) = q else {
+            panic!("expected SELECT");
+        };
+        let Expr::BinaryOp(op) = sel.where_clause.unwrap() else {
+            panic!("expected binary op");
+        };
+        assert!(matches!(op.right, Expr::Literal(Literal::Number(_))));
     }
 
     #[test]
@@ -1422,8 +1478,8 @@ mod tests {
             Query::Select(sel) => match sel.where_clause.unwrap() {
                 Expr::Between { value, low, high } => {
                     assert!(matches!(*value, Expr::Column(c) if c == "year"));
-                    assert!(matches!(*low, Expr::Literal(Literal::Number(_))));
-                    assert!(matches!(*high, Expr::Literal(Literal::Number(_))));
+                    assert!(matches!(*low, Expr::Literal(Literal::Integer(_))));
+                    assert!(matches!(*high, Expr::Literal(Literal::Integer(_))));
                 }
                 _ => panic!("Expected BETWEEN"),
             },

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -1210,7 +1210,7 @@ mod tests {
     }
 
     #[test]
-    fn test_number_literal() {
+    fn test_integer_literal_parsing() {
         let query = parse("SELECT * WHERE year = 2024").unwrap();
         match query {
             Query::Select(sel) => match sel.where_clause.unwrap() {
@@ -1218,7 +1218,7 @@ mod tests {
                     Expr::Literal(Literal::Integer(n)) => {
                         assert_eq!(n, 2024);
                     }
-                    _ => panic!("Expected number literal"),
+                    _ => panic!("Expected integer literal"),
                 },
                 _ => panic!("Expected binary op"),
             },
@@ -1263,6 +1263,28 @@ mod tests {
             panic!("expected binary op");
         };
         assert!(matches!(op.right, Expr::Literal(Literal::Number(_))));
+    }
+
+    #[test]
+    fn test_negative_integer_literal() {
+        // Negative integer literals: the expression-level unary-minus rule
+        // strips the `-` before the literal parser runs, so `-42` becomes
+        // `Unary(Neg, Integer(42))` rather than `Integer(-42)`. Both forms
+        // evaluate to `Value::Integer(-42)`.
+        let q = parse("SELECT * WHERE x = -42").unwrap();
+        let Query::Select(sel) = q else {
+            panic!("expected SELECT");
+        };
+        let Expr::BinaryOp(op) = sel.where_clause.unwrap() else {
+            panic!("expected binary op");
+        };
+        match op.right {
+            Expr::UnaryOp(unary) => {
+                assert_eq!(unary.op, UnaryOperator::Neg);
+                assert!(matches!(unary.operand, Expr::Literal(Literal::Integer(42))));
+            }
+            other => panic!("expected Unary(Neg, Integer(42)), got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -930,8 +930,8 @@ fn date_literal<'a>() -> impl Parser<'a, ParserInput<'a>, NaiveDate, ParserExtra
         })
 }
 
-/// Parse a numeric literal as either `Literal::Integer` (no decimal point) or
-/// `Literal::Number` (has a decimal point, or whole-number value exceeds i64).
+/// Parse a numeric literal as either `Literal::Integer` (no fractional part) or
+/// `Literal::Number` (has a fractional part, or whole-number value exceeds i64).
 ///
 /// Distinguishing integer from decimal at the parser level matches BQL/SQL
 /// semantics and lets functions that strictly require integer arguments

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -480,6 +480,24 @@ fn test_root_with_segment_count() {
     assert!(roots.contains("Income:Salary"));
 }
 
+/// Regression test for POSSIGN with literal integer arguments. Before the
+/// #938 fix, `POSSIGN(100, 'Income:Salary')` reached only the `Value::Number`
+/// arm because literals were always parsed as Number. After the fix, the
+/// arg becomes `Value::Integer(100)` and would have failed without the
+/// matching arm added in `eval_possign`.
+#[test]
+fn test_possign_with_integer_literal_arg() {
+    let directives = make_test_directives();
+
+    // Income (credit-normal) → sign is negated
+    let result = execute_query("SELECT POSSIGN(100, 'Income:Salary')", &directives);
+    assert!(matches!(result.rows[0][0], Value::Number(n) if n == dec!(-100)));
+
+    // Assets (debit-normal) → sign preserved
+    let result = execute_query("SELECT POSSIGN(100, 'Assets:Bank:Checking')", &directives);
+    assert!(matches!(result.rows[0][0], Value::Number(n) if n == dec!(100)));
+}
+
 /// Side-effect of the #938 fix: SUBSTR previously could not be invoked with
 /// literal integer arguments because `(String, Integer, Integer)` arms in
 /// `eval_substr` were unreachable when literals only produced `Number`.

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -480,6 +480,25 @@ fn test_root_with_segment_count() {
     assert!(roots.contains("Income:Salary"));
 }
 
+/// Follow-up to #938: now that whole-number literals reach integer-only paths,
+/// `ROOT(account, -1)` would previously cast `-1i64 as usize` to `usize::MAX`
+/// and silently return the full account string. The fix in `eval_root` rejects
+/// negatives with a typed error.
+#[test]
+fn test_root_rejects_negative_segment_count() {
+    let directives = make_test_directives();
+    let query = parse("SELECT ROOT(account, -1)").expect("query should parse");
+    let mut executor = Executor::new(&directives);
+    let err = executor
+        .execute(&query)
+        .expect_err("ROOT with negative segment count should error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("non-negative"),
+        "error should mention non-negative, got: {msg}"
+    );
+}
+
 /// Regression test for POSSIGN with literal integer arguments. Before the
 /// #938 fix, `POSSIGN(100, 'Income:Salary')` reached only the `Value::Number`
 /// arm because literals were always parsed as Number. After the fix, the

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -452,6 +452,58 @@ fn test_execute_account_functions() {
     assert_eq!(result.columns.len(), 3);
 }
 
+/// Regression test for issue #938: `ROOT(account, n)` was rejecting integer
+/// literals because the parser produced `Value::Number(Decimal)` for all
+/// numeric literals, while `eval_root` strictly required `Value::Integer`.
+/// Fixed by teaching the parser to emit `Literal::Integer` for whole-number
+/// literals.
+#[test]
+fn test_root_with_segment_count() {
+    let directives = make_test_directives();
+    let result = execute_query("SELECT DISTINCT ROOT(account, 2)", &directives);
+
+    assert_eq!(result.columns.len(), 1);
+    let roots: std::collections::HashSet<String> = result
+        .rows
+        .iter()
+        .filter_map(|row| match &row[0] {
+            Value::String(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+
+    // Test fixture has Assets:Bank:{Checking,Savings}, Expenses:{Food,Transport},
+    // Income:Salary. ROOT(_, 2) keeps the first two segments.
+    assert!(roots.contains("Assets:Bank"));
+    assert!(roots.contains("Expenses:Food"));
+    assert!(roots.contains("Expenses:Transport"));
+    assert!(roots.contains("Income:Salary"));
+}
+
+/// Side-effect of the #938 fix: SUBSTR previously could not be invoked with
+/// literal integer arguments because `(String, Integer, Integer)` arms in
+/// `eval_substr` were unreachable when literals only produced `Number`.
+#[test]
+fn test_substr_with_integer_literal_args() {
+    let directives = make_test_directives();
+    let result = execute_query("SELECT DISTINCT SUBSTR(account, 0, 6)", &directives);
+
+    let prefixes: std::collections::HashSet<String> = result
+        .rows
+        .iter()
+        .filter_map(|row| match &row[0] {
+            Value::String(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+
+    // Account names like "Assets:Bank:Checking" → first 6 chars "Assets",
+    // "Expenses:Food" → "Expens", "Income:Salary" → "Income".
+    assert!(prefixes.contains("Assets"));
+    assert!(prefixes.contains("Expens"));
+    assert!(prefixes.contains("Income"));
+}
+
 // ============================================================================
 // JOURNAL Query Tests
 // ============================================================================
@@ -1200,10 +1252,10 @@ fn test_insert_values() {
 
     assert_eq!(result.rows.len(), 2);
     assert_eq!(result.rows[0][0], Value::String("Checking".to_string()));
-    // Numbers are parsed as Decimal (Number type)
-    assert_eq!(result.rows[0][1], Value::Number(dec!(100)));
+    // Whole-number literals parse as Integer (see issue #938).
+    assert_eq!(result.rows[0][1], Value::Integer(100));
     assert_eq!(result.rows[1][0], Value::String("Savings".to_string()));
-    assert_eq!(result.rows[1][1], Value::Number(dec!(500)));
+    assert_eq!(result.rows[1][1], Value::Integer(500));
 }
 
 #[test]
@@ -1279,10 +1331,10 @@ fn test_select_from_table_with_order_limit() {
     let result = executor.execute(&select_query).expect("should execute");
 
     assert_eq!(result.rows.len(), 3);
-    // Numbers are parsed as Decimal (Number type)
-    assert_eq!(result.rows[0][0], Value::Number(dec!(5)));
-    assert_eq!(result.rows[1][0], Value::Number(dec!(4)));
-    assert_eq!(result.rows[2][0], Value::Number(dec!(3)));
+    // Whole-number literals parse as Integer (see issue #938).
+    assert_eq!(result.rows[0][0], Value::Integer(5));
+    assert_eq!(result.rows[1][0], Value::Integer(4));
+    assert_eq!(result.rows[2][0], Value::Integer(3));
 }
 
 #[test]
@@ -1585,8 +1637,8 @@ fn test_select_from_table_filter() {
         .expect("should execute");
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result.rows[0][0], Value::Number(dec!(10)));
-    assert_eq!(result.rows[1][0], Value::Number(dec!(20)));
+    assert_eq!(result.rows[0][0], Value::Integer(10));
+    assert_eq!(result.rows[1][0], Value::Integer(20));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes issue #938 — `ROOT(account, n)` always failed with `type error: ROOT second arg must be integer`.

The root cause runs deeper than ROOT: the BQL parser produced `Literal::Number(Decimal)` for **every** numeric literal, leaving `Literal::Integer` as a dead variant. Any function whose type check strictly required `Value::Integer` was therefore unreachable from a user query — `ROOT(_, n)`, `SUBSTR(s, start, len)`, the `(Integer, Integer)` arm of `IDIV`, etc.

## Fix

- `parser.rs`: replace `decimal()` with `number_literal()`, which branches on the presence of a decimal point. Whole-number literals → `Literal::Integer(i64)`; literals with a fractional part → `Literal::Number(Decimal)`. Whole-number literals exceeding i64 range fall back to `Number` so we don't reject large constants.
- `executor/functions/position.rs`: add the missing `Value::Integer` arm to `POSSIGN`. With the parser fix, `POSSIGN(100, 'Income:Salary')` now reaches code that previously couldn't be exercised by literals.

Existing arithmetic, comparison, sort, aggregation, and `to_bool` paths in `operators.rs` already handle Integer/Number cross-coercion both directions, so no other sites need changes.

## Wire-format impact

The CLI's `--json` output and the WASM playground's `CellValue` serialization distinguish `Number` (emitted as JSON string, e.g. `"100"`) from `Integer` (emitted as JSON number, e.g. `100`). Queries that previously returned a numeric literal — or selected from a `CREATE TABLE` populated with literal integers — will now emit JSON numbers instead of strings. Text output (`format_value`) is unchanged because `Number(100).normalize()` and `Integer(100)` both stringify to `"100"`. This brings the JSON output in line with what consumers naturally expect for integer values.

## Tests

- New parser tests: `test_integer_vs_decimal_literal` (verifies `42` → Integer, `42.0` → Number), `test_integer_overflow_falls_back_to_number`, `test_negative_integer_literal` (documents the unary-minus interaction).
- New integration tests: `test_root_with_segment_count` (the #938 reproducer), `test_substr_with_integer_literal_args` (secondary fix), `test_possign_with_integer_literal_arg` (regression for the POSSIGN arm).
- Renamed `test_number_literal` → `test_integer_literal_parsing` to match what it asserts now.
- Updated 3 existing integration tests (`test_insert_values`, `test_select_from_table_with_order_limit`, `test_select_from_table_filter`) and 1 existing parser test (`test_between`) that were asserting the old (buggy) `Value::Number` behavior.

## Verification

- `cargo test -p rustledger-query`: 487 tests pass
- `cargo test -p rustledger-lsp -p rustledger -p rustledger-loader -p rustledger-importer`: all green (372 + 128 + 226)
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

## Test plan

- [ ] CI: Clippy, Test, Doctests, Compatibility tests
- [ ] Verify `SELECT ROOT(account, 2) FROM bean-example.beancount` returns shortened account names
- [ ] Verify `SUBSTR` with literal int args works in the playground
- [ ] Verify any external scripts consuming `rledger query --json` still parse correctly given the Number→Integer wire-format change for integer literals

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)