### PR TITLE
fix(ci): catch multi-line weak-count assertions in plugin-test lint

### DIFF
--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -3051,13 +3051,17 @@ fn test_auto_tag_adds_tag_for_expense() {
         .iter()
         .find(|d| d.directive_type == "transaction")
         .unwrap();
-    if let DirectiveData::Transaction(data) = &txn.data {
-        assert_eq!(
-            data.tags.len(),
-            1,
-            "auto_tag should add exactly one tag for the single matching posting"
+    let DirectiveData::Transaction(data) = &txn.data else {
+        panic!(
+            "directive_type was 'transaction' but data variant is {:?} — impossible state",
+            txn.data
         );
-    }
+    };
+    assert_eq!(
+        data.tags.len(),
+        1,
+        "auto_tag should add exactly one tag for the single matching posting"
+    );
 }
 
 // ============================================================================

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -1752,12 +1752,13 @@ fn test_check_commodity_undeclared() {
 
     let output = plugin.process(input);
 
-    assert!(
-        !output.errors.is_empty(),
-        "expected warning for undeclared USD"
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "exactly one warning for the single undeclared currency"
     );
     assert!(
-        output.errors.iter().any(|e| e.message.contains("USD")),
+        output.errors[0].message.contains("USD"),
         "warning should mention USD"
     );
 }
@@ -3051,9 +3052,10 @@ fn test_auto_tag_adds_tag_for_expense() {
         .find(|d| d.directive_type == "transaction")
         .unwrap();
     if let DirectiveData::Transaction(data) = &txn.data {
-        assert!(
-            !data.tags.is_empty(),
-            "auto_tag should add a tag for Expenses:Food posting"
+        assert_eq!(
+            data.tags.len(),
+            1,
+            "auto_tag should add exactly one tag for the single matching posting"
         );
     }
 }
@@ -3131,9 +3133,10 @@ fn test_pedantic_runs_multiple_validators() {
         ),
     ]);
     let output = plugin.process(input);
-    assert!(
-        !output.errors.is_empty(),
-        "pedantic should catch leaf-only violation"
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "exactly one error for the single leaf-only violation"
     );
 }
 
@@ -3217,9 +3220,14 @@ fn test_sell_gains_warns_missing_gains_posting() {
     ]);
     let output = plugin.process(input);
     // Should warn about missing Income:Capital-Gains posting
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "exactly one warning for the single sale missing gains posting"
+    );
     assert!(
-        !output.errors.is_empty(),
-        "should warn about missing gains posting"
+        output.errors[0].message.contains("gain") || output.errors[0].message.contains("Gain"),
+        "warning should reference the missing gains posting"
     );
 }
 
@@ -3274,9 +3282,10 @@ fn test_commodity_attr_error_with_missing_required_attr() {
     let input =
         make_input_with_config(vec![make_commodity("2024-01-01", "AAPL")], "{'name': null}");
     let output = plugin.process(input);
-    assert!(
-        !output.errors.is_empty(),
-        "should error when required 'name' attribute is missing"
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "exactly one error for the single commodity missing required 'name'"
     );
 }
 

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -151,9 +151,17 @@ PAT_D="${WB}"'assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_
 # siblings but use `\s*` (which includes `\n`), a bounded ident
 # match to avoid swallowing the rest of the file, and PCRE
 # negative-lookbehind to skip `prop_assert!` / `debug_assert!`.
+#
+# IMPORTANT: ML_PAT_B/D restrict the LHS to count-shaped expressions
+# the same way single-line PAT_B/D do — `.count()`/`.len()`/`.size()`
+# method calls or `*_count`/`*_len`/`*_size` (or bare `count`/`len`/
+# `size`) idents. Without this restriction the multi-line patterns
+# would false-positive on every `assert_ne!(balance, 0)` style check
+# (Copilot review on PR #1005).
+COUNT_LHS='(?:\w[\w.]*\.(?:count|len|size)\(\)|(?:\w+_)?(?:count|len|size))'
 ML_PAT_C='(?<!\w)assert!\(\s*!\w[\w.]*\.is_empty\(\)'
-ML_PAT_B='(?<!\w)assert_ne!\(\s*\w[\w.()]*\s*,\s*0\s*[,)]'
-ML_PAT_D='(?<!\w)assert!\(\s*\w[\w.()]*\s*!=\s*0\s*[,)]'
+ML_PAT_B='(?<!\w)assert_ne!\(\s*'"$COUNT_LHS"'\s*,\s*0\s*[,)]'
+ML_PAT_D='(?<!\w)assert!\(\s*'"$COUNT_LHS"'\s*!=\s*0\s*[,)]'
 
 bad=""
 for pat in "$PAT_A" "$PAT_B" "$PAT_C" "$PAT_D"; do

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -81,6 +81,37 @@ has_allow_above() {
     sed -n "${start},${lineno}p" "$file" | grep -qE "${annotation}:[[:space:]]*\S"
 }
 
+# Find multi-line regex matches across all `*.rs` files under $1 and
+# emit them in `path:lineno:first-line-of-match` format that the rest
+# of the script consumes like `grep -rn` output.
+#
+# `grep -rEn` is line-anchored, so `assert!(\n  !x.is_empty()` (the
+# multi-line form, very common when the assertion has a message arg)
+# slips through the line-by-line patterns above. Python's `re` with
+# `DOTALL` handles cross-line matches cleanly and gives us correct
+# line numbers; bash + grep can't easily do both.
+#
+# Args: $1 = tests dir, remaining args = patterns to find.
+find_multiline_in_rs() {
+    local dir="$1"
+    shift
+    python3 - "$dir" "$@" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+dir_arg = sys.argv[1]
+patterns = sys.argv[2:]
+for path in sorted(Path(dir_arg).rglob("*.rs")):
+    text = path.read_text()
+    for pat in patterns:
+        for m in re.finditer(pat, text, flags=re.DOTALL):
+            lineno = text.count("\n", 0, m.start()) + 1
+            first_line = m.group(0).split("\n", 1)[0]
+            print(f"{path}:{lineno}:{first_line}")
+PYEOF
+}
+
 # ----------------------------------------------------------------------
 # Policy 1: no weak count assertions on emission counts
 # ----------------------------------------------------------------------
@@ -100,10 +131,29 @@ echo "[1/2] weak count assertions"
 #
 # Per-match allowlist: `// allow weak-count: <reason>` within 5
 # leading lines.
-PAT_A='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*(>|>=)[[:space:]]*[0-9]+'
-PAT_B='assert_ne!\([^,]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^,]*,[[:space:]]*0[[:space:]]*[,)]'
-PAT_C='assert!\([[:space:]]*!.+\.is_empty\(\)'
-PAT_D='assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*!=[[:space:]]*0[[:space:]]*[,)]'
+# `(^|[^[:alnum:]_])` prefix is a word-boundary check. Without it,
+# `prop_assert!(...)` and `debug_assert!(...)` would match the
+# `assert!(...)` substring inside them. property tests legitimately
+# use lower-bound assertions (different inputs produce different
+# output shapes), and `debug_assert!` is for invariants, not test
+# coverage. Both should be ignored.
+WB='(^|[^[:alnum:]_])'
+PAT_A="${WB}"'assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*(>|>=)[[:space:]]*[0-9]+'
+PAT_B="${WB}"'assert_ne!\([^,]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^,]*,[[:space:]]*0[[:space:]]*[,)]'
+PAT_C="${WB}"'assert!\([[:space:]]*!.+\.is_empty\(\)'
+PAT_D="${WB}"'assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_(count|len|size)))[^)]*!=[[:space:]]*0[[:space:]]*[,)]'
+
+# Multi-line forms of the same shapes. The line-anchored ERE patterns
+# above miss `assert!(\n    !x.is_empty(), "msg"\n)` and friends, which
+# is the more common form when the assertion carries a message arg.
+# These run via Python (re.DOTALL) so newlines between `(` and the
+# operand don't break matching. Patterns mirror their single-line
+# siblings but use `\s*` (which includes `\n`), a bounded ident
+# match to avoid swallowing the rest of the file, and PCRE
+# negative-lookbehind to skip `prop_assert!` / `debug_assert!`.
+ML_PAT_C='(?<!\w)assert!\(\s*!\w[\w.]*\.is_empty\(\)'
+ML_PAT_B='(?<!\w)assert_ne!\(\s*\w[\w.()]*\s*,\s*0\s*[,)]'
+ML_PAT_D='(?<!\w)assert!\(\s*\w[\w.()]*\s*!=\s*0\s*[,)]'
 
 bad=""
 for pat in "$PAT_A" "$PAT_B" "$PAT_C" "$PAT_D"; do
@@ -116,6 +166,26 @@ for pat in "$PAT_A" "$PAT_B" "$PAT_C" "$PAT_D"; do
         fi
     done <<< "$matches"
 done
+
+# Multi-line scan. Filter out anything already caught by the
+# single-line passes above (same file:lineno) so we don't double-
+# report.
+ml_matches=$(find_multiline_in_rs "$TESTS_DIR" "$ML_PAT_C" "$ML_PAT_B" "$ML_PAT_D")
+if [ -n "$ml_matches" ]; then
+    while IFS= read -r match; do
+        [ -z "$match" ] && continue
+        # Skip if the same file:lineno already appears in `bad`
+        # (single-line pattern already caught it).
+        IFS=: read -r ml_file ml_lineno _ <<< "$match"
+        if grep -qF "${ml_file}:${ml_lineno}:" <<< "$bad"; then
+            continue
+        fi
+        if ! has_allow_above "$match" "allow weak-count"; then
+            bad="${bad}${match}"$'\n'
+        fi
+    done <<< "$ml_matches"
+fi
+
 bad="${bad%$'\n'}"
 
 if [ -n "$bad" ]; then

--- a/scripts/test-plugin-test-quality.sh
+++ b/scripts/test-plugin-test-quality.sh
@@ -115,6 +115,56 @@ run_case "shape D: assert!(price_count != 0)" 1 \
     '#[test] fn t() { let price_count = 0; assert!(price_count != 0); }'
 
 # ----------------------------------------------------------------------
+# Multi-line forms (the line-anchored grep above misses these — the
+# multi-line form is more common when the assert carries a message).
+# ----------------------------------------------------------------------
+
+run_case "multi-line shape C: assert!(\\\\n    !x.is_empty(),\\\\n    \"msg\"\\\\n)" 1 \
+    '#[test] fn t() {
+    assert!(
+        !output.errors.is_empty(),
+        "should warn"
+    );
+}'
+
+run_case "multi-line shape B: assert_ne!(\\\\n    x.len(),\\\\n    0\\\\n)" 1 \
+    '#[test] fn t() {
+    assert_ne!(
+        emitted.len(),
+        0
+    );
+}'
+
+run_case "multi-line shape D: assert!(\\\\n    x.len() != 0,\\\\n    \"msg\"\\\\n)" 1 \
+    '#[test] fn t() {
+    assert!(
+        emitted.len() != 0,
+        "msg"
+    );
+}'
+
+# ----------------------------------------------------------------------
+# Word-boundary guards: prop_assert! / debug_assert! must NOT match
+# even though they contain the literal substring `assert!`.
+# ----------------------------------------------------------------------
+
+run_case "prop_assert!(!x.is_empty()) does NOT fire (property tests)" 0 \
+    '#[test] fn t() {
+    prop_assert!(
+        !output.directives.is_empty(),
+        "Plugin should produce valid output"
+    );
+}'
+
+run_case "debug_assert!(!x.is_empty()) does NOT fire (invariant)" 0 \
+    'fn invariant() {
+    debug_assert!(
+        !cache.is_empty(),
+        "cache should be populated by init"
+    );
+}'
+
+# ----------------------------------------------------------------------
 # Allow annotation
 # ----------------------------------------------------------------------
 

--- a/scripts/test-plugin-test-quality.sh
+++ b/scripts/test-plugin-test-quality.sh
@@ -164,6 +164,26 @@ run_case "debug_assert!(!x.is_empty()) does NOT fire (invariant)" 0 \
     );
 }'
 
+# Multi-line ML_PAT_B/D used to match ANY `, 0` / `!= 0` assertion;
+# they're now scoped to count/len/size LHS the same as PAT_B/D
+# (Copilot review on PR #1005). These guards confirm non-count
+# zero-comparisons do NOT fire the lint.
+run_case "ML_PAT_B guard: assert_ne!(balance, 0) (non-count) does NOT fire" 0 \
+    '#[test] fn t() {
+    assert_ne!(
+        balance,
+        0
+    );
+}'
+
+run_case "ML_PAT_D guard: assert!(balance != 0) (non-count) does NOT fire" 0 \
+    '#[test] fn t() {
+    assert!(
+        balance != 0,
+        "should be non-zero"
+    );
+}'
+
 # ----------------------------------------------------------------------
 # Allow annotation
 # ----------------------------------------------------------------------


### PR DESCRIPTION
fix(ci): catch multi-line weak-count assertions in plugin-test lint

The lint script's regex was line-anchored (`grep -rEn`), so the
multi-line form of `assert!(...)` slipped through:

    assert!(
        !output.errors.is_empty(),
        "should warn about X"
    );

This is the more common form when the assertion has a message arg.
A scan of the current test file found 5 such uncaught instances —
each one is the same shape as the #992 bug (accepts "1 OR 100"
silently).

## Fix

Added a Python-based multi-line scan alongside the existing bash
grep. Python's `re.DOTALL` cleanly handles cross-line matches and
preserves correct line numbers; bash + grep can't easily do both.

Three new multi-line patterns mirror the single-line PAT_B/C/D
shapes. The single-line patterns also got a `(^|[^[:alnum:]_])`
word-boundary prefix and the multi-line ones got `(?<!\w)` — so
`prop_assert!(!x.is_empty())` and `debug_assert!(!x.is_empty())`
no longer false-positive (they contain the substring `assert!(`
but are semantically different).

The script now needs Python 3 — already a dep for several other
scripts (compat-bql-test.py, trace_to_rust_test.py).

## Tightened tests

Five existing tests had the multi-line `!is_empty()` shape:

- `test_check_commodity_undeclared` (line 1755)
- `test_auto_tag_adds_tag_for_expense` (line 3054)
- `test_pedantic_runs_multiple_validators` (line 3134)
- `test_sell_gains_warns_missing_gains_posting` (line 3220)
- `test_commodity_attr_error_with_missing_required_attr` (line 3277)

All five now use `assert_eq!(x.len(), 1, ...)` since each scenario
emits exactly one error/warning/tag. Verified locally (88/88 plugin
tests pass).

## Self-test

Extended `scripts/test-plugin-test-quality.sh` with 5 new cases
(21 → 26 total): 3 multi-line shape cases + 2 false-positive
guards (`prop_assert!`, `debug_assert!` must not fire).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
