### PR TITLE
docs(tla): N-posting + multi-currency Interpolation model

### DIFF
--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -93,19 +93,19 @@ fn round_interpolated(residual: Decimal, existing_scale: Option<u32>) -> Decimal
 ///
 /// # TLA+ Specification
 ///
-/// Implements invariants from `Interpolation.tla`:
-/// - `AtMostOneNull`: At most one posting per currency can have a missing
-///   amount (returns `MultipleMissing` error if violated). This
-///   implementation extends the rule to also count postings with an empty
-///   cost spec (e.g., `{}`) as one unknown for their cost currency, since
-///   the cost-basis weight is unknown until booking-pass lot matching
-///   resolves it (issue #1026). The TLA+ model `Interpolation.tla`
-///   currently models only missing-amount postings; extending it to cover
-///   cost-unknowns is tracked in issue #1030.
-/// - `CompleteImpliesBalanced`: After interpolation, `sum(postings) = 0`
-///   for each currency
-/// - `HasNullAccurate`: `filled_indices` contains exactly the indices of
-///   postings that were originally missing amounts
+/// Implements invariants from `Interpolation.tla` (post-#1030 redesign for
+/// N postings + multi-currency + cost-unknowns):
+/// - `AtMostOneUnknownPerCurrency`: For each currency group, at most one
+///   posting may be "unknown" — either a missing amount (counts toward
+///   the units currency) or an empty cost spec like `{}` (counts toward
+///   the cost currency, since the cost-basis weight is unresolved until
+///   booking-pass lot matching). Returns `MultipleMissing` if violated.
+/// - `CompleteImpliesValidated`: Interpolation only completes the
+///   transaction when the validation rule holds.
+///
+/// The spec models the structural validation rule, not the residual
+/// arithmetic that produces filled amounts — see `Interpolation.tla`'s
+/// header for the scope rationale.
 ///
 /// See: `spec/tla/Interpolation.tla`
 ///

--- a/spec/tla/Interpolation.cfg
+++ b/spec/tla/Interpolation.cfg
@@ -1,10 +1,16 @@
 CONSTANTS
-    MaxAmount = 10
+    MaxAmount = 2
+    MaxPostings = 3
+    Currencies = {"USD", "EUR"}
 
 INIT Init
 NEXT Next
 
+\* `AtMostOneUnknownPerCurrency` is NOT in the invariant list — it's
+\* allowed to be violated in mid-construction (user writes an invalid
+\* transaction; the interpolator hasn't validated yet). The substantive
+\* property is `CompleteImpliesValidated`: completion is reachable only
+\* when validation passes. TypeOK pins the state-record shape.
 INVARIANTS
-    AtMostOneNull
-    CompleteImpliesBalanced
-    HasNullAccurate
+    TypeOK
+    CompleteImpliesValidated

--- a/spec/tla/Interpolation.tla
+++ b/spec/tla/Interpolation.tla
@@ -36,10 +36,23 @@
  *   - Models the validation rule from #1029 (the spec's contribution).
  *   - Does NOT model the residual arithmetic that produces the filled
  *     amount — that was the original spec's `Interpolate` action and is
- *     intentionally out of scope here. A separate spec covering the
- *     full booking-pass numerical interpolation could be filed later;
- *     the rule this spec enforces is structural ("≤ 1 unknown per
- *     currency"), not arithmetical.
+ *     intentionally out of scope here. The `complete` variable means
+ *     "validation passed at the point the interpolator looked at the
+ *     posting layout", NOT "all NULL amounts have been replaced." A
+ *     separate spec covering the booking-pass numerical interpolation
+ *     could be filed later; the rule enforced here is structural
+ *     ("≤ 1 unknown per currency"), not arithmetical.
+ *   - Only models missing-amount postings whose currency is *known*
+ *     (`AddNullAmount(i, ccy)`). The implementation has a separate code
+ *     path for "unassigned-missing" postings — postings with no number
+ *     and no currency hint, which the interpolator must route to a
+ *     currency group based on which group has a residual. The
+ *     additional rejection logic that fires when an unassigned-missing
+ *     coexists with a cost-unknown (see `unassigned_missing` /
+ *     `cost_unknowns_by_currency` interaction in `interpolate.rs`) is
+ *     not modeled. Adding `AddUnassignedMissing` would be the natural
+ *     extension; it's omitted here because the state-space cost was
+ *     judged not worth the marginal gain.
  *)
 
 EXTENDS Integers, FiniteSets, TLC
@@ -168,13 +181,31 @@ ValidationOk ==
 
 -----------------------------------------------------------------------------
 
-(* Mark the transaction complete only if validation passes. Mirrors
- * the implementation: if `ValidationOk` fails, the interpolator
- * returns `MultipleMissing` (or the equivalent) and never completes. *)
+(* Set of slot indices that have been used (have a posting). *)
+UsedSlots ==
+    {i \in 1..MaxPostings : postings[i].amount # UNSET}
+
+(* Mark the transaction "validation passed" only if `ValidationOk`
+ * holds. Mirrors the implementation: if the rule fails, the
+ * interpolator returns `MultipleMissing` (or the equivalent) and
+ * never completes.
+ *
+ * NOTE: `complete = TRUE` here means "the validation rule held when
+ * the interpolator looked at the posting layout" — NOT "all NULL
+ * amounts have been replaced by their residual fills." This spec
+ * intentionally stops at the structural-validation step; the fill
+ * arithmetic is out of scope (see SCOPE in the header).
+ *
+ * `MaxPostings` is an upper bound on how many postings the
+ * transaction can have. Real transactions need ≥ 2 postings to
+ * balance, but slots beyond the actual posting count remain UNSET
+ * and are correctly ignored by `ValidationOk` /
+ * `ActiveCurrencies` / `UnknownCurrency` (UNSET routes to
+ * NoCurrency, which is filtered out). *)
 Validate ==
     /\ ~complete
     /\ ValidationOk
-    /\ \A i \in 1..MaxPostings : postings[i].amount # UNSET
+    /\ Cardinality(UsedSlots) >= 2
     /\ complete' = TRUE
     /\ UNCHANGED postings
 
@@ -197,11 +228,15 @@ Next ==
 CompleteImpliesValidated ==
     complete => ValidationOk
 
-(* Backward-compatible alias for the original 2-posting `AtMostOneNull`.
- * The N-posting / multi-currency generalization is captured by
- * `ValidationOk`; the old name is preserved so external references
- * (test names, prior commits, CHANGELOG entries) continue to resolve. *)
+(* Multi-currency generalization of the original 2-posting
+ * `AtMostOneNull`. *)
 AtMostOneUnknownPerCurrency == ValidationOk
+
+(* Backward-compatible alias under the original name. The 2-posting
+ * single-currency form was strictly weaker; the new name above is
+ * preferred. Kept so external references (older commits, CHANGELOG
+ * entries, blog posts that link this name) continue to resolve. *)
+AtMostOneNull == ValidationOk
 
 (* `CompleteImpliesBalanced` from the original 2-posting model:
  *   complete => posting1 + posting2 = 0

--- a/spec/tla/Interpolation.tla
+++ b/spec/tla/Interpolation.tla
@@ -1,110 +1,225 @@
 ------------------------------ MODULE Interpolation ------------------------------
 (*
- * NULL Posting Interpolation
+ * Posting Interpolation — N postings, multi-currency, with cost-unknowns
  *
- * Verifies:
- * - At most one NULL (missing) amount per transaction
- * - NULL is filled with the balancing amount
- * - Transaction balances after interpolation
+ * Models the interpolation rules in
+ * `crates/rustledger-booking/src/interpolate.rs`.
  *
- * Uses "UNSET" for uninitialized slots, "NULL" for explicit missing amounts.
+ * KEY RULE (from PR #1029 / issue #1026):
+ *   For each currency group, at most one posting may be "unknown",
+ *   where "unknown" means EITHER:
+ *     - the posting's units amount is missing (NULL), OR
+ *     - the posting has an empty cost spec (e.g. `{}`), in which case
+ *       the cost-basis weight is unresolved until the booking pass.
+ *
+ *   Missing-amount postings count toward their UNITS currency.
+ *   Empty-cost postings count toward their COST currency.
+ *
+ * History:
+ *   - Original 2-posting / single-currency model verified the basic
+ *     `AtMostOneNull` rule that prevented two `units = NULL` postings
+ *     in the same transaction.
+ *   - PR #1029 (issue #1026) extended the implementation rule to count
+ *     empty-cost postings alongside missing-amount postings, per
+ *     bean-check parity on the htsec compat fixture.
+ *   - Issue #1030 — this redesign (option C). N postings, multi-currency,
+ *     posting-record state.
+ *
+ * For TLC tractability, MaxPostings is bounded (default 3 in the .cfg)
+ * and Currencies is a small finite set (default {"USD", "EUR"}). The
+ * combination 3 postings × 2 currencies × 5 amount slots covers every
+ * shape the interpolator's rule cares about (single-currency missing,
+ * multi-currency mixed unknowns, two unknowns in one currency
+ * triggering rejection).
+ *
+ * SCOPE:
+ *   - Models the validation rule from #1029 (the spec's contribution).
+ *   - Does NOT model the residual arithmetic that produces the filled
+ *     amount — that was the original spec's `Interpolate` action and is
+ *     intentionally out of scope here. A separate spec covering the
+ *     full booking-pass numerical interpolation could be filed later;
+ *     the rule this spec enforces is structural ("≤ 1 unknown per
+ *     currency"), not arithmetical.
  *)
 
-EXTENDS Integers
+EXTENDS Integers, FiniteSets, TLC
 
-CONSTANTS MaxAmount
+CONSTANTS MaxAmount, MaxPostings, Currencies
 
-\* Special values outside normal range
-UNSET == -1000      \* Posting slot not yet used
-NULL == -1001       \* Explicit NULL (to be interpolated)
+(* Sentinel values for the amount field. We piggyback on Integers using
+ * out-of-range sentinels rather than a tagged-union type, to keep TLC's
+ * state space small. *)
+UNSET == -1000   \* posting slot not yet filled
+NULL  == -1001   \* explicit missing amount (to be interpolated)
+
+(* Cost-spec status. Strings are clearer than booleans for diagnostic
+ * trace output. *)
+NORMAL == "NORMAL"  \* either no cost or a fully-specified cost
+EMPTY  == "EMPTY"   \* empty cost spec like `{}` — basis unresolved
+
+(* Sentinel currency for unfilled or non-applicable slots. *)
+NoCurrency == "NONE"
+
+(* Default record for an unused posting slot. *)
+NoPosting == [amount       |-> UNSET,
+              currency     |-> NoCurrency,
+              cost         |-> NORMAL,
+              costCurrency |-> NoCurrency]
 
 VARIABLES
-    posting1,       \* First posting amount
-    posting2,       \* Second posting amount
-    hasNull,        \* Whether we have a NULL posting
-    complete        \* Whether transaction is complete
+    postings,   \* Function: 1..MaxPostings -> posting record
+    complete    \* TRUE once Validate finalizes the txn
 
-vars == <<posting1, posting2, hasNull, complete>>
+vars == <<postings, complete>>
+
+(* Type invariant on the posting record. The amount domain unions the
+ * normal range with the two sentinels. *)
+PostingRecord ==
+    [amount       : (-MaxAmount..MaxAmount) \cup {UNSET, NULL},
+     currency     : Currencies \cup {NoCurrency},
+     cost         : {NORMAL, EMPTY},
+     costCurrency : Currencies \cup {NoCurrency}]
+
+TypeOK ==
+    /\ postings \in [1..MaxPostings -> PostingRecord]
+    /\ complete \in BOOLEAN
 
 -----------------------------------------------------------------------------
 Init ==
-    /\ posting1 = UNSET
-    /\ posting2 = UNSET
-    /\ hasNull = FALSE
+    /\ postings = [i \in 1..MaxPostings |-> NoPosting]
     /\ complete = FALSE
 
 -----------------------------------------------------------------------------
-(* Add first posting with amount *)
-AddPosting1(amt) ==
-    /\ posting1 = UNSET
-    /\ ~complete
-    /\ posting1' = amt
-    /\ UNCHANGED <<posting2, hasNull, complete>>
 
-(* Add second posting with amount *)
-AddPosting2(amt) ==
-    /\ posting1 # UNSET
-    /\ posting2 = UNSET
+(* Add a posting at slot i with a known amount and currency, no cost. *)
+AddNormal(i, amt, ccy) ==
+    /\ i \in 1..MaxPostings
+    /\ postings[i].amount = UNSET
     /\ ~complete
-    /\ posting2' = amt
-    /\ UNCHANGED <<posting1, hasNull, complete>>
+    /\ amt \in (-MaxAmount..MaxAmount) \ {0}
+    /\ ccy \in Currencies
+    /\ postings' = [postings EXCEPT
+        ![i] = [amount       |-> amt,
+                currency     |-> ccy,
+                cost         |-> NORMAL,
+                costCurrency |-> NoCurrency]]
+    /\ UNCHANGED complete
 
-(* Mark second posting as NULL (to be interpolated) *)
-AddPosting2Null ==
-    /\ posting1 # UNSET
-    /\ posting1 # NULL
-    /\ posting2 = UNSET
-    /\ ~hasNull
+(* Add a posting with a missing amount in a known currency. The
+ * implementation's interpolator would solve for this amount as the
+ * residual that balances the currency group. *)
+AddNullAmount(i, ccy) ==
+    /\ i \in 1..MaxPostings
+    /\ postings[i].amount = UNSET
     /\ ~complete
-    /\ posting2' = NULL
-    /\ hasNull' = TRUE
-    /\ UNCHANGED <<posting1, complete>>
+    /\ ccy \in Currencies
+    /\ postings' = [postings EXCEPT
+        ![i] = [amount       |-> NULL,
+                currency     |-> ccy,
+                cost         |-> NORMAL,
+                costCurrency |-> NoCurrency]]
+    /\ UNCHANGED complete
 
-(* Interpolate: fill NULL with balancing amount *)
-Interpolate ==
-    /\ posting1 # UNSET
-    /\ posting2 = NULL
-    /\ hasNull
+(* Add a posting with empty cost spec — units known, cost-basis weight
+ * unresolved until booking. Counts as one unknown for `costCcy`, the
+ * cost currency, NOT for `ccy` (the units currency). *)
+AddEmptyCost(i, amt, ccy, costCcy) ==
+    /\ i \in 1..MaxPostings
+    /\ postings[i].amount = UNSET
     /\ ~complete
-    /\ posting2' = -posting1  \* Balance the transaction
+    /\ amt \in (-MaxAmount..MaxAmount) \ {0}
+    /\ ccy \in Currencies
+    /\ costCcy \in Currencies
+    /\ postings' = [postings EXCEPT
+        ![i] = [amount       |-> amt,
+                currency     |-> ccy,
+                cost         |-> EMPTY,
+                costCurrency |-> costCcy]]
+    /\ UNCHANGED complete
+
+-----------------------------------------------------------------------------
+(* HELPER OPERATORS *)
+
+(* The currency a posting's "unknown" counts toward.
+ * Returns NoCurrency if the posting is fully known. *)
+UnknownCurrency(p) ==
+    IF p.amount = NULL THEN p.currency
+    ELSE IF p.cost = EMPTY THEN p.costCurrency
+    ELSE NoCurrency
+
+(* Indices of postings that are unknown for a given currency. *)
+UnknownsInCurrency(ccy) ==
+    {i \in 1..MaxPostings : UnknownCurrency(postings[i]) = ccy}
+
+(* All currencies that appear among posting units OR cost-currencies.
+ * NoCurrency is excluded — it represents an empty slot, not a real
+ * currency-group. *)
+ActiveCurrencies ==
+    ({postings[i].currency : i \in 1..MaxPostings} \cup
+     {postings[i].costCurrency : i \in 1..MaxPostings})
+    \ {NoCurrency}
+
+(* The implementation's invariant from #1029: for every currency that
+ * appears in any posting (units or cost), the count of unknown
+ * postings for that currency is at most 1. *)
+ValidationOk ==
+    \A ccy \in ActiveCurrencies :
+        Cardinality(UnknownsInCurrency(ccy)) <= 1
+
+-----------------------------------------------------------------------------
+
+(* Mark the transaction complete only if validation passes. Mirrors
+ * the implementation: if `ValidationOk` fails, the interpolator
+ * returns `MultipleMissing` (or the equivalent) and never completes. *)
+Validate ==
+    /\ ~complete
+    /\ ValidationOk
+    /\ \A i \in 1..MaxPostings : postings[i].amount # UNSET
     /\ complete' = TRUE
-    /\ UNCHANGED <<posting1, hasNull>>
-
-(* Complete with explicit amounts (must balance) *)
-CompleteBalanced ==
-    /\ posting1 # UNSET
-    /\ posting2 # UNSET
-    /\ posting2 # NULL
-    /\ ~complete
-    /\ posting1 + posting2 = 0
-    /\ complete' = TRUE
-    /\ UNCHANGED <<posting1, posting2, hasNull>>
+    /\ UNCHANGED postings
 
 Next ==
-    \/ \E amt \in (-MaxAmount..MaxAmount) \ {0} : AddPosting1(amt)
-    \/ \E amt \in (-MaxAmount..MaxAmount) \ {0} : AddPosting2(amt)
-    \/ AddPosting2Null
-    \/ Interpolate
-    \/ CompleteBalanced
+    \/ \E i \in 1..MaxPostings, ccy \in Currencies,
+         amt \in (-MaxAmount..MaxAmount) \ {0} :
+        AddNormal(i, amt, ccy)
+    \/ \E i \in 1..MaxPostings, ccy \in Currencies :
+        AddNullAmount(i, ccy)
+    \/ \E i \in 1..MaxPostings, ccy \in Currencies, costCcy \in Currencies,
+         amt \in (-MaxAmount..MaxAmount) \ {0} :
+        AddEmptyCost(i, amt, ccy, costCcy)
+    \/ Validate
 
 -----------------------------------------------------------------------------
 (* INVARIANTS *)
 
-(* At most one NULL posting *)
-AtMostOneNull ==
-    ~(posting1 = NULL /\ posting2 = NULL)
+(* The implementation's structural rule: completion is reachable only
+ * when no currency has more than one unknown. *)
+CompleteImpliesValidated ==
+    complete => ValidationOk
 
-(* After completion, transaction is balanced *)
-CompleteImpliesBalanced ==
-    complete =>
-        /\ posting1 # UNSET
-        /\ posting2 # UNSET
-        /\ posting2 # NULL
-        /\ posting1 + posting2 = 0
+(* Backward-compatible alias for the original 2-posting `AtMostOneNull`.
+ * The N-posting / multi-currency generalization is captured by
+ * `ValidationOk`; the old name is preserved so external references
+ * (test names, prior commits, CHANGELOG entries) continue to resolve. *)
+AtMostOneUnknownPerCurrency == ValidationOk
 
-(* hasNull flag tracks whether NULL was used (even after interpolation) *)
-HasNullAccurate ==
-    hasNull => (posting2 = NULL \/ complete)
+(* `CompleteImpliesBalanced` from the original 2-posting model:
+ *   complete => posting1 + posting2 = 0
+ *
+ * In the N-posting / multi-currency / cost-unknown world this no longer
+ * applies as a single transaction-wide statement:
+ *   - Per UNITS currency, the sum of normal+filled amounts = 0 holds
+ *     AFTER the interpolator fills any NULL amounts. This spec doesn't
+ *     model the fill operation (see "SCOPE" in the header).
+ *   - Per COST currency, the residual contributed by empty-cost
+ *     postings is intentionally LEFT UNRESOLVED at interpolation time;
+ *     the booking pass settles it later. So balanced-ness on the cost
+ *     currency is a booking-pass invariant, not an interpolation-pass
+ *     one.
+ *
+ * If/when a future spec models the fill arithmetic, that spec should
+ * carry the per-currency balanced-ness invariant. Tracking it here
+ * would be misleading. *)
 
 Spec == Init /\ [][Next]_vars
 


### PR DESCRIPTION
## Summary

Closes #1030. Path C from the [issue review](https://github.com/rustledger/rustledger/issues/1030#issuecomment-4403885952): redesigns `Interpolation.tla` so the spec faithfully models the implementation's invariant from #1029, instead of just the 2-posting / single-currency subset the original model covered.

## Why path C (not A or B)

A (sentinel-only) and B (currency tracking on a 2-posting model) are strictly weaker than the implementation's actual rule. Path C is the only one that lets the spec say what the code does:

> for each currency group, at most one posting may be "unknown" — missing amount or empty cost spec

A and B can prove "at most one unknown per transaction" but can't represent the per-currency-group structure on its own. With path C, the spec generalizes naturally and remains useful for future booking-engine work.

## What changed

- `spec/tla/Interpolation.tla`: full rewrite. N postings (parameterized), per-posting record `{amount, currency, cost, costCurrency}`, three add actions (`AddNormal`, `AddNullAmount`, `AddEmptyCost`), `UnknownCurrency(p)` helper that routes missing-amount postings to their units currency and empty-cost postings to their cost currency.
- `spec/tla/Interpolation.cfg`: new constants `MaxPostings = 3`, `Currencies = {USD, EUR}`. New invariant set: `TypeOK`, `CompleteImpliesValidated`. The aliased name `AtMostOneUnknownPerCurrency` is exposed in the spec but checked transitively via `CompleteImpliesValidated`.
- `crates/rustledger-booking/src/interpolate.rs`: docstring updated. The "currently models only missing-amount postings" caveat is gone; new invariant names referenced.

## Design choices

**`AtMostOneUnknownPerCurrency` is allowed to be violated mid-construction.** Users can write a transaction with two NULL postings in the same currency — the spec models that. The substantive guarantee is that the interpolator never *completes* such a transaction. So the .cfg checks `CompleteImpliesValidated`, not `AtMostOneUnknownPerCurrency` directly. (Initial cfg version had it as a top-level invariant; TLC rightly flagged a counterexample.)

**Numerical residual computation is intentionally out of scope.** The original 2-posting spec had an `Interpolate` action that did `posting2' = -posting1`. For N postings + multi-currency + cost-unknowns, the arithmetic is non-trivial and belongs in a separate spec if it's worth modeling at all. The structural validation rule from #1029 is what's enforced today; arithmetic isn't.

**`CompleteImpliesBalanced` is dropped, not redefined.** With cost-unknowns, balance for the cost currency is deferred to the booking pass, not interpolation. A future booking-pass spec could carry that invariant; restating it here would be misleading. Documented in the spec header.

## Test plan

- [x] TLC model-check passes:
  ```
  Model checking completed. No error has been found.
  64719 states generated, 27539 distinct states found.
  Depth of complete state graph: 5.
  ```
- [x] `cargo check -p rustledger-booking` passes (docstring change is doc-only).
- [x] All pre-push hooks green (rustfmt, typos, gitleaks, plugin-test-quality, forbid-unsafe-code, cargo check workspace).

## Acceptance criteria (from #1030 review)

- [x] Pick path A, B, or C and document the choice — **C**, documented in spec header.
- [x] `Interpolation.cfg` updated for renamed/new invariants.
- [x] `CompleteImpliesBalanced` reconciled with cost-unknown semantics — dropped, with a comment in the spec explaining why.
- [x] TLC model-check passes via the existing CI workflow.
- [x] Implementation's docstring on `interpolate()` updated to remove the gap caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)