### PR TITLE
fix(query): per-currency precision through PIVOT via column-name fallback

### DIFF
--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -90,7 +90,7 @@ impl Executor<'_> {
         &self,
         result: &QueryResult,
         pivot_exprs: &[Expr],
-        _targets: &[Target],
+        targets: &[Target],
     ) -> Result<QueryResult, QueryError> {
         if pivot_exprs.is_empty() {
             return Ok(result.clone());
@@ -112,14 +112,34 @@ impl Executor<'_> {
         pivot_values.sort_by(|a, b| self.compare_values_for_sort(a, b));
         pivot_values.dedup();
 
-        // Identify the "value" column (usually the last one, or the one
-        // with the aggregate). The row-builder below excludes it from
+        // Identify the "value" column — the LAST VISIBLE SELECT target,
+        // not just the last column in `result`. `execute_select` appends
+        // hidden columns for ORDER BY targets that aren't in SELECT;
+        // those live at positions `targets.len()..result.columns.len()`,
+        // and using `result.columns.len() - 1` would misidentify a
+        // hidden column as the value column to pivot, producing
+        // garbage output.
+        //
+        // Caught by Copilot review on PR #1033. Pivoting in the
+        // presence of hidden ORDER BY columns also has a separate bug
+        // with the post-pivot strip — see #1034 for that one (it doesn't
+        // affect this PR's scope as long as we identify the right
+        // value column here).
+        //
+        // The row-builder below excludes the value column from
         // `group_cols`, so the column header MUST exclude it too —
         // otherwise post-pivot rows have len = group_cols + pivots while
         // columns has len = (orig - pivot_col) + pivots, off by one.
         // Pre-fix, the resulting mismatch silently dropped the SUM cell
         // from JSON output (#1023's e2e test caught this).
-        let value_col_idx = result.columns.len() - 1;
+        let value_col_idx = if targets.is_empty() {
+            // Defensive: targets shouldn't be empty when pivot_by is set
+            // (parser/planner would reject), but if it ever is, fall
+            // back to the prior assumption rather than panicking.
+            result.columns.len().saturating_sub(1)
+        } else {
+            targets.len() - 1
+        };
 
         // Build new column names: original columns (except pivot AND
         // value) + pivot values.

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -112,17 +112,24 @@ impl Executor<'_> {
         pivot_values.sort_by(|a, b| self.compare_values_for_sort(a, b));
         pivot_values.dedup();
 
-        // Build new column names: original columns (except pivot) + pivot values
+        // Identify the "value" column (usually the last one, or the one
+        // with the aggregate). The row-builder below excludes it from
+        // `group_cols`, so the column header MUST exclude it too —
+        // otherwise post-pivot rows have len = group_cols + pivots while
+        // columns has len = (orig - pivot_col) + pivots, off by one.
+        // Pre-fix, the resulting mismatch silently dropped the SUM cell
+        // from JSON output (#1023's e2e test caught this).
+        let value_col_idx = result.columns.len() - 1;
+
+        // Build new column names: original columns (except pivot AND
+        // value) + pivot values.
         let mut new_columns: Vec<String> = result
             .columns
             .iter()
             .enumerate()
-            .filter(|(i, _)| *i != pivot_col_idx)
+            .filter(|(i, _)| *i != pivot_col_idx && *i != value_col_idx)
             .map(|(_, c)| c.clone())
             .collect();
-
-        // Identify the "value" column (usually the last one, or the one with aggregate)
-        let value_col_idx = result.columns.len() - 1;
 
         // Add pivot value columns
         for pv in &pivot_values {

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -1182,7 +1182,7 @@ mod tests {
     // `None` for those rows. The renderer needs a column-name fallback
     // to recover the precision context.
 
-    /// Pivoted rows have `None` group_key but the column name is a
+    /// Pivoted rows have `None` `group_key` but the column name is a
     /// currency code. The width-calc and print passes both consult the
     /// column-name fallback, so a `Value::Number(0.000)` in a USD-named
     /// column should render as `0.00` (matching USD's tracked 2dp).

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -123,13 +123,9 @@ fn write_text<W: Write>(
         .collect();
 
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let row_hint = currency_hints.get(row_idx).copied().flatten();
         for (i, value) in row.iter().enumerate() {
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
-            // Row sidecar wins over column-name fallback (#1023): aggregate
-            // rows always know their grouping currency more precisely than
-            // any column-name heuristic could.
-            let cell_hint = row_hint.or_else(|| column_currency_hints.get(i).copied().flatten());
+            let cell_hint = resolve_cell_hint(&currency_hints, &column_currency_hints, row_idx, i);
             let len = format_value_with_hint(value, numberify, col_ctx, cell_hint).len();
             if i < widths.len() && len > widths[i] {
                 widths[i] = len;
@@ -171,17 +167,12 @@ fn write_text<W: Write>(
 
     // Print rows using per-column display contexts
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let row_hint = currency_hints.get(row_idx).copied().flatten();
-
         for (i, value) in row.iter().enumerate() {
             if i > 0 {
                 write!(writer, "  ")?;
             }
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
-            // Row sidecar wins over column-name fallback (#1023). Must
-            // match the same precedence used in the width-calculation
-            // pass above — otherwise widths and rendered values disagree.
-            let cell_hint = row_hint.or_else(|| column_currency_hints.get(i).copied().flatten());
+            let cell_hint = resolve_cell_hint(&currency_hints, &column_currency_hints, row_idx, i);
             let formatted = format_value_with_hint(value, numberify, col_ctx, cell_hint);
             if i < widths.len() {
                 // Right-align numeric columns to match Python beancount
@@ -362,6 +353,29 @@ fn currency_hint_for_row<'a>(
             _ => None,
         })
     })
+}
+
+/// Combine row sidecar and column-name hints into a single per-cell hint.
+///
+/// Precedence: **row hint wins** over column-name fallback. The row sidecar
+/// came from the actual GROUP BY key (`add_aggregate_row`), so it's a more
+/// authoritative signal than the column name (a heuristic from
+/// `looks_like_currency`).
+///
+/// Pinning the precedence in one helper guarantees the width-calculation
+/// pass and the print pass agree — they MUST, otherwise rendered widths
+/// don't match the rendered values they were sized for.
+fn resolve_cell_hint<'a>(
+    row_hints: &[Option<&'a str>],
+    col_hints: &[Option<&'a str>],
+    row_idx: usize,
+    col_idx: usize,
+) -> Option<&'a str> {
+    row_hints
+        .get(row_idx)
+        .copied()
+        .flatten()
+        .or_else(|| col_hints.get(col_idx).copied().flatten())
 }
 
 /// Format a value with optional GROUP BY currency hint (issue #988).
@@ -1404,5 +1418,107 @@ mod tests {
         // fixture brittle). The text-renderer behavior IS the contract
         // this PR changes; the JSON path goes through `write_json`
         // unchanged.
+    }
+
+    /// Multi-currency PIVOT: USD column at 2dp, JPY column at 0dp on the
+    /// same row. Each pivoted column must use its OWN precision via the
+    /// per-column hint — the column-name fallback isn't a single global
+    /// setting, it's resolved per cell.
+    #[test]
+    fn test_text_pivoted_multi_currency_uses_per_column_precision() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        // USD seeded at 2dp, JPY at 0dp.
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+        ctx.update(dec!(100), "JPY");
+        ctx.update(dec!(200), "JPY");
+
+        // Simulate post-PIVOT shape: same row has BOTH a USD value at
+        // scale 3 and a JPY value at scale 2. After the per-column
+        // fallback, USD should render at 2dp and JPY at 0dp.
+        let mut result = QueryResult::new(vec!["account".into(), "USD".into(), "JPY".into()]);
+        result.add_row(vec![
+            Value::String("Assets:Cash".into()),
+            Value::Number(dec!(0.000)),
+            Value::Number(dec!(50.00)),
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        let data_row = text
+            .lines()
+            .find(|l| l.contains("Assets:Cash"))
+            .unwrap_or_else(|| panic!("expected Assets:Cash row; raw output:\n{text}"));
+
+        // Pull both numeric cells. Whitespace-split is safe here — both
+        // numeric cells have no internal whitespace and the account name
+        // has no spaces.
+        let tokens: Vec<&str> = data_row.split_whitespace().collect();
+        let [_account, usd_cell, jpy_cell] = tokens.as_slice() else {
+            panic!("expected 3 whitespace-separated tokens, got: {tokens:?}");
+        };
+        assert_eq!(
+            *usd_cell, "0.00",
+            "USD column should render at 2dp; row was {data_row:?}"
+        );
+        assert_eq!(
+            *jpy_cell, "50",
+            "JPY column should render at 0dp (integer); row was {data_row:?}"
+        );
+    }
+
+    /// Defensive regression test: a non-pivoted query with a column
+    /// aliased as a currency code (e.g. `SELECT … AS USD`) must NOT have
+    /// its values silently quantized when the active context tracks USD
+    /// for unrelated reasons.
+    ///
+    /// The column-name fallback's `ctx.get_precision().is_some()` guard
+    /// would let the hint kick in if USD is tracked. The expected behavior
+    /// here is debatable — but pinning it as a test means a future change
+    /// will be a deliberate choice, not a silent drift.
+    ///
+    /// Today's contract: WITH tracked USD precision, the fallback DOES
+    /// quantize cells in the USD-aliased column. This is the same
+    /// behavior PIVOT relies on; we're just acknowledging that
+    /// non-pivoted queries inherit it too. If it turns out to be a real
+    /// problem in practice, the fix is to gate the fallback on something
+    /// PIVOT-specific (e.g. a boolean on `QueryResult` set by
+    /// `apply_pivot`).
+    #[test]
+    fn test_non_pivoted_currency_named_column_inherits_fallback_quantization() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        // Non-pivoted result: column literally named USD, value at scale 3.
+        // No row sidecar (so `currency_hints` is empty for this row).
+        let mut result = QueryResult::new(vec!["label".into(), "USD".into()]);
+        result.add_row(vec![
+            Value::String("test".into()),
+            Value::Number(dec!(0.000)),
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        // With USD tracked at 2dp, the column-name fallback applies even
+        // outside the PIVOT path. Pin this behavior so a future tightening
+        // (e.g. PIVOT-only fallback) is a deliberate change.
+        let data_row = text
+            .lines()
+            .find(|l| l.contains("test"))
+            .unwrap_or_else(|| panic!("expected `test` row; raw output:\n{text}"));
+        let last_cell = data_row.split_whitespace().last().expect("non-empty row");
+        assert_eq!(
+            last_cell, "0.00",
+            "currency-named column drives quantization regardless of PIVOT path; row was {data_row:?}"
+        );
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -89,6 +89,32 @@ fn write_text<W: Write>(
         Vec::new()
     };
 
+    // Resolve per-column currency hints from column names (issue #1023).
+    //
+    // PIVOT BY currency reshapes rows: the GROUP BY currency moves into
+    // column position, and each pivoted column's *name* is a currency
+    // code (e.g. "USD", "JPY"). The pivot path uses `add_row` (not
+    // `add_aggregate_row`), so the per-row sidecar is `None` for those
+    // rows — we'd lose the precision context if we relied on
+    // `currency_hints` alone.
+    //
+    // Same false-positive guard as `currency_hint_for_row`: the column
+    // name must both look like a currency AND have tracked precision.
+    // The precision check is what stops a literal column named "USD"
+    // (when no USD has been observed) from routing through
+    // `DisplayContext::format`'s normalize path and stripping zeros.
+    let column_currency_hints: Vec<Option<&str>> = result
+        .columns
+        .iter()
+        .map(|col| {
+            if looks_like_currency(col) && ctx.get_precision(col).is_some() {
+                Some(col.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
     // Calculate column widths using per-column contexts
     let mut widths: Vec<usize> = result
         .columns
@@ -97,10 +123,14 @@ fn write_text<W: Write>(
         .collect();
 
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = currency_hints.get(row_idx).copied().flatten();
+        let row_hint = currency_hints.get(row_idx).copied().flatten();
         for (i, value) in row.iter().enumerate() {
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
-            let len = format_value_with_hint(value, numberify, col_ctx, currency_hint).len();
+            // Row sidecar wins over column-name fallback (#1023): aggregate
+            // rows always know their grouping currency more precisely than
+            // any column-name heuristic could.
+            let cell_hint = row_hint.or_else(|| column_currency_hints.get(i).copied().flatten());
+            let len = format_value_with_hint(value, numberify, col_ctx, cell_hint).len();
             if i < widths.len() && len > widths[i] {
                 widths[i] = len;
             }
@@ -141,14 +171,18 @@ fn write_text<W: Write>(
 
     // Print rows using per-column display contexts
     for (row_idx, row) in result.rows.iter().enumerate() {
-        let currency_hint = currency_hints.get(row_idx).copied().flatten();
+        let row_hint = currency_hints.get(row_idx).copied().flatten();
 
         for (i, value) in row.iter().enumerate() {
             if i > 0 {
                 write!(writer, "  ")?;
             }
             let col_ctx = col_contexts.get(i).unwrap_or(ctx);
-            let formatted = format_value_with_hint(value, numberify, col_ctx, currency_hint);
+            // Row sidecar wins over column-name fallback (#1023). Must
+            // match the same precedence used in the width-calculation
+            // pass above — otherwise widths and rendered values disagree.
+            let cell_hint = row_hint.or_else(|| column_currency_hints.get(i).copied().flatten());
+            let formatted = format_value_with_hint(value, numberify, col_ctx, cell_hint);
             if i < widths.len() {
                 // Right-align numeric columns to match Python beancount
                 if i < is_numeric_col.len() && is_numeric_col[i] {
@@ -1124,5 +1158,251 @@ mod tests {
             Some("USD"),
             "first-wins: [USD, EUR] should pick USD"
         );
+    }
+
+    // ─── Issue #1023: PIVOT BY currency precision ────────────────────────
+    //
+    // After PIVOT, the GROUP BY currency moves into column position and
+    // each pivoted column's *name* is a currency code. The pivot path
+    // uses `add_row` (not `add_aggregate_row`), so the per-row sidecar is
+    // `None` for those rows. The renderer needs a column-name fallback
+    // to recover the precision context.
+
+    /// Pivoted rows have `None` group_key but the column name is a
+    /// currency code. The width-calc and print passes both consult the
+    /// column-name fallback, so a `Value::Number(0.000)` in a USD-named
+    /// column should render as `0.00` (matching USD's tracked 2dp).
+    #[test]
+    fn test_text_pivoted_column_uses_column_name_as_currency_hint() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(2.00), "USD");
+
+        // Simulate post-PIVOT shape: the value cell is a Number whose
+        // precision context lives in the column name "USD". No row
+        // sidecar (mirrors what `apply_pivot` produces).
+        let mut result = QueryResult::new(vec!["account".into(), "USD".into()]);
+        result.add_row(vec![
+            Value::String("Assets:Cash".into()),
+            Value::Number(dec!(0.000)),
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        let data_row = text
+            .lines()
+            .find(|l| l.contains("Assets:Cash"))
+            .unwrap_or_else(|| panic!("expected an Assets:Cash row; raw output:\n{text}"));
+        let last_cell = data_row
+            .split_whitespace()
+            .last()
+            .unwrap_or_else(|| panic!("expected non-empty data row; got: {data_row:?}"));
+        assert_eq!(
+            last_cell, "0.00",
+            "pivoted column named USD should drive 2dp quantization; row was {data_row:?}, raw output:\n{text}"
+        );
+    }
+
+    /// False-positive guard: a column literally named "USD" but with no
+    /// tracked precision in the active context must NOT route through
+    /// `DisplayContext::format` — the unknown-currency fallback there
+    /// calls `normalize()` which strips trailing zeros. Without this
+    /// gate, `0.000` would render as `0` (worse than the unfixed state).
+    #[test]
+    fn test_text_pivoted_column_with_untracked_currency_falls_back_safely() {
+        // No DisplayContext seeding for USD — `get_precision("USD")`
+        // returns None.
+        let ctx = DisplayContext::new();
+
+        let mut result = rustledger_query::QueryResult::new(vec!["account".into(), "USD".into()]);
+        result.add_row(vec![
+            Value::String("Assets:Cash".into()),
+            Value::Number(dec!(0.000)),
+        ]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        // Without a tracked USD precision, the column-name fallback must
+        // be filtered out and `format_value`'s default path retains the
+        // natural 3dp scale.
+        assert!(
+            text.contains("0.000"),
+            "untracked USD must NOT route through format → would strip zeros; got {text:?}"
+        );
+        assert!(
+            !text.lines().any(|l| {
+                l.contains("Assets:Cash")
+                    && l.split_whitespace()
+                        .last()
+                        .is_some_and(|c| c == "0" || c == "0.00")
+            }),
+            "must not emit `0` (normalize-stripped) or `0.00` (false-positive quantize); got {text:?}"
+        );
+    }
+
+    /// Precedence: row sidecar wins over column-name fallback. When both
+    /// supply a hint (rare but possible: `GROUP BY currency PIVOT BY
+    /// some_other_col`), the row's sidecar is the more authoritative
+    /// signal — it came from the actual GROUP BY key, not a heuristic
+    /// over the column header.
+    #[test]
+    fn test_row_sidecar_wins_over_column_name_fallback() {
+        use rustledger_query::QueryResult;
+
+        let mut ctx = DisplayContext::new();
+        // Both currencies tracked, but at different scales: USD=2dp, JPY=0dp.
+        ctx.update(dec!(1.00), "USD");
+        ctx.update(dec!(100), "JPY");
+
+        // Column name says JPY (0dp); row sidecar says USD (2dp).
+        // The row sidecar must win → 2dp quantization.
+        let mut result = QueryResult::new(vec!["account".into(), "JPY".into()]);
+        result.add_aggregate_row(
+            vec![
+                Value::String("Assets:Cash".into()),
+                Value::Number(dec!(0.000)),
+            ],
+            vec![Value::String("USD".into())],
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        let data_row = text
+            .lines()
+            .find(|l| l.contains("Assets:Cash"))
+            .unwrap_or_else(|| panic!("expected Assets:Cash row; raw output:\n{text}"));
+        let last_cell = data_row.split_whitespace().last().expect("non-empty row");
+        assert_eq!(
+            last_cell, "0.00",
+            "row sidecar (USD, 2dp) must beat column name (JPY, 0dp); row was {data_row:?}"
+        );
+    }
+
+    /// End-to-end integration test for issue #1023.
+    /// Drives `SELECT currency, account, SUM(number) GROUP BY currency,
+    /// account PIVOT BY currency` through the full pipeline. Mirrors
+    /// `test_e2e_sum_group_by_currency_text_output_matches_per_currency_precision`
+    /// but adds the PIVOT clause that was regressing #988's fix.
+    ///
+    /// Pins:
+    /// - The pivoted USD column quantizes to 2dp via column-name fallback.
+    /// - The non-pivoted columns (here just `account`) are unaffected.
+    /// - JSON output for the same query stays lossless (AC #2).
+    #[test]
+    fn test_e2e_pivot_by_currency_text_output_matches_per_currency_precision() {
+        use rustledger_core::{Amount, Directive, Posting, Transaction};
+        use rustledger_query::{Executor, parse};
+
+        let date = |y, m, d| rustledger_core::naive_date(y, m, d).unwrap();
+
+        // Two USD postings whose SUM lands at scale 3 (mixing 0.000 and
+        // 5.00 in rust_decimal yields a 3dp natural form). The PIVOT
+        // BY currency would lose the precision hint without #1023's
+        // column-name fallback.
+        let directives = vec![
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "Coffee")
+                    .with_flag('*')
+                    .with_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(5.00), "USD"),
+                    ))
+                    .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(-5.00), "USD"))),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 16), "Refund")
+                    .with_flag('*')
+                    .with_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(0.000), "USD"),
+                    ))
+                    .with_posting(Posting::new("Assets:Bank", Amount::new(dec!(0.0), "USD"))),
+            ),
+        ];
+
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(5.00), "USD");
+        ctx.update(dec!(-5.00), "USD");
+
+        let mut executor = Executor::new(&directives);
+        let query = parse(
+            "SELECT account, currency, SUM(number) \
+             GROUP BY account, currency \
+             PIVOT BY currency",
+        )
+        .expect("parse should succeed");
+        let result = executor.execute(&query).expect("execute should succeed");
+
+        // After PIVOT, the per-row sidecar is None (apply_pivot's
+        // contract — it uses add_row, not add_aggregate_row). This
+        // contract is exactly why #1023 needed the column-name fallback.
+        assert!(
+            !result.has_aggregate_rows()
+                || (0..result.rows.len()).all(|i| result.group_key(i).is_none()),
+            "post-PIVOT rows should have no per-row group_key; the column-name fallback is what carries the hint"
+        );
+
+        // The USD column must exist as a pivoted output column.
+        assert!(
+            result.columns.iter().any(|c| c == "USD"),
+            "expected pivoted USD column, got columns={:?}",
+            result.columns
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("write_text ok");
+        let text = String::from_utf8(buf).expect("utf8");
+
+        // The bug surface is "the rendered text contains 0.000". Without
+        // #1023's column-name fallback, the post-PIVOT SUM cell would
+        // render at rust_decimal's natural 3dp scale. With the fix, USD's
+        // tracked 2dp drives the column, so 0.000 should NOT appear in
+        // the pivoted USD cell.
+        //
+        // We check this two ways:
+        //   1. The full output (excluding the row-count footer line)
+        //      must not contain "0.000" — this is the cleanest contract.
+        //   2. At least one data row must contain "0.00" (anchored as a
+        //      whole token) — confirms quantization actually happened
+        //      and we're not just missing data.
+        let data_section = text
+            .lines()
+            .filter(|l| !l.contains("row(s)"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !data_section.contains("0.000"),
+            "USD pivoted column must be quantized to 2dp; found 0.000 in output:\n{text}"
+        );
+
+        let saw_quantized = text.lines().any(|l| {
+            !l.contains("row(s)")
+                && l.split_whitespace()
+                    .any(|t| t == "0.00" || t.ends_with(".00"))
+        });
+        assert!(
+            saw_quantized,
+            "expected at least one 2dp-quantized cell in the data section; raw output:\n{text}"
+        );
+
+        // AC #2 (lossless non-text output) is independently pinned by
+        // `test_json_aggregate_output_preserves_unquantized_decimal`,
+        // `test_csv_aggregate_output_preserves_unquantized_decimal`, and
+        // `test_beancount_aggregate_output_preserves_unquantized_decimal`
+        // above — those use hand-built `QueryResult`s with a known
+        // unquantized scale, which is more reliable than building one
+        // through the executor (rust_decimal's add behavior can normalize
+        // scales in ways that depend on input shape, making a contrived
+        // fixture brittle). The text-renderer behavior IS the contract
+        // this PR changes; the JSON path goes through `write_json`
+        // unchanged.
     }
 }

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -156,3 +156,17 @@ name = "prices-from-plugin-by-date"
 query = "SELECT date, currency, amount FROM #prices ORDER BY date, currency"
 notes = "Plugin-emitted price content — catches @@ vs @ confusion (issue #992)"
 preserve_order = true
+
+# ----------------------------------------------------------------------
+# PIVOT BY currency — issue #1023. The #988 fix (per-currency
+# precision via row sidecar) was partial: PIVOT discards the sidecar
+# because `apply_pivot` uses `add_row` instead of `add_aggregate_row`.
+# The pivoted column NAME carries the currency, so the renderer needs
+# a column-name fallback to recover the precision context.
+# ----------------------------------------------------------------------
+
+[[query]]
+name = "sum-by-account-pivot-by-currency"
+query = "SELECT account, currency, SUM(number) GROUP BY account, currency PIVOT BY currency ORDER BY account LIMIT 10"
+notes = "PIVOT BY currency precision — catches the post-#1022 regression where pivoted SUM cells lost per-currency quantization (issue #1023)"
+preserve_order = true

--- a/tests/compatibility/bql-queries.toml
+++ b/tests/compatibility/bql-queries.toml
@@ -158,15 +158,9 @@ notes = "Plugin-emitted price content — catches @@ vs @ confusion (issue #992)
 preserve_order = true
 
 # ----------------------------------------------------------------------
-# PIVOT BY currency — issue #1023. The #988 fix (per-currency
-# precision via row sidecar) was partial: PIVOT discards the sidecar
-# because `apply_pivot` uses `add_row` instead of `add_aggregate_row`.
-# The pivoted column NAME carries the currency, so the renderer needs
-# a column-name fallback to recover the precision context.
+# PIVOT BY queries are intentionally NOT in this corpus. bean-query's
+# PIVOT BY takes TWO columns (pivot value + group key) where rledger
+# takes ONE. The two tools produce structurally different output for
+# any PIVOT query, so a row-by-row diff would be permanently red.
+# Tracking the semantic reconciliation separately — see #1034.
 # ----------------------------------------------------------------------
-
-[[query]]
-name = "sum-by-account-pivot-by-currency"
-query = "SELECT account, currency, SUM(number) GROUP BY account, currency PIVOT BY currency ORDER BY account LIMIT 10"
-notes = "PIVOT BY currency precision — catches the post-#1022 regression where pivoted SUM cells lost per-currency quantization (issue #1023)"
-preserve_order = true


### PR DESCRIPTION
## Summary

- Closes #1023. PR #1022's per-currency precision fix (#988) regressed for queries that combined `GROUP BY currency` with `PIVOT BY` — `apply_pivot` uses `add_row` instead of `add_aggregate_row`, so the per-row sidecar drops to `None` and the renderer can't recover the precision context.
- Fix: column-name fallback. After PIVOT, each pivoted column's *name* IS the currency code. Renderer consults the column name when the row sidecar is `None`, with the same false-positive guard (`ctx.get_precision().is_some()`) the row path uses.
- **Also fixes a pre-existing column/row length bug in `apply_pivot`.** This is a behavioral change for *every* PIVOT query, not just precision-affected ones — see "Behavioral change" below.

## ⚠️ Behavioral change: PIVOT output column shape

Pre-fix, `apply_pivot` produced output where the column header and row data didn't agree on length. Concretely, for `SELECT account, currency, SUM(number) GROUP BY account, currency PIVOT BY currency`:

| | Pre-fix | Post-fix |
|---|---|---|
| Headers | `[account, SUM, USD]` (3 cols) | `[account, USD]` (2 cols) |
| Row data | `[Assets:Bank, -5.00]` (2 cells) | `[Assets:Bank, -5.00]` (2 cells) |
| JSON | `{"SUM": "-5.00", "account": "Assets:Bank"}` — **SUM column was eating the pivoted USD value, USD column was always empty** | `{"USD": "-5.00", "account": "Assets:Bank"}` |

Anyone with a PIVOT query in production was getting wrong column→value mapping. This PR silently fixes it. **If you have PIVOT queries in dashboards or scripts, re-validate the column names.**

## Why column-name fallback over a column-sidecar

Discussed in the issue review. The pivoted column names are already populated correctly by `apply_pivot` (`Self::value_to_string(pv)`), so adding ~10 lines to consult them is cheaper than a new sidecar field + new invariant. The same shape-check + precision-tracked gate prevents false positives.

## Implementation

- `crates/rustledger/src/cmd/query/output.rs::write_text`:
  - Precompute `column_currency_hints` once (parallel to `currency_hints`).
  - New `resolve_cell_hint` helper centralizes the precedence: `row_hint.or(col_hint)`. Both width-calc and print passes use it, so they can't drift.
- `crates/rustledger-query/src/executor/sort.rs::apply_pivot`: also exclude `value_col_idx` from `new_columns` so columns and rows agree on shape.

## Test plan

- [x] 5 new unit tests for the cell-level hint behavior:
  - `test_text_pivoted_column_uses_column_name_as_currency_hint` — happy path.
  - `test_text_pivoted_column_with_untracked_currency_falls_back_safely` — pins the false-positive guard (untracked column "USD" must NOT route through `format` → would strip trailing zeros via `normalize()`).
  - `test_row_sidecar_wins_over_column_name_fallback` — precedence.
  - `test_text_pivoted_multi_currency_uses_per_column_precision` — USD (2dp) + JPY (0dp) on the same row, each column uses its own precision.
  - `test_non_pivoted_currency_named_column_inherits_fallback_quantization` — defensive regression test: pins the behavior of a non-pivoted query with a column aliased as a currency code (e.g. `SELECT … AS USD`). Today's contract: tracked currency drives quantization regardless of PIVOT path.
- [x] 1 e2e test `test_e2e_pivot_by_currency_text_output_matches_per_currency_precision` driving `SELECT account, currency, SUM(number) GROUP BY account, currency PIVOT BY currency` through Executor → write_text.
- [x] All 511 `rustledger-query` lib tests pass.
- [x] All 20 `cmd::query::output` tests pass (15 existing + 5 new).
- [x] `cargo clippy --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] All pre-push hooks green.

## Acceptance criteria

- [x] **AC #1**: `SELECT currency, account, SUM(number) GROUP BY currency, account PIVOT BY currency` text output uses per-currency precision in each pivot column. Pinned by the e2e test.
- [x] **AC #2**: CSV/JSON output stays lossless. Pinned by the existing `test_*_aggregate_output_preserves_unquantized_decimal` tests (the JSON renderer doesn't take a `DisplayContext`, so per-currency quantization can't bleed in by accident).
- [x] **AC #3**: integration test added under `crates/rustledger/src/cmd/query/output.rs` (`test_e2e_pivot_by_currency_text_output_matches_per_currency_precision`).

## Why no BQL compat fixture

A draft commit added a `sum-by-account-pivot-by-currency` query to `bql-queries.toml`, but local verification against `bean-query` revealed that bean-query's `PIVOT BY` takes **two columns** (pivot value + group key) where rledger takes **one**. The two tools produce structurally different output for any PIVOT query, so a compat-harness diff is permanently red regardless of correctness. The fixture was removed and a comment placed in `bql-queries.toml` pointing to #1034, where the semantic-reconciliation question is tracked alongside two pre-existing PIVOT robustness gaps surfaced during the review.

## Out of scope

- Multi-currency PIVOT cases where the pivoted column names *aren't* currencies (e.g., `PIVOT BY year`). The column-name path returns `None` for non-currency-shaped names, so those fall back to the existing behavior — no regression.
- The PIVOT semantic divergence with bean-query — tracked in #1034.

Closes #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
