### PR TITLE
fix(plugin): long_short falls through cleanly when reduction lacks cost date

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
+++ b/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
@@ -154,6 +154,24 @@ fn process_long_short(input: PluginInput) -> PluginOutput {
                 continue;
             };
 
+            // Fall through if ANY reduction lacks a parseable cost
+            // date. Without it the plugin can't classify holding
+            // period, and pre-fix (issue #1010) it would silently
+            // drop the generic Income:Capital-Gains posting in the
+            // post-loop filter, leaving the transaction unbalanced.
+            // Falling through preserves the user's ledger.
+            let any_missing_cost_date = reductions.iter().any(|p| {
+                p.cost
+                    .as_ref()
+                    .and_then(|c| c.date.as_ref())
+                    .and_then(|d| d.parse::<NaiveDate>().ok())
+                    .is_none()
+            });
+            if any_missing_cost_date {
+                new_directives.push(directive);
+                continue;
+            }
+
             let mut short_gains = Decimal::ZERO;
             let mut long_gains = Decimal::ZERO;
 

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -6493,18 +6493,17 @@ fn test_capital_gains_long_short_classifies_long_term() {
 
 /// Reduction posting with NO cost date, generic `Income:Capital-Gains`
 /// posting present. The plugin reaches the classification loop but
-/// can't compute holding period from a date-less cost, so neither
-/// `short_gains` nor `long_gains` accumulates anything.
+/// can't compute holding period from a date-less cost.
 ///
-/// CURRENT BEHAVIOR (this test pins it): the generic Income:
-/// Capital-Gains posting is silently DROPPED and no :Short/:Long
-/// replacement is emitted, leaving the transaction unbalanced. This
-/// is almost certainly a bug in the plugin (it should either fall
-/// through the whole transaction unchanged when classification
-/// fails, or surface an error). When it gets fixed, this test
-/// should be updated to assert the new behavior.
+/// FIXED behavior (issue #1010): the plugin now falls through the
+/// entire transaction unchanged when any reduction lacks a parseable
+/// cost date. Pre-fix it would silently drop the generic Income:
+/// Capital-Gains posting in the post-loop filter, leaving the
+/// transaction unbalanced. This test pins the corrected behavior:
+/// the original transaction (with the Income:Capital-Gains posting
+/// intact) is preserved and no :Short/:Long replacement is emitted.
 #[test]
-fn test_capital_gains_long_short_no_cost_date_drops_generic_posting() {
+fn test_capital_gains_long_short_no_cost_date_passes_through_unchanged() {
     let plugin = CapitalGainsLongShortPlugin;
     // Build a transaction with:
     //   - a reduction posting (cost+units+price), but cost.date = None
@@ -6598,8 +6597,8 @@ fn test_capital_gains_long_short_no_cost_date_drops_generic_posting() {
         );
     };
 
-    // No :Short or :Long replacement was added (gains stayed at 0
-    // because the loop couldn't classify without a cost date).
+    // No :Short or :Long replacement is emitted — the plugin now
+    // falls through entirely when classification is impossible.
     assert_eq!(
         data.postings
             .iter()
@@ -6610,21 +6609,26 @@ fn test_capital_gains_long_short_no_cost_date_drops_generic_posting() {
         "no Short/Long postings emitted when cost_date is missing"
     );
 
-    // CURRENT BEHAVIOR: the generic Income:Capital-Gains posting was
-    // silently dropped by the post-loop filter. This leaves the
-    // transaction unbalanced — likely a plugin bug. If a future PR
-    // fixes the plugin to fall through cleanly when classification
-    // fails (preserving the original generic posting), update this
-    // assertion to expect the posting to be present.
+    // The generic Income:Capital-Gains posting is PRESERVED — the
+    // pre-fix behavior of silently dropping it (issue #1010) would
+    // leave the transaction unbalanced. The fix: skip the whole
+    // transaction when any reduction lacks a cost date.
     assert_eq!(
         data.postings
             .iter()
             .filter(|p| p.account == "Income:Capital-Gains")
             .count(),
-        0,
-        "generic Income:Capital-Gains posting is currently dropped — \
-         likely plugin bug; this test pins the behavior so a future fix \
-         is caught"
+        1,
+        "generic Income:Capital-Gains posting must be preserved when \
+         the plugin falls through (issue #1010 fix)"
+    );
+
+    // The full transaction is unchanged — same number of postings as
+    // input (asset + cash + Income:Capital-Gains = 3).
+    assert_eq!(
+        data.postings.len(),
+        3,
+        "all three input postings preserved on fall-through"
     );
 }
 


### PR DESCRIPTION
fix(plugin): long_short falls through cleanly when reduction lacks cost date

Closes #1010.

## Bug

The `long_short` capital-gains classifier silently dropped the
generic `Income:Capital-Gains` posting from a transaction whenever
any reduction posting (cost+units+price) had `cost.date == None`.

Trace:

1. `has_generic = true` → plugin enters the rewrite path
2. `reductions` is non-empty → past the early-return
3. The reduction loop's `if let Some(cost_date) = cost_date` skips
   gain accumulation when the date is missing → `short_gains` and
   `long_gains` stay at 0
4. `new_postings` is built by FILTERING OUT the matching generic
   postings
5. Both `short_gains != 0` and `long_gains != 0` are false → no
   :Short / :Long replacement is emitted
6. The synthesized transaction is pushed with the generic
   Income:Capital-Gains posting silently removed → unbalanced

## Fix

Detect the condition early and fall through the entire transaction
unchanged. Right after parsing `entry_date`:

    let any_missing_cost_date = reductions.iter().any(|p| {
        p.cost.as_ref()
            .and_then(|c| c.date.as_ref())
            .and_then(|d| d.parse::<NaiveDate>().ok())
            .is_none()
    });
    if any_missing_cost_date {
        new_directives.push(directive);
        continue;
    }

Matches the early-return pattern already used elsewhere in the
plugin when classification is impossible (e.g., unparsable
`entry_date`).

## Test

Renamed and inverted
`test_capital_gains_long_short_no_cost_date_drops_generic_posting`
→ `..._passes_through_unchanged`. Now asserts:

- No :Short or :Long replacement is emitted (gains stay at 0)
- The generic `Income:Capital-Gains` posting IS preserved
- The transaction's full posting count is unchanged (3 → 3)

Pre-fix the test pinned the buggy behavior with a comment noting
"this is almost certainly a plugin bug." The PR that introduced
the test (#1007) is referenced in the issue.

## Verified

- 143/143 plugin integration tests pass
- Lint OK, clippy clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
