### PR TITLE
fix(loader): match Python entry order on same date (closes #1049)

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -266,6 +266,23 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
         run_booking(&mut directives, effective_method, &mut errors);
     }
 
+    // Booking has consumed the cost-reduction-aware order; switch to a
+    // file-position tie-break that's order-equivalent to Python
+    // beancount's `(date, type_priority, lineno)` for downstream
+    // consumers (plugins, validation, BQL queries, display). We sort by
+    // `(date, priority, file_id, span.start)` — `span.start` is a byte
+    // offset and `file_id` indexes the `SourceMap`, so within a file
+    // the offset orders directives the same way line numbers would
+    // (line N starts before line N+1), without paying for the byte→line
+    // conversion. Across files the `file_id` tie-break preserves the
+    // include order they were added to the `SourceMap`. Without this
+    // re-sort, BQL output diverges from bean-query on fixtures that
+    // mix augmentation and reduction transactions on the same date —
+    // same rows, different tie-break (issue #1049, ~10 of 53 BQL
+    // compat mismatches). Stable sort preserves the existing in-loader
+    // order among directives with identical sort keys.
+    directives.sort_by_key(|d| (d.value.date(), d.value.priority(), d.file_id, d.span.start));
+
     // 3. Run plugins (including document discovery when run_plugins is enabled)
     // Note: Document discovery only runs when run_plugins is true to respect raw mode semantics.
     // LoadOptions::raw() sets run_plugins=false to prevent any directive mutations.

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -1562,3 +1562,87 @@ fn precision_metadata_string_value_falls_back() {
     assert_eq!(result.display_context.get_precision("USD"), Some(2));
     assert!(!result.display_context.has_fixed_precision("USD"));
 }
+
+#[test]
+fn same_date_directives_keep_file_order_after_booking() {
+    // Issue #1049: the loader's pre-booking sort uses
+    // `(date, priority, has_cost_reduction)` so the booking engine
+    // sees augmentations before reductions on the same date (issue
+    // #841). After booking runs, we re-sort by `(date, priority,
+    // file_id, span.start)` to match Python beancount's
+    // `(date, type_priority, lineno)` order — otherwise BQL output
+    // diverges from bean-query on same-date tie-breaks.
+    //
+    // This fixture has a Sell stamped *before* a Buy in the file but
+    // on the same date. Booking reorders them so the Buy creates the
+    // lot first; the post-booking re-sort then restores file order
+    // for downstream consumers.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("same_date_order.beancount");
+    std::fs::write(
+        &path,
+        r#"2024-01-01 open Assets:Stock
+2024-01-01 open Assets:Cash
+2024-01-01 open Equity:Opening
+
+2024-01-10 * "Initial cash"
+  Assets:Cash       2000.00 USD
+  Equity:Opening   -2000.00 USD
+
+2024-01-15 * "Sell — appears first in file"
+  Assets:Stock     -5 STK {100.00 USD}
+  Assets:Cash     500.00 USD
+
+2024-01-15 * "Buy — appears second in file but creates the lot"
+  Assets:Stock     10 STK {100.00 USD}
+  Assets:Cash   -1000.00 USD
+"#,
+    )
+    .unwrap();
+    let options = LoadOptions::default();
+    let ledger = load(&path, &options).expect("should load");
+
+    // Booking succeeded — the Sell found a matching lot from the Buy
+    // even though it's textually earlier (issue #841).
+    assert!(
+        ledger
+            .errors
+            .iter()
+            .all(|e| !matches!(e.severity, ErrorSeverity::Error)),
+        "booking should succeed across same-date sell-before-buy: {:?}",
+        ledger
+            .errors
+            .iter()
+            .filter(|e| matches!(e.severity, ErrorSeverity::Error))
+            .collect::<Vec<_>>()
+    );
+
+    // Find the two same-date transactions and assert file order is
+    // preserved: the textually-first "Sell" before the textually-second "Buy".
+    let target_date = jiff::civil::date(2024, 1, 15);
+    let txns_on_date: Vec<&str> = ledger
+        .directives
+        .iter()
+        .filter_map(|d| {
+            if let rustledger_core::Directive::Transaction(t) = &d.value
+                && t.date == target_date
+            {
+                return Some(t.narration.as_str());
+            }
+            None
+        })
+        .collect();
+    assert_eq!(
+        txns_on_date.len(),
+        2,
+        "expected two same-date transactions, got {txns_on_date:?}"
+    );
+    assert!(
+        txns_on_date[0].starts_with("Sell"),
+        "textually-first Sell should come first after post-booking sort, got: {txns_on_date:?}"
+    );
+    assert!(
+        txns_on_date[1].starts_with("Buy"),
+        "textually-second Buy should come second, got: {txns_on_date:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- The loader's pre-booking sort uses `(date, priority, has_cost_reduction)` so the booking engine sees augmentations before reductions on the same date (issue #841 — rustledger explicitly orders the buy before the sell so lots exist when matched).
- That reorder leaked into BQL output and diverged from bean-query, which iterates entries in `(date, type_priority, lineno)` order. ~10 of 53 remaining BQL compat mismatches all clustered on this tie-break.
- After booking finishes, re-sort by `(date, priority, file_id, span.start)` — matching Python's `entry_sortkey` — so plugins, validation, and queries all see the same order bean-query does.

## Why this is safe for #841

Booking has already consumed the cost-reduction-aware order by the time we re-sort. The booked transactions carry their resolved lots inline, so re-ordering directives afterwards doesn't unmatch anything. The new regression test pins both invariants on a single fixture: same-date sell-before-buy in the file → booking still succeeds AND post-load order matches file order.

## Compat impact

| | Mismatches | Pass rate |
|---|---|---|
| base | 111 | 78.24% |
| fix | 101 | **80.20%** |
| **delta** | **−10** | **+1.96 pp** |

8 of the 9 queries the issue called out flip from fail → pass on `testdata_source_ofx_test_fidelity_ira_journal.beancount` (the 9th, `count-prices-from-plugin`, is in a separate failure class — implicit-prices behavior, not sort tie-break). 2 additional queries on `example.beancount` flip too. **0 regressions.**

Newly passing query/file pairs:

```
+ journal-assets-at-cost on example.beancount
+ journal-assets-at-units on example.beancount
+ balance-running-assets, journal-assets, journal-assets-at-cost,
  journal-assets-at-units, position-by-date, weight-by-date
  on testdata_source_ofx_test_fidelity_ira_journal.beancount
```

## Test plan

- [x] New loader regression test `same_date_directives_keep_file_order_after_booking` — same-date sell-before-buy fixture, asserts (a) booking succeeds and (b) post-load order is file order.
- [x] `cargo test -p rustledger-loader --all-features` — 67 + 7 + 60 + 2 passed (added test included).
- [x] `cargo test -p rustledger-booking --all-features` — 85 + 8 passed (no booking regressions).
- [x] `cargo test -p rustledger-query --all-features` — 137 + 358 + 13 + 3 passed.
- [x] `cargo clippy -p rustledger-loader --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] BQL compat suite (709 fixtures × 17 queries, 510 valid pairs) — **+10 passes, 0 regressions**.

Closes #1049