### PR TITLE
fix(price): preserve per-spec tickers in fallback chains (closes #963)

### DIFF
--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -20,7 +20,7 @@
 //! behavior and avoids wasting API calls on commodities the user no longer
 //! holds. Pass `include_inactive: true` to skip the activity filter.
 
-use crate::config::{CommodityMapping, DetailedMapping, FallbackEntry, SourceRef};
+use crate::config::{CommodityMapping, DetailedMapping, FallbackDetail, FallbackEntry, SourceRef};
 use rust_decimal::Decimal;
 use rustledger_core::{Directive, MetaValue};
 use rustledger_loader::Options;
@@ -147,9 +147,11 @@ fn build_mapping(specs: &[PriceSpec]) -> Option<CommodityMapping> {
     // queried with `GBP-EUR` (ecbrates' shape) instead of `GBP`.
     let entries: Vec<FallbackEntry> = specs
         .iter()
-        .map(|s| FallbackEntry::Detailed {
-            source: s.source.clone(),
-            ticker: Some(s.ticker.clone()),
+        .map(|s| {
+            FallbackEntry::Detailed(FallbackDetail {
+                source: s.source.clone(),
+                ticker: Some(s.ticker.clone()),
+            })
         })
         .collect();
     Some(CommodityMapping::Detailed(DetailedMapping {

--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -20,7 +20,7 @@
 //! behavior and avoids wasting API calls on commodities the user no longer
 //! holds. Pass `include_inactive: true` to skip the activity filter.
 
-use crate::config::{CommodityMapping, DetailedMapping, SourceRef};
+use crate::config::{CommodityMapping, DetailedMapping, FallbackEntry, SourceRef};
 use rust_decimal::Decimal;
 use rustledger_core::{Directive, MetaValue};
 use rustledger_loader::Options;
@@ -140,13 +140,24 @@ fn build_mapping(specs: &[PriceSpec]) -> Option<CommodityMapping> {
             quote_currency: None,
         }));
     }
-    // Multiple specs: build a fallback chain. The ticker is taken from the
-    // first spec; it's the user's responsibility to ensure ticker symbols
-    // are interchangeable across sources in their `price:` chain (matching
-    // bean-price's contract).
-    let sources: Vec<String> = specs.iter().map(|s| s.source.clone()).collect();
+    // Multiple specs: build a fallback chain that PRESERVES each spec's
+    // ticker. Issue #963: previously we collapsed all sources onto the
+    // first spec's ticker, which broke metadata like
+    // `price: "EUR:ecbrates/GBP-EUR,EUR:ecb/GBP"` — the ECB source got
+    // queried with `GBP-EUR` (ecbrates' shape) instead of `GBP`.
+    let entries: Vec<FallbackEntry> = specs
+        .iter()
+        .map(|s| FallbackEntry::Detailed {
+            source: s.source.clone(),
+            ticker: Some(s.ticker.clone()),
+        })
+        .collect();
     Some(CommodityMapping::Detailed(DetailedMapping {
-        source: SourceRef::Fallback(sources),
+        source: SourceRef::Fallback(entries),
+        // The parent ticker is no longer load-bearing for fallback chains
+        // (each entry carries its own), but keep the first spec's ticker
+        // here as a sensible fallback if a future change ever consults
+        // `parent.ticker` directly.
         ticker: Some(specs[0].ticker.clone()),
         quote_currency: None,
     }))

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -187,8 +187,10 @@ impl PriceSourceRegistry {
 
     /// Fetch a price using the configured mapping.
     ///
-    /// This method resolves the commodity to the appropriate source and ticker
-    /// based on the configuration, then fetches the price.
+    /// This method resolves the commodity to the appropriate source and
+    /// ticker based on the configuration, then fetches the price. When a
+    /// fallback chain is in play, each entry's per-source ticker is used
+    /// (issue #963).
     pub fn fetch_price(
         &self,
         commodity: &str,
@@ -196,12 +198,12 @@ impl PriceSourceRegistry {
         date: Option<NaiveDate>,
         mapping: &HashMap<String, CommodityMapping>,
     ) -> Result<PriceResponse> {
-        let (source_names, ticker) = self.resolve_mapping(commodity, mapping);
+        let attempts = self.resolve_mapping(commodity, mapping);
 
         let mut last_error = None;
         let mut unknown_sources = Vec::new();
 
-        for source_name in &source_names {
+        for (source_name, ticker) in &attempts {
             if let Some(source) = self.get(source_name) {
                 let request = PriceRequest {
                     ticker: ticker.clone(),
@@ -245,29 +247,42 @@ impl PriceSourceRegistry {
         Err(err_msg)
     }
 
-    /// Resolve a commodity to its source(s) and ticker.
+    /// Resolve a commodity to a list of `(source, ticker)` attempts to
+    /// try in order. Each fallback entry can carry its own ticker so a
+    /// chain like `EUR:ecbrates/GBP-EUR,EUR:ecb/GBP` queries each source
+    /// with the ticker shape it expects (issue #963).
     fn resolve_mapping(
         &self,
         commodity: &str,
         mapping: &HashMap<String, CommodityMapping>,
-    ) -> (Vec<String>, String) {
+    ) -> Vec<(String, String)> {
         if let Some(commodity_mapping) = mapping.get(commodity) {
             match commodity_mapping {
                 CommodityMapping::Simple(ticker) => {
-                    (vec![self.default_source.clone()], ticker.clone())
+                    vec![(self.default_source.clone(), ticker.clone())]
                 }
                 CommodityMapping::Detailed(d) => {
-                    let ticker = d.ticker.clone().unwrap_or_else(|| commodity.to_string());
-                    let sources = match &d.source {
-                        SourceRef::Single(s) => vec![s.clone()],
-                        SourceRef::Fallback(sources) => sources.clone(),
-                    };
-                    (sources, ticker)
+                    let parent_ticker = d.ticker.clone().unwrap_or_else(|| commodity.to_string());
+                    match &d.source {
+                        SourceRef::Single(s) => vec![(s.clone(), parent_ticker)],
+                        SourceRef::Fallback(entries) => entries
+                            .iter()
+                            .map(|e| {
+                                // Per-entry ticker wins; otherwise fall back to the
+                                // parent ticker. This mirrors the metadata semantics
+                                // the discovery layer encodes for chained `price:`.
+                                let t = e
+                                    .ticker()
+                                    .map_or_else(|| parent_ticker.clone(), str::to_string);
+                                (e.source_name().to_string(), t)
+                            })
+                            .collect(),
+                    }
                 }
             }
         } else {
             // No mapping - use default source with commodity as ticker
-            (vec![self.default_source.clone()], commodity.to_string())
+            vec![(self.default_source.clone(), commodity.to_string())]
         }
     }
 }
@@ -299,6 +314,7 @@ pub fn fetch_price(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::FallbackEntry;
 
     #[test]
     fn test_price_request_builder() {
@@ -358,9 +374,8 @@ mod tests {
             CommodityMapping::Simple("BTC-USD".to_string()),
         );
 
-        let (sources, ticker) = registry.resolve_mapping("BTC", &mapping);
-        assert_eq!(sources, vec!["yahoo"]);
-        assert_eq!(ticker, "BTC-USD");
+        let attempts = registry.resolve_mapping("BTC", &mapping);
+        assert_eq!(attempts, vec![("yahoo".to_string(), "BTC-USD".to_string())]);
     }
 
     #[test]
@@ -370,15 +385,23 @@ mod tests {
         mapping.insert(
             "EUR".to_string(),
             CommodityMapping::Detailed(crate::config::DetailedMapping {
-                source: SourceRef::Fallback(vec!["ecb".to_string(), "ratesapi".to_string()]),
+                source: SourceRef::Fallback(vec![
+                    FallbackEntry::Name("ecb".to_string()),
+                    FallbackEntry::Name("ratesapi".to_string()),
+                ]),
                 ticker: None,
                 quote_currency: None,
             }),
         );
 
-        let (sources, ticker) = registry.resolve_mapping("EUR", &mapping);
-        assert_eq!(sources, vec!["ecb", "ratesapi"]);
-        assert_eq!(ticker, "EUR");
+        let attempts = registry.resolve_mapping("EUR", &mapping);
+        assert_eq!(
+            attempts,
+            vec![
+                ("ecb".to_string(), "EUR".to_string()),
+                ("ratesapi".to_string(), "EUR".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -386,9 +409,79 @@ mod tests {
         let registry = PriceSourceRegistry::default();
         let mapping = HashMap::new();
 
-        let (sources, ticker) = registry.resolve_mapping("AAPL", &mapping);
-        assert_eq!(sources, vec!["yahoo"]);
-        assert_eq!(ticker, "AAPL");
+        let attempts = registry.resolve_mapping("AAPL", &mapping);
+        assert_eq!(attempts, vec![("yahoo".to_string(), "AAPL".to_string())]);
+    }
+
+    /// Issue #963: a fallback chain whose entries carry per-source
+    /// tickers must query each source with that source's own ticker.
+    /// Previously all sources reused the first spec's ticker.
+    #[test]
+    fn test_resolve_mapping_fallback_uses_per_source_tickers() {
+        let registry = PriceSourceRegistry::default();
+        let mut mapping = HashMap::new();
+        mapping.insert(
+            "GBP".to_string(),
+            CommodityMapping::Detailed(crate::config::DetailedMapping {
+                source: SourceRef::Fallback(vec![
+                    FallbackEntry::Detailed {
+                        source: "ecbrates".to_string(),
+                        ticker: Some("GBP-EUR".to_string()),
+                    },
+                    FallbackEntry::Detailed {
+                        source: "ecb".to_string(),
+                        ticker: Some("GBP".to_string()),
+                    },
+                ]),
+                ticker: Some("GBP-EUR".to_string()),
+                quote_currency: Some("EUR".to_string()),
+            }),
+        );
+
+        let attempts = registry.resolve_mapping("GBP", &mapping);
+        assert_eq!(
+            attempts,
+            vec![
+                ("ecbrates".to_string(), "GBP-EUR".to_string()),
+                ("ecb".to_string(), "GBP".to_string()),
+            ],
+            "each fallback source must use its own ticker (issue #963)"
+        );
+    }
+
+    /// Mixed-shape fallback: a bare-string entry inherits the parent
+    /// ticker, while an object entry uses its own. Verifies the
+    /// `FallbackEntry::Name(_)` arm of `resolve_mapping` falls through
+    /// to `parent_ticker` correctly.
+    #[test]
+    fn test_resolve_mapping_fallback_mixed_entries_inherit_parent_ticker() {
+        let registry = PriceSourceRegistry::default();
+        let mut mapping = HashMap::new();
+        mapping.insert(
+            "BTC".to_string(),
+            CommodityMapping::Detailed(crate::config::DetailedMapping {
+                source: SourceRef::Fallback(vec![
+                    FallbackEntry::Name("yahoo".to_string()),
+                    FallbackEntry::Detailed {
+                        source: "coingecko".to_string(),
+                        ticker: Some("bitcoin".to_string()),
+                    },
+                ]),
+                ticker: Some("BTC-USD".to_string()),
+                quote_currency: None,
+            }),
+        );
+
+        let attempts = registry.resolve_mapping("BTC", &mapping);
+        assert_eq!(
+            attempts,
+            vec![
+                // Bare-string entry inherits parent ticker.
+                ("yahoo".to_string(), "BTC-USD".to_string()),
+                // Detailed entry uses its own ticker.
+                ("coingecko".to_string(), "bitcoin".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -314,7 +314,7 @@ pub fn fetch_price(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::FallbackEntry;
+    use crate::config::{FallbackDetail, FallbackEntry};
 
     #[test]
     fn test_price_request_builder() {
@@ -424,14 +424,14 @@ mod tests {
             "GBP".to_string(),
             CommodityMapping::Detailed(crate::config::DetailedMapping {
                 source: SourceRef::Fallback(vec![
-                    FallbackEntry::Detailed {
+                    FallbackEntry::Detailed(FallbackDetail {
                         source: "ecbrates".to_string(),
                         ticker: Some("GBP-EUR".to_string()),
-                    },
-                    FallbackEntry::Detailed {
+                    }),
+                    FallbackEntry::Detailed(FallbackDetail {
                         source: "ecb".to_string(),
                         ticker: Some("GBP".to_string()),
-                    },
+                    }),
                 ]),
                 ticker: Some("GBP-EUR".to_string()),
                 quote_currency: Some("EUR".to_string()),
@@ -462,10 +462,10 @@ mod tests {
             CommodityMapping::Detailed(crate::config::DetailedMapping {
                 source: SourceRef::Fallback(vec![
                     FallbackEntry::Name("yahoo".to_string()),
-                    FallbackEntry::Detailed {
+                    FallbackEntry::Detailed(FallbackDetail {
                         source: "coingecko".to_string(),
                         ticker: Some("bitcoin".to_string()),
-                    },
+                    }),
                 ]),
                 ticker: Some("BTC-USD".to_string()),
                 quote_currency: None,

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -182,14 +182,26 @@ pub enum FallbackEntry {
     Name(String),
 
     /// Source paired with its own ticker.
-    Detailed {
-        /// Source name (e.g. `"yahoo"`, `"ecb"`).
-        source: String,
-        /// Ticker shape this specific source expects. Overrides the
-        /// parent `DetailedMapping.ticker` for this attempt only.
-        #[serde(default)]
-        ticker: Option<String>,
-    },
+    Detailed(FallbackDetail),
+}
+
+/// `{source, ticker}` form of a fallback chain entry.
+///
+/// Lives in its own struct (rather than as an inline variant payload)
+/// so it can carry `#[serde(deny_unknown_fields)]` — without it, a
+/// typo like `{ source = "ecb", tickre = "GBP" }` would silently
+/// deserialize as `Detailed { source = "ecb", ticker = None }` and
+/// fall back to the parent ticker, masking the misconfiguration.
+/// Mirrors the same guard `DetailedMapping` carries (issue #952).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FallbackDetail {
+    /// Source name (e.g. `"yahoo"`, `"ecb"`).
+    pub source: String,
+    /// Ticker shape this specific source expects. Overrides the
+    /// parent `DetailedMapping.ticker` for this attempt only.
+    #[serde(default)]
+    pub ticker: Option<String>,
 }
 
 impl FallbackEntry {
@@ -198,7 +210,7 @@ impl FallbackEntry {
     pub fn source_name(&self) -> &str {
         match self {
             Self::Name(s) => s,
-            Self::Detailed { source, .. } => source,
+            Self::Detailed(d) => &d.source,
         }
     }
 
@@ -207,7 +219,7 @@ impl FallbackEntry {
     pub fn ticker(&self) -> Option<&str> {
         match self {
             Self::Name(_) => None,
-            Self::Detailed { ticker, .. } => ticker.as_deref(),
+            Self::Detailed(d) => d.ticker.as_deref(),
         }
     }
 }
@@ -1629,6 +1641,32 @@ ticker = "BTC-USD"
         assert_eq!(entries[0].ticker(), None);
         assert_eq!(entries[1].source_name(), "coingecko");
         assert_eq!(entries[1].ticker(), Some("bitcoin"));
+    }
+
+    /// Copilot review on PR #970: without `deny_unknown_fields`, a
+    /// typo in a fallback chain object (e.g. `tickre = "GBP"`) would
+    /// silently deserialize with `ticker = None` and fall back to the
+    /// parent ticker, masking the misconfiguration. `FallbackDetail`
+    /// carries `deny_unknown_fields` so the typo errors at config load,
+    /// matching the guard `DetailedMapping` already has (#952).
+    ///
+    /// Caveat: `SourceRef` and `CommodityMapping` are `serde(untagged)`,
+    /// so the inner "unknown field `tickre`" error gets wrapped into a
+    /// generic "data did not match any variant" by the time it reaches
+    /// the caller. We only assert load failure here — that's enough to
+    /// catch the regression. (Without `deny_unknown_fields`, this same
+    /// input deserializes successfully with `ticker = None`, the wrong
+    /// answer.)
+    #[test]
+    fn test_parse_commodity_mapping_fallback_rejects_unknown_field_in_entry() {
+        let content = r#"
+[price.mapping.GBP]
+source = [
+  { source = "ecb", tickre = "GBP" },
+]
+"#;
+        toml::from_str::<Config>(content)
+            .expect_err("a typo in a fallback chain entry must error at load");
     }
 
     #[test]

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -163,8 +163,53 @@ pub enum SourceRef {
     /// A single source name.
     Single(String),
 
-    /// Fallback chain of sources (try in order).
-    Fallback(Vec<String>),
+    /// Fallback chain of sources (try in order). Each entry can be a
+    /// bare source name (uses the parent `DetailedMapping.ticker`) or
+    /// an object with its own `ticker` (preserves per-source tickers
+    /// for cases like `"EUR:ecbrates/GBP-EUR,EUR:ecb/GBP"` where the
+    /// two sources expect different ticker shapes — issue #963).
+    Fallback(Vec<FallbackEntry>),
+}
+
+/// One entry in a fallback chain. Accepts either a bare source name
+/// or `{source = "...", ticker = "..."}` so per-source tickers can be
+/// preserved through the chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FallbackEntry {
+    /// Bare source name. Ticker comes from `DetailedMapping.ticker`
+    /// (or the commodity name if that's also unset).
+    Name(String),
+
+    /// Source paired with its own ticker.
+    Detailed {
+        /// Source name (e.g. `"yahoo"`, `"ecb"`).
+        source: String,
+        /// Ticker shape this specific source expects. Overrides the
+        /// parent `DetailedMapping.ticker` for this attempt only.
+        #[serde(default)]
+        ticker: Option<String>,
+    },
+}
+
+impl FallbackEntry {
+    /// The source name this entry refers to.
+    #[must_use]
+    pub fn source_name(&self) -> &str {
+        match self {
+            Self::Name(s) => s,
+            Self::Detailed { source, .. } => source,
+        }
+    }
+
+    /// The ticker for this entry, if it has its own.
+    #[must_use]
+    pub fn ticker(&self) -> Option<&str> {
+        match self {
+            Self::Name(_) => None,
+            Self::Detailed { ticker, .. } => ticker.as_deref(),
+        }
+    }
 }
 
 /// Default configuration options.
@@ -1518,8 +1563,11 @@ source = ["ecb", "ratesapi"]
         }
 
         if let Some(CommodityMapping::Detailed(d)) = config.price.mapping.get("EUR") {
-            if let SourceRef::Fallback(sources) = &d.source {
-                assert_eq!(sources, &["ecb", "ratesapi"]);
+            if let SourceRef::Fallback(entries) = &d.source {
+                let names: Vec<&str> = entries.iter().map(FallbackEntry::source_name).collect();
+                assert_eq!(names, vec!["ecb", "ratesapi"]);
+                // Bare-string entries have no per-source ticker.
+                assert!(entries.iter().all(|e| e.ticker().is_none()));
             } else {
                 panic!("Expected Fallback source");
             }
@@ -1528,6 +1576,59 @@ source = ["ecb", "ratesapi"]
         } else {
             panic!("Expected Detailed mapping for EUR");
         }
+    }
+
+    /// Issue #963: a fallback chain entry can carry its own ticker so
+    /// that `price: "EUR:ecbrates/GBP-EUR,EUR:ecb/GBP"`-style metadata
+    /// survives into the executor without collapsing all sources onto
+    /// the first spec's ticker.
+    #[test]
+    fn test_parse_commodity_mapping_fallback_with_per_source_tickers() {
+        let content = r#"
+[price.mapping.GBP]
+source = [
+  { source = "ecbrates", ticker = "GBP-EUR" },
+  { source = "ecb", ticker = "GBP" },
+]
+quote_currency = "EUR"
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        let Some(CommodityMapping::Detailed(d)) = config.price.mapping.get("GBP") else {
+            panic!("Expected Detailed mapping for GBP");
+        };
+        let SourceRef::Fallback(entries) = &d.source else {
+            panic!("Expected Fallback source");
+        };
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].source_name(), "ecbrates");
+        assert_eq!(entries[0].ticker(), Some("GBP-EUR"));
+        assert_eq!(entries[1].source_name(), "ecb");
+        assert_eq!(entries[1].ticker(), Some("GBP"));
+    }
+
+    /// Mixed chain: bare names and `{source, ticker}` objects in the
+    /// same list both deserialize via `serde(untagged)` on FallbackEntry.
+    #[test]
+    fn test_parse_commodity_mapping_fallback_mixed_entry_shapes() {
+        let content = r#"
+[price.mapping.BTC]
+source = [
+  "yahoo",
+  { source = "coingecko", ticker = "bitcoin" },
+]
+ticker = "BTC-USD"
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        let Some(CommodityMapping::Detailed(d)) = config.price.mapping.get("BTC") else {
+            panic!("Expected Detailed mapping for BTC");
+        };
+        let SourceRef::Fallback(entries) = &d.source else {
+            panic!("Expected Fallback source");
+        };
+        assert_eq!(entries[0].source_name(), "yahoo");
+        assert_eq!(entries[0].ticker(), None);
+        assert_eq!(entries[1].source_name(), "coingecko");
+        assert_eq!(entries[1].ticker(), Some("bitcoin"));
     }
 
     #[test]

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -1607,7 +1607,7 @@ quote_currency = "EUR"
     }
 
     /// Mixed chain: bare names and `{source, ticker}` objects in the
-    /// same list both deserialize via `serde(untagged)` on FallbackEntry.
+    /// same list both deserialize via `serde(untagged)` on `FallbackEntry`.
     #[test]
     fn test_parse_commodity_mapping_fallback_mixed_entry_shapes() {
         let content = r#"

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -54,7 +54,9 @@ Annotate a commodity with how to fetch its price. The format is `<quote-currency
   price: "EUR:ecb/AUD-EUR"
 ```
 
-The first source in the chain is tried first; subsequent ones act as fallbacks. The quote currency in the metadata overrides the global `--currency` for that one symbol, so you can mix USD-quoted stocks and EUR-quoted bonds in the same run.
+The first source in the chain is tried first; subsequent ones act as fallbacks. **Each spec carries its own ticker** — so `EUR:ecbrates/GBP-EUR,EUR:ecb/GBP` queries `ecbrates` with ticker `GBP-EUR` and, on failure, queries `ecb` with ticker `GBP`. (Issue #963: prior to this fix, all sources reused the first spec's ticker, which broke chains where sources expect different ticker shapes for the same underlying.)
+
+The quote currency in the metadata overrides the global `--currency` for that one symbol, so you can mix USD-quoted stocks and EUR-quoted bonds in the same run.
 
 Commodities that don't have `price:` metadata fall back to a name heuristic: ticker-shaped names (uppercase letters, digits, dashes; ≤ 10 chars) are still picked up, preserving the previous behavior.
 
@@ -205,9 +207,19 @@ ticker = "ETH"
 source = "ecb"
 quote_currency = "EUR"  # quote AUD in EUR even when --currency is USD
 
-# Fallback chain
+# Fallback chain (bare source names — all use the parent ticker)
 [price.mapping.VTI]
 source = ["yahoo", "alphavantage"]
+
+# Fallback chain with per-source tickers (issue #963).
+# Use this when sources expect different ticker shapes for the same
+# underlying instrument — e.g. ratesapi-style `GBP-EUR` vs ecb-style `GBP`.
+[price.mapping.GBP]
+source = [
+  { source = "ecbrates", ticker = "GBP-EUR" },
+  { source = "ecb", ticker = "GBP" },
+]
+quote_currency = "EUR"
 
 # Custom external command source
 [price.sources.mybank]


### PR DESCRIPTION
## Summary

Issue #963 reports that
\`\`\`beancount
1970-01-01 commodity GBP
  price: \"EUR:ecbrates/GBP-EUR,EUR:ecb/GBP\"
\`\`\`
fails with:
\`\`\`
Error fetching GBP: Failed to fetch ECB rate for GBP-EUR; note: unknown sources skipped: ecbrates
\`\`\`

**Root cause:** the discovery layer (PR #951) built a fallback chain that collapsed every source onto the FIRST spec's ticker. Once \`ecbrates\` was skipped (it's not a built-in source), \`ecb\` got queried with ticker \`GBP-EUR\` instead of \`GBP\` — ECB rejected the bogus ticker shape.

This fix preserves per-spec tickers all the way through the pipeline.

## Changes

- New \`FallbackEntry\` enum (\`config.rs\`). Either a bare source name (inherits parent ticker) or \`{source = \"...\", ticker = \"...\"}\`. \`#[serde(untagged)]\` keeps the legacy \`source = [\"a\", \"b\"]\` config form parsing unchanged, and lets you mix both shapes in the same list.
- \`SourceRef::Fallback(Vec<String>)\` → \`SourceRef::Fallback(Vec<FallbackEntry>)\`. \`discovery.rs::build_mapping\` now emits \`FallbackEntry::Detailed\` per spec, carrying that spec's ticker.
- \`PriceSourceRegistry::resolve_mapping\` returns \`Vec<(String, String)>\` — (source, ticker) pairs — instead of \`(Vec<String>, String)\`. \`fetch_price\` iterates pairs so each fallback attempt uses its own source's ticker.

## Tests

New regression tests:
- \`config::tests::test_parse_commodity_mapping_fallback_with_per_source_tickers\`
- \`config::tests::test_parse_commodity_mapping_fallback_mixed_entry_shapes\`
- \`cmd::price::tests::test_resolve_mapping_fallback_uses_per_source_tickers\` (the #963 regression)
- \`cmd::price::tests::test_resolve_mapping_fallback_mixed_entries_inherit_parent_ticker\`

Existing \`test_resolve_mapping_*\` tests updated for the new return type. **237 rustledger lib tests pass.**

## Bean-price compat note

The reporter's follow-up comment on #963 confirmed bean-price treats the comma-syntax as invalid; chained \`price:\` is a deliberate rustledger extension. PR #965 already documented the broader \`--undeclared\` divergence; #967 tracks the audit. This PR makes the extension actually work as advertised when sources expect different ticker shapes.

## Test plan

- [x] \`cargo test -p rustledger --lib\` (237 passed)
- [x] \`cargo clippy -p rustledger --all-features -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] CI green

Closes #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)