### PR TITLE
feat(price): bean-price audit bundle (refs #967, #972 follow-up)

### DIFF
--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -72,6 +72,12 @@ pub struct CsvConfig {
     /// Whether to use the built-in merchant dictionary as a fallback.
     /// The dictionary provides common merchant patterns at low priority.
     pub use_merchant_dict: bool,
+    /// Whether to drop rows whose amount parses to exactly zero. Defaults to
+    /// true for back-compat: most banks emit zero-amount rows for status
+    /// markers and importing them as transactions adds noise. Set false to
+    /// preserve every source row (matches the user's expectation when
+    /// auditing migrated data — see issue #972).
+    pub skip_zero_amounts: bool,
 }
 
 impl Default for CsvConfig {
@@ -95,6 +101,7 @@ impl Default for CsvConfig {
             mappings: Vec::new(),
             regex_mappings: Vec::new(),
             use_merchant_dict: false,
+            skip_zero_amounts: true,
         }
     }
 }
@@ -385,6 +392,14 @@ impl CsvConfigBuilder {
     /// Enable the built-in merchant dictionary as a fallback.
     pub const fn use_merchant_dict(mut self, enable: bool) -> Self {
         self.config.use_merchant_dict = enable;
+        self
+    }
+
+    /// Set whether to drop rows whose amount parses to zero. Default: true.
+    /// Pass `false` to preserve every source row, matching auditor expectations
+    /// when migrating from another tool (issue #972).
+    pub const fn skip_zero_amounts(mut self, skip: bool) -> Self {
+        self.config.skip_zero_amounts = skip;
         self
     }
 

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -322,19 +322,35 @@ impl CsvImporter {
         // If we have separate debit/credit columns
         if csv_config.debit_column.is_some() || csv_config.credit_column.is_some() {
             let mut amount = Decimal::ZERO;
+            // Track whether ANY non-blank cell failed to parse. A blank cell
+            // is normal (banks leave one of debit/credit blank), but a non-
+            // blank cell that won't parse is a malformed row — surface it
+            // instead of silently importing 0 (which becomes a real 0.00
+            // transaction once `--include-zero-amounts` is set).
+            let mut any_parse_failure = false;
 
             if let Some(debit_col) = &csv_config.debit_column
                 && let Ok(debit_str) = self.get_column(record, debit_col, header_map)
-                && let Ok(val) = self.config.amount_format.parse(debit_str)
+                && !debit_str.trim().is_empty()
             {
-                amount -= val; // Debits are negative
+                match self.config.amount_format.parse(debit_str) {
+                    Ok(val) => amount -= val, // Debits are negative
+                    Err(_) => any_parse_failure = true,
+                }
             }
 
             if let Some(credit_col) = &csv_config.credit_column
                 && let Ok(credit_str) = self.get_column(record, credit_col, header_map)
-                && let Ok(val) = self.config.amount_format.parse(credit_str)
+                && !credit_str.trim().is_empty()
             {
-                amount += val; // Credits are positive
+                match self.config.amount_format.parse(credit_str) {
+                    Ok(val) => amount += val, // Credits are positive
+                    Err(_) => any_parse_failure = true,
+                }
+            }
+
+            if any_parse_failure && amount == Decimal::ZERO {
+                anyhow::bail!("Failed to parse debit/credit amount");
             }
 
             return Ok(amount);

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -349,7 +349,12 @@ impl CsvImporter {
                 }
             }
 
-            if any_parse_failure && amount == Decimal::ZERO {
+            // Strict: any non-blank cell that fails to parse is a malformed
+            // row, regardless of what the other side produced. Returning a
+            // half-credit value would silently mask the error (e.g. typo'd
+            // debit "abc" + credit "100" would import as +100, dropping the
+            // true debit).
+            if any_parse_failure {
                 anyhow::bail!("Failed to parse debit/credit amount");
             }
 
@@ -464,6 +469,44 @@ mod tests {
             let amount = txn.postings[0].amount().unwrap();
             assert_eq!(amount.number, Decimal::from_str("2500.00").unwrap());
         }
+    }
+
+    #[test]
+    fn test_csv_import_malformed_debit_or_credit_warns() {
+        // Per Copilot review on PR #982: a non-blank debit/credit cell that
+        // fails to parse should surface as a warning, not silently become a
+        // 0.00 (or half-valued) transaction. Blank cells remain normal.
+        let config = ImporterConfig::csv()
+            .account("Assets:Bank")
+            .currency("USD")
+            .date_column("Date")
+            .narration_column("Description")
+            .debit_column("Debit")
+            .credit_column("Credit")
+            .build()
+            .unwrap();
+
+        // Both sides non-blank: debit malformed, credit valid. The credit-only
+        // path would silently import +100 and drop the typo'd debit; we want
+        // the row rejected with a warning instead.
+        let csv = "Date,Description,Debit,Credit\n2024-01-15,Bad debit,abc,100.00\n";
+        let result = config.extract_from_string(csv).unwrap();
+        assert!(
+            result.directives.is_empty(),
+            "malformed debit must not produce a transaction"
+        );
+        assert_eq!(result.warnings.len(), 1);
+        assert!(
+            result.warnings[0].contains("parse"),
+            "warning should mention parse failure: {}",
+            result.warnings[0]
+        );
+
+        // Both blank: no warning (skipped as zero by default).
+        let csv_blank = "Date,Description,Debit,Credit\n2024-01-15,Empty,,\n";
+        let result = config.extract_from_string(csv_blank).unwrap();
+        assert!(result.directives.is_empty());
+        assert!(result.warnings.is_empty(), "blank cells must not warn");
     }
 
     #[test]

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -209,8 +209,9 @@ impl CsvImporter {
         // Get amount
         let amount = self.parse_amount(record, csv_config, header_map)?;
 
-        // Skip zero amount transactions
-        if amount == Decimal::ZERO {
+        // Skip zero-amount rows by default. Users can opt out via
+        // `skip_zero_amounts(false)` to preserve every source row (issue #972).
+        if csv_config.skip_zero_amounts && amount == Decimal::ZERO {
             return Ok(None);
         }
 
@@ -787,6 +788,31 @@ not-a-date,Coffee,-5.00
     }
 
     #[test]
+    fn test_csv_import_zero_amount_preserved_when_opted_in() {
+        // Issue #972 follow-up: skip_zero_amounts(false) keeps the row.
+        let config = ImporterConfig::csv()
+            .account("Assets:Bank")
+            .currency("USD")
+            .date_column("Date")
+            .narration_column("Description")
+            .amount_column("Amount")
+            .skip_zero_amounts(false)
+            .build()
+            .unwrap();
+
+        let csv_content = r"Date,Description,Amount
+2024-01-15,Zero balance marker,0.00
+2024-01-16,Normal,-10.00
+";
+
+        let result = config.extract_from_string(csv_content).unwrap();
+        assert_eq!(result.directives.len(), 2, "both rows should be kept");
+        if let Directive::Transaction(txn) = &result.directives[0] {
+            assert_eq!(txn.narration.as_str(), "Zero balance marker");
+        }
+    }
+
+    #[test]
     fn test_csv_import_default_currency() {
         // No currency specified - should default to USD
         let config = ImporterConfig::csv()
@@ -938,6 +964,7 @@ not-a-date,Coffee,-5.00
             mappings: Vec::new(),
             regex_mappings: Vec::new(),
             use_merchant_dict: false,
+            skip_zero_amounts: true,
         };
 
         let importer = CsvImporter::new(ImporterConfig {

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -132,6 +132,12 @@ pub struct Args {
     #[arg(long)]
     invert_sign: bool,
 
+    /// Preserve rows whose amount is exactly zero (e.g. balance markers).
+    /// Default behavior drops them, matching most banks' use of zero rows
+    /// as status filler — see issue #972.
+    #[arg(long)]
+    include_zero_amounts: bool,
+
     /// Auto-detect CSV format (delimiter, columns, date format)
     #[arg(long, conflicts_with_all = [
         "date_column", "date_format", "narration_column", "amount_column",
@@ -313,7 +319,10 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
             eprintln!("  date_format: {}", inferred.date_format);
             eprintln!("  has_header: {}", inferred.has_header);
 
-            let csv_config = inferred.to_csv_config();
+            let mut csv_config = inferred.to_csv_config();
+            if args.include_zero_amounts {
+                csv_config.skip_zero_amounts = false;
+            }
             ImporterConfig {
                 account: args.account.clone(),
                 currency: Some(args.currency.clone()),
@@ -332,6 +341,7 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
                 .delimiter(args.delimiter)
                 .skip_rows(args.skip_rows)
                 .invert_sign(args.invert_sign)
+                .skip_zero_amounts(!args.include_zero_amounts)
                 .has_header(!args.no_header);
 
             if let Some(payee) = &args.payee_column {

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -371,6 +371,19 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
             builder.build()?
         };
 
+        // Apply --include-zero-amounts uniformly across all config sources
+        // (--importer entry, explicit --config, --auto, raw CLI). Without this,
+        // the flag silently has no effect when the config came from a TOML
+        // entry — see Copilot review on PR #982.
+        let config = if args.include_zero_amounts {
+            let mut config = config;
+            let rustledger_importer::config::ImporterType::Csv(csv) = &mut config.importer_type;
+            csv.skip_zero_amounts = false;
+            config
+        } else {
+            config
+        };
+
         config.extract(file)?
     };
 

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -273,6 +273,8 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
             &discovered,
             &price_config.mapping,
             &combined_mapping,
+            &existing_prices,
+            price_config.effective_default_source(),
             date,
         );
     }
@@ -473,28 +475,34 @@ fn fetch_with_source(
 
 /// Print the resolved fetch plan for `--dry-run`. One line per symbol:
 ///   `<symbol> /<currency> @ <date> <source>(<ticker>)[, <source>(<ticker>)...]`
+/// Symbols whose `(symbol, currency, date)` is already in `existing_prices`
+/// are annotated `skip: existing` (matching the real run's `--clobber` gate)
+/// unless `--clobber` is set.
 fn dump_fetch_plan(
     args: &PriceArgs,
     symbols: &[String],
     discovered: &HashMap<String, DiscoveredCommodity>,
     config_mapping: &HashMap<String, CommodityMapping>,
     combined_mapping: &HashMap<String, CommodityMapping>,
+    existing_prices: &HashSet<(String, String, NaiveDate)>,
+    default_source: &str,
     date: Option<NaiveDate>,
 ) -> Result<()> {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     let date_str = date.map_or_else(|| "today".to_string(), |d| d.to_string());
+    let fetch_date = date.unwrap_or_else(|| jiff::Zoned::now().date());
 
     for symbol in symbols {
         let currency = resolve_quote_currency(symbol, discovered, config_mapping, &args.currency);
 
         // --source and --source-cmd bypass the mapping entirely.
-        let attempts: Vec<(String, String)> = if let Some(cmd) = &args.source_cmd {
-            vec![(format!("source-cmd:{cmd}"), symbol.clone())]
+        let attempts: Vec<(String, String)> = if args.source_cmd.is_some() {
+            vec![("source-cmd".to_string(), symbol.clone())]
         } else if let Some(s) = &args.source {
             vec![(s.clone(), symbol.clone())]
         } else {
-            describe_attempts(symbol, combined_mapping)
+            describe_attempts(symbol, combined_mapping, default_source)
         };
 
         let attempts_str = if attempts.is_empty() {
@@ -507,23 +515,39 @@ fn dump_fetch_plan(
                 .join(", ")
         };
 
-        writeln!(handle, "{symbol} /{currency} @ {date_str} {attempts_str}")?;
+        let skipped = !args.clobber
+            && existing_prices.contains(&(symbol.clone(), currency.clone(), fetch_date));
+        let suffix = if skipped {
+            "  [skip: existing price]"
+        } else {
+            ""
+        };
+
+        writeln!(
+            handle,
+            "{symbol} /{currency} @ {date_str} {attempts_str}{suffix}"
+        )?;
     }
     Ok(())
 }
 
 /// Walk a `CommodityMapping` into the ordered list of (source, ticker) pairs
-/// the registry would attempt. Used by `dump_fetch_plan`.
+/// the registry would attempt. Used by `dump_fetch_plan`. `Simple` mappings
+/// resolve their source name to the configured default (e.g. `yahoo`) so the
+/// dump shows what will actually run, not the placeholder string `default`.
 fn describe_attempts(
     symbol: &str,
     combined_mapping: &HashMap<String, CommodityMapping>,
+    default_source: &str,
 ) -> Vec<(String, String)> {
     use crate::config::SourceRef;
     let Some(m) = combined_mapping.get(symbol) else {
         return Vec::new();
     };
     match m {
-        CommodityMapping::Simple(ticker) => vec![("default".to_string(), ticker.clone())],
+        CommodityMapping::Simple(ticker) => {
+            vec![(default_source.to_string(), ticker.clone())]
+        }
         CommodityMapping::Detailed(d) => {
             let parent_ticker = d.ticker.as_deref().unwrap_or(symbol);
             match &d.source {
@@ -1067,5 +1091,102 @@ mod tests {
             Some(CommodityMapping::Simple(s)) => assert_eq!(s, "AAPL-CLI"),
             other => panic!("CLI must win, got {other:?}"),
         }
+    }
+
+    // ========== --dry-run / describe_attempts ==========
+
+    #[test]
+    fn describe_attempts_simple_mapping_uses_configured_default() {
+        // Simple mappings should resolve to the actual configured default source,
+        // not the placeholder "default" — otherwise the dry-run dump is useless
+        // for confirming what will run.
+        let mut combined = HashMap::new();
+        combined.insert(
+            "AAPL".to_string(),
+            CommodityMapping::Simple("AAPL".to_string()),
+        );
+        let attempts = describe_attempts("AAPL", &combined, "yahoo");
+        assert_eq!(attempts, vec![("yahoo".to_string(), "AAPL".to_string())]);
+    }
+
+    #[test]
+    fn describe_attempts_walks_fallback_chain_with_per_source_tickers() {
+        // Regression for #963: each fallback entry's own ticker must show up,
+        // not the parent's, so the dry-run accurately previews chained behavior.
+        use crate::config::{DetailedMapping, FallbackDetail, FallbackEntry, SourceRef};
+        let mut combined = HashMap::new();
+        combined.insert(
+            "GBP".to_string(),
+            CommodityMapping::Detailed(DetailedMapping {
+                source: SourceRef::Fallback(vec![
+                    FallbackEntry::Detailed(FallbackDetail {
+                        source: "ecbrates".to_string(),
+                        ticker: Some("GBP-EUR".to_string()),
+                    }),
+                    FallbackEntry::Detailed(FallbackDetail {
+                        source: "ecb".to_string(),
+                        ticker: Some("GBP".to_string()),
+                    }),
+                ]),
+                ticker: Some("GBP".to_string()),
+                quote_currency: Some("EUR".to_string()),
+            }),
+        );
+        let attempts = describe_attempts("GBP", &combined, "yahoo");
+        assert_eq!(
+            attempts,
+            vec![
+                ("ecbrates".to_string(), "GBP-EUR".to_string()),
+                ("ecb".to_string(), "GBP".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn describe_attempts_unmapped_returns_empty() {
+        // Unmapped symbols (CLI-only, no metadata, no config, no --source) should
+        // produce zero attempts so the dry-run prints `<unmapped>`.
+        let attempts = describe_attempts("AAPL", &HashMap::new(), "yahoo");
+        assert!(attempts.is_empty());
+    }
+
+    // ========== --clobber / -C parsing ==========
+
+    #[test]
+    fn test_price_args_clobber_flag() {
+        // --clobber requires -f, so test with -f present.
+        let args = Args::parse_from(["price", "-f", "ledger.beancount", "--clobber"]);
+        assert!(args.price_args.clobber);
+
+        // Short form -C also works.
+        let args = Args::parse_from(["price", "-f", "ledger.beancount", "-C"]);
+        assert!(args.price_args.clobber);
+
+        // Default is false.
+        let args = Args::parse_from(["price", "AAPL"]);
+        assert!(!args.price_args.clobber);
+    }
+
+    #[test]
+    fn test_price_args_clobber_requires_file() {
+        // --clobber without -f should error (declared `requires = "file"`).
+        let result = Args::try_parse_from(["price", "AAPL", "--clobber"]);
+        assert!(result.is_err(), "--clobber without -f must be rejected");
+    }
+
+    // ========== --dry-run parsing ==========
+
+    #[test]
+    fn test_price_args_dry_run_flag() {
+        let args = Args::parse_from(["price", "AAPL", "--dry-run"]);
+        assert!(args.price_args.dry_run);
+
+        // Short form -n.
+        let args = Args::parse_from(["price", "AAPL", "-n"]);
+        assert!(args.price_args.dry_run);
+
+        // dry-run does not require -f (works with explicit symbols).
+        let args = Args::try_parse_from(["price", "AAPL", "-n"]);
+        assert!(args.is_ok());
     }
 }

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -275,6 +275,7 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
             &combined_mapping,
             &existing_prices,
             price_config.effective_default_source(),
+            price_config.effective_use_default_source(),
             date,
         );
     }
@@ -317,6 +318,13 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         // (symbol, effective_currency, fetch_date) already exists in the file.
         // Match bean-price's semantics: existing prices are kept unless
         // --clobber is set.
+        //
+        // Limitation: this checks the REQUESTED date (`--date` or today). Some
+        // sources return a different effective date for "latest" — ECB, for
+        // instance, returns the last published business day on weekends. An
+        // existing directive dated to the source's actual quote date will not
+        // be matched here, so a duplicate may still be emitted. Fixing this
+        // requires a post-fetch re-check; tracked as a follow-up.
         if !args.clobber {
             let fetch_date = date.unwrap_or_else(|| jiff::Zoned::now().date());
             if existing_prices.contains(&(symbol.clone(), effective_currency.clone(), fetch_date)) {
@@ -478,6 +486,7 @@ fn fetch_with_source(
 /// Symbols whose `(symbol, currency, date)` is already in `existing_prices`
 /// are annotated `skip: existing` (matching the real run's `--clobber` gate)
 /// unless `--clobber` is set.
+#[allow(clippy::too_many_arguments)]
 fn dump_fetch_plan(
     args: &PriceArgs,
     symbols: &[String],
@@ -486,6 +495,7 @@ fn dump_fetch_plan(
     combined_mapping: &HashMap<String, CommodityMapping>,
     existing_prices: &HashSet<(String, String, NaiveDate)>,
     default_source: &str,
+    use_default_source: bool,
     date: Option<NaiveDate>,
 ) -> Result<()> {
     let stdout = io::stdout();
@@ -497,13 +507,25 @@ fn dump_fetch_plan(
         let currency = resolve_quote_currency(symbol, discovered, config_mapping, &args.currency);
 
         // --source and --source-cmd bypass the mapping entirely.
-        let attempts: Vec<(String, String)> = if args.source_cmd.is_some() {
+        let mut attempts: Vec<(String, String)> = if args.source_cmd.is_some() {
             vec![("source-cmd".to_string(), symbol.clone())]
         } else if let Some(s) = &args.source {
             vec![(s.clone(), symbol.clone())]
         } else {
             describe_attempts(symbol, combined_mapping, default_source)
         };
+        // Mirror the runtime fallback: with `use_default_source = true`, a
+        // CLI-only symbol that isn't in any mapping still goes to
+        // `default_source` rather than erroring. Without this, dry-run
+        // disagrees with the actual fetch plan for users who opted back
+        // into default-source dispatch.
+        if attempts.is_empty()
+            && use_default_source
+            && args.source_cmd.is_none()
+            && args.source.is_none()
+        {
+            attempts.push((default_source.to_string(), symbol.clone()));
+        }
 
         let attempts_str = if attempts.is_empty() {
             "<unmapped>".to_string()

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rustledger_core::NaiveDate;
 use rustledger_loader::LoadOptions;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -103,6 +103,18 @@ pub struct PriceArgs {
     /// a future release; prefer the granular flags. Hidden from help.
     #[arg(long, requires = "file", hide = true)]
     all_commodities: bool,
+
+    /// Print the list of symbols and resolved (source, ticker, currency)
+    /// tuples that would be fetched, then exit. No network calls.
+    /// Matches `bean-price --dry-run`.
+    #[arg(short = 'n', long)]
+    dry_run: bool,
+
+    /// Overwrite prices already present in the input file rather than
+    /// skipping them. Matches `bean-price --clobber`. Only meaningful
+    /// with `-f`; ignored otherwise.
+    #[arg(short = 'C', long, requires = "file")]
+    clobber: bool,
 }
 
 /// Run the price command.
@@ -155,7 +167,14 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     }
     let effective_inactive = args.inactive || args.all_commodities;
     let effective_undeclared = args.undeclared || args.all_commodities;
-    let discovered: HashMap<String, DiscoveredCommodity> = if let Some(ref file) = args.file {
+    // Tuple keys for `--clobber`: every existing `price` directive in the file
+    // identifies a (symbol, quote_currency, date) we should skip fetching for
+    // unless `--clobber` is set. Built alongside discovery to avoid loading
+    // the ledger twice.
+    let (discovered, existing_prices): (
+        HashMap<String, DiscoveredCommodity>,
+        HashSet<(String, String, NaiveDate)>,
+    ) = if let Some(ref file) = args.file {
         // Load with booking so interpolated postings (units missing in source,
         // filled in by the booking engine) get explicit amounts. Without this,
         // the active-commodity check at `discovery::active_commodities` would
@@ -171,14 +190,25 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         };
         let ledger = rustledger_loader::load(file, &opts)
             .with_context(|| format!("failed to load {} for symbol discovery", file.display()))?;
-        discover_symbols(
+        let discovered = discover_symbols(
             &ledger.directives,
             &ledger.options,
             effective_inactive,
             effective_undeclared,
-        )
+        );
+        let mut existing = HashSet::new();
+        for spanned in &ledger.directives {
+            if let rustledger_core::Directive::Price(p) = &spanned.value {
+                existing.insert((
+                    p.currency.as_str().to_string(),
+                    p.amount.currency.as_str().to_string(),
+                    p.date,
+                ));
+            }
+        }
+        (discovered, existing)
     } else {
-        HashMap::new()
+        (HashMap::new(), HashSet::new())
     };
 
     // Stable order: alphabetical by symbol so output is deterministic across
@@ -234,6 +264,19 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         None
     };
 
+    let combined_mapping = build_combined_mapping(&price_config.mapping, &discovered, &cli_mapping);
+
+    if args.dry_run {
+        return dump_fetch_plan(
+            args,
+            &symbols_to_fetch,
+            &discovered,
+            &price_config.mapping,
+            &combined_mapping,
+            date,
+        );
+    }
+
     // Handle --source-cmd (ad-hoc external command)
     // This is placed after symbol discovery so -f flag works with --source-cmd
     if let Some(cmd) = &args.source_cmd {
@@ -244,10 +287,9 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
             date,
             price_config,
             &discovered,
+            &existing_prices,
         );
     }
-
-    let combined_mapping = build_combined_mapping(&price_config.mapping, &discovered, &cli_mapping);
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
@@ -268,6 +310,22 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
         // the merged map below; only currency resolution stays config-only.
         let effective_currency =
             resolve_quote_currency(symbol, &discovered, &price_config.mapping, &args.currency);
+
+        // --clobber: skip fetch when an explicit `price` directive for
+        // (symbol, effective_currency, fetch_date) already exists in the file.
+        // Match bean-price's semantics: existing prices are kept unless
+        // --clobber is set.
+        if !args.clobber {
+            let fetch_date = date.unwrap_or_else(|| jiff::Zoned::now().date());
+            if existing_prices.contains(&(symbol.clone(), effective_currency.clone(), fetch_date)) {
+                if args.verbose {
+                    eprintln!(
+                        "{symbol}: skipped (existing price for {fetch_date} {effective_currency}; pass --clobber to refetch)"
+                    );
+                }
+                continue;
+            }
+        }
 
         // Check cache first
         let key = cache_key(source_name_for_cache, symbol, &effective_currency, date);
@@ -413,6 +471,82 @@ fn fetch_with_source(
     source.fetch_price(&request)
 }
 
+/// Print the resolved fetch plan for `--dry-run`. One line per symbol:
+///   `<symbol> /<currency> @ <date> <source>(<ticker>)[, <source>(<ticker>)...]`
+fn dump_fetch_plan(
+    args: &PriceArgs,
+    symbols: &[String],
+    discovered: &HashMap<String, DiscoveredCommodity>,
+    config_mapping: &HashMap<String, CommodityMapping>,
+    combined_mapping: &HashMap<String, CommodityMapping>,
+    date: Option<NaiveDate>,
+) -> Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    let date_str = date.map_or_else(|| "today".to_string(), |d| d.to_string());
+
+    for symbol in symbols {
+        let currency = resolve_quote_currency(symbol, discovered, config_mapping, &args.currency);
+
+        // --source and --source-cmd bypass the mapping entirely.
+        let attempts: Vec<(String, String)> = if let Some(cmd) = &args.source_cmd {
+            vec![(format!("source-cmd:{cmd}"), symbol.clone())]
+        } else if let Some(s) = &args.source {
+            vec![(s.clone(), symbol.clone())]
+        } else {
+            describe_attempts(symbol, combined_mapping)
+        };
+
+        let attempts_str = if attempts.is_empty() {
+            "<unmapped>".to_string()
+        } else {
+            attempts
+                .iter()
+                .map(|(s, t)| format!("{s}({t})"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        writeln!(handle, "{symbol} /{currency} @ {date_str} {attempts_str}")?;
+    }
+    Ok(())
+}
+
+/// Walk a `CommodityMapping` into the ordered list of (source, ticker) pairs
+/// the registry would attempt. Used by `dump_fetch_plan`.
+fn describe_attempts(
+    symbol: &str,
+    combined_mapping: &HashMap<String, CommodityMapping>,
+) -> Vec<(String, String)> {
+    use crate::config::SourceRef;
+    let Some(m) = combined_mapping.get(symbol) else {
+        return Vec::new();
+    };
+    match m {
+        CommodityMapping::Simple(ticker) => vec![("default".to_string(), ticker.clone())],
+        CommodityMapping::Detailed(d) => {
+            let parent_ticker = d.ticker.as_deref().unwrap_or(symbol);
+            match &d.source {
+                SourceRef::Single(s) => vec![(s.clone(), parent_ticker.to_string())],
+                SourceRef::Fallback(entries) => entries
+                    .iter()
+                    .map(|e| match e {
+                        crate::config::FallbackEntry::Name(s) => {
+                            (s.clone(), parent_ticker.to_string())
+                        }
+                        crate::config::FallbackEntry::Detailed(fd) => (
+                            fd.source.clone(),
+                            fd.ticker
+                                .clone()
+                                .unwrap_or_else(|| parent_ticker.to_string()),
+                        ),
+                    })
+                    .collect(),
+            }
+        }
+    }
+}
+
 /// Write a price response to the output.
 fn write_price(
     handle: &mut impl Write,
@@ -441,6 +575,7 @@ fn run_with_external_command(
     date: Option<NaiveDate>,
     price_config: &PriceConfig,
     discovered: &HashMap<String, DiscoveredCommodity>,
+    existing_prices: &HashSet<(String, String, NaiveDate)>,
 ) -> Result<()> {
     use crate::cmd::price::external::ExternalCommandSource;
 
@@ -465,6 +600,21 @@ fn run_with_external_command(
         // silently wipe out a config-file `Detailed.quote_currency`.
         let effective_currency =
             resolve_quote_currency(symbol, discovered, &price_config.mapping, &args.currency);
+
+        // --clobber: skip when an existing price for this (symbol, currency, date)
+        // is already in the file. Same rule as the network fetch path.
+        if !args.clobber {
+            let fetch_date = date.unwrap_or_else(|| jiff::Zoned::now().date());
+            if existing_prices.contains(&(symbol.clone(), effective_currency.clone(), fetch_date)) {
+                if args.verbose {
+                    eprintln!(
+                        "{symbol}: skipped (existing price for {fetch_date} {effective_currency}; pass --clobber to refetch)"
+                    );
+                }
+                continue;
+            }
+        }
+
         let request = PriceRequest {
             ticker: symbol.clone(),
             currency: effective_currency.clone(),

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -112,7 +112,7 @@ Two CLI flags **bypass** the mapping system entirely and override everything bel
 
 When neither bypass is in effect, the merged source mapping is built with this precedence (high to low):
 
-1. CLI `--mapping <SYMBOL>:<TICKER>[:<SOURCE>]` (per-symbol override at runtime)
+1. CLI `--mapping <SYMBOL>:<TICKER>` (per-symbol override at runtime; the optional `:<SOURCE>` form is not yet parsed — pair with `--source` if you need to override both)
 2. `price:` metadata on the commodity directive (each fallback entry preserves its own ticker — see issue #963)
 3. Config-file `[price.mapping.X]` entries
 4. **Synthesized `Simple(<symbol>)` default-source dispatch** — only for commodities discovered from the ledger that opted in via `quote_currency:` metadata, the `--undeclared` ticker-shape heuristic, or that lack their own metadata source spec. Without this synthesis, those commodities would hit the explicit-source-required guard below.
@@ -354,7 +354,7 @@ Run with cron:
 
 ## Differences from `bean-price`
 
-Most behavior matches Python `bean-price` 1:1 (verified via the differential test harness in `crates/rustledger/tests/bean_price_compat.rs`). A few intentional divergences:
+Commodity discovery is exercised against `bean-price` directly via the differential harness in `crates/rustledger/tests/bean_price_compat.rs` (asserts the `(symbol, quote_currency)` set matches). Source-resolution / fallback-chain behavior is not yet covered by the harness — it relies on code inspection plus the unit tests in `price_cmd.rs`. Known intentional divergences:
 
 | Area | rledger | bean-price | Reason |
 |---|---|---|---|

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -32,6 +32,8 @@ rledger price [OPTIONS] [SYMBOL]...
 | `--inactive` | Include commodities not currently held (matches `bean-price --inactive`). Requires `-f`. |
 | `--undeclared` | Also discover ticker-shaped commodities lacking `price:`/`quote_currency:` metadata. Approximate analogue of `bean-price --undeclared` (see note below). Requires `-f`. |
 | `--list-sources` | List configured sources and exit |
+| `-n, --dry-run` | Print resolved fetch plan and exit; no network. Matches `bean-price --dry-run`. |
+| `-C, --clobber` | Re-fetch prices even when the input file already has a `price` directive for that `(symbol, currency, date)`. Requires `-f`. Matches `bean-price --clobber`. |
 | `--no-cache` | Disable the price cache for this run |
 | `--clear-cache` | Clear the price cache before fetching |
 | `-v, --verbose` | Show verbose output |
@@ -103,21 +105,28 @@ rledger price -f main.beancount --inactive --undeclared
 
 ### Precedence for source/ticker resolution
 
-When multiple configurations apply to the same symbol, the order from highest to lowest precedence is:
+Two CLI flags **bypass** the mapping system entirely and override everything below:
 
-1. CLI `--mapping` (per-symbol overrides on the command line)
-2. CLI `--source` (forces source for every symbol in the run)
-3. `price:` metadata on the commodity directive
-4. Config-file `[price.mapping]` entries
-5. Default source from `[price.default_source]` (or `yahoo`)
+- `--source-cmd <CMD>`: every symbol is fetched by running `<CMD>` as an external program. Mapping/metadata/config are ignored for the source decision.
+- `--source <NAME>`: every symbol is fetched from the named built-in or configured source. Mapping/metadata/config are ignored for the source decision (but `quote_currency:` metadata still drives the per-symbol quote currency — see below).
+
+When neither bypass is in effect, the merged source mapping is built with this precedence (high to low):
+
+1. CLI `--mapping <SYMBOL>:<TICKER>[:<SOURCE>]` (per-symbol override at runtime)
+2. `price:` metadata on the commodity directive (each fallback entry preserves its own ticker — see issue #963)
+3. Config-file `[price.mapping.X]` entries
+4. **Synthesized `Simple(<symbol>)` default-source dispatch** — only for commodities discovered from the ledger that opted in via `quote_currency:` metadata, the `--undeclared` ticker-shape heuristic, or that lack their own metadata source spec. Without this synthesis, those commodities would hit the explicit-source-required guard below.
+5. Otherwise: **error** (the strict default from issue #966 — see "Explicit source declaration required by default" below). Disable with `[price] use_default_source = true`.
 
 ### Quote currency resolution
 
 The currency a price is quoted in is resolved separately, since a single source mapping can be queried in different currencies. From highest to lowest precedence:
 
-1. `quote_currency:` metadata on the commodity directive (or the first quote currency listed in a chained `price:` value)
+1. `quote_currency:` metadata on the commodity directive (or the first quote currency listed in a chained `price:` value) — issue #952
 2. `quote_currency = "..."` in the `[price.mapping.X]` config-file block
 3. The global `--currency` flag (or its default, `USD`)
+
+The same effective currency is then passed to `--source-cmd` external commands as `--currency <CCY>`. If the command's output omits a currency (e.g. emits a number-only line), the response adopts the requested currency rather than defaulting to USD — issue #979.
 
 Note that `[price.mapping.X]` blocks reject unknown keys: a typo like `currency = "EUR"` (vs the supported `quote_currency`) will fail config load with a clear error rather than being silently dropped.
 
@@ -305,6 +314,25 @@ rledger price BTC -m "BTC:BTC-USD"
 rledger price -f ledger.beancount -b
 ```
 
+### Debugging Discovery (Dry Run)
+
+Print what would be fetched without making any network calls. Each line shows the resolved `(symbol, quote_currency, date, source(s)/ticker(s))`:
+
+```bash
+rledger price -f ledger.beancount -n
+# AAPL /USD @ today yahoo(AAPL)
+# GBP  /EUR @ today ecbrates(GBP-EUR), ecb(GBP)
+# SAP  /EUR @ today yahoo(SAP.DE)
+```
+
+### Re-fetch Existing Prices (`--clobber`)
+
+By default, `rledger price -f` skips fetching for `(symbol, currency, date)` tuples that already have a `price` directive in the file (matches `bean-price`). Pass `--clobber` to fetch them anyway — the new directives can then replace the old ones in your file:
+
+```bash
+rledger price -f ledger.beancount --clobber -b > prices.beancount
+```
+
 ### Append to Price File
 
 ```bash
@@ -323,6 +351,20 @@ Run with cron:
 ```cron
 0 18 * * 1-5 /path/to/update-prices.sh
 ```
+
+## Differences from `bean-price`
+
+Most behavior matches Python `bean-price` 1:1 (verified via the differential test harness in `crates/rustledger/tests/bean_price_compat.rs`). A few intentional divergences:
+
+| Area | rledger | bean-price | Reason |
+|---|---|---|---|
+| Default discovery | strict: only commodities with `price:`/`quote_currency:` metadata that you currently hold | same since #965 | matches upstream after #962 fix |
+| `--undeclared` | walks `commodity` directives, applies a ticker-shape heuristic | walks **transactions** and unions all currencies, no shape filter | avoids spurious lookups for currency codes like `BAM`; closer alignment tracked as a follow-up |
+| Verbose output | plain `Fetching prices for: [...]` and `{symbol}: cached (source: …)` lines on stderr | Python `logging`-style `INFO: Fetching …` lines with module prefixes | rledger writes for a human reader, not for log aggregation; doubling `-v` is not currently supported |
+| `--no-cache` | disables the rledger disk cache (single TTL across all sources) | `--no-cache` plus per-source cache config | rledger's cache is global; per-source config is not currently exposed |
+| `--date` | passes the date through to source requests; the active-commodity filter still uses the latest balances | walks the file as-of `--date` for both balance computation and price lookup | small divergence; documented but not fixed yet |
+
+Suggesting alignment? File an issue against the audit umbrella in #967.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

Bundles the cheap items from issue #967's bean-price compatibility audit plus the #972 zero-skip follow-up the original reporter expected. New behavior is opt-in or follows back-compat defaults; nothing existing changes shape.

Refs #967, addresses #972 follow-up.

## What's in this PR

### `--dry-run` / `-n` on `rledger price` (audit item 1)

Print the resolved fetch plan and exit; no network. Matches `bean-price --dry-run`.

```
$ rledger price -f ledger.beancount -n
AAPL /USD @ today yahoo(AAPL)
GBP  /EUR @ today ecbrates(GBP-EUR), ecb(GBP)
SAP  /EUR @ today yahoo(SAP.DE)
```

Honors `--source` / `--source-cmd` bypasses, walks fallback chains, preserves per-source tickers from #963/#970, picks up `--date`.

### `--clobber` / `-C` on `rledger price` (audit item 2)

Skip fetching when the input file already has a `price` directive for `(symbol, quote_currency, date)`. Default behavior matches `bean-price` (skip existing). `--clobber` re-fetches.

```
$ rledger price -f ledger.beancount -b -v
AAPL: skipped (existing price for 2026-05-03 USD; pass --clobber to refetch)
2026-05-03 price MSFT 1.00 USD
$ rledger price -f ledger.beancount -b --clobber
2026-05-03 price AAPL 1.00 USD
2026-05-03 price MSFT 1.00 USD
```

### `--include-zero-amounts` on `rledger extract` (#972 follow-up)

The original reporter expected zero-amount rows to be preserved when migrating from GnuCash. The default still drops them (back-compat); the new flag flips it for one run.

```
$ rledger extract /path/to/bug.csv --auto --include-zero-amounts
```

API: `CsvConfigBuilder::skip_zero_amounts(false)`.

### Documentation (audit items 3, 4, 5, 6)

`docs/commands/price.md`:
- **Item 5**: precedence re-doc refreshed for the post-#970/#971 code. Promotes `--source` / `--source-cmd` to top-level bypasses, adds the `Simple(symbol)` synthesis rung for `quote_currency:`-only / `--undeclared` discovery, points at #966's strict default and #979's currency-fallback rule.
- **Item 6** (logging format), **Item 3** (cache), **Item 4** (`--date` semantics): documented as known divergences in a new "Differences from `bean-price`" table. Code-level alignment for items 3 and 4 is left as separate efforts since they're investigations rather than concrete fixes.
- New `--dry-run` and `--clobber` rows in the Options table, with worked examples.

## Test plan

- [x] `cargo test -p rustledger --lib` (255 passing)
- [x] `cargo test -p rustledger-importer` (130+ passing, including new `test_csv_import_zero_amount_preserved_when_opted_in`)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Bean-price compat harness passes (pre-push hook ran it)
- [x] Manual `rledger price -f X -n` against a fixture with USD, EUR, and a fallback chain — output correct
- [x] Manual `rledger price -f X --clobber` and without — skip vs refetch behavior verified
- [x] Manual `rledger extract /tmp/bug.csv --auto --include-zero-amounts` — preserves the `0.00` row that `bug.csv` (issue #972 reproduction) emits

## What's NOT in this PR (per #967 audit)

- **Acceptance criterion #1** (differential test fixture) was already shipped in #978.
- **Code-level fixes for items 3 and 4** (cache granularity, `--date` semantics) — those are documented divergences but not fixed; would need their own PRs.
- **#923 IBKR importer** — explicitly deferred.
