### PR TITLE
ci(lint): add ML_PAT_A multi-line variant for weak `>= N` count assertions

### DIFF
--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -3815,15 +3815,16 @@ fn test_check_drained_adds_balance_assertions_on_close() {
     ]);
     let output = plugin.process(input);
     assert!(output.errors.is_empty());
-    // Should have added balance assertion directives
-    let balance_count = output
-        .directives
-        .iter()
-        .filter(|d| d.directive_type == "balance")
-        .count();
-    assert!(
-        balance_count > 0,
-        "should insert balance assertions after close"
+    // Should have added a balance assertion per (closed account,
+    // currency). Here: one Close on Assets:Bank (USD only) → 1 balance.
+    assert_eq!(
+        output
+            .directives
+            .iter()
+            .filter(|d| d.directive_type == "balance")
+            .count(),
+        1,
+        "exactly one balance assertion for the single closed account+currency"
     );
 }
 

--- a/scripts/check-plugin-test-quality.sh
+++ b/scripts/check-plugin-test-quality.sh
@@ -159,6 +159,7 @@ PAT_D="${WB}"'assert!\([^)]*((\.(count|len|size)\(\))|\b(count|len|size|[a-z_]+_
 # would false-positive on every `assert_ne!(balance, 0)` style check
 # (Copilot review on PR #1005).
 COUNT_LHS='(?:\w[\w.]*\.(?:count|len|size)\(\)|(?:\w+_)?(?:count|len|size))'
+ML_PAT_A='(?<!\w)assert!\(\s*'"$COUNT_LHS"'\s*(?:>|>=)\s*\d+'
 ML_PAT_C='(?<!\w)assert!\(\s*!\w[\w.]*\.is_empty\(\)'
 ML_PAT_B='(?<!\w)assert_ne!\(\s*'"$COUNT_LHS"'\s*,\s*0\s*[,)]'
 ML_PAT_D='(?<!\w)assert!\(\s*'"$COUNT_LHS"'\s*!=\s*0\s*[,)]'
@@ -178,7 +179,7 @@ done
 # Multi-line scan. Filter out anything already caught by the
 # single-line passes above (same file:lineno) so we don't double-
 # report.
-ml_matches=$(find_multiline_in_rs "$TESTS_DIR" "$ML_PAT_C" "$ML_PAT_B" "$ML_PAT_D")
+ml_matches=$(find_multiline_in_rs "$TESTS_DIR" "$ML_PAT_A" "$ML_PAT_B" "$ML_PAT_C" "$ML_PAT_D")
 if [ -n "$ml_matches" ]; then
     while IFS= read -r match; do
         [ -z "$match" ] && continue

--- a/scripts/test-plugin-test-quality.sh
+++ b/scripts/test-plugin-test-quality.sh
@@ -119,6 +119,38 @@ run_case "shape D: assert!(price_count != 0)" 1 \
 # multi-line form is more common when the assert carries a message).
 # ----------------------------------------------------------------------
 
+run_case "multi-line shape A: assert!(\\\\n    x.len() >= 1,\\\\n    \"msg\"\\\\n)" 1 \
+    '#[test] fn t() {
+    assert!(
+        emitted.len() >= 1,
+        "should emit at least one"
+    );
+}'
+
+run_case "multi-line shape A: assert!(\\\\n    price_count >= 1\\\\n) (precomputed — original #992 shape)" 1 \
+    '#[test] fn t() {
+    let price_count = 0;
+    assert!(
+        price_count >= 1,
+        "got at least one price"
+    );
+}'
+
+run_case "multi-line shape A: assert!(\\\\n    x.count() > 0\\\\n)" 1 \
+    '#[test] fn t() {
+    assert!(
+        items.count() > 0
+    );
+}'
+
+run_case "ML_PAT_A guard: prop_assert!(\\\\n    x.len() >= 1\\\\n) does NOT fire" 0 \
+    '#[test] fn t() {
+    prop_assert!(
+        emitted.len() >= 1,
+        "Plugin should produce output"
+    );
+}'
+
 run_case "multi-line shape C: assert!(\\\\n    !x.is_empty(),\\\\n    \"msg\"\\\\n)" 1 \
     '#[test] fn t() {
     assert!(


### PR DESCRIPTION
ci(lint): add ML_PAT_A multi-line variant for weak `>= N` count assertions

Closes #1011.

## What

`scripts/check-plugin-test-quality.sh` had multi-line variants for
shapes B (`assert_ne!`), C (`!is_empty()`), and D (`!= 0`) added in
#1005. Shape A — `assert!(x.len() >= N)` / precomputed-count — only
had its single-line PAT_A. So a multi-line write of the original
#992 bug shape:

    assert!(
        txn_count >= 3,
        "forecast should expand to at least 3 transactions"
    );

slipped past the lint. PR #1008 caught one such instance by hand;
PR #1012 caught two more.

## Fix

Added `ML_PAT_A` mirroring single-line `PAT_A` with the same
count-shaped LHS restriction (`COUNT_LHS`) and the negative
lookbehind for `prop_assert!`/`debug_assert!` that the other
multi-line patterns already use:

    ML_PAT_A='(?<!\w)assert!\(\s*'"$COUNT_LHS"'\s*(?:>|>=)\s*\d+'

Wired into the existing `find_multiline_in_rs` call.

## Knock-on: tightened one existing test

The new pattern caught a real instance in
`test_check_drained_adds_balance_assertions_on_close`:

    assert!(
        balance_count > 0,
        "should insert balance assertions after close"
    );

The plugin emits exactly one balance assertion per (closed account,
currency); test setup has one Close on Assets:Bank with USD only,
so we expect 1. Tightened to `assert_eq!(.count(), 1, ...)`.

## Self-test

Extended `scripts/test-plugin-test-quality.sh` with 4 new cases
(28 → 32 total):
- multi-line `assert!(\n    x.len() >= 1,\n    "msg"\n)`
- multi-line `assert!(\n    price_count >= 1\n)` (the actual #992 shape)
- multi-line `assert!(\n    x.count() > 0\n)`
- false-positive guard: multi-line `prop_assert!(\n    x.len() >= 1\n)`
  must NOT fire

## Verified

- 143/143 plugin tests pass (one pre-existing test tightened, no new
  test functions)
- `scripts/check-plugin-test-quality.sh`: OK (clean on current main)
- `scripts/test-plugin-test-quality.sh`: 32/32
- `cargo clippy -p rustledger-plugin --all-features --all-targets`:
  clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
