### PR TITLE
test: oracle/proptest coverage for fast_parse_decimal, display_precision, OFX amounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,7 @@ dependencies = [
  "insta",
  "logos 0.16.1",
  "logosky",
+ "proptest",
  "rkyv 0.8.16",
  "rust_decimal",
  "rust_decimal_macros",

--- a/crates/rustledger-importer/tests/ofx_amount_fixtures.rs
+++ b/crates/rustledger-importer/tests/ofx_amount_fixtures.rs
@@ -1,0 +1,142 @@
+//! Differential tests for OFX amount parsing.
+//!
+//! The OFX importer delegates number parsing to the third-party `ofxy` crate. These tests
+//! construct OFX content with known amounts (sub-cent, negative, large) and assert that
+//! every posting carries the exact `Decimal` value from the source — so that any silent
+//! corruption by `ofxy` would surface here, the same way #972 surfaced for CSV.
+
+use rust_decimal::Decimal;
+use rustledger_importer::OfxImporter;
+use std::str::FromStr;
+
+fn ofx_with_transactions(txns: &str) -> String {
+    format!(
+        "OFXHEADER:100\nDATA:OFXSGML\nVERSION:102\nSECURITY:NONE\nENCODING:USASCII\n\
+         CHARSET:1252\nCOMPRESSION:NONE\nOLDFILEUID:NONE\nNEWFILEUID:NONE\n\n\
+         <OFX>\n<SIGNONMSGSRSV1>\n<SONRS>\n<STATUS>\n<CODE>0\n<SEVERITY>INFO\n</STATUS>\n\
+         <DTSERVER>20240115120000\n<LANGUAGE>ENG\n</SONRS>\n</SIGNONMSGSRSV1>\n\
+         <BANKMSGSRSV1>\n<STMTTRNRS>\n<TRNUID>1001\n<STATUS>\n<CODE>0\n<SEVERITY>INFO\n</STATUS>\n\
+         <STMTRS>\n<CURDEF>USD\n\
+         <BANKACCTFROM>\n<BANKID>123456789\n<ACCTID>987654321\n<ACCTTYPE>CHECKING\n</BANKACCTFROM>\n\
+         <BANKTRANLIST>\n<DTSTART>20240101\n<DTEND>20240131\n{txns}\
+         </BANKTRANLIST>\n\
+         <LEDGERBAL>\n<BALAMT>5000.00\n<DTASOF>20240131\n</LEDGERBAL>\n\
+         </STMTRS>\n</STMTTRNRS>\n</BANKMSGSRSV1>\n</OFX>"
+    )
+}
+
+fn stmttrn(fitid: &str, amount: &str, name: &str) -> String {
+    format!(
+        "<STMTTRN>\n<TRNTYPE>OTHER\n<DTPOSTED>20240115\n<TRNAMT>{amount}\n<FITID>{fitid}\n<NAME>{name}\n</STMTTRN>\n"
+    )
+}
+
+fn assert_ofx_amounts(amounts: &[&str]) {
+    let txns: String = amounts
+        .iter()
+        .enumerate()
+        .map(|(i, amt)| stmttrn(&format!("txn-{i:03}"), amt, &format!("Payee {i}")))
+        .collect();
+    let content = ofx_with_transactions(&txns);
+
+    let importer = OfxImporter::new("Assets:Bank:Checking", "USD");
+    let result = importer
+        .extract_from_string(&content)
+        .expect("OFX content should parse");
+
+    assert!(
+        result.warnings.is_empty(),
+        "expected no warnings, got: {:?}",
+        result.warnings
+    );
+    assert_eq!(
+        result.directives.len(),
+        amounts.len(),
+        "every input row must produce a transaction"
+    );
+
+    for (directive, amount_str) in result.directives.iter().zip(amounts.iter()) {
+        let txn = directive
+            .as_transaction()
+            .expect("directive should be a transaction");
+        let bank_posting = txn
+            .postings
+            .iter()
+            .find(|p| p.account.as_str() == "Assets:Bank:Checking")
+            .expect("each transaction must have an Assets:Bank:Checking posting");
+        let actual = bank_posting
+            .amount()
+            .expect("bank posting must have a complete amount")
+            .number;
+        let want = Decimal::from_str(amount_str).expect("test fixture amount must parse");
+        assert_eq!(
+            actual, want,
+            "OFX amount {amount_str:?}: parsed {actual} but expected {want}"
+        );
+    }
+}
+
+#[test]
+fn ofx_preserves_normal_amounts() {
+    assert_ofx_amounts(&["1.00", "-50.00", "1500.00", "-25.50", "1234.56"]);
+}
+
+#[test]
+fn ofx_preserves_sub_cent_amounts() {
+    // The bug class from #972: any silent precision loss in `ofxy`'s amount parser
+    // would corrupt these.
+    assert_ofx_amounts(&["0.01", "-0.01", "0.05", "-0.05", "0.001", "-0.001"]);
+}
+
+#[test]
+fn ofx_preserves_zero_amount() {
+    // Non-zero is the common case but a $0.00 fee/marker line should still parse.
+    let content = ofx_with_transactions(&stmttrn("txn-zero", "0.00", "Marker"));
+    let importer = OfxImporter::new("Assets:Bank:Checking", "USD");
+    let result = importer
+        .extract_from_string(&content)
+        .expect("OFX should parse");
+    assert!(
+        result.warnings.is_empty(),
+        "warnings: {:?}",
+        result.warnings
+    );
+    assert_eq!(result.directives.len(), 1);
+    let posting = result.directives[0]
+        .as_transaction()
+        .unwrap()
+        .postings
+        .iter()
+        .find(|p| p.account.as_str() == "Assets:Bank:Checking")
+        .unwrap();
+    assert_eq!(posting.amount().unwrap().number, Decimal::ZERO);
+}
+
+#[test]
+fn ofx_negative_routes_to_expenses_positive_to_income() {
+    let txns = format!(
+        "{}{}",
+        stmttrn("dr", "-12.34", "Outflow"),
+        stmttrn("cr", "98.76", "Inflow"),
+    );
+    let content = ofx_with_transactions(&txns);
+    let importer = OfxImporter::new("Assets:Bank:Checking", "USD");
+    let result = importer.extract_from_string(&content).unwrap();
+    assert_eq!(result.directives.len(), 2);
+
+    let txn0 = result.directives[0].as_transaction().unwrap();
+    let contra0 = txn0
+        .postings
+        .iter()
+        .find(|p| p.account.as_str() != "Assets:Bank:Checking")
+        .unwrap();
+    assert_eq!(contra0.account.as_str(), "Expenses:Unknown");
+
+    let txn1 = result.directives[1].as_transaction().unwrap();
+    let contra1 = txn1
+        .postings
+        .iter()
+        .find(|p| p.account.as_str() != "Assets:Bank:Checking")
+        .unwrap();
+    assert_eq!(contra1.account.as_str(), "Income:Unknown");
+}

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -899,4 +899,59 @@ mod tests {
         assert_eq!(opts3.warnings.len(), 1);
         assert_eq!(opts3.warnings[0].code, "E7002");
     }
+
+    #[test]
+    fn test_display_precision_basic() {
+        let mut opts = Options::new();
+        opts.set("display_precision", "USD:0.01");
+        assert!(opts.warnings.is_empty(), "warnings: {:?}", opts.warnings);
+        assert_eq!(opts.display_precision.get("USD"), Some(&2));
+    }
+
+    #[test]
+    fn test_display_precision_high_precision() {
+        let mut opts = Options::new();
+        opts.set("display_precision", "BTC:0.00000001");
+        assert!(opts.warnings.is_empty());
+        assert_eq!(opts.display_precision.get("BTC"), Some(&8));
+    }
+
+    #[test]
+    fn test_display_precision_zero_decimals() {
+        // "JPY:1" → no fractional digits → precision 0.
+        let mut opts = Options::new();
+        opts.set("display_precision", "JPY:1");
+        assert!(opts.warnings.is_empty());
+        assert_eq!(opts.display_precision.get("JPY"), Some(&0));
+    }
+
+    #[test]
+    fn test_display_precision_repeatable_per_currency() {
+        let mut opts = Options::new();
+        opts.set("display_precision", "USD:0.01");
+        opts.set("display_precision", "EUR:0.001");
+        assert!(opts.warnings.is_empty(), "warnings: {:?}", opts.warnings);
+        assert_eq!(opts.display_precision.get("USD"), Some(&2));
+        assert_eq!(opts.display_precision.get("EUR"), Some(&3));
+    }
+
+    #[test]
+    fn test_display_precision_missing_colon_warns() {
+        let mut opts = Options::new();
+        opts.set("display_precision", "USD0.01");
+        assert_eq!(opts.warnings.len(), 1);
+        assert_eq!(opts.warnings[0].code, "E7002");
+        assert!(opts.warnings[0].message.contains("CURRENCY:EXAMPLE"));
+        assert!(opts.display_precision.is_empty());
+    }
+
+    #[test]
+    fn test_display_precision_invalid_example_warns() {
+        let mut opts = Options::new();
+        opts.set("display_precision", "USD:abc");
+        assert_eq!(opts.warnings.len(), 1);
+        assert_eq!(opts.warnings[0].code, "E7002");
+        assert!(opts.warnings[0].message.contains("Invalid precision"));
+        assert!(opts.display_precision.is_empty());
+    }
 }

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -35,6 +35,7 @@ rkyv = { workspace = true, optional = true }
 rust_decimal_macros = "1.40"
 insta.workspace = true
 criterion.workspace = true
+proptest.workspace = true
 
 [[bench]]
 name = "parser_bench"

--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -2930,8 +2930,7 @@ mod tests {
             "9223372036854775807",   // i64::MAX exactly
             "9223372036854775806.0", // forces overflow on next mul10 → opt-out OK
             "99999999999999999999",  // 20 nines, must opt out (overflow)
-            ".5",                    // leading-decimal form
-            "5.",                    // trailing-decimal form
+            "5.",                    // trailing-decimal form (lexer accepts `(\.\d*)?`)
         ] {
             assert_fast_path_matches_oracle(s);
         }
@@ -2939,8 +2938,7 @@ mod tests {
 
     #[test]
     fn fast_parse_decimal_rejects_malformed() {
-        // These never reach the fast path in practice (the lexer's Number token excludes them),
-        // but the function must safely return None rather than produce a wrong value.
+        // "1,000" is a valid lexer Number token but parse_number routes commas to the slow path; the rest the lexer rejects outright. Either way fast_parse_decimal must return None.
         for s in ["", "1.2.3", "abc", "1e5", "-1", "+1", "1,000"] {
             assert_eq!(fast_parse_decimal(s), None, "should reject {s:?}");
         }
@@ -2962,9 +2960,7 @@ mod tests {
     }
 
     proptest::proptest! {
-        // Generates strings matching the lexer's Number token grammar that the fast path claims
-        // to handle: `[0-9]+(\.[0-9]+)?`. When fast_parse_decimal returns Some, it must equal
-        // Decimal::from_str on the same string.
+        // Bounded comma-free subset of the lexer's Number grammar that fast_parse_decimal can plausibly accept; longer/comma inputs go to the slow path so we don't generate them here.
         #[test]
         fn fast_parse_decimal_agrees_with_decimal_from_str(
             s in "[0-9]{1,18}(\\.[0-9]{1,18})?"
@@ -2976,8 +2972,6 @@ mod tests {
             }
         }
 
-        // Round-trip property: any Decimal we render with `Display` whose string fits the fast
-        // path's grammar must parse back via parse_number to the original value.
         #[test]
         fn parse_number_round_trips_through_display(
             mantissa in 0i64..=i64::MAX,
@@ -2985,8 +2979,7 @@ mod tests {
         ) {
             let original = Decimal::new(mantissa, scale);
             let s = original.to_string();
-            // parse_number is invoked through the full lexer/parser; here we test the
-            // fast path directly because the output string contains no commas/sign.
+            // Display output has no commas/sign so we can hit fast_parse_decimal directly without going through the lexer.
             let fast = fast_parse_decimal(&s);
             let oracle = Decimal::from_str(&s).ok();
             if let Some(f) = fast {

--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -2887,4 +2887,115 @@ mod tests {
             "slash-separated date in expression context should produce a parse error"
         );
     }
+
+    // ========== fast_parse_decimal differential tests ==========
+
+    fn assert_fast_path_matches_oracle(s: &str) {
+        let fast = fast_parse_decimal(s);
+        let oracle = Decimal::from_str(s).ok();
+        match (fast, oracle) {
+            (Some(f), Some(o)) => assert_eq!(
+                f, o,
+                "fast_parse_decimal({s:?})={f} disagreed with Decimal::from_str={o}"
+            ),
+            (Some(f), None) => {
+                panic!("fast_parse_decimal accepted {s:?} as {f} but Decimal::from_str rejected")
+            }
+            (None, _) => {} // fast path opt-out is always allowed; the slow path takes over.
+        }
+    }
+
+    #[test]
+    fn fast_parse_decimal_matches_oracle_on_known_inputs() {
+        for s in [
+            "0",
+            "1",
+            "10",
+            "100",
+            "1000",
+            "0.0",
+            "0.00",
+            "0.000",
+            "0.1",
+            "0.01",
+            "0.001",
+            "0.0001",
+            "1.0",
+            "1.00",
+            "1.23",
+            "1.230",
+            "100.50",
+            "1234.56",
+            "0.1234567890123456789", // 19 fractional digits, mantissa fits in i64
+            "9223372036854775807",   // i64::MAX exactly
+            "9223372036854775806.0", // forces overflow on next mul10 → opt-out OK
+            "99999999999999999999",  // 20 nines, must opt out (overflow)
+            ".5",                    // leading-decimal form
+            "5.",                    // trailing-decimal form
+        ] {
+            assert_fast_path_matches_oracle(s);
+        }
+    }
+
+    #[test]
+    fn fast_parse_decimal_rejects_malformed() {
+        // These never reach the fast path in practice (the lexer's Number token excludes them),
+        // but the function must safely return None rather than produce a wrong value.
+        for s in ["", "1.2.3", "abc", "1e5", "-1", "+1", "1,000"] {
+            assert_eq!(fast_parse_decimal(s), None, "should reject {s:?}");
+        }
+    }
+
+    #[test]
+    fn fast_parse_decimal_zero_with_leading_zeros() {
+        // Direct echo of the importer bug class (#972): make sure the fast path doesn't
+        // strip post-decimal leading zeros.
+        assert_eq!(
+            fast_parse_decimal("0.01"),
+            Some(Decimal::from_str("0.01").unwrap())
+        );
+        assert_eq!(
+            fast_parse_decimal("0.001"),
+            Some(Decimal::from_str("0.001").unwrap())
+        );
+        assert_eq!(fast_parse_decimal("0.00"), Some(Decimal::ZERO));
+    }
+
+    proptest::proptest! {
+        // Generates strings matching the lexer's Number token grammar that the fast path claims
+        // to handle: `[0-9]+(\.[0-9]+)?`. When fast_parse_decimal returns Some, it must equal
+        // Decimal::from_str on the same string.
+        #[test]
+        fn fast_parse_decimal_agrees_with_decimal_from_str(
+            s in "[0-9]{1,18}(\\.[0-9]{1,18})?"
+        ) {
+            let fast = fast_parse_decimal(&s);
+            let oracle = Decimal::from_str(&s).ok();
+            if let Some(f) = fast {
+                proptest::prop_assert_eq!(Some(f), oracle);
+            }
+        }
+
+        // Round-trip property: any Decimal we render with `Display` whose string fits the fast
+        // path's grammar must parse back via parse_number to the original value.
+        #[test]
+        fn parse_number_round_trips_through_display(
+            mantissa in 0i64..=i64::MAX,
+            scale in 0u32..=18
+        ) {
+            let original = Decimal::new(mantissa, scale);
+            let s = original.to_string();
+            // parse_number is invoked through the full lexer/parser; here we test the
+            // fast path directly because the output string contains no commas/sign.
+            let fast = fast_parse_decimal(&s);
+            let oracle = Decimal::from_str(&s).ok();
+            if let Some(f) = fast {
+                proptest::prop_assert_eq!(f, original);
+            }
+            // When the fast path opts out, the slow path (Decimal::from_str) must succeed.
+            if fast.is_none() {
+                proptest::prop_assert_eq!(oracle, Some(original));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Re-opens #975 (auto-closed when the source branch was renamed from \`test/...\` to \`chore/...\` to satisfy the branch-name validation workflow). All commits and the Copilot review-comment fixes are carried over.

## Summary

Followup to #972/#974. Applies the same testing discipline (\"oracle when one exists\") to the three remaining numeric-parsing sites the audit flagged. **No production code changes** — purely test additions.

## What's covered

### \`rustledger-parser::fast_parse_decimal\` (HIGH risk → covered)

The hot-path number parser in the beancount lexer. Hand-written state machine — same shape of code that bit us in #972. Now:

- **Differential test** against \`Decimal::from_str\` over a fixed input table (zero, sub-cent, leading zeros, max-precision, i64 boundary).
- **Proptest** generating strings matching the comma-free subset of the lexer's Number grammar that the fast path actually sees; when fast_parse_decimal returns Some, it must equal the oracle.
- **Round-trip property**: any Decimal we render with Display must parse back through the fast path (or fall through to the slow path correctly).
- **Targeted regressions**: 0.00, 0.01, 0.001 — the bug class from #972, applied at the parser layer.
- **Negative path**: rejects \`\"\"\`, \`\"1.2.3\"\`, \`\"abc\"\`, \`\"1e5\"\`, \`\"-1\"\`, \`\"+1\"\`, \`\"1,000\"\`.

### \`rustledger-loader::display_precision\` (MEDIUM risk → covered)

Previously zero unit tests — silently degraded to default on invalid input.

- Basic (\`USD:0.01\` → 2 places)
- High precision (\`BTC:0.00000001\` → 8 places)
- Zero decimals (\`JPY:1\` → 0 places)
- Repeatable per-currency
- Invalid format warns (missing colon, non-decimal example) and is not silently accepted

### \`rustledger-importer\` OFX amounts (HIGH risk → covered)

Existing OFX tests used \`match { Ok => ..., Err => println!(...) }\` — they passed even when the OFX library failed to parse, and never asserted on the actual posting amounts. New \`tests/ofx_amount_fixtures.rs\`:

- Constructs OFX content with sub-cent (\`0.01\`, \`0.001\`), negative-sub-cent (\`-0.001\`), zero, and normal amounts.
- Asserts each posting's Decimal equals the source, no warnings.
- Asserts negative amounts route to \`Expenses:Unknown\` and positives to \`Income:Unknown\`.

Confirms \`ofxy 0.2.0\` does **not** have the silent-corruption bug class from #972, and serves as a regression guard.

## Review history (carried over from #975)

Copilot raised three substantive inline comments, all addressed in commit 3dd09742:

1. Removed \`\".5\"\` from the known-inputs table — the lexer's Number token requires an integer prefix, so a bare leading-decimal never reaches the parser.
2. Fixed the malformed-rejects comment — \`\"1,000\"\` IS a valid lexer Number token; parse_number routes commas to the slow path before calling fast_parse_decimal.
3. Fixed the proptest comment — kept the regex (bounded comma-free subset, what the fast path actually sees) but stopped misclaiming it matches the full lexer grammar.

## Test plan

- [x] All new tests pass locally
- [x] cargo check / clippy / fmt clean