### PR TITLE
perf(validate): pre-batch Path::exists() for Document directives

### DIFF
--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -498,68 +498,73 @@ fn today() -> NaiveDate {
     jiff::Zoned::now().date()
 }
 
-/// Pre-resolve `Path::exists()` for every candidate path that
-/// [`validate_document`] would otherwise check inside the main
-/// per-directive loop. Returns a `(path -> exists)` lookup map.
+/// Pre-resolve each unique `Document` directive's path so the main
+/// per-directive loop can answer "does this document exist?" with a
+/// hashmap lookup instead of a syscall.
 ///
-/// When `check_documents` is disabled there's nothing to resolve; we
-/// return an empty map. Otherwise we enumerate the same candidate
-/// paths the validator would build — absolute path, `document_base`
-/// join, each `document_dirs` join, or the fallback — and check
-/// existence in one batch. For ledgers with many `Document`
-/// directives this serializes I/O into a single rayon fan-out instead
-/// of one syscall per directive in the main loop.
+/// Returns a `doc.path -> found` map. Resolution mirrors
+/// [`validators::document::validate_document`]: absolute paths check
+/// themselves; relative paths try `document_base`, then each entry of
+/// `document_dirs` in order with short-circuit on first hit, then fall
+/// back to the path as-is. Two `Document` directives with the same
+/// `path` resolve identically, so the map dedupes naturally.
 ///
-/// Mirrors the resolution logic in
-/// [`validators::document::validate_document`]; if that logic changes
-/// the candidate enumeration here must follow.
+/// The per-document resolutions run via [`rayon::par_iter`] above
+/// [`PARALLEL_DOC_EXISTS_THRESHOLD`]; below that, the dispatch
+/// overhead outweighs the I/O parallelism. Crucially the unit of
+/// parallel work is **one Document**, not one candidate path — this
+/// preserves the short-circuit on `document_dirs` so we don't issue
+/// more total syscalls than the pre-fix sequential code did. Caught
+/// by Copilot review on PR #1082.
+///
+/// When `check_documents` is disabled the function short-circuits to
+/// an empty map.
 fn build_document_exists_cache<D: ValidatableDirective>(
     directives: &[D],
     options: &ValidationOptions,
-) -> FxHashMap<std::path::PathBuf, bool> {
+) -> FxHashMap<String, bool> {
     if !options.check_documents {
         return FxHashMap::default();
     }
 
-    // Collect unique candidate paths once. FxHashSet so we don't
-    // pay for duplicate exists() calls if two Document directives
-    // reference the same file.
-    let mut candidates: FxHashSet<std::path::PathBuf> = FxHashSet::default();
+    // Collect unique doc.path strings. Each (doc_path, options) pair
+    // resolves to exactly one (found?) bool, so deduping here saves
+    // syscalls when the same path is referenced by multiple Document
+    // directives.
+    let mut paths: FxHashSet<&str> = FxHashSet::default();
     for d in directives {
         if let Directive::Document(doc) = d.directive() {
-            let doc_path = std::path::Path::new(&doc.path);
-            if doc_path.is_absolute() {
-                candidates.insert(doc_path.to_path_buf());
-            } else if let Some(base) = &options.document_base {
-                candidates.insert(base.join(doc_path));
-            } else if !options.document_dirs.is_empty() {
-                for dir in &options.document_dirs {
-                    candidates.insert(dir.join(doc_path));
-                }
-            } else {
-                candidates.insert(doc_path.to_path_buf());
-            }
+            paths.insert(doc.path.as_str());
         }
     }
+    let paths: Vec<&str> = paths.into_iter().collect();
 
-    let candidates: Vec<std::path::PathBuf> = candidates.into_iter().collect();
+    // One closure-per-path resolves it through the same priority
+    // chain the validator uses. Stops on the first hit so a Document
+    // found in `document_dirs[0]` still costs exactly one syscall —
+    // matching pre-fix sequential I/O cost, but in parallel across
+    // Documents.
+    let resolve = |s: &str| -> (String, bool) {
+        let doc_path = std::path::Path::new(s);
+        let found = if doc_path.is_absolute() {
+            doc_path.exists()
+        } else if let Some(base) = &options.document_base {
+            base.join(doc_path).exists()
+        } else if !options.document_dirs.is_empty() {
+            options
+                .document_dirs
+                .iter()
+                .any(|dir| dir.join(doc_path).exists())
+        } else {
+            doc_path.exists()
+        };
+        (s.to_string(), found)
+    };
 
-    if candidates.len() >= PARALLEL_DOC_EXISTS_THRESHOLD {
-        candidates
-            .into_par_iter()
-            .map(|p| {
-                let exists = p.exists();
-                (p, exists)
-            })
-            .collect()
+    if paths.len() >= PARALLEL_DOC_EXISTS_THRESHOLD {
+        paths.into_par_iter().map(resolve).collect()
     } else {
-        candidates
-            .into_iter()
-            .map(|p| {
-                let exists = p.exists();
-                (p, exists)
-            })
-            .collect()
+        paths.into_iter().map(resolve).collect()
     }
 }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -60,6 +60,11 @@ use rustledger_core::NaiveDate;
 /// Threshold for using parallel sort. For small collections, sequential sort
 /// is faster due to reduced threading overhead.
 const PARALLEL_SORT_THRESHOLD: usize = 5000;
+
+/// Threshold for fanning the per-Document `Path::exists()` pre-pass
+/// out via rayon. Below this, the dispatch overhead outweighs the
+/// per-syscall savings.
+const PARALLEL_DOC_EXISTS_THRESHOLD: usize = 64;
 use rust_decimal::Decimal;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustledger_core::{BookingMethod, Commodity, Directive, InternedStr, Inventory};
@@ -344,6 +349,13 @@ fn validate_inner<D: ValidatableDirective>(
     options: ValidationOptions,
     today: NaiveDate,
 ) -> Vec<ValidationError> {
+    // Pre-pass: batch-resolve `Path::exists()` for every `Document`
+    // directive's candidate paths. The lookup map is consulted by
+    // `validate_document` instead of issuing individual exists()
+    // syscalls inside the main loop. Skipped entirely when
+    // `check_documents` is disabled (no candidate paths needed).
+    let document_exists_cache = build_document_exists_cache(directives, &options);
+
     let mut state = LedgerState::with_options(options);
     let mut errors = Vec::new();
 
@@ -421,7 +433,7 @@ fn validate_inner<D: ValidatableDirective>(
                 validate_pad(&mut state, pad, &mut errors);
             }
             Directive::Document(doc) => {
-                validate_document(&state, doc, &mut errors);
+                validate_document(&state, doc, &document_exists_cache, &mut errors);
             }
             Directive::Note(note) => {
                 validate_note(&state, note, &mut errors);
@@ -484,6 +496,71 @@ fn validate_inner<D: ValidatableDirective>(
 /// `jiff::Zoned::now()` syscall per re-validation.
 fn today() -> NaiveDate {
     jiff::Zoned::now().date()
+}
+
+/// Pre-resolve `Path::exists()` for every candidate path that
+/// [`validate_document`] would otherwise check inside the main
+/// per-directive loop. Returns a `(path -> exists)` lookup map.
+///
+/// When `check_documents` is disabled there's nothing to resolve; we
+/// return an empty map. Otherwise we enumerate the same candidate
+/// paths the validator would build — absolute path, `document_base`
+/// join, each `document_dirs` join, or the fallback — and check
+/// existence in one batch. For ledgers with many `Document`
+/// directives this serializes I/O into a single rayon fan-out instead
+/// of one syscall per directive in the main loop.
+///
+/// Mirrors the resolution logic in
+/// [`validators::document::validate_document`]; if that logic changes
+/// the candidate enumeration here must follow.
+fn build_document_exists_cache<D: ValidatableDirective>(
+    directives: &[D],
+    options: &ValidationOptions,
+) -> FxHashMap<std::path::PathBuf, bool> {
+    if !options.check_documents {
+        return FxHashMap::default();
+    }
+
+    // Collect unique candidate paths once. FxHashSet so we don't
+    // pay for duplicate exists() calls if two Document directives
+    // reference the same file.
+    let mut candidates: FxHashSet<std::path::PathBuf> = FxHashSet::default();
+    for d in directives {
+        if let Directive::Document(doc) = d.directive() {
+            let doc_path = std::path::Path::new(&doc.path);
+            if doc_path.is_absolute() {
+                candidates.insert(doc_path.to_path_buf());
+            } else if let Some(base) = &options.document_base {
+                candidates.insert(base.join(doc_path));
+            } else if !options.document_dirs.is_empty() {
+                for dir in &options.document_dirs {
+                    candidates.insert(dir.join(doc_path));
+                }
+            } else {
+                candidates.insert(doc_path.to_path_buf());
+            }
+        }
+    }
+
+    let candidates: Vec<std::path::PathBuf> = candidates.into_iter().collect();
+
+    if candidates.len() >= PARALLEL_DOC_EXISTS_THRESHOLD {
+        candidates
+            .into_par_iter()
+            .map(|p| {
+                let exists = p.exists();
+                (p, exists)
+            })
+            .collect()
+    } else {
+        candidates
+            .into_iter()
+            .map(|p| {
+                let exists = p.exists();
+                (p, exists)
+            })
+            .collect()
+    }
 }
 
 /// Validate a stream of directives.
@@ -1033,6 +1110,68 @@ mod tests {
         assert!(
             !errors.iter().any(|e| e.code == ErrorCode::DocumentNotFound),
             "Absolute path should work even with wrong document_dirs: {errors:?}"
+        );
+    }
+
+    /// Regression test for the parallel `Path::exists()` pre-pass.
+    /// Constructs enough Document directives (mix of found + missing)
+    /// to cross `PARALLEL_DOC_EXISTS_THRESHOLD` and confirms that:
+    ///
+    /// 1. The found documents validate without `DocumentNotFound`.
+    /// 2. The missing documents still report `DocumentNotFound`.
+    /// 3. The error-context "searched: ..." message survives the
+    ///    cache-routed code path (was constructed inline before).
+    #[test]
+    fn test_validate_document_parallel_batch_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let doc_subdir = dir.path().join("docs");
+        std::fs::create_dir_all(&doc_subdir).unwrap();
+
+        // PARALLEL_DOC_EXISTS_THRESHOLD = 64. Generate 100 documents:
+        // even-numbered exist, odd-numbered don't.
+        let mut directives: Vec<Directive> =
+            vec![Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank"))];
+        for i in 0..100 {
+            let filename = format!("receipt_{i}.pdf");
+            if i % 2 == 0 {
+                std::fs::write(doc_subdir.join(&filename), "x").unwrap();
+            }
+            directives.push(Directive::Document(Document {
+                date: date(2024, 1, 15),
+                account: "Assets:Bank".into(),
+                path: filename,
+                tags: vec![],
+                links: vec![],
+                meta: Default::default(),
+            }));
+        }
+
+        let options = ValidationOptions::default().with_document_dirs(vec![doc_subdir]);
+        let errors = validate_with_options(&directives, options);
+
+        let not_found_count = errors
+            .iter()
+            .filter(|e| e.code == ErrorCode::DocumentNotFound)
+            .count();
+        assert_eq!(
+            not_found_count, 50,
+            "exactly 50 of 100 documents should error as not-found"
+        );
+
+        // Spot-check that the error context message still mentions the
+        // searched document_dirs path (it's built from
+        // state.options.document_dirs, independently of the cache).
+        let example = errors
+            .iter()
+            .find(|e| e.code == ErrorCode::DocumentNotFound)
+            .expect("should have at least one not-found error");
+        assert!(
+            example
+                .context
+                .as_deref()
+                .is_some_and(|c| c.contains("searched")),
+            "error context should mention the searched dirs, got: {:?}",
+            example.context
         );
     }
 

--- a/crates/rustledger-validate/src/validators/document.rs
+++ b/crates/rustledger-validate/src/validators/document.rs
@@ -2,7 +2,7 @@
 
 use rustc_hash::FxHashMap;
 use rustledger_core::{Document, Note};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::LedgerState;
 use crate::error::{ErrorCode, ValidationError};
@@ -38,15 +38,14 @@ pub fn validate_note(state: &LedgerState, note: &Note, errors: &mut Vec<Validati
 ///
 /// The `exists_cache` is consulted instead of calling `Path::exists()`
 /// directly. The caller (see `build_document_exists_cache` in `lib.rs`)
-/// pre-resolves all candidate paths in one rayon batch before the
-/// main per-directive loop, so this function stays syscall-free in the
-/// hot path. The cache is empty when `check_documents` is disabled —
-/// also fine, because the lookups in this function are gated by the
-/// same flag.
+/// resolves each unique `doc.path` once via the same priority chain
+/// above, with rayon parallelism across Documents. The cache is empty
+/// when `check_documents` is disabled — fine, because the lookups in
+/// this function are gated by the same flag.
 pub fn validate_document(
     state: &LedgerState,
     doc: &Document,
-    exists_cache: &FxHashMap<PathBuf, bool>,
+    exists_cache: &FxHashMap<String, bool>,
     errors: &mut Vec<ValidationError>,
 ) {
     // Check account exists
@@ -60,46 +59,48 @@ pub fn validate_document(
 
     // Check if document file exists (if enabled)
     if state.options.check_documents {
-        let doc_path = Path::new(&doc.path);
-        let lookup = |p: &Path| exists_cache.get(p).copied().unwrap_or(false);
-
-        let mut file_was_found = false;
-        let full_path = if doc_path.is_absolute() {
-            file_was_found = lookup(doc_path);
-            doc_path.to_path_buf()
-        } else if let Some(base) = &state.options.document_base {
-            let p = base.join(doc_path);
-            file_was_found = lookup(&p);
-            p
-        } else if !state.options.document_dirs.is_empty() {
-            // Try resolving relative path against each document directory
-            let mut found = None;
-            for dir in &state.options.document_dirs {
-                let candidate = dir.join(doc_path);
-                if lookup(&candidate) {
-                    found = Some(candidate);
-                    break;
-                }
+        // Cache should have an entry for every Document we encounter
+        // because both walk the same `directives` slice. A miss would
+        // indicate a divergence bug between the pre-pass and this
+        // function. In release builds, a miss falls back to a fresh
+        // syscall — correct behavior either way, just slower.
+        let file_was_found = exists_cache.get(&doc.path).copied().unwrap_or_else(|| {
+            debug_assert!(
+                false,
+                "Document path `{}` missing from pre-resolved exists_cache — \
+                 build_document_exists_cache enumeration must match this validator's resolution",
+                doc.path
+            );
+            // Defensive fallback: redo the resolution inline. Matches
+            // the priority chain in build_document_exists_cache so the
+            // result is equivalent.
+            let doc_path = Path::new(&doc.path);
+            if doc_path.is_absolute() {
+                doc_path.exists()
+            } else if let Some(base) = &state.options.document_base {
+                base.join(doc_path).exists()
+            } else if !state.options.document_dirs.is_empty() {
+                state
+                    .options
+                    .document_dirs
+                    .iter()
+                    .any(|dir| dir.join(doc_path).exists())
+            } else {
+                doc_path.exists()
             }
-            match found {
-                Some(p) => {
-                    file_was_found = true;
-                    p
-                }
-                None => doc_path.to_path_buf(),
-            }
-        } else {
-            file_was_found = lookup(doc_path);
-            doc_path.to_path_buf()
-        };
+        });
 
         if !file_was_found {
+            let doc_path = Path::new(&doc.path);
             let mut error = ValidationError::new(
                 ErrorCode::DocumentNotFound,
                 format!("Document file not found: {}", doc.path),
                 doc.date,
             );
 
+            // The error-context message is independent of the cache —
+            // it walks options.document_dirs to build the "searched: …"
+            // list. Same logic as before the cache was introduced.
             if doc_path.is_relative()
                 && state.options.document_base.is_none()
                 && !state.options.document_dirs.is_empty()
@@ -112,7 +113,17 @@ pub fn validate_document(
                     .collect();
                 error = error.with_context(format!("searched: {}", searched.join(", ")));
             } else {
-                error = error.with_context(format!("resolved path: {}", full_path.display()));
+                // Reconstruct the resolved path the same way the original
+                // validator did: absolute as-is, document_base join, or
+                // fallback to the raw path.
+                let resolved = if doc_path.is_absolute() {
+                    doc_path.to_path_buf()
+                } else if let Some(base) = &state.options.document_base {
+                    base.join(doc_path)
+                } else {
+                    doc_path.to_path_buf()
+                };
+                error = error.with_context(format!("resolved path: {}", resolved.display()));
             }
 
             errors.push(error);

--- a/crates/rustledger-validate/src/validators/document.rs
+++ b/crates/rustledger-validate/src/validators/document.rs
@@ -1,7 +1,8 @@
 //! Document and note validation.
 
+use rustc_hash::FxHashMap;
 use rustledger_core::{Document, Note};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::LedgerState;
 use crate::error::{ErrorCode, ValidationError};
@@ -34,7 +35,20 @@ pub fn validate_note(state: &LedgerState, note: &Note, errors: &mut Vec<Validati
 /// represents an explicit base set by the caller (e.g. the main ledger
 /// directory), whereas `document_dirs` is a search path derived from
 /// `option "documents"` declarations.
-pub fn validate_document(state: &LedgerState, doc: &Document, errors: &mut Vec<ValidationError>) {
+///
+/// The `exists_cache` is consulted instead of calling `Path::exists()`
+/// directly. The caller (see `build_document_exists_cache` in `lib.rs`)
+/// pre-resolves all candidate paths in one rayon batch before the
+/// main per-directive loop, so this function stays syscall-free in the
+/// hot path. The cache is empty when `check_documents` is disabled —
+/// also fine, because the lookups in this function are gated by the
+/// same flag.
+pub fn validate_document(
+    state: &LedgerState,
+    doc: &Document,
+    exists_cache: &FxHashMap<PathBuf, bool>,
+    errors: &mut Vec<ValidationError>,
+) {
     // Check account exists
     if !state.accounts.contains_key(&doc.account) {
         errors.push(ValidationError::new(
@@ -47,21 +61,22 @@ pub fn validate_document(state: &LedgerState, doc: &Document, errors: &mut Vec<V
     // Check if document file exists (if enabled)
     if state.options.check_documents {
         let doc_path = Path::new(&doc.path);
+        let lookup = |p: &Path| exists_cache.get(p).copied().unwrap_or(false);
 
         let mut file_was_found = false;
         let full_path = if doc_path.is_absolute() {
-            file_was_found = doc_path.exists();
+            file_was_found = lookup(doc_path);
             doc_path.to_path_buf()
         } else if let Some(base) = &state.options.document_base {
             let p = base.join(doc_path);
-            file_was_found = p.exists();
+            file_was_found = lookup(&p);
             p
         } else if !state.options.document_dirs.is_empty() {
             // Try resolving relative path against each document directory
             let mut found = None;
             for dir in &state.options.document_dirs {
                 let candidate = dir.join(doc_path);
-                if candidate.exists() {
+                if lookup(&candidate) {
                     found = Some(candidate);
                     break;
                 }
@@ -74,7 +89,7 @@ pub fn validate_document(state: &LedgerState, doc: &Document, errors: &mut Vec<V
                 None => doc_path.to_path_buf(),
             }
         } else {
-            file_was_found = doc_path.exists();
+            file_was_found = lookup(doc_path);
             doc_path.to_path_buf()
         };
 


### PR DESCRIPTION
## Summary

Closes #1070. Lands the third sub-fix from that issue; the first two (unified `validate_inner` + `today` parameterization) shipped in #1079.

Before this change, `validate_document` called `Path::exists()` inline inside the main per-directive loop, serializing one syscall per `Document` directive's candidate path. For receipt-tracking workflows that auto-discover documents via `option "documents"`, this serialized I/O blocked the validation phase unnecessarily.

## Change

**(1) Pre-pass `build_document_exists_cache`** in `validate_inner`:
- Enumerates every candidate path (absolute, `document_base`-joined, each `document_dirs`-joined) for every `Document` directive into a `FxHashSet<PathBuf>` (deduped — same file referenced twice = one syscall).
- Bulk-resolves into a `FxHashMap<PathBuf, bool>` lookup.
- When the candidate count exceeds `PARALLEL_DOC_EXISTS_THRESHOLD = 64`, the resolution fans out via `rayon::par_iter`. Below that, it stays sequential to avoid threading overhead.
- When `check_documents` is disabled, short-circuits to an empty map — no pre-pass cost.

**(2) `validate_document` takes a `&FxHashMap<PathBuf, bool>` cache** and consults it instead of calling `Path::exists()` directly. The path-resolution logic (which candidate dir matched, how to build the `searched: ...` error context) is unchanged — only the existence check is routed through the cache.

## Why the threshold of 64

A ballpark balance:
- Each `Path::exists()` is a `stat`-equivalent syscall (~1–5 μs typical).
- Rayon job dispatch is ~1–5 μs per task.
- Below ~64 documents, sequential resolution is comparable or faster.
- Above that, parallelism dominates. A ledger with 1000 documents goes from ~1–5 ms serialized to ~one syscall's worth of wall-clock on a multi-core machine.

## Test plan

- [x] `cargo test -p rustledger-validate --all-features` — 96 tests pass (was 95; new `test_validate_document_parallel_batch_check` constructs 100 mixed found/missing documents to exercise the parallel-threshold path)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p rustledger-validate --all-features --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --all-features --all-targets` — clean
- [ ] CI (compatibility, regression, MSRV)

## API

`validate_document` is private to the crate (`validators` module is `mod` not `pub mod` in `lib.rs`), so the signature change is internal-only. No public-API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)