### PR TITLE
fix(price): error on unmapped fetch instead of silent default-source dispatch (closes #966)

### DIFF
--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -62,9 +62,13 @@ struct PriceSpec {
 
 /// Discover the set of commodities to fetch prices for from a loaded ledger.
 ///
-/// Returns a map from commodity symbol to discovery info. Caller-supplied
-/// CLI symbols are always included (with empty discovery info) so they
-/// override or augment file-based discovery.
+/// Returns a map from commodity symbol to discovery info, covering only
+/// commodities present in the ledger that meet the discovery criteria.
+/// CLI-supplied symbols are intentionally NOT injected here — the caller
+/// handles them separately so that explicit `rledger price BAM`
+/// invocations hit the explicit-source-required check (#966) instead of
+/// the auto-synthesized default-source mapping that file-discovered
+/// commodities get.
 ///
 /// `inactive` corresponds to `bean-price --inactive`: when false (the
 /// default), only commodities with a non-zero balance on at least one open
@@ -84,7 +88,6 @@ struct PriceSpec {
 pub fn discover_symbols(
     directives: &[Spanned<Directive>],
     options: &Options,
-    cli_symbols: &[String],
     inactive: bool,
     undeclared: bool,
 ) -> HashMap<String, DiscoveredCommodity> {
@@ -142,11 +145,6 @@ pub fn discover_symbols(
         }
 
         out.insert(symbol.to_string(), info);
-    }
-
-    // CLI-supplied symbols always pass through with default (empty) info.
-    for symbol in cli_symbols {
-        out.entry(symbol.clone()).or_default();
     }
 
     out
@@ -532,7 +530,7 @@ mod tests {
                     )),
             ),
         ]);
-        let discovered = discover_symbols(&dirs, &Options::new(), &[], false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
 
         // Even though "Vanguard_VTI" doesn't pass the ticker heuristic,
         // it has price: metadata, so it's discovered.
@@ -553,27 +551,24 @@ mod tests {
         let dirs = directives(vec![Directive::Commodity(comm)]);
 
         // Default: no active postings means OLD is not discovered.
-        let discovered = discover_symbols(&dirs, &Options::new(), &[], false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
         assert!(!discovered.contains_key("OLD"));
 
         // Opt-in: inactive=true brings it back.
-        let discovered_all = discover_symbols(&dirs, &Options::new(), &[], true, false);
+        let discovered_all = discover_symbols(&dirs, &Options::new(), true, false);
         assert!(discovered_all.contains_key("OLD"));
     }
 
+    /// `discover_symbols` returns only file-discovered commodities; CLI
+    /// symbols are now handled separately by the caller (`price_cmd.rs`)
+    /// so they can be subjected to the explicit-source-required check
+    /// (#966) instead of getting auto-synthesized default-source
+    /// mappings like file-discovered symbols do.
     #[test]
-    fn cli_symbols_always_included_with_default_info() {
+    fn discover_returns_empty_for_empty_ledger() {
         let dirs: Vec<Spanned<Directive>> = vec![];
-        let discovered = discover_symbols(
-            &dirs,
-            &Options::new(),
-            &["MANUAL".to_string()],
-            false,
-            false,
-        );
-        let info = discovered.get("MANUAL").unwrap();
-        assert!(info.mapping.is_none());
-        assert!(info.quote_currency.is_none());
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
+        assert!(discovered.is_empty());
     }
 
     /// Issue #962: a ticker-shaped commodity name without `price:`
@@ -600,14 +595,14 @@ mod tests {
             ),
         ]);
 
-        let strict = discover_symbols(&dirs, &Options::new(), &[], false, false);
+        let strict = discover_symbols(&dirs, &Options::new(), false, false);
         assert!(
             !strict.contains_key("BAM"),
             "BAM has no `price:` metadata, must not be discovered by default (#962)"
         );
 
         // `--undeclared` brings the heuristic back.
-        let with_undeclared = discover_symbols(&dirs, &Options::new(), &[], false, true);
+        let with_undeclared = discover_symbols(&dirs, &Options::new(), false, true);
         assert!(with_undeclared.contains_key("BAM"));
     }
 
@@ -634,7 +629,7 @@ mod tests {
         ]);
 
         // Even with --undeclared, the empty price: opt-out wins.
-        let discovered = discover_symbols(&dirs, &Options::new(), &[], false, true);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, true);
         assert!(!discovered.contains_key("BAM"));
     }
 
@@ -665,7 +660,7 @@ mod tests {
             ),
         ]);
 
-        let discovered = discover_symbols(&dirs, &Options::new(), &[], false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
         let info = discovered
             .get("GOVT_EU")
             .expect("quote_currency: alone should opt into discovery");
@@ -682,7 +677,7 @@ mod tests {
             date(2024, 1, 1),
             "OLD",
         ))]);
-        let discovered = discover_symbols(&dirs, &Options::new(), &[], true, true);
+        let discovered = discover_symbols(&dirs, &Options::new(), true, true);
         assert!(discovered.contains_key("OLD"));
     }
 
@@ -762,7 +757,7 @@ mod tests {
             ),
         ]);
 
-        let discovered = discover_symbols(&dirs, &Options::new(), &[], false, true);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, true);
         assert!(!discovered.contains_key("BAM"));
     }
 

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -68,6 +68,10 @@ pub struct PriceSourceRegistry {
     sources: HashMap<String, Arc<dyn PriceSource>>,
     default_source: String,
     timeout: Duration,
+    /// When false, a commodity with no explicit source declaration
+    /// errors instead of silently using `default_source`. See #966 and
+    /// `PriceConfig::use_default_source`.
+    use_default_source: bool,
 }
 
 impl PriceSourceRegistry {
@@ -150,6 +154,7 @@ impl PriceSourceRegistry {
             sources,
             default_source: config.effective_default_source().to_string(),
             timeout,
+            use_default_source: config.effective_use_default_source(),
         }
     }
 
@@ -191,6 +196,13 @@ impl PriceSourceRegistry {
     /// ticker based on the configuration, then fetches the price. When a
     /// fallback chain is in play, each entry's per-source ticker is used
     /// (issue #963).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the commodity has no explicit source
+    /// declaration (no CLI `--source`, no `[price.mapping.X]` in config,
+    /// no `price:` metadata) and `[price] use_default_source = false`
+    /// (the default). See issue #966.
     pub fn fetch_price(
         &self,
         commodity: &str,
@@ -198,7 +210,7 @@ impl PriceSourceRegistry {
         date: Option<NaiveDate>,
         mapping: &HashMap<String, CommodityMapping>,
     ) -> Result<PriceResponse> {
-        let attempts = self.resolve_mapping(commodity, mapping);
+        let attempts = self.resolve_mapping(commodity, mapping)?;
 
         let mut last_error = None;
         let mut unknown_sources = Vec::new();
@@ -251,13 +263,19 @@ impl PriceSourceRegistry {
     /// try in order. Each fallback entry can carry its own ticker so a
     /// chain like `EUR:ecbrates/GBP-EUR,EUR:ecb/GBP` queries each source
     /// with the ticker shape it expects (issue #963).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `mapping` has no entry for `commodity` and
+    /// `use_default_source` is false. The error message lists the
+    /// remediation paths so users can pick whichever fits their workflow.
     fn resolve_mapping(
         &self,
         commodity: &str,
         mapping: &HashMap<String, CommodityMapping>,
-    ) -> Vec<(String, String)> {
+    ) -> Result<Vec<(String, String)>> {
         if let Some(commodity_mapping) = mapping.get(commodity) {
-            match commodity_mapping {
+            let attempts = match commodity_mapping {
                 CommodityMapping::Simple(ticker) => {
                     vec![(self.default_source.clone(), ticker.clone())]
                 }
@@ -279,11 +297,25 @@ impl PriceSourceRegistry {
                             .collect(),
                     }
                 }
-            }
-        } else {
-            // No mapping - use default source with commodity as ticker
-            vec![(self.default_source.clone(), commodity.to_string())]
+            };
+            return Ok(attempts);
         }
+
+        // No mapping. Issue #966: silently dispatching to `default_source`
+        // is the failure mode where currency codes like `BAM` get sent to
+        // Yahoo and return a stock price for an unrelated ticker. Refuse
+        // unless the user has opted in via `[price] use_default_source = true`.
+        if self.use_default_source {
+            return Ok(vec![(self.default_source.clone(), commodity.to_string())]);
+        }
+        Err(anyhow::anyhow!(
+            "no price source configured for {commodity}. Either pass `--source <name>`, \
+             add `[price.mapping.{commodity}]` to your config, annotate the commodity \
+             with `price: \"<quote>:<source>/<ticker>\"` metadata in your beancount file, \
+             or set `[price] use_default_source = true` to fall back to the default \
+             source ({default}) for unmapped symbols.",
+            default = self.default_source,
+        ))
     }
 }
 
@@ -374,7 +406,7 @@ mod tests {
             CommodityMapping::Simple("BTC-USD".to_string()),
         );
 
-        let attempts = registry.resolve_mapping("BTC", &mapping);
+        let attempts = registry.resolve_mapping("BTC", &mapping).unwrap();
         assert_eq!(attempts, vec![("yahoo".to_string(), "BTC-USD".to_string())]);
     }
 
@@ -394,7 +426,7 @@ mod tests {
             }),
         );
 
-        let attempts = registry.resolve_mapping("EUR", &mapping);
+        let attempts = registry.resolve_mapping("EUR", &mapping).unwrap();
         assert_eq!(
             attempts,
             vec![
@@ -404,12 +436,55 @@ mod tests {
         );
     }
 
+    /// Issue #966: by default, resolving a commodity that has no
+    /// mapping (and no `--source` was provided at the call site) is an
+    /// error rather than a silent dispatch to `default_source`. The
+    /// error message points the user at the three remediation paths.
     #[test]
-    fn test_resolve_mapping_no_mapping() {
+    fn test_resolve_mapping_no_mapping_errors_by_default() {
         let registry = PriceSourceRegistry::default();
         let mapping = HashMap::new();
 
-        let attempts = registry.resolve_mapping("AAPL", &mapping);
+        let result = registry.resolve_mapping("AAPL", &mapping);
+        let err = result.expect_err("default behavior must refuse unmapped symbols");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("AAPL"),
+            "error must name the offending symbol: {msg}"
+        );
+        // Each remediation path must be discoverable from the error.
+        assert!(
+            msg.contains("--source"),
+            "error must mention --source: {msg}"
+        );
+        assert!(
+            msg.contains("[price.mapping.AAPL]"),
+            "error must mention the per-symbol config block: {msg}"
+        );
+        assert!(
+            msg.contains("price:"),
+            "error must mention the metadata path: {msg}"
+        );
+        assert!(
+            msg.contains("use_default_source"),
+            "error must mention the opt-in flag: {msg}"
+        );
+    }
+
+    /// `[price] use_default_source = true` restores the previous
+    /// behavior — unmapped symbols dispatch to `default_source`.
+    #[test]
+    fn test_resolve_mapping_no_mapping_uses_default_when_opted_in() {
+        let config = PriceConfig {
+            use_default_source: Some(true),
+            ..PriceConfig::default()
+        };
+        let registry = PriceSourceRegistry::new(&config);
+        let mapping = HashMap::new();
+
+        let attempts = registry
+            .resolve_mapping("AAPL", &mapping)
+            .expect("opt-in must allow default-source dispatch");
         assert_eq!(attempts, vec![("yahoo".to_string(), "AAPL".to_string())]);
     }
 
@@ -438,7 +513,7 @@ mod tests {
             }),
         );
 
-        let attempts = registry.resolve_mapping("GBP", &mapping);
+        let attempts = registry.resolve_mapping("GBP", &mapping).unwrap();
         assert_eq!(
             attempts,
             vec![
@@ -472,7 +547,7 @@ mod tests {
             }),
         );
 
-        let attempts = registry.resolve_mapping("BTC", &mapping);
+        let attempts = registry.resolve_mapping("BTC", &mapping).unwrap();
         assert_eq!(
             attempts,
             vec![

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -309,11 +309,15 @@ impl PriceSourceRegistry {
             return Ok(vec![(self.default_source.clone(), commodity.to_string())]);
         }
         Err(anyhow::anyhow!(
-            "no price source configured for {commodity}. Either pass `--source <name>`, \
-             add `[price.mapping.{commodity}]` to your config, annotate the commodity \
-             with `price: \"<quote>:<source>/<ticker>\"` metadata in your beancount file, \
-             or set `[price] use_default_source = true` to fall back to the default \
-             source ({default}) for unmapped symbols.",
+            "no price source configured for {commodity}. Pick one:\n  \
+             - pass `--source <name>` (e.g. `--source ecb`),\n  \
+             - pass `--mapping {commodity}:<TICKER>`,\n  \
+             - add `[price.mapping.{commodity}]` to your rledger config,\n  \
+             - annotate the commodity in your beancount file with \
+             `price: \"<quote>:<source>/<ticker>\"` or `quote_currency: \"<currency>\"` \
+             and load the file with `-f`,\n  \
+             - or set `[price] use_default_source = true` in your config to fall back \
+             to the default source ({default}) for unmapped symbols.",
             default = self.default_source,
         ))
     }
@@ -439,7 +443,8 @@ mod tests {
     /// Issue #966: by default, resolving a commodity that has no
     /// mapping (and no `--source` was provided at the call site) is an
     /// error rather than a silent dispatch to `default_source`. The
-    /// error message points the user at the three remediation paths.
+    /// error message points the user at every remediation path so they
+    /// don't have to guess which one applies to their workflow.
     #[test]
     fn test_resolve_mapping_no_mapping_errors_by_default() {
         let registry = PriceSourceRegistry::default();
@@ -452,23 +457,19 @@ mod tests {
             msg.contains("AAPL"),
             "error must name the offending symbol: {msg}"
         );
-        // Each remediation path must be discoverable from the error.
-        assert!(
-            msg.contains("--source"),
-            "error must mention --source: {msg}"
-        );
-        assert!(
-            msg.contains("[price.mapping.AAPL]"),
-            "error must mention the per-symbol config block: {msg}"
-        );
-        assert!(
-            msg.contains("price:"),
-            "error must mention the metadata path: {msg}"
-        );
-        assert!(
-            msg.contains("use_default_source"),
-            "error must mention the opt-in flag: {msg}"
-        );
+        // Every remediation path must be discoverable from the error so
+        // the user can pick whichever one fits their workflow.
+        for needle in [
+            "--source",
+            "--mapping",
+            "[price.mapping.AAPL]",
+            "price:",
+            "quote_currency:",
+            "-f",
+            "use_default_source",
+        ] {
+            assert!(msg.contains(needle), "error must mention `{needle}`: {msg}");
+        }
     }
 
     /// `[price] use_default_source = true` restores the previous

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -174,21 +174,26 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         discover_symbols(
             &ledger.directives,
             &ledger.options,
-            &args.symbols,
             effective_inactive,
             effective_undeclared,
         )
     } else {
-        let mut out = HashMap::new();
-        for s in &args.symbols {
-            out.insert(s.clone(), DiscoveredCommodity::default());
-        }
-        out
+        HashMap::new()
     };
 
     // Stable order: alphabetical by symbol so output is deterministic across
-    // runs (the underlying discovery uses a HashMap).
+    // runs (the underlying discovery uses a HashMap). Symbols come from
+    // both file-based discovery and explicit CLI args; we union them, but
+    // remember which set each symbol belongs to so the explicit-fetch
+    // path (#966) only fires for CLI-only symbols (file-discovered
+    // commodities have already passed through metadata- or `--undeclared`-
+    // based opt-in checks).
     let mut symbols_to_fetch: Vec<String> = discovered.keys().cloned().collect();
+    for s in &args.symbols {
+        if !discovered.contains_key(s) {
+            symbols_to_fetch.push(s.clone());
+        }
+    }
     symbols_to_fetch.sort();
 
     if symbols_to_fetch.is_empty() {
@@ -243,11 +248,29 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     // ones via `HashMap::insert`). The effective high-to-low order is:
     //   1. CLI --mapping (last to insert, wins)
     //   2. Discovered `price:` metadata from commodity directives (#948)
-    //   3. Config [price.mapping] (first to insert, lowest precedence)
+    //   3. Synthesized default-source mapping for file-discovered commodities
+    //      that opted in via `quote_currency:` only or matched `--undeclared`
+    //      (their `info.mapping` is `None` but discovery has already decided
+    //      they should be fetched — without synthesizing a mapping here,
+    //      `resolve_mapping` would fire the #966 explicit-source-required
+    //      error and fail those flows).
+    //   4. Config [price.mapping] (lowest precedence among config sources)
+    //
+    // CLI-only symbols (in `args.symbols` but not in `discovered`) are
+    // intentionally NOT auto-mapped here — they hit `resolve_mapping`'s
+    // error path unless the user passed `--source`, `--mapping`, or set
+    // `[price] use_default_source = true`. That's the #966 fix.
     let mut combined_mapping = price_config.mapping.clone();
     for (symbol, info) in &discovered {
         if let Some(m) = &info.mapping {
             combined_mapping.insert(symbol.clone(), m.clone());
+        } else {
+            // File-discovered with no source spec — discovery already
+            // opted this commodity in (via `quote_currency:` metadata or
+            // `--undeclared`). Synthesize a Simple mapping pointing at
+            // the default source so `fetch_price` doesn't trip the
+            // explicit-source-required guard.
+            combined_mapping.insert(symbol.clone(), CommodityMapping::Simple(symbol.clone()));
         }
     }
     for (k, v) in cli_mapping {

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -195,6 +195,9 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         }
     }
     symbols_to_fetch.sort();
+    // Dedup repeated CLI args (e.g. `rledger price AAPL AAPL`) so we
+    // don't fetch the same symbol twice.
+    symbols_to_fetch.dedup();
 
     if symbols_to_fetch.is_empty() {
         eprintln!(
@@ -244,38 +247,7 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         );
     }
 
-    // Merge mappings in increasing precedence (later inserts override earlier
-    // ones via `HashMap::insert`). The effective high-to-low order is:
-    //   1. CLI --mapping (last to insert, wins)
-    //   2. Discovered `price:` metadata from commodity directives (#948)
-    //   3. Synthesized default-source mapping for file-discovered commodities
-    //      that opted in via `quote_currency:` only or matched `--undeclared`
-    //      (their `info.mapping` is `None` but discovery has already decided
-    //      they should be fetched — without synthesizing a mapping here,
-    //      `resolve_mapping` would fire the #966 explicit-source-required
-    //      error and fail those flows).
-    //   4. Config [price.mapping] (lowest precedence among config sources)
-    //
-    // CLI-only symbols (in `args.symbols` but not in `discovered`) are
-    // intentionally NOT auto-mapped here — they hit `resolve_mapping`'s
-    // error path unless the user passed `--source`, `--mapping`, or set
-    // `[price] use_default_source = true`. That's the #966 fix.
-    let mut combined_mapping = price_config.mapping.clone();
-    for (symbol, info) in &discovered {
-        if let Some(m) = &info.mapping {
-            combined_mapping.insert(symbol.clone(), m.clone());
-        } else {
-            // File-discovered with no source spec — discovery already
-            // opted this commodity in (via `quote_currency:` metadata or
-            // `--undeclared`). Synthesize a Simple mapping pointing at
-            // the default source so `fetch_price` doesn't trip the
-            // explicit-source-required guard.
-            combined_mapping.insert(symbol.clone(), CommodityMapping::Simple(symbol.clone()));
-        }
-    }
-    for (k, v) in cli_mapping {
-        combined_mapping.insert(k, v);
-    }
+    let combined_mapping = build_combined_mapping(&price_config.mapping, &discovered, &cli_mapping);
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
@@ -346,6 +318,51 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build the merged commodity-to-source mapping used during fetch.
+///
+/// Precedence (high to low):
+/// 1. CLI `--mapping <SYMBOL>:<TICKER>` (always wins).
+/// 2. Discovered `price:` metadata on a commodity directive.
+/// 3. Config-file `[price.mapping.X]` entries (preserved when discovery
+///    found the same commodity but only via `quote_currency:` /
+///    `--undeclared` — i.e. `info.mapping = None`).
+/// 4. Synthesized `Simple(symbol)` for file-discovered commodities that
+///    opt in via `quote_currency:` only or matched `--undeclared` and
+///    have no config entry. Without this, `resolve_mapping` would fire
+///    the #966 explicit-source-required error and break those flows.
+///
+/// CLI-only symbols (in `args.symbols` but not in `discovered`) are
+/// intentionally NOT auto-mapped — they hit `resolve_mapping`'s error
+/// path unless the user passed `--source`, `--mapping`, or set
+/// `[price] use_default_source = true`. That's the #966 fix.
+fn build_combined_mapping(
+    config_mapping: &HashMap<String, CommodityMapping>,
+    discovered: &HashMap<String, DiscoveredCommodity>,
+    cli_mapping: &HashMap<String, CommodityMapping>,
+) -> HashMap<String, CommodityMapping> {
+    let mut combined = config_mapping.clone();
+    for (symbol, info) in discovered {
+        if let Some(m) = &info.mapping {
+            // Discovered metadata explicitly named a source — overrides
+            // any config entry for the same symbol.
+            combined.insert(symbol.clone(), m.clone());
+        } else {
+            // No source spec from metadata. Synthesize a default-source
+            // mapping ONLY if the config doesn't already cover this
+            // symbol — otherwise we'd silently overwrite a deliberate
+            // `[price.mapping.X]` block with a Simple default-source
+            // dispatch.
+            combined
+                .entry(symbol.clone())
+                .or_insert_with(|| CommodityMapping::Simple(symbol.clone()));
+        }
+    }
+    for (k, v) in cli_mapping {
+        combined.insert(k.clone(), v.clone());
+    }
+    combined
 }
 
 /// Resolve the effective quote currency for a single symbol.
@@ -766,5 +783,139 @@ mod tests {
             resolve_quote_currency("AAPL", &discovered, &mapping, "USD"),
             "USD"
         );
+    }
+
+    /// Regression for self-review on PR #971: when discovery returns an
+    /// `info.mapping = None` for a symbol that ALSO has a config-level
+    /// `[price.mapping.X]` entry, the synthesized `Simple` default-source
+    /// mapping must NOT overwrite the user's deliberate config block.
+    #[test]
+    fn build_combined_mapping_preserves_config_for_quote_currency_only_commodity() {
+        // Config: BTC dispatches to coinbase.
+        let mut config_mapping = HashMap::new();
+        config_mapping.insert(
+            "BTC".to_string(),
+            CommodityMapping::Detailed(crate::config::DetailedMapping {
+                source: crate::config::SourceRef::Single("coinbase".to_string()),
+                ticker: Some("BTC-USD".to_string()),
+                quote_currency: None,
+            }),
+        );
+
+        // Discovery: BTC has `quote_currency: "USD"` only, no `price:`.
+        // -> `info.mapping = None`.
+        let mut discovered = HashMap::new();
+        discovered.insert(
+            "BTC".to_string(),
+            DiscoveredCommodity {
+                mapping: None,
+                quote_currency: Some("USD".to_string()),
+            },
+        );
+
+        let combined = build_combined_mapping(&config_mapping, &discovered, &HashMap::new());
+
+        let entry = combined.get("BTC").expect("BTC must remain in mapping");
+        match entry {
+            CommodityMapping::Detailed(d) => {
+                match &d.source {
+                    crate::config::SourceRef::Single(s) => assert_eq!(
+                        s, "coinbase",
+                        "config-level coinbase mapping must survive discovery synthesis"
+                    ),
+                    crate::config::SourceRef::Fallback(_) => {
+                        panic!("expected Single source, got Fallback")
+                    }
+                }
+                assert_eq!(d.ticker.as_deref(), Some("BTC-USD"));
+            }
+            CommodityMapping::Simple(_) => {
+                panic!("expected Detailed mapping; synthesis silently overwrote config");
+            }
+        }
+    }
+
+    /// `quote_currency:`-only / `--undeclared` symbols WITHOUT a config
+    /// entry must be synthesized to `Simple(symbol)` so they dispatch
+    /// through the default source rather than tripping the #966
+    /// explicit-source-required guard.
+    #[test]
+    fn build_combined_mapping_synthesizes_simple_for_unmapped_discovered_symbol() {
+        let config_mapping = HashMap::new();
+        let mut discovered = HashMap::new();
+        discovered.insert(
+            "GOVT_EU".to_string(),
+            DiscoveredCommodity {
+                mapping: None,
+                quote_currency: Some("EUR".to_string()),
+            },
+        );
+
+        let combined = build_combined_mapping(&config_mapping, &discovered, &HashMap::new());
+
+        match combined.get("GOVT_EU") {
+            Some(CommodityMapping::Simple(s)) => assert_eq!(s, "GOVT_EU"),
+            other => panic!("expected synthesized Simple(\"GOVT_EU\"), got {other:?}"),
+        }
+    }
+
+    /// Discovered metadata with a real source/ticker overrides any
+    /// config entry for that symbol (existing precedence rule from
+    /// #948/#951; pinned here so the synthesis refactor doesn't break it).
+    #[test]
+    fn build_combined_mapping_discovered_metadata_overrides_config() {
+        let mut config_mapping = HashMap::new();
+        config_mapping.insert(
+            "AAPL".to_string(),
+            CommodityMapping::Simple("AAPL-OLD".to_string()),
+        );
+        let mut discovered = HashMap::new();
+        discovered.insert(
+            "AAPL".to_string(),
+            DiscoveredCommodity {
+                mapping: Some(CommodityMapping::Detailed(crate::config::DetailedMapping {
+                    source: crate::config::SourceRef::Single("yahoo".to_string()),
+                    ticker: Some("AAPL".to_string()),
+                    quote_currency: None,
+                })),
+                quote_currency: None,
+            },
+        );
+
+        let combined = build_combined_mapping(&config_mapping, &discovered, &HashMap::new());
+        match combined.get("AAPL") {
+            Some(CommodityMapping::Detailed(d)) => match &d.source {
+                crate::config::SourceRef::Single(s) => assert_eq!(s, "yahoo"),
+                crate::config::SourceRef::Fallback(_) => {
+                    panic!("expected Single source, got Fallback")
+                }
+            },
+            other => panic!("expected metadata to override config, got {other:?}"),
+        }
+    }
+
+    /// CLI `--mapping` always wins, even over discovered metadata.
+    #[test]
+    fn build_combined_mapping_cli_mapping_wins_over_discovery() {
+        let config_mapping = HashMap::new();
+        let mut discovered = HashMap::new();
+        discovered.insert(
+            "AAPL".to_string(),
+            DiscoveredCommodity {
+                mapping: Some(CommodityMapping::Simple("AAPL-DISCOVERED".to_string())),
+                quote_currency: None,
+            },
+        );
+        let mut cli_mapping = HashMap::new();
+        cli_mapping.insert(
+            "AAPL".to_string(),
+            CommodityMapping::Simple("AAPL-CLI".to_string()),
+        );
+
+        let combined = build_combined_mapping(&config_mapping, &discovered, &cli_mapping);
+        match combined.get("AAPL") {
+            Some(CommodityMapping::Simple(s)) => assert_eq!(s, "AAPL-CLI"),
+            other => panic!("CLI must win, got {other:?}"),
+        }
     }
 }

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -94,6 +94,15 @@ pub struct PriceConfig {
     /// Commodity to source/ticker mappings.
     #[serde(default)]
     pub mapping: HashMap<String, CommodityMapping>,
+
+    /// When `false` (the default), fetching a commodity that has no
+    /// CLI `--source`, no `[price.mapping.X]` config, and no `price:`
+    /// metadata is an error rather than a silent dispatch to
+    /// `default_source`. Prevents the failure mode in #966 where, e.g.,
+    /// `rledger price BAM` was sent to Yahoo and returned a stock
+    /// price for an unrelated ticker that happened to share the
+    /// symbol. Set to `true` to opt back into the previous behavior.
+    pub use_default_source: Option<bool>,
 }
 
 /// Configuration for a custom price source.
@@ -634,6 +643,15 @@ impl PriceConfig {
     /// Default: 1800 seconds (30 minutes), matching Python bean-price.
     pub fn effective_cache_ttl(&self) -> u64 {
         self.cache_ttl.unwrap_or(1800)
+    }
+
+    /// Whether to fall back to `default_source` for commodities lacking
+    /// any explicit source declaration. Defaults to `false` so silent
+    /// bad-data fetches (#966) don't happen — opt-in via
+    /// `[price] use_default_source = true` to restore the prior
+    /// behavior.
+    pub fn effective_use_default_source(&self) -> bool {
+        self.use_default_source.unwrap_or(false)
     }
 }
 
@@ -1725,6 +1743,7 @@ currency = "EUR"
                     );
                     m
                 },
+                use_default_source: None,
             },
             ..Default::default()
         };
@@ -1747,6 +1766,7 @@ currency = "EUR"
                     );
                     m
                 },
+                use_default_source: None,
             },
             ..Default::default()
         };

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -614,6 +614,9 @@ impl PriceConfig {
         if other.cache_ttl.is_some() {
             self.cache_ttl = other.cache_ttl;
         }
+        if other.use_default_source.is_some() {
+            self.use_default_source = other.use_default_source;
+        }
 
         // Merge sources (other's sources override)
         for (name, source) in other.sources {
@@ -1793,6 +1796,7 @@ currency = "EUR"
         let config = PriceConfig::default();
         assert_eq!(config.effective_default_source(), "yahoo");
         assert_eq!(config.effective_timeout(), 30);
+        assert!(!config.effective_use_default_source());
 
         let custom = PriceConfig {
             default_source: Some("coinbase".to_string()),
@@ -1801,5 +1805,48 @@ currency = "EUR"
         };
         assert_eq!(custom.effective_default_source(), "coinbase");
         assert_eq!(custom.effective_timeout(), 60);
+    }
+
+    /// Copilot review on PR #971: the new `use_default_source` flag
+    /// must participate in layered config merging — without this,
+    /// setting it in a project/user config wouldn't take effect.
+    #[test]
+    fn test_merge_price_config_use_default_source() {
+        let base = Config {
+            price: PriceConfig {
+                use_default_source: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let override_cfg = Config {
+            price: PriceConfig {
+                use_default_source: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let merged = base.merge(override_cfg);
+        assert_eq!(merged.price.use_default_source, Some(true));
+
+        // And the reverse: explicit `false` in a higher-precedence layer
+        // overrides a `true` from a lower-precedence layer.
+        let base_true = Config {
+            price: PriceConfig {
+                use_default_source: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let override_false = Config {
+            price: PriceConfig {
+                use_default_source: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = base_true.merge(override_false);
+        assert_eq!(merged.price.use_default_source, Some(false));
     }
 }

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -59,7 +59,9 @@ The first source in the chain is tried first; subsequent ones act as fallbacks. 
 
 The quote currency in the metadata overrides the global `--currency` for that one symbol, so you can mix USD-quoted stocks and EUR-quoted bonds in the same run.
 
-`price: ""` (empty string, or whitespace-only) is an explicit **opt-out from `-f / --file` discovery**: the commodity is never picked up from the ledger, even with `--undeclared`. Useful for currency codes that happen to collide with stock tickers (e.g. `BAM`, `UKW`) — see issue #962. Note: a symbol passed *explicitly* on the command line (e.g. `rledger price BAM`) is always fetched regardless of the opt-out, since CLI args are explicit user intent.
+`price: ""` (empty string, or whitespace-only) is an explicit **opt-out from `-f / --file` discovery**: the commodity is never picked up from the ledger, even with `--undeclared`. Useful for currency codes that happen to collide with stock tickers (e.g. `BAM`, `UKW`) — see issue #962.
+
+Note: the opt-out only affects file-based discovery. A symbol passed explicitly on the command line (e.g. `rledger price BAM`) is **not silently routed to `default_source`** — it goes through the same explicit-source-required check as any other CLI symbol (#966). To fetch a commodity that has a `price: ""` opt-out, you still need to give it an explicit source (`--source`, `--mapping`, a config block, or set `[price] use_default_source = true`).
 
 ### 2. `quote_currency:` metadata
 

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -125,10 +125,14 @@ Fetching a symbol that has none of:
 - a CLI `--source <name>` flag,
 - a `[price.mapping.X]` entry in your config,
 - a `price:` metadata annotation on the commodity directive,
+- a `quote_currency:` metadata annotation on the commodity directive (treated as opt-in to default-source dispatch with that quote currency),
+- a match against `--undeclared` (ticker-shape heuristic on a `commodity` directive without metadata),
 
 is an **error** rather than a silent dispatch to the configured `default_source`. This prevents the failure mode where currency codes (e.g. `BAM`, the Bosnian convertible mark) get sent to Yahoo and return a stock price for an unrelated ticker that happens to share the symbol.
 
-To restore the previous behavior — where unmapped symbols always go to `default_source` — set:
+The four metadata/discovery paths above all opt into default-source dispatch — the strict guard only fires on commodities the user has *not* indicated should be fetched.
+
+To restore the previous behavior — where every unmapped symbol on the CLI also goes to `default_source` — set:
 
 ```toml
 [price]

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -119,6 +119,22 @@ The currency a price is quoted in is resolved separately, since a single source 
 
 Note that `[price.mapping.X]` blocks reject unknown keys: a typo like `currency = "EUR"` (vs the supported `quote_currency`) will fail config load with a clear error rather than being silently dropped.
 
+### Explicit source declaration required by default (issue #966)
+
+Fetching a symbol that has none of:
+- a CLI `--source <name>` flag,
+- a `[price.mapping.X]` entry in your config,
+- a `price:` metadata annotation on the commodity directive,
+
+is an **error** rather than a silent dispatch to the configured `default_source`. This prevents the failure mode where currency codes (e.g. `BAM`, the Bosnian convertible mark) get sent to Yahoo and return a stock price for an unrelated ticker that happens to share the symbol.
+
+To restore the previous behavior — where unmapped symbols always go to `default_source` — set:
+
+```toml
+[price]
+use_default_source = true
+```
+
 ## Price Caching
 
 Prices are cached to disk to reduce API calls. By default, cached prices expire after **30 minutes** (matching Python `bean-price` behavior).
@@ -206,6 +222,14 @@ Configure sources, mappings, and fallback chains in config:
 default_source = "yahoo"
 timeout = 30
 cache_ttl = 1800
+
+# Issue #966: by default, fetching a commodity that has no
+# `--source` flag, no [price.mapping.X] entry, and no `price:`
+# metadata is an error rather than a silent dispatch to
+# `default_source`. This prevents currency codes (e.g. BAM) from
+# being routed to a stock source and returning unrelated prices.
+# Set this to true to opt back into the previous behavior.
+# use_default_source = false
 
 [price.mapping]
 # Simple ticker mapping


### PR DESCRIPTION
> **Stacked on #970** (per-spec tickers in fallback chains). This PR's diff shows only the #966 changes; once #970 merges, this PR's base auto-switches to main.

## Summary

Issue #966: \`rledger price BAM\` was sending the symbol to Yahoo (the default source) and returning a stock price for an unrelated ticker that happened to share the symbol. The discovery-side fix in #965 addressed the \`-f\` flow but explicit fetches still produced silent bad data.

Per the reporter's [follow-up comment](https://github.com/rustledger/rustledger/issues/966#issuecomment-4361311505), this PR makes the default behavior **refuse** to fetch when no explicit source declaration exists, covering all three paths the user has to opt in:

- CLI \`--source <name>\`
- A \`[price.mapping.X]\` block in config
- A \`price:\` metadata annotation on the commodity directive

If none are set, \`resolve_mapping\` returns an error whose message lists exactly those three remediation paths plus the new opt-in flag.

## Changes

- New \`PriceConfig.use_default_source: Option<bool>\` (defaults to false) with helper \`effective_use_default_source()\`.
- \`PriceSourceRegistry\` captures the flag at construction.
- \`resolve_mapping\` returns \`Result<Vec<(String, String)>>\`. When the commodity has no mapping AND the flag is false, returns an error with the directive remediation message.
- \`fetch_price\` propagates the error.

The CLI \`--source\` flag bypasses \`resolve_mapping\` entirely (it routes through \`fetch_with_source\`), so users who just want a quick one-off fetch still have a single-flag escape hatch: \`rledger price --source yahoo BAM\`.

## Tests

- \`test_resolve_mapping_no_mapping_errors_by_default\` — the #966 regression. Asserts the error names the symbol and mentions all four remediation paths.
- \`test_resolve_mapping_no_mapping_uses_default_when_opted_in\` — setting \`use_default_source = true\` restores the previous behavior.
- All existing \`test_resolve_mapping_*\` tests updated for the new Result signature. **238 rustledger lib tests pass.**

## Test plan

- [x] \`cargo test -p rustledger --lib\`
- [x] \`cargo clippy -p rustledger --all-features -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] CI green

Closes #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)