### PR TITLE
fix(importer): preserve sub-cent amounts; replace buggy parse_sym (closes #972)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,6 +3401,7 @@ dependencies = [
  "format_num_pattern",
  "jiff",
  "ofxy",
+ "proptest",
  "rust_decimal",
  "rustledger-core",
  "rustledger-ops",

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -30,6 +30,7 @@ chrono = "0.4"                      # ofxy exposes chrono::DateTime; needed for 
 
 [dev-dependencies]
 tempfile.workspace = true
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -689,10 +689,6 @@ mod tests {
     }
 
     // ========== AmountFormat::parse Tests (regression for #972) ==========
-    //
-    // Differential test: every value the default (POSIX) parser accepts must equal
-    // `Decimal::from_str` on the same string. This catches the upstream `parse_sym`
-    // bug class — silent miscoding of values containing zeros after the decimal.
 
     fn assert_matches_oracle(s: &str) {
         let ours = AmountFormat::default()
@@ -792,7 +788,7 @@ mod tests {
     #[test]
     fn parse_german_locale_swaps_decimal_and_grouping() {
         // de_DE uses ',' as decimal separator and '.' as grouping. "1.234,56" -> 1234.56.
-        let f = AmountFormat::Symbols(NumberSymbols::numeric(Locale::de_DE));
+        let f = AmountFormat::Symbols(NumberSymbols::monetary(Locale::de_DE));
         let v = f.parse("1.234,56").unwrap();
         assert_eq!(v, Decimal::from_str("1234.56").unwrap());
     }
@@ -800,15 +796,12 @@ mod tests {
     #[test]
     fn parse_german_locale_sub_cent() {
         // The same bug class would corrupt sub-unit German amounts: "0,01" must not become 0,1.
-        let f = AmountFormat::Symbols(NumberSymbols::numeric(Locale::de_DE));
+        let f = AmountFormat::Symbols(NumberSymbols::monetary(Locale::de_DE));
         let v = f.parse("0,01").unwrap();
         assert_eq!(v, Decimal::from_str("0.01").unwrap());
     }
 
     proptest::proptest! {
-        // Round-trip property: any Decimal we render with `Display` must parse back to itself
-        // through the default (POSIX) `AmountFormat::parse`. Generates values across the full
-        // i64 range with up to 9 fractional digits.
         #[test]
         fn parse_default_round_trips_through_display(
             mantissa in i64::MIN..=i64::MAX,

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -124,7 +124,8 @@ fn parse_with_symbols(s: &str, sym: &NumberSymbols) -> Result<Decimal, rust_deci
     for c in s.chars() {
         if c.is_ascii_digit() {
             buf.push(c);
-        } else if c == sym.negative_sym {
+        } else if c == sym.negative_sym || c == '-' {
+            // Always accept ASCII '-' even if the locale's negative_sym differs (e.g. U+2212): otherwise the sign silently flips.
             buf.push('-');
         } else if c == sym.decimal_sep {
             buf.push('.');
@@ -799,6 +800,18 @@ mod tests {
         let f = AmountFormat::Symbols(NumberSymbols::monetary(Locale::de_DE));
         let v = f.parse("0,01").unwrap();
         assert_eq!(v, Decimal::from_str("0.01").unwrap());
+    }
+
+    #[test]
+    fn parse_ascii_minus_honored_when_locale_uses_unicode_minus() {
+        // If the configured locale's negative_sym is U+2212 but the CSV emits ASCII '-' (the
+        // common real-world case), the sign must not be silently dropped. Regression for
+        // Copilot's review on PR #974.
+        let mut sym = NumberSymbols::monetary(Locale::POSIX);
+        sym.negative_sym = '\u{2212}';
+        let f = AmountFormat::Symbols(sym);
+        let v = f.parse("-0.01").unwrap();
+        assert_eq!(v, Decimal::from_str("-0.01").unwrap());
     }
 
     proptest::proptest! {

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -3,9 +3,9 @@
 use crate::ImportResult;
 use crate::csv_importer::CsvImporter;
 use anyhow::{Context, Result};
-use format_num_pattern::{Locale, NumberFormat, NumberSymbols, core::parse_sym, fmt_to, parse_fmt};
+use format_num_pattern::{Locale, NumberFormat, NumberSymbols, fmt_to, parse_fmt};
 use rust_decimal::Decimal;
-use std::{fmt::Display, ops::Neg, path::Path};
+use std::{fmt::Display, ops::Neg, path::Path, str::FromStr};
 
 /// Configuration for an importer.
 #[derive(Debug, Clone)]
@@ -117,15 +117,33 @@ pub enum AmountFormat {
     Format(NumberFormat),
 }
 
+// Do not replace with `format_num_pattern::core::parse_sym`: its `clean_num` strips post-decimal
+// leading zeros, so "0.00" fails and "0.01" silently parses as 0.1. See issue #972.
+fn parse_with_symbols(s: &str, sym: &NumberSymbols) -> Result<Decimal, rust_decimal::Error> {
+    let mut buf = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_digit() {
+            buf.push(c);
+        } else if c == sym.negative_sym {
+            buf.push('-');
+        } else if c == sym.decimal_sep {
+            buf.push('.');
+        } else if c == sym.exponent_lower_sym || c == sym.exponent_upper_sym {
+            buf.push('e');
+        }
+    }
+    Decimal::from_str(&buf)
+}
+
 impl AmountFormat {
     /// Attempt to parse a string using the given format.
     pub fn parse(&self, amount: &str) -> Result<Decimal> {
         let value: Decimal = match self {
-            Self::Symbols(number_symbols) => parse_sym(amount, number_symbols)
-                .with_context(|| format!("unable to parse using symbols: {number_symbols:?}")),
+            Self::Symbols(number_symbols) => parse_with_symbols(amount, number_symbols)
+                .with_context(|| format!("unable to parse using symbols: {number_symbols:?}"))?,
             Self::Format(number_format) => parse_fmt(amount, number_format)
-                .with_context(|| format!("unable to parse using given format: {number_format}")),
-        }?;
+                .with_context(|| format!("unable to parse using given format: {number_format}"))?,
+        };
 
         if amount.trim().starts_with('(') && amount.trim().ends_with(')') {
             Ok(value.neg())
@@ -668,5 +686,138 @@ mod tests {
     fn test_column_spec_index() {
         let spec = ColumnSpec::Index(5);
         assert!(matches!(spec, ColumnSpec::Index(5)));
+    }
+
+    // ========== AmountFormat::parse Tests (regression for #972) ==========
+    //
+    // Differential test: every value the default (POSIX) parser accepts must equal
+    // `Decimal::from_str` on the same string. This catches the upstream `parse_sym`
+    // bug class — silent miscoding of values containing zeros after the decimal.
+
+    fn assert_matches_oracle(s: &str) {
+        let ours = AmountFormat::default()
+            .parse(s)
+            .unwrap_or_else(|e| panic!("default parser rejected {s:?}: {e:?}"));
+        let oracle = Decimal::from_str(s)
+            .unwrap_or_else(|e| panic!("oracle Decimal::from_str rejected {s:?}: {e:?}"));
+        assert_eq!(
+            ours, oracle,
+            "default parser disagreed with Decimal::from_str on {s:?}"
+        );
+    }
+
+    #[test]
+    fn parse_default_matches_decimal_from_str_oracle() {
+        for s in [
+            "0",
+            "0.0",
+            "0.00",
+            "0.000",
+            "0.1",
+            "0.01",
+            "0.001",
+            "0.0001",
+            "0.10",
+            "0.05",
+            "0.50",
+            "-0",
+            "-0.0",
+            "-0.00",
+            "-0.1",
+            "-0.01",
+            "-0.001",
+            "1",
+            "1.0",
+            "1.00",
+            "1.23",
+            "1.230",
+            "10",
+            "100",
+            "1234",
+            "1234.56",
+            "-1",
+            "-1.00",
+            "-1.23",
+            "-1234.56",
+            "1234567890.1234567890",
+        ] {
+            assert_matches_oracle(s);
+        }
+    }
+
+    #[test]
+    fn parse_default_zero_amount_succeeds() {
+        // Direct regression for issue #972 reporter's case.
+        assert_eq!(
+            AmountFormat::default().parse("0.00").unwrap(),
+            Decimal::ZERO
+        );
+    }
+
+    #[test]
+    fn parse_default_one_cent_is_not_ten_cents() {
+        // The silent-corruption case: the buggy parser returned 0.1 for "0.01".
+        let v = AmountFormat::default().parse("0.01").unwrap();
+        assert_eq!(v, Decimal::from_str("0.01").unwrap());
+        assert_ne!(v, Decimal::from_str("0.1").unwrap());
+    }
+
+    #[test]
+    fn parse_default_negative_one_cent() {
+        let v = AmountFormat::default().parse("-0.01").unwrap();
+        assert_eq!(v, Decimal::from_str("-0.01").unwrap());
+    }
+
+    #[test]
+    fn parse_default_sub_cent() {
+        let v = AmountFormat::default().parse("0.001").unwrap();
+        assert_eq!(v, Decimal::from_str("0.001").unwrap());
+    }
+
+    #[test]
+    fn parse_default_parens_as_negative() {
+        // Accountancy convention: (123.45) means -123.45.
+        let v = AmountFormat::default().parse("(0.01)").unwrap();
+        assert_eq!(v, Decimal::from_str("-0.01").unwrap());
+    }
+
+    #[test]
+    fn parse_default_drops_currency_symbols_and_grouping() {
+        // POSIX symbols set decimal_sep='.', positive_sym=' '. Group separator and
+        // any unrecognized chars (currency, whitespace) are silently dropped.
+        let v = AmountFormat::default().parse("$1,234.56").unwrap();
+        assert_eq!(v, Decimal::from_str("1234.56").unwrap());
+    }
+
+    #[test]
+    fn parse_german_locale_swaps_decimal_and_grouping() {
+        // de_DE uses ',' as decimal separator and '.' as grouping. "1.234,56" -> 1234.56.
+        let f = AmountFormat::Symbols(NumberSymbols::numeric(Locale::de_DE));
+        let v = f.parse("1.234,56").unwrap();
+        assert_eq!(v, Decimal::from_str("1234.56").unwrap());
+    }
+
+    #[test]
+    fn parse_german_locale_sub_cent() {
+        // The same bug class would corrupt sub-unit German amounts: "0,01" must not become 0,1.
+        let f = AmountFormat::Symbols(NumberSymbols::numeric(Locale::de_DE));
+        let v = f.parse("0,01").unwrap();
+        assert_eq!(v, Decimal::from_str("0.01").unwrap());
+    }
+
+    proptest::proptest! {
+        // Round-trip property: any Decimal we render with `Display` must parse back to itself
+        // through the default (POSIX) `AmountFormat::parse`. Generates values across the full
+        // i64 range with up to 9 fractional digits.
+        #[test]
+        fn parse_default_round_trips_through_display(
+            mantissa in i64::MIN..=i64::MAX,
+            scale in 0u32..=9
+        ) {
+            let original = Decimal::new(mantissa, scale);
+            let s = original.to_string();
+            let parsed = AmountFormat::default().parse(&s).unwrap();
+            proptest::prop_assert_eq!(parsed, original);
+        }
     }
 }

--- a/crates/rustledger-importer/tests/csv_amount_fixtures.rs
+++ b/crates/rustledger-importer/tests/csv_amount_fixtures.rs
@@ -1,0 +1,82 @@
+//! End-to-end tests covering amount-parsing edge cases that real-world bank exports hit.
+//!
+//! Regression for issue #972: a CSV row with a sub-cent amount (interest accrual,
+//! rounding line, sub-cent FX, fee dust) used to be silently corrupted by 10×.
+//!
+//! Note: the zero-amount row is included in the fixture to confirm it no longer triggers
+//! a parse warning. The CSV importer's downstream behavior of skipping zero-amount rows
+//! is intentional and tested elsewhere (`csv_importer::tests::test_csv_import_zero_amount_skips_row`).
+
+use rust_decimal::Decimal;
+use rustledger_importer::ImporterConfig;
+use std::str::FromStr;
+
+const FIXTURE: &str = "\
+Date,Description,Amount
+2024-10-20,Zero balance entry,0.00
+2024-10-21,One cent interest,0.01
+2024-10-22,Sub-cent FX residual,0.001
+2024-10-23,Five cents,0.05
+2024-10-24,Negative one cent,-0.01
+2024-10-25,Negative sub-cent,-0.001
+2024-10-26,Normal amount,1.00
+2024-10-27,Normal with cents,1.23
+2024-10-28,Larger amount,1234.56
+";
+
+#[test]
+fn realistic_bank_export_parses_every_amount_correctly() {
+    let config = ImporterConfig::csv()
+        .account("Assets:Bank:Checking")
+        .currency("USD")
+        .date_column("Date")
+        .narration_column("Description")
+        .amount_column("Amount")
+        .build()
+        .unwrap();
+
+    let result = config.extract_from_string(FIXTURE).unwrap();
+
+    // Zero-amount rows are intentionally skipped downstream of parsing — but they must
+    // *parse* cleanly. Before #972 the zero row produced a "Failed to parse amount" warning.
+    assert!(
+        result.warnings.is_empty(),
+        "expected no parse warnings, got: {:?}",
+        result.warnings
+    );
+
+    // Every non-zero row must round-trip to the exact decimal value from the source.
+    let expected = [
+        ("One cent interest", "0.01"),
+        ("Sub-cent FX residual", "0.001"),
+        ("Five cents", "0.05"),
+        ("Negative one cent", "-0.01"),
+        ("Negative sub-cent", "-0.001"),
+        ("Normal amount", "1.00"),
+        ("Normal with cents", "1.23"),
+        ("Larger amount", "1234.56"),
+    ];
+    assert_eq!(result.directives.len(), expected.len());
+
+    for (directive, (narration, amount_str)) in result.directives.iter().zip(expected.iter()) {
+        let txn = directive
+            .as_transaction()
+            .expect("directive should be a transaction");
+        assert_eq!(txn.narration.as_str(), *narration);
+
+        let bank_posting = txn
+            .postings
+            .iter()
+            .find(|p| p.account.as_str() == "Assets:Bank:Checking")
+            .expect("each transaction should have an Assets:Bank:Checking posting");
+        let actual = bank_posting
+            .amount()
+            .expect("the bank posting should carry a complete amount")
+            .number;
+        let want = Decimal::from_str(amount_str).unwrap();
+        assert_eq!(
+            actual, want,
+            "row {narration:?}: parsed {actual} but expected {want}"
+        );
+    }
+}

--- a/crates/rustledger-importer/tests/csv_amount_fixtures.rs
+++ b/crates/rustledger-importer/tests/csv_amount_fixtures.rs
@@ -1,11 +1,4 @@
-//! End-to-end tests covering amount-parsing edge cases that real-world bank exports hit.
-//!
-//! Regression for issue #972: a CSV row with a sub-cent amount (interest accrual,
-//! rounding line, sub-cent FX, fee dust) used to be silently corrupted by 10×.
-//!
-//! Note: the zero-amount row is included in the fixture to confirm it no longer triggers
-//! a parse warning. The CSV importer's downstream behavior of skipping zero-amount rows
-//! is intentional and tested elsewhere (`csv_importer::tests::test_csv_import_zero_amount_skips_row`).
+//! Regression for issue #972: sub-cent CSV amounts (e.g. `0.01`) used to silently parse as `0.1`.
 
 use rust_decimal::Decimal;
 use rustledger_importer::ImporterConfig;
@@ -37,15 +30,14 @@ fn realistic_bank_export_parses_every_amount_correctly() {
 
     let result = config.extract_from_string(FIXTURE).unwrap();
 
-    // Zero-amount rows are intentionally skipped downstream of parsing — but they must
-    // *parse* cleanly. Before #972 the zero row produced a "Failed to parse amount" warning.
+    // The zero-amount row must parse cleanly (no warning). It's then dropped downstream
+    // by the importer's intentional zero-skip — covered by csv_importer's own tests.
     assert!(
         result.warnings.is_empty(),
         "expected no parse warnings, got: {:?}",
         result.warnings
     );
 
-    // Every non-zero row must round-trip to the exact decimal value from the source.
     let expected = [
         ("One cent interest", "0.01"),
         ("Sub-cent FX residual", "0.001"),

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -724,10 +724,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.rand]]
-version = "0.8.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.rawpointer]]
 version = "0.2.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2244,6 +2244,15 @@ criteria = "safe-to-run"
 version = "1.2.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.rand]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.8.5"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.rand_chacha]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -3249,6 +3258,16 @@ version = "0.2.0"
 notes = """
 A tiny bit of unsafe code to implement functionality that isn't in stable rust
 yet, but it's all valid. Otherwise it's a pretty simple crate.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rand]]
+who = "Henrik Skupin <mail@hskupin.info>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.6"
+notes = """
+Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
+feature. No new dependencies or unsafe code.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
## Summary

Fixes a silent data-corruption bug in CSV import. The default `AmountFormat::Symbols` parser delegated to `format_num_pattern::core::parse_sym`, whose `clean_num` strips zeros after the decimal separator the same way it strips integer-side leading zeros. The result:

| Input | Buggy result | Correct |
|---|---|---|
| `0.00` | `Failed to parse amount` (warning) | `0` |
| `0.01` | **silently `0.1`** (10× wrong) | `0.01` |
| `0.05` | **silently `0.5`** | `0.05` |
| `0.001` | **silently `0.1`** (100× wrong) | `0.001` |
| `-0.01` | **silently `-0.1`** | `-0.01` |
| `1.00`, `1.23` | correct | correct |

The reporter (#972) hit the `0.00` case during a GnuCash → rledger migration and noticed the warning. The much more dangerous case is the silent 10×/100× corruption of any sub-unit amount with leading zeros in the fractional portion (interest accruals, rounding lines, sub-cent FX, fee dust).

## What changed

- `crates/rustledger-importer/src/config.rs`: `AmountFormat::parse` for the `Symbols` variant now translates symbol → ASCII directly and parses via `Decimal::from_str`, instead of calling `parse_sym`. The `Format` variant still uses `parse_fmt`, which is structurally distinct (`unmap_num` is token-driven and does not have the bug).
- `Cargo.toml`: add `proptest` dev-dep on the importer crate.

## Why a local replacement instead of upgrading the dep

`format_num_pattern` 0.9.4 is the latest published release. Upstream's `parse_sym` test suite has exactly one test (`\"111\"`), with no fractional inputs at all, so the bug class isn't likely to be caught upstream soon.

## Tests

- **Differential / oracle test**: a fixed table of strings asserts `AmountFormat::default().parse(s) == Decimal::from_str(s)`. This is the test that would have caught the bug on day one — `Decimal::from_str` is a free correct reference for the POSIX locale.
- **Round-trip property test** (`proptest`): generate any `Decimal` (i64 mantissa × scale 0..=9), render with `Display`, parse back, assert equal.
- **Targeted regressions**: `0.00` succeeds; `0.01 != 0.1`; `-0.01`; `0.001`; parens-as-negative `(0.01)` → `-0.01`; currency symbols and group separators dropped.
- **Non-POSIX locale**: German `1.234,56` → `1234.56`; `0,01` → `0.01` (the same bug class would have hit German amounts too).
- **Integration fixture** (`tests/csv_amount_fixtures.rs`): a realistic bank-export CSV with zero, sub-cent, negative-sub-cent, and normal amounts. Asserts no parse warnings and every non-zero row's posting carries the exact expected `Decimal`.

## Out of scope

The CSV importer's downstream `if amount == ZERO { skip }` (csv_importer.rs:212-215) is intentional and tested elsewhere; it's preserved here. After this fix the reporter's `0.00` row no longer triggers a 'Failed to parse' warning, but it is still silently skipped at the importer level. Whether to surface zero-amount rows is a separate design question; happy to open a follow-up issue if the reporter or maintainers want to revisit it.

## Test plan

- [ ] CI green on all targets
- [ ] `cargo test -p rustledger-importer --all-features` passes locally (verified)
- [ ] Manual: `rledger extract` on a CSV with `0.01`, `0.05`, `0.001`, `-0.01` produces correct values (verified)

Closes #972