### PR TITLE
fix(query): JOURNAL AT cost/units collapses balance column (closes #957)

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -825,6 +825,23 @@ impl Executor<'_> {
                                 .map_or(Value::Null, |p| Value::Position(Box::new(p.clone())))
                         };
 
+                        // Apply the same AT-mode transformation to the balance
+                        // column that bean-query's `summary_func(balance)`
+                        // applies. Issue #957: previously the balance always
+                        // showed the full cumulative inventory regardless of
+                        // AT mode; that diverged from bean-query, where AT
+                        // cost collapses the balance to cost-currency totals
+                        // and AT units strips lots from the balance.
+                        let balance_for_row = if let Some(at_func) = &query.at_function {
+                            match at_func.to_uppercase().as_str() {
+                                "COST" => cumulative_balance.at_cost(),
+                                "UNITS" => cumulative_balance.at_units(),
+                                _ => cumulative_balance.clone(),
+                            }
+                        } else {
+                            cumulative_balance.clone()
+                        };
+
                         let row = vec![
                             Value::Date(txn.date),
                             Value::String(txn.flag.to_string()),
@@ -836,7 +853,7 @@ impl Executor<'_> {
                             Value::String(txn.narration.to_string()),
                             Value::String(posting.account.to_string()),
                             position_value,
-                            Value::Inventory(Box::new(cumulative_balance.clone())),
+                            Value::Inventory(Box::new(balance_for_row)),
                         ];
                         result.add_row(row);
                     }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -17,6 +17,31 @@ use crate::error::QueryError;
 use super::Executor;
 use super::types::{QueryResult, Row, Table, Value, hash_row};
 
+/// Normalized form of a `JOURNAL ... AT <mode>` clause.
+///
+/// Computed once per query rather than calling `to_uppercase()` per row —
+/// avoids per-row allocations and lets the inner loop branch on a copy
+/// type. `Other` covers any unrecognized AT mode (treated like the
+/// default branch in row construction).
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum AtMode {
+    None,
+    Cost,
+    Units,
+    Other,
+}
+
+impl AtMode {
+    const fn from_query(at_function: Option<&str>) -> Self {
+        match at_function {
+            None => Self::None,
+            Some(s) if s.eq_ignore_ascii_case("COST") => Self::Cost,
+            Some(s) if s.eq_ignore_ascii_case("UNITS") => Self::Units,
+            Some(_) => Self::Other,
+        }
+    }
+}
+
 impl Executor<'_> {
     /// Execute a SELECT query.
     pub(super) fn execute_select(&self, query: &SelectQuery) -> Result<QueryResult, QueryError> {
@@ -746,6 +771,11 @@ impl Executor<'_> {
         // in PR #940; the JOURNAL command was missed in that change. Issue #955.
         let mut cumulative_balance = rustledger_core::Inventory::new();
 
+        // Normalize the AT mode once per query rather than calling
+        // to_uppercase() per row (which would allocate twice — once for
+        // position_value, once for balance_for_row). Issue #957 self-review.
+        let at_mode = AtMode::from_query(query.at_function.as_deref());
+
         // Filter transactions that touch the account
         for directive in self.directives {
             if let Directive::Transaction(txn) = directive {
@@ -785,7 +815,8 @@ impl Executor<'_> {
                             cumulative_balance.add(p.clone());
                         }
 
-                        // Apply AT function if specified.
+                        // Apply AT function if specified, using the at_mode
+                        // precomputed once per query above.
                         //
                         // - default (no AT): show the full Position (units +
                         //   cost when present), matching bean-query's
@@ -796,33 +827,28 @@ impl Executor<'_> {
                         //   the original units — so the output currency is
                         //   not guaranteed to be the cost currency.
                         // - AT UNITS: show just the units, dropping cost.
-                        let position_value = if let Some(at_func) = &query.at_function {
-                            match at_func.to_uppercase().as_str() {
-                                "COST" => {
-                                    if let Some(units) = posting.amount() {
-                                        if let Some(cost_spec) = &posting.cost
-                                            && let Some(cost) =
-                                                cost_spec.resolve(units.number, txn.date)
-                                        {
-                                            let total = units.number * cost.number;
-                                            Value::Amount(Amount::new(total, &cost.currency))
-                                        } else {
-                                            Value::Amount(units.clone())
-                                        }
+                        let position_value = match at_mode {
+                            AtMode::None => pos
+                                .as_ref()
+                                .map_or(Value::Null, |p| Value::Position(Box::new(p.clone()))),
+                            AtMode::Cost => {
+                                if let Some(units) = posting.amount() {
+                                    if let Some(cost_spec) = &posting.cost
+                                        && let Some(cost) =
+                                            cost_spec.resolve(units.number, txn.date)
+                                    {
+                                        let total = units.number * cost.number;
+                                        Value::Amount(Amount::new(total, &cost.currency))
                                     } else {
-                                        Value::Null
+                                        Value::Amount(units.clone())
                                     }
+                                } else {
+                                    Value::Null
                                 }
-                                "UNITS" => posting
-                                    .amount()
-                                    .map_or(Value::Null, |u| Value::Amount(u.clone())),
-                                _ => posting
-                                    .amount()
-                                    .map_or(Value::Null, |u| Value::Amount(u.clone())),
                             }
-                        } else {
-                            pos.as_ref()
-                                .map_or(Value::Null, |p| Value::Position(Box::new(p.clone())))
+                            AtMode::Units | AtMode::Other => posting
+                                .amount()
+                                .map_or(Value::Null, |u| Value::Amount(u.clone())),
                         };
 
                         // Apply the same AT-mode transformation to the balance
@@ -832,14 +858,10 @@ impl Executor<'_> {
                         // AT mode; that diverged from bean-query, where AT
                         // cost collapses the balance to cost-currency totals
                         // and AT units strips lots from the balance.
-                        let balance_for_row = if let Some(at_func) = &query.at_function {
-                            match at_func.to_uppercase().as_str() {
-                                "COST" => cumulative_balance.at_cost(),
-                                "UNITS" => cumulative_balance.at_units(),
-                                _ => cumulative_balance.clone(),
-                            }
-                        } else {
-                            cumulative_balance.clone()
+                        let balance_for_row = match at_mode {
+                            AtMode::Cost => cumulative_balance.at_cost(),
+                            AtMode::Units => cumulative_balance.at_units(),
+                            AtMode::None | AtMode::Other => cumulative_balance.clone(),
                         };
 
                         let row = vec![

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -803,6 +803,188 @@ fn test_journal_at_units_position_is_amount_not_position() {
     }
 }
 
+/// Regression test for issue #957: `JOURNAL ... AT cost` must collapse the
+/// balance column to cost-currency totals, matching `bean-query`'s
+/// `cost(balance)` translation. Previously the balance column showed the
+/// full lot detail regardless of AT mode.
+#[test]
+fn test_journal_at_cost_collapses_balance_to_cost_currency() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Brokerage" AT cost"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    assert_eq!(result.rows.len(), 1);
+    let balance = match &result.rows[0][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions = balance.positions();
+    assert_eq!(positions.len(), 1);
+    // 10 AAPL { 150 USD } collapsed to 1500 USD (cost-currency total).
+    assert_eq!(positions[0].units.number, dec!(1500));
+    assert_eq!(positions[0].units.currency.as_str(), "USD");
+    assert!(
+        positions[0].cost.is_none(),
+        "AT cost balance must drop the lot annotation; got {:?}",
+        positions[0].cost
+    );
+}
+
+/// Regression test for issue #957: `JOURNAL ... AT units` must strip cost
+/// annotations from every position in the balance column.
+#[test]
+fn test_journal_at_units_strips_cost_from_balance() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Buy AAPL")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Brokerage" AT units"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    let balance = match &result.rows[0][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions = balance.positions();
+    assert_eq!(positions.len(), 1);
+    // AT units shows units only — same number / currency as the position.
+    assert_eq!(positions[0].units.number, dec!(10));
+    assert_eq!(positions[0].units.currency.as_str(), "AAPL");
+    assert!(
+        positions[0].cost.is_none(),
+        "AT units balance must drop the lot annotation; got {:?}",
+        positions[0].cost
+    );
+}
+
+/// Regression test for issue #957 edge case: positions without cost are kept
+/// as-is by `Inventory::at_cost()` (matches bean-query's `cost()` fallback).
+/// A `JOURNAL ... AT cost` over a USD-only ledger should pass USD through
+/// unchanged in the balance, not error or drop the position.
+#[test]
+fn test_journal_at_cost_balance_preserves_no_cost_positions() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Deposit")
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(100), "USD")))
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-100), "USD"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Cash" AT cost"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    let balance = match &result.rows[0][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions = balance.positions();
+    assert_eq!(positions.len(), 1);
+    assert_eq!(positions[0].units.number, dec!(100));
+    assert_eq!(positions[0].units.currency.as_str(), "USD");
+}
+
+/// Regression test for issue #957 edge case: a balance with positions in
+/// multiple cost currencies stays multi-currency under `AT cost` (matches
+/// bean-query — `cost(balance)` does not unify across cost currencies).
+#[test]
+fn test_journal_at_cost_balance_keeps_mixed_cost_currencies() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        // Lot 1: 10 AAPL @ 150 USD = 1500 USD cost basis.
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Buy AAPL USD lot")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+        // Lot 2: 5 AAPL @ 130 EUR = 650 EUR cost basis. (Same commodity,
+        // different cost currency — atypical but legal.)
+        Directive::Transaction(
+            Transaction::new(date(2024, 3, 1), "Buy AAPL EUR lot")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(5), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(130))
+                            .with_currency("EUR"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-650), "EUR"),
+                )),
+        ),
+    ];
+    let query = parse(r#"JOURNAL "Assets:Brokerage" AT cost"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    // After both rows, the balance has both USD and EUR cost-currency totals.
+    let last_balance = match &result.rows[1][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let mut by_currency: std::collections::HashMap<&str, rust_decimal::Decimal> =
+        std::collections::HashMap::new();
+    for p in last_balance.positions() {
+        by_currency.insert(p.units.currency.as_str(), p.units.number);
+    }
+    assert_eq!(by_currency.get("USD"), Some(&dec!(1500)));
+    assert_eq!(by_currency.get("EUR"), Some(&dec!(650)));
+    assert_eq!(
+        by_currency.len(),
+        2,
+        "AT cost must not collapse across cost currencies; got {by_currency:?}"
+    );
+}
+
 // ============================================================================
 // BALANCES Query Tests
 // ============================================================================

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -848,6 +848,70 @@ fn test_journal_at_cost_collapses_balance_to_cost_currency() {
     );
 }
 
+/// Lock-in test for #957 deep review: `JOURNAL ... AT cost FROM <filter>`
+/// must compose correctly. The FROM clause filters which transactions enter
+/// the cumulative balance, and AT cost then collapses what's there to cost
+/// currency totals. Both mechanisms exist (covered separately by
+/// `test_journal_from_clause_filters_cumulative_balance` and
+/// `test_journal_at_cost_collapses_balance_to_cost_currency`); this asserts
+/// they work together in the same row.
+#[test]
+fn test_journal_at_cost_with_from_clause_filters_then_collapses() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+        // 2024 transaction — should pass `FROM year = 2024` filter.
+        Directive::Transaction(
+            Transaction::new(date(2024, 6, 1), "Buy AAPL")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(150))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+        // 2025 transaction — should be filtered out, not contribute to balance.
+        Directive::Transaction(
+            Transaction::new(date(2025, 6, 1), "Buy MSFT")
+                .with_posting(
+                    Posting::new("Assets:Brokerage", Amount::new(dec!(20), "MSFT")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(300))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new(
+                    "Equity:Opening",
+                    Amount::new(dec!(-6000), "USD"),
+                )),
+        ),
+    ];
+    let query =
+        parse(r#"JOURNAL "Assets:Brokerage" AT cost FROM year = 2024"#).expect("should parse");
+    let mut executor = Executor::new(&directives);
+    let result = executor.execute(&query).expect("should execute");
+
+    // Only the 2024 row passes FROM; AT cost collapses its balance to 1500 USD.
+    assert_eq!(result.rows.len(), 1);
+    let balance = match &result.rows[0][6] {
+        Value::Inventory(inv) => inv,
+        other => panic!("expected Inventory, got {other:?}"),
+    };
+    let positions = balance.positions();
+    assert_eq!(
+        positions.len(),
+        1,
+        "only 2024 transaction should contribute"
+    );
+    assert_eq!(positions[0].units.number, dec!(1500));
+    assert_eq!(positions[0].units.currency.as_str(), "USD");
+}
+
 /// Regression test for issue #957: `JOURNAL ... AT units` must strip cost
 /// annotations from every position in the balance column.
 #[test]

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -119,3 +119,15 @@ name = "journal-assets"
 query = "JOURNAL 'Assets'"
 notes = "JOURNAL form — different code path from SELECT; order-sensitive"
 preserve_order = true
+
+[[query]]
+name = "journal-assets-at-cost"
+query = "JOURNAL 'Assets' AT cost"
+notes = "JOURNAL AT cost — exercises summary_func(balance) collapsing per-row balance to cost-currency totals (issue #957)"
+preserve_order = true
+
+[[query]]
+name = "journal-assets-at-units"
+query = "JOURNAL 'Assets' AT units"
+notes = "JOURNAL AT units — exercises summary_func(balance) stripping cost annotations from balance (issue #957)"
+preserve_order = true


### PR DESCRIPTION
## Summary

`JOURNAL ... AT cost` and `JOURNAL ... AT units` only applied the AT-mode transformation to the position column, leaving the balance column as the full cumulative inventory with `{ lot }` annotations. Python `bean-query` translates `JOURNAL ... AT <mode>` into a SELECT where **both** the position and balance columns are wrapped in `summary_func(...)`, so AT cost collapses both to cost-currency totals; AT units strips lots from both. This PR makes our JOURNAL match.

## Reproducer

```bash
cat > /tmp/x.bean <<'BEAN'
2024-01-01 open Assets:Brokerage
2024-01-01 open Equity:Opening
2024-02-01 * "Buy AAPL"
  Assets:Brokerage  10 AAPL { 150 USD }
  Equity:Opening   -1500 USD
BEAN
rledger query "JOURNAL 'Assets:Brokerage' AT cost" /tmp/x.bean
```

- **Before:** balance column shows `10 AAPL { 150 USD }` (full lot detail).
- **After:** balance column shows `1500 USD` (cost-currency total, matching `bean-query`).

## Fix

In `execute_journal`, after building the row's `cumulative_balance` view, apply `Inventory::at_cost()` / `at_units()` symmetrically to `query.at_function`. Reuses the existing methods that `execute_balances` already uses correctly. Five lines added:

```rust
let balance_for_row = if let Some(at_func) = &query.at_function {
    match at_func.to_uppercase().as_str() {
        "COST" => cumulative_balance.at_cost(),
        "UNITS" => cumulative_balance.at_units(),
        _ => cumulative_balance.clone(),
    }
} else {
    cumulative_balance.clone()
};
```

## Edge cases preserved

`Inventory::at_cost()` already has the right semantics (verified against `crates/rustledger-core/src/inventory/mod.rs:554`):

- **Positions with cost** → collapsed to cost-currency total (`10 AAPL { 150 USD }` becomes `1500 USD`).
- **Positions without cost** → returned as-is. Matches the AT-cost position-side fallback Copilot flagged in PR #956: when no cost is resolvable, fall back to the original units, don't error.
- **Mixed cost currencies** → multi-currency inventory preserved (`1500 USD 650 EUR`), not collapsed across cost currencies. Matches `bean-query`'s `cost(balance)`.

## Tests

Four new regression tests in `crates/rustledger-query/tests/bql_integration_test.rs`:

- `test_journal_at_cost_collapses_balance_to_cost_currency` — primary case: `10 AAPL { 150 USD }` → balance `1500 USD`, no lot annotation.
- `test_journal_at_units_strips_cost_from_balance` — `AAPL { 150 USD }` → balance `10 AAPL`, no lot annotation.
- `test_journal_at_cost_balance_preserves_no_cost_positions` — USD-only ledger under AT cost: USD passes through unchanged. Locks in the no-cost-fallback behavior.
- `test_journal_at_cost_balance_keeps_mixed_cost_currencies` — USD lot + EUR lot of same commodity: balance retains both `1500 USD` and `650 EUR`, not collapsed across currencies.

## Compat suite

Two new queries in `tests/compatibility/bql-queries.toml`:

```toml
[[query]]
name = "journal-assets-at-cost"
query = "JOURNAL 'Assets' AT cost"
preserve_order = true

[[query]]
name = "journal-assets-at-units"
query = "JOURNAL 'Assets' AT units"
preserve_order = true
```

These exercise the new code path against `bean-query` so future regressions are caught by the compat run.

## Verification

- `cargo test -p rustledger-query`: 497 tests pass (was 493, +4 new)
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

## Compat impact

Closes a known divergence from `bean-query`. Should move the BQL match rate up on the next compat run once the new queries land in the suite.

## Test plan

- [ ] CI: Test, Clippy, Doctests, Format, Compatibility
- [ ] Compat run: new `journal-assets-at-cost` / `journal-assets-at-units` queries should pass byte-for-byte against `bean-query` (modulo whitespace) on relevant fixtures
- [ ] Manual: reproducer above produces `1500 USD` in the balance column

## Out of scope

Stacks cleanly with PR #959 (which fixes `BALANCES` non-idempotency). The two PRs touch different functions and merge in any order.

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)