### PR TITLE
perf: trivial quick wins bundle (blake3 cache, parking_lot, FxHasher, wasm fat-LTO)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,6 +3363,7 @@ version = "0.14.1"
 dependencies = [
  "criterion",
  "jiff",
+ "parking_lot",
  "proptest",
  "rkyv 0.8.16",
  "rust_decimal",
@@ -3414,6 +3415,7 @@ dependencies = [
 name = "rustledger-loader"
 version = "0.14.1"
 dependencies = [
+ "blake3",
  "glob",
  "jiff",
  "rayon",
@@ -3427,7 +3429,6 @@ dependencies = [
  "rustledger-plugin",
  "rustledger-plugin-types",
  "rustledger-validate",
- "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ lto = "fat"
 # WASM-optimized profile (use with: cargo build --profile wasm-release)
 [profile.wasm-release]
 inherits = "release"
+lto = "fat"          # Override `release`'s "thin" — WASM doesn't hit the Apple linker bug
 opt-level = 3        # Speed over size (~21% larger, ~60% faster)
 panic = 'abort'      # Smaller binary, no unwinding
 

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 rkyv = { workspace = true, optional = true }
 rustc-hash.workspace = true
+parking_lot.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/rustledger-core/src/intern.rs
+++ b/crates/rustledger-core/src/intern.rs
@@ -392,33 +392,36 @@ impl CurrencyInterner {
 
 /// Thread-safe string interner using a mutex.
 ///
-/// Use this when interning strings from multiple threads.
+/// Use this when interning strings from multiple threads. Backed by
+/// `parking_lot::Mutex` which avoids the OS-level syscall that
+/// `std::sync::Mutex` requires on lock/unlock and is non-poisoning, so
+/// `lock()` returns the guard directly without an `.unwrap()`.
 #[derive(Debug, Default)]
 pub struct SyncStringInterner {
-    inner: std::sync::Mutex<StringInterner>,
+    inner: parking_lot::Mutex<StringInterner>,
 }
 
 impl SyncStringInterner {
     /// Create a new thread-safe interner.
     pub fn new() -> Self {
         Self {
-            inner: std::sync::Mutex::new(StringInterner::new()),
+            inner: parking_lot::Mutex::new(StringInterner::new()),
         }
     }
 
     /// Intern a string (thread-safe).
     pub fn intern(&self, s: &str) -> InternedStr {
-        self.inner.lock().unwrap().intern(s)
+        self.inner.lock().intern(s)
     }
 
     /// Get the number of unique strings.
     pub fn len(&self) -> usize {
-        self.inner.lock().unwrap().len()
+        self.inner.lock().len()
     }
 
     /// Check if empty.
     pub fn is_empty(&self) -> bool {
-        self.inner.lock().unwrap().is_empty()
+        self.inner.lock().is_empty()
     }
 }
 

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 default = ["cache", "full"]
 
 # Enable rkyv-based binary caching for faster loads
-cache = ["dep:rkyv", "dep:sha2", "rustledger-parser/rkyv"]
+cache = ["dep:rkyv", "dep:blake3", "rustledger-parser/rkyv"]
 
 # Full processing: booking + plugins + validation (like Python's loader.load_file())
 full = ["booking", "plugins", "validation"]
@@ -39,7 +39,7 @@ thiserror.workspace = true
 jiff.workspace = true
 glob.workspace = true
 rkyv = { workspace = true, optional = true }
-sha2 = { workspace = true, optional = true }
+blake3 = { workspace = true, optional = true }
 rustc-hash.workspace = true
 rayon.workspace = true
 

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -196,7 +196,12 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 /// v1: Initial release with string-based Decimal/NaiveDate
 /// v2: Binary Decimal (16 bytes) and `NaiveDate` (i32 days)
 /// v3: Fixed account type defaults in `CachedOptions`
-const CACHE_VERSION: u32 = 3;
+/// v4: Hash algorithm switched from SHA-256 to BLAKE3 — same 32-byte
+///     output so the header layout is unchanged, but old hashes won't
+///     match new files. Bumping the version short-circuits stale
+///     caches at the header check instead of paying the rkyv
+///     deserialize cost only to fail the hash compare.
+const CACHE_VERSION: u32 = 4;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -29,11 +29,11 @@
 //!   target directory doesn't exist, [`save_cache_entry`] creates it.
 
 use crate::Options;
+use blake3::Hasher;
 use rust_decimal::Decimal;
 use rustledger_core::Directive;
 use rustledger_core::intern::StringInterner;
 use rustledger_parser::Spanned;
-use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -205,7 +205,7 @@ struct CacheHeader {
     magic: [u8; 8],
     /// Cache format version.
     version: u32,
-    /// SHA-256 hash of source files.
+    /// BLAKE3 hash of source files (path + mtime + size).
     hash: [u8; 32],
     /// Length of the serialized data.
     data_len: u64,
@@ -253,7 +253,7 @@ impl CacheHeader {
 /// contribute only their path to the hash. This is intentional — the resulting
 /// hash mismatch will cause a cache miss on next load.
 fn compute_hash(files: &[&Path]) -> [u8; 32] {
-    let mut hasher = Sha256::new();
+    let mut hasher = Hasher::new();
 
     for file in files {
         // Hash the file path
@@ -264,15 +264,15 @@ fn compute_hash(files: &[&Path]) -> [u8; 32] {
             if let Ok(mtime) = metadata.modified()
                 && let Ok(duration) = mtime.duration_since(std::time::UNIX_EPOCH)
             {
-                hasher.update(duration.as_secs().to_le_bytes());
-                hasher.update(duration.subsec_nanos().to_le_bytes());
+                hasher.update(&duration.as_secs().to_le_bytes());
+                hasher.update(&duration.subsec_nanos().to_le_bytes());
             }
             // Hash the file size
-            hasher.update(metadata.len().to_le_bytes());
+            hasher.update(&metadata.len().to_le_bytes());
         }
     }
 
-    hasher.finalize().into()
+    *hasher.finalize().as_bytes()
 }
 
 /// Environment variable that overrides the default cache filename pattern.

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -210,9 +210,13 @@ impl Value {
 pub type Row = Vec<Value>;
 
 /// Compute a hash for a row (for DISTINCT deduplication).
+///
+/// Uses `FxHasher` (the same non-cryptographic hash backing every
+/// `FxHashMap` in the workspace). DISTINCT / GROUP BY keys are internal
+/// dedup tokens — they need speed, not DoS-resistance.
 pub fn hash_row(row: &Row) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    let mut hasher = DefaultHasher::new();
+    use std::hash::Hasher;
+    let mut hasher = rustc_hash::FxHasher::default();
     for value in row {
         value.hash_value(&mut hasher);
     }
@@ -221,8 +225,8 @@ pub fn hash_row(row: &Row) -> u64 {
 
 /// Compute a hash for a single value (for PIVOT lookups).
 pub fn hash_single_value(value: &Value) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    let mut hasher = DefaultHasher::new();
+    use std::hash::Hasher;
+    let mut hasher = rustc_hash::FxHasher::default();
     value.hash_value(&mut hasher);
     hasher.finish()
 }

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -215,7 +215,6 @@ pub type Row = Vec<Value>;
 /// `FxHashMap` in the workspace). DISTINCT / GROUP BY keys are internal
 /// dedup tokens — they need speed, not DoS-resistance.
 pub fn hash_row(row: &Row) -> u64 {
-    use std::hash::Hasher;
     let mut hasher = rustc_hash::FxHasher::default();
     for value in row {
         value.hash_value(&mut hasher);
@@ -225,7 +224,6 @@ pub fn hash_row(row: &Row) -> u64 {
 
 /// Compute a hash for a single value (for PIVOT lookups).
 pub fn hash_single_value(value: &Value) -> u64 {
-    use std::hash::Hasher;
     let mut hasher = rustc_hash::FxHasher::default();
     value.hash_value(&mut hasher);
     hasher.finish()

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -600,10 +600,6 @@ criteria = "safe-to-deploy"
 version = "0.4.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-conv]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.ofxy]]
 version = "0.2.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1850,6 +1850,12 @@ criteria = "safe-to-deploy"
 delta = "0.50.1 -> 0.50.3"
 notes = "CI changes, Rust changes, nothing out of the ordinary."
 
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
+
 [[audits.bytecode-alliance.audits.num-traits]]
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
@@ -3218,6 +3224,23 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.26 -> 0.4.29"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.oorandom]]


### PR DESCRIPTION
## Summary

Closes #1065.

Four no-architecture, mostly-one-line swaps. Each is too small to merit its own PR; bundled here so they ship together as a single "perf-quick-wins" change.

| # | Change | Files |
|---|---|---|
| 1 | Cache hash: `sha2::Sha256` → `blake3::Hasher` | `crates/rustledger-loader/src/cache.rs`, `crates/rustledger-loader/Cargo.toml` |
| 2 | `SyncStringInterner`: `std::sync::Mutex` → `parking_lot::Mutex` | `crates/rustledger-core/src/intern.rs`, `crates/rustledger-core/Cargo.toml` |
| 3 | BQL `hash_row` / `hash_single_value`: `DefaultHasher` → `FxHasher` | `crates/rustledger-query/src/executor/types.rs` |
| 4 | `wasm-release` profile: add `lto = "fat"` override | `Cargo.toml` |

### Why bundled?

Each item is < 10 lines of meaningful change and uses dependencies already in the workspace (`blake3 = "1"`, `parking_lot = "0.12"`, `rustc-hash`). Bundling avoids 4 separate PR review cycles for what amounts to "swap the import."

### Notes

- `sha2` stays in the workspace because other crates use it for non-cache purposes (`synthetic/manifest`, `ffi-wasi`, `wasm`, `plugin`). Only `rustledger-loader` drops the dep.
- `parking_lot::Mutex` is non-poisoning, so the call sites simplify from `.lock().unwrap()` to `.lock()`. No semantic change — none of the previous unwraps would have triggered (the mutex is short-lived around interner ops).
- The cache binary format already used a 32-byte hash, so BLAKE3 (also 32 bytes) is a drop-in replacement at the struct level. Any cache file written before this PR will be invalidated on first load (hash mismatch → re-parse), which is the same as any other cache-format change.

## Test plan

- [x] `cargo test -p rustledger-core -p rustledger-loader -p rustledger-query --all-features` — all green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [ ] CI checks (compatibility, regression, MSRV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)