### PR TITLE
test: address late Copilot review on #977 (rename + warnings assert)

### DIFF
--- a/crates/rustledger-importer/tests/ofx_amount_fixtures.rs
+++ b/crates/rustledger-importer/tests/ofx_amount_fixtures.rs
@@ -122,6 +122,11 @@ fn ofx_negative_routes_to_expenses_positive_to_income() {
     let content = ofx_with_transactions(&txns);
     let importer = OfxImporter::new("Assets:Bank:Checking", "USD");
     let result = importer.extract_from_string(&content).unwrap();
+    assert!(
+        result.warnings.is_empty(),
+        "warnings: {:?}",
+        result.warnings
+    );
     assert_eq!(result.directives.len(), 2);
 
     let txn0 = result.directives[0].as_transaction().unwrap();

--- a/crates/rustledger-parser/src/winnow_parser.rs
+++ b/crates/rustledger-parser/src/winnow_parser.rs
@@ -2973,7 +2973,7 @@ mod tests {
         }
 
         #[test]
-        fn parse_number_round_trips_through_display(
+        fn fast_parse_decimal_round_trips_through_display(
             mantissa in 0i64..=i64::MAX,
             scale in 0u32..=18
         ) {


### PR DESCRIPTION
Followup to **#977** (already merged). Two of three Copilot inline comments arrived after the merge happened, so they ride along here as a small follow-up.

## What's addressed

- **Rename `parse_number_round_trips_through_display` → `fast_parse_decimal_round_trips_through_display`.** The proptest never calls `parse_number`; it round-trips through `fast_parse_decimal` directly. The old name was misleading.
- **Assert `result.warnings.is_empty()` in `ofx_negative_routes_to_expenses_positive_to_income`.** Every other OFX test in the file already asserts this; the routing test was the outlier and could pass while silently dropping rows on parse warnings.

## What was rejected (false positive)

Copilot flagged that `ofx_with_transactions`'s `format!` string with `\<newline>` continuations would inject leading whitespace into the OFX body. **It does not** — Rust's `\<newline>` continuation strips the newline AND all subsequent whitespace per the language reference. Verified with a standalone `rustc` repro:

```rust
let s = "foo\n\
         bar\n";
// produces: "foo\nbar\n" (no embedded spaces)
```

So no change needed there.

## Test plan

- [x] `cargo test -p rustledger-parser --lib` (101 passing)
- [x] `cargo test -p rustledger-importer --test ofx_amount_fixtures` (4 passing)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean