### PR TITLE
ci(plugin-tests): policy + lint script for plugin-test quality (Phase 5 of #992 plan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
+      - name: Self-test the lint script (catches regressions in the regexes)
+        run: ./scripts/test-plugin-test-quality.sh
       - name: Run plugin-test-quality lints
         run: ./scripts/check-plugin-test-quality.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,12 @@ jobs:
   # Plugin-test policies (Phase 5 of plugin-testing-quality plan, see #992).
   # Catches weak count assertions and `(partial)` test ports that tend to
   # silently mask plugin bugs.
+  #
+  # Always runs (no `should_build` gate), because the policy script and
+  # CONTRIBUTING.md changes themselves can land in docs-only PRs and we
+  # still want to lint the test files against the current policy.
   plugin-test-quality:
     name: Plugin Test Quality
-    needs: [changes]
-    if: needs.changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
@@ -214,11 +216,20 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, ci, doctest, regressions]
+    needs: [changes, fmt, unsafe-invariant, plugin-test-quality, ci, doctest, regressions]
     steps:
       - name: Check results
         run: |
-          # If no code changes, all jobs will be skipped - that's OK
+          # plugin-test-quality always runs (no should_build gate), so its
+          # result is always required.
+          plugin_quality="${{ needs.plugin-test-quality.result }}"
+          echo "plugin-test-quality result: $plugin_quality"
+          if [[ "$plugin_quality" != "success" ]]; then
+            echo "plugin-test-quality must pass"
+            exit 1
+          fi
+
+          # If no code changes, the remaining build jobs are skipped - that's OK
           if [[ "${{ needs.changes.outputs.should_build }}" == "false" ]]; then
             echo "No code changes - build skipped (OK)"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,20 @@ jobs:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
       - name: Verify forbid-unsafe-code invariant
         run: ./scripts/check-unsafe-invariant.sh
+
+  # Plugin-test policies (Phase 5 of plugin-testing-quality plan, see #992).
+  # Catches weak count assertions and `(partial)` test ports that tend to
+  # silently mask plugin bugs.
+  plugin-test-quality:
+    name: Plugin Test Quality
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
+      - name: Run plugin-test-quality lints
+        run: ./scripts/check-plugin-test-quality.sh
+
   # Main CI matrix - check, clippy, test, doc (only on code changes)
   ci:
     name: ${{ matrix.name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,20 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      # Plugin-test policy lint — sub-second grep-level check that
+      # enforces the rules from CONTRIBUTING.md → "Plugin testing
+      # requirements". Catches weak count assertions and `(partial)`
+      # test ports that historically masked plugin bugs (see issue #992).
+      # Runs on every push because policy violations can land in any
+      # PR that touches the plugin tests directory; the cost is
+      # negligible and CI also enforces the same script.
+      - id: plugin-test-quality
+        name: plugin-test-quality (CONTRIBUTING.md policies)
+        entry: scripts/check-plugin-test-quality.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
       # Bean-price compatibility harness — only fires when files that could
       # change rledger ↔ bean-price discovery behavior are touched. Runs
       # inside `nix develop` so `bean-price` is on PATH (added in #976).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ Native beancount plugins live in `crates/rustledger-plugin/src/native/plugins/` 
 
 4. **Differential coverage where applicable**. If your plugin reimplements a beancount built-in, drop a fixture under `tests/compatibility/files/plugin/<name>/` that enables the plugin via `plugin "..."` directive. The BQL compat harness (PR #1000, `scripts/compat-bql-test.py`) automatically diffs rledger's output against bean-check's. No new harness code is required — just the fixture.
 
-5. **Type-driven exhaustive matching**. When consuming an enum-shaped input (e.g. `PriceAnnotationData::view()`), use `match` and let the compiler enforce that every variant is handled. Don't extract a discriminator field manually and conditional on it — that's the bug shape from #992.
+5. **Type-driven exhaustive matching**. When consuming an enum-shaped input, use `match` and let the compiler enforce that every variant is handled. Don't extract a discriminator field manually and condition on it — that's the bug shape from #992. (Example: `PriceAnnotationData::view()` from `rustledger-plugin-types` returns a typed enum; new consumers should `match` on its arms rather than reading the underlying `is_total: bool`. The view API is added in PR #999.)
 
 ### For numeric plugins specifically
 
@@ -249,7 +249,7 @@ Property tests run 256 cases per CI run by default. They catch bugs example test
 2. Tests at `crates/rustledger-plugin/tests/native_plugins_test.rs` covering the matrix above
 3. Fixtures under `tests/compatibility/files/plugin/<name>/` if the plugin is a beancount reimplementation
 4. At least one proptest case if numeric computation
-5. Mutation-survival ≤ 10% on the new code (CI enforces, see Phase 3 of plugin-testing plan)
+5. Mutation-survival ≤ 10% on the new code (target; CI runs `cargo mutants` and warns today, see Phase 3 of the plugin-testing plan for the planned blocking gate)
 
 ### Why these requirements exist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,55 @@ If your PR hasn't been reviewed, feel free to ping in the PR comments.
 - Close related issues
 - Update documentation if needed
 
+## Plugin testing requirements
+
+Native beancount plugins live in `crates/rustledger-plugin/src/native/plugins/` and are tested in `crates/rustledger-plugin/tests/native_plugins_test.rs`. Issue #992 surfaced a class of bug where a plugin silently emitted wrong output because the consumer ignored a discriminator field (`is_total`) and the test had a weak count assertion (`assert!(count >= 1)`). The plan in #992 documents the structural fixes; the requirements below codify them so future plugins don't regress.
+
+### Required for every new or modified plugin
+
+1. **Test matrix, not "happy path"**. Cover every input variant the plugin can encounter:
+   - Each branch of every input enum (e.g. `@`, `@@`, cost, both, none for posting prices)
+   - Edge cases (empty, zero, negative, missing optional fields)
+   - Each output kind the plugin can emit
+
+2. **Strict count assertions**. Use `assert_eq!(emitted.len(), 1)` — **never** `assert!(emitted.len() >= 1)`. The latter accepts both correct emission and over-emission, which is exactly the failure mode that hid the #992 double-emit bug.
+
+3. **No `(partial)` test ports**. When porting tests from upstream beancount's `<plugin>_test.py`, port the **whole file** or document explicitly which cases are intentionally skipped and why. Test files with `// Converted from … (partial)` comments are no longer accepted.
+
+4. **Differential coverage where applicable**. If your plugin reimplements a beancount built-in, drop a fixture under `tests/compatibility/files/plugin/<name>/` that enables the plugin via `plugin "..."` directive. The BQL compat harness (PR #1000, `scripts/compat-bql-test.py`) automatically diffs rledger's output against bean-check's. No new harness code is required — just the fixture.
+
+5. **Type-driven exhaustive matching**. When consuming an enum-shaped input (e.g. `PriceAnnotationData::view()`), use `match` and let the compiler enforce that every variant is handled. Don't extract a discriminator field manually and conditional on it — that's the bug shape from #992.
+
+### For numeric plugins specifically
+
+Plugins that compute new numbers from existing ones (`implicit_prices`, `unrealized`, `sell_gains`, `coherent_cost`, `check_average_cost`) MUST also include at least one property test (`proptest`) covering an algebraic invariant. Examples:
+
+- `implicit_prices`: emitted price round-trips through `PriceDatabase` to the original
+- `unrealized`: `Sum(realized) + Sum(unrealized) = Sum(total)` at any cutoff date
+- `sell_gains`: gains posting balances the transaction
+- `no_duplicates`: output has no duplicates by `(date, type, key fields)`
+
+Property tests run 256 cases per CI run by default. They catch bugs example tests miss because the input space is too large to enumerate manually.
+
+### When adding a new plugin
+
+1. Implementation in `crates/rustledger-plugin/src/native/plugins/<name>.rs`
+2. Tests at `crates/rustledger-plugin/tests/native_plugins_test.rs` covering the matrix above
+3. Fixtures under `tests/compatibility/files/plugin/<name>/` if the plugin is a beancount reimplementation
+4. At least one proptest case if numeric computation
+5. Mutation-survival ≤ 10% on the new code (CI enforces, see Phase 3 of plugin-testing plan)
+
+### Why these requirements exist
+
+See issue #992, which traced a single rendering bug to a chain of mutually-reinforcing test gaps:
+
+- `(partial)` upstream test port (only the cost path was covered, not `@`/`@@`)
+- `assert!(count >= 1)` — accepted both 1 emission AND 100 emissions
+- Two parallel implementations of the same logic (plugin path vs query path) that diverged because nothing tied them together
+- `is_total: bool` consumed without exhaustive matching
+
+Each requirement above closes one of those gaps. Following all of them eliminates the bug class structurally.
+
 ## Questions?
 
 Open an issue or discussion on GitHub.

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -3079,9 +3079,13 @@ fn test_no_unused_warns_on_unused_account() {
         ),
     ]);
     let output = plugin.process(input);
-    assert!(!output.errors.is_empty(), "should warn about Assets:Unused");
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "exactly one error for the single unused account"
+    );
     assert!(
-        output.errors.iter().any(|e| e.message.contains("Unused")),
+        output.errors[0].message.contains("Unused"),
         "error should mention the unused account"
     );
 }
@@ -3635,7 +3639,11 @@ fn test_zerosum_requires_config() {
         make_transaction("2024-01-15", "Test", vec![("Assets:Cash", "100", "USD")]),
     ]);
     let output = plugin.process(input);
-    assert!(!output.errors.is_empty(), "should error without config");
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "exactly one error for missing required config"
+    );
     assert!(output.errors[0].message.contains("requires configuration"));
 }
 

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -2243,7 +2243,10 @@ fn test_registry_list_all() {
     let registry = NativePluginRegistry::new();
     let plugins = registry.list();
 
-    // Should have at least 13 plugins (14 minus auto_tag which might be different)
+    // Should have at least 13 plugins (14 minus auto_tag which might be different).
+    // allow weak-count: registry-shape test — count grows as plugins are added,
+    // pinning to a specific value would force every plugin addition to update
+    // this test. See scripts/check-plugin-test-quality.sh.
     assert!(plugins.len() >= 13, "should have at least 13 plugins");
 }
 

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -7,7 +7,11 @@
 # Catches:
 #   1. Weak count assertions like `assert!(... >= N)` on emission counts.
 #      The original #992 bug shipped because the test had `assert!(count >= 1)`,
-#      which accepted both correct and over-emission.
+#      which accepted both correct and over-emission. Catches both spaced
+#      (`x >= 1`) and unspaced (`x>=1`) variants. To opt out (e.g. on
+#      registry-shape tests where the count grows with each plugin
+#      addition), prefix the assert with `// allow weak-count: <reason>`
+#      within 5 lines of leading context.
 #   2. `(partial)` test ports — incomplete upstream test conversions.
 #      A full port catches more bugs than a partial one; partials had
 #      historically been used as a shortcut and the comment was the only
@@ -39,26 +43,35 @@ echo "[1/2] weak count assertions ('assert!(... >= N)' / '> N')"
 #   - registry tests (filenames or comments mentioning "registry")
 #   - explicit allow comments: "// allow weak-count: <reason>"
 
-WEAK_PATTERN='assert!\([^)]*(\.count|\.len)\(\)[^)]*( >=| >) [0-9]+'
-# `-B 5` includes up to 5 lines above each match, so we can find
-# `// allow weak-count` annotations in the leading comment block.
-raw=$(grep -rEnB 5 "$WEAK_PATTERN" "$TESTS_DIR" 2>/dev/null || true)
+# Match three weak-assertion shapes:
+#   1. `assert!(x.count() >= N)` / `assert!(x.len() > N)` (with optional whitespace)
+#   2. `assert!(x.count()>=N)` / `assert!(x.len()>N)` (no whitespace)
+#   3. `assert!(price_count >= N)` — precomputed count var (any ident ending
+#      in `_count`, `_len`, `_size`, or named exactly `count`/`len`/`size`).
+# The original #992 bug used pattern 3 (`assert!(price_count >= 1)`).
+WEAK_PATTERN='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*[[:space:]]*(>|>=)[[:space:]]*[0-9]+'
 
-# awk script: split on `--`, check each block for "allow weak-count",
-# emit only the assert line from blocks that DON'T have the annotation.
-bad=$(echo "$raw" | awk '
-BEGIN { allowed = 0; assert_line = "" }
-/^--$/ {
-    if (!allowed && assert_line != "") print assert_line
-    allowed = 0; assert_line = ""
-    next
-}
-/allow weak-count/ { allowed = 1 }
-/assert!\(.*\.(count|len)\(\).*( >=| >) [0-9]+/ { assert_line = $0 }
-END {
-    if (!allowed && assert_line != "") print assert_line
-}
-')
+# Find every line matching the pattern with file:line prefixes.
+# Then for each match, check the 5 preceding lines for the
+# `// allow weak-count` opt-out annotation. Pre-fix used `grep -B 5`
+# + an awk block parser that lost violations when multiple matches
+# were close together within the same 5-line context window.
+matches=$(grep -rEn "$WEAK_PATTERN" "$TESTS_DIR" 2>/dev/null || true)
+
+bad=""
+while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    # match looks like: path/to/file.rs:LINENO:assert!(...)
+    file_part="${match%%:*}"
+    rest="${match#*:}"
+    lineno="${rest%%:*}"
+    # Look back 5 lines for the opt-out annotation.
+    start=$(( lineno > 5 ? lineno - 5 : 1 ))
+    if ! sed -n "${start},${lineno}p" "$file_part" | grep -q "allow weak-count"; then
+        bad="${bad}${match}"$'\n'
+    fi
+done <<< "$matches"
+bad="${bad%$'\n'}"  # trim trailing newline
 
 if [ -n "$bad" ]; then
     echo "  ERROR: weak count assertions found (no 'allow weak-count' annotation)"

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 # Lint plugin tests against the policies in CONTRIBUTING.md ("Plugin
-# testing requirements"). Runs in CI and as a pre-push step.
+# testing requirements"). Runs in CI and as a pre-push hook.
 #
 # Phase 5 of the plugin-testing-quality plan documented in issue #992.
 #
 # Catches:
-#   1. Weak count assertions like `assert!(... >= N)` on emission counts.
-#      The original #992 bug shipped because the test had `assert!(count >= 1)`,
-#      which accepted both correct and over-emission. Catches both spaced
-#      (`x >= 1`) and unspaced (`x>=1`) variants. To opt out (e.g. on
-#      registry-shape tests where the count grows with each plugin
-#      addition), prefix the assert with `// allow weak-count: <reason>`
-#      within 5 lines of leading context.
+#   1. Weak count assertions on emission counts. Three semantically-
+#      identical shapes — all accept "1 emission OR 100", which is the
+#      failure mode that hid #992:
+#         assert!(emitted.len() >= 1)         / assert!(price_count >= 1)
+#         assert_ne!(emitted.len(), 0)
+#         assert!(!emitted.is_empty())
+#      To opt out (e.g. on registry-shape tests where the count grows
+#      with each plugin addition), prefix the assertion with
+#      `// allow weak-count: <reason>` within 5 lines of leading
+#      context.
 #   2. `(partial)` test ports — incomplete upstream test conversions.
-#      A full port catches more bugs than a partial one; partials had
-#      historically been used as a shortcut and the comment was the only
-#      evidence of incomplete coverage.
+#      Matches the literal `Converted from ... (partial)` shape that
+#      historically marked a half-done port; opt-out is
+#      `// allow partial: <reason>`.
 #
 # Usage: scripts/check-plugin-test-quality.sh
 # Exit code 0 if clean, 1 if any policy violation found.
@@ -25,53 +28,86 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TESTS_DIR="$REPO_ROOT/crates/rustledger-plugin/tests"
 
+# Hard-fail if the tests directory disappeared (path moved, broken
+# worktree, etc.). Pre-fix this script silenced grep stderr with
+# `2>/dev/null` and used `|| true` to swallow non-zero exits, which
+# meant a missing TESTS_DIR would make the lint silently pass with
+# "All policies pass". Two npm releases shipped that way in the past
+# (per project memory `feedback_no_error_swallowing.md`); we
+# explicitly differentiate "no matches" (grep exit 1) from "real
+# error" (grep exit 2+) below.
+if [ ! -d "$TESTS_DIR" ]; then
+    echo "ERROR: tests directory not found at $TESTS_DIR" >&2
+    exit 1
+fi
+
 EXIT=0
 
 echo "=== Checking plugin-test-quality policies ==="
 echo ""
 
+# Run grep, tolerating "no matches" (exit 1) but failing loudly on
+# real errors (exit 2+). Caller passes pattern + dir; we echo the
+# matches to stdout. Returns success either way; on real error we
+# bail the whole script via `exit 1`.
+grep_or_die() {
+    local pat="$1"
+    local dir="$2"
+    local rc=0
+    local out
+    out=$(grep -rEn "$pat" "$dir") || rc=$?
+    case "$rc" in
+        0|1) printf '%s' "$out" ;;
+        *)
+            echo "ERROR: grep failed for pattern '$pat' under $dir (exit $rc)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# For a `path:lineno:line` match, scan the 5 lines ending at lineno
+# (inclusive) for the given allow annotation. Returns 0 if found.
+has_allow_above() {
+    local match="$1"
+    local annotation="$2"
+    local file lineno start
+    IFS=: read -r file lineno _ <<< "$match"
+    start=$(( lineno > 5 ? lineno - 5 : 1 ))
+    sed -n "${start},${lineno}p" "$file" | grep -q "$annotation"
+}
+
 # ----------------------------------------------------------------------
 # Policy 1: no weak count assertions on emission counts
 # ----------------------------------------------------------------------
 
-echo "[1/2] weak count assertions ('assert!(... >= N)' / '> N')"
+echo "[1/2] weak count assertions"
 
-# Match: assert!(<anything>.{count|len}()<anything>(>= or >)<digit>)
-# The pattern is intentionally narrow — `assert!(plugins.len() >= 13)`
-# in registry-shape tests is fine (it tests a registration property,
-# not emission). We exclude:
-#   - registry tests (filenames or comments mentioning "registry")
-#   - explicit allow comments: "// allow weak-count: <reason>"
-
-# Match three weak-assertion shapes:
-#   1. `assert!(x.count() >= N)` / `assert!(x.len() > N)` (with optional whitespace)
-#   2. `assert!(x.count()>=N)` / `assert!(x.len()>N)` (no whitespace)
-#   3. `assert!(price_count >= N)` — precomputed count var (any ident ending
-#      in `_count`, `_len`, `_size`, or named exactly `count`/`len`/`size`).
-# The original #992 bug used pattern 3 (`assert!(price_count >= 1)`).
-WEAK_PATTERN='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*[[:space:]]*(>|>=)[[:space:]]*[0-9]+'
-
-# Find every line matching the pattern with file:line prefixes.
-# Then for each match, check the 5 preceding lines for the
-# `// allow weak-count` opt-out annotation. Pre-fix used `grep -B 5`
-# + an awk block parser that lost violations when multiple matches
-# were close together within the same 5-line context window.
-matches=$(grep -rEn "$WEAK_PATTERN" "$TESTS_DIR" 2>/dev/null || true)
+# Three shapes — all accept "1 OR 100":
+#   A. `assert!(x.len() >= N)` / `assert!(x.count() > N)` and
+#      precomputed `*_count` / `*_len` / `*_size` (or bare
+#      `count`/`len`/`size`) idents. The original #992 bug used
+#      `assert!(price_count >= 1)`.
+#   B. `assert_ne!(x.len(), 0)` / `assert_ne!(emitted_count, 0)`
+#   C. `assert!(!x.is_empty())`
+#
+# Per-match allowlist: `// allow weak-count: <reason>` within 5
+# leading lines.
+PAT_A='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*(>|>=)[[:space:]]*[0-9]+'
+PAT_B='assert_ne!\([^,]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^,]*,[[:space:]]*0[[:space:]]*[,)]'
+PAT_C='assert!\([[:space:]]*!.+\.is_empty\(\)'
 
 bad=""
-while IFS= read -r match; do
-    [ -z "$match" ] && continue
-    # match looks like: path/to/file.rs:LINENO:assert!(...)
-    file_part="${match%%:*}"
-    rest="${match#*:}"
-    lineno="${rest%%:*}"
-    # Look back 5 lines for the opt-out annotation.
-    start=$(( lineno > 5 ? lineno - 5 : 1 ))
-    if ! sed -n "${start},${lineno}p" "$file_part" | grep -q "allow weak-count"; then
-        bad="${bad}${match}"$'\n'
-    fi
-done <<< "$matches"
-bad="${bad%$'\n'}"  # trim trailing newline
+for pat in "$PAT_A" "$PAT_B" "$PAT_C"; do
+    matches=$(grep_or_die "$pat" "$TESTS_DIR")
+    [ -z "$matches" ] && continue
+    while IFS= read -r match; do
+        [ -z "$match" ] && continue
+        if ! has_allow_above "$match" "allow weak-count"; then
+            bad="${bad}${match}"$'\n'
+        fi
+    done <<< "$matches"
+done
+bad="${bad%$'\n'}"
 
 if [ -n "$bad" ]; then
     echo "  ERROR: weak count assertions found (no 'allow weak-count' annotation)"
@@ -94,20 +130,33 @@ echo ""
 
 echo "[2/2] '(partial)' test port labels"
 
-# `(partial)` in a test comment means an upstream test was only partly
-# converted to Rust. CONTRIBUTING.md requires either full ports or
-# explicit per-case skip annotations.
+# Match the historical bad shape `// Converted from <something> (partial)`
+# specifically — broader `(partial)` substring matches would false-positive
+# on unrelated comments like "(partial overlap with foo)". Opt-out:
+# `// allow partial: <reason>` in the 5 leading lines.
+PARTIAL_PATTERN='Converted from.*\(partial\)'
 
-partial_matches=$(grep -rn "(partial)" "$TESTS_DIR" 2>/dev/null || true)
-
+partial_bad=""
+partial_matches=$(grep_or_die "$PARTIAL_PATTERN" "$TESTS_DIR")
 if [ -n "$partial_matches" ]; then
+    while IFS= read -r match; do
+        [ -z "$match" ] && continue
+        if ! has_allow_above "$match" "allow partial"; then
+            partial_bad="${partial_bad}${match}"$'\n'
+        fi
+    done <<< "$partial_matches"
+fi
+partial_bad="${partial_bad%$'\n'}"
+
+if [ -n "$partial_bad" ]; then
     echo "  ERROR: '(partial)' test port labels found"
     echo ""
-    echo "$partial_matches"
+    echo "$partial_bad"
     echo ""
     echo "  Either:"
     echo "  - Port the remaining upstream test cases, OR"
-    echo "  - Document each skipped case explicitly with rationale"
+    echo "  - Document each skipped case explicitly with rationale, OR"
+    echo "  - Add '// allow partial: <reason>' if it's a false positive"
     echo ""
     EXIT=1
 else

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Lint plugin tests against the policies in CONTRIBUTING.md ("Plugin
+# testing requirements"). Runs in CI and as a pre-push step.
+#
+# Phase 5 of the plugin-testing-quality plan documented in issue #992.
+#
+# Catches:
+#   1. Weak count assertions like `assert!(... >= N)` on emission counts.
+#      The original #992 bug shipped because the test had `assert!(count >= 1)`,
+#      which accepted both correct and over-emission.
+#   2. `(partial)` test ports — incomplete upstream test conversions.
+#      A full port catches more bugs than a partial one; partials had
+#      historically been used as a shortcut and the comment was the only
+#      evidence of incomplete coverage.
+#
+# Usage: scripts/check-plugin-test-quality.sh
+# Exit code 0 if clean, 1 if any policy violation found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TESTS_DIR="$REPO_ROOT/crates/rustledger-plugin/tests"
+
+EXIT=0
+
+echo "=== Checking plugin-test-quality policies ==="
+echo ""
+
+# ----------------------------------------------------------------------
+# Policy 1: no weak count assertions on emission counts
+# ----------------------------------------------------------------------
+
+echo "[1/2] weak count assertions ('assert!(... >= N)' / '> N')"
+
+# Match: assert!(<anything>.{count|len}()<anything>(>= or >)<digit>)
+# The pattern is intentionally narrow — `assert!(plugins.len() >= 13)`
+# in registry-shape tests is fine (it tests a registration property,
+# not emission). We exclude:
+#   - registry tests (filenames or comments mentioning "registry")
+#   - explicit allow comments: "// allow weak-count: <reason>"
+
+WEAK_PATTERN='assert!\([^)]*(\.count|\.len)\(\)[^)]*( >=| >) [0-9]+'
+# `-B 5` includes up to 5 lines above each match, so we can find
+# `// allow weak-count` annotations in the leading comment block.
+raw=$(grep -rEnB 5 "$WEAK_PATTERN" "$TESTS_DIR" 2>/dev/null || true)
+
+# awk script: split on `--`, check each block for "allow weak-count",
+# emit only the assert line from blocks that DON'T have the annotation.
+bad=$(echo "$raw" | awk '
+BEGIN { allowed = 0; assert_line = "" }
+/^--$/ {
+    if (!allowed && assert_line != "") print assert_line
+    allowed = 0; assert_line = ""
+    next
+}
+/allow weak-count/ { allowed = 1 }
+/assert!\(.*\.(count|len)\(\).*( >=| >) [0-9]+/ { assert_line = $0 }
+END {
+    if (!allowed && assert_line != "") print assert_line
+}
+')
+
+if [ -n "$bad" ]; then
+    echo "  ERROR: weak count assertions found (no 'allow weak-count' annotation)"
+    echo ""
+    echo "$bad"
+    echo ""
+    echo "  Replace with strict assert_eq!(...) or add explicit allow:"
+    echo "    // allow weak-count: <reason>"
+    echo "    assert!(emitted.len() >= 1, \"...\")"
+    echo ""
+    EXIT=1
+else
+    echo "  OK"
+fi
+echo ""
+
+# ----------------------------------------------------------------------
+# Policy 2: no `(partial)` test ports
+# ----------------------------------------------------------------------
+
+echo "[2/2] '(partial)' test port labels"
+
+# `(partial)` in a test comment means an upstream test was only partly
+# converted to Rust. CONTRIBUTING.md requires either full ports or
+# explicit per-case skip annotations.
+
+partial_matches=$(grep -rn "(partial)" "$TESTS_DIR" 2>/dev/null || true)
+
+if [ -n "$partial_matches" ]; then
+    echo "  ERROR: '(partial)' test port labels found"
+    echo ""
+    echo "$partial_matches"
+    echo ""
+    echo "  Either:"
+    echo "  - Port the remaining upstream test cases, OR"
+    echo "  - Document each skipped case explicitly with rationale"
+    echo ""
+    EXIT=1
+else
+    echo "  OK"
+fi
+echo ""
+
+# ----------------------------------------------------------------------
+
+if [ "$EXIT" -eq 0 ]; then
+    echo "=== All plugin-test-quality policies pass ==="
+else
+    echo "=== Plugin-test-quality FAILED ==="
+    echo ""
+    echo "See CONTRIBUTING.md → 'Plugin testing requirements' for the policy."
+    echo "See issue #992 for the bug class these policies prevent."
+fi
+
+exit "$EXIT"

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -26,7 +26,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TESTS_DIR="$REPO_ROOT/crates/rustledger-plugin/tests"
+# Override-able for the script's self-test (see test-plugin-test-quality.sh).
+# Defaults to the real plugin tests dir for normal CI/pre-push use.
+TESTS_DIR="${TESTS_DIR:-$REPO_ROOT/crates/rustledger-plugin/tests}"
 
 # Hard-fail if the tests directory disappeared (path moved, broken
 # worktree, etc.). Pre-fix this script silenced grep stderr with
@@ -66,14 +68,17 @@ grep_or_die() {
 }
 
 # For a `path:lineno:line` match, scan the 5 lines ending at lineno
-# (inclusive) for the given allow annotation. Returns 0 if found.
+# (inclusive) for the given allow annotation. Requires a NON-EMPTY
+# reason after the colon — `// allow weak-count:` (no reason) doesn't
+# count, because the whole point of the opt-out is to force the author
+# to articulate why the lint should be bypassed. Returns 0 if found.
 has_allow_above() {
     local match="$1"
     local annotation="$2"
     local file lineno start
     IFS=: read -r file lineno _ <<< "$match"
     start=$(( lineno > 5 ? lineno - 5 : 1 ))
-    sed -n "${start},${lineno}p" "$file" | grep -q "$annotation"
+    sed -n "${start},${lineno}p" "$file" | grep -qE "${annotation}:[[:space:]]*\S"
 }
 
 # ----------------------------------------------------------------------
@@ -82,22 +87,26 @@ has_allow_above() {
 
 echo "[1/2] weak count assertions"
 
-# Three shapes — all accept "1 OR 100":
+# Four shapes — all accept "1 OR 100":
 #   A. `assert!(x.len() >= N)` / `assert!(x.count() > N)` and
 #      precomputed `*_count` / `*_len` / `*_size` (or bare
 #      `count`/`len`/`size`) idents. The original #992 bug used
 #      `assert!(price_count >= 1)`.
 #   B. `assert_ne!(x.len(), 0)` / `assert_ne!(emitted_count, 0)`
 #   C. `assert!(!x.is_empty())`
+#   D. `assert!(x.len() != 0)` / `assert!(price_count != 0)` —
+#      semantically identical to B but written as an inequality
+#      instead of using `assert_ne!`.
 #
 # Per-match allowlist: `// allow weak-count: <reason>` within 5
 # leading lines.
 PAT_A='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*(>|>=)[[:space:]]*[0-9]+'
 PAT_B='assert_ne!\([^,]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^,]*,[[:space:]]*0[[:space:]]*[,)]'
 PAT_C='assert!\([[:space:]]*!.+\.is_empty\(\)'
+PAT_D='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*!=[[:space:]]*0[[:space:]]*[,)]'
 
 bad=""
-for pat in "$PAT_A" "$PAT_B" "$PAT_C"; do
+for pat in "$PAT_A" "$PAT_B" "$PAT_C" "$PAT_D"; do
     matches=$(grep_or_die "$pat" "$TESTS_DIR")
     [ -z "$matches" ] && continue
     while IFS= read -r match; do

--- a/scripts/test-plugin-test-quality.sh
+++ b/scripts/test-plugin-test-quality.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Self-test for check-plugin-test-quality.sh.
+#
+# The lint script's regexes are non-trivial; a typo or accidental
+# deletion of a pattern would silently disable detection. This test
+# generates synthetic test files in a temp dir, points the lint at
+# them via `TESTS_DIR`, and asserts that each known-bad shape gets
+# caught and each known-clean shape does not.
+#
+# Usage: scripts/test-plugin-test-quality.sh
+# Exit code 0 if all cases pass, 1 if any case fails.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LINT_SCRIPT="$REPO_ROOT/scripts/check-plugin-test-quality.sh"
+
+if [ ! -x "$LINT_SCRIPT" ]; then
+    echo "ERROR: lint script not found or not executable: $LINT_SCRIPT" >&2
+    exit 1
+fi
+
+TMPDIR=$(mktemp -d -t plugin-lint-test.XXXXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+# Run the lint with $TMPDIR as TESTS_DIR. Asserts:
+#   - exit code matches $expected_exit (0 or 1)
+#   - if $must_match is non-empty, the output contains it (substring)
+run_case() {
+    local name="$1"
+    local expected_exit="$2"
+    local content="$3"
+    local must_match="${4:-}"
+
+    printf '%s\n' "$content" > "$TMPDIR/synth_test.rs"
+
+    local out rc=0
+    out=$(TESTS_DIR="$TMPDIR" "$LINT_SCRIPT" 2>&1) || rc=$?
+
+    if [ "$rc" != "$expected_exit" ]; then
+        echo "FAIL  [$name]"
+        echo "  expected exit $expected_exit, got $rc"
+        echo "  --- script output ---"
+        echo "$out" | sed 's/^/  /'
+        echo "  ---"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if [ -n "$must_match" ] && ! grep -qF "$must_match" <<< "$out"; then
+        echo "FAIL  [$name]"
+        echo "  output missing substring: '$must_match'"
+        echo "  --- script output ---"
+        echo "$out" | sed 's/^/  /'
+        echo "  ---"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    PASS=$((PASS + 1))
+    echo "PASS  [$name]"
+}
+
+echo "=== Self-testing plugin-test-quality lint ==="
+echo ""
+
+# ----------------------------------------------------------------------
+# Shape A: assert!(... >= N) / >
+# ----------------------------------------------------------------------
+
+run_case "shape A: assert!(x.len() >= 1)" 1 \
+    '#[test] fn t() { assert!(emitted.len() >= 1); }' \
+    "synth_test.rs:1:"
+
+run_case "shape A: assert!(x.count() > 0)" 1 \
+    '#[test] fn t() { assert!(emitted.count() > 0); }'
+
+run_case "shape A: precomputed price_count >= 1 (the actual #992 bug shape)" 1 \
+    '#[test] fn t() { let price_count = 0; assert!(price_count >= 1); }'
+
+run_case "shape A: bare 'count >= 1'" 1 \
+    '#[test] fn t() { let count = 0; assert!(count >= 1); }'
+
+# ----------------------------------------------------------------------
+# Shape B: assert_ne!(..., 0)
+# ----------------------------------------------------------------------
+
+run_case "shape B: assert_ne!(x.len(), 0)" 1 \
+    '#[test] fn t() { assert_ne!(emitted.len(), 0); }'
+
+run_case "shape B: with msg" 1 \
+    '#[test] fn t() { assert_ne!(emitted.len(), 0, "msg"); }'
+
+# ----------------------------------------------------------------------
+# Shape C: assert!(!x.is_empty())
+# ----------------------------------------------------------------------
+
+run_case "shape C: assert!(!x.is_empty())" 1 \
+    '#[test] fn t() { assert!(!emitted.is_empty()); }'
+
+run_case "shape C: with msg" 1 \
+    '#[test] fn t() { assert!(!output.errors.is_empty(), "msg"); }'
+
+# ----------------------------------------------------------------------
+# Shape D: assert!(x.len() != 0)
+# ----------------------------------------------------------------------
+
+run_case "shape D: assert!(x.len() != 0)" 1 \
+    '#[test] fn t() { assert!(emitted.len() != 0); }'
+
+run_case "shape D: assert!(price_count != 0)" 1 \
+    '#[test] fn t() { let price_count = 0; assert!(price_count != 0); }'
+
+# ----------------------------------------------------------------------
+# Allow annotation
+# ----------------------------------------------------------------------
+
+run_case "allow annotation with reason suppresses violation" 0 \
+    '#[test] fn t() {
+    // allow weak-count: stable shape
+    assert!(plugins.len() >= 13);
+}'
+
+run_case "EMPTY allow reason still fires lint (item 2 from review)" 1 \
+    '#[test] fn t() {
+    // allow weak-count:
+    assert!(plugins.len() >= 13);
+}'
+
+run_case "whitespace-only allow reason still fires" 1 \
+    '#[test] fn t() {
+    // allow weak-count:
+    assert!(plugins.len() >= 13);
+}'
+
+# ----------------------------------------------------------------------
+# Clean shapes (must NOT fire)
+# ----------------------------------------------------------------------
+
+run_case "clean: assert_eq!(x.len(), 1)" 0 \
+    '#[test] fn t() { assert_eq!(emitted.len(), 1); }'
+
+run_case "clean: assert_eq!(x.len(), 0)" 0 \
+    '#[test] fn t() { assert_eq!(emitted.len(), 0); }'
+
+run_case "clean: assert!(x.len() == 1) (positive equality)" 0 \
+    '#[test] fn t() { assert!(emitted.len() == 1); }'
+
+run_case "clean: no asserts at all" 0 \
+    'fn t() { let x = vec![1, 2, 3]; let _ = x.len(); }'
+
+# ----------------------------------------------------------------------
+# Partial-port shape
+# ----------------------------------------------------------------------
+
+run_case "partial: 'Converted from x_test.py (partial)'" 1 \
+    '// Converted from foo_test.py (partial)
+#[test] fn t() {}' \
+    "Converted from foo_test.py (partial)"
+
+run_case "partial: false positive — '(partial overlap with foo)' should NOT fire" 0 \
+    '// Edge case (partial overlap with foo): handle gracefully
+#[test] fn t() {}'
+
+run_case "partial: allow annotation with reason suppresses" 0 \
+    '// allow partial: documentation reference, not a port
+// Converted from foo_test.py (partial)
+#[test] fn t() {}'
+
+# ----------------------------------------------------------------------
+# Missing-dir hard-fail (regression: pre-fix this silently passed)
+# ----------------------------------------------------------------------
+
+if TESTS_DIR=/nonexistent/dir-that-does-not-exist "$LINT_SCRIPT" >/dev/null 2>&1; then
+    echo "FAIL  [missing TESTS_DIR should hard-fail]"
+    echo "  script returned 0 for nonexistent dir — this is the bug from"
+    echo "  feedback_no_error_swallowing.md. Should exit non-zero."
+    FAIL=$((FAIL + 1))
+else
+    PASS=$((PASS + 1))
+    echo "PASS  [missing TESTS_DIR hard-fails]"
+fi
+
+# ----------------------------------------------------------------------
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Phase 5 of the plugin-testing-quality plan from #992. **Standing policy + CI gate** for the bug class that produced the original issue.

## Why

The chain that allowed #992 to ship:

1. `(partial)` upstream test port (only the cost path, not `@` / `@@`)
2. `assert!(price_count >= 1)` — accepted both 1 and 100 emissions
3. Two parallel implementations (plugin vs query) that drifted because nothing tied them together
4. `is_total: bool` consumed without exhaustive matching

Phases 0a–0c and 2 fixed those structurally. This PR codifies the policies so the next plugin doesn't reintroduce the bug shape.

## What ships

### CONTRIBUTING.md — "Plugin testing requirements" section

Five policies for plugin contributions:

1. Test matrix, not happy path
2. Strict count assertions (`assert_eq!`, never `>=`)
3. No `(partial)` test ports
4. Differential coverage where applicable (drop a fixture under `tests/compatibility/files/plugin/<name>/` — the harness from #1000 picks it up)
5. Type-driven exhaustive matching (use `match` on enum-shaped inputs)

For numeric plugins specifically: at least one proptest case.

### scripts/check-plugin-test-quality.sh

CI lint enforcing the two most mechanical policies. Catches three semantically-identical weak-assertion shapes:

- `assert!(emitted.len() >= 1)` / `assert!(price_count >= 1)` (the actual #992 line)
- `assert_ne!(emitted.len(), 0)`
- `assert!(!emitted.is_empty())`

All three accept "1 emission OR 100", which is exactly the failure mode that hid #992.

For `(partial)` test ports, matches the literal `Converted from … (partial)` shape that historically marked half-done ports.

Both checks have an explicit per-match allowlist:

- `// allow weak-count: <reason>` (used legitimately on the registry-list test where the count grows with each plugin)
- `// allow partial: <reason>` (escape hatch for unrelated `(partial)` substrings)

The lookback for the allow annotation reads up to 5 lines above the match using a bash loop with `sed -n` — replaced an earlier awk block parser that lost violations when multiple matches fell inside the same context window.

Per the project's `feedback_no_error_swallowing.md`, grep is invoked with explicit exit-code handling that distinguishes "no matches" (exit 1, fine) from real errors (exit 2+, hard-fail with a message). No `2>/dev/null || true`.

### CI integration

New `Plugin Test Quality` job in `.github/workflows/ci.yml`:

- Runs on **every** PR, not gated on `should_build` — policy/script/CONTRIBUTING changes need linting too
- Listed in the `build` aggregator's `needs:` with an explicit `if [[ result != "success" ]]; then exit 1` — so branch protection on `build` enforces it as a real merge gate

### Pre-push hook

Wired into `.pre-commit-config.yaml` as a `pre-push` stage so contributors catch violations locally before opening a PR. Sub-second cost.

### Test tightening (knock-on)

Two existing assertions in `native_plugins_test.rs` (`test_no_unused_warns_on_unused_account`, `test_zerosum_requires_config`) used `assert!(!output.errors.is_empty(), ...)`. Tightened to `assert_eq!(output.errors.len(), 1, ...)` to match the new lint and the spirit of the policy.

## Verified

```
$ ./scripts/check-plugin-test-quality.sh
=== Checking plugin-test-quality policies ===

[1/2] weak count assertions
  OK

[2/2] '(partial)' test port labels
  OK

=== All plugin-test-quality policies pass ===
```

The single legitimate `assert!(... >= N)` in the test file is `test_registry_list_all` — annotated with `// allow weak-count: registry-shape test` per the policy. All 88 `native_plugins_test` tests pass after the assertion tightening.

## Related

- #992 — the bug that motivated the plan
- #997 — Phase 0a fix (merged)
- #998 — Phase 0b audit (Phase 1 backlog)
- #999 — Phase 0c type-safety view enum
- #1000 — Phase 2 differential harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
