### PR TITLE
chore(ci): bump beancount_reds_plugins pin to include box_accrual

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -57,7 +57,15 @@ jobs:
           # Pinned to immutable commits so compat CI is reproducible —
           # tracking HEAD turns unrelated upstream commits into
           # spurious red CI here. Bump deliberately when needed.
-          pip install git+https://github.com/redstreet/beancount_reds_plugins@41af12d13c6ba5b2949b2939dfa180f43a5cb307
+          # Bumped to include the box_accrual plugin (added 2025-10-14
+          # in commit 6d67ce6cbdb5b36e71e76adb5c741ef6734ec407). The
+          # previous pin (41af12d) predated the plugin, so bean-check
+          # failed with ModuleNotFoundError on the
+          # `beancount_reds_plugins/box_accrual/test.beancount` fixture
+          # while rledger (which has a native port) succeeded — the
+          # `rust_only_pass` divergence reported in #990 was
+          # environmental, not semantic.
+          pip install git+https://github.com/redstreet/beancount_reds_plugins@c94911f15ddb8776eac8280e6688ead578aaf344
           pip install git+https://github.com/Evernight/beancount-lazy-plugins@1a685eddbd5e15e420fdf93604506eed6ca94c45
       # Cache downloaded test files to avoid re-cloning repos every run
       - name: Cache compatibility test files


### PR DESCRIPTION
## Summary

The pinned `beancount_reds_plugins` commit in `compat.yml` (`41af12d`, ~early-2024) predated the `box_accrual` plugin (added 2025-10-14, commit `6d67ce6`). The compat fixture `beancount_reds_plugins/box_accrual/test.beancount` is downloaded unpinned from upstream HEAD by `scripts/fetch-compat-test-files.sh`, so the file references a plugin that isn't installed in CI's Python env.

Result: bean-check failed with `ModuleNotFoundError: No module named 'beancount_reds_plugins.box_accrual'`, while rledger (which has a native Rust port of the plugin in its built-in registry) succeeded. The compat harness flagged this as `rust_only_pass`, but the divergence was purely environmental, not semantic.

Bumped to `c94911f` (latest stable as of 2026-04-12). After this lands, the box_accrual fixture should reach `python_ok = true, rust_ok = true`.

## Investigation context

This came out of the #990 review. Two `rust_only_pass` cases were reported:

- `box_accrual/test.beancount` — environmental (this PR fixes it)
- `htsec/example-htsec-output.beancount` — real validation gap (separate issue to follow)

The htsec case is a genuine missing-validator bug in rledger (negative inventories from selling without prior buy lots, plus unsolvable interpolation). It will be filed and fixed separately.

## Test plan

- [x] Verified `c94911f` includes `box_accrual` and `daf` plugins.
- [ ] CI compat run on this PR should show the box_accrual fixture moving from `rust_only_pass` to `both_ok`.

Refs #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)