### PR TITLE
chore(nix): add beanprice to dev shell for bean-price differential tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,8 +142,36 @@
             }
           );
 
+          # beanprice isn't packaged in nixpkgs (it's a separate PyPI distribution
+          # since beancount v3). Build it locally so we can run differential tests
+          # of `rledger price` against `bean-price` from CI / dev shells.
+          beanprice = pkgs.python312Packages.buildPythonApplication {
+            pname = "beanprice";
+            version = "2.1.0";
+            pyproject = true;
+
+            src = pkgs.python312Packages.fetchPypi {
+              pname = "beanprice";
+              version = "2.1.0";
+              hash = "sha256-2Q0mZB97rthEPN/bVUXDj40B+XYE7UrUFzsCNZiYKxM=";
+            };
+
+            build-system = with pkgs.python312Packages; [ setuptools ];
+
+            dependencies = with pkgs.python312Packages; [
+              beancount
+              python-dateutil
+              requests
+              curl-cffi
+              diskcache
+            ];
+
+            # Network-bound tests; skip in the build sandbox.
+            doCheck = false;
+          };
+
           # Python with beancount for compatibility testing
-          pythonWithBeancount = pkgs.python311.withPackages (
+          pythonWithBeancount = pkgs.python312.withPackages (
             ps: with ps; [
               beancount
               beanquery # For bean-query CLI (BQL)
@@ -210,6 +238,7 @@
 
             # Python for compat testing
             pythonWithBeancount
+            beanprice # `bean-price` CLI for differential price tests
           ];
 
         in
@@ -359,7 +388,7 @@
               echo "  - WASM: wasm32-unknown-unknown target (wasm-bindgen)"
               echo "  - WASI: wasm32-wasip1 target (wasmtime)"
               echo "  - TLA+: $(if command -v tlc >/dev/null; then tlc -help 2>&1 | grep -i version | head -1 | sed 's/^[[:space:]]*//'; else echo 'not available'; fi)"
-              echo "  - Python: $(python --version) with beancount"
+              echo "  - Python: $(python --version) with beancount + beanprice (bean-price CLI)"
               echo "  - Podman: $(podman --version)"
               echo ""
 


### PR DESCRIPTION
## Summary

Adds the \`bean-price\` CLI to the dev shell. Unblocks #967's acceptance criterion #1 (differential tests of \`rledger price\` against \`bean-price\`).

## Why

\`beanprice\` is a separate PyPI distribution since beancount v3 and is **not** packaged in nixpkgs. Without it on PATH there is no way to drive a side-by-side comparison for the bean-price compat sweep tracked in #967.

## What changed

- New \`beanprice\` derivation built locally as a \`buildPythonApplication\` from PyPI (sdist 2.1.0, hash pinned).
- Added to the default dev shell's package list.
- **Bumped \`pythonWithBeancount\` from python311 to python312**. beanprice's \`curl-cffi 0.14.0\` dependency pulls in \`sphinx 9.1.0\`, which requires Python ≥ 3.12. python311 is also approaching EOL.
- Tweaked the dev-shell greeting to mention beanprice.

## Verification

- \`nix --extra-experimental-features 'nix-command flakes' build .#devShells.x86_64-linux.default\` succeeds.
- \`bean-price\`, \`bean-check\`, \`bean-query\` all on PATH.
- \`cargo check --workspace\` still passes (no Rust impact from the python bump).

## Test plan

- [ ] CI green
- [ ] Reviewer can run \`nix develop\` and confirm \`bean-price --help\` works

Refs #967.