### PR TITLE
fix(price): --source-cmd honors requested currency on number-only output (closes #979)

### DIFF
--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -76,8 +76,14 @@ impl ExternalCommandSource {
         }
     }
 
-    /// Parse output in simple format: `150.00 USD`
-    fn parse_simple_format(&self, line: &str) -> Result<(Decimal, String)> {
+    /// Parse output in simple format: `150.00 USD`. When the line omits a currency,
+    /// fall back to `requested_currency` (the value rledger passed via `--currency`)
+    /// rather than a hardcoded default — see issue #979.
+    fn parse_simple_format(
+        &self,
+        line: &str,
+        requested_currency: &str,
+    ) -> Result<(Decimal, String)> {
         let parts: Vec<&str> = line.split_whitespace().collect();
         if parts.len() >= 2 {
             let price = Decimal::from_str(parts[0])
@@ -87,14 +93,19 @@ impl ExternalCommandSource {
         } else if parts.len() == 1 {
             let price = Decimal::from_str(parts[0])
                 .with_context(|| format!("Invalid price value: {}", parts[0]))?;
-            Ok((price, "USD".to_string()))
+            Ok((price, requested_currency.to_string()))
         } else {
             anyhow::bail!("Invalid simple format output: {line}")
         }
     }
 
-    /// Parse output in JSON format.
-    fn parse_json_format(&self, line: &str) -> Result<(Decimal, String, Option<NaiveDate>)> {
+    /// Parse output in JSON format. Same `requested_currency` fallback rule as
+    /// `parse_simple_format`: missing `currency` field adopts the requested currency.
+    fn parse_json_format(
+        &self,
+        line: &str,
+        requested_currency: &str,
+    ) -> Result<(Decimal, String, Option<NaiveDate>)> {
         let json: serde_json::Value =
             serde_json::from_str(line).with_context(|| "Invalid JSON output")?;
 
@@ -114,7 +125,7 @@ impl ExternalCommandSource {
         let currency = json
             .get("currency")
             .and_then(|v| v.as_str())
-            .map_or_else(|| "USD".to_string(), String::from);
+            .map_or_else(|| requested_currency.to_string(), String::from);
 
         let date = json
             .get("date")
@@ -238,7 +249,7 @@ impl PriceSource for ExternalCommandSource {
 
             // Try JSON format first
             if line.starts_with('{') {
-                let (price, currency, date) = self.parse_json_format(line)?;
+                let (price, currency, date) = self.parse_json_format(line, &request.currency)?;
                 return Ok(PriceResponse {
                     price,
                     currency,
@@ -261,7 +272,7 @@ impl PriceSource for ExternalCommandSource {
             }
 
             // Try simple format
-            let (price, currency) = self.parse_simple_format(line)?;
+            let (price, currency) = self.parse_simple_format(line, &request.currency)?;
             return Ok(PriceResponse {
                 price,
                 currency,
@@ -282,17 +293,19 @@ mod tests {
     fn test_parse_simple_format() {
         let source = ExternalCommandSource::new(vec![], Duration::from_secs(30), HashMap::new());
 
-        let (price, currency) = source.parse_simple_format("150.00 USD").unwrap();
+        let (price, currency) = source.parse_simple_format("150.00 USD", "USD").unwrap();
         assert_eq!(price, Decimal::from_str("150.00").unwrap());
         assert_eq!(currency, "USD");
 
-        let (price, currency) = source.parse_simple_format("  99.99  EUR  ").unwrap();
+        // Explicit currency in output always wins over the requested fallback.
+        let (price, currency) = source.parse_simple_format("  99.99  EUR  ", "USD").unwrap();
         assert_eq!(price, Decimal::from_str("99.99").unwrap());
         assert_eq!(currency, "EUR");
 
-        let (price, currency) = source.parse_simple_format("42").unwrap();
+        // Number-only output adopts the requested currency (regression for #979).
+        let (price, currency) = source.parse_simple_format("42", "EUR").unwrap();
         assert_eq!(price, Decimal::from(42));
-        assert_eq!(currency, "USD");
+        assert_eq!(currency, "EUR");
     }
 
     #[test]
@@ -300,7 +313,10 @@ mod tests {
         let source = ExternalCommandSource::new(vec![], Duration::from_secs(30), HashMap::new());
 
         let (price, currency, date) = source
-            .parse_json_format(r#"{"price": 150.00, "currency": "USD", "date": "2024-01-15"}"#)
+            .parse_json_format(
+                r#"{"price": 150.00, "currency": "USD", "date": "2024-01-15"}"#,
+                "USD",
+            )
             .unwrap();
         assert_eq!(price, Decimal::from_str("150.00").unwrap());
         assert_eq!(currency, "USD");
@@ -309,9 +325,12 @@ mod tests {
             Some(rustledger_core::naive_date(2024, 1, 15).unwrap())
         );
 
-        let (price, currency, date) = source.parse_json_format(r#"{"price": "99.99"}"#).unwrap();
+        // Missing "currency" field adopts the requested currency (regression for #979).
+        let (price, currency, date) = source
+            .parse_json_format(r#"{"price": "99.99"}"#, "GBP")
+            .unwrap();
         assert_eq!(price, Decimal::from_str("99.99").unwrap());
-        assert_eq!(currency, "USD");
+        assert_eq!(currency, "GBP");
         assert!(date.is_none());
     }
 

--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -76,9 +76,8 @@ impl ExternalCommandSource {
         }
     }
 
-    /// Parse output in simple format: `150.00 USD`. When the line omits a currency,
-    /// fall back to `requested_currency` (the value rledger passed via `--currency`)
-    /// rather than a hardcoded default — see issue #979.
+    /// Parse output in simple format: `150.00 USD`. Number-only lines adopt
+    /// `requested_currency` rather than a hardcoded default.
     fn parse_simple_format(
         &self,
         line: &str,
@@ -99,8 +98,7 @@ impl ExternalCommandSource {
         }
     }
 
-    /// Parse output in JSON format. Same `requested_currency` fallback rule as
-    /// `parse_simple_format`: missing `currency` field adopts the requested currency.
+    /// Parse output in JSON format. A missing `currency` field adopts `requested_currency`.
     fn parse_json_format(
         &self,
         line: &str,
@@ -332,6 +330,12 @@ mod tests {
         assert_eq!(price, Decimal::from_str("99.99").unwrap());
         assert_eq!(currency, "GBP");
         assert!(date.is_none());
+
+        // Explicit "currency" in the JSON wins over the requested fallback.
+        let (_, currency, _) = source
+            .parse_json_format(r#"{"price": "99.99", "currency": "JPY"}"#, "GBP")
+            .unwrap();
+        assert_eq!(currency, "JPY");
     }
 
     #[test]

--- a/crates/rustledger/tests/bean_price_compat.rs
+++ b/crates/rustledger/tests/bean_price_compat.rs
@@ -80,24 +80,11 @@ fn extract_rledger_jobs(stdout: &str) -> BTreeSet<(String, String)> {
 }
 
 // `TempDir` (not `NamedTempFile`) so the script file has no open write handle — exec on Linux fails with ETXTBSY otherwise.
-//
-// Echo back the `--currency` arg rledger passes so the simple-format parser preserves
-// the requested currency. Without this, parse_simple_format hardcodes USD on
-// number-only output (a real bug in `--source-cmd`'s simple parser; tracked separately).
 fn stub_source() -> (TempDir, PathBuf) {
     use std::os::unix::fs::PermissionsExt;
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("stub-source.sh");
-    let script = "#!/usr/bin/env bash\n\
-                  ccy=USD\n\
-                  while [ $# -gt 0 ]; do\n\
-                  \x20\x20case \"$1\" in\n\
-                  \x20\x20\x20\x20--currency) ccy=\"$2\"; shift 2 ;;\n\
-                  \x20\x20\x20\x20*) shift ;;\n\
-                  \x20\x20esac\n\
-                  done\n\
-                  echo \"1.00 $ccy\"\n";
-    std::fs::write(&path, script).unwrap();
+    std::fs::write(&path, "#!/usr/bin/env bash\necho 1.00\n").unwrap();
     let mut perms = std::fs::metadata(&path).unwrap().permissions();
     perms.set_mode(0o755);
     std::fs::set_permissions(&path, perms).unwrap();


### PR DESCRIPTION
## Summary

Closes #979. `ExternalCommandSource::parse_simple_format` and `parse_json_format` both fell back to a hardcoded `"USD"` when the source-cmd's output omitted a currency, ignoring the value rledger had passed via `--currency`. Result: any non-USD commodity imported via `--source-cmd` with a price-only stub got silently relabeled as USD.

## Reproduce (pre-fix)

```bash
cat > /tmp/sap.beancount <<EOF
2024-01-01 commodity SAP
  price: "EUR:yahoo/SAP.DE"
2024-01-01 open Assets:DE
2024-01-01 open Equity:Open
2024-01-15 * "buy"
  Assets:DE  20 SAP {120 EUR}
  Equity:Open
EOF

printf '#!/bin/sh\necho 1.00\n' > /tmp/stub && chmod +x /tmp/stub

rledger price -f /tmp/sap.beancount --beancount --source-cmd /tmp/stub
# Pre-fix:  2026-05-03 price SAP 1.00 USD   <- wrong
# Post-fix: 2026-05-03 price SAP 1.00 EUR   <- correct
```

## Fix

Threaded `&request.currency` through `parse_simple_format` and `parse_json_format`. Their explicit-currency branches are unchanged: an explicit currency in the output still wins over the requested fallback. `parse_beancount_format` is unaffected — its format requires a currency token, so an omitted currency already errored.

## Tests

- Updated unit tests in `external.rs` to exercise the new fallback rule for both formats.
- Dropped the workaround stub in `crates/rustledger/tests/bean_price_compat.rs` that previously echoed `--currency` back specifically to mask this bug. The mixed-currency fixture (USD AAPL + EUR SAP) now proves the fix end-to-end with a bare `echo 1.00` stub. If this regresses in future, the harness will catch it for free.

## Test plan

- [x] `cargo test -p rustledger` passes (price/external + bean_price_compat both green)
- [x] `cargo clippy -p rustledger --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual reproduction of the SAP fixture above shows EUR (not USD) post-fix
