### PR TITLE
feat(price): --date as-of + harness source-resolution diff (refs #967)

### DIFF
--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -34,7 +34,7 @@
 
 use crate::config::{CommodityMapping, DetailedMapping, FallbackDetail, FallbackEntry, SourceRef};
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, MetaValue};
+use rustledger_core::{Directive, MetaValue, NaiveDate};
 use rustledger_loader::Options;
 use rustledger_parser::Spanned;
 use std::collections::{HashMap, HashSet};
@@ -90,11 +90,12 @@ pub fn discover_symbols(
     options: &Options,
     inactive: bool,
     undeclared: bool,
+    as_of: Option<NaiveDate>,
 ) -> HashMap<String, DiscoveredCommodity> {
     let active = if inactive {
         None
     } else {
-        Some(active_commodities(directives, options))
+        Some(active_commodities(directives, options, as_of))
     };
 
     let mut out: HashMap<String, DiscoveredCommodity> = HashMap::new();
@@ -321,12 +322,21 @@ fn looks_like_ticker(symbol: &str) -> bool {
 ///
 /// The "Assets" / "Liabilities" prefix is read from `options` so ledgers
 /// using translated account roots (`Activos`, `Aktiva`, etc.) work too.
-fn active_commodities(directives: &[Spanned<Directive>], options: &Options) -> HashSet<String> {
+fn active_commodities(
+    directives: &[Spanned<Directive>],
+    options: &Options,
+    as_of: Option<NaiveDate>,
+) -> HashSet<String> {
     let assets_prefix = format!("{}:", options.name_assets);
     let liabilities_prefix = format!("{}:", options.name_liabilities);
     let is_balance_sheet = |account: &str| {
         account.starts_with(&assets_prefix) || account.starts_with(&liabilities_prefix)
     };
+    // Match bean-price's file-as-of-date semantics: with --date, both balance
+    // computation and account-close handling reflect the state on that date,
+    // not the latest. A commodity held on `as_of` but liquidated since then
+    // should still be considered active for the historical fetch.
+    let in_window = |date: NaiveDate| as_of.is_none_or(|cutoff| date <= cutoff);
 
     let mut balances: HashMap<(String, String), Decimal> = HashMap::new();
     let mut closed: HashSet<String> = HashSet::new();
@@ -334,6 +344,9 @@ fn active_commodities(directives: &[Spanned<Directive>], options: &Options) -> H
     for spanned in directives {
         match &spanned.value {
             Directive::Transaction(txn) => {
+                if !in_window(txn.date) {
+                    continue;
+                }
                 for posting in &txn.postings {
                     let account = posting.account.as_str();
                     if !is_balance_sheet(account) {
@@ -346,6 +359,9 @@ fn active_commodities(directives: &[Spanned<Directive>], options: &Options) -> H
                 }
             }
             Directive::Close(close) => {
+                if !in_window(close.date) {
+                    continue;
+                }
                 closed.insert(close.account.to_string());
             }
             _ => {}
@@ -473,13 +489,89 @@ mod tests {
                     )),
             ),
         ]);
-        let active = active_commodities(&dirs, &Options::new());
+        let active = active_commodities(&dirs, &Options::new(), None);
         assert!(active.contains("AAPL"));
         assert!(active.contains("EUR"));
         assert!(
             !active.contains("BTC"),
             "BTC was fully sold, should not be active"
         );
+    }
+
+    #[test]
+    fn as_of_filter_includes_holdings_at_that_date_only() {
+        // Bean-price compat: with --date X, the active filter should reflect
+        // balances ON X, not the latest. A commodity bought before X then
+        // fully sold afterwards must STILL be active when fetching as-of X.
+        let dirs = directives(vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "buy SHIB")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(100), "SHIB"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-100), "SHIB"),
+                    )),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 6, 1), "sell SHIB")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(-100), "SHIB"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(100), "SHIB"),
+                    )),
+            ),
+        ]);
+
+        // No as_of: the latest balance is zero — SHIB is NOT active.
+        let active_now = active_commodities(&dirs, &Options::new(), None);
+        assert!(!active_now.contains("SHIB"));
+
+        // as_of in the holding window: SHIB IS active.
+        let active_during = active_commodities(&dirs, &Options::new(), Some(date(2024, 4, 1)));
+        assert!(
+            active_during.contains("SHIB"),
+            "SHIB held on 2024-04-01 should be active when fetching as-of that date"
+        );
+
+        // as_of after the sell: SHIB no longer active.
+        let active_after = active_commodities(&dirs, &Options::new(), Some(date(2024, 12, 31)));
+        assert!(!active_after.contains("SHIB"));
+    }
+
+    #[test]
+    fn as_of_ignores_close_directive_after_cutoff() {
+        // A close in the future shouldn't retroactively wipe out balances
+        // that were active on the as-of date.
+        let dirs = directives(vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Brokerage")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "buy")
+                    .with_posting(Posting::new(
+                        "Assets:Brokerage",
+                        Amount::new(dec!(10), "DOGE"),
+                    ))
+                    .with_posting(Posting::new(
+                        "Equity:Opening",
+                        Amount::new(dec!(-10), "DOGE"),
+                    )),
+            ),
+            Directive::Close(Close::new(date(2024, 12, 31), "Assets:Brokerage")),
+        ]);
+        // As of mid-2024 the account is still open and DOGE is held.
+        let active = active_commodities(&dirs, &Options::new(), Some(date(2024, 6, 1)));
+        assert!(active.contains("DOGE"));
+        // After the close directive's date, DOGE is no longer active.
+        let active_after = active_commodities(&dirs, &Options::new(), Some(date(2025, 1, 1)));
+        assert!(!active_after.contains("DOGE"));
     }
 
     #[test]
@@ -503,7 +595,7 @@ mod tests {
             ),
             Directive::Close(Close::new(date(2024, 12, 31), "Assets:Brokerage")),
         ]);
-        let active = active_commodities(&dirs, &Options::new());
+        let active = active_commodities(&dirs, &Options::new(), None);
         assert!(!active.contains("DEFUNCT"));
     }
 
@@ -530,7 +622,7 @@ mod tests {
                     )),
             ),
         ]);
-        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false, None);
 
         // Even though "Vanguard_VTI" doesn't pass the ticker heuristic,
         // it has price: metadata, so it's discovered.
@@ -551,11 +643,11 @@ mod tests {
         let dirs = directives(vec![Directive::Commodity(comm)]);
 
         // Default: no active postings means OLD is not discovered.
-        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false, None);
         assert!(!discovered.contains_key("OLD"));
 
         // Opt-in: inactive=true brings it back.
-        let discovered_all = discover_symbols(&dirs, &Options::new(), true, false);
+        let discovered_all = discover_symbols(&dirs, &Options::new(), true, false, None);
         assert!(discovered_all.contains_key("OLD"));
     }
 
@@ -567,7 +659,7 @@ mod tests {
     #[test]
     fn discover_returns_empty_for_empty_ledger() {
         let dirs: Vec<Spanned<Directive>> = vec![];
-        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false, None);
         assert!(discovered.is_empty());
     }
 
@@ -595,14 +687,14 @@ mod tests {
             ),
         ]);
 
-        let strict = discover_symbols(&dirs, &Options::new(), false, false);
+        let strict = discover_symbols(&dirs, &Options::new(), false, false, None);
         assert!(
             !strict.contains_key("BAM"),
             "BAM has no `price:` metadata, must not be discovered by default (#962)"
         );
 
         // `--undeclared` brings the heuristic back.
-        let with_undeclared = discover_symbols(&dirs, &Options::new(), false, true);
+        let with_undeclared = discover_symbols(&dirs, &Options::new(), false, true, None);
         assert!(with_undeclared.contains_key("BAM"));
     }
 
@@ -629,7 +721,7 @@ mod tests {
         ]);
 
         // Even with --undeclared, the empty price: opt-out wins.
-        let discovered = discover_symbols(&dirs, &Options::new(), false, true);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, true, None);
         assert!(!discovered.contains_key("BAM"));
     }
 
@@ -660,7 +752,7 @@ mod tests {
             ),
         ]);
 
-        let discovered = discover_symbols(&dirs, &Options::new(), false, false);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, false, None);
         let info = discovered
             .get("GOVT_EU")
             .expect("quote_currency: alone should opt into discovery");
@@ -677,7 +769,7 @@ mod tests {
             date(2024, 1, 1),
             "OLD",
         ))]);
-        let discovered = discover_symbols(&dirs, &Options::new(), true, true);
+        let discovered = discover_symbols(&dirs, &Options::new(), true, true, None);
         assert!(discovered.contains_key("OLD"));
     }
 
@@ -757,7 +849,7 @@ mod tests {
             ),
         ]);
 
-        let discovered = discover_symbols(&dirs, &Options::new(), false, true);
+        let discovered = discover_symbols(&dirs, &Options::new(), false, true, None);
         assert!(!discovered.contains_key("BAM"));
     }
 
@@ -784,7 +876,7 @@ mod tests {
                     )),
             ),
         ]);
-        let active = active_commodities(&dirs, &Options::new());
+        let active = active_commodities(&dirs, &Options::new(), None);
         assert!(active.contains("AAPL"));
     }
 }

--- a/crates/rustledger/src/cmd/price/discovery.rs
+++ b/crates/rustledger/src/cmd/price/discovery.rs
@@ -544,6 +544,14 @@ mod tests {
         // as_of after the sell: SHIB no longer active.
         let active_after = active_commodities(&dirs, &Options::new(), Some(date(2024, 12, 31)));
         assert!(!active_after.contains("SHIB"));
+
+        // Boundary: exactly on the buy date — buy applies, SHIB active.
+        let active_buy_day = active_commodities(&dirs, &Options::new(), Some(date(2024, 2, 1)));
+        assert!(active_buy_day.contains("SHIB"));
+
+        // Boundary: exactly on the sell date — both buy and sell apply, balance=0.
+        let active_sell_day = active_commodities(&dirs, &Options::new(), Some(date(2024, 6, 1)));
+        assert!(!active_sell_day.contains("SHIB"));
     }
 
     #[test]
@@ -572,6 +580,10 @@ mod tests {
         // After the close directive's date, DOGE is no longer active.
         let active_after = active_commodities(&dirs, &Options::new(), Some(date(2025, 1, 1)));
         assert!(!active_after.contains("DOGE"));
+
+        // Boundary: exactly on the close date — close is inclusive, so DOGE inactive.
+        let active_close_day = active_commodities(&dirs, &Options::new(), Some(date(2024, 12, 31)));
+        assert!(!active_close_day.contains("DOGE"));
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -167,6 +167,20 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     }
     let effective_inactive = args.inactive || args.all_commodities;
     let effective_undeclared = args.undeclared || args.all_commodities;
+
+    // Parse `--date` early so it can be threaded into discovery. Without
+    // this, `--date 2020-01-01 -f file` would still use today's balances
+    // for the active-commodity filter — wrong for historical fetches and
+    // diverges from `bean-price`, which walks the file as-of `--date`.
+    let date: Option<NaiveDate> = if let Some(ref d) = args.date {
+        Some(
+            d.parse::<NaiveDate>()
+                .with_context(|| format!("Invalid date: {d}"))?,
+        )
+    } else {
+        None
+    };
+
     // Tuple keys for `--clobber`: every existing `price` directive in the file
     // identifies a (symbol, quote_currency, date) we should skip fetching for
     // unless `--clobber` is set. Built alongside discovery to avoid loading
@@ -195,6 +209,7 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
             &ledger.options,
             effective_inactive,
             effective_undeclared,
+            date,
         );
         let mut existing = HashSet::new();
         for spanned in &ledger.directives {
@@ -253,16 +268,6 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     if args.verbose {
         eprintln!("Fetching prices for: {symbols_to_fetch:?}");
     }
-
-    // Parse target date
-    let date = if let Some(ref d) = args.date {
-        Some(
-            d.parse::<NaiveDate>()
-                .with_context(|| format!("Invalid date: {d}"))?,
-        )
-    } else {
-        None
-    };
 
     let combined_mapping = build_combined_mapping(&price_config.mapping, &discovered, &cli_mapping);
 

--- a/crates/rustledger/tests/bean_price_compat.rs
+++ b/crates/rustledger/tests/bean_price_compat.rs
@@ -264,7 +264,9 @@ fn extract_bean_price_attempts(stdout: &str) -> BTreeSet<(String, String, String
 fn extract_rledger_attempts(stdout: &str) -> BTreeSet<(String, String, String, String)> {
     let mut out = BTreeSet::new();
     for line in stdout.lines() {
-        // Drop the trailing skip annotation if present.
+        // Drop the trailing skip annotation if present. The two-space prefix
+        // is what `dump_fetch_plan` writes; if that ever changes, this strip
+        // becomes a no-op and the skip suffix is parsed as a bogus source.
         let line = line.split("  [skip:").next().unwrap_or(line).trim_end();
 
         let mut parts = line.split_whitespace();

--- a/crates/rustledger/tests/bean_price_compat.rs
+++ b/crates/rustledger/tests/bean_price_compat.rs
@@ -1,18 +1,18 @@
-//! Differential test harness: `rledger price` vs `bean-price` commodity discovery.
+//! Differential test harness: `rledger price` vs `bean-price`.
 //!
-//! Drives both binaries against fixture beancount files and asserts the set of
-//! `(symbol, quote_currency)` pairs they would fetch is identical. Foundation for
-//! issue #967's compat audit; per-candidate items can add their own fixtures here.
+//! Two layers of comparison against fixture beancount files:
 //!
-//! **Scope**: commodity discovery only. Source-resolution precedence (audit item 5),
-//! per-spec ticker preservation (#970), and fallback chains (#963/#970) cannot be
-//! tested through this harness because rledger's `--source-cmd` flag bypasses the
-//! source layer entirely. Validating those requires either an HTTP mock or a future
-//! `--dry-run` flag on rledger that mirrors `bean-price -n`.
+//! 1. **Commodity discovery** — `bean-price -n` vs `rledger price --source-cmd`,
+//!    asserting the same `(symbol, quote_currency)` set is discovered.
+//!
+//! 2. **Source resolution** — `bean-price -n` vs `rledger price -n`, asserting
+//!    the same `(symbol, currency, source, ticker)` tuples are produced. This
+//!    covers source-precedence (audit item 5), per-spec ticker preservation (#970),
+//!    and fallback chains (#963/#970) that the discovery-only layer can't see.
 //!
 //! `bean-price` ships in the nix dev shell (#976). On non-nix workflows the test
-//! skips with a notice rather than failing; CI runs in the dev shell so the
-//! skip path doesn't fire there.
+//! skips with a notice rather than failing; CI doesn't currently use the dev
+//! shell, so the harness is enforced via the pre-push hook.
 
 #![cfg(unix)]
 
@@ -201,6 +201,165 @@ fn rledger_and_bean_price_discover_same_commodities_basic() {
 #[test]
 fn rledger_and_bean_price_discover_same_commodities_mixed_currencies() {
     assert_same_commodities(FIXTURE_MIXED_CURRENCIES, "mixed_currencies");
+}
+
+// ===== Layer 2: source-resolution differential (uses both binaries' dry-run) =====
+
+/// Strip bean-price's `beanprice.sources.` module prefix so source names match
+/// rledger's bare names (`yahoo`, `ecb`, ...).
+fn normalize_source(s: &str) -> String {
+    s.strip_prefix("beanprice.sources.")
+        .unwrap_or(s)
+        .to_string()
+}
+
+/// Parse `bean-price -n` output. Each line ends with
+///   `[ beanprice.sources.yahoo(AAPL), beanprice.sources.google(VTI) ]`
+/// We extract the bracket section and split on commas.
+fn extract_bean_price_attempts(stdout: &str) -> BTreeSet<(String, String, String, String)> {
+    let mut out = BTreeSet::new();
+    for line in stdout.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(sym) = parts.next() else { continue };
+        let Some(cur_raw) = parts.next() else {
+            continue;
+        };
+        let Some(cur) = cur_raw.strip_prefix('/') else {
+            continue;
+        };
+        if parts.next() != Some("@") {
+            continue;
+        }
+        // Locate the bracket payload regardless of how many tokens precede it.
+        let Some(open) = line.find('[') else { continue };
+        let Some(close) = line.rfind(']') else {
+            continue;
+        };
+        if close <= open {
+            continue;
+        }
+        let inside = line[open + 1..close].trim();
+        for entry in inside.split(',') {
+            let entry = entry.trim();
+            // `module.path.name(TICKER)` — split on the last '(' before ')'.
+            let Some(paren_open) = entry.rfind('(') else {
+                continue;
+            };
+            let Some(paren_close) = entry.rfind(')') else {
+                continue;
+            };
+            if paren_close <= paren_open {
+                continue;
+            }
+            let source = normalize_source(entry[..paren_open].trim());
+            let ticker = entry[paren_open + 1..paren_close].trim().to_string();
+            out.insert((sym.to_string(), cur.to_string(), source, ticker));
+        }
+    }
+    out
+}
+
+/// Parse `rledger price -n` output. Format:
+///   `<symbol> /<currency> @ <date> <source>(<ticker>)[, <source>(<ticker>)...][  [skip: ...]]`
+fn extract_rledger_attempts(stdout: &str) -> BTreeSet<(String, String, String, String)> {
+    let mut out = BTreeSet::new();
+    for line in stdout.lines() {
+        // Drop the trailing skip annotation if present.
+        let line = line.split("  [skip:").next().unwrap_or(line).trim_end();
+
+        let mut parts = line.split_whitespace();
+        let Some(sym) = parts.next() else { continue };
+        let Some(cur_raw) = parts.next() else {
+            continue;
+        };
+        let Some(cur) = cur_raw.strip_prefix('/') else {
+            continue;
+        };
+        if parts.next() != Some("@") {
+            continue;
+        }
+        let _date = parts.next();
+        // Everything left is the source list. Rejoin to handle the
+        // ", " separator (split_whitespace would split on it too).
+        let rest = parts.collect::<Vec<_>>().join(" ");
+        for entry in rest.split(", ") {
+            let entry = entry.trim();
+            if entry == "<unmapped>" {
+                continue;
+            }
+            let Some(paren_open) = entry.rfind('(') else {
+                continue;
+            };
+            let Some(paren_close) = entry.rfind(')') else {
+                continue;
+            };
+            if paren_close <= paren_open {
+                continue;
+            }
+            let source = entry[..paren_open].trim().to_string();
+            let ticker = entry[paren_open + 1..paren_close].trim().to_string();
+            out.insert((sym.to_string(), cur.to_string(), source, ticker));
+        }
+    }
+    out
+}
+
+fn run_bean_price_attempts(
+    fixture: &std::path::Path,
+) -> BTreeSet<(String, String, String, String)> {
+    let out = Command::new("bean-price")
+        .args(["-n", fixture.to_str().unwrap()])
+        .output()
+        .expect("bean-price -n should execute");
+    assert!(
+        out.status.success(),
+        "bean-price exited non-zero: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    extract_bean_price_attempts(&String::from_utf8_lossy(&out.stdout))
+}
+
+fn run_rledger_attempts(fixture: &std::path::Path) -> BTreeSet<(String, String, String, String)> {
+    let out = Command::new(env!("CARGO_BIN_EXE_rledger"))
+        .args(["price", "-f", fixture.to_str().unwrap(), "-n"])
+        .output()
+        .expect("rledger price -n should execute");
+    assert!(
+        out.status.success(),
+        "rledger price -n exited non-zero: stderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+    extract_rledger_attempts(&String::from_utf8_lossy(&out.stdout))
+}
+
+fn assert_same_attempts(fixture: &str, label: &str) {
+    if !bean_price_available() {
+        eprintln!(
+            "skipping bean-price compat ({label}): bean-price not on PATH \
+             (run inside `nix develop` to enable)"
+        );
+        return;
+    }
+    let f = write_fixture(fixture);
+    let bean = run_bean_price_attempts(f.path());
+    let rledger = run_rledger_attempts(f.path());
+    assert_eq!(
+        bean, rledger,
+        "fixture {label}: bean-price and rledger price disagreed on (symbol, currency, source, ticker).\n\
+         bean-price = {bean:?}\n\
+         rledger    = {rledger:?}"
+    );
+}
+
+#[test]
+fn rledger_and_bean_price_resolve_same_attempts_basic() {
+    assert_same_attempts(FIXTURE_BASIC, "basic");
+}
+
+#[test]
+fn rledger_and_bean_price_resolve_same_attempts_mixed_currencies() {
+    assert_same_attempts(FIXTURE_MIXED_CURRENCIES, "mixed_currencies");
 }
 
 // Sanity check: when we're inside `nix develop`, `bean-price` must be on PATH —

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -362,7 +362,6 @@ Commodity discovery is exercised against `bean-price` directly via the different
 | `--undeclared` | walks `commodity` directives, applies a ticker-shape heuristic | walks **transactions** and unions all currencies, no shape filter | avoids spurious lookups for currency codes like `BAM`; closer alignment tracked as a follow-up |
 | Verbose output | plain `Fetching prices for: [...]` and `{symbol}: cached (source: …)` lines on stderr | Python `logging`-style `INFO: Fetching …` lines with module prefixes | rledger writes for a human reader, not for log aggregation; doubling `-v` is not currently supported |
 | `--no-cache` | disables the rledger disk cache (single TTL across all sources) | `--no-cache` plus per-source cache config | rledger's cache is global; per-source config is not currently exposed |
-| `--date` | passes the date through to source requests; the active-commodity filter still uses the latest balances | walks the file as-of `--date` for both balance computation and price lookup | small divergence; documented but not fixed yet |
 
 Suggesting alignment? File an issue against the audit umbrella in #967.
 


### PR DESCRIPTION
## Summary

Two follow-ups from issue #967's punch list. Stacked on top of #982 (the bean-price audit bundle).

### Item 4 from #967: `--date` as-of for the active-commodity filter

Before this change, `rledger price -f file.beancount --date 2020-01-01` parsed the date and passed it to source requests, but the active filter that decides which commodities to include used the **latest** balances. A commodity bought before 2020 and sold afterward was excluded from the historical fetch. Bean-price walks the file as-of `--date` for both balance computation and price lookup; this aligns rledger.

- `discover_symbols` and `active_commodities` now take `Option<NaiveDate>`.
- Transactions with `date > as_of` are skipped from the balance roll-up.
- `Close` directives after `as_of` are ignored (the account WAS open then).
- `price_cmd.rs` parses `args.date` once, early, and threads it into discovery.

New regression tests: `as_of_filter_includes_holdings_at_that_date_only`, `as_of_ignores_close_directive_after_cutoff`.

### Harness extension: source-resolution differential

The compat harness (#978) previously compared only commodity discovery — there was no rledger equivalent of `bean-price -n`. With `--dry-run` now landed in #982, the harness can compare the full `(symbol, currency, source, ticker)` resolution between the two binaries.

That covers what the discovery-only layer couldn't:
- source precedence (audit item 5)
- per-spec ticker preservation (#970)
- fallback chains (#963/#970)

New tests: `rledger_and_bean_price_resolve_same_attempts_basic`, `rledger_and_bean_price_resolve_same_attempts_mixed_currencies`. Both pass against the existing fixtures.

### Docs

Dropped the `--date` row from the "Differences from `bean-price`" table since it's no longer a divergence.

## Test plan

- [x] `cargo test -p rustledger --lib` (263 passing, +2 new)
- [x] `cargo test -p rustledger --test bean_price_compat` (5 passing, +2 new)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Pre-push hook ran the bean-price compat harness (passed)

## Stacking

Based on `feat/bean-price-audit-bundle` (#982). When #982 merges, this rebases cleanly onto main.

Refs #967.
