### PR TITLE
fix(query): build_balances_with_filter returns fresh map (closes #958)

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -849,11 +849,12 @@ impl Executor<'_> {
 
     /// Execute a BALANCES query.
     pub(super) fn execute_balances(
-        &mut self,
+        &self,
         query: &crate::ast::BalancesQuery,
     ) -> Result<QueryResult, QueryError> {
-        // Build up balances by processing all transactions (with FROM filtering)
-        self.build_balances_with_filter(query.from.as_ref())?;
+        // Build up balances by processing all transactions (with FROM filtering).
+        // Local map rather than struct state — see issue #958.
+        let balances = self.build_balances_with_filter(query.from.as_ref())?;
 
         let columns = vec!["account".to_string(), "balance".to_string()];
         let mut result = QueryResult::new(columns.clone());
@@ -867,12 +868,12 @@ impl Executor<'_> {
             .collect();
 
         // Sort accounts for consistent output
-        let mut accounts: Vec<_> = self.balances.keys().collect();
+        let mut accounts: Vec<_> = balances.keys().collect();
         accounts.sort();
 
         for account in accounts {
-            // Safety: account comes from self.balances.keys(), so it's guaranteed to exist
-            let Some(balance) = self.balances.get(account) else {
+            // Safety: account comes from balances.keys(), so it's guaranteed to exist
+            let Some(balance) = balances.get(account) else {
                 continue; // Defensive: skip if somehow the key disappeared
             };
 

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -32,8 +32,6 @@ pub struct Executor<'a> {
     directives: &'a [Directive],
     /// Spanned directives (optional, for source location support).
     spanned_directives: Option<&'a [Spanned<Directive>]>,
-    /// Account balances (built up during query).
-    balances: FxHashMap<InternedStr, Inventory>,
     /// Price database for `VALUE()` conversions.
     price_db: crate::price::PriceDatabase,
     /// Target currency for `VALUE()` conversions.
@@ -98,7 +96,6 @@ impl<'a> Executor<'a> {
         Self {
             directives,
             spanned_directives: None,
-            balances: FxHashMap::default(),
             price_db,
             target_currency: None,
             query_date: jiff::Zoned::now().date(),
@@ -176,7 +173,6 @@ impl<'a> Executor<'a> {
         Self {
             directives: &[], // Empty - we use spanned_directives instead
             spanned_directives: Some(spanned_directives),
-            balances: FxHashMap::default(),
             price_db,
             target_currency: None,
             query_date: jiff::Zoned::now().date(),
@@ -263,8 +259,21 @@ impl<'a> Executor<'a> {
         }
     }
 
-    /// Execute a SELECT query.
-    fn build_balances_with_filter(&mut self, from: Option<&FromClause>) -> Result<(), QueryError> {
+    /// Compute per-account inventories for a `BALANCES` query.
+    ///
+    /// Returns a fresh map rather than mutating shared state on `self` so that
+    /// sequential queries on the same `Executor` produce independent results.
+    /// See issue #958 for the bug that motivated this signature: a previous
+    /// implementation accumulated into `self.balances` without clearing,
+    /// causing a second `BALANCES` call to double-count and a `BALANCES FROM
+    /// year=2024` followed by `BALANCES FROM year=2025` to return a confused
+    /// union of both filters.
+    fn build_balances_with_filter(
+        &self,
+        from: Option<&FromClause>,
+    ) -> Result<FxHashMap<InternedStr, Inventory>, QueryError> {
+        let mut balances: FxHashMap<InternedStr, Inventory> = FxHashMap::default();
+
         for directive in self.directives {
             if let Directive::Transaction(txn) = directive {
                 // Apply FROM filter if present
@@ -277,7 +286,7 @@ impl<'a> Executor<'a> {
 
                 for posting in &txn.postings {
                     if let Some(units) = posting.amount() {
-                        let balance = self.balances.entry(posting.account.clone()).or_default();
+                        let balance = balances.entry(posting.account.clone()).or_default();
 
                         let pos = if let Some(cost_spec) = &posting.cost {
                             if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
@@ -293,7 +302,8 @@ impl<'a> Executor<'a> {
                 }
             }
         }
-        Ok(())
+
+        Ok(balances)
     }
 
     /// Collect postings matching the FROM and WHERE clauses.

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -274,7 +274,19 @@ impl<'a> Executor<'a> {
     ) -> Result<FxHashMap<InternedStr, Inventory>, QueryError> {
         let mut balances: FxHashMap<InternedStr, Inventory> = FxHashMap::default();
 
-        for directive in self.directives {
+        // Iterate over whichever directive source is populated. When the
+        // Executor is built via `new_with_sources`, `self.directives` is empty
+        // and the data lives in `spanned_directives` — same pattern as
+        // `collect_postings` and the system-table builders. Without this,
+        // BALANCES silently returned an empty result set for source-location-
+        // aware Executors (e.g. LSP / source-mapped queries).
+        let all_directives: Vec<&Directive> = if let Some(spanned) = self.spanned_directives {
+            spanned.iter().map(|s| &s.value).collect()
+        } else {
+            self.directives.iter().collect()
+        };
+
+        for directive in all_directives {
             if let Directive::Transaction(txn) = directive {
                 // Apply FROM filter if present
                 if let Some(from_clause) = from

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -848,6 +848,41 @@ fn test_balances_idempotent_across_sequential_runs() {
     );
 }
 
+/// Regression test for the Copilot-flagged sub-issue on PR #959: an
+/// `Executor` constructed via `new_with_sources` (used when source-location
+/// info is needed) put directives in `spanned_directives` and left
+/// `directives` empty. `build_balances_with_filter` previously iterated
+/// only `self.directives`, so BALANCES on a source-mapped Executor silently
+/// returned an empty result. The fix iterates whichever source is
+/// populated, mirroring `collect_postings` and the system-table builders.
+#[test]
+fn test_balances_works_with_spanned_directives_executor() {
+    use rustledger_loader::SourceMap;
+    use rustledger_parser::{Span, Spanned};
+
+    let dirs = make_test_directives();
+    let spanned: Vec<Spanned<rustledger_core::Directive>> = dirs
+        .iter()
+        .cloned()
+        .map(|d| Spanned {
+            value: d,
+            span: Span::new(0, 50),
+            file_id: 0,
+        })
+        .collect();
+    let source_map = SourceMap::new();
+
+    let mut executor = Executor::new_with_sources(&spanned, &source_map);
+    let result = executor
+        .execute(&parse("BALANCES").expect("should parse"))
+        .expect("BALANCES on source-mapped Executor should work");
+
+    assert!(
+        !result.is_empty(),
+        "source-mapped Executor must return non-empty BALANCES; previously returned empty"
+    );
+}
+
 /// Regression test for issue #958 (FROM-filter variant): sequential `BALANCES`
 /// with different FROM clauses must each return only their own filter's
 /// view. Before the fix, the second run accumulated its filter on top of

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -829,6 +829,83 @@ fn test_execute_balances_with_from() {
     assert!(!result.is_empty());
 }
 
+/// Regression test for issue #958: sequential `BALANCES` queries on the same
+/// `Executor` must produce identical results. Before the fix,
+/// `build_balances_with_filter` accumulated into a struct field without
+/// clearing, so the second run returned doubled balances.
+#[test]
+fn test_balances_idempotent_across_sequential_runs() {
+    let directives = make_test_directives();
+    let query = parse("BALANCES").expect("should parse");
+    let mut executor = Executor::new(&directives);
+
+    let r1 = executor.execute(&query).expect("first run");
+    let r2 = executor.execute(&query).expect("second run");
+
+    assert_eq!(
+        r1.rows, r2.rows,
+        "BALANCES must return identical results when run twice on the same Executor"
+    );
+}
+
+/// Regression test for issue #958 (FROM-filter variant): sequential `BALANCES`
+/// with different FROM clauses must each return only their own filter's
+/// view. Before the fix, the second run accumulated its filter on top of
+/// the first run's residual state — a union, not a fresh view — producing
+/// output matching no single query.
+#[test]
+fn test_balances_with_different_from_filters_are_independent() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 6, 1), "2024 deposit")
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(100), "USD")))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-100), "USD"),
+                )),
+        ),
+        Directive::Transaction(
+            Transaction::new(date(2025, 6, 1), "2025 deposit")
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(500), "USD")))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-500), "USD"),
+                )),
+        ),
+    ];
+
+    let mut executor = Executor::new(&directives);
+
+    // Run year=2024 first to populate any latent state.
+    let q_2024 = parse("BALANCES FROM year = 2024").expect("should parse");
+    let _ = executor.execute(&q_2024).expect("2024 run");
+
+    // Now run year=2025. Should reflect only 2025 transactions.
+    let q_2025 = parse("BALANCES FROM year = 2025").expect("should parse");
+    let r_2025 = executor.execute(&q_2025).expect("2025 run");
+
+    // Find the Assets:Cash row.
+    let cash_row = r_2025
+        .rows
+        .iter()
+        .find(|row| matches!(&row[0], Value::String(s) if s == "Assets:Cash"))
+        .expect("Assets:Cash should appear in 2025 results");
+
+    let inv = match &cash_row[1] {
+        Value::Inventory(i) => i,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions = inv.positions();
+    assert_eq!(positions.len(), 1);
+    assert_eq!(
+        positions[0].units.number,
+        dec!(500),
+        "year=2025 BALANCES must show 500 USD, not 600 USD (2024 + 2025 union)"
+    );
+}
+
 // ----------------------------------------------------------------------------
 // `balance` column — cumulative across WHERE-filtered postings (bean-query
 // semantics). See issue #929 and the surrounding discussion.


### PR DESCRIPTION
## Summary

`Executor::build_balances_with_filter` accumulated into the `self.balances` field without clearing it first. Sequential `BALANCES` queries on the same `Executor` produced wrong results:

- Identical sequential calls: every balance doubled.
- Different FROM filters: the second result was a union of both filters, matching no single query.

The field's own doc comment described the intended semantic — *"Account balances (built up during query)"* — fresh-per-query, not cumulative across runs. The implementation contradicted that intent.

## Fix

Change `build_balances_with_filter` to return a fresh `FxHashMap<InternedStr, Inventory>` rather than mutating `self.balances`. `execute_balances` consumes the return value directly.

```rust
// Before:
fn build_balances_with_filter(&mut self, from: Option<&FromClause>) -> Result<(), QueryError> {
    for ... { self.balances.entry(...).or_default().add(pos); }
    Ok(())
}

// After:
fn build_balances_with_filter(
    &self,
    from: Option<&FromClause>,
) -> Result<FxHashMap<InternedStr, Inventory>, QueryError> {
    let mut balances: FxHashMap<...> = FxHashMap::default();
    for ... { balances.entry(...).or_default().add(pos); }
    Ok(balances)
}
```

Both `build_balances_with_filter` and `execute_balances` drop their `&mut self` requirement; `&self` suffices now.

The `balances` field on `Executor` is **removed entirely**. After PR #956 (which removed `JOURNAL`'s pollution of this field), `execute_balances` was the only remaining reader. The field was function-local working memory that had escaped to struct level; eliminating it makes sequential-query correctness a property of the type rather than a discipline callers must remember.

## Why structural over a one-line `clear()`

A `self.balances.clear()` at function entry would have fixed today's symptom in one line, but left a footgun: a field whose contract is "fresh per call" still living on a struct that allows arbitrary cross-call use. The next person to write a method touching `self.balances` either remembers the clear-on-entry rule or recreates this bug. Removing the field eliminates the failure mode permanently.

This change also finishes the cleanup arc started in #956 — that PR removed `execute_journal`'s mutation of `self.balances` and made it `&self`. With this PR, the field is gone entirely.

## Tests

Two new regression tests in `bql_integration_test.rs`:

- `test_balances_idempotent_across_sequential_runs` — `BALANCES` then `BALANCES` on the same `Executor` returns identical rows. Locks in the basic idempotency.
- `test_balances_with_different_from_filters_are_independent` — `BALANCES FROM year = 2024` then `BALANCES FROM year = 2025` returns only 2025 transactions in the second result (500 USD, not 600 USD which would be the union of both years). This is the worse-than-doubling case noted in #958.

## Verification

- `cargo test -p rustledger-query`: 495 tests pass (was 493, +2 new)
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

## Behavior change / migration

This is a strict improvement for any consumer that reuses an `Executor`:

- CLI (`rledger query`): unchanged — creates a fresh `Executor` per invocation.
- WASM API and other library consumers: unchanged for current call sites (all single-query). Future programmatic users get correct behavior automatically.
- The `Executor::balances` field was `pub(crate)`; no external API surface affected.

## Test plan

- [ ] CI: Test, Clippy, Doctests, Format, Compatibility
- [ ] Compat suite: `BALANCES` queries should be unaffected (no current call site reused an Executor in a way that triggered the bug)
- [ ] Manual: programmatic `Executor::execute(BALANCES)` × 2 returns identical results

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)