### PR TITLE
fix(core): match Beancount Position.__str__ in BQL output + escape labels

### DIFF
--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -130,12 +130,29 @@ impl Cost {
 
 impl fmt::Display for Cost {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{{} {}", self.number, self.currency)?;
+        // Match Beancount's `Position.__str__` format: `{ 520 USD}` —
+        // single space after the opening brace, no space before the
+        // closing brace. The space matters for BQL-output compat: the
+        // compat harness diffs row-by-row against bean-query, and the
+        // pre-fix `{520 USD}` form accounted for ~137 of 510 file ×
+        // query mismatches. Verified against beanquery 0.2.0 + beancount
+        // 3.2.3 (matches what CI installs and what the dev shell now
+        // ships via the compat container — see PR #1047). Source-level
+        // `format_cost_spec` (used by `rledger format` to round-trip
+        // ledger files) keeps the no-space `{N CCY}` form because that
+        // matches Beancount's `print` command output, not its
+        // `Position.__str__`.
+        write!(f, "{{ {} {}", self.number, self.currency)?;
         if let Some(date) = self.date {
             write!(f, ", {date}")?;
         }
         if let Some(label) = &self.label {
-            write!(f, ", \"{label}\"")?;
+            // Escape via `format::escape_string` so labels containing
+            // `"`, `\`, or `\n` round-trip safely. Without this a label
+            // like `say "hi"` would render as `"say "hi""` — a parse
+            // error if anyone tried to feed it back to a Beancount-
+            // compatible reader.
+            write!(f, ", \"{}\"", crate::format::escape_string(label))?;
         }
         write!(f, "}}")
     }
@@ -394,6 +411,46 @@ mod tests {
         assert!(s.contains("USD"));
         assert!(s.contains("2024-01-15"));
         assert!(s.contains("lot1"));
+    }
+
+    /// Exact-format regression covering both fixes in this PR:
+    /// - leading space inside `{` (matches Beancount Position.__str__)
+    /// - special-character escaping in labels via `format::escape_string`
+    #[test]
+    fn test_cost_display_escapes_special_characters_in_label() {
+        // Bare per-unit cost — pin the leading-space form.
+        let bare = Cost::new(dec!(520), "USD");
+        assert_eq!(format!("{bare}"), "{ 520 USD}");
+
+        // With date.
+        let dated = Cost::new(dec!(520.00), "USD").with_date(date(2024, 1, 15));
+        assert_eq!(format!("{dated}"), "{ 520.00 USD, 2024-01-15}");
+
+        // Embedded double-quote.
+        let quoted = Cost::new(dec!(100.00), "USD")
+            .with_date(date(2024, 1, 15))
+            .with_label("say \"hi\"");
+        assert_eq!(
+            format!("{quoted}"),
+            "{ 100.00 USD, 2024-01-15, \"say \\\"hi\\\"\"}"
+        );
+
+        // Embedded backslash.
+        let backslash = Cost::new(dec!(50.00), "USD").with_label("path\\to\\lot");
+        assert_eq!(
+            format!("{backslash}"),
+            "{ 50.00 USD, \"path\\\\to\\\\lot\"}"
+        );
+
+        // Embedded newline.
+        let newline = Cost::new(dec!(75.00), "USD").with_label("line1\nline2");
+        assert_eq!(format!("{newline}"), "{ 75.00 USD, \"line1\\nline2\"}");
+
+        // Plain label still works (no escaping changes for safe chars).
+        let plain = Cost::new(dec!(540.00), "USD")
+            .with_date(date(2024, 2, 15))
+            .with_label("lot-A");
+        assert_eq!(format!("{plain}"), "{ 540.00 USD, 2024-02-15, \"lot-A\"}");
     }
 
     #[test]

--- a/crates/rustledger-ffi-wasi/src/commands/clamp.rs
+++ b/crates/rustledger-ffi-wasi/src/commands/clamp.rs
@@ -461,6 +461,7 @@ mod tests {
         })
     }
 
+    #[allow(clippy::needless_pass_by_value)] // test helper; ergonomic with `vec![]` literals
     fn make_transaction(date: &str, postings: Vec<serde_json::Value>) -> serde_json::Value {
         serde_json::json!({
             "type": "transaction",
@@ -609,12 +610,11 @@ mod tests {
         assert!(result.entries.len() >= 3);
 
         // Check that a summary transaction was created
-        let summary_txns: Vec<_> = result
+        let has_summary_txn = result
             .entries
             .iter()
-            .filter(|e| e["type"] == "transaction" && e["meta"]["filename"] == "<summarization>")
-            .collect();
-        assert!(!summary_txns.is_empty(), "Should have summary transactions");
+            .any(|e| e["type"] == "transaction" && e["meta"]["filename"] == "<summarization>");
+        assert!(has_summary_txn, "Should have summary transactions");
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -765,6 +765,7 @@ include "accounts.beancount"
     fn test_total_cost_produces_per_unit_cost() {
         use helpers::load_and_book;
         use rustledger_core::Directive;
+        use std::str::FromStr;
 
         let source = r#"
 2020-01-01 open Assets:Investments:PROP PROP
@@ -803,7 +804,6 @@ include "accounts.beancount"
             .expect("total cost {{}} should be converted to per-unit cost, but number_per is None");
 
         // 150.00 / 273.2200 ≈ 0.5490
-        use std::str::FromStr;
         let expected = rustledger_core::Decimal::from_str("0.5490").unwrap();
         let diff = (per_unit - expected).abs();
         assert!(
@@ -889,17 +889,6 @@ include "accounts.beancount"
     /// Parity: total cost `{{ }}` produces identical per-unit costs.
     #[test]
     fn test_parity_total_cost() {
-        let source = r#"
-2020-01-01 open Assets:Investments PROP
-2020-01-01 open Assets:Bank AUD
-
-2020-01-16 * "Buy"
-  Assets:Investments  273.2200 PROP {{150.00 AUD}}
-  Assets:Bank         -150.00 AUD
-"#;
-        let cli = cli_process(source);
-        let wasm = wasm_process(source);
-
         fn get_cost_per_unit(
             directives: &[rustledger_core::Directive],
         ) -> rustledger_core::Decimal {
@@ -915,6 +904,17 @@ include "accounts.beancount"
                 .expect("should have a cost")
         }
 
+        let source = r#"
+2020-01-01 open Assets:Investments PROP
+2020-01-01 open Assets:Bank AUD
+
+2020-01-16 * "Buy"
+  Assets:Investments  273.2200 PROP {{150.00 AUD}}
+  Assets:Bank         -150.00 AUD
+"#;
+        let cli = cli_process(source);
+        let wasm = wasm_process(source);
+
         assert_eq!(
             get_cost_per_unit(&cli),
             get_cost_per_unit(&wasm),
@@ -925,17 +925,6 @@ include "accounts.beancount"
     /// Parity: interpolation fills in missing amounts identically.
     #[test]
     fn test_parity_interpolation() {
-        let source = r#"
-2024-01-01 open Assets:Bank USD
-2024-01-01 open Expenses:Food USD
-
-2024-01-15 * "Coffee"
-  Expenses:Food  5.00 USD
-  Assets:Bank
-"#;
-        let cli = cli_process(source);
-        let wasm = wasm_process(source);
-
         fn get_bank_amount(directives: &[rustledger_core::Directive]) -> rustledger_core::Decimal {
             directives
                 .iter()
@@ -953,6 +942,17 @@ include "accounts.beancount"
                 })
                 .expect("should have bank posting with amount")
         }
+
+        let source = r#"
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Expenses:Food USD
+
+2024-01-15 * "Coffee"
+  Expenses:Food  5.00 USD
+  Assets:Bank
+"#;
+        let cli = cli_process(source);
+        let wasm = wasm_process(source);
 
         assert_eq!(
             get_bank_amount(&cli),
@@ -993,6 +993,7 @@ include "accounts.beancount"
     #[test]
     fn test_parsed_ledger_serialize_roundtrip() {
         use crate::cache;
+        use crate::editor::EditorCache;
         use crate::helpers::load_and_book;
 
         let source = r#"
@@ -1040,7 +1041,6 @@ option "operating_currency" "USD"
         );
 
         // Verify the from_cache path works (re-parses source for editor features)
-        use crate::editor::EditorCache;
         let parse_result = rustledger_parser::parse(source);
         let editor_cache = EditorCache::new(source, &parse_result);
         assert!(

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -446,8 +446,12 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
             } else {
                 let mut s = ctx.format_amount(p.units.number, p.units.currency.as_str());
                 if let Some(ref cost) = p.cost {
+                    // `{ N CCY}` — leading space inside `{` matches
+                    // Beancount Position.__str__. Pre-fix this emitted
+                    // `{N CCY}` and accounted for ~137 of 510 BQL
+                    // compat (file × query) mismatches.
                     s.push_str(&format!(
-                        " {{{}}}",
+                        " {{ {}}}",
                         ctx.format_amount(cost.number, cost.currency.as_str())
                     ));
                 }
@@ -513,8 +517,10 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
                     } else {
                         let mut s = ctx.format_amount(p.units.number, p.units.currency.as_str());
                         if let Some(ref cost) = p.cost {
+                            // See `Value::Position` arm above for why
+                            // there's a leading space after `{`.
                             s.push_str(&format!(
-                                " {{{}}}",
+                                " {{ {}}}",
                                 ctx.format_amount(cost.number, cost.currency.as_str())
                             ));
                         }
@@ -633,13 +639,20 @@ mod tests {
     use rust_decimal_macros::dec;
     use rustledger_core::{Amount, Cost, Inventory, Position};
 
-    /// Issue #987: cost-spec braces in BQL output had a leading space
-    /// inside the open brace (`{ 128.99 USD}` instead of `{128.99 USD}`),
-    /// diverging from `bean-query`. Pin both the `Position` and
-    /// `Inventory` paths so a future change to the format string can't
-    /// silently regress.
+    /// Cost-spec braces in BQL output match Beancount's
+    /// `Position.__str__`: `{ 128.99 USD}` — single space after `{`,
+    /// no space before `}`.
+    ///
+    /// Earlier (#987) tests pinned the no-leading-space form after
+    /// comparing against an older bean-query release that emitted
+    /// `{128.99 USD}`. With beanquery 0.2.0 + beancount 3.2.3 (what
+    /// CI installs and the dev shell ships via the compat container,
+    /// PR #1047), bean-query renders with the leading space — so
+    /// matching it closes ~137 of 510 BQL compat (file × query)
+    /// mismatches. Pin both `Position` and `Inventory` paths so a
+    /// future format change can't silently regress.
     #[test]
-    fn test_position_with_cost_renders_without_leading_space_inside_braces() {
+    fn test_position_with_cost_matches_beancount_position_str() {
         let pos = Position::with_cost(
             Amount::new(dec!(8.373), "RGAGX"),
             Cost::new(dec!(128.99), "USD"),
@@ -649,17 +662,17 @@ mod tests {
         let rendered = format_value(&value, false, &ctx);
 
         assert!(
-            !rendered.contains("{ "),
-            "expected no leading space after `{{`, got {rendered:?}"
+            rendered.contains("{ 128.99 USD}"),
+            "expected `{{ 128.99 USD}}` (matching bean-query), got {rendered:?}"
         );
         assert!(
-            rendered.contains("{128.99 USD}"),
-            "expected `{{128.99 USD}}` in output, got {rendered:?}"
+            !rendered.contains(" }"),
+            "no space immediately before `}}`, got {rendered:?}"
         );
     }
 
     #[test]
-    fn test_inventory_with_cost_renders_without_leading_space_inside_braces() {
+    fn test_inventory_with_cost_matches_beancount_position_str() {
         let mut inv = Inventory::new();
         inv.add(Position::with_cost(
             Amount::new(dec!(8.373), "RGAGX"),
@@ -674,12 +687,8 @@ mod tests {
         let rendered = format_value(&value, false, &ctx);
 
         assert!(
-            !rendered.contains("{ "),
-            "expected no leading space after `{{`, got {rendered:?}"
-        );
-        assert!(
-            rendered.contains("{128.99 USD}") && rendered.contains("{131.73 USD}"),
-            "expected both costs rendered without leading space, got {rendered:?}"
+            rendered.contains("{ 128.99 USD}") && rendered.contains("{ 131.73 USD}"),
+            "expected both costs rendered with leading space, got {rendered:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Two correctness fixes in the cost-spec rendering used by BQL output. Now that #1047 has merged and the dev shell ships beancount 3.2.3 in a compat container, we can verify locally that bean-query emits `{ 520 USD}` (with the leading space) — which means the brace-spacing fix that was originally proposed and then mistakenly reverted is actually correct.

## What changed

### 1. Brace spacing (closes ~137 BQL compat mismatches)

`Cost::Display` and `format_value` (in `query/output.rs`, both `Value::Position` and `Value::Inventory` arms) now emit `{ N CCY}` — single space after `{`, no space before `}` — matching Beancount's `Position.__str__`. The BQL compat harness on PR #1043 flagged ~137 of 510 file × query mismatches that were purely this rendering gap.

The previous `{N CCY}` form was pinned by tests added in #987 against an older bean-query release. Both tests are flipped to assert the new format and renamed accordingly.

Source-level `format_cost_spec` (used by `rledger format` to emit ledger files) keeps the no-space `{N CCY}` form — matches Beancount's `print` command output, not its `Position.__str__`. The two formats coexist on the upstream side too.

### 2. Label escaping

`Cost::Display` routes label rendering through `format::escape_string`, so labels containing `"`, `\\`, or newline render correctly. Pre-fix a label like `say "hi"` rendered as `"say "hi""` — a parse error if fed back to a Beancount reader.

### 3. Drive-by clippy fixes

`-D warnings` surfaced 4 pre-existing pedantic warnings unrelated to this PR but blocking pre-push:

- `crates/rustledger-wasm/src/lib.rs` (×3): hoisted inner `fn`/`use` items to the top of their test bodies (`items_after_statements`)
- `crates/rustledger-ffi-wasi/src/commands/clamp.rs` (×2): rewrote `.collect()` + `.is_empty()` as `.any(...)`, added scoped `#[allow(clippy::needless_pass_by_value)]` on a test helper

## Test plan

- [x] New `test_cost_display_escapes_special_characters_in_label` covers both fixes — bare cost, with date, with date+label, embedded `"`/`\\`/`\\n`, plain label.
- [x] Renamed `test_position_with_cost_matches_beancount_position_str` and `test_inventory_with_cost_matches_beancount_position_str` (was `..._renders_without_leading_space_inside_braces`) now assert the leading-space form.
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-push hook (cargo check + plugin-test-quality + bean-price compat) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)