### PR TITLE
fix(plugin): match Python implicit_prices on reductions and same-day dedup

### DIFF
--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -85,6 +85,24 @@ fn cost_fingerprint(cost: &CostData, units_number: Decimal) -> Option<String> {
 /// reducing-sell-with-`{}` posting on fixtures like fava-portfolio-
 /// returns (closes the residual ~5 over-emit cases left behind by
 /// #1048).
+///
+/// Pipeline assumption: this plugin operates on **post-booking**
+/// directives. Postings that would cross zero (e.g. a `-150` sell
+/// against a `+100` lot) have already been split by the booker into
+/// two postings — one fully-reducing leg against the existing lot
+/// and one augmenting/creating leg for the residual. Our inline
+/// inventory update sees them sequentially and correctly classifies
+/// the residual leg as not-REDUCED. If the plugin is ever moved
+/// earlier in the pipeline, the gate would over-suppress on
+/// pre-split crossing postings.
+///
+/// Lots with a cost spec that carries neither `number_per` nor
+/// `number_total` (e.g. bare `{2024-01-01}`) aren't tracked in the
+/// inventory — `cost_fingerprint` returns `None` and the posting
+/// passes through the cost-emit branch directly. Python's
+/// `Inventory.add_amount` would still track these, but since the
+/// cost-derived emit path also requires a number, the tracker
+/// participation doesn't change emit decisions.
 pub struct ImplicitPricesPlugin;
 
 impl NativePlugin for ImplicitPricesPlugin {

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -1,14 +1,60 @@
 //! Plugin that generates price entries from transaction costs and prices.
 
 use crate::types::{
-    AmountData, DirectiveData, DirectiveWrapper, PluginInput, PluginOutput, PriceAnnotationData,
-    PriceAnnotationView, PriceData,
+    AmountData, CostData, DirectiveData, DirectiveWrapper, PluginInput, PluginOutput,
+    PriceAnnotationData, PriceAnnotationView, PriceData,
 };
 use rust_decimal::Decimal;
 use rustledger_core::extract_per_unit_price;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
 use super::super::NativePlugin;
+
+/// Canonical key for tracking lots in the per-account inventory used
+/// by the cost-only "skip on REDUCED" check. Mirrors what Python
+/// beancount's `Inventory.add_amount` keys lots on:
+/// `(currency, Cost(number, currency, date, label))`. We carry the
+/// account too so we get per-account tracking.
+type LotKey = (String, String, Option<String>);
+
+/// Build the cost-fingerprint half of [`LotKey`]. `None` for postings
+/// without a cost spec; otherwise a stable string of the lot's
+/// distinguishing fields. Two postings with the same `LotKey` will
+/// match against each other in the inventory tracker, exactly as
+/// `Inventory.add_amount` would.
+///
+/// The per-unit number is parsed to [`Decimal`] and then *normalized*
+/// (trailing-zero-stripped) before stringifying — without that step,
+/// numerically equivalent costs like `"100"` and `"100.00"` would
+/// produce different lot keys, so a sell at `{100 USD}` against a
+/// prior buy at `{100.00 USD}` wouldn't classify as `REDUCED` and the
+/// phantom price emit this gate exists to prevent would slip back in.
+/// Caught by Copilot review on PR #1061.
+///
+/// We canonicalize `number_per` from `number_total` (dividing by
+/// `|units|`) when only the total is set — keeps the key consistent
+/// regardless of which form the cost was originally written in. After
+/// booking has run the `number_per` field is normally populated
+/// anyway, but we don't assume that.
+fn cost_fingerprint(cost: &CostData, units_number: Decimal) -> Option<String> {
+    let currency = cost.currency.as_deref()?;
+    let per_unit_decimal: Decimal = if let Some(per_str) = &cost.number_per {
+        Decimal::from_str(per_str).ok()?
+    } else if let Some(total_str) = &cost.number_total {
+        let total = Decimal::from_str(total_str).ok()?;
+        if units_number.is_zero() {
+            return None;
+        }
+        total / units_number.abs()
+    } else {
+        return None;
+    };
+    let per_unit = per_unit_decimal.normalize().to_string();
+    let date = cost.date.as_deref().unwrap_or("");
+    let label = cost.label.as_deref().unwrap_or("");
+    Some(format!("{per_unit}|{currency}|{date}|{label}"))
+}
 
 /// Plugin that generates price entries from transaction postings.
 ///
@@ -23,6 +69,22 @@ use super::super::NativePlugin;
 /// (off by a factor of `units`) AND emitted both an annotation-derived
 /// AND a cost-derived price for postings that had both. Both bugs
 /// disappear once the helper is the single source of truth.
+///
+/// Augment-vs-reduce gating: Python's plugin uses
+/// `Inventory.add_position` and skips emitting the cost-derived price
+/// when the posting matched as `MatchResult.REDUCED` (a sell against
+/// an existing lot). Without that check, sells written as `-N CCY {}`
+/// — which booking later resolves to a specific lot's cost — produce
+/// a phantom price entry per match. We mirror that here by tracking
+/// per-account positions keyed on `(account, units.currency,
+/// cost-fingerprint)` and treating a posting as REDUCED when the
+/// running quantity for its key has the opposite sign. Price
+/// annotations (`@`/`@@`) still emit unconditionally even on reducing
+/// postings — Python's `from_price` branch fires before the REDUCED
+/// check too. Without this gate rledger over-emitted ~4 prices per
+/// reducing-sell-with-`{}` posting on fixtures like fava-portfolio-
+/// returns (closes the residual ~5 over-emit cases left behind by
+/// #1048).
 pub struct ImplicitPricesPlugin;
 
 impl NativePlugin for ImplicitPricesPlugin {
@@ -37,6 +99,20 @@ impl NativePlugin for ImplicitPricesPlugin {
     fn process(&self, input: PluginInput) -> PluginOutput {
         let mut new_directives = Vec::new();
         let mut generated_prices = Vec::new();
+
+        // Per-account lot quantities, keyed identically to Python's
+        // `Inventory.add_amount`. Used solely to detect REDUCED for
+        // the cost-derived emit gate.
+        let mut inventory: HashMap<LotKey, Decimal> = HashMap::new();
+
+        // Dedup of emitted prices by `(date, base_currency, number,
+        // quote_currency)` — mirrors Python's `new_price_entry_map`
+        // which silently drops a second emit for the same key on the
+        // same day. Without this, two postings on the same day that
+        // resolve to the same per-unit price (e.g., two buys at the
+        // same lot cost) produce two identical entries in `#prices`,
+        // inflating the count vs bean-check.
+        let mut emitted_keys: HashSet<(String, String, String, String)> = HashSet::new();
 
         for wrapper in &input.directives {
             new_directives.push(wrapper.clone());
@@ -103,11 +179,63 @@ impl NativePlugin for ImplicitPricesPlugin {
                     Some((per, total, currency))
                 });
 
-                let Some((per_unit, quote_currency)) =
-                    extract_per_unit_price(units_number, annotation, cost)
-                else {
+                // Update the per-account lot tracker BEFORE deciding
+                // whether to emit. The pre-update quantity is what
+                // tells us whether this posting reduces an existing
+                // lot (Python's `MatchResult.REDUCED`).
+                let reduced = if let Some(c) = posting.cost.as_ref()
+                    && let Some(fp) = cost_fingerprint(c, units_number)
+                {
+                    let key = (posting.account.clone(), units.currency.clone(), Some(fp));
+                    let prior = inventory.get(&key).copied().unwrap_or(Decimal::ZERO);
+                    let was_reduction = !prior.is_zero()
+                        && prior.is_sign_negative() != units_number.is_sign_negative();
+                    inventory.insert(key, prior + units_number);
+                    was_reduction
+                } else {
+                    false
+                };
+
+                // Two-phase resolution to mirror Python's
+                // `if posting.price → emit; elif cost && !REDUCED → emit`:
+                // we ask the helper for the annotation-only price first
+                // (passing `None` for cost), and only fall back to the
+                // cost path when the posting is augmenting (or a
+                // first-time CREATED). Calling the helper twice is
+                // cheap and avoids duplicating its priority logic.
+                let from_annotation =
+                    extract_per_unit_price(units_number, annotation, None::<(_, _, String)>);
+                let chosen = match (from_annotation, reduced) {
+                    (Some(p), _) => Some(p),
+                    (None, false) => extract_per_unit_price(units_number, None, cost),
+                    (None, true) => None,
+                };
+
+                let Some((per_unit, quote_currency)) = chosen else {
                     continue;
                 };
+
+                // Dedup key uses the *normalized* (trailing-zero-stripped)
+                // decimal string so two postings with the same numeric
+                // per-unit value but different scales (e.g. "100" vs
+                // "100.00") collapse to the same key — Python's
+                // `new_price_entry_map` compares the numeric value, not
+                // its string form. The emitted price keeps the
+                // un-normalized representation so user-facing output
+                // preserves whatever scale the cost spec produced.
+                // Caught by Copilot review on PR #1061.
+                let per_unit_str = per_unit.to_string();
+                let dedup_key = (
+                    wrapper.date.clone(),
+                    units.currency.clone(),
+                    per_unit.normalize().to_string(),
+                    quote_currency.clone(),
+                );
+                if !emitted_keys.insert(dedup_key) {
+                    // Same (date, base, number, quote) already emitted —
+                    // skip. Matches Python beancount's silent dedup.
+                    continue;
+                }
 
                 generated_prices.push(DirectiveWrapper {
                     directive_type: "price".to_string(),
@@ -117,7 +245,7 @@ impl NativePlugin for ImplicitPricesPlugin {
                     data: DirectiveData::Price(PriceData {
                         currency: units.currency.clone(),
                         amount: AmountData {
-                            number: per_unit.to_string(),
+                            number: per_unit_str,
                             currency: quote_currency,
                         },
                         metadata: vec![],

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -2802,6 +2802,62 @@ fn test_implicit_prices_reduced_gate_and_dedup_are_scale_insensitive() {
     );
 }
 
+/// Over-sell crossing zero: the booker pre-splits a `-150` sell against
+/// a `+100` lot into two postings — a fully-reducing `-100` leg matched
+/// to the existing lot, and an augmenting `-50` leg creating a new
+/// short position. Our inline inventory update sees them in order, so
+/// the first leg classifies REDUCED (no emit) and the second leg sees
+/// `prior=0` and classifies CREATED (emit). Hard-coded here to lock in
+/// the assumption that this plugin runs on post-booking input —
+/// regression-guards against future pipeline reordering that would
+/// hand us un-split crossing postings.
+#[test]
+fn test_implicit_prices_oversell_crossing_zero_emits_for_residual_leg() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // Initial buy of 100 X at 1 USD.
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy",
+            "Assets:Brokerage",
+            ("100", "X"),
+            ("1", "USD"),
+            "Assets:Cash",
+        ),
+        // Booker's split form of "sell -150 X": leg 1 fully reduces
+        // the existing lot at the same cost. No emit expected.
+        make_transaction_with_cost(
+            "2024-03-01",
+            "Reducing leg",
+            "Assets:Brokerage",
+            ("-100", "X"),
+            ("1", "USD"),
+            "Assets:Cash",
+        ),
+        // Leg 2 creates a -50 short position at a (hypothetical) new
+        // cost basis. Emit expected.
+        make_transaction_with_cost(
+            "2024-03-01",
+            "New-short leg",
+            "Assets:Brokerage",
+            ("-50", "X"),
+            ("2", "USD"),
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
+    assert_eq!(
+        prices.len(),
+        2,
+        "buy + residual short leg emit; reducing leg suppressed. Got: {prices:?}"
+    );
+    assert!(prices.contains(&("X".into(), "1".into(), "USD".into())));
+    assert!(prices.contains(&("X".into(), "2".into(), "USD".into())));
+}
+
 /// Posting with NO price annotation and NO cost: emits nothing.
 #[test]
 fn test_implicit_prices_emits_nothing_for_plain_transfer() {

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -2605,6 +2605,203 @@ fn test_implicit_prices_zero_unit_total_falls_through_to_cost_currency() {
     );
 }
 
+/// Reducing-sell gate: a sell whose cost spec resolves to an existing
+/// lot (Python's `MatchResult.REDUCED`) must NOT emit an extra price.
+/// Pre-fix this plugin emitted one phantom price per matched lot, so a
+/// `Sell -50 X {1 USD}` against a prior `Buy +100 X {1 USD}` would
+/// produce a duplicate `1 USD` price entry, and a `Sell -250 X {}` that
+/// FIFO-matched three different cost lots would produce three phantom
+/// prices. Python's `implicit_prices` plugin gates the cost-derived
+/// emit on `Inventory.add_position` returning anything except
+/// `MatchResult.REDUCED`; we mirror that here with a per-account lot
+/// tracker. Closes the residual ~5 over-emit cases left behind by
+/// #1048 (e.g. fava-portfolio-returns/example_stock: py=6 rs=10).
+#[test]
+fn test_implicit_prices_skips_reducing_sell_with_cost() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // Buy 100 X {1 USD} on 2024-02-01 — augmenting, emit price.
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy 100 X",
+            "Assets:Brokerage",
+            ("100", "X"),
+            ("1", "USD"),
+            "Assets:Cash",
+        ),
+        // Sell -50 X {1 USD} on 2024-03-01 — reduces the buy's lot,
+        // must NOT emit an extra price.
+        make_transaction_with_cost(
+            "2024-03-01",
+            "Sell 50 X",
+            "Assets:Brokerage",
+            ("-50", "X"),
+            ("1", "USD"),
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
+    assert_eq!(
+        prices,
+        vec![("X".into(), "1".into(), "USD".into())],
+        "exactly one implicit price (from the buy); the sell must not \
+         re-emit the same lot's cost as a price"
+    );
+}
+
+/// Companion to the above: a reducing sell with both `{cost}` AND a
+/// `@` price annotation still emits the *annotation* price (Python's
+/// `from_price` branch fires regardless of REDUCED). The cost-derived
+/// emit is suppressed, but the annotation isn't.
+#[test]
+fn test_implicit_prices_reducing_sell_with_annotation_emits_from_price() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy",
+            "Assets:Brokerage",
+            ("10", "X"),
+            ("100", "USD"),
+            "Assets:Cash",
+        ),
+        // -5 X {100 USD} @ 110 USD: reducing, but the annotation
+        // should still produce a 110 USD price.
+        make_transaction_with_cost_and_price(
+            "2024-03-01",
+            "Sell with explicit price",
+            "Assets:Brokerage",
+            ("-5", "X"),
+            ("100", "USD"), // cost (matches the lot)
+            ("110", "USD"), // @ annotation
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
+    // Two emits: 100 from the buy's cost, 110 from the sell's annotation.
+    // Crucially NOT three (no extra 100 from the sell's cost-from-REDUCED).
+    assert_eq!(prices.len(), 2, "exactly two emits: buy-cost + sell-@");
+    assert!(prices.contains(&("X".into(), "100".into(), "USD".into())));
+    assert!(prices.contains(&("X".into(), "110".into(), "USD".into())));
+}
+
+/// Same-day dedup: two augmenting buys on the same day at the same
+/// per-unit cost emit ONE price, not two. Mirrors Python's
+/// `new_price_entry_map` keyed by `(date, base_currency, number,
+/// quote_currency)`. Without this gate, fixtures with multi-asset
+/// portfolio buys (where the same fund is bought across several
+/// accounts on the same date at the same NAV) inflate `#prices`'s
+/// row count compared to bean-check. Concrete impact on
+/// `beangrow/example_ledger.beancount`: 854 → 782 rows after dedup,
+/// matching bean-query exactly.
+#[test]
+fn test_implicit_prices_dedup_same_day_same_price() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:RetirementA"),
+        make_open("2024-01-01", "Assets:RetirementB"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // Two buys on the same day at the same per-unit price.
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy in account A",
+            "Assets:RetirementA",
+            ("10", "FUND"),
+            ("100", "USD"),
+            "Assets:Cash",
+        ),
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy in account B",
+            "Assets:RetirementB",
+            ("20", "FUND"),
+            ("100", "USD"),
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
+    assert_eq!(
+        prices,
+        vec![("FUND".into(), "100".into(), "USD".into())],
+        "two same-day same-price buys should dedup to one emit"
+    );
+}
+
+/// Scale-insensitivity of the REDUCED gate AND same-day dedup.
+/// Numerically equal costs / prices written with different scales
+/// (`"100"` vs `"100.00"`) must produce the same lot key and the same
+/// dedup key, matching Python's `(date, base, number, quote)`
+/// Decimal-value comparison. Pre-fix the keys used raw `.to_string()`,
+/// so `"100"` and `"100.00"` were distinct keys — a reducing sell at
+/// `{100 USD}` against a prior buy at `{100.00 USD}` would NOT
+/// classify as REDUCED, slipping the phantom price emit back in.
+/// Caught by Copilot review on PR #1061.
+#[test]
+fn test_implicit_prices_reduced_gate_and_dedup_are_scale_insensitive() {
+    let plugin = ImplicitPricesPlugin;
+    let input = make_input(vec![
+        make_open("2024-01-01", "Assets:Brokerage"),
+        make_open("2024-01-01", "Assets:Cash"),
+        // Buy: cost spec written with scale 2 ("100.00").
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy",
+            "Assets:Brokerage",
+            ("10", "X"),
+            ("100.00", "USD"),
+            "Assets:Cash",
+        ),
+        // Buy again on the same day at the same numeric price, but
+        // written with scale 0 ("100"). Pre-fix the dedup key
+        // ("100" vs "100.00") would treat these as distinct and emit
+        // BOTH prices. Post-fix only one emit.
+        make_transaction_with_cost(
+            "2024-02-01",
+            "Buy more",
+            "Assets:Brokerage",
+            ("5", "X"),
+            ("100", "USD"),
+            "Assets:Cash",
+        ),
+        // Sell using the scale-0 form ("100") against the scale-2
+        // existing lot. Pre-fix REDUCED gate would miss this and emit
+        // a phantom price. Post-fix it classifies as REDUCED → no emit.
+        make_transaction_with_cost(
+            "2024-03-01",
+            "Sell",
+            "Assets:Brokerage",
+            ("-5", "X"),
+            ("100", "USD"),
+            "Assets:Cash",
+        ),
+    ]);
+    let output = plugin.process(input.clone());
+    let prices = implicit_prices_emitted(&input, &output);
+    assert_eq!(
+        prices.len(),
+        1,
+        "exactly one emit: the first buy. Second buy dedups, sell is \
+         REDUCED. Got: {prices:?}"
+    );
+    assert_eq!(prices[0].0, "X", "base currency carries through");
+    assert_eq!(prices[0].2, "USD", "quote currency carries through");
+    // The emitted number string is whatever the FIRST buy's cost spec
+    // produced (scale 2 here, since the buy was written "100.00").
+    // The dedup key normalizes for comparison but doesn't normalize
+    // the user-facing emitted form.
+    assert_eq!(
+        prices[0].1, "100.00",
+        "emitted price preserves the first-emit cost's intrinsic scale"
+    );
+}
+
 /// Posting with NO price annotation and NO cost: emits nothing.
 #[test]
 fn test_implicit_prices_emits_nothing_for_plain_transfer() {


### PR DESCRIPTION
## Summary

Two gaps left over from #1048 caused rledger's `implicit_prices` plugin to over-emit `Price` directives compared to bean-check. Surfaced as the 5 real `count-prices-from-plugin` failures the runtime fingerprint in #1060 left visible (e.g., `fava-portfolio-returns/example_stock.beancount`: py=6 rs=10).

### 1. Reducing-sell gate

Python's plugin emits a cost-derived price only when `Inventory.add_position` returns anything except `MatchResult.REDUCED`. rledger was emitting unconditionally, so a sell written as `-N CCY {}` — where booking later resolves the empty cost spec to a specific lot's cost — produced a phantom price entry per match.

Mirror Python's logic: track per-account lot quantities keyed identically to `Inventory.add_amount` (`account, units.currency, cost-fingerprint`) and treat a posting as REDUCED when the running quantity has the opposite sign. Price annotations (`@`/`@@`) still emit unconditionally on reducing postings — Python's `from_price` branch fires before the REDUCED check too.

### 2. Same-day, same-price dedup

Python's `new_price_entry_map` keyed by `(date, base_currency, number, quote_currency)` silently drops a second emit for the same key. Multi-asset portfolio fixtures (e.g. `beangrow/example_ledger.beancount`) buy the same fund across several accounts on the same day at the same NAV — each posting was producing a duplicate `Price` entry. Add the same dedup set.

## Compat impact

| | Real mismatches | Runs matching | Effective pass rate |
|---|---|---|---|
| pre-fix (post-#1060) | 166 | 1928 | 92.37% |
| post-fix | **156** | **1938** | **92.83%** |
| **delta** | **−10** | **+10** | **+0.46 pp** |

Verified end-to-end on the issue's two named fixtures:

| fixture | bean-query | rledger pre | rledger post |
|---|---|---|---|
| `fava-portfolio-returns/.../example_stock.beancount` | 6 | 10 | **6** |
| `beangrow/example_ledger.beancount` | 782 | 857 | **782** |

## Test plan

Three regression tests in `crates/rustledger-plugin/tests/native_plugins_test.rs`:

- [x] `test_implicit_prices_skips_reducing_sell_with_cost` — one buy + one matching sell → one price, not two.
- [x] `test_implicit_prices_reducing_sell_with_annotation_emits_from_price` — reducing sell with both `{cost}` and `@ price` still emits the annotation's price (Python's `from_price` fires regardless of REDUCED).
- [x] `test_implicit_prices_dedup_same_day_same_price` — two same-day buys at the same per-unit cost dedup to one emit.

- [x] `cargo test -p rustledger-plugin --all-features` — 121 + 174 + 8 passed (3 new added).
- [x] `cargo test -p rustledger-query --all-features` — 137 + 370 + 13 + 3 passed (no regressions).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p rustledger-plugin --all-features --tests -- -D warnings` — clean.
- [x] BQL compat suite (200 fixtures × 17 queries) — **+10 matches, 0 regressions**.

Closes the 5 residual `count-prices-from-plugin` over-emit cases that #1060's runtime fingerprint left flagged as REAL.
