### PR TITLE
fix(query): quantize SUM-aggregate text output via GROUP BY currency

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -105,7 +105,7 @@ impl Executor<'_> {
 
             // Group and aggregate
             let grouped = self.group_postings(&postings, group_by_exprs.as_ref())?;
-            for (_, group) in grouped {
+            for (group_key, group) in grouped {
                 // Use extended_targets to include hidden columns for ORDER BY
                 let row = self.evaluate_aggregate_row(&extended_targets, &group)?;
 
@@ -123,7 +123,10 @@ impl Executor<'_> {
                     continue;
                 }
 
-                result.add_row(row);
+                // Carry the GROUP BY key alongside the aggregated row so the
+                // text renderer can recover per-row currency context for
+                // numeric aggregates (issue #988).
+                result.add_aggregate_row(row, group_key);
             }
         } else {
             // Check if query has window functions

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -224,7 +224,7 @@ impl Executor<'_> {
 
         // Apply LIMIT
         if let Some(limit) = query.limit {
-            result.rows.truncate(limit as usize);
+            result.truncate(limit as usize);
         }
 
         Ok(result)
@@ -338,7 +338,7 @@ impl Executor<'_> {
 
         // Apply LIMIT
         if let Some(limit) = outer_query.limit {
-            result.rows.truncate(limit as usize);
+            result.truncate(limit as usize);
         }
 
         Ok(result)
@@ -460,7 +460,7 @@ impl Executor<'_> {
 
         // Apply LIMIT
         if let Some(limit) = query.limit {
-            result.rows.truncate(limit as usize);
+            result.truncate(limit as usize);
         }
 
         Ok(result)
@@ -590,7 +590,7 @@ impl Executor<'_> {
 
         // Apply LIMIT
         if let Some(limit) = query.limit {
-            result.rows.truncate(limit as usize);
+            result.truncate(limit as usize);
         }
 
         Ok(result)

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -67,8 +67,10 @@ impl Executor<'_> {
             sort_specs.push((idx, ascending));
         }
 
-        // Sort the rows
-        result.rows.sort_by(|a, b| {
+        // Sort the rows. Use `QueryResult::sort_by` (not `result.rows.sort_by`)
+        // so the per-row `row_group_keys` sidecar stays in lockstep — see
+        // issue #988 / PR #1022 review.
+        result.sort_by(|a, b| {
             for (idx, ascending) in &sort_specs {
                 if *idx >= a.len() || *idx >= b.len() {
                     continue;

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -68,8 +68,9 @@ impl Executor<'_> {
         }
 
         // Sort the rows. Use `QueryResult::sort_by` (not `result.rows.sort_by`)
-        // so the per-row `row_group_keys` sidecar stays in lockstep — see
-        // issue #988 / PR #1022 review.
+        // so the per-row `row_group_keys` sidecar stays in lockstep — without
+        // this, the renderer would apply a row's currency hint to a different
+        // row's content after sort.
         result.sort_by(|a, b| {
             for (idx, ascending) in &sort_specs {
                 if *idx >= a.len() || *idx >= b.len() {

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -246,11 +246,11 @@ pub struct QueryResult {
     /// context for `Value::Number` cells emitted by `SUM` / `AVG` (issue
     /// #988 — display-precision fix that stays lossless for JSON/CSV).
     ///
-    /// Reach in directly only inside `rustledger-query` and only with
-    /// extreme care — every mutation must be matched by a parallel
-    /// mutation to `rows`. External crates should use `group_key()`.
-    #[doc(hidden)]
-    pub row_group_keys: Vec<Option<Vec<Value>>>,
+    /// `pub(crate)` so external consumers can't accidentally violate the
+    /// parallel-vector invariant; reach in directly only inside this crate
+    /// and only with extreme care. External access goes through
+    /// [`Self::group_key`].
+    pub(crate) row_group_keys: Vec<Option<Vec<Value>>>,
 }
 
 impl QueryResult {
@@ -264,6 +264,9 @@ impl QueryResult {
     }
 
     /// Add a row to the result with no GROUP BY context (non-aggregate path).
+    /// The sidecar (`row_group_keys`) records `None` for this row, so the
+    /// text renderer applies no per-currency quantization (issue #988).
+    /// Aggregate paths must use [`Self::add_aggregate_row`] instead.
     pub fn add_row(&mut self, row: Row) {
         self.rows.push(row);
         self.row_group_keys.push(None);
@@ -512,5 +515,23 @@ mod tests {
         r.add_aggregate_row(vec![Value::Integer(42)], vec![]);
 
         assert_eq!(r.group_key(0), None);
+    }
+
+    /// `sort_by`'s lockstep invariant is enforced by an unconditional
+    /// `assert_eq!`. This test deliberately corrupts the sidecar (by
+    /// pushing to `rows` without a matching push to `row_group_keys`)
+    /// then calls `sort_by`, expecting a panic. Pins the safety net
+    /// against accidental removal of the assert.
+    #[test]
+    #[should_panic(expected = "QueryResult invariant violated")]
+    fn test_sort_by_panics_on_lockstep_violation() {
+        let mut r = QueryResult::new(vec!["x".into()]);
+        // Reach in directly to corrupt the sidecar — the only way to
+        // hit the assert without going through the helpers (which are
+        // designed to make it impossible). Available because tests live
+        // inside `rustledger-query` and `row_group_keys` is `pub(crate)`.
+        r.rows.push(vec![Value::Integer(1)]);
+        // Deliberately skip pushing to `row_group_keys`.
+        r.sort_by(|_, _| std::cmp::Ordering::Equal);
     }
 }

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -297,9 +297,20 @@ impl QueryResult {
     /// row index is out of range. This is the public read-side of the
     /// `row_group_keys` sidecar — prefer it over reaching into the
     /// field directly.
+    ///
+    /// Returns `&[Value]` rather than `&Vec<Value>` so callers aren't
+    /// tied to the specific container type.
     #[must_use]
-    pub fn group_key(&self, row_idx: usize) -> Option<&Vec<Value>> {
-        self.row_group_keys.get(row_idx).and_then(|k| k.as_ref())
+    pub fn group_key(&self, row_idx: usize) -> Option<&[Value]> {
+        self.row_group_keys.get(row_idx).and_then(|k| k.as_deref())
+    }
+
+    /// Whether any row in the result was produced by aggregation. Lets
+    /// downstream renderers short-circuit per-row hint lookups when
+    /// the cache would be all `None` anyway (issue #988 follow-up).
+    #[must_use]
+    pub fn has_aggregate_rows(&self) -> bool {
+        self.row_group_keys.iter().any(Option::is_some)
     }
 
     /// Truncate to the first `len` rows, keeping `row_group_keys` in
@@ -325,11 +336,16 @@ impl QueryResult {
             self.row_group_keys.len(),
             "QueryResult invariant violated: rows.len() must equal row_group_keys.len()"
         );
+        let n = self.rows.len();
         let mut paired: Vec<(Row, Option<Vec<Value>>)> = std::mem::take(&mut self.rows)
             .into_iter()
             .zip(std::mem::take(&mut self.row_group_keys))
             .collect();
         paired.sort_by(|(a, _), (b, _)| compare(a, b));
+        // Pre-allocate the now-empty Vecs back to known capacity to skip
+        // the incremental-grow allocations during push-back.
+        self.rows.reserve_exact(n);
+        self.row_group_keys.reserve_exact(n);
         for (row, key) in paired {
             self.rows.push(row);
             self.row_group_keys.push(key);
@@ -468,9 +484,9 @@ mod tests {
 
         // After sort, row[0] is EUR, row[1] is GBP, row[2] is USD.
         // The sidecar MUST have followed.
-        assert_eq!(r.group_key(0), Some(&vec![Value::String("EUR".into())]));
-        assert_eq!(r.group_key(1), Some(&vec![Value::String("GBP".into())]));
-        assert_eq!(r.group_key(2), Some(&vec![Value::String("USD".into())]));
+        assert_eq!(r.group_key(0), Some(&[Value::String("EUR".into())][..]));
+        assert_eq!(r.group_key(1), Some(&[Value::String("GBP".into())][..]));
+        assert_eq!(r.group_key(2), Some(&[Value::String("USD".into())][..]));
     }
 
     /// `truncate` drops the same suffix from rows AND `row_group_keys`.
@@ -482,8 +498,8 @@ mod tests {
         assert_eq!(r.rows.len(), 2);
         assert_eq!(r.row_group_keys.len(), 2);
         // Surviving keys are the first two: USD, EUR.
-        assert_eq!(r.group_key(0), Some(&vec![Value::String("USD".into())]));
-        assert_eq!(r.group_key(1), Some(&vec![Value::String("EUR".into())]));
+        assert_eq!(r.group_key(0), Some(&[Value::String("USD".into())][..]));
+        assert_eq!(r.group_key(1), Some(&[Value::String("EUR".into())][..]));
         // Out-of-range index returns None gracefully.
         assert_eq!(r.group_key(2), None);
     }
@@ -501,9 +517,9 @@ mod tests {
 
         assert_eq!(r.rows.len(), 3);
         assert_eq!(r.row_group_keys.len(), 3);
-        assert_eq!(r.group_key(0), Some(&vec![Value::String("USD".into())]));
+        assert_eq!(r.group_key(0), Some(&[Value::String("USD".into())][..]));
         assert_eq!(r.group_key(1), None);
-        assert_eq!(r.group_key(2), Some(&vec![Value::String("EUR".into())]));
+        assert_eq!(r.group_key(2), Some(&[Value::String("EUR".into())][..]));
     }
 
     /// Empty `group_key` arg means "no GROUP BY context" — sidecar
@@ -533,5 +549,19 @@ mod tests {
         r.rows.push(vec![Value::Integer(1)]);
         // Deliberately skip pushing to `row_group_keys`.
         r.sort_by(|_, _| std::cmp::Ordering::Equal);
+    }
+
+    /// Direct test for `add_row`: the non-aggregate path records `None`
+    /// in the sidecar, keeping the parallel-vector invariant. Covered
+    /// indirectly by `test_add_row_and_add_aggregate_row_mixed` but
+    /// pinned standalone here so the contract is unambiguous.
+    #[test]
+    fn test_add_row_records_none_in_sidecar() {
+        let mut r = QueryResult::new(vec!["x".into()]);
+        r.add_row(vec![Value::Integer(1)]);
+
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.row_group_keys.len(), 1);
+        assert_eq!(r.group_key(0), None);
     }
 }

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -234,6 +234,12 @@ pub struct QueryResult {
     pub columns: Vec<String>,
     /// Result rows.
     pub rows: Vec<Row>,
+    /// Per-row GROUP BY key values, parallel to `rows`. `None` for rows
+    /// produced outside aggregation. Populated by the aggregate execution
+    /// path; used by the text renderer to recover the per-row currency
+    /// context for `Value::Number` cells emitted by `SUM` / `AVG` (issue
+    /// #988 — display-precision fix that stays lossless for JSON/CSV).
+    pub row_group_keys: Vec<Option<Vec<Value>>>,
 }
 
 impl QueryResult {
@@ -242,12 +248,26 @@ impl QueryResult {
         Self {
             columns,
             rows: Vec::new(),
+            row_group_keys: Vec::new(),
         }
     }
 
-    /// Add a row to the result.
+    /// Add a row to the result with no GROUP BY context (non-aggregate path).
     pub fn add_row(&mut self, row: Row) {
         self.rows.push(row);
+        self.row_group_keys.push(None);
+    }
+
+    /// Add a row produced by aggregation, recording the GROUP BY key values
+    /// alongside it. The renderer consults the key to quantize numeric
+    /// aggregates against the per-currency display precision (issue #988).
+    pub fn add_aggregate_row(&mut self, row: Row, group_key: Vec<Value>) {
+        self.rows.push(row);
+        self.row_group_keys.push(if group_key.is_empty() {
+            None
+        } else {
+            Some(group_key)
+        });
     }
 
     /// Number of rows.

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -270,6 +270,33 @@ impl QueryResult {
         });
     }
 
+    /// Truncate to the first `len` rows, keeping `row_group_keys` in
+    /// lockstep so the parallel-vector invariant survives LIMIT.
+    pub fn truncate(&mut self, len: usize) {
+        self.rows.truncate(len);
+        self.row_group_keys.truncate(len);
+    }
+
+    /// Sort rows by a comparator, keeping `row_group_keys` in lockstep.
+    /// Pair-sort prevents the sidecar from desynchronizing after ORDER BY
+    /// (otherwise text rendering would apply the wrong currency hint to
+    /// a row — caught by review on PR #1022).
+    pub fn sort_by<F>(&mut self, mut compare: F)
+    where
+        F: FnMut(&Row, &Row) -> std::cmp::Ordering,
+    {
+        debug_assert_eq!(self.rows.len(), self.row_group_keys.len());
+        let mut paired: Vec<(Row, Option<Vec<Value>>)> = std::mem::take(&mut self.rows)
+            .into_iter()
+            .zip(std::mem::take(&mut self.row_group_keys))
+            .collect();
+        paired.sort_by(|(a, _), (b, _)| compare(a, b));
+        for (row, key) in paired {
+            self.rows.push(row);
+            self.row_group_keys.push(key);
+        }
+    }
+
     /// Number of rows.
     pub const fn len(&self) -> usize {
         self.rows.len()

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -228,6 +228,12 @@ pub fn hash_single_value(value: &Value) -> u64 {
 }
 
 /// Query result containing column names and rows.
+///
+/// **Invariant**: `rows.len() == row_group_keys.len()`. Always. Mutating
+/// either field directly will violate this; use the helper methods
+/// (`add_row`, `add_aggregate_row`, `truncate`, `sort_by`, etc.) that
+/// keep both vectors in lockstep. The invariant is enforced at runtime
+/// with `assert_eq!` inside `sort_by`.
 #[derive(Debug, Clone)]
 pub struct QueryResult {
     /// Column names.
@@ -239,6 +245,11 @@ pub struct QueryResult {
     /// path; used by the text renderer to recover the per-row currency
     /// context for `Value::Number` cells emitted by `SUM` / `AVG` (issue
     /// #988 — display-precision fix that stays lossless for JSON/CSV).
+    ///
+    /// Reach in directly only inside `rustledger-query` and only with
+    /// extreme care — every mutation must be matched by a parallel
+    /// mutation to `rows`. External crates should use `group_key()`.
+    #[doc(hidden)]
     pub row_group_keys: Vec<Option<Vec<Value>>>,
 }
 
@@ -261,6 +272,14 @@ impl QueryResult {
     /// Add a row produced by aggregation, recording the GROUP BY key values
     /// alongside it. The renderer consults the key to quantize numeric
     /// aggregates against the per-currency display precision (issue #988).
+    ///
+    /// Multi-column GROUP BY note: when several columns are grouped (e.g.
+    /// `GROUP BY account, currency`), the entire key is preserved here.
+    /// The renderer's currency-hint extraction (`currency_hint_for_row`
+    /// in `rustledger/src/cmd/query/output.rs`) takes the *first*
+    /// currency-shaped string in iteration order — so put the currency
+    /// column first if both are currency-shaped, which is rare in
+    /// practice but possible.
     pub fn add_aggregate_row(&mut self, row: Row, group_key: Vec<Value>) {
         self.rows.push(row);
         self.row_group_keys.push(if group_key.is_empty() {
@@ -268,6 +287,16 @@ impl QueryResult {
         } else {
             Some(group_key)
         });
+    }
+
+    /// Get the GROUP BY key for a given row, if it was produced by
+    /// aggregation. Returns `None` for non-aggregate rows or when the
+    /// row index is out of range. This is the public read-side of the
+    /// `row_group_keys` sidecar — prefer it over reaching into the
+    /// field directly.
+    #[must_use]
+    pub fn group_key(&self, row_idx: usize) -> Option<&Vec<Value>> {
+        self.row_group_keys.get(row_idx).and_then(|k| k.as_ref())
     }
 
     /// Truncate to the first `len` rows, keeping `row_group_keys` in
@@ -280,12 +309,19 @@ impl QueryResult {
     /// Sort rows by a comparator, keeping `row_group_keys` in lockstep.
     /// Pair-sort prevents the sidecar from desynchronizing after ORDER BY
     /// (otherwise text rendering would apply the wrong currency hint to
-    /// a row — caught by review on PR #1022).
+    /// a row).
     pub fn sort_by<F>(&mut self, mut compare: F)
     where
         F: FnMut(&Row, &Row) -> std::cmp::Ordering,
     {
-        debug_assert_eq!(self.rows.len(), self.row_group_keys.len());
+        // Hard assert (not debug_assert!): the invariant is load-bearing
+        // for correctness; a release-mode mismatch would silently apply
+        // the wrong currency hint to rows after sort.
+        assert_eq!(
+            self.rows.len(),
+            self.row_group_keys.len(),
+            "QueryResult invariant violated: rows.len() must equal row_group_keys.len()"
+        );
         let mut paired: Vec<(Row, Option<Vec<Value>>)> = std::mem::take(&mut self.rows)
             .into_iter()
             .zip(std::mem::take(&mut self.row_group_keys))
@@ -391,5 +427,90 @@ mod tests {
             "Value enum too large: {} bytes",
             size_of::<Value>()
         );
+    }
+
+    // ─── QueryResult parallel-vector invariant (issue #988) ───────────
+    //
+    // The `row_group_keys` sidecar must stay aligned with `rows` across
+    // every mutation. These tests pin the contract for the helpers that
+    // mutate both vectors. A failure here means future renderer logic
+    // would apply the wrong currency hint to a row.
+
+    fn make_keyed_result() -> QueryResult {
+        let mut r = QueryResult::new(vec!["currency".into(), "sum".into()]);
+        r.add_aggregate_row(
+            vec![Value::String("USD".into()), Value::Integer(100)],
+            vec![Value::String("USD".into())],
+        );
+        r.add_aggregate_row(
+            vec![Value::String("EUR".into()), Value::Integer(50)],
+            vec![Value::String("EUR".into())],
+        );
+        r.add_aggregate_row(
+            vec![Value::String("GBP".into()), Value::Integer(75)],
+            vec![Value::String("GBP".into())],
+        );
+        r
+    }
+
+    /// `sort_by` reorders rows AND `row_group_keys` together.
+    #[test]
+    fn test_sort_by_keeps_row_group_keys_in_lockstep() {
+        let mut r = make_keyed_result();
+        // Sort by the integer column ascending: 50 (EUR), 75 (GBP), 100 (USD).
+        r.sort_by(|a, b| match (&a[1], &b[1]) {
+            (Value::Integer(x), Value::Integer(y)) => x.cmp(y),
+            _ => std::cmp::Ordering::Equal,
+        });
+
+        // After sort, row[0] is EUR, row[1] is GBP, row[2] is USD.
+        // The sidecar MUST have followed.
+        assert_eq!(r.group_key(0), Some(&vec![Value::String("EUR".into())]));
+        assert_eq!(r.group_key(1), Some(&vec![Value::String("GBP".into())]));
+        assert_eq!(r.group_key(2), Some(&vec![Value::String("USD".into())]));
+    }
+
+    /// `truncate` drops the same suffix from rows AND `row_group_keys`.
+    #[test]
+    fn test_truncate_keeps_row_group_keys_in_lockstep() {
+        let mut r = make_keyed_result();
+        r.truncate(2);
+
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.row_group_keys.len(), 2);
+        // Surviving keys are the first two: USD, EUR.
+        assert_eq!(r.group_key(0), Some(&vec![Value::String("USD".into())]));
+        assert_eq!(r.group_key(1), Some(&vec![Value::String("EUR".into())]));
+        // Out-of-range index returns None gracefully.
+        assert_eq!(r.group_key(2), None);
+    }
+
+    /// Mixed aggregate / non-aggregate rows: `add_row` writes `None` to
+    /// the sidecar so the invariant is preserved when the two paths
+    /// interleave (e.g. a synthetic explanatory row appended after an
+    /// aggregate).
+    #[test]
+    fn test_add_row_and_add_aggregate_row_mixed() {
+        let mut r = QueryResult::new(vec!["x".into()]);
+        r.add_aggregate_row(vec![Value::Integer(1)], vec![Value::String("USD".into())]);
+        r.add_row(vec![Value::Integer(2)]);
+        r.add_aggregate_row(vec![Value::Integer(3)], vec![Value::String("EUR".into())]);
+
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.row_group_keys.len(), 3);
+        assert_eq!(r.group_key(0), Some(&vec![Value::String("USD".into())]));
+        assert_eq!(r.group_key(1), None);
+        assert_eq!(r.group_key(2), Some(&vec![Value::String("EUR".into())]));
+    }
+
+    /// Empty `group_key` arg means "no GROUP BY context" — sidecar
+    /// records `None` so callers don't see a misleading `Some(vec![])`.
+    #[test]
+    fn test_add_aggregate_row_empty_key_records_none() {
+        let mut r = QueryResult::new(vec!["count".into()]);
+        // Pure aggregate (e.g. SELECT COUNT(*)) has no GROUP BY at all.
+        r.add_aggregate_row(vec![Value::Integer(42)], vec![]);
+
+        assert_eq!(r.group_key(0), None);
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -264,8 +264,7 @@ fn update_column_context(col_ctx: &mut DisplayContext, value: &Value, ledger_ctx
 /// uppercase string in the key) would route a `Value::Number` through
 /// `DisplayContext::format`, whose unknown-currency fallback calls
 /// `normalize()` and *strips* trailing zeros (`0.000` → `0`), making
-/// output worse than the pre-fix state. Caught by Copilot review on PR
-/// #1022.
+/// output worse than the pre-fix state.
 fn looks_like_currency(s: &str) -> bool {
     if s.is_empty() || s.len() > 24 {
         return false;
@@ -282,30 +281,30 @@ fn looks_like_currency(s: &str) -> bool {
 
 /// Find the per-row currency hint for issue #988 quantization.
 ///
-/// Scans the row's GROUP BY key (from `row_group_keys[row_idx]`) for the
+/// Scans the row's GROUP BY key (from `QueryResult::group_key`) for the
 /// first string that both *looks* like a currency AND has tracked precision
 /// in the active `DisplayContext`. The precision check is essential — see
 /// `looks_like_currency`'s docstring for why a heuristic-only filter would
 /// regress output.
+///
+/// Multi-currency-column GROUP BY (rare but possible) takes the *first*
+/// match in iteration order — see `QueryResult::add_aggregate_row`'s
+/// docstring for the contract.
 fn currency_hint_for_row<'a>(
     result: &'a rustledger_query::QueryResult,
     row_idx: usize,
     ctx: &DisplayContext,
 ) -> Option<&'a str> {
-    result
-        .row_group_keys
-        .get(row_idx)
-        .and_then(|k| k.as_ref())
-        .and_then(|key_values| {
-            key_values.iter().find_map(|v| match v {
-                Value::String(s)
-                    if looks_like_currency(s) && ctx.get_precision(s.as_str()).is_some() =>
-                {
-                    Some(s.as_str())
-                }
-                _ => None,
-            })
+    result.group_key(row_idx).and_then(|key_values| {
+        key_values.iter().find_map(|v| match v {
+            Value::String(s)
+                if looks_like_currency(s) && ctx.get_precision(s.as_str()).is_some() =>
+            {
+                Some(s.as_str())
+            }
+            _ => None,
         })
+    })
 }
 
 /// Format a value with optional GROUP BY currency hint (issue #988).
@@ -603,10 +602,16 @@ mod tests {
     // SUM-aggregate text output should match bean-query's per-currency
     // precision. With `SELECT currency, SUM(number) GROUP BY currency`, the
     // SUM cell receives the GROUP BY currency from the row sidecar and
-    // quantizes via DisplayContext, so `0.00 USD` inputs sum to `0.00`
-    // rather than rust_decimal's natural `0.000`. JSON / CSV / beancount
-    // paths still go through `format_value` (no hint), preserving the
-    // unquantized value (AC #4: lossless non-text output).
+    // quantizes via DisplayContext. Concretely, the bug shows up when
+    // inputs have varying scales (e.g. one `0.000` mixed with several
+    // `0.00`s): `rust_decimal::Decimal::add` returns max-scale, so the sum
+    // keeps the wider `0.000` form even though USD's tracked precision is
+    // 2dp. After the fix, the per-currency hint pulls the SUM through
+    // `DisplayContext::format(_, "USD")`, rounding back to 2dp.
+    //
+    // JSON / CSV / beancount paths still go through `format_value` (no
+    // hint), preserving the unquantized value (AC #4: lossless non-text
+    // output).
 
     /// Heuristic detection of currency-shaped strings (used by the text
     /// renderer to find the GROUP BY currency in a row's sidecar).
@@ -697,6 +702,213 @@ mod tests {
             madeup_hint, None,
             "untracked currency must NOT be returned as a hint — would cause \
              DisplayContext::format to strip trailing zeros via normalize()"
+        );
+    }
+
+    // ─── AC #4: lossless CSV / JSON / beancount output ───────────────────
+    //
+    // The fix MUST NOT bleed into non-text renderers. Aggregate values
+    // there should still be the unquantized rust_decimal — JSON consumers
+    // parsing exact scales depend on this. These tests pin the contract
+    // by rendering an aggregate `Value::Number(0.000)` with a USD
+    // GROUP BY key context that *would* be quantized in text mode.
+
+    /// CSV of an aggregate row preserves the unquantized decimal even
+    /// when a GROUP BY currency would otherwise drive 2dp quantization.
+    #[test]
+    fn test_csv_aggregate_output_preserves_unquantized_decimal() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        let mut result = QueryResult::new(vec!["currency".into(), "sum".into()]);
+        result.add_aggregate_row(
+            vec![Value::String("USD".into()), Value::Number(dec!(0.000))],
+            vec![Value::String("USD".into())],
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_csv(&result, &mut buf, false, &ctx).expect("csv ok");
+        let csv = String::from_utf8(buf).expect("utf8");
+
+        assert!(
+            csv.contains("USD,0.000"),
+            "expected unquantized 0.000 in CSV, got {csv:?}"
+        );
+        assert!(
+            !csv.contains("USD,0.00\n") && !csv.contains("USD,0.00,"),
+            "CSV must NOT have been quantized to 0.00, got {csv:?}"
+        );
+    }
+
+    /// JSON of an aggregate row likewise preserves the unquantized
+    /// decimal — JSON consumers (e.g. downstream pipelines reading
+    /// `bean-query --format json`) get the raw `rust_decimal` scale.
+    #[test]
+    fn test_json_aggregate_output_preserves_unquantized_decimal() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+        // ctx is unused by write_json (path takes no DisplayContext) but
+        // building one mirrors the realistic call-site.
+        let _ = ctx;
+
+        let mut result = QueryResult::new(vec!["currency".into(), "sum".into()]);
+        result.add_aggregate_row(
+            vec![Value::String("USD".into()), Value::Number(dec!(0.000))],
+            vec![Value::String("USD".into())],
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_json(&result, &mut buf).expect("json ok");
+        let json = String::from_utf8(buf).expect("utf8");
+
+        assert!(
+            json.contains("\"0.000\""),
+            "expected unquantized \"0.000\" in JSON, got {json}"
+        );
+        assert!(
+            !json.contains("\"0.00\"") || json.matches("\"0.00\"").count() == 0,
+            "JSON must NOT contain 0.00 (would mean it was quantized), got {json}"
+        );
+    }
+
+    /// `bean-query`-style beancount output similarly stays at the
+    /// natural decimal scale.
+    #[test]
+    fn test_beancount_aggregate_output_preserves_unquantized_decimal() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        let mut result = QueryResult::new(vec!["currency".into(), "sum".into()]);
+        result.add_aggregate_row(
+            vec![Value::String("USD".into()), Value::Number(dec!(0.000))],
+            vec![Value::String("USD".into())],
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_beancount(&result, &mut buf, &ctx).expect("beancount ok");
+        let out = String::from_utf8(buf).expect("utf8");
+
+        assert!(
+            out.contains("0.000"),
+            "expected unquantized 0.000 in beancount output, got {out:?}"
+        );
+    }
+
+    /// Mirror of the AC #4 tests for the *text* renderer: same input
+    /// MUST be quantized. This is the bug we're fixing — without the
+    /// hint, text output would also keep 0.000. Together with the
+    /// three lossless tests above, this pins the divergence: text
+    /// quantizes, everything else doesn't.
+    #[test]
+    fn test_text_aggregate_output_quantizes_via_currency_hint() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+        ctx.update(dec!(3.00), "USD");
+
+        let mut result = QueryResult::new(vec!["currency".into(), "sum".into()]);
+        result.add_aggregate_row(
+            vec![Value::String("USD".into()), Value::Number(dec!(0.000))],
+            vec![Value::String("USD".into())],
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        assert!(
+            text.contains("0.00") && !text.contains("0.000"),
+            "text output should be quantized to 2dp via USD hint, got {text:?}"
+        );
+    }
+
+    /// End-to-end integration test (the canary the issue's compat
+    /// harness would fire). Drives a real BQL query
+    /// `SELECT currency, SUM(number) GROUP BY currency` through the
+    /// Executor and the text renderer, then asserts the rendered
+    /// output is quantized to USD's tracked precision (2dp) instead of
+    /// `rust_decimal`'s natural 3dp.
+    ///
+    /// This is the only test in the file that exercises the FULL
+    /// pipeline — Executor populates `row_group_keys`, `write_text`
+    /// reads via `currency_hint_for_row`, format dispatches through
+    /// `DisplayContext::format`. A regression that breaks the wiring
+    /// (e.g. someone reverting `add_aggregate_row` to `add_row` in
+    /// the executor) would fire here even if the helper-level tests
+    /// stay green.
+    #[test]
+    fn test_e2e_sum_group_by_currency_text_output_matches_per_currency_precision() {
+        use rustledger_core::{Amount, Directive, Posting, Transaction};
+        use rustledger_query::{Executor, parse};
+
+        let date = |y, m, d| rustledger_core::naive_date(y, m, d).unwrap();
+
+        // Build a tiny ledger where SUM(number) GROUP BY currency on USD
+        // mixes scales: 5.00 + (-5.00) + 0.000 = 0.000 (rust_decimal
+        // natural). Without the fix this renders as `0.000`. With the
+        // fix and a USD-tracked DisplayContext at 2dp, it should render
+        // as `0.00`.
+        let directives = vec![
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "Coffee")
+                    .with_flag('*')
+                    .with_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(5.00), "USD"),
+                    ))
+                    .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-5.00), "USD"))),
+            ),
+            // A scale-3 input that bumps SUM's natural scale to 3.
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 16), "Refund")
+                    .with_flag('*')
+                    .with_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(0.000), "USD"),
+                    ))
+                    .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(0.0), "USD"))),
+            ),
+        ];
+
+        // Build a DisplayContext that would naturally come from the
+        // loader observing typical USD amounts at 2dp.
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(5.00), "USD");
+        ctx.update(dec!(-5.00), "USD");
+
+        let mut executor = Executor::new(&directives);
+        let query =
+            parse("SELECT currency, SUM(number) GROUP BY currency").expect("parse should succeed");
+        let result = executor.execute(&query).expect("execute should succeed");
+
+        // The executor MUST have recorded the GROUP BY currency.
+        // Otherwise the renderer can't know to quantize.
+        assert!(
+            result.group_key(0).is_some(),
+            "aggregate executor must populate row_group_keys; got None for row 0"
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("write_text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        // The aggregate cell for USD must NOT have the 3dp form.
+        // (The full text contains the column header and currency cell
+        // too; assert on the SUM scale specifically.)
+        assert!(
+            !text.contains("0.000"),
+            "text output should be quantized to USD's 2dp; raw output:\n{text}"
         );
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -76,16 +76,7 @@ fn write_text<W: Write>(
         .collect();
 
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = result
-            .row_group_keys
-            .get(row_idx)
-            .and_then(|k| k.as_ref())
-            .and_then(|key_values| {
-                key_values.iter().find_map(|v| match v {
-                    Value::String(s) if looks_like_currency(s) => Some(s.as_str()),
-                    _ => None,
-                })
-            });
+        let currency_hint = currency_hint_for_row(result, row_idx, ctx);
         for (i, value) in row.iter().enumerate() {
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
             let len = format_value_with_hint(value, numberify, col_ctx, currency_hint).len();
@@ -129,22 +120,7 @@ fn write_text<W: Write>(
 
     // Print rows using per-column display contexts
     for (row_idx, row) in result.rows.iter().enumerate() {
-        // Per-row currency hint recovered from the GROUP BY key (issue #988):
-        // when a row was produced by an aggregate over `GROUP BY currency`,
-        // the renderer needs the currency to quantize Value::Number cells
-        // (e.g. `SUM(number)`) at the right per-currency precision. Without
-        // this, a SUM of two `0.00 USD` values keeps `rust_decimal`'s natural
-        // wider scale and renders `0.000` instead of `0.00`.
-        let currency_hint = result
-            .row_group_keys
-            .get(row_idx)
-            .and_then(|k| k.as_ref())
-            .and_then(|key_values| {
-                key_values.iter().find_map(|v| match v {
-                    Value::String(s) if looks_like_currency(s) => Some(s.as_str()),
-                    _ => None,
-                })
-            });
+        let currency_hint = currency_hint_for_row(result, row_idx, ctx);
 
         for (i, value) in row.iter().enumerate() {
             if i > 0 {
@@ -276,16 +252,20 @@ fn update_column_context(col_ctx: &mut DisplayContext, value: &Value, ledger_ctx
     }
 }
 
-/// Heuristic: does a string look like a beancount currency? Used to detect
-/// the currency-column entry in a row's GROUP BY key so the renderer can
-/// apply per-currency precision to a sibling SUM/AVG cell (issue #988).
+/// Heuristic: does a string look like a beancount currency? Used as a
+/// pre-filter when scanning a row's GROUP BY key for a candidate currency
+/// to drive per-cell precision lookup (issue #988). Beancount currencies
+/// are 1-24 chars, start with an uppercase letter, and only contain
+/// `[A-Z0-9'._-]`.
 ///
-/// Beancount currencies are 1-24 chars, start with an uppercase letter, and
-/// only contain `[A-Z0-9'._-]`. The check is conservative — false negatives
-/// just leave the cell at default precision (the pre-fix behavior); false
-/// positives would let an unrelated string drive precision lookup, but the
-/// `DisplayContext::format` call falls back to default if the "currency"
-/// has no recorded precision, so the worst case is a no-op.
+/// This is only step one of two. The caller (`currency_hint_for_row`) ALSO
+/// checks that the candidate has tracked precision in the `DisplayContext`
+/// before returning it — without that gate, a false-positive (unrelated
+/// uppercase string in the key) would route a `Value::Number` through
+/// `DisplayContext::format`, whose unknown-currency fallback calls
+/// `normalize()` and *strips* trailing zeros (`0.000` → `0`), making
+/// output worse than the pre-fix state. Caught by Copilot review on PR
+/// #1022.
 fn looks_like_currency(s: &str) -> bool {
     if s.is_empty() || s.len() > 24 {
         return false;
@@ -300,6 +280,34 @@ fn looks_like_currency(s: &str) -> bool {
     })
 }
 
+/// Find the per-row currency hint for issue #988 quantization.
+///
+/// Scans the row's GROUP BY key (from `row_group_keys[row_idx]`) for the
+/// first string that both *looks* like a currency AND has tracked precision
+/// in the active `DisplayContext`. The precision check is essential — see
+/// `looks_like_currency`'s docstring for why a heuristic-only filter would
+/// regress output.
+fn currency_hint_for_row<'a>(
+    result: &'a rustledger_query::QueryResult,
+    row_idx: usize,
+    ctx: &DisplayContext,
+) -> Option<&'a str> {
+    result
+        .row_group_keys
+        .get(row_idx)
+        .and_then(|k| k.as_ref())
+        .and_then(|key_values| {
+            key_values.iter().find_map(|v| match v {
+                Value::String(s)
+                    if looks_like_currency(s) && ctx.get_precision(s.as_str()).is_some() =>
+                {
+                    Some(s.as_str())
+                }
+                _ => None,
+            })
+        })
+}
+
 /// Format a value with optional GROUP BY currency hint (issue #988).
 ///
 /// When `currency_hint` is set and the value is a `Value::Number` (typically
@@ -311,6 +319,11 @@ fn looks_like_currency(s: &str) -> bool {
 /// The hint is *only* consulted by the text renderer — JSON / CSV /
 /// beancount output paths still use `format_value`, keeping their values
 /// lossless (issue #988 acceptance criterion #4).
+///
+/// The caller is responsible for ensuring the hint resolves to a currency
+/// with tracked precision (`ctx.get_precision(currency).is_some()`) — pass
+/// `None` otherwise. See `currency_hint_for_row` for the canonical
+/// extraction path.
 pub(super) fn format_value_with_hint(
     value: &Value,
     numberify: bool,
@@ -647,21 +660,43 @@ mod tests {
         );
     }
 
-    /// Negative path: a non-currency hint string is filtered out by the
-    /// `looks_like_currency` check at the call site, so `format_value_with_hint`
-    /// never sees it. Pin that the helper itself still does the right thing
-    /// when handed a non-currency-shaped string (falls through to ctx,
-    /// which has no entry, so returns default precision).
+    /// Critical regression test (Copilot review on PR #1022 caught this):
+    /// `DisplayContext::format(n, currency)` falls back to `n.normalize()`
+    /// when the currency has no tracked precision, which STRIPS trailing
+    /// zeros. So a false-positive hint isn't a no-op — it would render
+    /// `0.000` as `0`, making output WORSE than the pre-fix state. The
+    /// gate lives in `currency_hint_for_row` (only returns hints for
+    /// currencies that pass `ctx.get_precision().is_some()`); this test
+    /// pins that contract end-to-end.
     #[test]
-    fn test_format_value_with_hint_unknown_currency_falls_back_safely() {
-        let ctx = DisplayContext::new();
-        let v = Value::Number(dec!(1.5));
-        // "MADEUP" passes looks_like_currency but ctx has no entry — safe.
-        let rendered = format_value_with_hint(&v, false, &ctx, Some("MADEUP"));
-        // Just assert it's a string representation of 1.5 (default scale).
-        assert!(
-            rendered.contains("1.5"),
-            "expected 1.5 in output, got {rendered:?}"
+    fn test_currency_hint_for_row_filters_untracked_currencies() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        let mut result = QueryResult::new(vec!["currency".into(), "sum".into()]);
+        // Row 0: GROUP BY key contains tracked USD → hint returned.
+        result.add_aggregate_row(
+            vec![Value::String("USD".into()), Value::Number(dec!(0.000))],
+            vec![Value::String("USD".into())],
+        );
+        // Row 1: GROUP BY key contains MADEUP — passes shape check but
+        // has no tracked precision → hint MUST be filtered out.
+        result.add_aggregate_row(
+            vec![Value::String("MADEUP".into()), Value::Number(dec!(0.000))],
+            vec![Value::String("MADEUP".into())],
+        );
+
+        let usd_hint = currency_hint_for_row(&result, 0, &ctx);
+        let madeup_hint = currency_hint_for_row(&result, 1, &ctx);
+
+        assert_eq!(usd_hint, Some("USD"));
+        assert_eq!(
+            madeup_hint, None,
+            "untracked currency must NOT be returned as a hint — would cause \
+             DisplayContext::format to strip trailing zeros via normalize()"
         );
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -68,6 +68,14 @@ fn write_text<W: Write>(
         }
     }
 
+    // Resolve per-row currency hints once. The hint feeds both the
+    // width-calculation pass and the print pass; computing per-pass
+    // would duplicate the lookup. The borrow lives for the rest of
+    // this function (no mutation of `result` between here and print).
+    let currency_hints: Vec<Option<&str>> = (0..result.rows.len())
+        .map(|i| currency_hint_for_row(result, i, ctx))
+        .collect();
+
     // Calculate column widths using per-column contexts
     let mut widths: Vec<usize> = result
         .columns
@@ -76,7 +84,7 @@ fn write_text<W: Write>(
         .collect();
 
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = currency_hint_for_row(result, row_idx, ctx);
+        let currency_hint = currency_hints[row_idx];
         for (i, value) in row.iter().enumerate() {
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
             let len = format_value_with_hint(value, numberify, col_ctx, currency_hint).len();
@@ -120,7 +128,7 @@ fn write_text<W: Write>(
 
     // Print rows using per-column display contexts
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = currency_hint_for_row(result, row_idx, ctx);
+        let currency_hint = currency_hints[row_idx];
 
         for (i, value) in row.iter().enumerate() {
             if i > 0 {
@@ -255,8 +263,10 @@ fn update_column_context(col_ctx: &mut DisplayContext, value: &Value, ledger_ctx
 /// Heuristic: does a string look like a beancount currency? Used as a
 /// pre-filter when scanning a row's GROUP BY key for a candidate currency
 /// to drive per-cell precision lookup (issue #988). Beancount currencies
-/// are 1-24 chars, start with an uppercase letter, and only contain
-/// `[A-Z0-9'._-]`.
+/// are 2-24 chars (the spec allows shorter, but every real-world ticker
+/// is at least 2 — the lower bound is a defensive narrowing of the
+/// heuristic since single uppercase letters mostly aren't currencies),
+/// start with an uppercase letter, and only contain `[A-Z0-9'._-]`.
 ///
 /// This is only step one of two. The caller (`currency_hint_for_row`) ALSO
 /// checks that the candidate has tracked precision in the `DisplayContext`
@@ -266,7 +276,7 @@ fn update_column_context(col_ctx: &mut DisplayContext, value: &Value, ledger_ctx
 /// `normalize()` and *strips* trailing zeros (`0.000` → `0`), making
 /// output worse than the pre-fix state.
 fn looks_like_currency(s: &str) -> bool {
-    if s.is_empty() || s.len() > 24 {
+    if s.len() < 2 || s.len() > 24 {
         return false;
     }
     let mut chars = s.chars();
@@ -330,6 +340,20 @@ pub(super) fn format_value_with_hint(
     currency_hint: Option<&str>,
 ) -> String {
     if let (Value::Number(n), Some(currency)) = (value, currency_hint) {
+        // Debug-only tripwire for the contract documented above: fire if a
+        // future caller passes a hint without filtering through the
+        // precision gate first. Only meaningful inside this branch — for
+        // non-Number values the hint is ignored, so a "bad" hint there is
+        // harmless. Release builds skip the check; the worst observable
+        // effect is the strip-trailing-zeros regression that the gate
+        // was designed to prevent.
+        debug_assert!(
+            ctx.get_precision(currency).is_some(),
+            "format_value_with_hint called with currency {currency:?} lacking \
+             tracked precision in the DisplayContext — would silently strip \
+             trailing zeros via the normalize() fallback. Filter via \
+             currency_hint_for_row first."
+        );
         return ctx.format(*n, currency);
     }
     format_value(value, numberify, ctx)
@@ -628,6 +652,7 @@ mod tests {
     #[test]
     fn test_looks_like_currency_rejects_non_currencies() {
         assert!(!looks_like_currency(""));
+        assert!(!looks_like_currency("U")); // single char (real currencies are 2+)
         assert!(!looks_like_currency("usd")); // lowercase first
         assert!(!looks_like_currency("123")); // starts with digit
         assert!(!looks_like_currency("hello world")); // space
@@ -665,14 +690,13 @@ mod tests {
         );
     }
 
-    /// Critical regression test (Copilot review on PR #1022 caught this):
-    /// `DisplayContext::format(n, currency)` falls back to `n.normalize()`
-    /// when the currency has no tracked precision, which STRIPS trailing
-    /// zeros. So a false-positive hint isn't a no-op — it would render
-    /// `0.000` as `0`, making output WORSE than the pre-fix state. The
-    /// gate lives in `currency_hint_for_row` (only returns hints for
-    /// currencies that pass `ctx.get_precision().is_some()`); this test
-    /// pins that contract end-to-end.
+    /// Critical regression: `DisplayContext::format(n, currency)` falls
+    /// back to `n.normalize()` when the currency has no tracked precision,
+    /// which STRIPS trailing zeros. So a false-positive hint isn't a no-op
+    /// — it would render `0.000` as `0`, making output WORSE than the
+    /// pre-fix state. The gate lives in `currency_hint_for_row` (only
+    /// returns hints for currencies that pass `ctx.get_precision().is_some()`);
+    /// this test pins that contract end-to-end.
     #[test]
     fn test_currency_hint_for_row_filters_untracked_currencies() {
         use rustledger_query::QueryResult;
@@ -733,13 +757,19 @@ mod tests {
         write_csv(&result, &mut buf, false, &ctx).expect("csv ok");
         let csv = String::from_utf8(buf).expect("utf8");
 
-        assert!(
-            csv.contains("USD,0.000"),
-            "expected unquantized 0.000 in CSV, got {csv:?}"
-        );
-        assert!(
-            !csv.contains("USD,0.00\n") && !csv.contains("USD,0.00,"),
-            "CSV must NOT have been quantized to 0.00, got {csv:?}"
+        // Parse the data row by splitting on lines and commas — robust
+        // to either `\n` or `\r\n` line endings that platform-specific
+        // String/I/O might emit.
+        let data_row = csv
+            .lines()
+            .nth(1)
+            .expect("CSV should have a header line + 1 data row");
+        let cells: Vec<&str> = data_row.split(',').collect();
+        assert_eq!(cells.len(), 2, "expected 2 columns, got: {cells:?}");
+        assert_eq!(cells[0], "USD");
+        assert_eq!(
+            cells[1], "0.000",
+            "CSV sum cell must be the unquantized 0.000 (lossless AC #4)"
         );
     }
 
@@ -750,12 +780,9 @@ mod tests {
     fn test_json_aggregate_output_preserves_unquantized_decimal() {
         use rustledger_query::QueryResult;
 
-        let mut ctx = DisplayContext::new();
-        ctx.update(dec!(1.00), "USD");
-        ctx.update(dec!(2.00), "USD");
-        // ctx is unused by write_json (path takes no DisplayContext) but
-        // building one mirrors the realistic call-site.
-        let _ = ctx;
+        // `write_json` takes no DisplayContext — it serializes raw Decimal
+        // values via `to_string()`, so per-currency precision can't bleed
+        // into the JSON path even by accident.
 
         let mut result = QueryResult::new(vec!["currency".into(), "sum".into()]);
         result.add_aggregate_row(
@@ -767,13 +794,19 @@ mod tests {
         write_json(&result, &mut buf).expect("json ok");
         let json = String::from_utf8(buf).expect("utf8");
 
+        // Lossless: the literal string "0.000" appears as the Number's
+        // serialized form. Quoted (since the JSON emitter stringifies
+        // decimals to preserve precision).
         assert!(
-            json.contains("\"0.000\""),
+            json.contains(r#""0.000""#),
             "expected unquantized \"0.000\" in JSON, got {json}"
         );
+        // And the quantized form must NOT appear. `r#""0.00""#` is a
+        // unique substring (the closing quote distinguishes it from
+        // `"0.000"` — `0.000` contains `0.00` but not `0.00"`).
         assert!(
-            !json.contains("\"0.00\"") || json.matches("\"0.00\"").count() == 0,
-            "JSON must NOT contain 0.00 (would mean it was quantized), got {json}"
+            !json.contains(r#""0.00""#),
+            "JSON must NOT contain quantized \"0.00\", got {json}"
         );
     }
 
@@ -903,12 +936,124 @@ mod tests {
         write_text(&result, &mut buf, false, &ctx).expect("write_text ok");
         let text = String::from_utf8(buf).expect("utf8");
 
-        // The aggregate cell for USD must NOT have the 3dp form.
-        // (The full text contains the column header and currency cell
-        // too; assert on the SUM scale specifically.)
+        // Anchor the assertion on the data-row's last whitespace-
+        // separated token (the SUM cell, right-aligned). Avoids a
+        // brittle global substring scan: e.g. an unrelated "0.0001"
+        // elsewhere in the table would defeat a `!text.contains("0.000")`
+        // check, but the column-anchored slice is the actual contract.
+        let data_row = text
+            .lines()
+            .find(|l| l.contains("USD"))
+            .unwrap_or_else(|| panic!("expected a USD data row; raw output:\n{text}"));
+        let sum_cell = data_row
+            .split_whitespace()
+            .last()
+            .unwrap_or_else(|| panic!("expected non-empty data row; got: {data_row:?}"));
+        assert_eq!(
+            sum_cell, "0.00",
+            "SUM cell should be quantized to USD's 2dp; row was {data_row:?}, raw output:\n{text}"
+        );
+    }
+
+    /// Implicit GROUP BY: when the SELECT clause mixes aggregate and
+    /// non-aggregate exprs without an explicit `GROUP BY`, the executor
+    /// implicitly groups by the non-aggregate columns
+    /// (`extract_implicit_group_by_exprs` in
+    /// `rustledger-query/src/executor/aggregation.rs`). This test
+    /// verifies the implicit path also populates `row_group_keys` with
+    /// the currency, so the renderer's quantization works for queries
+    /// that omit `GROUP BY` — bean-query's most common shape.
+    #[test]
+    fn test_e2e_implicit_group_by_currency_text_output_quantized() {
+        use rustledger_core::{Amount, Directive, Posting, Transaction};
+        use rustledger_query::{Executor, parse};
+
+        let date = |y, m, d| rustledger_core::naive_date(y, m, d).unwrap();
+
+        let directives = vec![
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "T1")
+                    .with_flag('*')
+                    .with_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(5.00), "USD"),
+                    ))
+                    .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-5.00), "USD"))),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 16), "T2")
+                    .with_flag('*')
+                    .with_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(0.000), "USD"),
+                    ))
+                    .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(0.0), "USD"))),
+            ),
+        ];
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(5.00), "USD");
+        ctx.update(dec!(-5.00), "USD");
+
+        let mut executor = Executor::new(&directives);
+        // Note: NO `GROUP BY currency` — implicit grouping kicks in.
+        let query = parse("SELECT currency, SUM(number)").expect("parse should succeed");
+        let result = executor.execute(&query).expect("execute should succeed");
+
         assert!(
-            !text.contains("0.000"),
-            "text output should be quantized to USD's 2dp; raw output:\n{text}"
+            result.group_key(0).is_some(),
+            "implicit-group-by aggregate must populate row_group_keys"
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("write_text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        let data_row = text
+            .lines()
+            .find(|l| l.contains("USD"))
+            .unwrap_or_else(|| panic!("expected USD data row; raw output:\n{text}"));
+        let sum_cell = data_row.split_whitespace().last().expect("non-empty row");
+        assert_eq!(
+            sum_cell, "0.00",
+            "implicit GROUP BY should quantize same as explicit; got {sum_cell:?} \
+             in row {data_row:?}\n full output:\n{text}"
+        );
+    }
+
+    /// Multi-column GROUP BY: when the key has both a non-currency
+    /// column (account) and a currency column, the renderer should
+    /// pick the currency-shaped string regardless of position. Pins
+    /// the contract documented on `add_aggregate_row`.
+    #[test]
+    fn test_currency_hint_for_row_finds_currency_in_multi_column_group_by_key() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        let mut result = QueryResult::new(vec!["account".into(), "currency".into(), "sum".into()]);
+        // Key order: [account="Assets:Bank", currency="USD"]. account
+        // doesn't pass `looks_like_currency` (lowercase chars + colon),
+        // so the iterator skips to the second key element and picks USD.
+        result.add_aggregate_row(
+            vec![
+                Value::String("Assets:Bank".into()),
+                Value::String("USD".into()),
+                Value::Number(dec!(0.000)),
+            ],
+            vec![
+                Value::String("Assets:Bank".into()),
+                Value::String("USD".into()),
+            ],
+        );
+
+        let hint = currency_hint_for_row(&result, 0, &ctx);
+        assert_eq!(
+            hint,
+            Some("USD"),
+            "expected USD hint extracted from second key element"
         );
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -75,10 +75,20 @@ fn write_text<W: Write>(
         .map(std::string::String::len)
         .collect();
 
-    for row in &result.rows {
+    for (row_idx, row) in result.rows.iter().enumerate() {
+        let currency_hint = result
+            .row_group_keys
+            .get(row_idx)
+            .and_then(|k| k.as_ref())
+            .and_then(|key_values| {
+                key_values.iter().find_map(|v| match v {
+                    Value::String(s) if looks_like_currency(s) => Some(s.as_str()),
+                    _ => None,
+                })
+            });
         for (i, value) in row.iter().enumerate() {
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
-            let len = format_value(value, numberify, col_ctx).len();
+            let len = format_value_with_hint(value, numberify, col_ctx, currency_hint).len();
             if i < widths.len() && len > widths[i] {
                 widths[i] = len;
             }
@@ -118,13 +128,30 @@ fn write_text<W: Write>(
     writeln!(writer)?;
 
     // Print rows using per-column display contexts
-    for row in &result.rows {
+    for (row_idx, row) in result.rows.iter().enumerate() {
+        // Per-row currency hint recovered from the GROUP BY key (issue #988):
+        // when a row was produced by an aggregate over `GROUP BY currency`,
+        // the renderer needs the currency to quantize Value::Number cells
+        // (e.g. `SUM(number)`) at the right per-currency precision. Without
+        // this, a SUM of two `0.00 USD` values keeps `rust_decimal`'s natural
+        // wider scale and renders `0.000` instead of `0.00`.
+        let currency_hint = result
+            .row_group_keys
+            .get(row_idx)
+            .and_then(|k| k.as_ref())
+            .and_then(|key_values| {
+                key_values.iter().find_map(|v| match v {
+                    Value::String(s) if looks_like_currency(s) => Some(s.as_str()),
+                    _ => None,
+                })
+            });
+
         for (i, value) in row.iter().enumerate() {
             if i > 0 {
                 write!(writer, "  ")?;
             }
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
-            let formatted = format_value(value, numberify, col_ctx);
+            let formatted = format_value_with_hint(value, numberify, col_ctx, currency_hint);
             if i < widths.len() {
                 // Right-align numeric columns to match Python beancount
                 if i < is_numeric_col.len() && is_numeric_col[i] {
@@ -247,6 +274,53 @@ fn update_column_context(col_ctx: &mut DisplayContext, value: &Value, ledger_ctx
         }
         _ => {}
     }
+}
+
+/// Heuristic: does a string look like a beancount currency? Used to detect
+/// the currency-column entry in a row's GROUP BY key so the renderer can
+/// apply per-currency precision to a sibling SUM/AVG cell (issue #988).
+///
+/// Beancount currencies are 1-24 chars, start with an uppercase letter, and
+/// only contain `[A-Z0-9'._-]`. The check is conservative — false negatives
+/// just leave the cell at default precision (the pre-fix behavior); false
+/// positives would let an unrelated string drive precision lookup, but the
+/// `DisplayContext::format` call falls back to default if the "currency"
+/// has no recorded precision, so the worst case is a no-op.
+fn looks_like_currency(s: &str) -> bool {
+    if s.is_empty() || s.len() > 24 {
+        return false;
+    }
+    let mut chars = s.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_uppercase() {
+        return false;
+    }
+    chars.all(|c| {
+        c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '\'' | '.' | '_' | '-')
+    })
+}
+
+/// Format a value with optional GROUP BY currency hint (issue #988).
+///
+/// When `currency_hint` is set and the value is a `Value::Number` (typically
+/// produced by an aggregate like `SUM(number)` over a `GROUP BY currency`),
+/// route through `DisplayContext::format` for per-currency quantization so
+/// the rendered scale matches bean-query (e.g. `0.00` not `0.000`). Without
+/// the hint, behavior is identical to `format_value`.
+///
+/// The hint is *only* consulted by the text renderer — JSON / CSV /
+/// beancount output paths still use `format_value`, keeping their values
+/// lossless (issue #988 acceptance criterion #4).
+pub(super) fn format_value_with_hint(
+    value: &Value,
+    numberify: bool,
+    ctx: &DisplayContext,
+    currency_hint: Option<&str>,
+) -> String {
+    if let (Value::Number(n), Some(currency)) = (value, currency_hint) {
+        return ctx.format(*n, currency);
+    }
+    format_value(value, numberify, ctx)
 }
 
 pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext) -> String {
@@ -509,6 +583,85 @@ mod tests {
         assert!(
             rendered.contains("{128.99 USD}") && rendered.contains("{131.73 USD}"),
             "expected both costs rendered without leading space, got {rendered:?}"
+        );
+    }
+
+    // ─── Issue #988 ──────────────────────────────────────────────────────
+    // SUM-aggregate text output should match bean-query's per-currency
+    // precision. With `SELECT currency, SUM(number) GROUP BY currency`, the
+    // SUM cell receives the GROUP BY currency from the row sidecar and
+    // quantizes via DisplayContext, so `0.00 USD` inputs sum to `0.00`
+    // rather than rust_decimal's natural `0.000`. JSON / CSV / beancount
+    // paths still go through `format_value` (no hint), preserving the
+    // unquantized value (AC #4: lossless non-text output).
+
+    /// Heuristic detection of currency-shaped strings (used by the text
+    /// renderer to find the GROUP BY currency in a row's sidecar).
+    #[test]
+    fn test_looks_like_currency_accepts_typical_currencies() {
+        assert!(looks_like_currency("USD"));
+        assert!(looks_like_currency("EUR"));
+        assert!(looks_like_currency("BTC"));
+        assert!(looks_like_currency("V0AAA"));
+        assert!(looks_like_currency("X.Y"));
+        assert!(looks_like_currency("ABC-123"));
+    }
+
+    #[test]
+    fn test_looks_like_currency_rejects_non_currencies() {
+        assert!(!looks_like_currency(""));
+        assert!(!looks_like_currency("usd")); // lowercase first
+        assert!(!looks_like_currency("123")); // starts with digit
+        assert!(!looks_like_currency("hello world")); // space
+        assert!(!looks_like_currency(&"A".repeat(25))); // too long
+    }
+
+    /// Pinning the format dispatch: a `Value::Number` cell rendered with
+    /// a currency hint goes through `DisplayContext::format(n, currency)`,
+    /// not `format_default(n)`. Without the hint, behavior is unchanged
+    /// from `format_value`.
+    #[test]
+    fn test_format_value_with_hint_routes_number_through_per_currency_ctx() {
+        let mut ctx = DisplayContext::new();
+        // Seed USD precision at 2dp by observing typical USD amounts.
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+        ctx.update(dec!(3.00), "USD");
+
+        // A SUM-of-USD-zeros that came out at scale 3 from rust_decimal:
+        let sum_value = Value::Number(dec!(0.000));
+
+        let with_hint = format_value_with_hint(&sum_value, false, &ctx, Some("USD"));
+        let without_hint = format_value_with_hint(&sum_value, false, &ctx, None);
+
+        // With the hint, USD's per-currency precision (2dp) wins.
+        assert_eq!(
+            with_hint, "0.00",
+            "expected 2dp via USD ctx, got {with_hint:?}"
+        );
+        // Without the hint, we fall back to format_value's default (preserves
+        // the natural 3dp scale from rust_decimal).
+        assert_eq!(
+            without_hint, "0.000",
+            "expected default-format to keep rust_decimal natural scale, got {without_hint:?}"
+        );
+    }
+
+    /// Negative path: a non-currency hint string is filtered out by the
+    /// `looks_like_currency` check at the call site, so `format_value_with_hint`
+    /// never sees it. Pin that the helper itself still does the right thing
+    /// when handed a non-currency-shaped string (falls through to ctx,
+    /// which has no entry, so returns default precision).
+    #[test]
+    fn test_format_value_with_hint_unknown_currency_falls_back_safely() {
+        let ctx = DisplayContext::new();
+        let v = Value::Number(dec!(1.5));
+        // "MADEUP" passes looks_like_currency but ctx has no entry — safe.
+        let rendered = format_value_with_hint(&v, false, &ctx, Some("MADEUP"));
+        // Just assert it's a string representation of 1.5 (default scale).
+        assert!(
+            rendered.contains("1.5"),
+            "expected 1.5 in output, got {rendered:?}"
         );
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -70,11 +70,24 @@ fn write_text<W: Write>(
 
     // Resolve per-row currency hints once. The hint feeds both the
     // width-calculation pass and the print pass; computing per-pass
-    // would duplicate the lookup. The borrow lives for the rest of
-    // this function (no mutation of `result` between here and print).
-    let currency_hints: Vec<Option<&str>> = (0..result.rows.len())
-        .map(|i| currency_hint_for_row(result, i, ctx))
-        .collect();
+    // would duplicate the lookup.
+    //
+    // Lifetime: the `&str` entries borrow from `result.row_group_keys`.
+    // Safe because `result` is `&`-borrowed for the rest of this
+    // function — any future refactor that mutates `result` mid-stream
+    // would break this and the borrow checker would point at the cache.
+    //
+    // Short-circuit: when no row has a GROUP BY key (the common case for
+    // non-aggregate queries), every hint would be `None` — skip the
+    // allocation entirely. Access via `currency_hints.get(i).copied().flatten()`
+    // tolerates the empty Vec.
+    let currency_hints: Vec<Option<&str>> = if result.has_aggregate_rows() {
+        (0..result.rows.len())
+            .map(|i| currency_hint_for_row(result, i, ctx))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     // Calculate column widths using per-column contexts
     let mut widths: Vec<usize> = result
@@ -84,7 +97,7 @@ fn write_text<W: Write>(
         .collect();
 
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = currency_hints[row_idx];
+        let currency_hint = currency_hints.get(row_idx).copied().flatten();
         for (i, value) in row.iter().enumerate() {
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
             let len = format_value_with_hint(value, numberify, col_ctx, currency_hint).len();
@@ -128,7 +141,7 @@ fn write_text<W: Write>(
 
     // Print rows using per-column display contexts
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = currency_hints[row_idx];
+        let currency_hint = currency_hints.get(row_idx).copied().flatten();
 
         for (i, value) in row.iter().enumerate() {
             if i > 0 {
@@ -1054,6 +1067,62 @@ mod tests {
             hint,
             Some("USD"),
             "expected USD hint extracted from second key element"
+        );
+    }
+
+    /// Pins the documented "first match wins" contract on
+    /// `add_aggregate_row`: when TWO currency-shaped strings appear in
+    /// the GROUP BY key (rare but possible — e.g.
+    /// `GROUP BY currency, quote_currency`), iteration picks the first
+    /// one. A future change to `find_map` → `last`, scoring, or
+    /// alphabetical-min would break this test (which is the point —
+    /// the contract is load-bearing for downstream behavior).
+    #[test]
+    fn test_currency_hint_for_row_first_currency_wins_when_multiple() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        // Both EUR and USD have tracked precision so the gate doesn't
+        // disambiguate — only the iteration order does.
+        ctx.update(dec!(1.00), "EUR");
+        ctx.update(dec!(2.00), "EUR");
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        let mut result = QueryResult::new(vec![
+            "currency".into(),
+            "quote_currency".into(),
+            "sum".into(),
+        ]);
+        // Row 0 key: [EUR, USD]. First-wins → EUR.
+        result.add_aggregate_row(
+            vec![
+                Value::String("EUR".into()),
+                Value::String("USD".into()),
+                Value::Number(dec!(0.000)),
+            ],
+            vec![Value::String("EUR".into()), Value::String("USD".into())],
+        );
+        // Row 1 key: [USD, EUR] — reversed. Confirms the result tracks
+        // key order, not some side property of EUR/USD specifically.
+        result.add_aggregate_row(
+            vec![
+                Value::String("USD".into()),
+                Value::String("EUR".into()),
+                Value::Number(dec!(0.000)),
+            ],
+            vec![Value::String("USD".into()), Value::String("EUR".into())],
+        );
+
+        assert_eq!(
+            currency_hint_for_row(&result, 0, &ctx),
+            Some("EUR"),
+            "first-wins: [EUR, USD] should pick EUR"
+        );
+        assert_eq!(
+            currency_hint_for_row(&result, 1, &ctx),
+            Some("USD"),
+            "first-wins: [USD, EUR] should pick USD"
         );
     }
 }


### PR DESCRIPTION
## Summary

`SUM(number) GROUP BY currency` (and equivalent implicit-grouping patterns) emit a `Value::Number` that carries no currency context, so text rendering went through the fallback `format_default` path that preserves rust_decimal's natural scale. When inputs had varying scales (e.g. one `0.00` + one `5.213`), the sum kept the wider scale and rendered `0.000` / `5.213` instead of bean-query's `0.00` / `5.21`. Of the ~99 post-#986 BQL compat mismatches, **~15 fell into this bucket**.

## Why Option B, not Option A

Issue #988 recommended **Option A** (quantize at aggregation time). But that conflicts with its own **AC #4: "CSV/JSON output of aggregates remains lossless"** — quantizing in the aggregator mutates inputs for *all* output paths, not just text. JSON consumers parsing exact decimal scales would see truncated values.

This PR implements **Option B** as described in the issue body: plumb GROUP BY currency through to the renderer, quantize at text-render time only.

## Implementation

- `QueryResult` gains `row_group_keys: Vec<Option<Vec<Value>>>` — a parallel sidecar to `rows`. Aggregate path populates it via the new `add_aggregate_row(row, group_key)`; non-aggregate path still calls `add_row(row)` and gets `None` slots.
- `cmd/query/output.rs::write_text` looks up the row's sidecar, finds the first currency-shaped string in the GROUP BY key (heuristic: uppercase initial, `[A-Z0-9'._-]`, ≤24 chars), and passes it as a hint to a new `format_value_with_hint`.
- `format_value_with_hint` routes `Value::Number` cells through `DisplayContext::format(n, currency)` when a hint is present — per-currency precision via the same path used for `Value::Amount`.
- CSV / JSON / beancount renderers still call `format_value` unchanged → lossless preserved → **AC #4 satisfied**.

## Test plan

- [x] 4 new unit tests in `cmd::query::output::tests`:
  - `test_looks_like_currency_accepts_typical_currencies` / `..._rejects_non_currencies` — pin the heuristic
  - `test_format_value_with_hint_routes_number_through_per_currency_ctx` — pins the central dispatch: `Value::Number(0.000)` renders as `\"0.00\"` with USD hint vs `\"0.000\"` without
  - `test_format_value_with_hint_unknown_currency_falls_back_safely` — defense-in-depth for false-positive currency detection
- [x] All 131 `rustledger-query` lib tests still pass.
- [x] All existing `rustledger --lib cmd::query` tests still pass.
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Pre-push hooks all green.
- [ ] Maintainer: run the BQL compat harness from the issue's reproduction steps to confirm the ~15 precision-only mismatches resolve.

## What's NOT changed

- The aggregator (`executor/aggregation.rs`) — SUM still preserves full precision in `Value::Number`. CSV/JSON serializers see the raw decimal.
- The brace-format logic from #987 — out of scope per the issue.
- The 6 booking-time interpolation precision diffs — separate issue (#989 territory).

Closes #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)