### PR TITLE
feat(doctor): label fixed-precision source in display-context

### DIFF
--- a/crates/rustledger/src/cmd/doctor/display_context.rs
+++ b/crates/rustledger/src/cmd/doctor/display_context.rs
@@ -296,9 +296,13 @@ mod tests {
 
     #[test]
     fn fixed_with_sources_but_currency_not_in_either_falls_back_to_programmatic() {
-        // Defensive: if the source map doesn't list a currency that has
-        // a fixed override, the only explanation is a programmatic call.
-        // Same label as the None-sources case.
+        // Defensive degradation: if the source map doesn't list a currency
+        // that has a fixed override, the most likely explanation is a
+        // programmatic `set_fixed_precision` call (i.e. someone built the
+        // context outside the loader path). A bug in `collect_fixed_sources`
+        // could ALSO produce this state — the renderer's behavior here is
+        // to fall back gracefully rather than misattribute. Same label as
+        // the None-sources case.
         let mut ctx = DisplayContext::new();
         ctx.update(dec!(1.234), "USD");
         ctx.set_fixed_precision("USD", 2);
@@ -447,13 +451,70 @@ option "display_precision" "USD:0.001"
         );
     }
 
+    /// E2E: invalid `precision:` metadata coexisting with a valid
+    /// `option "display_precision"`. The loader applies the option,
+    /// skips the invalid metadata (validator emits E5003), and the
+    /// effective precision comes from the option. The doctor label
+    /// must say "fixed via option", NOT "fixed via commodity metadata"
+    /// — pinning that `collect_fixed_sources`'s `parse_precision_meta`
+    /// gate matches the loader's gate. Without this test, a future
+    /// "simplification" of `collect_fixed_sources` (e.g. dropping the
+    /// validity check and treating any `precision` key as
+    /// metadata-sourced) would silently mislabel the override.
+    #[test]
+    fn e2e_invalid_metadata_with_option_labels_as_option() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("e2e_invalid.beancount");
+        std::fs::write(
+            &path,
+            r#"option "display_precision" "USD:0.01"
+
+2024-01-01 commodity USD
+  precision: -1
+
+2024-01-01 open Assets:USD
+2024-01-01 open Equity:Opening
+
+2024-01-15 * "USD"
+  Assets:USD       100.00 USD
+  Equity:Opening
+"#,
+        )
+        .unwrap();
+
+        let mut buf: Vec<u8> = Vec::new();
+        cmd_display_context(&path, &mut buf).expect("cmd should succeed");
+        let out = String::from_utf8(buf).unwrap();
+
+        let usd = currency_section(&out, "USD");
+        assert!(
+            usd.contains("(fixed via option \"display_precision\")"),
+            "USD should be option-sourced (invalid metadata is skipped); section:\n{usd}"
+        );
+        assert!(
+            !usd.contains("commodity metadata"),
+            "invalid metadata must NOT be labeled metadata-sourced; section:\n{usd}"
+        );
+    }
+
     /// Extract the per-currency block from a doctor output. Returns
     /// everything from the line after `<CCY>:` up to the next blank
     /// line (or end-of-output). Used by `e2e_*` tests to scope label
     /// assertions to the right currency.
+    ///
+    /// Panics if the currency isn't in the output — silent fallthrough
+    /// would let a typo'd test name silently assert against the doctor
+    /// header section.
+    ///
+    /// The header search is anchored to a preceding newline (`\n<CCY>:\n`)
+    /// so a mid-line mention of `<CCY>:` (e.g. an inline summary that a
+    /// future format change might add) doesn't match.
     fn currency_section<'a>(out: &'a str, currency: &str) -> &'a str {
-        let header = format!("{currency}:\n");
-        let start = out.find(&header).map(|i| i + header.len()).unwrap_or(0);
+        let header = format!("\n{currency}:\n");
+        let start = out
+            .find(&header)
+            .unwrap_or_else(|| panic!("currency {currency:?} not found in output:\n{out}"))
+            + header.len();
         let rest = &out[start..];
         let end = rest.find("\n\n").unwrap_or(rest.len());
         &rest[..end]

--- a/crates/rustledger/src/cmd/doctor/display_context.rs
+++ b/crates/rustledger/src/cmd/doctor/display_context.rs
@@ -72,12 +72,11 @@ fn collect_fixed_sources(load_result: &LoadResult) -> FixedSources {
 /// override.
 ///
 /// Pinned strings (issue #1031 AC):
-/// - option only:    `(fixed via option "display_precision")`
-/// - metadata only:  `(fixed via commodity metadata)`
-/// - both:           `(fixed via commodity metadata, overrides option "display_precision")`
-/// - programmatic:   `(fixed via programmatic source)` — only reachable
-///                   from test paths that hand-build a `DisplayContext`
-///                   without a `LoadResult`.
+/// - option only: `(fixed via option "display_precision")`
+/// - metadata only: `(fixed via commodity metadata)`
+/// - both: `(fixed via commodity metadata, overrides option "display_precision")`
+/// - programmatic: `(fixed via programmatic source)` — only reachable from
+///   test paths that hand-build a `DisplayContext` without a `LoadResult`.
 fn fixed_label_suffix(
     currency: &str,
     has_fixed: bool,
@@ -410,25 +409,53 @@ option "display_precision" "USD:0.001"
         cmd_display_context(&path, &mut buf).expect("cmd should succeed");
         let out = String::from_utf8(buf).unwrap();
 
+        // Scope each label assertion to the per-currency block so a bug
+        // that produced the right *count* of labels in the wrong sections
+        // would still fire (Copilot review on PR #1036).
+        assert_eq!(
+            currency_section(&out, "GBP").trim_end(),
+            "  effective: 2 dp (fixed via option \"display_precision\")\n  \
+             distribution: dp=2: 1",
+            "GBP block; full output:\n{out}"
+        );
+        assert_eq!(
+            currency_section(&out, "BTC").trim_end(),
+            "  effective: 8 dp (fixed via commodity metadata)\n  \
+             distribution: dp=8: 1",
+            "BTC block; full output:\n{out}"
+        );
+        // USD has the override case AND a non-trivial mode/max difference
+        // (option=3dp, metadata=4dp; observed 2dp). Scope to the section
+        // and check the label substring; the mode/max specifics aren't
+        // the contract this test is pinning.
+        let usd_section = currency_section(&out, "USD");
         assert!(
-            out.contains("GBP:") && out.contains("(fixed via option \"display_precision\")"),
-            "GBP should be labeled option-only; got:\n{out}"
+            usd_section
+                .contains("(fixed via commodity metadata, overrides option \"display_precision\")"),
+            "USD section should carry the override label; section was:\n{usd_section}"
         );
         assert!(
-            out.contains("BTC:") && out.contains("(fixed via commodity metadata)"),
-            "BTC should be labeled metadata-only; got:\n{out}"
+            !usd_section.contains("(fixed via option \"display_precision\")\n"),
+            "USD section must NOT carry the option-only label; section was:\n{usd_section}"
         );
-        assert!(
-            out.contains("USD:")
-                && out.contains(
-                    "(fixed via commodity metadata, overrides option \"display_precision\")"
-                ),
-            "USD should be labeled metadata-overrides-option; got:\n{out}"
-        );
-        // None of the labels should be the legacy `(fixed override)` form.
+
+        // None of the labels should be the legacy `(fixed override)` form
+        // anywhere in the output.
         assert!(
             !out.contains("(fixed override)"),
             "legacy source-agnostic label should be gone; got:\n{out}"
         );
+    }
+
+    /// Extract the per-currency block from a doctor output. Returns
+    /// everything from the line after `<CCY>:` up to the next blank
+    /// line (or end-of-output). Used by `e2e_*` tests to scope label
+    /// assertions to the right currency.
+    fn currency_section<'a>(out: &'a str, currency: &str) -> &'a str {
+        let header = format!("{currency}:\n");
+        let start = out.find(&header).map(|i| i + header.len()).unwrap_or(0);
+        let rest = &out[start..];
+        let end = rest.find("\n\n").unwrap_or(rest.len());
+        &rest[..end]
     }
 }

--- a/crates/rustledger/src/cmd/doctor/display_context.rs
+++ b/crates/rustledger/src/cmd/doctor/display_context.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
-use rustledger_core::{DisplayContext, Precision};
-use rustledger_loader::Loader;
+use rustledger_core::{Directive, DisplayContext, Precision};
+use rustledger_loader::{LoadResult, Loader};
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::PathBuf;
 
@@ -11,17 +12,110 @@ pub(super) fn cmd_display_context<W: Write>(file: &PathBuf, writer: &mut W) -> R
         .with_context(|| format!("failed to load {}", file.display()))?;
 
     let label = format!("Display Context for {}", file.display());
-    render_display_context(&load_result.display_context, &label, writer)
+    let sources = collect_fixed_sources(&load_result);
+    render_display_context(&load_result.display_context, &label, Some(&sources), writer)
+}
+
+/// Origin of a fixed-precision override for a currency (issue #1031).
+///
+/// Used by the doctor renderer to label `(fixed via …)` so users can
+/// tell whether a precision override came from the file-level
+/// `option "display_precision"`, from per-commodity `precision:` metadata
+/// (PR #1032 / issue #991), or both.
+#[derive(Debug, Default)]
+struct FixedSources {
+    /// Currencies that have an entry in `options.display_precision`.
+    option: HashSet<String>,
+    /// Currencies that have a valid `precision:` metadata declaration on
+    /// at least one `commodity` directive. Multi-declaration is last-wins
+    /// in the loader; for the doctor label, a currency is "metadata-sourced"
+    /// if any valid declaration exists.
+    metadata: HashSet<String>,
+}
+
+/// Walk a `LoadResult` to compute the source map.
+///
+/// Note on the `option "display_precision"` source: rledger only parses
+/// the colon-encoded form (`"USD:0.01"`). If the option value fails to
+/// parse, `options.display_precision` doesn't get the entry — the parser
+/// emits an `E7002` warning separately. So checking `display_precision`
+/// keys is sufficient; we don't need to look at the raw option strings.
+fn collect_fixed_sources(load_result: &LoadResult) -> FixedSources {
+    let option: HashSet<String> = load_result
+        .options
+        .display_precision
+        .keys()
+        .cloned()
+        .collect();
+
+    let metadata: HashSet<String> = load_result
+        .directives
+        .iter()
+        .filter_map(|spanned| {
+            let Directive::Commodity(comm) = &spanned.value else {
+                return None;
+            };
+            let value = comm.meta.get("precision")?;
+            // Same gate the loader uses: invalid values fall back to
+            // inference, so they're not "metadata-sourced" for label
+            // purposes.
+            rustledger_core::parse_precision_meta(value).ok()?;
+            Some(comm.currency.as_str().to_string())
+        })
+        .collect();
+
+    FixedSources { option, metadata }
+}
+
+/// Suffix string for a currency's fixed-precision label, given the
+/// source map. Returns the empty string if the currency has no fixed
+/// override.
+///
+/// Pinned strings (issue #1031 AC):
+/// - option only:    `(fixed via option "display_precision")`
+/// - metadata only:  `(fixed via commodity metadata)`
+/// - both:           `(fixed via commodity metadata, overrides option "display_precision")`
+/// - programmatic:   `(fixed via programmatic source)` — only reachable
+///                   from test paths that hand-build a `DisplayContext`
+///                   without a `LoadResult`.
+fn fixed_label_suffix(
+    currency: &str,
+    has_fixed: bool,
+    sources: Option<&FixedSources>,
+) -> &'static str {
+    if !has_fixed {
+        return "";
+    }
+    let Some(srcs) = sources else {
+        return " (fixed via programmatic source)";
+    };
+    let in_meta = srcs.metadata.contains(currency);
+    let in_opt = srcs.option.contains(currency);
+    match (in_meta, in_opt) {
+        (true, true) => " (fixed via commodity metadata, overrides option \"display_precision\")",
+        (true, false) => " (fixed via commodity metadata)",
+        (false, true) => " (fixed via option \"display_precision\")",
+        // The currency has a fixed override but no LoadResult-derived
+        // source. That's the programmatic-call path, same as the
+        // sources=None case above.
+        (false, false) => " (fixed via programmatic source)",
+    }
 }
 
 /// Render the diagnostic view of a `DisplayContext` to `writer`.
 ///
 /// Split from `cmd_display_context` so the rendering can be unit-tested
-/// against a manually-constructed context without going through file
-/// I/O.
+/// against a manually-constructed context without going through file I/O.
+///
+/// `sources` carries the per-currency fixed-precision origin map. Pass
+/// `Some(&sources)` from the cmd path (computed via
+/// [`collect_fixed_sources`]); pass `None` from tests that hand-build a
+/// `DisplayContext` and don't care about source labels — the renderer
+/// will fall back to `(fixed via programmatic source)`.
 fn render_display_context<W: Write>(
     dctx: &DisplayContext,
     label: &str,
+    sources: Option<&FixedSources>,
     writer: &mut W,
 ) -> Result<()> {
     writeln!(writer, "{label}")?;
@@ -54,10 +148,7 @@ fn render_display_context<W: Write>(
         // up with what BQL output will actually use.
         let effective = dctx.get_precision(currency);
         let effective_str = effective.map_or_else(|| "<none>".to_string(), |dp| dp.to_string());
-        // The override could come from `option "display_precision"` OR from
-        // a programmatic `set_fixed_precision` call. The "fixed" label is
-        // source-agnostic on purpose.
-        let suffix = if fixed { " (fixed override)" } else { "" };
+        let suffix = fixed_label_suffix(currency, fixed, sources);
         writeln!(writer, "  effective: {effective_str} dp{suffix}")?;
 
         // Distribution view — useful for understanding why mode != max.
@@ -90,10 +181,26 @@ mod tests {
     use super::*;
     use rust_decimal_macros::dec;
 
+    /// Render with no source map — exercises the programmatic-source
+    /// fallback. Used by tests that hand-build a `DisplayContext`.
     fn render(dctx: &DisplayContext) -> String {
         let mut buf: Vec<u8> = Vec::new();
-        render_display_context(dctx, "Display Context (test)", &mut buf).unwrap();
+        render_display_context(dctx, "Display Context (test)", None, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
+    }
+
+    /// Render with an explicit source map — exercises the labeled paths.
+    fn render_with(dctx: &DisplayContext, sources: &FixedSources) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        render_display_context(dctx, "Display Context (test)", Some(sources), &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn sources(option: &[&str], metadata: &[&str]) -> FixedSources {
+        FixedSources {
+            option: option.iter().map(|s| (*s).to_string()).collect(),
+            metadata: metadata.iter().map(|s| (*s).to_string()).collect(),
+        }
     }
 
     #[test]
@@ -103,6 +210,9 @@ mod tests {
         // Header still rendered before the early return.
         assert!(out.contains("Display Context (test)"));
         assert!(out.contains("Inference policy: MostCommon"));
+        // Stability: no `fixed via …` label when no currencies are
+        // observed (issue #1031 AC).
+        assert!(!out.contains("fixed via"));
     }
 
     #[test]
@@ -116,6 +226,8 @@ mod tests {
         // Mode == 2dp, all samples agree.
         assert!(out.contains("effective: 2 dp"));
         assert!(out.contains("distribution: dp=2: 5"));
+        // No fixed override → no `fixed via` label (stability AC #1031).
+        assert!(!out.contains("fixed via"));
         // Mode and max are equal here, so the side-by-side block must NOT fire.
         assert!(!out.contains("mode (MostCommon)"));
         assert!(!out.contains("max (Maximum)"));
@@ -135,17 +247,66 @@ mod tests {
     }
 
     #[test]
-    fn fixed_override_is_labeled() {
+    fn programmatic_fixed_override_falls_back_to_programmatic_label() {
+        // Hand-built context with no source map: render() passes None,
+        // exercising the programmatic-source fallback.
         let mut ctx = DisplayContext::new();
         ctx.update(dec!(1.234), "USD");
         ctx.set_fixed_precision("USD", 2);
         let out = render(&ctx);
-        // The override could come from option "display_precision" OR from
-        // set_fixed_precision; the label is source-agnostic.
-        assert!(out.contains("effective: 2 dp (fixed override)"));
+        assert!(out.contains("effective: 2 dp (fixed via programmatic source)"));
         // Distribution still shown so users can see what the inference
         // would have produced.
         assert!(out.contains("distribution: dp=3: 1"));
+    }
+
+    #[test]
+    fn fixed_via_option_only() {
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.234), "USD");
+        ctx.set_fixed_precision("USD", 2);
+        let srcs = sources(&["USD"], &[]);
+        let out = render_with(&ctx, &srcs);
+        assert!(out.contains("effective: 2 dp (fixed via option \"display_precision\")"));
+    }
+
+    #[test]
+    fn fixed_via_commodity_metadata_only() {
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.234), "USD");
+        ctx.set_fixed_precision("USD", 2);
+        let srcs = sources(&[], &["USD"]);
+        let out = render_with(&ctx, &srcs);
+        assert!(out.contains("effective: 2 dp (fixed via commodity metadata)"));
+    }
+
+    #[test]
+    fn fixed_via_both_metadata_overrides_option() {
+        // Both option AND commodity metadata set for USD. Per #991/#1032,
+        // metadata wins; the doctor label says so explicitly so users
+        // can debug precedence at a glance.
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.234), "USD");
+        ctx.set_fixed_precision("USD", 4);
+        let srcs = sources(&["USD"], &["USD"]);
+        let out = render_with(&ctx, &srcs);
+        assert!(out.contains(
+            "effective: 4 dp (fixed via commodity metadata, overrides option \"display_precision\")"
+        ));
+    }
+
+    #[test]
+    fn fixed_with_sources_but_currency_not_in_either_falls_back_to_programmatic() {
+        // Defensive: if the source map doesn't list a currency that has
+        // a fixed override, the only explanation is a programmatic call.
+        // Same label as the None-sources case.
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(1.234), "USD");
+        ctx.set_fixed_precision("USD", 2);
+        // Empty source map.
+        let srcs = sources(&[], &[]);
+        let out = render_with(&ctx, &srcs);
+        assert!(out.contains("effective: 2 dp (fixed via programmatic source)"));
     }
 
     #[test]
@@ -172,9 +333,10 @@ mod tests {
         // currencies() iterator includes fixed-only entries.
         let mut ctx = DisplayContext::new();
         ctx.set_fixed_precision("BTC", 8);
-        let out = render(&ctx);
+        let srcs = sources(&["BTC"], &[]);
+        let out = render_with(&ctx, &srcs);
         assert!(out.contains("BTC:"));
-        assert!(out.contains("effective: 8 dp (fixed override)"));
+        assert!(out.contains("effective: 8 dp (fixed via option \"display_precision\")"));
         // No distribution: line because no observations exist.
         let btc_section = out.split("BTC:").nth(1).unwrap_or("");
         assert!(!btc_section.contains("distribution:"));
@@ -191,5 +353,82 @@ mod tests {
         let eur_pos = out.find("EUR:").expect("EUR shown");
         let btc_pos = out.find("BTC:").expect("BTC shown");
         assert!(btc_pos < eur_pos && eur_pos < usd_pos);
+    }
+
+    #[test]
+    fn fixed_label_suffix_returns_empty_for_unfixed() {
+        // Unit-test the helper directly. No fixed override → no suffix
+        // regardless of source map state.
+        assert_eq!(fixed_label_suffix("USD", false, None), "");
+        let srcs = sources(&["USD"], &["USD"]);
+        assert_eq!(fixed_label_suffix("USD", false, Some(&srcs)), "");
+    }
+
+    /// End-to-end: drive `cmd_display_context` against a real fixture
+    /// that uses both `option "display_precision"` AND commodity-metadata
+    /// `precision:` declarations. Pins the integration between the
+    /// loader's source data and the renderer's labels.
+    #[test]
+    fn e2e_cmd_display_context_labels_each_source_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("e2e.beancount");
+        std::fs::write(
+            &path,
+            // GBP via option only.
+            // BTC via commodity metadata only.
+            // USD via BOTH (metadata wins per #991/#1032).
+            r#"option "display_precision" "GBP:0.01"
+option "display_precision" "USD:0.001"
+
+2024-01-01 commodity USD
+  precision: 4
+
+2024-01-01 commodity BTC
+  precision: 8
+
+2024-01-01 open Assets:USD
+2024-01-01 open Assets:GBP
+2024-01-01 open Assets:BTC
+2024-01-01 open Equity:Opening
+
+2024-01-15 * "USD"
+  Assets:USD       100.00 USD
+  Equity:Opening
+
+2024-01-15 * "GBP"
+  Assets:GBP       50.00 GBP
+  Equity:Opening
+
+2024-01-15 * "BTC"
+  Assets:BTC       0.50000000 BTC
+  Equity:Opening
+"#,
+        )
+        .unwrap();
+
+        let mut buf: Vec<u8> = Vec::new();
+        cmd_display_context(&path, &mut buf).expect("cmd should succeed");
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(
+            out.contains("GBP:") && out.contains("(fixed via option \"display_precision\")"),
+            "GBP should be labeled option-only; got:\n{out}"
+        );
+        assert!(
+            out.contains("BTC:") && out.contains("(fixed via commodity metadata)"),
+            "BTC should be labeled metadata-only; got:\n{out}"
+        );
+        assert!(
+            out.contains("USD:")
+                && out.contains(
+                    "(fixed via commodity metadata, overrides option \"display_precision\")"
+                ),
+            "USD should be labeled metadata-overrides-option; got:\n{out}"
+        );
+        // None of the labels should be the legacy `(fixed override)` form.
+        assert!(
+            !out.contains("(fixed override)"),
+            "legacy source-agnostic label should be gone; got:\n{out}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #1031. After #991 / #1032 landed (per-commodity `precision:` metadata), `rledger doctor display-context` was still emitting a source-agnostic `(fixed override)` for every currency with a fixed precision — actively unhelpful for users debugging precedence between `option "display_precision"` and commodity metadata.

This PR distinguishes the four source cases:

```
GBP:
  effective: 2 dp (fixed via option "display_precision")
  ...

BTC:
  effective: 8 dp (fixed via commodity metadata)
  ...

USD:
  effective: 4 dp (fixed via commodity metadata, overrides option "display_precision")
  ...
```

The "both" case is the highest-value debugging signal — at a glance, the user can see that metadata is winning over their option setting (per #991 precedence rule).

## Implementation

Option B from the issue (no `DisplayContext` API or rkyv archive change):

- `FixedSources` struct holds option/metadata `HashSet`s.
- `collect_fixed_sources(&LoadResult)` walks `options.display_precision` keys + `Commodity` directives via `parse_precision_meta` (same gate the loader uses — invalid values aren't labeled metadata-sourced).
- `render_display_context` gains an `Option<&FixedSources>` parameter; `None` triggers the programmatic-source fallback for tests that hand-build a `DisplayContext`.
- `fixed_label_suffix` helper centralizes the four-case match.

## Pinned label strings

Locked into AC and test assertions:

| Source | Label |
|---|---|
| option only | `(fixed via option "display_precision")` |
| metadata only | `(fixed via commodity metadata)` |
| both | `(fixed via commodity metadata, overrides option "display_precision")` |
| programmatic | `(fixed via programmatic source)` |

The programmatic-source label is only reachable from test paths today (the cmd path always produces a source map). Kept as a sensible fallback rather than panicking.

## Test plan

- [x] 14 tests pass (was 8). 5 existing `(fixed override)` assertions updated. 6 new tests cover the four source cases plus the defensive fallback and stability checks. 1 helper unit test for `fixed_label_suffix`. 1 e2e test driving `cmd_display_context` against a fixture exercising all three real-source cases (GBP option-only, BTC metadata-only, USD both).
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] All pre-push hooks green.

## Acceptance criteria (from #1031 review)

- [x] `doctor display-context` distinguishes four source cases with stable label strings (pinned in test assertions).
- [x] `render_display_context` signature gains an `Option<&FixedSources>` parameter; `None` means programmatic.
- [x] No change to `DisplayContext` public API or rkyv archive format.
- [x] Tests cover all four source cases plus the no-fixed-currency stability case.
- [x] Existing test assertions updated for the new label strings.
- [x] Render output for currencies with no fixed override is byte-identical (no `fixed via …` label, no other format changes).

## Note about `option "display_precision"` parse failures

rledger only parses the colon-encoded form (`"USD:0.01"`). If parsing fails, `options.display_precision` doesn't get the entry and the parser emits an `E7002` warning separately. So checking `display_precision` keys is sufficient — we don't need to look at raw option strings. Documented inline in `collect_fixed_sources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)