### PR TITLE
ci(cargo-vet): break infinite loop on idempotent regen

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -23,10 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     # Run for Dependabot PRs and trusted-maintainer PRs (OWNER/MEMBER).
     # Use author_association so we don't have to maintain a username list.
+    # Skip when the actor is rustledger-bot itself — that would be this
+    # workflow's own push, and re-triggering on it can cause an infinite
+    # loop if the regen produces a no-op tree (see "Skip when nothing
+    # actually changed" below for the structural fix).
     if: |
-      github.actor == 'dependabot[bot]' ||
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER'
+      github.actor != 'rustledger-bot[bot]' &&
+      (
+        github.actor == 'dependabot[bot]' ||
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER'
+      )
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -117,6 +124,20 @@ jobs:
               '{tree: $tree, base_tree: $base}' | \
               gh api "repos/$REPO/git/trees" --input - --jq '.sha')
             echo "New tree: $NEW_TREE"
+
+            # Skip when nothing actually changed at the tree level.
+            # This workflow checks out the BASE branch and regenerates
+            # exemptions against the PR's Cargo.lock, which produces a
+            # deterministic tree for a given lockfile. If the PR branch
+            # already has that tree (because a previous run of this
+            # workflow pushed it), `git diff --staged` may still see
+            # local changes (working-tree-vs-base) but the resulting
+            # tree is identical to the PR's current tree — which would
+            # create an empty commit that loops via `pull_request_target`.
+            if [ "$NEW_TREE" = "$BASE_TREE" ]; then
+              echo "No effective changes (tree unchanged); skipping empty commit to avoid loop"
+              exit 0
+            fi
 
             # Create commit (GitHub will sign this)
             NEW_COMMIT=$(gh api "repos/$REPO/git/commits" \


### PR DESCRIPTION
## Summary

PR #964 hit a real infinite loop in the `Cargo Vet Auto` workflow: 13 bot commits in 20 minutes, each "chore: regenerate cargo-vet exemptions" with the same tree SHA as its parent. The loop was only stopped by manual run cancellation.

## Root cause

The workflow checks out the **base branch** (`ref: github.base_ref`) and runs `cargo vet regenerate exemptions` against the PR's `Cargo.lock`. That produces a deterministic tree for a given lockfile.

Once a previous run pushed that tree to the PR, every subsequent run produces the **same** tree — but `git diff --staged` still reports changes (because the checkout starts from `base_ref`'s exemption file, not the PR's current state). The script enters the API-commit branch and creates a tree via `gh api ... git/trees`, which returns the same tree SHA the PR already has. The resulting commit has `tree == parent.tree` (an empty commit). Empty commits still trigger `pull_request_target` synchronize events (the `paths: 'Cargo.lock'` filter looks at the cumulative PR diff, not the latest push). Loop.

Verified: comparing two consecutive bot commits on PR #964 (`9a86b859` and `8d30f82d`) showed identical trees (`c84810a4...`) with empty `files: []`.

## Fix

Two layers:

1. **Structural (primary)** — after creating the new tree, compare it to `BASE_TREE`. If equal, `exit 0` before the commit step. Empty commits never get pushed.
2. **Defense in depth** — skip the workflow entirely when `github.actor == 'rustledger-bot[bot]'`. Even if a future change re-introduces an empty-commit path, the bot's own pushes can't re-trigger this workflow.

## Test plan

- [ ] Open a maintainer PR that bumps a small dep to a fresh patch version
- [ ] Verify the workflow runs once, regenerates exemptions, pushes a commit
- [ ] Verify subsequent synchronize events on that PR re-run the workflow but exit early at the "tree unchanged" check, with no further commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)