### PR TITLE
feat(display): precision: N metadata on commodity directives

### DIFF
--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -75,6 +75,55 @@ impl fmt::Display for MetaValue {
 /// Metadata is a key-value map attached to directives and postings.
 pub type Metadata = FxHashMap<String, MetaValue>;
 
+/// Try to interpret a [`MetaValue`] as a non-negative integer ≤ `u32::MAX`.
+///
+/// Used by the `precision` metadata feature on `commodity` directives (issue
+/// #991). Shared between the loader (which silently skips invalid values and
+/// falls back to inferred precision) and the validator (which surfaces the
+/// problem as an `InvalidPrecisionMetadata` warning), so both paths agree on
+/// what counts as valid.
+///
+/// # Errors
+///
+/// Returns a human-readable explanation when the value is not a number,
+/// is negative, has a fractional part, or is out of `u32` range.
+pub fn parse_precision_meta(value: &MetaValue) -> Result<u32, String> {
+    use rust_decimal::prelude::ToPrimitive;
+    let MetaValue::Number(n) = value else {
+        return Err(format!(
+            "expected a non-negative integer, got {} value",
+            meta_value_kind(value)
+        ));
+    };
+    if n.is_sign_negative() {
+        return Err(format!("expected a non-negative integer, got {n}"));
+    }
+    if !n.fract().is_zero() {
+        return Err(format!("expected an integer, got {n}"));
+    }
+    n.to_u32().ok_or_else(|| {
+        format!(
+            "value {n} exceeds the maximum supported precision ({})",
+            u32::MAX
+        )
+    })
+}
+
+const fn meta_value_kind(v: &MetaValue) -> &'static str {
+    match v {
+        MetaValue::String(_) => "string",
+        MetaValue::Account(_) => "account",
+        MetaValue::Currency(_) => "currency",
+        MetaValue::Tag(_) => "tag",
+        MetaValue::Link(_) => "link",
+        MetaValue::Date(_) => "date",
+        MetaValue::Number(_) => "number",
+        MetaValue::Bool(_) => "bool",
+        MetaValue::Amount(_) => "amount",
+        MetaValue::None => "none",
+    }
+}
+
 /// A posting within a transaction.
 ///
 /// Postings represent the individual legs of a transaction. Each posting
@@ -1665,5 +1714,49 @@ mod tests {
         );
         let dir_balance = Directive::Balance(balance.clone());
         assert_eq!(format!("{dir_balance}"), format!("{balance}"));
+    }
+
+    // ----- parse_precision_meta (issue #991) ---------------------------------
+
+    #[test]
+    fn parse_precision_meta_accepts_non_negative_integers() {
+        assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(0))), Ok(0));
+        assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(2))), Ok(2));
+        assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(28))), Ok(28));
+    }
+
+    #[test]
+    fn parse_precision_meta_rejects_negatives() {
+        let err = parse_precision_meta(&MetaValue::Number(dec!(-1))).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_precision_meta_rejects_fractional() {
+        let err = parse_precision_meta(&MetaValue::Number(dec!(2.5))).unwrap_err();
+        assert!(err.contains("integer"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_precision_meta_rejects_overflow() {
+        // 2^33 — out of u32 range.
+        let err = parse_precision_meta(&MetaValue::Number(dec!(8589934592))).unwrap_err();
+        assert!(err.contains("exceeds"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_precision_meta_rejects_non_number_variants() {
+        let cases = [
+            MetaValue::String("2".into()),
+            MetaValue::Bool(true),
+            MetaValue::None,
+            MetaValue::Tag("foo".into()),
+        ];
+        for case in cases {
+            assert!(
+                parse_precision_meta(&case).is_err(),
+                "should reject {case:?}"
+            );
+        }
     }
 }

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -1752,16 +1752,31 @@ mod tests {
 
     #[test]
     fn parse_precision_meta_rejects_non_number_variants() {
+        // Cover every non-Number `MetaValue` variant so the kind-labeling
+        // arms in `meta_value_kind` are all exercised. Each error message
+        // names the kind ("string value", "bool value", etc.) so users
+        // see what they actually wrote.
+        use crate::Amount;
+        use rust_decimal_macros::dec;
         let cases = [
-            MetaValue::String("2".into()),
-            MetaValue::Bool(true),
-            MetaValue::None,
-            MetaValue::Tag("foo".into()),
+            (MetaValue::String("2".into()), "string"),
+            (MetaValue::Account("Assets:Cash".into()), "account"),
+            (MetaValue::Currency("USD".into()), "currency"),
+            (MetaValue::Tag("foo".into()), "tag"),
+            (MetaValue::Link("bar".into()), "link"),
+            (MetaValue::Date(date(2024, 1, 1)), "date"),
+            (MetaValue::Bool(true), "bool"),
+            (MetaValue::Amount(Amount::new(dec!(2), "USD")), "amount"),
+            (MetaValue::None, "none"),
         ];
-        for case in cases {
+        for (case, kind) in cases {
+            let err = match parse_precision_meta(&case) {
+                Ok(_) => panic!("should have rejected {case:?}"),
+                Err(e) => e,
+            };
             assert!(
-                parse_precision_meta(&case).is_err(),
-                "should reject {case:?}"
+                err.contains(kind),
+                "error for {case:?} should mention kind {kind:?}, got: {err}"
             );
         }
     }

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -87,6 +87,7 @@ pub type Metadata = FxHashMap<String, MetaValue>;
 ///
 /// Returns a human-readable explanation when the value is not a number,
 /// is negative, has a fractional part, or is out of `u32` range.
+#[must_use = "ignoring the result silently drops invalid `precision:` metadata; the loader expects to skip invalid values, the validator expects to surface them"]
 pub fn parse_precision_meta(value: &MetaValue) -> Result<u32, String> {
     use rust_decimal::prelude::ToPrimitive;
     let MetaValue::Number(n) = value else {
@@ -1723,6 +1724,11 @@ mod tests {
         assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(0))), Ok(0));
         assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(2))), Ok(2));
         assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(28))), Ok(28));
+        // Integer-valued decimals (e.g. `precision: 2.0` in source) must
+        // round-trip the same as `precision: 2` — the parser will produce
+        // `Number(dec!(2.0))` for the dotted form.
+        assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(2.0))), Ok(2));
+        assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(0.000))), Ok(0));
     }
 
     #[test]

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -62,7 +62,7 @@ pub use cost::{Cost, CostSpec};
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, Query, Transaction,
-    sort_directives,
+    parse_precision_meta, sort_directives,
 };
 pub use display_context::{DEFAULT_CURRENCY, DisplayContext, Precision};
 pub use extract::{

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -715,6 +715,22 @@ fn build_display_context(directives: &[Spanned<Directive>], options: &Options) -
         ctx.set_fixed_precision(currency, *precision);
     }
 
+    // Apply per-commodity `precision: N` metadata (issue #991), AFTER the
+    // options loop so a commodity-level declaration wins over the global
+    // option. Multi-declaration of the same currency is last-wins (matches
+    // typical option-stacking semantics). Invalid values are silently
+    // skipped here — `rustledger-validate` surfaces them as
+    // `InvalidPrecisionMetadata` warnings (E5003) so users see the problem
+    // without breaking loading.
+    for spanned in directives {
+        if let Directive::Commodity(comm) = &spanned.value
+            && let Some(value) = comm.meta.get("precision")
+            && let Ok(precision) = rustledger_core::parse_precision_meta(value)
+        {
+            ctx.set_fixed_precision(comm.currency.as_str(), precision);
+        }
+    }
+
     ctx
 }
 

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -1360,12 +1360,14 @@ fn precision_metadata_zero_is_valid() {
 
 #[test]
 fn precision_metadata_wins_over_option_display_precision() {
-    // option says 2dp, commodity meta says 4dp → meta wins (per #991).
+    // option says 2dp (`USD:0.01` — the colon-encoded form rledger's
+    // option parser accepts; precision = scale of the example value),
+    // commodity meta says 4dp → meta wins (per #991).
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("precision_vs_option.beancount");
     std::fs::write(
         &path,
-        r#"option "display_precision" "USD" "2"
+        r#"option "display_precision" "USD:0.01"
 
 2024-01-01 commodity USD
   precision: 4
@@ -1416,8 +1418,10 @@ fn precision_metadata_multi_declaration_last_wins() {
 
 #[test]
 fn precision_metadata_invalid_falls_back_to_inference() {
-    // `precision: -1` is invalid → loader silently skips it and inference
-    // runs (USD postings are 4dp in this fixture).
+    // `precision: -1` is invalid → loader silently skips it. With no
+    // `option "display_precision"` set, inference takes over (USD postings
+    // are 4dp in this fixture). The option-present case is covered
+    // separately by `precision_metadata_invalid_with_option_keeps_option`.
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("precision_invalid.beancount");
     std::fs::write(
@@ -1464,6 +1468,40 @@ fn precision_metadata_non_integer_falls_back() {
     let result = load_raw(&path).expect("load");
     assert_eq!(result.display_context.get_precision("USD"), Some(3));
     assert!(!result.display_context.has_fixed_precision("USD"));
+}
+
+#[test]
+fn precision_metadata_invalid_with_option_keeps_option() {
+    // option says 2dp; commodity meta is invalid (-1). The invalid value is
+    // ignored; the option override stays at 2dp. Pins the precedence stack
+    // documented in docs/commands/query.md ("Overriding inference"):
+    //   valid precision metadata > option "display_precision" > inference.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_invalid_with_option.beancount");
+    std::fs::write(
+        &path,
+        r#"option "display_precision" "USD:0.01"
+
+2024-01-01 commodity USD
+  precision: -1
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1.2345 USD
+  Assets:Cash   -1.2345 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(
+        result.display_context.get_precision("USD"),
+        Some(2),
+        "option fixed precision must persist when commodity meta is invalid"
+    );
+    assert!(
+        result.display_context.has_fixed_precision("USD"),
+        "option fixed override must remain in effect"
+    );
 }
 
 #[test]

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -1467,6 +1467,42 @@ fn precision_metadata_non_integer_falls_back() {
 }
 
 #[test]
+fn precision_metadata_valid_then_invalid_keeps_first() {
+    // Same currency declared twice: first valid (2), second invalid (-1).
+    // The invalid declaration is silently skipped by the loader, so the
+    // earlier valid override stays in place. This pins the
+    // "first-valid-wins-when-later-is-invalid" behavior — it's a
+    // deliberate choice over strict last-wins because falling back to
+    // inference because of a typo two pages later would be more
+    // surprising. The validator still emits E5003 for the bad one
+    // (covered separately).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_valid_then_invalid.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity USD
+  precision: 2
+
+2024-06-01 commodity USD
+  precision: -1
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1.2345 USD
+  Assets:Cash   -1.2345 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(
+        result.display_context.get_precision("USD"),
+        Some(2),
+        "earlier valid precision must persist when a later declaration is invalid"
+    );
+    assert!(result.display_context.has_fixed_precision("USD"));
+}
+
+#[test]
 fn precision_metadata_string_value_falls_back() {
     // `precision: "abc"` is the wrong MetaValue variant → invalid →
     // inference wins (2dp here).

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -1301,3 +1301,190 @@ fn test_missing_wasm_plugin_reports_error() {
         ledger.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+// ----- precision: N metadata on commodity directives (issue #991) ------------
+//
+// All tests use load_raw (not the full load() path) so the assertions stay
+// scoped to display_context construction and aren't affected by validation /
+// booking. Validator behavior for invalid values is exercised separately.
+
+#[test]
+fn precision_metadata_sets_fixed_precision() {
+    // `precision: 2` alone should pin USD to 2dp regardless of the inferred
+    // dp distribution (here 4dp would normally win under MostCommon).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_meta.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity USD
+  precision: 2
+
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:Salary
+
+2024-01-15 * "test"
+  Assets:Cash       100.0000 USD
+  Income:Salary
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(
+        result.display_context.get_precision("USD"),
+        Some(2),
+        "commodity precision metadata should pin USD to 2dp"
+    );
+    assert!(result.display_context.has_fixed_precision("USD"));
+}
+
+#[test]
+fn precision_metadata_zero_is_valid() {
+    // JPY-style integer-only currency: `precision: 0` must be honored.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_zero.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity JPY
+  precision: 0
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "yen"
+  Assets:Cash    1000 JPY
+  Assets:Cash   -1000 JPY
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(result.display_context.get_precision("JPY"), Some(0));
+}
+
+#[test]
+fn precision_metadata_wins_over_option_display_precision() {
+    // option says 2dp, commodity meta says 4dp → meta wins (per #991).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_vs_option.beancount");
+    std::fs::write(
+        &path,
+        r#"option "display_precision" "USD" "2"
+
+2024-01-01 commodity USD
+  precision: 4
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1.00 USD
+  Assets:Cash   -1.00 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(
+        result.display_context.get_precision("USD"),
+        Some(4),
+        "commodity metadata must override option display_precision"
+    );
+}
+
+#[test]
+fn precision_metadata_multi_declaration_last_wins() {
+    // Two commodity directives for USD; the second's precision wins.
+    // Last-wins matches typical option-stacking semantics.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_multi.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity USD
+  precision: 2
+
+2024-06-01 commodity USD
+  precision: 6
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1 USD
+  Assets:Cash   -1 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(
+        result.display_context.get_precision("USD"),
+        Some(6),
+        "last commodity declaration's precision must win"
+    );
+}
+
+#[test]
+fn precision_metadata_invalid_falls_back_to_inference() {
+    // `precision: -1` is invalid → loader silently skips it and inference
+    // runs (USD postings are 4dp in this fixture).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_invalid.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity USD
+  precision: -1
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1.2345 USD
+  Assets:Cash   -1.2345 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(
+        result.display_context.get_precision("USD"),
+        Some(4),
+        "invalid precision must fall back to inferred dp"
+    );
+    assert!(
+        !result.display_context.has_fixed_precision("USD"),
+        "invalid precision must NOT install a fixed override"
+    );
+}
+
+#[test]
+fn precision_metadata_non_integer_falls_back() {
+    // `precision: 2.5` is non-integer → invalid → inference wins (3dp here).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_non_integer.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity USD
+  precision: 2.5
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1.234 USD
+  Assets:Cash   -1.234 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(result.display_context.get_precision("USD"), Some(3));
+    assert!(!result.display_context.has_fixed_precision("USD"));
+}
+
+#[test]
+fn precision_metadata_string_value_falls_back() {
+    // `precision: "abc"` is the wrong MetaValue variant → invalid →
+    // inference wins (2dp here).
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("precision_string.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 commodity USD
+  precision: "abc"
+
+2024-01-01 open Assets:Cash
+2024-01-15 * "test"
+  Assets:Cash    1.23 USD
+  Assets:Cash   -1.23 USD
+"#,
+    )
+    .unwrap();
+    let result = load_raw(&path).expect("load");
+    assert_eq!(result.display_context.get_precision("USD"), Some(2));
+    assert!(!result.display_context.has_fixed_precision("USD"));
+}

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -210,6 +210,38 @@ fn test_parse_commodity_directive() {
 }
 
 #[test]
+fn test_commodity_precision_metadata_round_trips() {
+    // Issue #991: per-commodity `precision: N` metadata must round-trip
+    // through parse → format → parse without changing value or type.
+    use rust_decimal_macros::dec;
+    use rustledger_core::{FormatConfig, MetaValue, format_directive};
+
+    let source = "2024-01-01 commodity USD\n  precision: 2\n";
+    let parsed = parse_ok(source);
+    let Directive::Commodity(comm) = &parsed.directives[0].value else {
+        panic!("expected commodity");
+    };
+    // First parse: stays a Number(2), not a string or anything else.
+    assert_eq!(
+        comm.meta.get("precision"),
+        Some(&MetaValue::Number(dec!(2))),
+        "parser must produce Number(2) for unquoted integer metadata"
+    );
+
+    // Format the directive and re-parse — the value must survive unchanged.
+    let formatted = format_directive(&parsed.directives[0].value, &FormatConfig::default());
+    let reparsed = parse_ok(&formatted);
+    let Directive::Commodity(comm2) = &reparsed.directives[0].value else {
+        panic!("expected commodity after re-parse");
+    };
+    assert_eq!(
+        comm2.meta.get("precision"),
+        Some(&MetaValue::Number(dec!(2))),
+        "round-tripped precision must remain Number(2); got formatted: {formatted:?}"
+    );
+}
+
+#[test]
 fn test_parse_query_directive() {
     let source = r#"2024-01-01 query "expenses" "SELECT account, SUM(position)""#;
     let result = parse_ok(source);

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -56,6 +56,8 @@ pub enum ErrorCode {
     UndeclaredCurrency,
     /// E5002: Currency not allowed in account.
     CurrencyNotAllowed,
+    /// E5003: Invalid `precision` metadata on commodity directive (warning).
+    InvalidPrecisionMetadata,
 
     // === Option Errors (E7xxx) ===
     /// E7001: Unknown option name.
@@ -105,6 +107,7 @@ impl ErrorCode {
             // Currency errors
             Self::UndeclaredCurrency => "E5001",
             Self::CurrencyNotAllowed => "E5002",
+            Self::InvalidPrecisionMetadata => "E5003",
             // Option errors
             Self::UnknownOption => "E7001",
             Self::InvalidOptionValue => "E7002",
@@ -126,6 +129,7 @@ impl ErrorCode {
                 | Self::SinglePosting
                 | Self::AccountCloseNotEmpty
                 | Self::DateOutOfOrder
+                | Self::InvalidPrecisionMetadata
         )
     }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -554,9 +554,8 @@ pub fn validate_spanned_with_options(
 /// Validate the rledger-specific `precision` metadata key on a commodity directive.
 ///
 /// Per #991, `precision: N` on a `commodity` directive sets a fixed display
-/// precision for that currency. The loader silently falls back to inference
-/// for invalid values; this validator is the channel that surfaces the
-/// problem to the user.
+/// precision for that currency. The loader silently ignores invalid values;
+/// this validator is the channel that surfaces the problem to the user.
 fn validate_commodity_precision_meta(comm: &Commodity, errors: &mut Vec<ValidationError>) {
     let Some(value) = comm.meta.get("precision") else {
         return;
@@ -565,7 +564,7 @@ fn validate_commodity_precision_meta(comm: &Commodity, errors: &mut Vec<Validati
         errors.push(ValidationError::new(
             ErrorCode::InvalidPrecisionMetadata,
             format!(
-                "invalid `precision` metadata on commodity {}: {reason}; falling back to inferred precision",
+                "invalid `precision` metadata on commodity {}: {reason}; this declaration is ignored — display precision falls back to `option \"display_precision\"` if set, otherwise to inference",
                 comm.currency
             ),
             comm.date,

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -33,6 +33,7 @@
 //! | E4005 | Negative cost amount |
 //! | E5001 | Currency not declared |
 //! | E5002 | Currency not allowed in account |
+//! | E5003 | Invalid `precision` metadata on commodity directive (warning) |
 //! | E7001 | Unknown option |
 //! | E7002 | Invalid option value |
 //! | E7003 | Duplicate option |
@@ -61,7 +62,7 @@ use rustledger_core::NaiveDate;
 const PARALLEL_SORT_THRESHOLD: usize = 5000;
 use rust_decimal::Decimal;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustledger_core::{BookingMethod, Directive, InternedStr, Inventory};
+use rustledger_core::{BookingMethod, Commodity, Directive, InternedStr, Inventory};
 use rustledger_parser::{SYNTHESIZED_FILE_ID, Spanned};
 
 /// Account state for tracking lifecycle.
@@ -371,6 +372,7 @@ pub fn validate_with_options(
             }
             Directive::Commodity(comm) => {
                 state.commodities.insert(comm.currency.clone());
+                validate_commodity_precision_meta(comm, &mut errors);
             }
             Directive::Pad(pad) => {
                 validate_pad(&mut state, pad, &mut errors);
@@ -493,6 +495,7 @@ pub fn validate_spanned_with_options(
             }
             Directive::Commodity(comm) => {
                 state.commodities.insert(comm.currency.clone());
+                validate_commodity_precision_meta(comm, &mut errors);
             }
             Directive::Pad(pad) => {
                 validate_pad(&mut state, pad, &mut errors);
@@ -548,12 +551,34 @@ pub fn validate_spanned_with_options(
     errors
 }
 
+/// Validate the rledger-specific `precision` metadata key on a commodity directive.
+///
+/// Per #991, `precision: N` on a `commodity` directive sets a fixed display
+/// precision for that currency. The loader silently falls back to inference
+/// for invalid values; this validator is the channel that surfaces the
+/// problem to the user.
+fn validate_commodity_precision_meta(comm: &Commodity, errors: &mut Vec<ValidationError>) {
+    let Some(value) = comm.meta.get("precision") else {
+        return;
+    };
+    if let Err(reason) = rustledger_core::parse_precision_meta(value) {
+        errors.push(ValidationError::new(
+            ErrorCode::InvalidPrecisionMetadata,
+            format!(
+                "invalid `precision` metadata on commodity {}: {reason}; falling back to inferred precision",
+                comm.currency
+            ),
+            comm.date,
+        ));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
     use rustledger_core::{
-        Amount, Balance, Close, Document, NaiveDate, Open, Pad, Posting, Transaction,
+        Amount, Balance, Close, Document, MetaValue, NaiveDate, Open, Pad, Posting, Transaction,
     };
 
     fn date(year: i32, month: u32, day: u32) -> NaiveDate {
@@ -1860,5 +1885,102 @@ mod tests {
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].code, ErrorCode::DuplicateOption);
+    }
+
+    // ----- E5003: invalid `precision` metadata on commodity (issue #991) ----
+
+    fn commodity_with_precision(value: MetaValue) -> Directive {
+        let mut meta = rustledger_core::Metadata::default();
+        meta.insert("precision".into(), value);
+        Directive::Commodity(
+            rustledger_core::Commodity::new(date(2024, 1, 1), "USD").with_meta(meta),
+        )
+    }
+
+    #[test]
+    fn precision_meta_valid_integer_emits_no_warning() {
+        let directives = vec![commodity_with_precision(MetaValue::Number(dec!(2)))];
+        let errors = validate(&directives);
+        assert!(
+            errors
+                .iter()
+                .all(|e| e.code != ErrorCode::InvalidPrecisionMetadata),
+            "valid precision must not produce a warning, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn precision_meta_zero_is_valid() {
+        let directives = vec![commodity_with_precision(MetaValue::Number(dec!(0)))];
+        let errors = validate(&directives);
+        assert!(
+            errors
+                .iter()
+                .all(|e| e.code != ErrorCode::InvalidPrecisionMetadata)
+        );
+    }
+
+    #[test]
+    fn precision_meta_negative_emits_e5003() {
+        let directives = vec![commodity_with_precision(MetaValue::Number(dec!(-1)))];
+        let errors = validate(&directives);
+        let warnings: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == ErrorCode::InvalidPrecisionMetadata)
+            .collect();
+        assert_eq!(warnings.len(), 1, "expected one E5003");
+        assert_eq!(warnings[0].code.severity(), Severity::Warning);
+        assert!(warnings[0].message.contains("non-negative"));
+    }
+
+    #[test]
+    fn precision_meta_non_integer_emits_e5003() {
+        let directives = vec![commodity_with_precision(MetaValue::Number(dec!(2.5)))];
+        let errors = validate(&directives);
+        let warnings: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == ErrorCode::InvalidPrecisionMetadata)
+            .collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("integer"));
+    }
+
+    #[test]
+    fn precision_meta_string_value_emits_e5003() {
+        let directives = vec![commodity_with_precision(MetaValue::String("abc".into()))];
+        let errors = validate(&directives);
+        let warnings: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == ErrorCode::InvalidPrecisionMetadata)
+            .collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("string"));
+    }
+
+    #[test]
+    fn precision_meta_out_of_u32_range_emits_e5003() {
+        // 2^33 — too big for u32.
+        let directives = vec![commodity_with_precision(MetaValue::Number(dec!(
+            8589934592
+        )))];
+        let errors = validate(&directives);
+        let warnings: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == ErrorCode::InvalidPrecisionMetadata)
+            .collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("exceeds"));
+    }
+
+    #[test]
+    fn precision_meta_e5003_is_warning_severity() {
+        // Pin the severity classification — InvalidPrecisionMetadata must be
+        // a warning (loading does not fail). Used by CLI / LSP renderers to
+        // pick the right color and exit code.
+        assert_eq!(
+            ErrorCode::InvalidPrecisionMetadata.severity(),
+            Severity::Warning
+        );
+        assert_eq!(ErrorCode::InvalidPrecisionMetadata.code(), "E5003");
     }
 }

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -1973,6 +1973,28 @@ mod tests {
     }
 
     #[test]
+    fn precision_meta_valid_then_invalid_same_currency_warns_only_once() {
+        // Two commodity directives for USD: first valid (2), second invalid
+        // (-1). The validator must surface the bad one as E5003 even though
+        // the loader pins the earlier valid override. This pairs with the
+        // loader-side test `precision_metadata_valid_then_invalid_keeps_first`.
+        let directives = vec![
+            commodity_with_precision(MetaValue::Number(dec!(2))),
+            commodity_with_precision(MetaValue::Number(dec!(-1))),
+        ];
+        let warnings: Vec<_> = validate(&directives)
+            .into_iter()
+            .filter(|e| e.code == ErrorCode::InvalidPrecisionMetadata)
+            .collect();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "exactly one E5003 expected (only the invalid declaration)"
+        );
+        assert!(warnings[0].message.contains("non-negative"));
+    }
+
+    #[test]
     fn precision_meta_e5003_is_warning_severity() {
         // Pin the severity classification — InvalidPrecisionMetadata must be
         // a warning (loading does not fail). Used by CLI / LSP renderers to

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -178,14 +178,44 @@ VBMPX:
 
 ### Overriding inference
 
-Inferred precision is a heuristic. To pin a currency's display precision explicitly, use the `display_precision` option in your beancount file:
+Inferred precision is a heuristic. There are two ways to pin a currency's display precision explicitly.
+
+**`option "display_precision"`** — file-level setting:
 
 ```beancount
 option "display_precision" "USD" "2"
 option "display_precision" "BTC" "8"
 ```
 
-Fixed overrides take precedence over inference for any matching currency, regardless of what the per-currency distribution shows. This is the recommended way to enforce a specific precision when the inferred mode would produce surprising results — for example, a small file with more `Price` directives than postings could see the inferred precision shift toward the price precision.
+**`precision: N` metadata on a `commodity` directive** (rledger extension, issue #991):
+
+```beancount
+2024-01-01 commodity USD
+  precision: 2
+
+2024-01-01 commodity BTC
+  precision: 8
+
+2024-01-01 commodity JPY
+  precision: 0
+```
+
+Both achieve the same outcome — pinning the displayed precision for that currency regardless of what the inferred distribution shows. Use whichever is more ergonomic: `option "display_precision"` keeps the configuration in one place, while `precision:` metadata co-locates the precision with the rest of the commodity declaration (asset class, ticker, etc.).
+
+**Precedence.** When both are set for the same currency, the per-commodity `precision:` metadata wins:
+
+```beancount
+option "display_precision" "USD" "2"
+
+2024-01-01 commodity USD
+  precision: 4    ; this wins — USD renders at 4dp
+```
+
+If the same currency has `precision:` metadata on multiple `commodity` directives, the last one in load order wins.
+
+**Validation.** `precision:` metadata must be a non-negative integer (0 through 4_294_967_295). Invalid values — strings, negatives, fractions, out-of-range — produce an `E5003` warning during validation and the loader silently falls back to inference for that currency. Loading does not fail.
+
+**Reserved key.** The `precision` key on `commodity` directives is reserved by the loader — pre-existing user-defined uses of this key on commodity directives will be reinterpreted as a precision override. Pick a different key (e.g. `display_precision`, `precision_note`) if you need to attach unrelated metadata.
 
 ### Naked-decimal columns
 

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -180,11 +180,11 @@ VBMPX:
 
 Inferred precision is a heuristic. There are two ways to pin a currency's display precision explicitly.
 
-**`option "display_precision"`** — file-level setting:
+**`option "display_precision"`** — file-level setting (precision is the scale of the example value):
 
 ```beancount
-option "display_precision" "USD" "2"
-option "display_precision" "BTC" "8"
+option "display_precision" "USD:0.01"      ; 2dp
+option "display_precision" "BTC:0.00000001" ; 8dp
 ```
 
 **`precision: N` metadata on a `commodity` directive** (rledger extension, issue #991):
@@ -205,7 +205,7 @@ Both achieve the same outcome — pinning the displayed precision for that curre
 **Precedence.** When both are set for the same currency, the per-commodity `precision:` metadata wins:
 
 ```beancount
-option "display_precision" "USD" "2"
+option "display_precision" "USD:0.01"  ; 2dp
 
 2024-01-01 commodity USD
   precision: 4    ; this wins — USD renders at 4dp
@@ -213,7 +213,7 @@ option "display_precision" "USD" "2"
 
 If the same currency has `precision:` metadata on multiple `commodity` directives, the last one in load order wins.
 
-**Validation.** `precision:` metadata must be a non-negative integer (0 through 4_294_967_295). Invalid values — strings, negatives, fractions, out-of-range — produce an `E5003` warning during validation and the loader silently falls back to inference for that currency. Loading does not fail.
+**Validation.** `precision:` metadata must be a non-negative integer (0 through 4_294_967_295). Invalid values — strings, negatives, fractions, out-of-range — produce an `E5003` warning during validation and the loader ignores that declaration. The currency's effective precision then falls back through the precedence stack: any other valid `precision:` metadata on the same currency, then `option "display_precision"` if set, then inference. Loading does not fail.
 
 **Reserved key.** The `precision` key on `commodity` directives is reserved by the loader — pre-existing user-defined uses of this key on commodity directives will be reinterpreted as a precision override. Pick a different key (e.g. `display_precision`, `precision_note`) if you need to attach unrelated metadata.
 

--- a/tests/regressions/precision-meta-on-commodity.beancount
+++ b/tests/regressions/precision-meta-on-commodity.beancount
@@ -1,0 +1,45 @@
+; Regression fixture for `precision: N` metadata on commodity directives
+; (issue #991, rledger-specific feature).
+;
+; This fixture is exercised by the compat harness (scripts/compat-bql-test.py)
+; to pin the upstream-compatibility property: bean-check must accept
+; `precision: N` on a commodity directive without error, since the metadata is
+; just a key/value pair to upstream beancount. The harness diffs bean-check
+; vs `rledger check` exit codes and AST counts; this fixture pins that they
+; both succeed.
+;
+; If a future bean-check version starts rejecting integer metadata values on
+; commodity directives, this fixture will turn red and we'll see it before
+; users do.
+;
+; The semantic effect (USD pinned to 2dp, JPY to 0dp) is rledger-specific
+; — bean-check ignores the key, so its display behavior is unchanged. That
+; divergence is intentional and is not under compat-harness scrutiny here.
+
+option "title" "Precision metadata on commodity directives"
+
+2024-01-01 commodity USD
+  precision: 2
+
+2024-01-01 commodity JPY
+  precision: 0
+
+2024-01-01 commodity BTC
+  precision: 8
+
+2024-01-01 open Assets:Cash:USD
+2024-01-01 open Assets:Cash:JPY
+2024-01-01 open Assets:Wallet:BTC
+2024-01-01 open Equity:Opening-Balances
+
+2024-01-15 * "USD opening"
+  Assets:Cash:USD          1234.56 USD
+  Equity:Opening-Balances
+
+2024-01-15 * "JPY opening"
+  Assets:Cash:JPY          100000 JPY
+  Equity:Opening-Balances
+
+2024-01-15 * "BTC opening"
+  Assets:Wallet:BTC        0.50000000 BTC
+  Equity:Opening-Balances


### PR DESCRIPTION
## Summary

- Per-commodity `precision: N` metadata on `commodity` directives — a rledger-specific override that wins over `option "display_precision"`. Closes #991.
- New `E5003 InvalidPrecisionMetadata` warning surfaces type/range errors via `rledger check` and the LSP without breaking loading (loader silently falls back to inferred precision).
- Shared `parse_precision_meta` helper in `rustledger-core` keeps loader and validator in lockstep on what counts as valid.

## What changed

| Crate | Change |
|---|---|
| `rustledger-core` | New `parse_precision_meta(&MetaValue) -> Result<u32, String>` helper next to `MetaValue`. Re-exported from `lib.rs`. |
| `rustledger-loader` | `build_display_context` walks Commodity directives **after** the `options.display_precision` loop and applies any valid `precision:` metadata. Multi-declaration is last-wins. |
| `rustledger-validate` | New `ErrorCode::InvalidPrecisionMetadata` (E5003, warning severity). `validate_commodity_precision_meta` helper called from both `validate_with_options` and `validate_spanned_with_options`. |
| `docs/commands/query.md` | "Overriding inference" section documents the feature, precedence vs option, validation, and the reserved-key caveat. |

## Why

Issue #991 calls this out as the explicit-precision lever blais pointed to in beanquery#275. `option "display_precision"` already exists but isn't where users expect to declare per-currency precision. Co-locating it with the commodity declaration matches user intuition.

## Test plan

- [x] `cargo check --all-features --all-targets` (clean)
- [x] `cargo clippy --all-features -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] 5 new core tests (`parse_precision_meta` variants — accepts non-negative integers, rejects negatives/fractional/overflow/non-Number variants)
- [x] 7 new validator tests (E5003 fires on negative/non-integer/string/out-of-range; valid integers and 0 are silent; severity classification pinned)
- [x] 7 new loader tests (precedence over option, multi-declaration last-wins, `precision: 0` accepted, invalid values fall back to inference for negatives/non-integers/string-values)
- [x] 1 new parser round-trip test (`parse → format → parse` preserves `precision: 2` as `MetaValue::Number(2)`)
- [x] Verified `bean-check` accepts the same fixture (compat: it's just a key/value pair to upstream)

## Behavior summary

```beancount
option "display_precision" "USD" "2"

2024-01-01 commodity USD
  precision: 4    ; this wins → USD renders at 4dp

2024-01-01 commodity JPY
  precision: 0    ; integer-only currency

2024-01-01 commodity BTC
  precision: -1   ; E5003 warning, falls back to inference
```

## Out of scope

- `doctor display-context` source labeling (option vs metadata vs programmatic) — split into follow-up #1031, requires either a tracking field on `DisplayContext` or render-time re-derivation. Not blocking the core feature.
- Upstream PR to bean-query.

Closes #991.