### PR TITLE
ci(bench): harden hyperfine/ledger/hledger install against silent failures

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -35,12 +35,21 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           pip install beancount
 
-          # Hyperfine
-          HYPERFINE_VERSION=$(curl -s https://api.github.com/repos/sharkdp/hyperfine/releases/latest | jq -r '.tag_name')
-          curl -sL "https://github.com/sharkdp/hyperfine/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
+          # Hyperfine — use authenticated `gh api` (5000/hr rate limit
+          # vs 60/hr unauth) and `curl -f` so an HTTP error fails the
+          # step rather than piping a 404 page into tar.
+          HYPERFINE_VERSION=$(gh api repos/sharkdp/hyperfine/releases/latest --jq '.tag_name')
+          if [ -z "${HYPERFINE_VERSION:-}" ] || [ "$HYPERFINE_VERSION" = "null" ]; then
+            echo "::error::Failed to fetch hyperfine latest release tag" >&2
+            exit 1
+          fi
+          curl -sSfL "https://github.com/sharkdp/hyperfine/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
           sudo mv "/tmp/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine" /usr/local/bin/
       - name: Build rustledger
         run: cargo build --release -p rustledger --no-default-features

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,7 +53,10 @@ jobs:
         with:
           node-version: '22'
       - name: Install dependencies
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           # Python beancount + beanquery (for BQL)
           pip install beancount beanquery
 
@@ -66,22 +69,36 @@ jobs:
             libboost-date-time-dev libboost-filesystem-dev libboost-iostreams-dev \
             libboost-regex-dev libboost-test-dev libedit-dev libgmp3-dev libmpfr-dev
 
-          # hledger (Haskell) - pre-built binary from GitHub
-          curl -sL https://github.com/simonmichael/hledger/releases/latest/download/hledger-linux-x64.tar.gz | tar xz -C /tmp
+          # hledger (Haskell) — `curl -f` so a 404 fails loudly instead
+          # of piping HTML into tar.
+          curl -sSfL https://github.com/simonmichael/hledger/releases/latest/download/hledger-linux-x64.tar.gz | tar xz -C /tmp
           sudo mv /tmp/hledger /usr/local/bin/
 
-          # Hyperfine for accurate benchmarking (use latest release)
-          HYPERFINE_VERSION=$(curl -s https://api.github.com/repos/sharkdp/hyperfine/releases/latest | jq -r '.tag_name')
-          curl -sL "https://github.com/sharkdp/hyperfine/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
+          # Hyperfine — authenticated `gh api` (5000/hr vs 60/hr) and
+          # `curl -f` so download errors don't cascade into "not in
+          # gzip format" (see issue surfaced in PR #1015 CI).
+          HYPERFINE_VERSION=$(gh api repos/sharkdp/hyperfine/releases/latest --jq '.tag_name')
+          if [ -z "${HYPERFINE_VERSION:-}" ] || [ "$HYPERFINE_VERSION" = "null" ]; then
+            echo "::error::Failed to fetch hyperfine latest release tag" >&2
+            exit 1
+          fi
+          curl -sSfL "https://github.com/sharkdp/hyperfine/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
           sudo mv "/tmp/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine" /usr/local/bin/
       - name: Build ledger from source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get latest release tag from GitHub API
-          LEDGER_VERSION=$(curl -s https://api.github.com/repos/ledger/ledger/releases/latest | jq -r '.tag_name')
+          set -euo pipefail
+          # Get latest release tag from GitHub API (authenticated).
+          LEDGER_VERSION=$(gh api repos/ledger/ledger/releases/latest --jq '.tag_name')
+          if [ -z "${LEDGER_VERSION:-}" ] || [ "$LEDGER_VERSION" = "null" ]; then
+            echo "::error::Failed to fetch ledger latest release tag" >&2
+            exit 1
+          fi
           echo "Building ledger ${LEDGER_VERSION}"
 
           cd /tmp
-          curl -sL "https://github.com/ledger/ledger/archive/refs/tags/${LEDGER_VERSION}.tar.gz" | tar xz
+          curl -sSfL "https://github.com/ledger/ledger/archive/refs/tags/${LEDGER_VERSION}.tar.gz" | tar xz
           cd "ledger-${LEDGER_VERSION#v}"
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_DOCS=OFF -DBUILD_WEB_DOCS=OFF
           cmake --build build --parallel $(nproc)
@@ -553,16 +570,23 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           pip install beancount beanquery
 
-          # hledger binary
-          curl -sL https://github.com/simonmichael/hledger/releases/latest/download/hledger-linux-x64.tar.gz | tar xz -C /tmp
+          # hledger binary — `curl -f` so HTTP errors fail the step.
+          curl -sSfL https://github.com/simonmichael/hledger/releases/latest/download/hledger-linux-x64.tar.gz | tar xz -C /tmp
           sudo mv /tmp/hledger /usr/local/bin/
 
-          # Hyperfine
-          HYPERFINE_VERSION=$(curl -s https://api.github.com/repos/sharkdp/hyperfine/releases/latest | jq -r '.tag_name')
-          curl -sL "https://github.com/sharkdp/hyperfine/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
+          # Hyperfine — authenticated lookup + hard-fail on download.
+          HYPERFINE_VERSION=$(gh api repos/sharkdp/hyperfine/releases/latest --jq '.tag_name')
+          if [ -z "${HYPERFINE_VERSION:-}" ] || [ "$HYPERFINE_VERSION" = "null" ]; then
+            echo "::error::Failed to fetch hyperfine latest release tag" >&2
+            exit 1
+          fi
+          curl -sSfL "https://github.com/sharkdp/hyperfine/releases/download/${HYPERFINE_VERSION}/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar xz -C /tmp
           sudo mv "/tmp/hyperfine-${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine" /usr/local/bin/
       - name: Build rustledger
         run: cargo build --release -p rustledger --no-default-features


### PR DESCRIPTION
## Summary

The `bench-pr` workflow failed on PR #1015 with `gzip: stdin: not in gzip format`. Root cause: the install step pattern was

```bash
HYPERFINE_VERSION=$(curl -s API | jq -r '.tag_name')
curl -sL "https://github.com/.../${HYPERFINE_VERSION}/..." | tar xz
```

When the **unauthenticated** GitHub API rate-limited the first call, `jq` returned `null`, and the next download grabbed a 404 page that wasn't a tarball. Both `curl -s` and `curl -sL` swallowed all errors — exactly the failure mode flagged in earlier feedback about silent error swallowing.

## Changes

Hardened all 5 install spots across `bench-pr.yml` and `bench.yml`:

- **`gh api` instead of `curl -s | jq`** for release-tag lookups. Authenticated via `GITHUB_TOKEN`, bumping rate limit from 60/hr to 5000/hr (the previous limit is shared across the runner-pool IP, so even one PR per minute can exhaust it).
- **`curl -sSfL` instead of `curl -sL`** for binary downloads (`-S` shows errors, `-f` fails on HTTP errors). A 404 now fails the step with a clean curl error instead of piping HTML to tar.
- **`set -euo pipefail`** so pipe failures and unset vars surface immediately.
- **Explicit null/empty check** on the version string as defense-in-depth.

## Why no functional change to passing runs

The hardening only changes failure behavior. When the API call succeeds and the download is a real tarball (the 99% case), the workflow runs identically. When it fails, the error message changes from "not in gzip format" to a clear annotation like:

```
::error::Failed to fetch hyperfine latest release tag
```

## Test plan

- [x] `actionlint` introduces no new findings on touched lines (pre-existing shellcheck info-level warnings on other lines remain)
- [x] YAML structure preserved (verified via Read)
- [x] No `|| true` / `2>/dev/null` patterns introduced (matches saved no-error-swallowing rule)
- [ ] CI: `PR Benchmarks` workflow runs on this PR and either succeeds (download path works) or fails loudly with a meaningful error (validates the hardening worked)

## Files changed

- `.github/workflows/bench-pr.yml` — 1 install block hardened
- `.github/workflows/bench.yml` — 4 install blocks hardened (main job: hledger + hyperfine + ledger; scaling job: hledger + hyperfine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)