### PR TITLE
feat(price): metadata-driven, active-commodity discovery (closes #948)

### DIFF
--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -449,4 +449,31 @@ mod tests {
         assert!(info.mapping.is_none());
         assert!(info.quote_currency.is_none());
     }
+
+    #[test]
+    fn active_filter_handles_explicit_amounts_on_balance_sheet_side() {
+        // Simulates the post-booking shape: every posting has explicit units,
+        // including the asset side. Confirms the active filter sees the
+        // asset-side amount and includes the commodity. The actual
+        // interpolation happens in the booking engine before this function
+        // sees the directives — `price_cmd.rs` calls `process::load` with
+        // booking enabled to ensure that.
+        let dirs = directives(vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(100), "AAPL"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-100), "AAPL"),
+                    )),
+            ),
+        ]);
+        let active = active_commodities(&dirs, &Options::new());
+        assert!(active.contains("AAPL"));
+    }
 }

--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -1,0 +1,452 @@
+//! Symbol discovery from beancount files.
+//!
+//! Walks a loaded ledger to identify which commodities to fetch prices for,
+//! matching the workflow `bean-price` exposes via the same metadata
+//! conventions:
+//!
+//! - `commodity` directives carrying a `price:` metadata key drive
+//!   metadata-based discovery. Format: `"<quote>:<source>/<ticker>"`,
+//!   optionally chained with `,` for fallback alternatives, e.g.
+//!   `"USD:yahoo/AAPL,USD:google/NASDAQ:AAPL"`.
+//! - `quote_currency:` metadata supplies a per-commodity quote currency,
+//!   used as the `--currency` default for that one symbol.
+//! - With no metadata, ticker-shaped commodity names (uppercase + digits +
+//!   dashes, ≤ 10 chars) are picked up via heuristic so existing users
+//!   aren't broken (issue #948).
+//!
+//! By default, only "active" commodities are returned: those with a non-zero
+//! balance in any open account, computed by walking transaction postings and
+//! summing per-(account, currency). This matches `bean-price`'s default
+//! behavior and avoids wasting API calls on commodities the user no longer
+//! holds. Pass `include_inactive: true` to skip the activity filter.
+
+use crate::config::{CommodityMapping, SourceRef};
+use rust_decimal::Decimal;
+use rustledger_core::{Directive, MetaValue};
+use rustledger_loader::Options;
+use rustledger_parser::Spanned;
+use std::collections::{HashMap, HashSet};
+
+/// What the discovery pass produces for a single commodity symbol.
+#[derive(Debug, Clone, Default)]
+pub struct DiscoveredCommodity {
+    /// Optional source/ticker mapping derived from `price:` metadata.
+    /// `None` means the symbol was found by name heuristic only.
+    pub mapping: Option<CommodityMapping>,
+    /// Optional per-commodity quote currency from `quote_currency:` metadata.
+    pub quote_currency: Option<String>,
+}
+
+/// One parsed entry from a `price:` metadata string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PriceSpec {
+    quote_currency: String,
+    source: String,
+    ticker: String,
+}
+
+/// Discover the set of commodities to fetch prices for from a loaded ledger.
+///
+/// Returns a map from commodity symbol to discovery info. Caller-supplied
+/// CLI symbols are always included (with empty discovery info) so they
+/// override or augment file-based discovery.
+///
+/// Takes the directive slice directly so it works with either `LoadResult`
+/// (raw load) or the post-processing `Ledger` type without coupling. Reads
+/// the configured account-type names from `options` so the
+/// active-commodity check works on ledgers using non-English account
+/// roots (e.g., `Activos:` instead of `Assets:`).
+pub fn discover_symbols(
+    directives: &[Spanned<Directive>],
+    options: &Options,
+    cli_symbols: &[String],
+    include_inactive: bool,
+) -> HashMap<String, DiscoveredCommodity> {
+    let active = if include_inactive {
+        None
+    } else {
+        Some(active_commodities(directives, options))
+    };
+
+    let mut out: HashMap<String, DiscoveredCommodity> = HashMap::new();
+
+    for spanned in directives {
+        let Directive::Commodity(comm) = &spanned.value else {
+            continue;
+        };
+        let symbol = comm.currency.as_str();
+        let info = build_discovery_info(&comm.meta);
+
+        // Skip commodities with no metadata that don't look like a ticker —
+        // preserves backward-compat with the old name-heuristic filter.
+        if info.mapping.is_none() && info.quote_currency.is_none() && !looks_like_ticker(symbol) {
+            continue;
+        }
+
+        // Skip inactive commodities unless the user opted in.
+        if let Some(ref active_set) = active
+            && !active_set.contains(symbol)
+        {
+            continue;
+        }
+
+        out.insert(symbol.to_string(), info);
+    }
+
+    // CLI-supplied symbols always pass through with default (empty) info.
+    for symbol in cli_symbols {
+        out.entry(symbol.clone()).or_default();
+    }
+
+    out
+}
+
+/// Build the per-commodity discovery info from its metadata map.
+fn build_discovery_info(meta: &rustledger_core::Metadata) -> DiscoveredCommodity {
+    let price_specs = meta
+        .get("price")
+        .and_then(metavalue_as_str)
+        .map(parse_price_metadata)
+        .unwrap_or_default();
+
+    let quote_currency = meta.get("quote_currency").and_then(|v| match v {
+        MetaValue::String(s) | MetaValue::Currency(s) => Some(s.clone()),
+        _ => None,
+    });
+
+    let mapping = build_mapping(&price_specs);
+
+    DiscoveredCommodity {
+        mapping,
+        // If `price:` already specified a quote currency, prefer that.
+        quote_currency: price_specs
+            .first()
+            .map(|s| s.quote_currency.clone())
+            .or(quote_currency),
+    }
+}
+
+/// Convert parsed `PriceSpec` entries into the existing `CommodityMapping`
+/// shape so the rest of the price pipeline doesn't need new branches.
+fn build_mapping(specs: &[PriceSpec]) -> Option<CommodityMapping> {
+    if specs.is_empty() {
+        return None;
+    }
+    if specs.len() == 1 {
+        let s = &specs[0];
+        return Some(CommodityMapping::Detailed {
+            source: SourceRef::Single(s.source.clone()),
+            ticker: Some(s.ticker.clone()),
+        });
+    }
+    // Multiple specs: build a fallback chain. The ticker is taken from the
+    // first spec; it's the user's responsibility to ensure ticker symbols
+    // are interchangeable across sources in their `price:` chain (matching
+    // bean-price's contract).
+    let sources: Vec<String> = specs.iter().map(|s| s.source.clone()).collect();
+    Some(CommodityMapping::Detailed {
+        source: SourceRef::Fallback(sources),
+        ticker: Some(specs[0].ticker.clone()),
+    })
+}
+
+/// Parse a `price:` metadata value into one or more specs.
+///
+/// Format: `"<quote>:<source>/<ticker>"`, comma-separated for alternatives.
+/// Malformed entries are silently skipped (matches `bean-price`'s lenient
+/// parsing).
+fn parse_price_metadata(raw: &str) -> Vec<PriceSpec> {
+    raw.split(',')
+        .filter_map(|chunk| {
+            let chunk = chunk.trim();
+            if chunk.is_empty() {
+                return None;
+            }
+            let (quote, rest) = chunk.split_once(':')?;
+            let (source, ticker) = rest.split_once('/')?;
+            let quote = quote.trim();
+            let source = source.trim();
+            let ticker = ticker.trim();
+            if quote.is_empty() || source.is_empty() || ticker.is_empty() {
+                return None;
+            }
+            Some(PriceSpec {
+                quote_currency: quote.to_string(),
+                source: source.to_string(),
+                ticker: ticker.to_string(),
+            })
+        })
+        .collect()
+}
+
+const fn metavalue_as_str(v: &MetaValue) -> Option<&str> {
+    match v {
+        MetaValue::String(s) | MetaValue::Currency(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+/// Heuristic preserved for backward compat: a name is "ticker-shaped" if it's
+/// uppercase ASCII letters / digits / dashes, length ≤ 10.
+fn looks_like_ticker(symbol: &str) -> bool {
+    !symbol.is_empty()
+        && symbol.len() <= 10
+        && symbol
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Compute the set of commodity codes that have a non-zero balance in at
+/// least one open balance-sheet (Assets or Liabilities) account.
+///
+/// Restricting to balance-sheet accounts is the correct definition of
+/// "currently held": Equity accounts (e.g. `Equity:Opening-Balances`)
+/// retain inverse balances of every commodity that ever moved through the
+/// ledger, so including them would mark long-closed positions as active.
+/// Income and Expenses are never holdings.
+///
+/// The "Assets" / "Liabilities" prefix is read from `options` so ledgers
+/// using translated account roots (`Activos`, `Aktiva`, etc.) work too.
+fn active_commodities(directives: &[Spanned<Directive>], options: &Options) -> HashSet<String> {
+    let assets_prefix = format!("{}:", options.name_assets);
+    let liabilities_prefix = format!("{}:", options.name_liabilities);
+    let is_balance_sheet = |account: &str| {
+        account.starts_with(&assets_prefix) || account.starts_with(&liabilities_prefix)
+    };
+
+    let mut balances: HashMap<(String, String), Decimal> = HashMap::new();
+    let mut closed: HashSet<String> = HashSet::new();
+
+    for spanned in directives {
+        match &spanned.value {
+            Directive::Transaction(txn) => {
+                for posting in &txn.postings {
+                    let account = posting.account.as_str();
+                    if !is_balance_sheet(account) {
+                        continue;
+                    }
+                    if let Some(amount) = posting.amount() {
+                        let key = (account.to_string(), amount.currency.to_string());
+                        *balances.entry(key).or_default() += amount.number;
+                    }
+                }
+            }
+            Directive::Close(close) => {
+                closed.insert(close.account.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    let mut active: HashSet<String> = HashSet::new();
+    for ((account, currency), amount) in &balances {
+        if !amount.is_zero() && !closed.contains(account) {
+            active.insert(currency.clone());
+        }
+    }
+    active
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+    use rustledger_core::{Amount, Close, Commodity, NaiveDate, Open, Posting, Transaction};
+    use rustledger_parser::Span;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        rustledger_core::naive_date(y, m, d).unwrap()
+    }
+
+    fn directives(items: Vec<Directive>) -> Vec<Spanned<Directive>> {
+        items
+            .into_iter()
+            .map(|d| Spanned::new(d, Span::new(0, 0)))
+            .collect()
+    }
+
+    #[test]
+    fn parses_single_price_spec() {
+        let specs = parse_price_metadata("USD:yahoo/AAPL");
+        assert_eq!(
+            specs,
+            vec![PriceSpec {
+                quote_currency: "USD".into(),
+                source: "yahoo".into(),
+                ticker: "AAPL".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_chained_price_specs() {
+        let specs = parse_price_metadata("USD:yahoo/AAPL, USD:google/NASDAQ:AAPL");
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].source, "yahoo");
+        assert_eq!(specs[1].source, "google");
+        // Ticker preserves embedded colons after the first / split.
+        assert_eq!(specs[1].ticker, "NASDAQ:AAPL");
+    }
+
+    #[test]
+    fn parse_price_skips_malformed_entries() {
+        let specs = parse_price_metadata("USD:yahoo/AAPL,bogus,EUR:ecb/EUR.USD");
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].quote_currency, "USD");
+        assert_eq!(specs[1].quote_currency, "EUR");
+    }
+
+    #[test]
+    fn ticker_heuristic_rejects_long_or_lowercase() {
+        assert!(looks_like_ticker("AAPL"));
+        assert!(looks_like_ticker("BTC-USD"));
+        assert!(looks_like_ticker("VTI2025"));
+        assert!(!looks_like_ticker("usd"));
+        assert!(!looks_like_ticker("Vanguard"));
+        assert!(!looks_like_ticker("VERYLONGTICKER"));
+        assert!(!looks_like_ticker(""));
+    }
+
+    #[test]
+    fn active_filter_keeps_held_commodities() {
+        // Bought 100 AAPL, never sold = active.
+        // Bought and sold all BTC = inactive.
+        // EUR cash held in Assets:Cash = active.
+        let dirs = directives(vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Commodity(Commodity::new(date(2024, 1, 1), "AAPL")),
+            Directive::Commodity(Commodity::new(date(2024, 1, 1), "BTC")),
+            Directive::Commodity(Commodity::new(date(2024, 1, 1), "EUR")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(100), "AAPL"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-100), "AAPL"),
+                    )),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 3, 1), "Buy BTC")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(1), "BTC"),
+                    ))
+                    .with_posting(Posting::new("Equity:Opening", Amount::new(dec!(-1), "BTC"))),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 4, 1), "Sell BTC")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(-1), "BTC"),
+                    ))
+                    .with_posting(Posting::new("Equity:Opening", Amount::new(dec!(1), "BTC"))),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 5, 1), "Receive EUR")
+                    .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(500), "EUR")))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-500), "EUR"),
+                    )),
+            ),
+        ]);
+        let active = active_commodities(&dirs, &Options::new());
+        assert!(active.contains("AAPL"));
+        assert!(active.contains("EUR"));
+        assert!(
+            !active.contains("BTC"),
+            "BTC was fully sold, should not be active"
+        );
+    }
+
+    #[test]
+    fn closed_account_balance_does_not_count_as_active() {
+        // A balance left over in a closed account is treated as inactive
+        // (the close directive supersedes; any non-zero residual is a
+        // validation problem, not an "active" signal for price fetching).
+        let dirs = directives(vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "Buy stale token")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(10), "DEFUNCT"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-10), "DEFUNCT"),
+                    )),
+            ),
+            Directive::Close(Close::new(date(2024, 12, 31), "Assets:Brokerage")),
+        ]);
+        let active = active_commodities(&dirs, &Options::new());
+        assert!(!active.contains("DEFUNCT"));
+    }
+
+    #[test]
+    fn discover_picks_up_metadata_driven_commodity() {
+        let mut comm = Commodity::new(date(2024, 1, 1), "Vanguard_VTI");
+        comm.meta.insert(
+            "price".to_string(),
+            MetaValue::String("USD:yahoo/VTI".into()),
+        );
+        let dirs = directives(vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Commodity(comm),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "Buy VTI")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(10), "Vanguard_VTI"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-10), "Vanguard_VTI"),
+                    )),
+            ),
+        ]);
+        let discovered = discover_symbols(&dirs, &Options::new(), &[], false);
+
+        // Even though "Vanguard_VTI" doesn't pass the ticker heuristic,
+        // it has price: metadata, so it's discovered.
+        let info = discovered
+            .get("Vanguard_VTI")
+            .expect("should be discovered");
+        assert!(info.mapping.is_some());
+        assert_eq!(info.quote_currency.as_deref(), Some("USD"));
+    }
+
+    #[test]
+    fn discover_skips_inactive_by_default() {
+        let mut comm = Commodity::new(date(2024, 1, 1), "OLD");
+        comm.meta.insert(
+            "price".to_string(),
+            MetaValue::String("USD:yahoo/OLD".into()),
+        );
+        let dirs = directives(vec![Directive::Commodity(comm)]);
+
+        // Default: no active postings means OLD is not discovered.
+        let discovered = discover_symbols(&dirs, &Options::new(), &[], false);
+        assert!(!discovered.contains_key("OLD"));
+
+        // Opt-in: include_inactive=true brings it back.
+        let discovered_all = discover_symbols(&dirs, &Options::new(), &[], true);
+        assert!(discovered_all.contains_key("OLD"));
+    }
+
+    #[test]
+    fn cli_symbols_always_included_with_default_info() {
+        let dirs: Vec<Spanned<Directive>> = vec![];
+        let discovered = discover_symbols(&dirs, &Options::new(), &["MANUAL".to_string()], false);
+        let info = discovered.get("MANUAL").unwrap();
+        assert!(info.mapping.is_none());
+        assert!(info.quote_currency.is_none());
+    }
+}

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -7,6 +7,7 @@
 //! - Fallback chains for reliability
 
 pub mod cache;
+pub mod discovery;
 pub mod external;
 pub mod sources;
 

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -3,6 +3,7 @@
 //! Fetches current prices for commodities from configurable online sources.
 
 use crate::cmd::completions::ShellType;
+use crate::cmd::price::discovery::{DiscoveredCommodity, discover_symbols};
 use crate::cmd::price::sources::PriceSource;
 use crate::cmd::price::{PriceRequest, PriceSourceRegistry};
 use crate::config::{CommodityMapping, PriceConfig};
@@ -80,6 +81,13 @@ pub struct PriceArgs {
     /// Clear the price cache before fetching.
     #[arg(long)]
     clear_cache: bool,
+
+    /// When discovering symbols from `-f`, include commodities that aren't
+    /// currently held (zero balance across all open accounts). The default
+    /// matches `bean-price`: only fetch prices for commodities you actually
+    /// hold.
+    #[arg(long)]
+    all_commodities: bool,
 }
 
 /// Run the price command.
@@ -112,8 +120,6 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         return list_sources(&registry);
     }
 
-    let mut symbols_to_fetch: Vec<String> = args.symbols.clone();
-
     // Build symbol mapping from CLI args
     let mut cli_mapping: HashMap<String, CommodityMapping> = HashMap::new();
     for mapping in &args.mapping {
@@ -122,32 +128,41 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         }
     }
 
-    // If a file is provided, extract commodity symbols
-    if let Some(ref file) = args.file {
+    // Discover symbols from the ledger (if -f given) plus any CLI symbols.
+    // The discovery layer handles `price:` / `quote_currency:` metadata and
+    // the active-commodity filter (issue #948).
+    let discovered: HashMap<String, DiscoveredCommodity> = if let Some(ref file) = args.file {
         let mut loader = Loader::new();
         let ledger = loader.load(file)?;
-
-        // Get commodities that might have ticker symbols
-        for spanned in &ledger.directives {
-            if let rustledger_core::Directive::Commodity(comm) = &spanned.value {
-                let symbol = comm.currency.as_str();
-                // Check if it looks like a ticker symbol (uppercase letters)
-                if symbol
-                    .chars()
-                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
-                    && symbol.len() <= 10
-                    && !symbols_to_fetch.contains(&symbol.to_string())
-                {
-                    symbols_to_fetch.push(symbol.to_string());
-                }
-            }
+        discover_symbols(
+            &ledger.directives,
+            &ledger.options,
+            &args.symbols,
+            args.all_commodities,
+        )
+    } else {
+        let mut out = HashMap::new();
+        for s in &args.symbols {
+            out.insert(s.clone(), DiscoveredCommodity::default());
         }
-    }
+        out
+    };
+
+    // Stable order: alphabetical by symbol so output is deterministic across
+    // runs (the underlying discovery uses a HashMap).
+    let mut symbols_to_fetch: Vec<String> = discovered.keys().cloned().collect();
+    symbols_to_fetch.sort();
 
     if symbols_to_fetch.is_empty() {
         eprintln!(
             "No symbols to fetch. Provide symbols as arguments or use -f with a beancount file."
         );
+        if !args.all_commodities && args.file.is_some() {
+            eprintln!(
+                "Hint: only commodities currently held are fetched by default. \
+                 Pass --all-commodities to include inactive ones."
+            );
+        }
         return Ok(());
     }
 
@@ -171,8 +186,16 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         return run_with_external_command(args, cmd, &symbols_to_fetch, date, price_config);
     }
 
-    // Merge CLI mapping with config mapping (CLI takes precedence)
+    // Merge mappings (highest precedence first):
+    //   1. CLI --mapping
+    //   2. Discovered `price:` metadata from commodity directives (#948)
+    //   3. Config [price.mapping]
     let mut combined_mapping = price_config.mapping.clone();
+    for (symbol, info) in &discovered {
+        if let Some(m) = &info.mapping {
+            combined_mapping.insert(symbol.clone(), m.clone());
+        }
+    }
     for (k, v) in cli_mapping {
         combined_mapping.insert(k, v);
     }
@@ -187,8 +210,15 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         .unwrap_or(price_config.effective_default_source());
 
     for symbol in &symbols_to_fetch {
+        // Per-commodity quote currency from `quote_currency:` (or first
+        // `price:` entry) overrides the global --currency for this symbol.
+        let effective_currency = discovered
+            .get(symbol)
+            .and_then(|d| d.quote_currency.as_deref())
+            .unwrap_or(&args.currency);
+
         // Check cache first
-        let key = cache_key(source_name_for_cache, symbol, &args.currency, date);
+        let key = cache_key(source_name_for_cache, symbol, effective_currency, date);
         if let Some(ref c) = cache
             && let Some(cached) = c.get(&key)
         {
@@ -201,9 +231,9 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
 
         // Fetch from network
         let result = if let Some(source_name) = &args.source {
-            fetch_with_source(&registry, source_name, symbol, &args.currency, date)
+            fetch_with_source(&registry, source_name, symbol, effective_currency, date)
         } else {
-            registry.fetch_price(symbol, &args.currency, date, &combined_mapping)
+            registry.fetch_price(symbol, effective_currency, date, &combined_mapping)
         };
 
         match result {
@@ -211,7 +241,7 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
                 if let Some(ref mut c) = cache {
                     // Use the actual source that responded (may differ from
                     // default due to fallback chains)
-                    let actual_key = cache_key(&response.source, symbol, &args.currency, date);
+                    let actual_key = cache_key(&response.source, symbol, effective_currency, date);
                     c.insert(&actual_key, &response);
                     // Also store under the default source key for fast lookup
                     if actual_key != key {
@@ -444,5 +474,17 @@ mod tests {
         let args = Args::parse_from(["price", "--clear-cache", "--no-cache", "AAPL"]);
         assert!(args.price_args.clear_cache);
         assert!(args.price_args.no_cache);
+    }
+
+    #[test]
+    fn test_price_args_all_commodities_default_off() {
+        let args = Args::parse_from(["price", "AAPL"]);
+        assert!(!args.price_args.all_commodities);
+    }
+
+    #[test]
+    fn test_price_args_all_commodities_flag() {
+        let args = Args::parse_from(["price", "--all-commodities", "-f", "ledger.beancount"]);
+        assert!(args.price_args.all_commodities);
     }
 }

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -10,7 +10,7 @@ use crate::config::{CommodityMapping, PriceConfig};
 use anyhow::{Context, Result};
 use clap::Parser;
 use rustledger_core::NaiveDate;
-use rustledger_loader::Loader;
+use rustledger_loader::LoadOptions;
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -132,8 +132,21 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     // The discovery layer handles `price:` / `quote_currency:` metadata and
     // the active-commodity filter (issue #948).
     let discovered: HashMap<String, DiscoveredCommodity> = if let Some(ref file) = args.file {
-        let mut loader = Loader::new();
-        let ledger = loader.load(file)?;
+        // Load with booking so interpolated postings (units missing in source,
+        // filled in by the booking engine) get explicit amounts. Without this,
+        // the active-commodity check at `discovery::active_commodities` would
+        // miss the held side of any auto-balanced posting and could mark
+        // currently-held commodities as inactive.
+        let opts = LoadOptions {
+            // Skip plugins / validation here: discovery only cares about
+            // booked postings, and plugin/validation failures shouldn't
+            // block fetching prices on an otherwise-loadable file.
+            run_plugins: false,
+            validate: false,
+            ..LoadOptions::default()
+        };
+        let ledger = rustledger_loader::load(file, &opts)
+            .with_context(|| format!("failed to load {} for symbol discovery", file.display()))?;
         discover_symbols(
             &ledger.directives,
             &ledger.options,
@@ -183,13 +196,21 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     // Handle --source-cmd (ad-hoc external command)
     // This is placed after symbol discovery so -f flag works with --source-cmd
     if let Some(cmd) = &args.source_cmd {
-        return run_with_external_command(args, cmd, &symbols_to_fetch, date, price_config);
+        return run_with_external_command(
+            args,
+            cmd,
+            &symbols_to_fetch,
+            date,
+            price_config,
+            &discovered,
+        );
     }
 
-    // Merge mappings (highest precedence first):
-    //   1. CLI --mapping
+    // Merge mappings in increasing precedence (later inserts override earlier
+    // ones via `HashMap::insert`). The effective high-to-low order is:
+    //   1. CLI --mapping (last to insert, wins)
     //   2. Discovered `price:` metadata from commodity directives (#948)
-    //   3. Config [price.mapping]
+    //   3. Config [price.mapping] (first to insert, lowest precedence)
     let mut combined_mapping = price_config.mapping.clone();
     for (symbol, info) in &discovered {
         if let Some(m) = &info.mapping {
@@ -316,6 +337,7 @@ fn run_with_external_command(
     symbols: &[String],
     date: Option<NaiveDate>,
     price_config: &PriceConfig,
+    discovered: &HashMap<String, DiscoveredCommodity>,
 ) -> Result<()> {
     use crate::cmd::price::external::ExternalCommandSource;
 
@@ -335,9 +357,15 @@ fn run_with_external_command(
     let mut handle = stdout.lock();
 
     for symbol in symbols {
+        // Honor per-commodity quote_currency / price: metadata for --source-cmd
+        // too, matching the network-fetch path.
+        let effective_currency = discovered
+            .get(symbol)
+            .and_then(|d| d.quote_currency.as_deref())
+            .unwrap_or(&args.currency);
         let request = PriceRequest {
             ticker: symbol.clone(),
-            currency: args.currency.clone(),
+            currency: effective_currency.to_string(),
             date,
         };
 

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -71,7 +71,7 @@ This sets the quote currency for `GOVT_EU` only, falling back to `--currency` fo
 
 ### 3. Active-only filtering
 
-By default, only commodities you currently **hold** are fetched. A commodity is considered active if at least one open account ends with a non-zero balance in that currency, computed by summing per-(account, currency) over every transaction posting and excluding accounts that have a `close` directive.
+By default, only commodities you currently **hold** are fetched. A commodity is considered active if at least one open *balance-sheet* account (Assets or Liabilities, using the configured `name_assets` / `name_liabilities` options for non-English ledgers) ends with a non-zero balance in that currency. Equity, Income, and Expenses accounts are excluded from the check; including them would mark every commodity that ever moved through `Equity:Opening-Balances` as active even after the position was fully closed. Closed accounts (those with a `close` directive) are also excluded.
 
 Pass `--all-commodities` to disable the filter and fetch prices for everything declared in the file (matching the pre-#948 behavior).
 

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -22,17 +22,76 @@ rledger price [OPTIONS] [SYMBOL]...
 
 | Option | Description |
 |--------|-------------|
-| `-f, --file <FILE>` | Beancount file to read commodities from |
+| `-f, --file <FILE>` | Beancount file to discover commodities from |
 | `-c, --currency <CURRENCY>` | Base currency for price quotes [default: USD] |
 | `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today) |
 | `-b, --beancount` | Output as beancount price directives |
 | `-s, --source <SOURCE>` | Use specific source (overrides mapping) |
 | `--source-cmd <CMD>` | Use ad-hoc external command as source |
 | `-m, --mapping <MAPPING>` | Symbol mapping (e.g., `VTI:VTI,BTC:BTC-USD`) |
+| `--all-commodities` | Include commodities not currently held (default: only active) |
 | `--list-sources` | List configured sources and exit |
 | `--no-cache` | Disable the price cache for this run |
 | `--clear-cache` | Clear the price cache before fetching |
 | `-v, --verbose` | Show verbose output |
+
+## Discovering Symbols from a Ledger
+
+`-f / --file` extracts the list of commodities to fetch from a beancount file, so you don't have to maintain a separate symbol list. Three things determine what gets discovered, all matching `bean-price` semantics (issue #948):
+
+### 1. `price:` metadata on `commodity` directives
+
+Annotate a commodity with how to fetch its price. The format is `<quote-currency>:<source>/<ticker>`, optionally chained with `,` for fallback:
+
+```beancount
+2024-01-01 commodity AAPL
+  price: "USD:yahoo/AAPL"
+
+2024-01-01 commodity Vanguard_VTI
+  price: "USD:yahoo/VTI,USD:google/NYSEARCA:VTI"
+
+2024-01-01 commodity AUD
+  price: "EUR:ecb/AUD-EUR"
+```
+
+The first source in the chain is tried first; subsequent ones act as fallbacks. The quote currency in the metadata overrides the global `--currency` for that one symbol, so you can mix USD-quoted stocks and EUR-quoted bonds in the same run.
+
+Commodities that don't have `price:` metadata fall back to a name heuristic: ticker-shaped names (uppercase letters, digits, dashes; ≤ 10 chars) are still picked up, preserving the previous behavior.
+
+### 2. `quote_currency:` metadata
+
+If you don't use `price:` but want a per-commodity quote currency:
+
+```beancount
+2024-01-01 commodity GOVT_EU
+  quote_currency: "EUR"
+```
+
+This sets the quote currency for `GOVT_EU` only, falling back to `--currency` for everything else.
+
+### 3. Active-only filtering
+
+By default, only commodities you currently **hold** are fetched. A commodity is considered active if at least one open account ends with a non-zero balance in that currency, computed by summing per-(account, currency) over every transaction posting and excluding accounts that have a `close` directive.
+
+Pass `--all-commodities` to disable the filter and fetch prices for everything declared in the file (matching the pre-#948 behavior).
+
+```bash
+# Default: only commodities you actually hold
+rledger price -f main.beancount
+
+# Include declared-but-unheld commodities
+rledger price -f main.beancount --all-commodities
+```
+
+### Precedence for source/ticker resolution
+
+When multiple configurations apply to the same symbol, the order from highest to lowest precedence is:
+
+1. CLI `--mapping` (per-symbol overrides on the command line)
+2. CLI `--source` (forces source for every symbol in the run)
+3. `price:` metadata on the commodity directive
+4. Config-file `[price.mapping]` entries
+5. Default source from `[price.default_source]` (or `yahoo`)
 
 ## Price Caching
 


### PR DESCRIPTION
## Summary

Issue #948 asks for `bean-price`-style symbol discovery: read the ledger, fetch prices for the commodities you actually hold, and use per-commodity `price:` metadata to drive source/ticker selection. Today's `-f` flag picks every commodity that looks ticker-shaped, so users with holdings named `Vanguard_VTI` get nothing while users who closed a position years ago keep paying for refetches.

This PR closes the gap in one shot.

## Changes

### 1. `price:` metadata drives source/ticker selection

Format mirrors `bean-price`: `"<quote-currency>:<source>/<ticker>"`, comma-chained for fallback.

\`\`\`beancount
2024-01-01 commodity AAPL
  price: "USD:yahoo/AAPL"

2024-01-01 commodity Vanguard_VTI
  price: "USD:yahoo/VTI,USD:google/NYSEARCA:VTI"

2024-01-01 commodity AUD
  price: "EUR:ecb/AUD-EUR"
\`\`\`

Parsed entries become a `CommodityMapping::Detailed` with `SourceRef::Single` or `SourceRef::Fallback`, so the rest of the price pipeline picks them up unchanged.

### 2. `quote_currency:` metadata for per-commodity quote currency

Sets the quote currency for one symbol, overriding `--currency`. `price:` metadata's first entry wins over a separate `quote_currency:` if both are set (matches Python beancount).

### 3. Active-only filtering by default

A commodity is fetched only if at least one open balance-sheet account (Assets / Liabilities, read from `options.name_assets` / `name_liabilities` so non-English ledgers work) ends with a non-zero balance in it. The previous behavior is reachable via the new `--all-commodities` flag.

**Why "balance-sheet" not "any account":** `Equity:Opening-Balances` retains inverse balances of every commodity that ever moved through the ledger, so a naive "non-zero anywhere" check would mark every long-closed position as still active. Restricting to Assets/Liabilities is what makes the check correct. A regression test guards this.

## Precedence for source/ticker resolution

High to low:
1. CLI \`--mapping\`
2. CLI \`--source\`
3. Discovered \`price:\` metadata (new)
4. Config \`[price.mapping]\`
5. Default source from \`[price.default_source]\`

## Backward compat

- Commodities with no metadata still pass the ticker-shape heuristic, so existing \`-f\` users keep working.
- CLI-positional symbols are always included regardless of file discovery.
- The activity filter is opt-out (\`--all-commodities\`) for users who want today's behavior.

## Implementation

New module \`crates/rustledger/src/cmd/price/discovery.rs\` keeps \`price_cmd.rs\` readable. Public API:

\`\`\`rust
pub struct DiscoveredCommodity { mapping, quote_currency }
pub fn discover_symbols(directives, options, cli_symbols, include_inactive)
\`\`\`

Takes a directive slice rather than the \`Ledger\` type so it works with both \`LoadResult\` (raw load) and \`Ledger\` (post-processing) without coupling.

## Tests

8 new unit tests in \`discovery.rs\`:
- \`parses_single_price_spec\` / \`parses_chained_price_specs\` / \`parse_price_skips_malformed_entries\`
- \`ticker_heuristic_rejects_long_or_lowercase\`
- \`active_filter_keeps_held_commodities\` (AAPL held → active, BTC fully sold → inactive, EUR cash → active)
- \`closed_account_balance_does_not_count_as_active\` (the Equity-Opening regression)
- \`discover_picks_up_metadata_driven_commodity\` (non-ticker name with \`price:\` is picked up)
- \`discover_skips_inactive_by_default\` + opt-in via \`include_inactive\`
- \`cli_symbols_always_included_with_default_info\`

2 new CLI parsing tests in \`price_cmd.rs\` for the \`--all-commodities\` flag.

## Verification

- \`cargo test -p rustledger\`: all green (224 + 27 + 43 + 7 + 65 + 17)
- \`cargo clippy --all-features --all-targets -- -D warnings\`: clean
- \`cargo fmt --check\`: clean

## Test plan

- [ ] CI: Clippy, Test, Doctests, Format, Compatibility
- [ ] Manual: \`rledger price -f main.beancount\` returns only currently-held commodities
- [ ] Manual: add a \`commodity\` directive with \`price: "EUR:ecb/AUD-EUR"\` and confirm it gets fetched from ECB in EUR (not the global default source)
- [ ] Manual: \`--all-commodities\` brings back all declared commodities

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)