### PR TITLE
chore: code-hygiene audit (B1 + E1 + E3)

### DIFF
--- a/crates/rustledger-core/src/format/transaction.rs
+++ b/crates/rustledger-core/src/format/transaction.rs
@@ -11,22 +11,23 @@ pub fn format_transaction(txn: &Transaction, config: &FormatConfig) -> String {
     let mut out = String::with_capacity(400);
 
     // Date and flag
-    write!(out, "{} {}", txn.date, txn.flag).unwrap();
+    write!(out, "{} {}", txn.date, txn.flag).expect("write to String is infallible");
 
     // Payee and narration
     if let Some(payee) = &txn.payee {
-        write!(out, " \"{}\"", super::escape_string(payee)).unwrap();
+        write!(out, " \"{}\"", super::escape_string(payee)).expect("write to String is infallible");
     }
-    write!(out, " \"{}\"", super::escape_string(&txn.narration)).unwrap();
+    write!(out, " \"{}\"", super::escape_string(&txn.narration))
+        .expect("write to String is infallible");
 
     // Tags
     for tag in &txn.tags {
-        write!(out, " #{tag}").unwrap();
+        write!(out, " #{tag}").expect("write to String is infallible");
     }
 
     // Links
     for link in &txn.links {
-        write!(out, " ^{link}").unwrap();
+        write!(out, " ^{link}").expect("write to String is infallible");
     }
 
     out.push('\n');
@@ -41,20 +42,20 @@ pub fn format_transaction(txn: &Transaction, config: &FormatConfig) -> String {
     for posting in &txn.postings {
         // Output comments that appear before this posting
         for comment in &posting.comments {
-            writeln!(out, "{}{}", &config.indent, comment).unwrap();
+            writeln!(out, "{}{}", &config.indent, comment).expect("write to String is infallible");
         }
         // Output the posting line
         let posting_line = format_posting(posting, config);
         // Append trailing comment on same line if present (only first one)
         if let Some(trailing) = posting.trailing_comments.first() {
-            writeln!(out, "{posting_line} {trailing}").unwrap();
+            writeln!(out, "{posting_line} {trailing}").expect("write to String is infallible");
         } else {
             out.push_str(&posting_line);
             out.push('\n');
         }
         // Output any additional trailing comments on their own lines
         for trailing in posting.trailing_comments.iter().skip(1) {
-            writeln!(out, "{}{}", &config.indent, trailing).unwrap();
+            writeln!(out, "{}{}", &config.indent, trailing).expect("write to String is infallible");
         }
         // Posting-level metadata (indented one level deeper than the posting)
         if !posting.meta.is_empty() {
@@ -64,7 +65,7 @@ pub fn format_transaction(txn: &Transaction, config: &FormatConfig) -> String {
 
     // Output transaction trailing comments (comments after all postings)
     for comment in &txn.trailing_comments {
-        writeln!(out, "{}{}", &config.indent, comment).unwrap();
+        writeln!(out, "{}{}", &config.indent, comment).expect("write to String is infallible");
     }
 
     out
@@ -77,7 +78,7 @@ pub fn format_posting(posting: &Posting, config: &FormatConfig) -> String {
 
     // Flag (if present)
     if let Some(flag) = posting.flag {
-        write!(line, "{flag} ").unwrap();
+        write!(line, "{flag} ").expect("write to String is infallible");
     }
 
     // Account

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -86,6 +86,8 @@
 //!
 //! The output will be in `target/wasm32-unknown-unknown/release/your_plugin.wasm`
 
+#![warn(missing_docs)]
+
 use serde::{Deserialize, Serialize};
 
 // ============================================================================


### PR DESCRIPTION
Three small fixes from a strategic code-health audit. No behavior change; documentation and consistency only.

## Findings

### B1 — `.unwrap()` / `.expect()` audit

Surveyed every `.unwrap()` and `.expect()` call in `crates/**/src` excluding embedded `#[cfg(test)]` modules.

| Total hits in library files | Production-code hits | Test-module hits |
|---|---|---|
| 1513 | **~97** | ~1416 |

Of the 97 production hits, broke down as:

- **~70 infallible-by-construction** — constant-arg `naive_date(...)`, regex compile from `&'static str` validated by tests, `write!` to `String` (cannot fail per the `fmt::Write` impl), URL `parse()` on hardcoded URIs like `"file:///unknown"`, `serde_json::to_value(...)` on serde-derived plain-data structs.
- **~20 already using `.expect()` with clear messages** — `expect("failed to spawn LSP worker thread")`, `expect("ACCOUNT_ENTRY_RE: invalid regex pattern")`, etc. Good.
- **10 bare `.unwrap()`** in `core/format/transaction.rs`, all `write!(out, …)` to a `String`. Sibling `core/format/directives.rs` already uses `.expect("write to String is infallible")` for the same pattern. **This PR converts the 10 to match** so the codebase has one consistent idiom for the infallible-write pattern.
- **Zero dangerous unwraps** — i.e., zero calls that could realistically panic on user input.

The bare-`.unwrap()` conversion has no behavior change (both panic on the same condition; `String`'s `fmt::Write` impl is infallible), but `.expect()` carries the invariant explicitly into the binary and into panic messages, which helps debugging if a future refactor ever changes the underlying type.

### E1 — `cargo deny check` and `cargo outdated`

```
advisories ok, bans ok, licenses ok, sources ok
```

Warnings: duplicate-version (transitive deps with multiple versions in the lockfile, e.g. `addr2line 0.25.1` + `0.26.1`). Allowed per workspace policy (`multiple_crate_versions = "allow"` in `Cargo.toml`).

`cargo outdated --root-deps-only --workspace` shows 4 deps with major-version-incompatible bumps available:

| Crate | Have | Latest |
|---|---|---|
| `ndarray` (in `rustledger-ops`) | 0.16.1 | 0.17.2 |
| `wasm-bindgen` (in `rustledger-wasm`) | 0.2.118 | 0.2.121 |
| `js-sys` (dev) | 0.3.95 | 0.3.98 |
| `wasm-bindgen-test` (dev) | 0.3.68 | 0.3.71 |

**No required action.** Each is a major bump (Cargo treats `0.x.y → 0.x.z` for `x>0` as semver-breaking) and needs a separate per-dep review. None are security-critical (advisory check passes).

### E3 — Documentation coverage

`cargo doc --no-deps --workspace --all-features` produces **zero warnings**. 12 of 13 lib crates already had `#![warn(missing_docs)]`; `rustledger-plugin-types` was the only one missing it. **This PR adds the lint** as a forwards-compat guard.

## Changes in this PR

| File | Change |
|---|---|
| `crates/rustledger-plugin-types/src/lib.rs` | Add `#![warn(missing_docs)]` (1 line). Already fully documented; no warnings to fix. |
| `crates/rustledger-core/src/format/transaction.rs` | Convert 10 `write!(...).unwrap()` to `.expect("write to String is infallible")` for consistency with sibling `format/directives.rs`. |

## Test plan

- [x] `cargo check -p rustledger-core -p rustledger-plugin-types --all-features` — clean
- [x] `cargo test -p rustledger-core --all-features --lib format` — 83/83 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p rustledger-core -p rustledger-plugin-types --all-features --all-targets -- -D warnings` — clean
- [ ] CI (compatibility, regression, MSRV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)