### PR TITLE
fix(plugin): correct @@ total-price handling and double-emit bug (closes #992)

### DIFF
--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -1,0 +1,183 @@
+//! Shared implicit-price extraction logic.
+//!
+//! Mirrors Python beancount's `implicit_prices` plugin behavior. Used
+//! by BOTH the BQL query path (`rustledger-query::price`) and the
+//! native `implicit_prices` plugin (`rustledger-plugin`). Centralizing
+//! avoids the parallel-implementations divergence that produced
+//! [issue #992]: the plugin emitted `@@` total amounts as per-unit
+//! prices, while the query path correctly divided them.
+//!
+//! The helper is a pure function over primitives (Decimals, bools,
+//! Options) rather than over rich types, because the plugin and query
+//! paths use different transaction representations
+//! (`crate::Transaction` vs `rustledger_plugin_types::TransactionData`).
+//! Each caller extracts the primitives from its own type and feeds them
+//! in.
+//!
+//! [issue #992]: https://github.com/rustledger/rustledger/issues/992
+
+use rust_decimal::Decimal;
+
+/// Decide the per-unit price implied by a posting.
+///
+/// Resolution order, mirroring upstream beancount's
+/// `beancount.plugins.implicit_prices`:
+///
+/// 1. **Price annotation** (`@` or `@@`) — if an amount is present.
+///    For `@@` (total), divides the total by `units_number.abs()`.
+///    For `@` (per-unit), returns the annotation amount directly.
+/// 2. **Cost spec** — only as a fallback when no usable price
+///    annotation. `number_per` is per-unit and used directly;
+///    `number_total` is divided by `units_number.abs()`.
+/// 3. **No price** — returns `None`.
+///
+/// Edge cases:
+/// - Zero units with a total-form input (annotation `@@` or
+///   `cost.number_total`): can't compute per-unit, falls through to
+///   the next priority. If nothing else is available, returns `None`.
+/// - Zero units with a per-unit-form input (annotation `@` or
+///   `cost.number_per`): the per-unit amount is returned as-is —
+///   "1 share = $X regardless of how many shares you transacted."
+#[must_use]
+pub fn extract_per_unit_price(
+    units_number: Decimal,
+    annotation_is_total: bool,
+    annotation_amount: Option<Decimal>,
+    cost_number_per: Option<Decimal>,
+    cost_number_total: Option<Decimal>,
+) -> Option<Decimal> {
+    // Priority 1: price annotation.
+    if let Some(amount) = annotation_amount {
+        if annotation_is_total {
+            if !units_number.is_zero() {
+                return Some(amount / units_number.abs());
+            }
+            // Zero units + total annotation → can't compute per-unit,
+            // fall through to cost. This matches the upstream behavior
+            // (the @@ amount is unusable without a unit count).
+        } else {
+            return Some(amount);
+        }
+    }
+
+    // Priority 2: cost spec.
+    if let Some(per) = cost_number_per {
+        return Some(per);
+    }
+    if let Some(total) = cost_number_total
+        && !units_number.is_zero()
+    {
+        return Some(total / units_number.abs());
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    // ===== Annotation cases =====
+
+    #[test]
+    fn unit_annotation_returns_amount_directly() {
+        // @ 1.40 EUR with 5 units → 1.40 (per-unit, used as-is).
+        let p = extract_per_unit_price(dec!(5), false, Some(dec!(1.40)), None, None);
+        assert_eq!(p, Some(dec!(1.40)));
+    }
+
+    #[test]
+    fn total_annotation_divides_by_unit_count() {
+        // @@ 1500 USD with 10 units → 1500 / 10 = 150.
+        let p = extract_per_unit_price(dec!(10), true, Some(dec!(1500)), None, None);
+        assert_eq!(p, Some(dec!(150)));
+    }
+
+    #[test]
+    fn total_annotation_uses_abs_unit_count() {
+        // The classic #992 reproducer: @@ 15152.07 EUR with -27204.53 BAM
+        // must produce 15152.07 / 27204.53 ≈ 0.557 (NOT -0.557, NOT 15152.07).
+        let p = extract_per_unit_price(dec!(-27204.53), true, Some(dec!(15152.07)), None, None);
+        let expected = dec!(15152.07) / dec!(27204.53);
+        assert_eq!(p, Some(expected));
+        assert!(p.unwrap() > dec!(0.55) && p.unwrap() < dec!(0.56));
+    }
+
+    #[test]
+    fn total_annotation_with_zero_units_falls_through_to_cost() {
+        // @@ 100 USD on 0 units → can't compute per-unit, but if a cost
+        // is also present, fall through to that.
+        let p = extract_per_unit_price(dec!(0), true, Some(dec!(100)), Some(dec!(50)), None);
+        assert_eq!(p, Some(dec!(50)));
+    }
+
+    #[test]
+    fn total_annotation_with_zero_units_and_no_cost_returns_none() {
+        let p = extract_per_unit_price(dec!(0), true, Some(dec!(100)), None, None);
+        assert_eq!(p, None);
+    }
+
+    // ===== Cost cases =====
+
+    #[test]
+    fn cost_per_unit_used_when_no_annotation() {
+        // 10 ABC {50.00 USD} → 50.00.
+        let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(50.00)), None);
+        assert_eq!(p, Some(dec!(50.00)));
+    }
+
+    #[test]
+    fn cost_total_divides_by_unit_count() {
+        // 10 ABC {{500 USD}} → 500 / 10 = 50.
+        let p = extract_per_unit_price(dec!(10), false, None, None, Some(dec!(500)));
+        assert_eq!(p, Some(dec!(50)));
+    }
+
+    #[test]
+    fn cost_total_with_zero_units_returns_none() {
+        let p = extract_per_unit_price(dec!(0), false, None, None, Some(dec!(500)));
+        assert_eq!(p, None);
+    }
+
+    // ===== Priority interactions =====
+
+    #[test]
+    fn annotation_wins_over_cost_when_both_present() {
+        // 5 ABC {1.25 EUR} @ 1.40 EUR → 1.40 (annotation wins).
+        // This is the case that originally surfaced as the plugin
+        // double-emitting in #992.
+        let p = extract_per_unit_price(dec!(5), false, Some(dec!(1.40)), Some(dec!(1.25)), None);
+        assert_eq!(p, Some(dec!(1.40)));
+    }
+
+    #[test]
+    fn total_annotation_wins_over_cost_per_unit() {
+        // -10 ABC {1.25 EUR} @@ 14 EUR → 14 / 10 = 1.40 (annotation wins).
+        let p = extract_per_unit_price(dec!(-10), true, Some(dec!(14)), Some(dec!(1.25)), None);
+        assert_eq!(p, Some(dec!(1.4)));
+    }
+
+    #[test]
+    fn cost_per_wins_over_cost_total_when_both_present() {
+        // {50 USD, 500 USD-total} — number_per takes precedence.
+        let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(50)), Some(dec!(999)));
+        assert_eq!(p, Some(dec!(50)));
+    }
+
+    // ===== Empty cases =====
+
+    #[test]
+    fn no_inputs_returns_none() {
+        let p = extract_per_unit_price(dec!(10), false, None, None, None);
+        assert_eq!(p, None);
+    }
+
+    #[test]
+    fn annotation_without_amount_falls_through_to_cost() {
+        // Incomplete annotation like `@ EUR` (no number) → ann_amount is
+        // None → fall through. Cost present → use it.
+        let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(7)), None);
+        assert_eq!(p, Some(dec!(7)));
+    }
+}

--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -13,9 +13,8 @@
 //! `rustledger_plugin_types::TransactionData` with `String`). Each
 //! caller assembles its annotation/cost descriptors with its own
 //! currency type and the helper returns the per-unit price already
-//! paired with the matching currency — making the
-//! mismatched-currency bug from PR #997's review impossible by
-//! construction.
+//! paired with the matching currency — making mismatched
+//! (number, currency) pairs impossible to construct.
 //!
 //! [issue #992]: https://github.com/rustledger/rustledger/issues/992
 
@@ -26,17 +25,17 @@ use rust_decimal::Decimal;
 ///
 /// The currency is returned alongside the per-unit `Decimal` so that
 /// callers can never accidentally pair a cost-derived value with the
-/// annotation currency (the bug Copilot caught on PR #997). The helper
-/// matches each value to the currency that came in with it.
+/// annotation currency. The helper matches each value to the currency
+/// that came in with it.
 ///
 /// Resolution order, mirroring upstream beancount's
 /// `beancount.plugins.implicit_prices`:
 ///
-/// 1. **Price annotation** (`@` or `@@`) — if both an amount and a
+/// 1. **Price annotation** (`@` or `@@`) — if a parsed number and
 ///    currency are present (`annotation` is `Some`).
 ///    For `@@` (`is_total = true`), divides the total by
 ///    `units_number.abs()`. For `@` (`is_total = false`), returns the
-///    annotation amount directly.
+///    number directly.
 /// 2. **Cost spec** — only as a fallback when no usable price
 ///    annotation. Within the cost spec, `number_per` takes precedence
 ///    over `number_total` when both are set (matching Python

--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -7,44 +7,41 @@
 //! [issue #992]: the plugin emitted `@@` total amounts as per-unit
 //! prices, while the query path correctly divided them.
 //!
-//! The helper is a pure function over primitives (Decimals, bools,
-//! Options) rather than over rich types, because the plugin and query
-//! paths use different transaction representations
-//! (`crate::Transaction` vs `rustledger_plugin_types::TransactionData`).
-//! Each caller extracts the primitives from its own type and feeds them
-//! in.
+//! The helper is generic over the currency type (`T`) because the
+//! plugin and query paths use different transaction representations
+//! (`crate::Transaction` with `InternedStr` vs
+//! `rustledger_plugin_types::TransactionData` with `String`). Each
+//! caller assembles its annotation/cost descriptors with its own
+//! currency type and the helper returns the per-unit price already
+//! paired with the matching currency — making the
+//! mismatched-currency bug from PR #997's review impossible by
+//! construction.
 //!
 //! [issue #992]: https://github.com/rustledger/rustledger/issues/992
 
 use rust_decimal::Decimal;
 
-/// Which input source produced an extracted implicit price.
+/// Decide the per-unit price implied by a posting and the quote
+/// currency to pair with it.
 ///
-/// Returned alongside the per-unit `Decimal` so callers know which
-/// quote-currency source to pair with it. Pre-fix (Copilot review on
-/// PR #997), callers picked the quote currency from the annotation
-/// even when the per-unit value came from the cost — for inputs like
-/// `0 ABC {50 USD} @@ 100 EUR` (zero-units total annotation falls
-/// through to cost), they emitted `50 EUR` instead of `50 USD`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ImplicitPriceSource {
-    /// Value came from the `@` / `@@` price annotation.
-    Annotation,
-    /// Value came from the `{...}` cost spec.
-    Cost,
-}
-
-/// Decide the per-unit price implied by a posting.
+/// The currency is returned alongside the per-unit `Decimal` so that
+/// callers can never accidentally pair a cost-derived value with the
+/// annotation currency (the bug Copilot caught on PR #997). The helper
+/// matches each value to the currency that came in with it.
 ///
 /// Resolution order, mirroring upstream beancount's
 /// `beancount.plugins.implicit_prices`:
 ///
-/// 1. **Price annotation** (`@` or `@@`) — if an amount is present.
-///    For `@@` (total), divides the total by `units_number.abs()`.
-///    For `@` (per-unit), returns the annotation amount directly.
+/// 1. **Price annotation** (`@` or `@@`) — if both an amount and a
+///    currency are present (`annotation` is `Some`).
+///    For `@@` (`is_total = true`), divides the total by
+///    `units_number.abs()`. For `@` (`is_total = false`), returns the
+///    annotation amount directly.
 /// 2. **Cost spec** — only as a fallback when no usable price
-///    annotation. `number_per` is per-unit and used directly;
-///    `number_total` is divided by `units_number.abs()`.
+///    annotation. Within the cost spec, `number_per` takes precedence
+///    over `number_total` when both are set (matching Python
+///    beancount's per-vs-total tie-break). `number_total` is divided
+///    by `units_number.abs()`.
 /// 3. **No price** — returns `None`.
 ///
 /// Edge cases:
@@ -54,36 +51,50 @@ pub enum ImplicitPriceSource {
 /// - Zero units with a per-unit-form input (annotation `@` or
 ///   `cost.number_per`): the per-unit amount is returned as-is —
 ///   "1 share = $X regardless of how many shares you transacted."
+///
+/// # Parameters
+///
+/// - `units_number`: the posting's unit count (sign-insensitive — the
+///   helper uses `.abs()` internally for total-form division).
+/// - `annotation`: `Some((is_total, amount, currency))` if the posting
+///   has a usable `@`/`@@` annotation. Callers should pass `None` for
+///   incomplete annotations (e.g. `@ EUR` without a number) so the
+///   helper falls through cleanly.
+/// - `cost`: `Some((number_per, number_total, currency))` if the
+///   posting has a `{...}` cost spec with at least one of `per`/`total`
+///   parsed. Both inner numbers are `Option<Decimal>` because the cost
+///   spec may have only one or the other.
 #[must_use]
-pub fn extract_per_unit_price(
+pub fn extract_per_unit_price<T>(
     units_number: Decimal,
-    annotation_is_total: bool,
-    annotation_amount: Option<Decimal>,
-    cost_number_per: Option<Decimal>,
-    cost_number_total: Option<Decimal>,
-) -> Option<(Decimal, ImplicitPriceSource)> {
+    annotation: Option<(bool, Decimal, T)>,
+    cost: Option<(Option<Decimal>, Option<Decimal>, T)>,
+) -> Option<(Decimal, T)> {
     // Priority 1: price annotation.
-    if let Some(amount) = annotation_amount {
-        if annotation_is_total {
+    if let Some((is_total, amount, currency)) = annotation {
+        if is_total {
             if !units_number.is_zero() {
-                return Some((amount / units_number.abs(), ImplicitPriceSource::Annotation));
+                return Some((amount / units_number.abs(), currency));
             }
-            // Zero units + total annotation → can't compute per-unit,
-            // fall through to cost. This matches the upstream behavior
-            // (the @@ amount is unusable without a unit count).
+            // Zero units + @@ → can't compute per-unit, fall through
+            // to cost. Currency is dropped along with the value, so the
+            // cost branch picks the cost's currency, not this one.
         } else {
-            return Some((amount, ImplicitPriceSource::Annotation));
+            return Some((amount, currency));
         }
     }
 
-    // Priority 2: cost spec.
-    if let Some(per) = cost_number_per {
-        return Some((per, ImplicitPriceSource::Cost));
-    }
-    if let Some(total) = cost_number_total
-        && !units_number.is_zero()
-    {
-        return Some((total / units_number.abs(), ImplicitPriceSource::Cost));
+    // Priority 2: cost spec. number_per wins over number_total when
+    // both are set.
+    if let Some((per, total, currency)) = cost {
+        if let Some(per) = per {
+            return Some((per, currency));
+        }
+        if let Some(total) = total
+            && !units_number.is_zero()
+        {
+            return Some((total / units_number.abs(), currency));
+        }
     }
 
     None
@@ -94,47 +105,54 @@ mod tests {
     use super::*;
     use rust_decimal_macros::dec;
 
+    // Tests use `&'static str` for the currency type for readability.
+    // Real callers pass `InternedStr` (query path) or `String`
+    // (plugin path).
+
     // ===== Annotation cases =====
 
     #[test]
     fn unit_annotation_returns_amount_directly() {
         // @ 1.40 EUR with 5 units → 1.40 (per-unit, used as-is).
-        let p = extract_per_unit_price(dec!(5), false, Some(dec!(1.40)), None, None);
-        assert_eq!(p, Some((dec!(1.40), ImplicitPriceSource::Annotation)));
+        let p = extract_per_unit_price(dec!(5), Some((false, dec!(1.40), "EUR")), None);
+        assert_eq!(p, Some((dec!(1.40), "EUR")));
     }
 
     #[test]
     fn total_annotation_divides_by_unit_count() {
         // @@ 1500 USD with 10 units → 1500 / 10 = 150.
-        let p = extract_per_unit_price(dec!(10), true, Some(dec!(1500)), None, None);
-        assert_eq!(p, Some((dec!(150), ImplicitPriceSource::Annotation)));
+        let p = extract_per_unit_price(dec!(10), Some((true, dec!(1500), "USD")), None);
+        assert_eq!(p, Some((dec!(150), "USD")));
     }
 
     #[test]
     fn total_annotation_uses_abs_unit_count() {
         // The classic #992 reproducer: @@ 15152.07 EUR with -27204.53 BAM
         // must produce 15152.07 / 27204.53 ≈ 0.557 (NOT -0.557, NOT 15152.07).
-        let p = extract_per_unit_price(dec!(-27204.53), true, Some(dec!(15152.07)), None, None);
+        let p = extract_per_unit_price(dec!(-27204.53), Some((true, dec!(15152.07), "EUR")), None);
         let expected = dec!(15152.07) / dec!(27204.53);
-        assert_eq!(p, Some((expected, ImplicitPriceSource::Annotation)));
+        assert_eq!(p, Some((expected, "EUR")));
         assert!(p.unwrap().0 > dec!(0.55) && p.unwrap().0 < dec!(0.56));
     }
 
     #[test]
     fn total_annotation_with_zero_units_falls_through_to_cost() {
-        // @@ 100 USD on 0 units → can't compute per-unit, but if a cost
-        // is also present, fall through to that. The SOURCE returned is
-        // Cost, so the caller knows to pick the cost's currency (this
-        // is the Copilot-flagged bug from PR #997: pre-fix, callers
-        // unconditionally picked the annotation currency, producing
-        // mismatched (number, currency) pairs).
-        let p = extract_per_unit_price(dec!(0), true, Some(dec!(100)), Some(dec!(50)), None);
-        assert_eq!(p, Some((dec!(50), ImplicitPriceSource::Cost)));
+        // @@ 100 EUR on 0 units → can't compute per-unit, fall through.
+        // Cost is `{50 USD}` so we return (50, "USD"), NOT (50, "EUR")
+        // — that's the Copilot-flagged bug from PR #997. Returning the
+        // currency alongside the value makes the mismatched pair
+        // impossible to construct.
+        let p = extract_per_unit_price(
+            dec!(0),
+            Some((true, dec!(100), "EUR")),
+            Some((Some(dec!(50)), None, "USD")),
+        );
+        assert_eq!(p, Some((dec!(50), "USD")));
     }
 
     #[test]
     fn total_annotation_with_zero_units_and_no_cost_returns_none() {
-        let p = extract_per_unit_price(dec!(0), true, Some(dec!(100)), None, None);
+        let p = extract_per_unit_price::<&str>(dec!(0), Some((true, dec!(100), "EUR")), None);
         assert_eq!(p, None);
     }
 
@@ -143,20 +161,20 @@ mod tests {
     #[test]
     fn cost_per_unit_used_when_no_annotation() {
         // 10 ABC {50.00 USD} → 50.00.
-        let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(50.00)), None);
-        assert_eq!(p, Some((dec!(50.00), ImplicitPriceSource::Cost)));
+        let p = extract_per_unit_price(dec!(10), None, Some((Some(dec!(50.00)), None, "USD")));
+        assert_eq!(p, Some((dec!(50.00), "USD")));
     }
 
     #[test]
     fn cost_total_divides_by_unit_count() {
         // 10 ABC {{500 USD}} → 500 / 10 = 50.
-        let p = extract_per_unit_price(dec!(10), false, None, None, Some(dec!(500)));
-        assert_eq!(p, Some((dec!(50), ImplicitPriceSource::Cost)));
+        let p = extract_per_unit_price(dec!(10), None, Some((None, Some(dec!(500)), "USD")));
+        assert_eq!(p, Some((dec!(50), "USD")));
     }
 
     #[test]
     fn cost_total_with_zero_units_returns_none() {
-        let p = extract_per_unit_price(dec!(0), false, None, None, Some(dec!(500)));
+        let p = extract_per_unit_price::<&str>(dec!(0), None, Some((None, Some(dec!(500)), "USD")));
         assert_eq!(p, None);
     }
 
@@ -165,39 +183,57 @@ mod tests {
     #[test]
     fn annotation_wins_over_cost_when_both_present() {
         // 5 ABC {1.25 EUR} @ 1.40 EUR → 1.40 (annotation wins).
-        // Source = Annotation so the caller pairs with the annotation's
-        // currency, not the cost's.
-        let p = extract_per_unit_price(dec!(5), false, Some(dec!(1.40)), Some(dec!(1.25)), None);
-        assert_eq!(p, Some((dec!(1.40), ImplicitPriceSource::Annotation)));
+        // Currency comes from the annotation — but in this case both
+        // happen to be EUR so the test cannot distinguish a buggy
+        // unconditional `annotation_currency.or(cost_currency)` from
+        // the correct source-aware pick. See the zero-units test for
+        // that distinction.
+        let p = extract_per_unit_price(
+            dec!(5),
+            Some((false, dec!(1.40), "EUR")),
+            Some((Some(dec!(1.25)), None, "EUR")),
+        );
+        assert_eq!(p, Some((dec!(1.40), "EUR")));
     }
 
     #[test]
     fn total_annotation_wins_over_cost_per_unit() {
         // -10 ABC {1.25 EUR} @@ 14 EUR → 14 / 10 = 1.40 (annotation wins).
-        let p = extract_per_unit_price(dec!(-10), true, Some(dec!(14)), Some(dec!(1.25)), None);
-        assert_eq!(p, Some((dec!(1.4), ImplicitPriceSource::Annotation)));
+        let p = extract_per_unit_price(
+            dec!(-10),
+            Some((true, dec!(14), "EUR")),
+            Some((Some(dec!(1.25)), None, "EUR")),
+        );
+        assert_eq!(p, Some((dec!(1.4), "EUR")));
     }
 
     #[test]
     fn cost_per_wins_over_cost_total_when_both_present() {
-        // {50 USD, 500 USD-total} — number_per takes precedence.
-        let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(50)), Some(dec!(999)));
-        assert_eq!(p, Some((dec!(50), ImplicitPriceSource::Cost)));
+        // {50 USD, 500 USD-total} — number_per takes precedence,
+        // matching Python beancount's tie-break.
+        let p = extract_per_unit_price(
+            dec!(10),
+            None,
+            Some((Some(dec!(50)), Some(dec!(999)), "USD")),
+        );
+        assert_eq!(p, Some((dec!(50), "USD")));
     }
 
     // ===== Empty cases =====
 
     #[test]
     fn no_inputs_returns_none() {
-        let p = extract_per_unit_price(dec!(10), false, None, None, None);
+        let p = extract_per_unit_price::<&str>(dec!(10), None, None);
         assert_eq!(p, None);
     }
 
     #[test]
     fn annotation_without_amount_falls_through_to_cost() {
-        // Incomplete annotation like `@ EUR` (no number) → ann_amount is
-        // None → fall through. Cost present → use it. Source is Cost.
-        let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(7)), None);
-        assert_eq!(p, Some((dec!(7), ImplicitPriceSource::Cost)));
+        // Incomplete annotation like `@ EUR` (no number) → caller
+        // passes `None` for annotation → fall through. Cost present →
+        // use it. The returned currency is the cost's, not anything
+        // remembered from the dropped annotation.
+        let p = extract_per_unit_price(dec!(10), None, Some((Some(dec!(7)), None, "USD")));
+        assert_eq!(p, Some((dec!(7), "USD")));
     }
 }

--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -18,6 +18,22 @@
 
 use rust_decimal::Decimal;
 
+/// Which input source produced an extracted implicit price.
+///
+/// Returned alongside the per-unit `Decimal` so callers know which
+/// quote-currency source to pair with it. Pre-fix (Copilot review on
+/// PR #997), callers picked the quote currency from the annotation
+/// even when the per-unit value came from the cost — for inputs like
+/// `0 ABC {50 USD} @@ 100 EUR` (zero-units total annotation falls
+/// through to cost), they emitted `50 EUR` instead of `50 USD`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImplicitPriceSource {
+    /// Value came from the `@` / `@@` price annotation.
+    Annotation,
+    /// Value came from the `{...}` cost spec.
+    Cost,
+}
+
 /// Decide the per-unit price implied by a posting.
 ///
 /// Resolution order, mirroring upstream beancount's
@@ -45,29 +61,29 @@ pub fn extract_per_unit_price(
     annotation_amount: Option<Decimal>,
     cost_number_per: Option<Decimal>,
     cost_number_total: Option<Decimal>,
-) -> Option<Decimal> {
+) -> Option<(Decimal, ImplicitPriceSource)> {
     // Priority 1: price annotation.
     if let Some(amount) = annotation_amount {
         if annotation_is_total {
             if !units_number.is_zero() {
-                return Some(amount / units_number.abs());
+                return Some((amount / units_number.abs(), ImplicitPriceSource::Annotation));
             }
             // Zero units + total annotation → can't compute per-unit,
             // fall through to cost. This matches the upstream behavior
             // (the @@ amount is unusable without a unit count).
         } else {
-            return Some(amount);
+            return Some((amount, ImplicitPriceSource::Annotation));
         }
     }
 
     // Priority 2: cost spec.
     if let Some(per) = cost_number_per {
-        return Some(per);
+        return Some((per, ImplicitPriceSource::Cost));
     }
     if let Some(total) = cost_number_total
         && !units_number.is_zero()
     {
-        return Some(total / units_number.abs());
+        return Some((total / units_number.abs(), ImplicitPriceSource::Cost));
     }
 
     None
@@ -84,14 +100,14 @@ mod tests {
     fn unit_annotation_returns_amount_directly() {
         // @ 1.40 EUR with 5 units → 1.40 (per-unit, used as-is).
         let p = extract_per_unit_price(dec!(5), false, Some(dec!(1.40)), None, None);
-        assert_eq!(p, Some(dec!(1.40)));
+        assert_eq!(p, Some((dec!(1.40), ImplicitPriceSource::Annotation)));
     }
 
     #[test]
     fn total_annotation_divides_by_unit_count() {
         // @@ 1500 USD with 10 units → 1500 / 10 = 150.
         let p = extract_per_unit_price(dec!(10), true, Some(dec!(1500)), None, None);
-        assert_eq!(p, Some(dec!(150)));
+        assert_eq!(p, Some((dec!(150), ImplicitPriceSource::Annotation)));
     }
 
     #[test]
@@ -100,16 +116,20 @@ mod tests {
         // must produce 15152.07 / 27204.53 ≈ 0.557 (NOT -0.557, NOT 15152.07).
         let p = extract_per_unit_price(dec!(-27204.53), true, Some(dec!(15152.07)), None, None);
         let expected = dec!(15152.07) / dec!(27204.53);
-        assert_eq!(p, Some(expected));
-        assert!(p.unwrap() > dec!(0.55) && p.unwrap() < dec!(0.56));
+        assert_eq!(p, Some((expected, ImplicitPriceSource::Annotation)));
+        assert!(p.unwrap().0 > dec!(0.55) && p.unwrap().0 < dec!(0.56));
     }
 
     #[test]
     fn total_annotation_with_zero_units_falls_through_to_cost() {
         // @@ 100 USD on 0 units → can't compute per-unit, but if a cost
-        // is also present, fall through to that.
+        // is also present, fall through to that. The SOURCE returned is
+        // Cost, so the caller knows to pick the cost's currency (this
+        // is the Copilot-flagged bug from PR #997: pre-fix, callers
+        // unconditionally picked the annotation currency, producing
+        // mismatched (number, currency) pairs).
         let p = extract_per_unit_price(dec!(0), true, Some(dec!(100)), Some(dec!(50)), None);
-        assert_eq!(p, Some(dec!(50)));
+        assert_eq!(p, Some((dec!(50), ImplicitPriceSource::Cost)));
     }
 
     #[test]
@@ -124,14 +144,14 @@ mod tests {
     fn cost_per_unit_used_when_no_annotation() {
         // 10 ABC {50.00 USD} → 50.00.
         let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(50.00)), None);
-        assert_eq!(p, Some(dec!(50.00)));
+        assert_eq!(p, Some((dec!(50.00), ImplicitPriceSource::Cost)));
     }
 
     #[test]
     fn cost_total_divides_by_unit_count() {
         // 10 ABC {{500 USD}} → 500 / 10 = 50.
         let p = extract_per_unit_price(dec!(10), false, None, None, Some(dec!(500)));
-        assert_eq!(p, Some(dec!(50)));
+        assert_eq!(p, Some((dec!(50), ImplicitPriceSource::Cost)));
     }
 
     #[test]
@@ -145,24 +165,24 @@ mod tests {
     #[test]
     fn annotation_wins_over_cost_when_both_present() {
         // 5 ABC {1.25 EUR} @ 1.40 EUR → 1.40 (annotation wins).
-        // This is the case that originally surfaced as the plugin
-        // double-emitting in #992.
+        // Source = Annotation so the caller pairs with the annotation's
+        // currency, not the cost's.
         let p = extract_per_unit_price(dec!(5), false, Some(dec!(1.40)), Some(dec!(1.25)), None);
-        assert_eq!(p, Some(dec!(1.40)));
+        assert_eq!(p, Some((dec!(1.40), ImplicitPriceSource::Annotation)));
     }
 
     #[test]
     fn total_annotation_wins_over_cost_per_unit() {
         // -10 ABC {1.25 EUR} @@ 14 EUR → 14 / 10 = 1.40 (annotation wins).
         let p = extract_per_unit_price(dec!(-10), true, Some(dec!(14)), Some(dec!(1.25)), None);
-        assert_eq!(p, Some(dec!(1.4)));
+        assert_eq!(p, Some((dec!(1.4), ImplicitPriceSource::Annotation)));
     }
 
     #[test]
     fn cost_per_wins_over_cost_total_when_both_present() {
         // {50 USD, 500 USD-total} — number_per takes precedence.
         let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(50)), Some(dec!(999)));
-        assert_eq!(p, Some(dec!(50)));
+        assert_eq!(p, Some((dec!(50), ImplicitPriceSource::Cost)));
     }
 
     // ===== Empty cases =====
@@ -176,8 +196,8 @@ mod tests {
     #[test]
     fn annotation_without_amount_falls_through_to_cost() {
         // Incomplete annotation like `@ EUR` (no number) → ann_amount is
-        // None → fall through. Cost present → use it.
+        // None → fall through. Cost present → use it. Source is Cost.
         let p = extract_per_unit_price(dec!(10), false, None, Some(dec!(7)), None);
-        assert_eq!(p, Some(dec!(7)));
+        assert_eq!(p, Some((dec!(7), ImplicitPriceSource::Cost)));
     }
 }

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod directive;
 pub mod display_context;
 pub mod extract;
 pub mod format;
+pub mod implicit_prices;
 pub mod intern;
 pub mod inventory;
 pub mod position;
@@ -69,6 +70,7 @@ pub use extract::{
     extract_currencies_iter, extract_payees, extract_payees_iter,
 };
 pub use format::{FormatConfig, format_directive};
+pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{
     AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -70,7 +70,7 @@ pub use extract::{
     extract_currencies_iter, extract_payees, extract_payees_iter,
 };
 pub use format::{FormatConfig, format_directive};
-pub use implicit_prices::extract_per_unit_price;
+pub use implicit_prices::{ImplicitPriceSource, extract_per_unit_price};
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{
     AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -70,7 +70,7 @@ pub use extract::{
     extract_currencies_iter, extract_payees, extract_payees_iter,
 };
 pub use format::{FormatConfig, format_directive};
-pub use implicit_prices::{ImplicitPriceSource, extract_per_unit_price};
+pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{
     AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -61,22 +61,22 @@ impl NativePlugin for ImplicitPricesPlugin {
                 // otherwise pass `None` so the helper falls through to
                 // cost cleanly (and won't pair a fall-through value
                 // with a stale annotation currency).
-                let annotation = posting.price.as_ref().and_then(|annotation| {
-                    let amount = annotation.amount.as_ref()?;
+                let annotation = posting.price.as_ref().and_then(|a| {
+                    let amount = a.amount.as_ref()?;
                     let number = Decimal::from_str(&amount.number).ok()?;
-                    Some((annotation.is_total, number, amount.currency.clone()))
+                    Some((a.is_total, number, amount.currency.clone()))
                 });
 
                 // Same shape for cost: only build the descriptor when
                 // a currency is present AND at least one of per/total
                 // parses.
-                let cost = posting.cost.as_ref().and_then(|cost| {
-                    let currency = cost.currency.clone()?;
-                    let per = cost
+                let cost = posting.cost.as_ref().and_then(|c| {
+                    let currency = c.currency.clone()?;
+                    let per = c
                         .number_per
                         .as_ref()
                         .and_then(|n| Decimal::from_str(n).ok());
-                    let total = cost
+                    let total = c
                         .number_total
                         .as_ref()
                         .and_then(|n| Decimal::from_str(n).ok());

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -1,13 +1,27 @@
 //! Plugin that generates price entries from transaction costs and prices.
 
-use crate::types::{DirectiveWrapper, PluginInput, PluginOutput};
+use crate::types::{
+    AmountData, DirectiveData, DirectiveWrapper, PluginInput, PluginOutput, PriceData,
+};
+use rust_decimal::Decimal;
+use rustledger_core::extract_per_unit_price;
+use std::str::FromStr;
 
 use super::super::NativePlugin;
 
-/// Plugin that generates price entries from transaction costs and prices.
+/// Plugin that generates price entries from transaction postings.
 ///
-/// When a transaction has a posting with a cost or price annotation,
-/// this plugin generates a corresponding Price directive.
+/// For each posting with a `@`/`@@` price annotation or a `{...}` cost
+/// spec, generates a corresponding `Price` directive. Mirrors Python
+/// beancount's `beancount.plugins.implicit_prices`.
+///
+/// Per-posting price math is delegated to
+/// [`rustledger_core::extract_per_unit_price`] — the same helper used
+/// by the BQL query path. Pre-fix (issue #992) this plugin had its own
+/// implementation that emitted `@@` total amounts as per-unit prices
+/// (off by a factor of `units`) AND emitted both an annotation-derived
+/// AND a cost-derived price for postings that had both. Both bugs
+/// disappear once the helper is the single source of truth.
 pub struct ImplicitPricesPlugin;
 
 impl NativePlugin for ImplicitPricesPlugin {
@@ -26,63 +40,86 @@ impl NativePlugin for ImplicitPricesPlugin {
         for wrapper in &input.directives {
             new_directives.push(wrapper.clone());
 
-            // Only process transactions
             if wrapper.directive_type != "transaction" {
                 continue;
             }
 
-            // Extract prices from transaction data
-            if let crate::types::DirectiveData::Transaction(ref txn) = wrapper.data {
-                for posting in &txn.postings {
-                    // Check for price annotation
-                    if let Some(ref units) = posting.units {
-                        if let Some(ref price) = posting.price {
-                            // Generate a price directive only if we have a complete amount
-                            if let Some(ref price_amount) = price.amount {
-                                let price_wrapper = DirectiveWrapper {
-                                    directive_type: "price".to_string(),
-                                    date: wrapper.date.clone(),
-                                    filename: None, // Plugin-generated
-                                    lineno: None,
-                                    data: crate::types::DirectiveData::Price(
-                                        crate::types::PriceData {
-                                            currency: units.currency.clone(),
-                                            amount: price_amount.clone(),
-                                            metadata: vec![],
-                                        },
-                                    ),
-                                };
-                                generated_prices.push(price_wrapper);
-                            }
-                        }
+            let DirectiveData::Transaction(ref txn) = wrapper.data else {
+                continue;
+            };
 
-                        // Check for cost with price info
-                        if let Some(ref cost) = posting.cost
-                            && let (Some(number), Some(currency)) =
-                                (&cost.number_per, &cost.currency)
-                        {
-                            let price_wrapper = DirectiveWrapper {
-                                directive_type: "price".to_string(),
-                                date: wrapper.date.clone(),
-                                filename: None, // Plugin-generated
-                                lineno: None,
-                                data: crate::types::DirectiveData::Price(crate::types::PriceData {
-                                    currency: units.currency.clone(),
-                                    amount: crate::types::AmountData {
-                                        number: number.clone(),
-                                        currency: currency.clone(),
-                                    },
-                                    metadata: vec![],
-                                }),
-                            };
-                            generated_prices.push(price_wrapper);
+            for posting in &txn.postings {
+                let Some(ref units) = posting.units else {
+                    continue;
+                };
+                let Ok(units_number) = Decimal::from_str(&units.number) else {
+                    continue;
+                };
+
+                // Pull annotation primitives.
+                let (annotation_is_total, annotation_amount, annotation_currency) =
+                    match &posting.price {
+                        Some(annotation) => {
+                            let amount_decimal = annotation
+                                .amount
+                                .as_ref()
+                                .and_then(|a| Decimal::from_str(&a.number).ok());
+                            let amount_currency =
+                                annotation.amount.as_ref().map(|a| a.currency.clone());
+                            (annotation.is_total, amount_decimal, amount_currency)
                         }
+                        None => (false, None, None),
+                    };
+
+                // Pull cost primitives.
+                let (cost_per, cost_total, cost_currency) = match &posting.cost {
+                    Some(cost) => {
+                        let per = cost
+                            .number_per
+                            .as_ref()
+                            .and_then(|n| Decimal::from_str(n).ok());
+                        let total = cost
+                            .number_total
+                            .as_ref()
+                            .and_then(|n| Decimal::from_str(n).ok());
+                        (per, total, cost.currency.clone())
                     }
-                }
+                    None => (None, None, None),
+                };
+
+                let Some(per_unit) = extract_per_unit_price(
+                    units_number,
+                    annotation_is_total,
+                    annotation_amount,
+                    cost_per,
+                    cost_total,
+                ) else {
+                    continue;
+                };
+
+                // Quote currency follows the same priority as the per-unit
+                // value: annotation first, cost as fallback.
+                let Some(quote_currency) = annotation_currency.or(cost_currency) else {
+                    continue;
+                };
+
+                generated_prices.push(DirectiveWrapper {
+                    directive_type: "price".to_string(),
+                    date: wrapper.date.clone(),
+                    filename: None, // plugin-generated
+                    lineno: None,
+                    data: DirectiveData::Price(PriceData {
+                        currency: units.currency.clone(),
+                        amount: AmountData {
+                            number: per_unit.to_string(),
+                            currency: quote_currency,
+                        },
+                        metadata: vec![],
+                    }),
+                });
             }
         }
 
-        // Add generated prices
         new_directives.extend(generated_prices);
 
         PluginOutput {

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -4,7 +4,7 @@ use crate::types::{
     AmountData, DirectiveData, DirectiveWrapper, PluginInput, PluginOutput, PriceData,
 };
 use rust_decimal::Decimal;
-use rustledger_core::extract_per_unit_price;
+use rustledger_core::{ImplicitPriceSource, extract_per_unit_price};
 use std::str::FromStr;
 
 use super::super::NativePlugin;
@@ -56,7 +56,11 @@ impl NativePlugin for ImplicitPricesPlugin {
                     continue;
                 };
 
-                // Pull annotation primitives.
+                // Pull annotation primitives. Tie the currency to a
+                // successfully-parsed number: if the number fails to
+                // parse, drop the currency too. Otherwise the
+                // helper would fall through to cost for the value but
+                // we'd still pair it with the annotation's currency.
                 let (annotation_is_total, annotation_amount, annotation_currency) =
                     match &posting.price {
                         Some(annotation) => {
@@ -64,8 +68,11 @@ impl NativePlugin for ImplicitPricesPlugin {
                                 .amount
                                 .as_ref()
                                 .and_then(|a| Decimal::from_str(&a.number).ok());
-                            let amount_currency =
-                                annotation.amount.as_ref().map(|a| a.currency.clone());
+                            let amount_currency = if amount_decimal.is_some() {
+                                annotation.amount.as_ref().map(|a| a.currency.clone())
+                            } else {
+                                None
+                            };
                             (annotation.is_total, amount_decimal, amount_currency)
                         }
                         None => (false, None, None),
@@ -87,7 +94,7 @@ impl NativePlugin for ImplicitPricesPlugin {
                     None => (None, None, None),
                 };
 
-                let Some(per_unit) = extract_per_unit_price(
+                let Some((per_unit, source)) = extract_per_unit_price(
                     units_number,
                     annotation_is_total,
                     annotation_amount,
@@ -97,9 +104,16 @@ impl NativePlugin for ImplicitPricesPlugin {
                     continue;
                 };
 
-                // Quote currency follows the same priority as the per-unit
-                // value: annotation first, cost as fallback.
-                let Some(quote_currency) = annotation_currency.or(cost_currency) else {
+                // Pair the quote currency with the SAME source the helper
+                // used. Pre-fix (Copilot review on PR #997) this was
+                // unconditionally `annotation_currency.or(cost_currency)`,
+                // which produced mismatched (number, currency) pairs when
+                // an unusable `@@` annotation fell through to cost.
+                let quote_currency = match source {
+                    ImplicitPriceSource::Annotation => annotation_currency,
+                    ImplicitPriceSource::Cost => cost_currency,
+                };
+                let Some(quote_currency) = quote_currency else {
                     continue;
                 };
 

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -4,7 +4,7 @@ use crate::types::{
     AmountData, DirectiveData, DirectiveWrapper, PluginInput, PluginOutput, PriceData,
 };
 use rust_decimal::Decimal;
-use rustledger_core::{ImplicitPriceSource, extract_per_unit_price};
+use rustledger_core::extract_per_unit_price;
 use std::str::FromStr;
 
 use super::super::NativePlugin;
@@ -56,64 +56,39 @@ impl NativePlugin for ImplicitPricesPlugin {
                     continue;
                 };
 
-                // Pull annotation primitives. Tie the currency to a
-                // successfully-parsed number: if the number fails to
-                // parse, drop the currency too. Otherwise the
-                // helper would fall through to cost for the value but
-                // we'd still pair it with the annotation's currency.
-                let (annotation_is_total, annotation_amount, annotation_currency) =
-                    match &posting.price {
-                        Some(annotation) => {
-                            let amount_decimal = annotation
-                                .amount
-                                .as_ref()
-                                .and_then(|a| Decimal::from_str(&a.number).ok());
-                            let amount_currency = if amount_decimal.is_some() {
-                                annotation.amount.as_ref().map(|a| a.currency.clone())
-                            } else {
-                                None
-                            };
-                            (annotation.is_total, amount_decimal, amount_currency)
-                        }
-                        None => (false, None, None),
-                    };
+                // Build the helper's annotation descriptor only when
+                // we have BOTH a parseable number and a currency —
+                // otherwise pass `None` so the helper falls through to
+                // cost cleanly (and won't pair a fall-through value
+                // with a stale annotation currency).
+                let annotation = posting.price.as_ref().and_then(|annotation| {
+                    let amount = annotation.amount.as_ref()?;
+                    let number = Decimal::from_str(&amount.number).ok()?;
+                    Some((annotation.is_total, number, amount.currency.clone()))
+                });
 
-                // Pull cost primitives.
-                let (cost_per, cost_total, cost_currency) = match &posting.cost {
-                    Some(cost) => {
-                        let per = cost
-                            .number_per
-                            .as_ref()
-                            .and_then(|n| Decimal::from_str(n).ok());
-                        let total = cost
-                            .number_total
-                            .as_ref()
-                            .and_then(|n| Decimal::from_str(n).ok());
-                        (per, total, cost.currency.clone())
+                // Same shape for cost: only build the descriptor when
+                // a currency is present AND at least one of per/total
+                // parses.
+                let cost = posting.cost.as_ref().and_then(|cost| {
+                    let currency = cost.currency.clone()?;
+                    let per = cost
+                        .number_per
+                        .as_ref()
+                        .and_then(|n| Decimal::from_str(n).ok());
+                    let total = cost
+                        .number_total
+                        .as_ref()
+                        .and_then(|n| Decimal::from_str(n).ok());
+                    if per.is_none() && total.is_none() {
+                        return None;
                     }
-                    None => (None, None, None),
-                };
+                    Some((per, total, currency))
+                });
 
-                let Some((per_unit, source)) = extract_per_unit_price(
-                    units_number,
-                    annotation_is_total,
-                    annotation_amount,
-                    cost_per,
-                    cost_total,
-                ) else {
-                    continue;
-                };
-
-                // Pair the quote currency with the SAME source the helper
-                // used. Pre-fix (Copilot review on PR #997) this was
-                // unconditionally `annotation_currency.or(cost_currency)`,
-                // which produced mismatched (number, currency) pairs when
-                // an unusable `@@` annotation fell through to cost.
-                let quote_currency = match source {
-                    ImplicitPriceSource::Annotation => annotation_currency,
-                    ImplicitPriceSource::Cost => cost_currency,
-                };
-                let Some(quote_currency) = quote_currency else {
+                let Some((per_unit, quote_currency)) =
+                    extract_per_unit_price(units_number, annotation, cost)
+                else {
                     continue;
                 };
 

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -146,6 +146,70 @@ fn make_price(date: &str, currency: &str, amount: &str, quote_currency: &str) ->
     }
 }
 
+/// Create a transaction with BOTH cost and a `@@` total price annotation.
+/// Used by the zero-units-fall-through-to-cost test which exercises the
+/// currency-pairing fix (see `test_implicit_prices_zero_unit_total_falls_through_to_cost_currency`).
+fn make_transaction_with_cost_and_price_total(
+    date: &str,
+    narration: &str,
+    account: &str,
+    units: (&str, &str),
+    cost: (&str, &str),
+    price_total: (&str, &str),
+    other_account: &str,
+) -> DirectiveWrapper {
+    DirectiveWrapper {
+        directive_type: "transaction".to_string(),
+        date: date.to_string(),
+        filename: None,
+        lineno: None,
+        data: DirectiveData::Transaction(TransactionData {
+            flag: "*".to_string(),
+            payee: None,
+            narration: narration.to_string(),
+            tags: vec![],
+            links: vec![],
+            metadata: vec![],
+            postings: vec![
+                PostingData {
+                    account: account.to_string(),
+                    units: Some(AmountData {
+                        number: units.0.to_string(),
+                        currency: units.1.to_string(),
+                    }),
+                    cost: Some(CostData {
+                        number_per: Some(cost.0.to_string()),
+                        number_total: None,
+                        currency: Some(cost.1.to_string()),
+                        date: None,
+                        label: None,
+                        merge: false,
+                    }),
+                    price: Some(PriceAnnotationData {
+                        is_total: true, // ← @@
+                        amount: Some(AmountData {
+                            number: price_total.0.to_string(),
+                            currency: price_total.1.to_string(),
+                        }),
+                        number: None,
+                        currency: None,
+                    }),
+                    flag: None,
+                    metadata: vec![],
+                },
+                PostingData {
+                    account: other_account.to_string(),
+                    units: None,
+                    cost: None,
+                    price: None,
+                    flag: None,
+                    metadata: vec![],
+                },
+            ],
+        }),
+    }
+}
+
 /// Create a transaction with BOTH cost and price (for capital gains on sales).
 fn make_transaction_with_cost_and_price(
     date: &str,
@@ -1780,27 +1844,48 @@ fn test_unique_prices_different_pairs_ok() {
 // ImplicitPricesPlugin Tests (from implicit_prices_test.py)
 // ============================================================================
 
-/// Helper that returns plugin-generated price directives only
-/// (filename = None), as a `Vec<(currency, number, quote_currency)>` for
-/// strict equality assertions.
+/// Helper that returns plugin-generated price directives only,
+/// as a `Vec<(currency, number, quote_currency)>` for strict equality
+/// assertions.
+///
+/// Computed as `output_prices − input_prices` so explicit input
+/// `price` directives don't get counted as plugin output. Pre-fix
+/// (Copilot review on PR #997) the previous version filtered on
+/// `filename: None`, but the test fixture's `make_price` helper also
+/// sets `filename: None` — so any test that included an explicit input
+/// price would have miscounted.
 ///
 /// Use this instead of `assert!(price_count >= N)` — the original test
 /// shape silently masked issue #992 because `>= 1` accepted both the
 /// correct emission AND the spurious extra one.
-fn implicit_prices_emitted(output: &PluginOutput) -> Vec<(String, String, String)> {
-    output
-        .directives
-        .iter()
-        .filter(|d| d.directive_type == "price" && d.filename.is_none())
-        .filter_map(|d| match &d.data {
-            DirectiveData::Price(p) => Some((
-                p.currency.clone(),
-                p.amount.number.clone(),
-                p.amount.currency.clone(),
-            )),
-            _ => None,
-        })
-        .collect()
+fn implicit_prices_emitted(
+    input: &PluginInput,
+    output: &PluginOutput,
+) -> Vec<(String, String, String)> {
+    fn extract(directives: &[DirectiveWrapper]) -> Vec<(String, String, String)> {
+        directives
+            .iter()
+            .filter(|d| d.directive_type == "price")
+            .filter_map(|d| match &d.data {
+                DirectiveData::Price(p) => Some((
+                    p.currency.clone(),
+                    p.amount.number.clone(),
+                    p.amount.currency.clone(),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+    let input_prices = extract(&input.directives);
+    let mut output_prices = extract(&output.directives);
+    // Remove one occurrence of each input price from output (multiset
+    // difference). What remains is the plugin's contribution.
+    for ip in &input_prices {
+        if let Some(pos) = output_prices.iter().position(|p| p == ip) {
+            output_prices.remove(pos);
+        }
+    }
+    output_prices
 }
 
 /// Build a transaction where the priced posting carries a price annotation
@@ -1875,10 +1960,73 @@ fn test_implicit_prices_from_cost() {
             "Assets:Cash",
         ),
     ]);
-    let output = plugin.process(input);
+    let output = plugin.process(input.clone());
     assert_eq!(
-        implicit_prices_emitted(&output),
+        implicit_prices_emitted(&input, &output),
         vec![("HOOL".into(), "520.00".into(), "USD".into())]
+    );
+}
+
+/// `cost.number_total` (`{{TOTAL CURRENCY}}` syntax) divides by units to
+/// produce a per-unit price. Pre-fix (Copilot review on PR #997) the
+/// plugin handled this branch but no test exercised it, so the
+/// string-parsing path was un-pinned.
+#[test]
+fn test_implicit_prices_from_cost_total() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // 10 ABC {{500 USD}} → per-unit = 500 / 10 = 50 USD.
+        // Built inline because no helper exists for cost_total.
+        DirectiveWrapper {
+            directive_type: "transaction".to_string(),
+            date: "2024-01-15".to_string(),
+            filename: None,
+            lineno: None,
+            data: DirectiveData::Transaction(TransactionData {
+                flag: "*".to_string(),
+                payee: None,
+                narration: "Buy with total cost".to_string(),
+                tags: vec![],
+                links: vec![],
+                metadata: vec![],
+                postings: vec![
+                    PostingData {
+                        account: "Assets:Brokerage".to_string(),
+                        units: Some(AmountData {
+                            number: "10".to_string(),
+                            currency: "ABC".to_string(),
+                        }),
+                        cost: Some(CostData {
+                            number_per: None,
+                            number_total: Some("500".to_string()),
+                            currency: Some("USD".to_string()),
+                            date: None,
+                            label: None,
+                            merge: false,
+                        }),
+                        price: None,
+                        flag: None,
+                        metadata: vec![],
+                    },
+                    PostingData {
+                        account: "Assets:Cash".to_string(),
+                        units: None,
+                        cost: None,
+                        price: None,
+                        flag: None,
+                        metadata: vec![],
+                    },
+                ],
+            }),
+        },
+    ]);
+    let output = plugin.process(input.clone());
+    assert_eq!(
+        implicit_prices_emitted(&input, &output),
+        vec![("ABC".into(), "50".into(), "USD".into())],
+        "{{TOTAL CURRENCY}} cost spec must divide by units.abs()"
     );
 }
 
@@ -1897,9 +2045,9 @@ fn test_implicit_prices_from_unit_annotation() {
             false, // is_total = false → @
         ),
     ]);
-    let output = plugin.process(input);
+    let output = plugin.process(input.clone());
     assert_eq!(
-        implicit_prices_emitted(&output),
+        implicit_prices_emitted(&input, &output),
         vec![("HOOL".into(), "530".into(), "USD".into())]
     );
 }
@@ -1921,8 +2069,8 @@ fn test_implicit_prices_from_total_annotation_issue_992() {
             true, // is_total = true → @@
         ),
     ]);
-    let output = plugin.process(input);
-    let prices = implicit_prices_emitted(&output);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
     // Exactly one price, NOT two (one of which used to be 15152.07
     // emitted as a per-unit price — the original bug).
     assert_eq!(prices.len(), 1, "exactly one price per posting");
@@ -1958,13 +2106,48 @@ fn test_implicit_prices_annotation_and_cost_emits_one_not_two() {
             "Assets:Cash",
         ),
     ]);
-    let output = plugin.process(input);
-    let prices = implicit_prices_emitted(&output);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
     assert_eq!(prices.len(), 1, "exactly one price (annotation wins)");
     assert_eq!(
         prices[0],
         ("ABC".into(), "1.40".into(), "EUR".into()),
         "annotation amount wins over cost"
+    );
+}
+
+/// Currency-pairing regression: `0 ABC @@ 100 EUR` with `{50 USD}` cost.
+/// Zero units make the @@ unusable; the helper falls through to the
+/// cost spec for the per-unit value (50). Pre-fix (Copilot review on
+/// PR #997), the plugin paired that 50 with the annotation's currency
+/// (EUR) instead of the cost's (USD), producing a mismatched
+/// `(50, EUR)` instead of the correct `(50, USD)`. The fix: the helper
+/// returns an `ImplicitPriceSource` discriminator, and the caller pairs
+/// the currency with the same source.
+#[test]
+fn test_implicit_prices_zero_unit_total_falls_through_to_cost_currency() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        make_transaction_with_cost_and_price_total(
+            "2024-01-15",
+            "Closing position with @@",
+            "Assets:Brokerage",
+            ("0", "ABC"), // ← zero units make @@ unusable
+            ("50", "USD"),
+            ("100", "EUR"), // total annotation
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
+    assert_eq!(prices.len(), 1, "exactly one price");
+    assert_eq!(
+        prices[0],
+        ("ABC".into(), "50".into(), "USD".into()),
+        "currency must come from the same source as the per-unit value (cost = USD), \
+         NOT the annotation (EUR). Pre-fix this returned (50, EUR)."
     );
 }
 
@@ -1981,8 +2164,40 @@ fn test_implicit_prices_emits_nothing_for_plain_transfer() {
             vec![("Assets:A", "100", "USD"), ("Assets:B", "-100", "USD")],
         ),
     ]);
-    let output = plugin.process(input);
-    assert!(implicit_prices_emitted(&output).is_empty());
+    let output = plugin.process(input.clone());
+    assert!(implicit_prices_emitted(&input, &output).is_empty());
+}
+
+/// Test-isolation regression: explicit input `price` directives MUST
+/// NOT be counted as plugin output. Pre-fix (Copilot review on PR #997)
+/// the helper filtered by `filename: None`, but the test fixture's
+/// `make_price` also sets that field to None — so any test that
+/// included an input price would have miscounted.
+#[test]
+fn test_implicit_prices_emitted_excludes_input_price_directives() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // Pre-existing explicit price directive
+        make_price("2024-01-10", "HOOL", "500.00", "USD"),
+        // Transaction that triggers the plugin
+        make_transaction_with_cost(
+            "2024-01-15",
+            "Buy stock",
+            "Assets:Brokerage",
+            ("10", "HOOL"),
+            ("520.00", "USD"),
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    // The explicit price (500.00) must NOT appear in plugin output.
+    // Only the cost-derived 520.00 should.
+    assert_eq!(
+        implicit_prices_emitted(&input, &output),
+        vec![("HOOL".into(), "520.00".into(), "USD".into())]
+    );
 }
 
 // ============================================================================

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -1780,12 +1780,89 @@ fn test_unique_prices_different_pairs_ok() {
 // ImplicitPricesPlugin Tests (from implicit_prices_test.py)
 // ============================================================================
 
-/// Test price generation from cost.
-/// Converted from: `test_add_implicit_prices__all_cases` (partial)
+/// Helper that returns plugin-generated price directives only
+/// (filename = None), as a `Vec<(currency, number, quote_currency)>` for
+/// strict equality assertions.
+///
+/// Use this instead of `assert!(price_count >= N)` — the original test
+/// shape silently masked issue #992 because `>= 1` accepted both the
+/// correct emission AND the spurious extra one.
+fn implicit_prices_emitted(output: &PluginOutput) -> Vec<(String, String, String)> {
+    output
+        .directives
+        .iter()
+        .filter(|d| d.directive_type == "price" && d.filename.is_none())
+        .filter_map(|d| match &d.data {
+            DirectiveData::Price(p) => Some((
+                p.currency.clone(),
+                p.amount.number.clone(),
+                p.amount.currency.clone(),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Build a transaction where the priced posting carries a price annotation
+/// (`@` or `@@`). Used by the implicit-prices tests below.
+fn make_txn_with_price_annotation(
+    date: &str,
+    narration: &str,
+    units: (&str, &str),
+    price: (&str, &str),
+    is_total: bool,
+) -> DirectiveWrapper {
+    DirectiveWrapper {
+        directive_type: "transaction".to_string(),
+        date: date.to_string(),
+        filename: None,
+        lineno: None,
+        data: DirectiveData::Transaction(TransactionData {
+            flag: "*".to_string(),
+            payee: None,
+            narration: narration.to_string(),
+            tags: vec![],
+            links: vec![],
+            metadata: vec![],
+            postings: vec![
+                PostingData {
+                    account: "Assets:Brokerage".to_string(),
+                    units: Some(AmountData {
+                        number: units.0.to_string(),
+                        currency: units.1.to_string(),
+                    }),
+                    cost: None,
+                    price: Some(PriceAnnotationData {
+                        amount: Some(AmountData {
+                            number: price.0.to_string(),
+                            currency: price.1.to_string(),
+                        }),
+                        is_total,
+                        number: None,
+                        currency: None,
+                    }),
+                    flag: None,
+                    metadata: vec![],
+                },
+                PostingData {
+                    account: "Assets:Cash".to_string(),
+                    units: None,
+                    cost: None,
+                    price: None,
+                    flag: None,
+                    metadata: vec![],
+                },
+            ],
+        }),
+    }
+}
+
+/// Cost-only path. Pinned with strict `assert_eq!` — replaces an earlier
+/// `>= 1` assertion that silently passed even when the plugin emitted
+/// extra spurious prices (issue #992).
 #[test]
 fn test_implicit_prices_from_cost() {
     let plugin = ImplicitPricesPlugin;
-
     let input = make_input(vec![
         make_open("2024-01-01", "Assets:Brokerage"),
         make_open("2024-01-01", "Assets:Cash"),
@@ -1798,33 +1875,114 @@ fn test_implicit_prices_from_cost() {
             "Assets:Cash",
         ),
     ]);
-
     let output = plugin.process(input);
-
-    // Should generate a price directive
-    let price_count = output
-        .directives
-        .iter()
-        .filter(|d| d.directive_type == "price")
-        .count();
-    assert!(
-        price_count >= 1,
-        "should generate at least 1 price directive"
+    assert_eq!(
+        implicit_prices_emitted(&output),
+        vec![("HOOL".into(), "520.00".into(), "USD".into())]
     );
+}
 
-    // Find the generated price
-    let price = output
-        .directives
-        .iter()
-        .find(|d| d.directive_type == "price");
-    assert!(price.is_some(), "should have a price directive");
+/// `@` per-unit annotation: the annotation amount is used directly.
+#[test]
+fn test_implicit_prices_from_unit_annotation() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        make_txn_with_price_annotation(
+            "2024-01-15",
+            "Sell at unit price",
+            ("-5", "HOOL"),
+            ("530", "USD"),
+            false, // is_total = false → @
+        ),
+    ]);
+    let output = plugin.process(input);
+    assert_eq!(
+        implicit_prices_emitted(&output),
+        vec![("HOOL".into(), "530".into(), "USD".into())]
+    );
+}
 
-    if let Some(p) = price
-        && let DirectiveData::Price(price_data) = &p.data
-    {
-        assert_eq!(price_data.currency, "HOOL");
-        assert_eq!(price_data.amount.currency, "USD");
-    }
+/// `@@` total annotation: the total is divided by `units.abs()` to produce
+/// a per-unit price. THIS IS THE ISSUE #992 REGRESSION TEST — pre-fix the
+/// plugin emitted the total amount directly as a per-unit price (off by
+/// a factor of `units`).
+#[test]
+fn test_implicit_prices_from_total_annotation_issue_992() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2020-01-01", "Assets:Insurance"),
+        make_txn_with_price_annotation(
+            "2025-01-23",
+            "insurance matured",
+            ("-27204.53", "BAM"),
+            ("15152.07", "EUR"),
+            true, // is_total = true → @@
+        ),
+    ]);
+    let output = plugin.process(input);
+    let prices = implicit_prices_emitted(&output);
+    // Exactly one price, NOT two (one of which used to be 15152.07
+    // emitted as a per-unit price — the original bug).
+    assert_eq!(prices.len(), 1, "exactly one price per posting");
+    let (base, num_str, quote) = &prices[0];
+    assert_eq!(base, "BAM");
+    assert_eq!(quote, "EUR");
+    // The per-unit price is 15152.07 / 27204.53 ≈ 0.5569...
+    let parsed: rust_decimal::Decimal = num_str.parse().expect("price parses");
+    assert!(
+        parsed > rust_decimal_macros::dec!(0.55) && parsed < rust_decimal_macros::dec!(0.56),
+        "@@ total must be divided by units.abs(); got {num_str}"
+    );
+}
+
+/// Posting with BOTH `{cost}` AND `@` annotation: the annotation wins,
+/// AND the plugin must emit exactly one price (not two). Pre-fix the
+/// plugin double-emitted: one from the annotation block, one from the
+/// cost block immediately after. This is the secondary bug from #992.
+#[test]
+fn test_implicit_prices_annotation_and_cost_emits_one_not_two() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // 5 ABC {1.25 EUR} @ 1.40 EUR
+        make_transaction_with_cost_and_price(
+            "2024-01-15",
+            "Sell with both cost and price",
+            "Assets:Brokerage",
+            ("-5", "ABC"),
+            ("1.25", "EUR"), // cost
+            ("1.40", "EUR"), // price annotation (per-unit)
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input);
+    let prices = implicit_prices_emitted(&output);
+    assert_eq!(prices.len(), 1, "exactly one price (annotation wins)");
+    assert_eq!(
+        prices[0],
+        ("ABC".into(), "1.40".into(), "EUR".into()),
+        "annotation amount wins over cost"
+    );
+}
+
+/// Posting with NO price annotation and NO cost: emits nothing.
+#[test]
+fn test_implicit_prices_emits_nothing_for_plain_transfer() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:A"),
+        make_open("2024-01-01", "Assets:B"),
+        make_transaction(
+            "2024-01-15",
+            "Plain transfer",
+            vec![("Assets:A", "100", "USD"), ("Assets:B", "-100", "USD")],
+        ),
+    ]);
+    let output = plugin.process(input);
+    assert!(implicit_prices_emitted(&output).is_empty());
 }
 
 // ============================================================================

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -130,7 +130,7 @@ impl PriceDatabase {
                 None => (None, None, None),
             };
 
-            let Some(per_unit) = rustledger_core::extract_per_unit_price(
+            let Some((per_unit, source)) = rustledger_core::extract_per_unit_price(
                 units.number,
                 annotation_is_total,
                 annotation_amount,
@@ -140,10 +140,16 @@ impl PriceDatabase {
                 continue;
             };
 
-            // Quote currency follows the same priority rule as the per-unit
-            // value: prefer the annotation's currency, fall back to cost's.
-            // The helper doesn't pick this — it returns only the magnitude.
-            let quote_currency = annotation_currency.or(cost_currency);
+            // Pair the quote currency with the SAME source the helper used
+            // for the per-unit value. Pre-fix (Copilot review on PR #997)
+            // this was unconditionally `annotation_currency.or(cost_currency)`,
+            // which produced mismatched (number, currency) pairs when an
+            // unusable `@@` annotation fell through to cost. The helper
+            // now returns the source so callers can select correctly.
+            let quote_currency = match source {
+                rustledger_core::ImplicitPriceSource::Annotation => annotation_currency,
+                rustledger_core::ImplicitPriceSource::Cost => cost_currency,
+            };
             let Some(quote) = quote_currency else {
                 continue;
             };

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -112,45 +112,29 @@ impl PriceDatabase {
                 continue;
             };
 
-            // Extract primitives for the shared helper.
-            let (annotation_is_total, annotation_amount, annotation_currency) = match &posting.price
-            {
-                Some(annotation) => {
-                    let amount = annotation.amount();
-                    (
-                        !annotation.is_unit(),
-                        amount.map(|a| a.number),
-                        amount.map(|a| a.currency.clone()),
-                    )
+            // Build the helper's annotation descriptor only when both
+            // an amount and currency are available; the helper pairs
+            // the returned per-unit value with the matching currency
+            // by construction.
+            let annotation = posting.price.as_ref().and_then(|annotation| {
+                let amount = annotation.amount()?;
+                Some((
+                    !annotation.is_unit(),
+                    amount.number,
+                    amount.currency.clone(),
+                ))
+            });
+            let cost = posting.cost.as_ref().and_then(|c| {
+                let currency = c.currency.clone()?;
+                if c.number_per.is_none() && c.number_total.is_none() {
+                    return None;
                 }
-                None => (false, None, None),
-            };
-            let (cost_per, cost_total, cost_currency) = match &posting.cost {
-                Some(c) => (c.number_per, c.number_total, c.currency.clone()),
-                None => (None, None, None),
-            };
+                Some((c.number_per, c.number_total, currency))
+            });
 
-            let Some((per_unit, source)) = rustledger_core::extract_per_unit_price(
-                units.number,
-                annotation_is_total,
-                annotation_amount,
-                cost_per,
-                cost_total,
-            ) else {
-                continue;
-            };
-
-            // Pair the quote currency with the SAME source the helper used
-            // for the per-unit value. Pre-fix (Copilot review on PR #997)
-            // this was unconditionally `annotation_currency.or(cost_currency)`,
-            // which produced mismatched (number, currency) pairs when an
-            // unusable `@@` annotation fell through to cost. The helper
-            // now returns the source so callers can select correctly.
-            let quote_currency = match source {
-                rustledger_core::ImplicitPriceSource::Annotation => annotation_currency,
-                rustledger_core::ImplicitPriceSource::Cost => cost_currency,
-            };
-            let Some(quote) = quote_currency else {
+            let Some((per_unit, quote)) =
+                rustledger_core::extract_per_unit_price(units.number, annotation, cost)
+            else {
                 continue;
             };
 
@@ -802,5 +786,44 @@ mod tests {
 
         // At 2024-01-15 or later, should use implicit price 1.40 (latest)
         assert_eq!(db.get_latest_price("ABC", "EUR"), Some(dec!(1.40)));
+    }
+
+    /// Currency-pairing regression for the query path. Mirrors the
+    /// plugin-side `test_implicit_prices_zero_unit_total_falls_through_to_cost_currency`
+    /// (Copilot review on PR #997). With zero units, the `@@` total
+    /// annotation is unusable, so the per-unit value falls through to
+    /// the cost spec — and the quote currency MUST come from the cost,
+    /// not the dropped annotation. Pre-fix, both paths emitted
+    /// `(50, EUR)` instead of `(50, USD)`. The shared helper now binds
+    /// each value to its source currency, making this bug structurally
+    /// impossible. This test pins the query path's behavior so a
+    /// future caller-side refactor cannot silently regress it.
+    #[test]
+    fn test_implicit_price_zero_units_total_annotation_uses_cost_currency() {
+        use rustledger_core::{CostSpec, Posting, PriceAnnotation, Transaction};
+
+        let txn = Transaction::new(date(2024, 1, 15), "Close position").with_posting(
+            Posting::new("Assets:Stocks", Amount::new(dec!(0), "ABC"))
+                .with_cost(
+                    CostSpec::default()
+                        .with_number_per(dec!(50))
+                        .with_currency("USD"),
+                )
+                .with_price(PriceAnnotation::Total(Amount::new(dec!(100), "EUR"))),
+        );
+
+        let db = PriceDatabase::from_directives(&[Directive::Transaction(txn)]);
+
+        // Per-unit value (50) was paired with USD (cost currency),
+        // not EUR (dropped annotation currency).
+        assert_eq!(
+            db.get_price("ABC", "USD", date(2024, 1, 15)),
+            Some(dec!(50))
+        );
+        // ABC→EUR has no path: no direct entry, no inverse EUR→ABC,
+        // no chain through any other currency. Pre-fix this would
+        // have been Some(50) because the bogus (50, EUR) entry was
+        // recorded.
+        assert_eq!(db.get_price("ABC", "EUR", date(2024, 1, 15)), None);
     }
 }

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -92,57 +92,63 @@ impl PriceDatabase {
 
     /// Add implicit prices from transaction postings.
     ///
-    /// Extracts prices from:
-    /// 1. Price annotations (`@ price` or `@@ total_price`) - takes priority
-    /// 2. Cost specifications (`{cost}`) when no valid price annotation
+    /// Delegates per-posting price math to
+    /// [`rustledger_core::extract_per_unit_price`], which is also used
+    /// by the native `implicit_prices` plugin
+    /// (`rustledger_plugin::native::plugins::implicit_prices`). Pre-fix
+    /// (issue #992) the two paths were independently implemented and
+    /// diverged on `@@` handling — the plugin emitted total amounts as
+    /// per-unit prices. The shared helper eliminates that drift by
+    /// construction.
     ///
-    /// This matches Python beancount's `implicit_prices` plugin behavior.
+    /// Resolution priority (matches Python beancount's
+    /// `implicit_prices` plugin):
+    /// 1. Price annotation (`@` or `@@`) when an amount is present
+    /// 2. Cost spec (`{...}`) as fallback
+    /// 3. Otherwise no price emitted
     pub fn add_implicit_prices_from_transaction(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
-            // Get the posting's units (the commodity being priced)
-            if let Some(units) = posting.amount() {
-                // Priority 1: Price annotation (@ or @@) - if it yields a valid amount.
-                // If the annotation exists but amount() is None, we fall through to cost.
-                if let Some(price_annotation) = &posting.price
-                    && let Some(price_amount) = price_annotation.amount()
-                {
-                    // For @@ (total), calculate per-unit price
-                    let per_unit_price = if price_annotation.is_unit() {
-                        price_amount.number
-                    } else if !units.number.is_zero() {
-                        // Total price divided by units
-                        price_amount.number / units.number.abs()
-                    } else {
-                        continue;
-                    };
+            let Some(units) = posting.amount() else {
+                continue;
+            };
 
-                    self.add_implicit_price(
-                        txn.date,
-                        &units.currency,
-                        per_unit_price,
-                        &price_amount.currency,
-                    );
-                    // Successfully extracted from price annotation, skip cost fallback
-                    continue;
+            // Extract primitives for the shared helper.
+            let (annotation_is_total, annotation_amount, annotation_currency) = match &posting.price
+            {
+                Some(annotation) => {
+                    let amount = annotation.amount();
+                    (
+                        !annotation.is_unit(),
+                        amount.map(|a| a.number),
+                        amount.map(|a| a.currency.clone()),
+                    )
                 }
+                None => (false, None, None),
+            };
+            let (cost_per, cost_total, cost_currency) = match &posting.cost {
+                Some(c) => (c.number_per, c.number_total, c.currency.clone()),
+                None => (None, None, None),
+            };
 
-                // Priority 2: Cost specification (fallback if no valid price from annotation)
-                if let Some(cost_spec) = &posting.cost {
-                    if let (Some(number_per), Some(currency)) =
-                        (&cost_spec.number_per, &cost_spec.currency)
-                    {
-                        self.add_implicit_price(txn.date, &units.currency, *number_per, currency);
-                    } else if let (Some(number_total), Some(currency)) =
-                        (&cost_spec.number_total, &cost_spec.currency)
-                    {
-                        // Calculate per-unit from total
-                        if !units.number.is_zero() {
-                            let per_unit = *number_total / units.number.abs();
-                            self.add_implicit_price(txn.date, &units.currency, per_unit, currency);
-                        }
-                    }
-                }
-            }
+            let Some(per_unit) = rustledger_core::extract_per_unit_price(
+                units.number,
+                annotation_is_total,
+                annotation_amount,
+                cost_per,
+                cost_total,
+            ) else {
+                continue;
+            };
+
+            // Quote currency follows the same priority rule as the per-unit
+            // value: prefer the annotation's currency, fall back to cost's.
+            // The helper doesn't pick this — it returns only the magnitude.
+            let quote_currency = annotation_currency.or(cost_currency);
+            let Some(quote) = quote_currency else {
+                continue;
+            };
+
+            self.add_implicit_price(txn.date, &units.currency, per_unit, &quote);
         }
     }
 


### PR DESCRIPTION
Closes #992. Phase 0a of the plugin-testing-quality plan.

## Bugs

The `implicit_prices` plugin had two bugs, both from being a separate
implementation of the same logic that already exists in
`rustledger-query::price::add_implicit_prices_from_transaction`:

1. **`@@` total amounts emitted as per-unit prices.** For
   `-27,204.53 BAM @@ 15,152.07 EUR`, the plugin emitted
   `1 BAM = 15,152.07 EUR` instead of `1 BAM = 0.557 EUR`. Off by a
   factor of `units.abs()`. The plugin read `posting.price.amount`
   directly without checking the `is_total` field on
   `PriceAnnotationData`.

2. **Double-emit when both `@` and `{cost}` are present.** A posting
   like `5 ABC {1.25 EUR} @ 1.40 EUR` produced two `Price` directives
   instead of one (annotation should win).

A third bug was caught during review:

3. **Currency-pairing on zero-units `@@` fall-through.** A posting
   like `0 ABC {50 USD} @@ 100 EUR` (zero units make the `@@` total
   unusable, so the per-unit value falls through to the cost) was
   emitted as `(50, EUR)` instead of `(50, USD)` — the value came
   from the cost but the currency was still picked from the dropped
   annotation. Affected the query path too.

## Fix

New `rustledger_core::extract_per_unit_price<T>` — generic helper
that encodes the priority rule once, used by both the BQL query
path AND the native `implicit_prices` plugin. Single source of
truth; divergence impossible by construction.

The helper is generic over the currency type so the two callers can
keep using their own representations (`InternedStr` for the query
path, `String` for the plugin's serializable types). The signature
binds the currency to its value at the type level:

```rust
pub fn extract_per_unit_price<T>(
    units_number: Decimal,
    annotation: Option<(bool, Decimal, T)>,
    cost: Option<(Option<Decimal>, Option<Decimal>, T)>,
) -> Option<(Decimal, T)>
```

Returning `(Decimal, T)` means a caller cannot accidentally re-pair
the per-unit value with the wrong currency — that's bug 3 made
structurally impossible.

## Tests

- **13 unit tests** on the helper (`crates/rustledger-core/src/implicit_prices.rs`):
  unit annotations, total annotations, the #992 reproducer specifically,
  tie-breaks when both annotation and cost present (annotation wins;
  within cost, `number_per` wins over `number_total`), zero-units edge
  cases, fall-through behavior for incomplete annotations, and the
  currency-pairing fall-through (bug 3).

- **8 plugin-level tests** replacing the old single "(partial)" test.
  All use strict `assert_eq!` on the `Vec<(currency, number,
  quote_currency)>` returned by an `implicit_prices_emitted` helper
  (computed as multiset diff `output_prices − input_prices`, so
  explicit input price directives don't get counted as plugin output):
  - `test_implicit_prices_from_cost` — `{cost.number_per}` path
  - `test_implicit_prices_from_cost_total` — `{{cost.number_total}}` path
  - `test_implicit_prices_from_unit_annotation` — `@` path
  - `test_implicit_prices_from_total_annotation_issue_992` — bug 1 regression
  - `test_implicit_prices_annotation_and_cost_emits_one_not_two` — bug 2 regression
  - `test_implicit_prices_zero_unit_total_falls_through_to_cost_currency` — bug 3 regression
  - `test_implicit_prices_emits_nothing_for_plain_transfer`
  - `test_implicit_prices_emitted_excludes_input_price_directives` — pins the
    multiset-diff isolation of the test helper itself

- **15 query-path tests** all green, including a new
  `test_implicit_price_zero_units_total_annotation_uses_cost_currency`
  that pins bug 3's behavior on the query side independently of the
  helper's internals (so a future caller-side refactor cannot silently
  regress it).

The old `assert!(price_count >= 1)` shape silently masked both
original bugs because it accepted both correct AND over-emission;
all new tests use strict equality.

## Why this happened in the first place

This is Phase 0a of a broader plan to prevent the next plugin bug.
See the issue tracking the rest of the work for details on:
- Phase 0b (audit other plugin tests for similar weakness)
- Phase 0c (convert `is_total: bool` to a real enum so consumers must
  handle both arms — the type system would have caught Bug 1; #999)
- Phase 1+ (full per-plugin test coverage, differential harness against
  bean-check, mutation testing, property tests, standing policy)

## Verification

- 13 helper tests + 8 plugin tests + 15 query tests + full workspace suite green
- Clippy clean, fmt clean
- The reproducer from the issue (`-27204.53 BAM @@ 15152.07 EUR`)
  now produces exactly one price: `BAM 0.5569... EUR`. Bug 1 fixed.
- Postings with both `@` and `{cost}` emit exactly one price (the
  annotation amount). Bug 2 fixed.
- Zero-units `@@ X EUR` with `{Y USD}` cost emits `(Y, USD)`. Bug 3 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
