### PR TITLE
fix(query): flip weight sign on credit-side @@ total-price postings (closes #1052)

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -268,35 +268,11 @@ impl Executor<'_> {
                 Ok(Value::Null)
             }
             "weight" => {
-                // Weight is the cost-converted amount used for transaction balancing.
-                // With cost: units × cost (in cost currency)
-                // With @ price: units × price (in price currency)
-                // With @@ price: the total price directly
-                // Otherwise: units as-is
-                if let Some(units) = posting.amount() {
-                    if let Some(cost) = &posting.cost
-                        && let Some(number_per) = &cost.number_per
-                        && let Some(currency) = &cost.currency
-                    {
-                        let total = units.number * number_per;
-                        return Ok(Value::Amount(Amount::new(total, currency.clone())));
-                    }
-                    if let Some(price_ann) = &posting.price
-                        && let Some(price_amt) = price_ann.amount()
-                    {
-                        return if price_ann.is_unit() {
-                            Ok(Value::Amount(Amount::new(
-                                units.number * price_amt.number,
-                                price_amt.currency.clone(),
-                            )))
-                        } else {
-                            Ok(Value::Amount(price_amt.clone()))
-                        };
-                    }
-                    Ok(Value::Amount(units.clone()))
-                } else {
-                    Ok(Value::Null)
-                }
+                // Delegate to the shared helper so this path can't drift
+                // from `build_postings_table`'s weight column. The two
+                // sites had drifted on `@@` sign handling, which was the
+                // root cause of issue #1052.
+                Ok(super::compute_posting_weight(posting, ctx.transaction.date))
             }
             "balance" => {
                 // Cumulative running balance across WHERE-filtered postings —

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -26,6 +26,61 @@ use rustledger_parser::Spanned;
 use crate::ast::{Expr, FromClause, FunctionCall, Query, Target};
 use crate::error::QueryError;
 
+/// Compute a posting's `weight` — the cost-converted amount used for
+/// transaction balancing.
+///
+/// Rules (matching Beancount):
+/// - Cost annotation present and resolvable: `units × cost_per_unit` in
+///   the cost currency. `CostSpec::resolve` handles `{{total ...}}` by
+///   dividing the total by `|units|`, so callers don't need to special-case
+///   that shape.
+/// - `@` per-unit price: `units × price` in the price currency. Sign
+///   carries through `units` naturally.
+/// - `@@` total price: `sign(units) × total` in the price currency. The
+///   `@@` amount is written as a positive magnitude in the source, so
+///   credit-side postings need an explicit sign flip — without it,
+///   `weight` returns `+T` where bean-query returns `−T` and the
+///   transaction can't balance against the matching cash side
+///   (issue #1052).
+/// - Otherwise (or if a cost spec was present but couldn't resolve and
+///   no usable price annotation either): `units` as-is.
+///
+/// Returns `Value::Null` for postings without resolved units. Used by
+/// both [`Executor::build_postings_table`] (the `#postings` table
+/// builder) and [`Executor::evaluate_column`] (the default-FROM column
+/// accessor) so the two paths can't drift again.
+pub(super) fn compute_posting_weight(
+    posting: &rustledger_core::Posting,
+    txn_date: NaiveDate,
+) -> Value {
+    let Some(units) = posting.amount() else {
+        return Value::Null;
+    };
+    if let Some(cost_spec) = &posting.cost
+        && let Some(cost) = cost_spec.resolve(units.number, txn_date)
+    {
+        return Value::Amount(Amount::new(units.number * cost.number, cost.currency));
+    }
+    if let Some(price_ann) = &posting.price
+        && let Some(price_amt) = price_ann.amount()
+    {
+        return if price_ann.is_unit() {
+            Value::Amount(Amount::new(
+                units.number * price_amt.number,
+                price_amt.currency.clone(),
+            ))
+        } else {
+            let signed = if units.number.is_sign_negative() {
+                -price_amt.number
+            } else {
+                price_amt.number
+            };
+            Value::Amount(Amount::new(signed, price_amt.currency.clone()))
+        };
+    }
+    Value::Amount(units.clone())
+}
+
 /// Query executor.
 pub struct Executor<'a> {
     /// All directives to query over.
@@ -2526,39 +2581,11 @@ impl<'a> Executor<'a> {
                     .and_then(|p| p.amount())
                     .map_or(Value::Null, |a| Value::Amount(a.clone()));
 
-                // Weight: the cost-converted amount used for transaction balancing.
-                // With cost: units × cost (in cost currency)
-                // With @ price: units × price (in price currency)
-                // With @@ price: the total price directly (already in target currency)
-                // Otherwise: units as-is
-                let weight_val = if let Some(units) = posting.amount() {
-                    if let Some(cost_spec) = &posting.cost {
-                        if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
-                            Value::Amount(Amount::new(units.number * cost.number, cost.currency))
-                        } else {
-                            Value::Amount(units.clone())
-                        }
-                    } else if let Some(price_ann) = &posting.price {
-                        if let Some(price_amt) = price_ann.amount() {
-                            if price_ann.is_unit() {
-                                // @ per-unit price: weight = units × price
-                                Value::Amount(Amount::new(
-                                    units.number * price_amt.number,
-                                    price_amt.currency.clone(),
-                                ))
-                            } else {
-                                // @@ total price: the amount IS the total weight
-                                Value::Amount(price_amt.clone())
-                            }
-                        } else {
-                            Value::Amount(units.clone())
-                        }
-                    } else {
-                        Value::Amount(units.clone())
-                    }
-                } else {
-                    Value::Null
-                };
+                // Weight delegates to `compute_posting_weight` so the
+                // `#postings` table and the default-FROM `weight` column
+                // accessor stay in lockstep — the two used to drift on
+                // `@@` sign handling (issue #1052).
+                let weight_val = compute_posting_weight(posting, txn.date);
 
                 let balance_val = Value::Inventory(Box::new(cumulative_balance.clone()));
                 let account_balance_val = account_balances

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7313,6 +7313,61 @@ fn test_weight_column_total_price_default_from() {
 }
 
 #[test]
+fn test_weight_total_price_credit_side_flips_sign() {
+    // Issue #1052: a posting like `-27204.53 BAM @@ 15152.07 EUR` (negative
+    // units, `@@` total price) must have weight `-15152.07 EUR`. The total
+    // amount is always written as a positive magnitude in the source, so
+    // `weight` has to flip sign on credit-side postings for the transaction
+    // to balance. Pre-fix we returned the @@ amount as-is, giving +15152.07
+    // and breaking parity with bean-query on `total_annotation.beancount`.
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Insurance")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Transaction(
+            Transaction::new(date(2025, 1, 23), "insurance matured")
+                .with_posting(
+                    Posting::new("Assets:Insurance", Amount::new(dec!(-27204.53), "BAM"))
+                        .with_price(PriceAnnotation::Total(Amount::new(dec!(15152.07), "EUR"))),
+                )
+                .with_posting(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(15152.07), "EUR"),
+                )),
+        ),
+    ];
+
+    // Path 1: #postings table (build_postings_table)
+    let result = execute_query(
+        "SELECT weight FROM #postings WHERE account = 'Assets:Insurance'",
+        &directives,
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::Amount(Amount::new(dec!(-15152.07), "EUR")),
+        "weight on a credit-side @@ posting must flip sign (#postings path)"
+    );
+
+    // Path 2: default FROM (evaluate_column)
+    let result = execute_query(
+        "SELECT weight WHERE account = 'Assets:Insurance'",
+        &directives,
+    );
+    assert_eq!(
+        result.rows[0][0],
+        Value::Amount(Amount::new(dec!(-15152.07), "EUR")),
+        "weight on a credit-side @@ posting must flip sign (default-FROM path)"
+    );
+
+    // Sanity check: positive-units side keeps the magnitude as-written.
+    let result = execute_query("SELECT weight WHERE account = 'Assets:Cash'", &directives);
+    assert_eq!(
+        result.rows[0][0],
+        Value::Amount(Amount::new(dec!(15152.07), "EUR")),
+        "Cash posting has positive units, weight should be +amount"
+    );
+}
+
+#[test]
 fn test_postings_table_lineno_query() {
     // The original issue (#820) mentions SELECT lineno should work
     let directives = make_postings_test_directives();


### PR DESCRIPTION
## Summary

A posting like `Assets:Insurance -27204.53 BAM @@ 15152.07 EUR` (negative units, `@@` total-price annotation) must report `weight = -15152.07 EUR` so the transaction balances against the matching `Assets:Cash 15152.07 EUR`. Pre-fix, both the `#postings` table builder (`mod.rs:2549`) and the default-FROM column accessor (`evaluation.rs:293`) cloned the `@@` amount as-is, returning `+15152.07 EUR` and breaking parity with bean-query on `tests/compatibility/files/plugins/implicit_prices/total_annotation.beancount`.

The `@@` amount is always written as a positive magnitude in the source — bean-query handles this by multiplying by `sign(units.number)` at weight time. Mirror that here in both sites; the `@` per-unit branch already gets the sign right naturally because it multiplies through `units.number`.

## Why this only affects `@@`, not `@`

For `@`: `weight = units × price`. Sign of `units` carries through.

For `@@`: `weight = total_amount` was the pre-fix formula — independent of units. Wrong on credit-side postings.

After fix: `weight = sign(units) × total_amount` — matches Beancount's reference.

## Compat impact

- BQL compat: −1 mismatch on `total_annotation.beancount` `weight-by-date` query (the issue's exact reproducer).

## Test plan

- [x] New `test_weight_total_price_credit_side_flips_sign` exercising both code paths (`#postings` and default-FROM) plus a positive-units sanity check on the cash side.
- [x] Existing `test_weight_column_total_price_default_from` (positive-units `@@`) still passes.
- [x] `cargo test -p rustledger-query --all-features --test bql_integration_test -- test_weight` — 2/2 pass.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p rustledger-query --all-features --tests -- -D warnings` — clean.
- [x] Manual repro: `rledger query …/total_annotation.beancount 'SELECT date, account, weight WHERE account ~ "Insurance" ORDER BY date'` now returns `-15152.07 EUR`, matching bean-query.

Closes #1052