### PR TITLE
fix(query): skip cumulative-balance clone when query doesn't reference it (closes #1080)

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -69,7 +69,7 @@ impl Executor<'_> {
         let mut result = QueryResult::new(column_names.clone());
 
         // Collect matching postings
-        let postings = self.collect_postings(query.from.as_ref(), query.where_clause.as_ref())?;
+        let postings = self.collect_postings(query)?;
 
         // Check if this is an aggregate query.
         // A query is aggregate if any SELECT target contains an aggregate function,

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -401,6 +401,18 @@ impl<'a> Executor<'a> {
         let needs_balance = query_references_column(query, "balance");
         let needs_account_balance = query_references_column(query, "account_balance");
 
+        // Tighter gate for the *pre-WHERE* `balance` clone — only
+        // required when the WHERE clause itself reads `balance`. For
+        // queries like `SELECT balance FROM #postings` (`balance` in
+        // SELECT, no WHERE-time read), the pre-snapshot is never
+        // observed; we skip the extra clone and let the post-WHERE
+        // refresh fill `ctx.balance`. Caught by Copilot review on
+        // PR #1085. `account_balance` doesn't need an analogous gate
+        // because it isn't refreshed post-WHERE — it's already the
+        // running total after the eager update above.
+        let where_reads_balance =
+            where_clause.is_some_and(|w| expr_references_column(w, "balance"));
+
         let mut postings = Vec::new();
         // Per-account running balance — accumulates every posting regardless of
         // FROM/WHERE filters, so `account_balance` always reflects the account's
@@ -500,12 +512,28 @@ impl<'a> Executor<'a> {
                     // `Inventory` is the hot allocation — it grows monotonically
                     // across the iteration, so a 22k-posting WHERE-filtered
                     // query was producing ~3 clones × thousands of positions per
-                    // posting (issue #1080 — multi-GB WASM heap growth). Skip
-                    // both clones when the query doesn't reference `balance`.
+                    // posting (issue #1080 — multi-GB WASM heap growth).
+                    //
+                    // `balance` and `account_balance` have asymmetric pre/post
+                    // semantics so they gate differently:
+                    //
+                    // * `balance` is refreshed post-WHERE below — its pre-WHERE
+                    //   slot only matters when the WHERE clause itself reads
+                    //   the column. For `SELECT balance FROM #postings` (no
+                    //   WHERE-time read), we skip the pre-WHERE clone entirely
+                    //   and let the post-WHERE refresh fill it. Saves one
+                    //   clone-per-posting versus the gating logic
+                    //   in the first cut of this fix (Copilot review on PR #1085).
+                    //
+                    // * `account_balance` is NOT refreshed post-WHERE —
+                    //   account_balances is updated *before* this block, so
+                    //   the value here is already the post-update running
+                    //   total. We populate it eagerly when `needs_account_balance`
+                    //   so SELECT / ORDER BY / HAVING / etc. can read it.
                     let mut ctx = PostingContext {
                         transaction: txn,
                         posting_index: i,
-                        balance: if needs_balance {
+                        balance: if where_reads_balance {
                             Some(cumulative_balance.clone())
                         } else {
                             None
@@ -2702,7 +2730,24 @@ fn expr_references_column(expr: &Expr, name: &str) -> bool {
     match expr {
         Expr::Column(col) => col.eq_ignore_ascii_case(name),
         Expr::Function(call) => call.args.iter().any(|a| expr_references_column(a, name)),
-        Expr::Window(call) => call.args.iter().any(|a| expr_references_column(a, name)),
+        Expr::Window(call) => {
+            // Function args + the OVER clause's PARTITION BY / ORDER BY
+            // expressions all need to be walked — a window function like
+            // `SUM(amount) OVER (PARTITION BY balance)` references
+            // `balance` in the partition-by, not the function args.
+            // Caught by Copilot review on PR #1085.
+            call.args.iter().any(|a| expr_references_column(a, name))
+                || call
+                    .over
+                    .partition_by
+                    .as_ref()
+                    .is_some_and(|ps| ps.iter().any(|p| expr_references_column(p, name)))
+                || call
+                    .over
+                    .order_by
+                    .as_ref()
+                    .is_some_and(|os| os.iter().any(|o| expr_references_column(&o.expr, name)))
+        }
         Expr::BinaryOp(op) => {
             expr_references_column(&op.left, name) || expr_references_column(&op.right, name)
         }
@@ -3970,5 +4015,60 @@ mod tests {
         assert_refs("SELECT account WHERE units(balance) IS NOT NULL", true);
         // Nested in BETWEEN
         assert_refs("SELECT account WHERE balance BETWEEN 0 AND 100", true);
+    }
+
+    /// `expr_references_column` must traverse the OVER clause of a
+    /// window function, not just its args. A reference to `balance`
+    /// inside `PARTITION BY` / `ORDER BY` of an `OVER` clause must
+    /// trigger the snapshot path. Caught by Copilot review on PR
+    /// #1085 — pre-fix this returned a false negative and the resulting
+    /// query would have read a `None` `ctx.balance`.
+    #[test]
+    fn test_expr_references_column_walks_window_over_clause() {
+        use crate::ast::{
+            BinaryOp, BinaryOperator, OrderSpec, SortDirection, WindowFunction, WindowSpec,
+        };
+
+        let col_balance = Expr::Column("balance".to_string());
+        let col_unrelated = Expr::Column("amount".to_string());
+
+        // PARTITION BY references balance.
+        let win_partition = Expr::Window(WindowFunction {
+            name: "row_number".to_string(),
+            args: vec![],
+            over: WindowSpec {
+                partition_by: Some(vec![col_balance.clone()]),
+                order_by: None,
+            },
+        });
+        assert!(
+            expr_references_column(&win_partition, "balance"),
+            "OVER (PARTITION BY balance) must be detected"
+        );
+        assert!(
+            !expr_references_column(&win_partition, "account"),
+            "should not match unrelated column"
+        );
+
+        // ORDER BY inside OVER references balance (nested in BinaryOp).
+        let win_order = Expr::Window(WindowFunction {
+            name: "row_number".to_string(),
+            args: vec![],
+            over: WindowSpec {
+                partition_by: None,
+                order_by: Some(vec![OrderSpec {
+                    expr: Expr::BinaryOp(Box::new(BinaryOp {
+                        left: col_balance,
+                        op: BinaryOperator::Add,
+                        right: col_unrelated,
+                    })),
+                    direction: SortDirection::Asc,
+                }]),
+            },
+        });
+        assert!(
+            expr_references_column(&win_order, "balance"),
+            "OVER (ORDER BY balance + amount) must be detected"
+        );
     }
 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -23,7 +23,7 @@ use rustledger_core::{MetaValue, Transaction};
 use rustledger_loader::SourceMap;
 use rustledger_parser::Spanned;
 
-use crate::ast::{Expr, FromClause, FunctionCall, Query, Target};
+use crate::ast::{Expr, FromClause, FunctionCall, Query, SelectQuery, Target};
 use crate::error::QueryError;
 
 /// Compute a posting's `weight` — the cost-converted amount used for
@@ -380,11 +380,27 @@ impl<'a> Executor<'a> {
     }
 
     /// Collect postings matching the FROM and WHERE clauses.
-    fn collect_postings(
-        &self,
-        from: Option<&FromClause>,
-        where_clause: Option<&Expr>,
-    ) -> Result<Vec<PostingContext<'a>>, QueryError> {
+    fn collect_postings(&self, query: &SelectQuery) -> Result<Vec<PostingContext<'a>>, QueryError> {
+        let from = query.from.as_ref();
+        let where_clause = query.where_clause.as_ref();
+
+        // Both `balance` (cumulative, WHERE-filtered) and `account_balance`
+        // (per-account, raw) are running-state columns. Each PostingContext
+        // built below carries snapshots — and `cumulative_balance` grows
+        // monotonically across the iteration, so cloning it per posting on
+        // a 100k-posting ledger was the runaway-allocation regression in
+        // issue #1080.
+        //
+        // Gate the clones on whether the query actually references the
+        // columns anywhere (SELECT / WHERE / ORDER BY / HAVING / GROUP BY /
+        // FROM filter). Queries that don't touch them (the common case —
+        // `SELECT account WHERE account ~ "^Assets"` references neither)
+        // skip the entire state-tracking + clone path. Pre-fix, the only
+        // gate was `where_clause.is_some()` for the pre-WHERE snapshot,
+        // which fired even when the WHERE didn't read balance.
+        let needs_balance = query_references_column(query, "balance");
+        let needs_account_balance = query_references_column(query, "account_balance");
+
         let mut postings = Vec::new();
         // Per-account running balance — accumulates every posting regardless of
         // FROM/WHERE filters, so `account_balance` always reflects the account's
@@ -434,11 +450,14 @@ impl<'a> Executor<'a> {
                         // Update per-account balances but don't include in results
                         // and don't touch the cumulative balance — these postings
                         // didn't make it past the FROM filter.
-                        for posting in &txn.postings {
-                            if let Some(pos) = resolve_position(posting, txn.date) {
-                                let bal =
-                                    account_balances.entry(posting.account.clone()).or_default();
-                                bal.add(pos);
+                        if needs_account_balance {
+                            for posting in &txn.postings {
+                                if let Some(pos) = resolve_position(posting, txn.date) {
+                                    let bal = account_balances
+                                        .entry(posting.account.clone())
+                                        .or_default();
+                                    bal.add(pos);
+                                }
                             }
                         }
                         continue;
@@ -464,8 +483,12 @@ impl<'a> Executor<'a> {
                     // Update the account-level running balance regardless of
                     // whether this posting passes WHERE — `account_balance`
                     // should always reflect the underlying ledger truth.
+                    // Skip the update entirely when the query doesn't read
+                    // account_balance (saves the `.clone()` + map probe per
+                    // posting; `Inventory::add` allocates internally so the
+                    // saving compounds across a long run).
                     let resolved = resolve_position(posting, txn.date);
-                    if let Some(pos) = resolved.clone() {
+                    if needs_account_balance && let Some(pos) = resolved.clone() {
                         let bal = account_balances.entry(posting.account.clone()).or_default();
                         bal.add(pos);
                     }
@@ -473,14 +496,25 @@ impl<'a> Executor<'a> {
                     // Build the context with both balance views. The cumulative
                     // snapshot is the running total *before* this posting; we
                     // update it after WHERE passes so postings rejected by WHERE
-                    // don't pollute the cumulative. Skip the pre-update clone
-                    // when there's no WHERE clause — nothing reads ctx.balance
-                    // before the post-WHERE refresh in that case.
+                    // don't pollute the cumulative. Cloning the cumulative
+                    // `Inventory` is the hot allocation — it grows monotonically
+                    // across the iteration, so a 22k-posting WHERE-filtered
+                    // query was producing ~3 clones × thousands of positions per
+                    // posting (issue #1080 — multi-GB WASM heap growth). Skip
+                    // both clones when the query doesn't reference `balance`.
                     let mut ctx = PostingContext {
                         transaction: txn,
                         posting_index: i,
-                        balance: where_clause.map(|_| cumulative_balance.clone()),
-                        account_balance: account_balances.get(&posting.account).cloned(),
+                        balance: if needs_balance {
+                            Some(cumulative_balance.clone())
+                        } else {
+                            None
+                        },
+                        account_balance: if needs_account_balance {
+                            account_balances.get(&posting.account).cloned()
+                        } else {
+                            None
+                        },
                         directive_index: Some(directive_index),
                     };
 
@@ -493,11 +527,14 @@ impl<'a> Executor<'a> {
 
                     // WHERE passed: contribute this posting to the cumulative
                     // balance and refresh the snapshot in ctx so SELECT sees
-                    // the post-update value.
-                    if let Some(pos) = resolved {
-                        cumulative_balance.add(pos);
+                    // the post-update value. Both steps are no-ops when the
+                    // query doesn't read `balance`.
+                    if needs_balance {
+                        if let Some(pos) = resolved {
+                            cumulative_balance.add(pos);
+                        }
+                        ctx.balance = Some(cumulative_balance.clone());
                     }
-                    ctx.balance = Some(cumulative_balance.clone());
                     postings.push(ctx);
                 }
             }
@@ -2652,6 +2689,82 @@ impl<'a> Executor<'a> {
         table
     }
 }
+
+/// Walk an [`Expr`] tree, returning `true` if any [`Expr::Column`]
+/// references the given column name (case-insensitive).
+///
+/// Used to decide whether [`Executor::collect_postings`] needs to
+/// materialize the per-posting `balance` / `account_balance` snapshots
+/// — they're expensive (cumulative `Inventory` clones per posting,
+/// the runaway cost in #1080) so we skip the work when no part of the
+/// query reads them.
+fn expr_references_column(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::Column(col) => col.eq_ignore_ascii_case(name),
+        Expr::Function(call) => call.args.iter().any(|a| expr_references_column(a, name)),
+        Expr::Window(call) => call.args.iter().any(|a| expr_references_column(a, name)),
+        Expr::BinaryOp(op) => {
+            expr_references_column(&op.left, name) || expr_references_column(&op.right, name)
+        }
+        Expr::UnaryOp(op) => expr_references_column(&op.operand, name),
+        Expr::Paren(inner) => expr_references_column(inner, name),
+        Expr::Between { value, low, high } => {
+            expr_references_column(value, name)
+                || expr_references_column(low, name)
+                || expr_references_column(high, name)
+        }
+        Expr::Set(items) => items.iter().any(|i| expr_references_column(i, name)),
+        Expr::Wildcard | Expr::Literal(_) => false,
+    }
+}
+
+/// Return `true` if any part of a `SelectQuery` references the given
+/// column. Walks SELECT targets, WHERE, GROUP BY, HAVING, PIVOT BY,
+/// ORDER BY, and the FROM filter expression. A subquery in FROM is
+/// treated as opaque — its inner references don't surface to the
+/// outer query's posting iterator.
+fn query_references_column(query: &SelectQuery, name: &str) -> bool {
+    if query
+        .targets
+        .iter()
+        .any(|t| expr_references_column(&t.expr, name))
+    {
+        return true;
+    }
+    if let Some(w) = &query.where_clause
+        && expr_references_column(w, name)
+    {
+        return true;
+    }
+    if let Some(g) = &query.group_by
+        && g.iter().any(|e| expr_references_column(e, name))
+    {
+        return true;
+    }
+    if let Some(h) = &query.having
+        && expr_references_column(h, name)
+    {
+        return true;
+    }
+    if let Some(p) = &query.pivot_by
+        && p.iter().any(|e| expr_references_column(e, name))
+    {
+        return true;
+    }
+    if let Some(o) = &query.order_by
+        && o.iter().any(|s| expr_references_column(&s.expr, name))
+    {
+        return true;
+    }
+    if let Some(from) = &query.from
+        && let Some(f) = &from.filter
+        && expr_references_column(f, name)
+    {
+        return true;
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::types::{hash_row, hash_single_value};
@@ -3817,5 +3930,45 @@ mod tests {
             result.rows[0][0],
             Value::Date(rustledger_core::naive_date(2024, 1, 15).unwrap())
         );
+    }
+
+    /// Verify `query_references_column` walks every relevant query
+    /// part. The `collect_postings` optimization in #1080 hinges on
+    /// this — a false negative here would skip the cumulative-balance
+    /// clone for a query that depends on it.
+    #[test]
+    fn test_query_references_column_covers_all_query_parts() {
+        // Helper: parse a SELECT and assert `balance` references in it.
+        fn assert_refs(sql: &str, expected: bool) {
+            let q = match parse(sql).unwrap() {
+                Query::Select(s) => s,
+                _ => panic!("expected Select for {sql:?}"),
+            };
+            assert_eq!(
+                query_references_column(&q, "balance"),
+                expected,
+                "query_references_column(balance) wrong for {sql:?}"
+            );
+        }
+
+        // Negative cases — no reference, should skip the clone.
+        assert_refs("SELECT account FROM #postings", false);
+        assert_refs("SELECT account WHERE account ~ '^Assets' LIMIT 10", false);
+
+        // Positive cases — balance referenced in different positions.
+        assert_refs("SELECT balance FROM #postings", true);
+        assert_refs("SELECT account WHERE balance > 0", true);
+        assert_refs("SELECT account ORDER BY balance", true);
+        assert_refs("SELECT account GROUP BY balance", true);
+        assert_refs(
+            "SELECT account, sum(balance) FROM #postings GROUP BY account",
+            true,
+        );
+        // Case-insensitive
+        assert_refs("SELECT BALANCE FROM #postings", true);
+        // Nested in function arg
+        assert_refs("SELECT account WHERE units(balance) IS NOT NULL", true);
+        // Nested in BETWEEN
+        assert_refs("SELECT account WHERE balance BETWEEN 0 AND 100", true);
     }
 }


### PR DESCRIPTION
## Summary

Closes #1080 (the WASM 49 GB / multi-minute query regression reported by @alensiljak).

The regression was introduced by **PR #940** (`fix(query): make `balance` a cumulative WHERE-filtered total`), which landed just after v0.14.1 was released to npm. PR #940 added two computed BQL columns (`balance` and `account_balance`) and built per-posting `PostingContext` snapshots holding cloned `Inventory` views of both running balances.

For a query like `SELECT account WHERE account ~ "^Assets" LIMIT 10` against the user's ledger (22k Asset postings, 855 accounts), the `cumulative_balance` `Inventory` grows monotonically — meaning we were cloning a 1000+-position `Inventory` ~2-3 times per posting, producing **~12 GB of allocation churn** in WASM linear memory and ~5.8 GB peak heap. The page hung for minutes while the OS paged the WASM memory in and out.

The query doesn't reference `balance` or `account_balance`. The entire clone storm was wasted work.

## Root cause

The pre-fix code at `executor/mod.rs:479-501` had one gate (`where_clause.is_some()`) that fired for any query with a WHERE, regardless of what that WHERE actually referenced:

```rust
balance: where_clause.map(|_| cumulative_balance.clone()),  // <- always clones if any WHERE
```

A query with `WHERE account ~ "^Assets"` (which has nothing to do with `balance`) still paid the per-posting clone cost.

## Fix

Walk the `SelectQuery` AST once at the top of `collect_postings` via a new `query_references_column` helper, then gate the work:

```rust
let needs_balance = query_references_column(query, "balance");
let needs_account_balance = query_references_column(query, "account_balance");
```

When `needs_balance` is `false`:
- Skip the pre-WHERE `cumulative_balance.clone()`
- Skip the `cumulative_balance.add()` update (no one reads it)
- Skip the post-WHERE `cumulative_balance.clone()` refresh
- `ctx.balance` stays `None`

Same gating for `account_balance` via `account_balances` map updates.

Queries that DO reference either column keep the exact pre-fix code path — semantics preserved bit-for-bit. All 523 existing query tests pass.

## `query_references_column`

Walks every query part:
- SELECT targets
- WHERE
- GROUP BY
- HAVING
- PIVOT BY
- ORDER BY
- FROM filter expression

Case-insensitive column-name match. Subqueries in FROM are treated as opaque (their inner references don't surface to the outer iterator). Tested with the new `test_query_references_column_covers_all_query_parts` test which exercises `balance` in every position (target / WHERE / ORDER BY / GROUP BY / function arg / BETWEEN bound).

## Expected impact

For the user's specific query (`SELECT account WHERE account ~ "^Assets" LIMIT 10` on 22k postings):
- **Pre-fix:** multi-minute wall time, 5.8 GB WASM heap, page freezes
- **Post-fix:** should drop to v0.14.1-equivalent (sub-second) since the `cumulative_balance` allocation churn is entirely eliminated

For queries that DO read `balance` / `account_balance`: no change. Semantics, tests, perf all identical to pre-fix.

For queries that read neither (the common case for browsing / filtering / projection queries): proportional speedup matching what the user reported on v0.14.1.

## Test plan

- [x] `cargo test -p rustledger-query --all-features` — 523 tests pass, including the new `test_query_references_column_covers_all_query_parts`
- [x] `cargo check --workspace --all-features --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p rustledger-query --all-features --all-targets -- -D warnings` — clean
- [ ] CI (compatibility, regression, MSRV)
- [ ] Field-test: rebuild WASM, send to @alensiljak for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)