### PR TITLE
fix(query): #prices excludes transaction-derived implicit prices (closes #1048)

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1732,6 +1732,13 @@ impl<'a> Executor<'a> {
     /// - date: The date of the price directive
     /// - currency: The base currency being priced
     /// - amount: The price as an Amount (number + quote currency)
+    ///
+    /// Only **explicit** Price directives surface here — those that
+    /// came from a `price` directive in the source or were emitted by
+    /// a declared plugin (e.g. `implicit_prices`). Transaction-derived
+    /// implicit prices that the executor's pass-2 walk added for
+    /// internal `VALUE()` lookups are intentionally excluded so the
+    /// `#prices` table matches `bean-query`'s output (issue #1048).
     fn build_prices_table(&self) -> Table {
         let columns = vec![
             "date".to_string(),
@@ -1740,8 +1747,11 @@ impl<'a> Executor<'a> {
         ];
         let mut table = Table::new(columns);
 
-        // Collect all price entries from the price database
-        let mut entries: Vec<_> = self.price_db.iter_entries().collect();
+        // Collect explicit price entries only — transaction-derived
+        // implicit prices are kept in the database for internal
+        // lookups but hidden from the `#prices` table for bean-query
+        // compat.
+        let mut entries: Vec<_> = self.price_db.iter_explicit_entries().collect();
         // Sort by (date, base_currency) for consistent, deterministic output
         entries.sort_by(|(currency_a, date_a, _, _), (currency_b, date_b, _, _)| {
             date_a.cmp(date_b).then_with(|| currency_a.cmp(currency_b))

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -10,7 +10,12 @@ use rustledger_core::{
 use std::collections::HashMap;
 
 /// A price entry.
+///
+/// Marked `#[non_exhaustive]` so future provenance/metadata fields can
+/// be added without breaking downstream struct-literal construction.
+/// Internal construction in this module isn't restricted.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct PriceEntry {
     /// Date of the price.
     pub date: NaiveDate,
@@ -18,6 +23,16 @@ pub struct PriceEntry {
     pub price: Decimal,
     /// Quote currency.
     pub currency: InternedStr,
+    /// `true` if sourced from an explicit `Price` directive (or a
+    /// plugin-emitted one — same shape after plugin runs); `false` if
+    /// derived from a transaction posting in the executor's pass-2
+    /// fallback. The `#prices` BQL table filters to `explicit: true`
+    /// to match `bean-query`, which only surfaces explicit Price
+    /// directives. Internal price lookups (`get_price`, `getprice()`
+    /// BQL function) still see all entries — that preserves the
+    /// rustledger UX extension where `VALUE()` works without the
+    /// `implicit_prices` plugin being declared (issues #567, #593).
+    pub explicit: bool,
 }
 
 /// Database of currency prices.
@@ -70,6 +85,15 @@ impl PriceDatabase {
     /// emitting ABC@EUR with a different value on the same date would
     /// have stored both. Now only the explicit value survives. In
     /// practice this only surfaces with hand-authored conflicts.
+    ///
+    /// **Provenance tagging** (issue #1048): each entry stores
+    /// `explicit: bool`. Pass-1 entries are `true`, pass-2
+    /// transaction-derived entries are `false`. The `#prices` BQL
+    /// table filters to `explicit: true` via `iter_explicit_entries`
+    /// to match `bean-query`, which only surfaces real `Price`
+    /// directives. Internal `get_price` / `convert` lookups see
+    /// both kinds — that's how `VALUE()` keeps working without the
+    /// `implicit_prices` plugin being declared.
     pub fn from_directives(directives: &[Directive]) -> Self {
         let mut db = Self::new();
 
@@ -109,11 +133,15 @@ impl PriceDatabase {
     }
 
     /// Add a price directive to the database.
+    ///
+    /// Marks the entry as `explicit: true` — these entries surface in
+    /// the `#prices` BQL table.
     pub fn add_price(&mut self, price: &PriceDirective) {
         let entry = PriceEntry {
             date: price.date,
             price: price.amount.number,
             currency: price.amount.currency.clone(),
+            explicit: true,
         };
 
         self.prices
@@ -207,6 +235,10 @@ impl PriceDatabase {
     }
 
     /// Add an implicit price entry.
+    ///
+    /// Marks the entry as `explicit: false` — internal lookups still
+    /// see it, but the `#prices` BQL table hides it (matches
+    /// bean-query, which only shows explicit Price directives).
     fn add_implicit_price(
         &mut self,
         date: NaiveDate,
@@ -218,6 +250,7 @@ impl PriceDatabase {
             date,
             price,
             currency: quote_currency.clone(),
+            explicit: false,
         };
 
         self.prices
@@ -456,13 +489,22 @@ impl PriceDatabase {
         self.prices.is_empty()
     }
 
-    /// Iterate over all price entries with their base currency.
+    /// Iterate over explicit price entries only — those sourced from
+    /// `Price` directives (either user-written or plugin-emitted).
+    /// Excludes transaction-derived entries added by the executor's
+    /// pass-2 fallback. Used by the `#prices` BQL table to match
+    /// `bean-query`'s behavior.
     ///
-    /// Returns tuples of (`base_currency`, `date`, `price`, `quote_currency`).
-    pub fn iter_entries(&self) -> impl Iterator<Item = (&str, NaiveDate, Decimal, &str)> {
+    /// For internal price *lookups* (e.g. `VALUE()`, `getprice()`),
+    /// use `get_price` / `convert` / `convert_latest` — those walk
+    /// the underlying entries without filtering, which preserves the
+    /// rustledger UX extension where implicit prices are usable for
+    /// conversion without declaring the `implicit_prices` plugin.
+    pub fn iter_explicit_entries(&self) -> impl Iterator<Item = (&str, NaiveDate, Decimal, &str)> {
         self.prices.iter().flat_map(|(base, entries)| {
             entries
                 .iter()
+                .filter(|e| e.explicit)
                 .map(move |e| (base.as_str(), e.date, e.price, e.currency.as_str()))
         })
     }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -5424,6 +5424,90 @@ fn test_prices_table_basic_select() {
     assert_eq!(result.rows[0][0], Value::Date(date(2025, 1, 1)));
 }
 
+/// Issue #1048: `#prices` must NOT include transaction-derived implicit
+/// prices unless the user declared the `implicit_prices` plugin.
+///
+/// Pre-fix, the BQL executor's pass-2 walk added implicit prices from
+/// every cost-bearing posting unconditionally, so `SELECT * FROM #prices`
+/// surfaced prices that bean-query's `#prices` does NOT — accounting
+/// for ~35 of 53 BQL compat mismatches before the fix.
+///
+/// Internal `VALUE()` lookups still see those entries (rustledger UX
+/// extension from #567/#593) — see
+/// `test_value_works_without_explicit_price_directive` below.
+#[test]
+fn test_prices_table_excludes_transaction_derived_implicit_prices() {
+    // No `Directive::Price` entries; only a buy with cost. bean-query
+    // would return 0 rows for `#prices` here.
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Stock")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 10), "Buy")
+                .with_posting(
+                    Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(520))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(-5200), "USD"))),
+        ),
+    ];
+
+    let result = execute_query("SELECT count(*) FROM #prices", &directives);
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Integer(0),
+        "#prices must be empty when no Price directive is declared, even if \
+         transactions carry cost annotations (bean-query compat — issue #1048)"
+    );
+}
+
+/// Companion to the test above: even though `#prices` is empty without
+/// a declared Price directive, internal `VALUE()` lookups still get
+/// the implicit prices from the executor's pass-2 walk. This is the
+/// rustledger UX extension from #567/#593 — `VALUE()` on cost-priced
+/// positions works without requiring the user to wire up the
+/// `implicit_prices` plugin. The fix for #1048 must NOT regress that.
+#[test]
+fn test_value_works_without_explicit_price_directive() {
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Stock")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 10), "Buy")
+                .with_posting(
+                    Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
+                        CostSpec::empty()
+                            .with_number_per(dec!(520))
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_posting(Posting::new("Assets:Cash", Amount::new(dec!(-5200), "USD"))),
+        ),
+    ];
+
+    let result = execute_query(
+        "SELECT account, value(position) WHERE account = 'Assets:Stock'",
+        &directives,
+    );
+    assert_eq!(result.len(), 1);
+    // 10 HOOL @ 520 USD (from the implicit price the pass-2 walk
+    // derives from the cost annotation) = 5200 USD.
+    if let Value::Amount(a) = &result.rows[0][1] {
+        assert_eq!(a.number, dec!(5200));
+        assert_eq!(a.currency, "USD");
+    } else {
+        panic!(
+            "VALUE() should resolve via implicit prices even without an \
+             explicit Price directive; got {:?}",
+            result.rows[0][1]
+        );
+    }
+}
+
 #[test]
 fn test_prices_table_select_all() {
     // Test: SELECT * FROM #prices


### PR DESCRIPTION
## Summary

The BQL `#prices` system table was including transaction-derived implicit prices that `bean-query` does not, accounting for **~35 of 53 remaining BQL compat mismatches** (66%) on the post-#1046 corpus.

## Why it happened

`PriceDatabase` is built in two passes:

1. **Explicit `Price` directives** — added unconditionally
2. **Transaction-derived implicit prices** — added as a fallback so `VALUE()` and `getprice()` work without requiring the user to declare the `implicit_prices` plugin (rustledger UX extension from #567/#593)

Pre-fix, `#prices` surfaced both kinds. `bean-query` has no equivalent extension — it only shows what's literally a `Price` directive. Result: a ledger with cost-bearing transactions but no `Price` directives returned non-empty `#prices` from rledger but empty from bean-query.

## What changed

Tag each `PriceEntry` with `explicit: bool`:

- `add_price` (explicit `Price` directive, plugin-emitted or user-written) sets `explicit: true`
- `add_implicit_price` (pass-2 transaction-derived) sets `explicit: false`
- New `iter_explicit_entries()` filters to `explicit: true`
- `build_prices_table` switches to `iter_explicit_entries()`

Internal `get_price()` lookups (`VALUE()`, `getprice()`, unrealized-gain calculations, etc.) still see all entries — the rustledger UX extension is preserved.

## Tests

Two new regression tests in `crates/rustledger-query/tests/bql_integration_test.rs`:

- `test_prices_table_excludes_transaction_derived_implicit_prices` — pins the fix
- `test_value_works_without_explicit_price_directive` — pins the rustledger UX extension

## Estimated BQL compat impact

89% → ~96% (closes ~35 of 53 remaining mismatches).

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)