### PR TITLE
docs: distinguish meta() from entry_meta()/any_meta() (closes #946)

### DIFF
--- a/docs/guides/budgeting.md
+++ b/docs/guides/budgeting.md
@@ -197,10 +197,15 @@ Query by budget category:
 ```bash
 rledger query ledger.beancount "
   SELECT sum(cost(position))
-  WHERE meta('budget-category') = 'food'
+  WHERE entry_meta('budget-category') = 'food'
     AND month(date) = 1 AND year(date) = 2024
 "
 ```
+
+> **Note:** Use `entry_meta(...)` (or `any_meta(...)`) when the metadata is on the
+> transaction header. The `meta(...)` function only inspects metadata attached
+> directly to a posting — see [BQL → Metadata functions](../reference/bql.md#metadata-functions)
+> for the full distinction.
 
 ## Monthly Budget Review
 

--- a/docs/reference/bql.md
+++ b/docs/reference/bql.md
@@ -189,6 +189,48 @@ SELECT min(date), max(date)
 | `leaf(account)` | Last account segment |
 | `parent(account)` | All but last segment |
 
+### Metadata Functions
+
+Beancount metadata can live on a **transaction** (the line under the header,
+before any postings) or on a **posting** (indented one level deeper than the
+posting itself). BQL exposes three lookup functions because the distinction
+matters at query time:
+
+| Function | Looks at | Use when |
+|----------|----------|----------|
+| `meta(key)` | Posting metadata only | The key is set per-posting (e.g. a `lot-id` on one leg of a transfer) |
+| `entry_meta(key)` | Transaction metadata only | The key is set on the transaction header (e.g. a `budget-category` shared by every posting) |
+| `any_meta(key)` | Posting first, then transaction | You don't know or don't care which level it's set on |
+
+All three return `NULL` when the key is absent at the relevant level — so a
+`WHERE meta('foo') = 'bar'` filter quietly drops every row when `foo` was
+actually set on the transaction.
+
+```beancount
+2024-01-15 * "Grocery Store"
+  budget-category: "food"          ; on the transaction
+  Expenses:Food:Groceries  85.00 USD
+    receipt-id: "R-12345"          ; on this posting only
+  Assets:Bank:Checking
+```
+
+```sql
+-- Doesn't match: budget-category is on the transaction, not the posting.
+SELECT account WHERE meta('budget-category') = 'food'
+
+-- Matches every posting in the transaction.
+SELECT account WHERE entry_meta('budget-category') = 'food'
+
+-- Matches whichever level happens to carry the key.
+SELECT account WHERE any_meta('budget-category') = 'food'
+
+-- Matches only the Expenses posting, since receipt-id is per-posting.
+SELECT account WHERE meta('receipt-id') = 'R-12345'
+```
+
+This mirrors Python `bean-query`'s `meta` / `entry_meta` / `any_meta`
+exactly, so queries are portable between the two engines.
+
 ### Examples
 
 ```sql


### PR DESCRIPTION
## Summary

Issue #946 reports that:

\`\`\`
beanquery> select * where meta('ticker') = 'VRP'
0 row(s)
\`\`\`

returns nothing for a transaction with \`ticker: \"VRP\"\` in its header. The behavior is **correct** — \`meta()\` looks at posting metadata only, exactly like Python \`bean-query\` — but our own [budgeting guide](docs/guides/budgeting.md) teaches the broken pattern. Anyone following the guide hits this wall.

## Changes

1. **\`docs/guides/budgeting.md\`** — the "Approach 4: Custom Metadata" example switched from \`meta('budget-category')\` to \`entry_meta('budget-category')\`. Added an inline note pointing readers at the BQL reference for the full distinction.
2. **\`docs/reference/bql.md\`** — new "Metadata Functions" subsection under "Scalar Functions" laying out the three-function distinction with a worked side-by-side ledger and four queries showing what matches and what doesn't. Notes that semantics mirror Python bean-query so queries are portable between engines.

## Why a doc-only fix

Changing \`meta()\` to fall back to entry metadata would diverge from Python beanquery, which is rustledger's stated compatibility target (see the \`tests/compatibility/\` suite at 99% match rate). The cost of fixing the docs is trivial; the cost of behavioral divergence is forever.

## Out of scope

\`docs/development/import-roadmap.md:1168\` also uses \`meta()\` against a hypothetical \`SELECT * FROM balance\` syntax, but that table doesn't exist today — that's roadmap/aspirational, not user-facing teaching, so leaving it alone.

## Test plan

- [ ] CI: Docs Validation (VitePress build catches dead links)
- [ ] Manual: visit the budgeting guide on the rendered site, confirm the link to \`#metadata-functions\` resolves
- [ ] Manual: run the corrected query against the example ledger from #946, confirm matching rows

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)