### PR TITLE
fix(query): JOURNAL position with cost + cumulative balance (closes #955)

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -761,34 +761,43 @@ impl Executor<'_> {
                         // Build the row
                         let balance = self.balances.entry(posting.account.clone()).or_default();
 
-                        // Only process complete amounts
-                        if let Some(units) = posting.amount() {
-                            let pos = if let Some(cost_spec) = &posting.cost {
-                                if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
-                                    Position::with_cost(units.clone(), cost)
-                                } else {
-                                    Position::simple(units.clone())
-                                }
+                        // Resolve the posting into a Position once. Used for
+                        // both the running balance accumulator and the
+                        // default-case position column. With cost when the
+                        // posting carries a cost annotation; bare units
+                        // otherwise.
+                        let pos = posting.amount().map(|units| {
+                            if let Some(cost_spec) = &posting.cost
+                                && let Some(cost) = cost_spec.resolve(units.number, txn.date)
+                            {
+                                Position::with_cost(units.clone(), cost)
                             } else {
                                 Position::simple(units.clone())
-                            };
-                            balance.add(pos.clone());
+                            }
+                        });
+
+                        if let Some(ref p) = pos {
+                            balance.add(p.clone());
                         }
 
-                        // Apply AT function if specified
+                        // Apply AT function if specified.
+                        //
+                        // - default (no AT): show the full Position (units +
+                        //   cost when present), matching bean-query's
+                        //   JOURNAL column. Issue #955.
+                        // - AT COST: show the cost-currency total (units ×
+                        //   per-unit cost). Drops the position shape.
+                        // - AT UNITS: show just the units, dropping cost.
                         let position_value = if let Some(at_func) = &query.at_function {
                             match at_func.to_uppercase().as_str() {
                                 "COST" => {
                                     if let Some(units) = posting.amount() {
-                                        if let Some(cost_spec) = &posting.cost {
-                                            if let Some(cost) =
+                                        if let Some(cost_spec) = &posting.cost
+                                            && let Some(cost) =
                                                 cost_spec.resolve(units.number, txn.date)
-                                            {
-                                                let total = units.number * cost.number;
-                                                Value::Amount(Amount::new(total, &cost.currency))
-                                            } else {
-                                                Value::Amount(units.clone())
-                                            }
+                                        {
+                                            let total = units.number * cost.number;
+                                            Value::Amount(Amount::new(total, &cost.currency))
                                         } else {
                                             Value::Amount(units.clone())
                                         }
@@ -804,9 +813,8 @@ impl Executor<'_> {
                                     .map_or(Value::Null, |u| Value::Amount(u.clone())),
                             }
                         } else {
-                            posting
-                                .amount()
-                                .map_or(Value::Null, |u| Value::Amount(u.clone()))
+                            pos.as_ref()
+                                .map_or(Value::Null, |p| Value::Position(Box::new(p.clone())))
                         };
 
                         let row = vec![

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -718,7 +718,7 @@ impl Executor<'_> {
 
     /// Execute a JOURNAL query.
     pub(super) fn execute_journal(
-        &mut self,
+        &self,
         query: &crate::ast::JournalQuery,
     ) -> Result<QueryResult, QueryError> {
         // JOURNAL is a shorthand for SELECT with specific columns
@@ -737,6 +737,14 @@ impl Executor<'_> {
             "balance".to_string(),
         ];
         let mut result = QueryResult::new(columns);
+
+        // Cumulative balance across every matched posting in this JOURNAL run.
+        // Matches Python `bean-query`'s JOURNAL → SELECT translation, where the
+        // `balance` column is `summary_func(balance)` over the running
+        // cumulative inventory of WHERE-filtered postings — not per-account.
+        // Aligns with the cumulative `balance` semantics introduced for SELECT
+        // in PR #940; the JOURNAL command was missed in that change. Issue #955.
+        let mut cumulative_balance = rustledger_core::Inventory::new();
 
         // Filter transactions that touch the account
         for directive in self.directives {
@@ -758,9 +766,6 @@ impl Executor<'_> {
                     };
 
                     if matches {
-                        // Build the row
-                        let balance = self.balances.entry(posting.account.clone()).or_default();
-
                         // Resolve the posting into a Position once. Used for
                         // both the running balance accumulator and the
                         // default-case position column. With cost when the
@@ -777,7 +782,7 @@ impl Executor<'_> {
                         });
 
                         if let Some(ref p) = pos {
-                            balance.add(p.clone());
+                            cumulative_balance.add(p.clone());
                         }
 
                         // Apply AT function if specified.
@@ -828,7 +833,7 @@ impl Executor<'_> {
                             Value::String(txn.narration.to_string()),
                             Value::String(posting.account.to_string()),
                             position_value,
-                            Value::Inventory(Box::new(balance.clone())),
+                            Value::Inventory(Box::new(cumulative_balance.clone())),
                         ];
                         result.add_row(row);
                     }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -790,8 +790,11 @@ impl Executor<'_> {
                         // - default (no AT): show the full Position (units +
                         //   cost when present), matching bean-query's
                         //   JOURNAL column. Issue #955.
-                        // - AT COST: show the cost-currency total (units ×
-                        //   per-unit cost). Drops the position shape.
+                        // - AT COST: when a cost annotation is present and
+                        //   resolves, show the cost-currency total
+                        //   (units × per-unit cost). Otherwise fall back to
+                        //   the original units — so the output currency is
+                        //   not guaranteed to be the cost currency.
                         // - AT UNITS: show just the units, dropping cost.
                         let position_value = if let Some(at_func) = &query.at_function {
                             match at_func.to_uppercase().as_str() {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -556,6 +556,80 @@ fn test_execute_journal_query() {
     assert!(!result.is_empty());
 }
 
+/// Regression test for issue #955 (Bug 2): the JOURNAL `balance` column was
+/// per-account, but Python `bean-query` translates JOURNAL to a SELECT where
+/// `balance` is the cumulative inventory across every WHERE-filtered posting
+/// (same semantic adopted for SELECT in PR #940). For a multi-account
+/// `JOURNAL "Assets"` query, each row should show the running combined
+/// inventory of all matched accounts up to that point — including currencies
+/// that this row's account doesn't directly carry.
+#[test]
+fn test_journal_balance_is_cumulative_across_matched_accounts() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        // Row 0: deposit USD into Assets:Cash.
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Deposit")
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(1000), "USD")))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1000), "USD"),
+                )),
+        ),
+        // Row 1: buy AAPL in Assets:Brokerage. Different currency, different
+        // account from the matched set. The balance here should include both
+        // the USD held in Assets:Cash AND the new AAPL.
+        Directive::Transaction(
+            Transaction::new(date(2024, 3, 1), "Buy AAPL")
+                .with_posting(Posting::new(
+                    "Assets:Brokerage",
+                    Amount::new(dec!(10), "AAPL"),
+                ))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets""#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    assert_eq!(result.rows.len(), 2, "two assets postings, two rows");
+
+    // Columns: date, flag, payee, narration, account, position, balance.
+    // Row 0's balance: just the USD from Assets:Cash.
+    let balance_0 = match &result.rows[0][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions_0 = balance_0.positions();
+    assert_eq!(positions_0.len(), 1);
+    assert_eq!(positions_0[0].units.currency.as_str(), "USD");
+    assert_eq!(positions_0[0].units.number, dec!(1000));
+
+    // Row 1's balance: the cumulative inventory now includes BOTH USD and
+    // AAPL — even though row 1's posting is on Assets:Brokerage and only
+    // adds AAPL. Per-account semantics would have lost the USD here.
+    let balance_1 = match &result.rows[1][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let mut currencies: Vec<&str> = balance_1
+        .positions()
+        .iter()
+        .map(|p| p.units.currency.as_str())
+        .collect();
+    currencies.sort_unstable();
+    assert_eq!(
+        currencies,
+        vec!["AAPL", "USD"],
+        "JOURNAL balance must be cumulative across matched accounts"
+    );
+}
+
 /// Regression test for issue #955 (Bug 1): the JOURNAL position column was
 /// emitting `Value::Amount(units)` instead of `Value::Position(pos)`,
 /// silently dropping cost annotations. With cost-bearing postings, the

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -676,6 +676,133 @@ fn test_journal_position_column_preserves_cost() {
     assert_eq!(cost.currency.as_str(), "USD");
 }
 
+/// Regression test for #955 deep review: `JOURNAL ... FROM <filter>` should
+/// only count postings from transactions that pass the FROM filter into the
+/// cumulative balance. A wildcard `JOURNAL "Assets"` over a ledger with two
+/// transactions, one matching the FROM filter and one not, should show only
+/// one row whose balance reflects only the matched transaction.
+#[test]
+fn test_journal_from_clause_filters_cumulative_balance() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        // 2024 transaction — should pass `FROM year = 2024` filter.
+        Directive::Transaction(
+            Transaction::new(date(2024, 6, 1), "Deposit 2024")
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(100), "USD")))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-100), "USD"),
+                )),
+        ),
+        // 2025 transaction — should NOT pass the filter.
+        Directive::Transaction(
+            Transaction::new(date(2025, 6, 1), "Deposit 2025")
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(500), "USD")))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets" FROM year = 2024"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    assert_eq!(result.rows.len(), 1, "FROM filter should drop the 2025 row");
+
+    let balance = match &result.rows[0][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions = balance.positions();
+    assert_eq!(positions.len(), 1);
+    assert_eq!(
+        positions[0].units.number,
+        dec!(100),
+        "cumulative balance must only include FROM-matched postings"
+    );
+}
+
+/// Regression test for #955 deep review: `JOURNAL ... AT cost` and
+/// `JOURNAL ... AT units` are documented to project the position column away
+/// from the full Position shape. They should keep emitting `Value::Amount`,
+/// not the Position the default branch now uses.
+///
+/// (Note: AT cost / AT units balance-column behavior diverges from
+/// bean-query and is tracked separately in #957.)
+#[test]
+fn test_journal_at_cost_position_is_amount_not_position() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Brokerage" AT cost"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    assert_eq!(result.rows.len(), 1);
+    let position = &result.rows[0][5];
+    match position {
+        Value::Amount(a) => {
+            // cost-currency total = 10 × 150 USD = 1500 USD
+            assert_eq!(a.number, dec!(1500));
+            assert_eq!(a.currency.as_str(), "USD");
+        }
+        other => panic!("AT cost should produce Value::Amount, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_journal_at_units_position_is_amount_not_position() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Brokerage" AT units"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    assert_eq!(result.rows.len(), 1);
+    let position = &result.rows[0][5];
+    match position {
+        Value::Amount(a) => {
+            // units only — cost dropped by definition of AT units.
+            assert_eq!(a.number, dec!(10));
+            assert_eq!(a.currency.as_str(), "AAPL");
+        }
+        other => panic!("AT units should produce Value::Amount, got {other:?}"),
+    }
+}
+
 // ============================================================================
 // BALANCES Query Tests
 // ============================================================================

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -556,6 +556,52 @@ fn test_execute_journal_query() {
     assert!(!result.is_empty());
 }
 
+/// Regression test for issue #955 (Bug 1): the JOURNAL position column was
+/// emitting `Value::Amount(units)` instead of `Value::Position(pos)`,
+/// silently dropping cost annotations. With cost-bearing postings, the
+/// position column now preserves `{ cost }` so it matches `bean-query`.
+#[test]
+fn test_journal_position_column_preserves_cost() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Brokerage""#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    assert_eq!(result.rows.len(), 1, "expected one matching posting");
+
+    // Columns: date, flag, payee, narration, account, position, balance.
+    let position = &result.rows[0][5];
+    let position_with_cost = match position {
+        Value::Position(p) => p,
+        other => panic!("expected Value::Position, got {other:?}"),
+    };
+    assert_eq!(position_with_cost.units.number, dec!(10));
+    assert_eq!(position_with_cost.units.currency.as_str(), "AAPL");
+    let cost = position_with_cost
+        .cost
+        .as_ref()
+        .expect("position column must preserve cost annotation");
+    assert_eq!(cost.number, dec!(150));
+    assert_eq!(cost.currency.as_str(), "USD");
+}
+
 // ============================================================================
 // BALANCES Query Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes both bugs in issue #955.

## Behavior change (heads-up for users)

This PR changes JOURNAL output for **wildcard patterns** like `JOURNAL "Assets"`. The balance column was previously per-account (each row showed only its own account's running inventory); after this PR, the balance column is the cumulative inventory across every WHERE-filtered posting that matched the pattern. This matches Python `bean-query` exactly (see investigation below) and aligns with the cumulative `balance` semantic adopted for SELECT in PR #940.

For single-account patterns (`JOURNAL "Assets:Cash"`), the output is unchanged — per-account is the same as cumulative when only one account matches.

## Bug 1: position column dropped cost annotations

`crates/rustledger-query/src/executor/execution.rs::execute_journal`

The builder computed a cost-aware `Position` solely for the per-account balance accumulator, then built `position_value` separately as `Value::Amount(units)` — which by definition can't carry a cost. So the balance column rendered with `{ cost }` correctly while the position column dropped it.

**Fix:** lift the `Position` resolution out of the balance-only branch and use it for both the running balance accumulator and the default-case position column. AT-COST and AT-UNITS branches kept on `Value::Amount` since they intentionally project away the position shape.

## Bug 2: balance was per-account, not cumulative

For `JOURNAL "Assets"` on a ledger with both IRAUSD (in `PreTax401k`) and USD (in `Cash`) holdings, Python `bean-query` rendered the balance as `18500.00 IRAUSD 3262.01 USD` — the cumulative inventory across all matched accounts. We rendered only this row's account's slice (`18500.00 IRAUSD`).

**Investigation:** beanquery's `compiler.py::transform_journal` translates JOURNAL into:

```
SELECT date, flag, MAXWIDTH(payee, 48), MAXWIDTH(narration, 80),
       account, {summary_func}(position), {summary_func}(balance)
```

The `balance` column there is the cumulative running inventory across every WHERE-filtered posting — same semantic we already adopted for SELECT in PR #940. The JOURNAL builder was missed in that change.

**Fix:** replace the per-account `self.balances.entry(...)` lookup in `execute_journal` with a single cumulative `Inventory` scoped to the JOURNAL run. Each row gets a clone of that inventory at that point.

Drive-by: `execute_journal` no longer mutates `self` — now takes `&self` rather than `&mut self`.

## Tests

Five new regression tests in `bql_integration_test.rs`:

- `test_journal_position_column_preserves_cost` — Bug 1: position column carries `Value::Position(...)` with the cost annotation intact.
- `test_journal_balance_is_cumulative_across_matched_accounts` — Bug 2: two-account scenario where the cumulative balance after row 2 must include both currencies. Per-account semantics would have failed it.
- `test_journal_from_clause_filters_cumulative_balance` — locks in that `JOURNAL ... FROM <filter>` correctly composes with the cumulative inventory (FROM-non-matching transactions stay out).
- `test_journal_at_cost_position_is_amount_not_position` — guards `AT cost` against future regression (still emits `Value::Amount` of the cost-currency total).
- `test_journal_at_units_position_is_amount_not_position` — same guard for `AT units`.

## Verification

- `cargo test -p rustledger-query`: 493 tests pass (was 488, +5 new)
- `cargo test -p rustledger`: 392 tests pass
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

## Compat impact

Should resolve a substantial portion of the `journal-assets` BQL compatibility failures (~18 tests). Some rows likely tripped on Bug 1, others on Bug 2, and a few on both. We'll see the breakdown on the next compat run after merge.

## Known limitations / follow-ups

Discovered during deep self-review of this PR:

- **#957** (filed): `JOURNAL ... AT cost` and `AT units` should also collapse the *balance* column to cost-currency / units-only totals, matching `bean-query`'s `summary_func(balance)` translation. We only collapse the position column. Out of scope here.
- **#958** (filed): `Executor::build_balances_with_filter` doesn't clear `self.balances` before populating, so sequential `BALANCES` queries on the same Executor double-count. Pre-existing latent bug, surfaced because removing JOURNAL's `self.balances` side effect (this PR) made the underlying issue more visible.

## Test plan

- [ ] CI: Test, Clippy, Doctests, Format, Compatibility
- [ ] Compat suite shows `journal-assets` pass count increase from 12 toward the upper bound
- [ ] Manual: `rledger query "JOURNAL 'Assets'" example.beancount` shows cost annotations on cost-bearing positions and cumulative multi-currency balances

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)