### PR TITLE
fix(query): drop leading space inside cost-spec braces in BQL output

### DIFF
--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -276,7 +276,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
                 let mut s = ctx.format_amount(p.units.number, p.units.currency.as_str());
                 if let Some(ref cost) = p.cost {
                     s.push_str(&format!(
-                        " {{ {}}}",
+                        " {{{}}}",
                         ctx.format_amount(cost.number, cost.currency.as_str())
                     ));
                 }
@@ -343,7 +343,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
                         let mut s = ctx.format_amount(p.units.number, p.units.currency.as_str());
                         if let Some(ref cost) = p.cost {
                             s.push_str(&format!(
-                                " {{ {}}}",
+                                " {{{}}}",
                                 ctx.format_amount(cost.number, cost.currency.as_str())
                             ));
                         }
@@ -453,5 +453,62 @@ fn escape_csv(s: &str) -> String {
         format!("\"{}\"", s.replace('"', "\"\""))
     } else {
         s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+    use rustledger_core::{Amount, Cost, Inventory, Position};
+
+    /// Issue #987: cost-spec braces in BQL output had a leading space
+    /// inside the open brace (`{ 128.99 USD}` instead of `{128.99 USD}`),
+    /// diverging from `bean-query`. Pin both the `Position` and
+    /// `Inventory` paths so a future change to the format string can't
+    /// silently regress.
+    #[test]
+    fn test_position_with_cost_renders_without_leading_space_inside_braces() {
+        let pos = Position::with_cost(
+            Amount::new(dec!(8.373), "RGAGX"),
+            Cost::new(dec!(128.99), "USD"),
+        );
+        let value = Value::Position(Box::new(pos));
+        let ctx = DisplayContext::new();
+        let rendered = format_value(&value, false, &ctx);
+
+        assert!(
+            !rendered.contains("{ "),
+            "expected no leading space after `{{`, got {rendered:?}"
+        );
+        assert!(
+            rendered.contains("{128.99 USD}"),
+            "expected `{{128.99 USD}}` in output, got {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn test_inventory_with_cost_renders_without_leading_space_inside_braces() {
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(8.373), "RGAGX"),
+            Cost::new(dec!(128.99), "USD"),
+        ));
+        inv.add(Position::with_cost(
+            Amount::new(dec!(8.199), "RGAGX"),
+            Cost::new(dec!(131.73), "USD"),
+        ));
+        let value = Value::Inventory(Box::new(inv));
+        let ctx = DisplayContext::new();
+        let rendered = format_value(&value, false, &ctx);
+
+        assert!(
+            !rendered.contains("{ "),
+            "expected no leading space after `{{`, got {rendered:?}"
+        );
+        assert!(
+            rendered.contains("{128.99 USD}") && rendered.contains("{131.73 USD}"),
+            "expected both costs rendered without leading space, got {rendered:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`rledger query` rendered positions with a leading space inside the cost-spec braces — `{ 128.99 USD}` — while `bean-query` doesn't:

```
# rledger (pre-fix)
Assets:US:Vanguard:RGAGX  8.373 RGAGX { 128.99 USD}  8.199 RGAGX { 131.73 USD}

# bean-query
Assets:US:Vanguard:RGAGX  8.373 RGAGX {128.99 USD}  8.199 RGAGX {131.73 USD}
```

Of the 99 remaining BQL compat mismatches identified alongside #986, **83 were this single rendering bug**. Fixing it pushes BQL parity from 78% → ~96% on the local 30-file corpus.

## Root cause

Two `format!(" {{ {}}}", ...)` calls in `crates/rustledger/src/cmd/query/output.rs` (the `Value::Position` and `Value::Inventory` arms) — the format string expanded to `" { COST}"`. The core `format_cost_spec` helper in `rustledger-core/src/format/amount.rs` was already correct; the divergence was local to the BQL output formatter.

## Changes

- `crates/rustledger/src/cmd/query/output.rs:279,346` — drop the leading space inside the braces.
- Add unit tests for the `Value::Position` and `Value::Inventory` rendering paths. No snapshot tests pinned the buggy output (which is how it shipped); the new tests assert the rendered string contains `{COST}` and does NOT contain `{ ` so a future format-string change can't silently regress.

## Test plan

- [x] `cargo test -p rustledger --lib cmd::query::output` — both new tests pass.
- [x] `cargo clippy -p rustledger --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Pre-push hooks pass.
- [ ] Maintainer-side BQL compat harness should show ~83 mismatches resolved (per issue #987 acceptance criteria).

## Out of scope

Per the issue: cost label rendering (`{COST, "label"}`) and `rledger format`'s round-trip beancount formatter are explicitly out of scope; this PR only touches the query output path.

Closes #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)