### PR TITLE
perf(core): structural sharing for Inventory positions to fix JOURNAL OOM (#1086)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +1198,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1285,7 +1294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1811,6 +1820,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +1970,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2450,7 +2474,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2984,6 +3008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,7 +3324,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3362,6 +3395,7 @@ name = "rustledger-core"
 version = "0.14.1"
 dependencies = [
  "criterion",
+ "im",
  "jiff",
  "proptest",
  "rkyv 0.8.16",
@@ -3896,6 +3930,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,7 +4105,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4080,7 +4124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5207,7 +5251,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,11 @@ blake3 = "1"
 # Inline-storage collections (avoids heap allocation for small sizes)
 smallvec = "1"
 
+# Persistent (structurally-shared) collections — O(1) clone for tree-based
+# vectors, used by Inventory.positions so JOURNAL-style row-per-snapshot
+# patterns become O(N log N) instead of O(N²). See issue #1086.
+im = { version = "15", features = ["serde"] }
+
 # Testing
 proptest = "1"
 criterion = "0.8"

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -679,7 +679,7 @@ mod tests {
         assert_eq!(inv.units("VIIIX"), dec!(1.763));
 
         // Check cost was calculated correctly (300/1.763 ≈ 170.16)
-        let pos = inv.positions().first().unwrap();
+        let pos = inv.positions().next().unwrap();
         assert!(pos.cost.is_some(), "Expected cost on position");
         eprintln!("Position cost: {:?}", pos.cost);
     }
@@ -765,7 +765,6 @@ mod tests {
         // Check that the AAPL position has cost with USD currency
         let aapl_pos = inv
             .positions()
-            .iter()
             .find(|p| p.units.currency.as_ref() == "AAPL")
             .expect("Should have AAPL position");
 
@@ -1005,7 +1004,7 @@ mod tests {
 
         // Check inventory has the position with correct cost
         let inv = engine.inventory(&"Assets:Abc".into()).unwrap();
-        let pos = inv.positions().first().unwrap();
+        let pos = inv.positions().next().unwrap();
         assert!(pos.cost.is_some(), "Position should have cost");
         let cost = pos.cost.as_ref().unwrap();
         assert_eq!(cost.currency.as_ref(), "USD", "Cost currency should be USD");

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -30,6 +30,7 @@ serde_json.workspace = true
 rkyv = { workspace = true, optional = true }
 rustc-hash.workspace = true
 smallvec.workspace = true
+im.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -782,7 +782,7 @@ impl Inventory {
 
         // Add back the remainder if non-zero
         if !new_units.is_zero() {
-            self.positions.push(Position::simple(Amount::new(
+            self.positions.push_back(Position::simple(Amount::new(
                 new_units,
                 units.currency.clone(),
             )));
@@ -872,7 +872,7 @@ impl Inventory {
         // Add back a single merged lot with the remainder
         let remaining = total_units + units.number; // units.number is negative for reductions
         if !remaining.is_zero() {
-            self.positions.push(Position::with_cost(
+            self.positions.push_back(Position::with_cost(
                 Amount::new(remaining, units.currency.clone()),
                 make_avg_cost(),
             ));

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -300,21 +300,27 @@ impl std::error::Error for AccountedBookingError {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Inventory {
     /// Persistent (structurally-shared) RRB-tree-backed vector. Cloning
-    /// is O(1) (Arc bump on tree nodes); `push_back` / indexed mutation
-    /// are O(log N) but share structure with previous versions. This is
-    /// the critical property for JOURNAL-style row-per-snapshot patterns
-    /// in BQL (issue #1086): N nested snapshots cost O(N) memory instead
-    /// of O(N²), and the per-row clone cost drops from O(positions) to
-    /// O(1). Booking and BQL aggregator mutations see a small constant-
-    /// factor slowdown (log₂ of typical-inventory size = 3-4 ops vs
-    /// Vec's amortized 1) but no measurable regression at realistic
-    /// inventory sizes (see `inventory_bench`).
+    /// is O(1) (Arc bump on the tree root); `push_back` / indexed mutation
+    /// are O(log N) per op but share structure with previous versions.
+    /// This is the critical property for JOURNAL-style row-per-snapshot
+    /// patterns in BQL (issue #1086): N nested snapshots cost O(base + Σ
+    /// deltas) memory instead of O(N · base), and the per-row clone cost
+    /// drops from O(positions) to O(1).
     ///
-    /// `rkyv` derives were dropped when this changed from `Vec<Position>`
-    /// to `im::Vector` because (a) `im::Vector` has no `rkyv` impl and
-    /// (b) no code path currently archives an `Inventory` (confirmed in
-    /// the `SmallVec` experiment for #1069). Serde still works (sequence-
-    /// typed wire format, identical for both containers).
+    /// The trade is real: booking and BQL aggregator mutations pay an
+    /// O(log N) tree walk vs `Vec`'s amortized O(1) push. Measured impact
+    /// scales with inventory size M: +85 ns/op at M=10, +1.6 µs/op at
+    /// M=100, +19 µs/op at M=500 (criterion `reduce_fifo/*`). For typical
+    /// small-M ledgers the overhead is sub-millisecond per `rledger
+    /// check`; the users who feel it are users with very large inventories,
+    /// the same users who hit the JOURNAL OOM today.
+    ///
+    /// `rkyv` derives were dropped because (a) `im::Vector` has no `rkyv`
+    /// impl and (b) no code path currently archives an `Inventory`
+    /// (confirmed in the `SmallVec` experiment for #1069). Pre-1.0 break;
+    /// downstream callers archiving `Inventory` directly will need to
+    /// archive `Vec<Position>` themselves. Serde wire format is unchanged
+    /// (sequence-typed, identical for both backings).
     positions: Vector<Position>,
     /// Index for O(1) lookup of simple positions (no cost) by currency.
     /// Maps currency to position index in the `positions` vector.

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -4,6 +4,7 @@
 //! [`Position`]s. It provides methods for adding and reducing positions
 //! using different booking methods (FIFO, LIFO, STRICT, NONE).
 
+use im::Vector;
 use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -297,23 +298,33 @@ impl std::error::Error for AccountedBookingError {}
 /// assert_eq!(inv.units("AAPL"), dec!(10));
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
-)]
 pub struct Inventory {
-    positions: Vec<Position>,
+    /// Persistent (structurally-shared) RRB-tree-backed vector. Cloning
+    /// is O(1) (Arc bump on tree nodes); `push_back` / indexed mutation
+    /// are O(log N) but share structure with previous versions. This is
+    /// the critical property for JOURNAL-style row-per-snapshot patterns
+    /// in BQL (issue #1086): N nested snapshots cost O(N) memory instead
+    /// of O(N²), and the per-row clone cost drops from O(positions) to
+    /// O(1). Booking and BQL aggregator mutations see a small constant-
+    /// factor slowdown (log₂ of typical-inventory size = 3-4 ops vs
+    /// Vec's amortized 1) but no measurable regression at realistic
+    /// inventory sizes (see `inventory_bench`).
+    ///
+    /// `rkyv` derives were dropped when this changed from `Vec<Position>`
+    /// to `im::Vector` because (a) `im::Vector` has no `rkyv` impl and
+    /// (b) no code path currently archives an `Inventory` (confirmed in
+    /// the `SmallVec` experiment for #1069). Serde still works (sequence-
+    /// typed wire format, identical for both containers).
+    positions: Vector<Position>,
     /// Index for O(1) lookup of simple positions (no cost) by currency.
-    /// Maps currency to position index in the `positions` Vec.
+    /// Maps currency to position index in the `positions` vector.
     /// Not serialized - rebuilt on demand.
     #[serde(skip)]
-    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Skip))]
     simple_index: FxHashMap<InternedStr, usize>,
     /// Cache of total units per currency for O(1) `units()` lookups.
     /// Updated incrementally on `add()` and `reduce()`.
     /// Not serialized - rebuilt on demand.
     #[serde(skip)]
-    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Skip))]
     units_cache: FxHashMap<InternedStr, Decimal>,
 }
 
@@ -333,14 +344,37 @@ impl Inventory {
         Self::default()
     }
 
-    /// Get all positions.
-    #[must_use]
-    pub fn positions(&self) -> &[Position] {
-        &self.positions
+    /// Iterate over all positions.
+    ///
+    /// Previously returned `&[Position]`; now returns an iterator
+    /// because the underlying storage is a tree-based persistent
+    /// vector (`im::Vector`) that doesn't expose a contiguous slice.
+    /// Most callers already iterate — for callers that need
+    /// random-access / indexed / `.len()` slice semantics, see
+    /// [`Self::position_list`].
+    pub fn positions(&self) -> impl Iterator<Item = &Position> + '_ {
+        self.positions.iter()
     }
 
-    /// Get mutable access to all positions.
-    pub const fn positions_mut(&mut self) -> &mut Vec<Position> {
+    /// Materialize all positions as a `Vec<&Position>` for slice-style
+    /// access (indexing, `.len()`, `.first()`, `.is_empty()`).
+    ///
+    /// Allocates `O(N)` pointers per call. Callers that only iterate
+    /// once should use [`Self::positions`] instead — this is for code
+    /// paths that need slice semantics.
+    #[must_use]
+    pub fn position_list(&self) -> Vec<&Position> {
+        self.positions.iter().collect()
+    }
+
+    /// Get mutable access to the underlying positions vector.
+    ///
+    /// Returns `&mut im::Vector<Position>` (was `&mut Vec<Position>`
+    /// before issue #1086). `im::Vector` supports the same surface
+    /// for `push_back`, `pop_back`, `retain`, indexed access, and
+    /// iteration — but mutations are O(log N) with structural sharing
+    /// instead of O(1) amortized.
+    pub const fn positions_mut(&mut self) -> &mut Vector<Position> {
         &mut self.positions
     }
 
@@ -356,7 +390,7 @@ impl Inventory {
 
     /// Get the number of positions (including empty ones).
     #[must_use]
-    pub const fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.positions.len()
     }
 
@@ -475,14 +509,14 @@ impl Inventory {
             let idx = self.positions.len();
             self.simple_index
                 .insert(position.units.currency.clone(), idx);
-            self.positions.push(position);
+            self.positions.push_back(position);
             return;
         }
 
         // For positions with cost, just add as a new lot.
         // This is O(1) and keeps all lots separate, matching Python beancount behavior.
         // Lot aggregation for display purposes is handled separately in query output.
-        self.positions.push(position);
+        self.positions.push_back(position);
     }
 
     /// Reduce positions from the inventory using the specified booking method.

--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -331,7 +331,6 @@ pub fn value_to_json(value: &rustledger_query::Value) -> serde_json::Value {
         Value::Inventory(inv) => {
             let positions: Vec<_> = inv
                 .positions()
-                .iter()
                 .map(|p| {
                     serde_json::json!({
                         "units": {

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -79,7 +79,6 @@ impl Executor<'_> {
                     (Value::Inventory(inv), Value::String(curr)) => {
                         let filtered: Vec<Position> = inv
                             .positions()
-                            .iter()
                             .filter(|p| p.units.currency.as_str() == curr)
                             .cloned()
                             .collect();
@@ -181,7 +180,6 @@ impl Executor<'_> {
             Value::Inventory(inv) => {
                 let positions: Vec<String> = inv
                     .positions()
-                    .iter()
                     .map(|p| format!("{} {}", p.units.number, p.units.currency))
                     .collect();
                 Ok(Value::String(positions.join(", ")))

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -163,7 +163,7 @@ impl Executor<'_> {
                 }
                 // If result has single currency matching target, return as Amount
                 // If result is empty, return zero in target currency (issue #586)
-                let positions = result.positions();
+                let positions: Vec<&Position> = result.positions().collect();
                 if positions.is_empty() {
                     Ok(Value::Amount(Amount::new(Decimal::ZERO, &target_currency)))
                 } else if positions.len() == 1 && positions[0].units.currency == target_currency {
@@ -378,7 +378,6 @@ impl Executor<'_> {
         // Find positions matching the currency
         let matching: Vec<_> = inv
             .positions()
-            .iter()
             .filter(|p| p.units.currency == key)
             .collect();
 

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -161,13 +161,24 @@ impl Executor<'_> {
                         result.add(Position::simple(pos.units.clone()));
                     }
                 }
-                // If result has single currency matching target, return as Amount
-                // If result is empty, return zero in target currency (issue #586)
-                let positions: Vec<&Position> = result.positions().collect();
-                if positions.is_empty() {
+                // If result has single currency matching target, return as Amount.
+                // If result is empty, return zero in target currency (issue #586).
+                // Peek the first two positions to decide; the single-match Amount
+                // is cloned eagerly (O(1) — `Decimal` + interned currency) so the
+                // iterator borrow is dropped before we move `result` below.
+                let single_match: Option<Amount> = {
+                    let mut iter = result.positions();
+                    match (iter.next(), iter.next()) {
+                        (Some(only), None) if only.units.currency == target_currency => {
+                            Some(only.units.clone())
+                        }
+                        _ => None,
+                    }
+                };
+                if let Some(units) = single_match {
+                    Ok(Value::Amount(units))
+                } else if result.is_empty() {
                     Ok(Value::Amount(Amount::new(Decimal::ZERO, &target_currency)))
-                } else if positions.len() == 1 && positions[0].units.currency == target_currency {
-                    Ok(Value::Amount(positions[0].units.clone()))
                 } else {
                     Ok(Value::Inventory(Box::new(result)))
                 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -673,7 +673,7 @@ impl<'a> Executor<'a> {
                     Value::Inventory(inv) => {
                         // For inventory, only return a number if all positions share the same
                         // currency. Summing across different currencies is not meaningful.
-                        let positions = inv.positions();
+                        let positions: Vec<&Position> = inv.positions().collect();
                         if positions.is_empty() {
                             return Ok(Value::Number(Decimal::ZERO));
                         }
@@ -702,7 +702,7 @@ impl<'a> Executor<'a> {
                     Value::Position(p) => Ok(Value::String(p.units.currency.to_string())),
                     Value::Inventory(inv) => {
                         // Return the currency of the first position, or Null if empty
-                        if let Some(pos) = inv.positions().first() {
+                        if let Some(pos) = inv.positions().next() {
                             Ok(Value::String(pos.units.currency.to_string()))
                         } else {
                             Ok(Value::Null)
@@ -1040,7 +1040,6 @@ impl<'a> Executor<'a> {
                     Value::Inventory(inv) => {
                         let filtered: Vec<Position> = inv
                             .positions()
-                            .iter()
                             .filter(|p| p.units.currency.as_str() == currency)
                             .cloned()
                             .collect();
@@ -1175,7 +1174,7 @@ impl<'a> Executor<'a> {
                         }
                         // If result has single currency matching target, return as Amount
                         // If result is empty, return zero in target currency (issue #586)
-                        let positions = result.positions();
+                        let positions: Vec<&Position> = result.positions().collect();
                         if positions.is_empty() {
                             Ok(Value::Amount(Amount::new(Decimal::ZERO, &target_currency)))
                         } else if positions.len() == 1
@@ -1630,7 +1629,6 @@ impl<'a> Executor<'a> {
                 Value::Position(p) => p.cost.as_ref().map(|c| c.currency.to_string()),
                 Value::Inventory(inv) => inv
                     .positions()
-                    .iter()
                     .find_map(|p| p.cost.as_ref().map(|c| c.currency.to_string())),
                 _ => None,
             };

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -673,21 +673,21 @@ impl<'a> Executor<'a> {
                     Value::Inventory(inv) => {
                         // For inventory, only return a number if all positions share the same
                         // currency. Summing across different currencies is not meaningful.
-                        let positions: Vec<&Position> = inv.positions().collect();
-                        if positions.is_empty() {
+                        // Single pass: track the first currency and running total, bail out
+                        // to Null on any currency mismatch.
+                        let mut iter = inv.positions();
+                        let Some(first) = iter.next() else {
                             return Ok(Value::Number(Decimal::ZERO));
+                        };
+                        let first_currency = &first.units.currency;
+                        let mut total = first.units.number;
+                        for pos in iter {
+                            if &pos.units.currency != first_currency {
+                                return Ok(Value::Null);
+                            }
+                            total += pos.units.number;
                         }
-                        let first_currency = &positions[0].units.currency;
-                        let all_same_currency = positions
-                            .iter()
-                            .all(|p| &p.units.currency == first_currency);
-                        if all_same_currency {
-                            let total: Decimal = positions.iter().map(|p| p.units.number).sum();
-                            Ok(Value::Number(total))
-                        } else {
-                            // Multiple currencies - return NULL rather than a meaningless sum
-                            Ok(Value::Null)
-                        }
+                        Ok(Value::Number(total))
                     }
                     Value::Null => Ok(Value::Null),
                     _ => Err(QueryError::Type(

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -479,8 +479,8 @@ impl Executor<'_> {
             (Value::Position(a), Value::Position(b)) => a.units.number.cmp(&b.units.number),
             // Compare inventories by first position's value (for single-currency)
             (Value::Inventory(a), Value::Inventory(b)) => {
-                let a_val = a.positions().first().map(|p| &p.units.number);
-                let b_val = b.positions().first().map(|p| &p.units.number);
+                let a_val = a.positions().next().map(|p| &p.units.number);
+                let b_val = b.positions().next().map(|p| &p.units.number);
                 match (a_val, b_val) {
                     (Some(av), Some(bv)) => av.cmp(bv),
                     (Some(_), None) => std::cmp::Ordering::Less,

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -605,7 +605,7 @@ fn test_journal_balance_is_cumulative_across_matched_accounts() {
         Value::Inventory(inv) => inv,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions_0 = balance_0.positions();
+    let positions_0 = balance_0.position_list();
     assert_eq!(positions_0.len(), 1);
     assert_eq!(positions_0[0].units.currency.as_str(), "USD");
     assert_eq!(positions_0[0].units.number, dec!(1000));
@@ -619,7 +619,6 @@ fn test_journal_balance_is_cumulative_across_matched_accounts() {
     };
     let mut currencies: Vec<&str> = balance_1
         .positions()
-        .iter()
         .map(|p| p.units.currency.as_str())
         .collect();
     currencies.sort_unstable();
@@ -715,7 +714,7 @@ fn test_journal_from_clause_filters_cumulative_balance() {
         Value::Inventory(inv) => inv,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions = balance.positions();
+    let positions = balance.position_list();
     assert_eq!(positions.len(), 1);
     assert_eq!(
         positions[0].units.number,
@@ -836,7 +835,7 @@ fn test_journal_at_cost_collapses_balance_to_cost_currency() {
         Value::Inventory(inv) => inv,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions = balance.positions();
+    let positions = balance.position_list();
     assert_eq!(positions.len(), 1);
     // 10 AAPL { 150 USD } collapsed to 1500 USD (cost-currency total).
     assert_eq!(positions[0].units.number, dec!(1500));
@@ -902,7 +901,7 @@ fn test_journal_at_cost_with_from_clause_filters_then_collapses() {
         Value::Inventory(inv) => inv,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions = balance.positions();
+    let positions = balance.position_list();
     assert_eq!(
         positions.len(),
         1,
@@ -942,7 +941,7 @@ fn test_journal_at_units_strips_cost_from_balance() {
         Value::Inventory(inv) => inv,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions = balance.positions();
+    let positions = balance.position_list();
     assert_eq!(positions.len(), 1);
     // AT units shows units only — same number / currency as the position.
     assert_eq!(positions[0].units.number, dec!(10));
@@ -980,7 +979,7 @@ fn test_journal_at_cost_balance_preserves_no_cost_positions() {
         Value::Inventory(inv) => inv,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions = balance.positions();
+    let positions = balance.position_list();
     assert_eq!(positions.len(), 1);
     assert_eq!(positions[0].units.number, dec!(100));
     assert_eq!(positions[0].units.currency.as_str(), "USD");
@@ -1178,7 +1177,7 @@ fn test_balances_with_different_from_filters_are_independent() {
         Value::Inventory(i) => i,
         other => panic!("expected Inventory, got {other:?}"),
     };
-    let positions = inv.positions();
+    let positions = inv.position_list();
     assert_eq!(positions.len(), 1);
     assert_eq!(
         positions[0].units.number,
@@ -1213,7 +1212,7 @@ fn test_balance_is_cumulative_across_accounts() {
     );
     // Row 3 cumulative: 5000 - 150 - 45 = 4805 USD.
     if let Value::Inventory(inv) = &result.rows[2][1] {
-        let positions = inv.positions();
+        let positions = inv.position_list();
         assert_eq!(
             positions.len(),
             1,
@@ -1260,7 +1259,7 @@ fn test_balance_carries_across_different_accounts() {
         &directives,
     );
     let inv = find_balance_by_account(&result, "Assets:Bank:Savings", 2);
-    assert_eq!(inv.positions()[0].units.number, dec!(5805));
+    assert_eq!(inv.position_list()[0].units.number, dec!(5805));
 }
 
 #[test]
@@ -1275,7 +1274,7 @@ fn test_account_balance_is_per_account() {
         &directives,
     );
     let savings = find_balance_by_account(&result, "Assets:Bank:Savings", 2);
-    assert_eq!(savings.positions()[0].units.number, dec!(1000));
+    assert_eq!(savings.position_list()[0].units.number, dec!(1000));
 
     // Pre-Savings, Checking has run 5000 - 150 - 45 = 4805 across the
     // first three Assets postings. Find the gas row (2024-01-22) by
@@ -1287,7 +1286,7 @@ fn test_account_balance_is_per_account() {
             && a == "Assets:Bank:Checking"
             && let Value::Inventory(inv) = &row[2]
         {
-            last_checking_balance = Some(inv.positions()[0].units.number);
+            last_checking_balance = Some(inv.position_list()[0].units.number);
         }
     }
     // After all 5 Checking postings (5000, -150, -45, -1000, -80): final = 3725.
@@ -1308,7 +1307,7 @@ fn test_where_rejected_postings_do_not_pollute_cumulative_balance() {
     // The very first row is the salary posting to Checking: balance = 5000.
     // If cumulative were polluted by Income's -5000, this would be 0.
     if let Value::Inventory(inv) = &result.rows[0][1] {
-        assert_eq!(inv.positions()[0].units.number, dec!(5000));
+        assert_eq!(inv.position_list()[0].units.number, dec!(5000));
     } else {
         panic!("expected Inventory at first row");
     }
@@ -5185,7 +5184,7 @@ fn test_value_no_currency_aggregated_returns_as_is() {
             assert_eq!(*a, expected, "Expected 80 USD amount");
         }
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             assert_eq!(positions.len(), 1, "Expected single-currency inventory");
             assert_eq!(positions[0].units, expected, "Expected 80 USD in inventory");
         }
@@ -7737,7 +7736,7 @@ fn test_convert_unconvertible_currency_kept_original() {
     // Should return an Inventory with both EUR and JPY (JPY kept as original)
     match &result.rows[0][0] {
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             assert_eq!(
                 positions.len(),
                 2,
@@ -8175,7 +8174,7 @@ fn test_convert_no_price_fallback() {
     // (this matches Python beancount fallback behavior)
     match &result.rows[0][1] {
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             assert_eq!(positions.len(), 1);
             assert_eq!(positions[0].units.number, dec!(100));
             assert_eq!(positions[0].units.currency.as_ref(), "USD");
@@ -8333,7 +8332,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
     let sum_value = match &sum_result.rows[0][0] {
         Value::Amount(a) => a.number,
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             assert_eq!(positions.len(), 1, "Expected single position in inventory");
             assert_eq!(positions[0].units.currency.as_ref(), "EUR");
             positions[0].units.number
@@ -8357,7 +8356,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
     let cost_sum_value = match &cost_sum_result.rows[0][0] {
         Value::Amount(a) => a.number,
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             assert_eq!(positions.len(), 1, "Expected single position in inventory");
             assert_eq!(positions[0].units.currency.as_ref(), "EUR");
             positions[0].units.number
@@ -8496,7 +8495,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
     let sum_value = match &sum_result.rows[0][0] {
         Value::Amount(a) => a.number,
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             assert_eq!(positions.len(), 1, "Expected single position in inventory");
             assert_eq!(positions[0].units.currency.as_ref(), "EUR");
             positions[0].units.number

--- a/crates/rustledger-validate/src/validators/account.rs
+++ b/crates/rustledger-validate/src/validators/account.rs
@@ -73,7 +73,6 @@ pub fn validate_close(state: &mut LedgerState, close: &Close, errors: &mut Vec<V
                 {
                     let positions: Vec<String> = inv
                         .positions()
-                        .iter()
                         .map(|p| format!("{} {}", p.units.number, p.units.currency))
                         .collect();
                     errors.push(

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -136,7 +136,7 @@ pub fn value_to_cell(value: &rustledger_query::Value) -> CellValue {
             }),
         },
         Value::Inventory(inv) => {
-            let positions = inv.positions();
+            let positions = inv.position_list();
             CellValue::Inventory {
                 positions: positions
                     .iter()

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -135,20 +135,17 @@ pub fn value_to_cell(value: &rustledger_query::Value) -> CellValue {
                 label: c.label.clone(),
             }),
         },
-        Value::Inventory(inv) => {
-            let positions = inv.position_list();
-            CellValue::Inventory {
-                positions: positions
-                    .iter()
-                    .map(|p| PositionValue {
-                        units: AmountValue {
-                            number: p.units.number.to_string(),
-                            currency: p.units.currency.to_string(),
-                        },
-                    })
-                    .collect(),
-            }
-        }
+        Value::Inventory(inv) => CellValue::Inventory {
+            positions: inv
+                .positions()
+                .map(|p| PositionValue {
+                    units: AmountValue {
+                        number: p.units.number.to_string(),
+                        currency: p.units.currency.to_string(),
+                    },
+                })
+                .collect(),
+        },
         Value::StringSet(set) => CellValue::StringSet(set.clone()),
         Value::Set(values) => {
             CellValue::Set(values.iter().map(|v| Box::new(value_to_cell(v))).collect())

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -6,6 +6,16 @@ use rustledger_core::{Directive, DisplayContext};
 use rustledger_query::{Executor, Value, parse as parse_query};
 use std::io::Write;
 
+/// Cap on the dynamic width passed to `write!("{:width$}", .., width = w)`.
+/// `std::fmt::rt::Argument::from_usize` panics with "Formatting argument
+/// out of range" when the runtime width exceeds `u16::MAX`. Cells wider
+/// than this cap are still written verbatim because `write!` does not
+/// truncate when content length exceeds the requested width — capping
+/// only suppresses padding, which is the correct fallback at this scale
+/// (no terminal can usefully align 65k-character columns). Surfaces on
+/// JOURNAL queries with thousands of lots in the `balance` column (#1086).
+const MAX_COLUMN_WIDTH: usize = u16::MAX as usize;
+
 pub(super) fn execute_query<W: Write>(
     query_str: &str,
     directives: &[Directive],
@@ -115,11 +125,13 @@ fn write_text<W: Write>(
         })
         .collect();
 
-    // Calculate column widths using per-column contexts
+    // Calculate column widths using per-column contexts. Each column is
+    // clamped to `MAX_COLUMN_WIDTH` to keep the dynamic width passed to
+    // `write!` below within the stdlib's `u16::MAX` cap — see the constant.
     let mut widths: Vec<usize> = result
         .columns
         .iter()
-        .map(std::string::String::len)
+        .map(|c| c.len().min(MAX_COLUMN_WIDTH))
         .collect();
 
     for (row_idx, row) in result.rows.iter().enumerate() {
@@ -128,7 +140,7 @@ fn write_text<W: Write>(
             let cell_hint = resolve_cell_hint(&currency_hints, &column_currency_hints, row_idx, i);
             let len = format_value_with_hint(value, numberify, col_ctx, cell_hint).len();
             if i < widths.len() && len > widths[i] {
-                widths[i] = len;
+                widths[i] = len.min(MAX_COLUMN_WIDTH);
             }
         }
     }
@@ -689,6 +701,35 @@ mod tests {
         assert!(
             rendered.contains("{ 128.99 USD}") && rendered.contains("{ 131.73 USD}"),
             "expected both costs rendered with leading space, got {rendered:?}"
+        );
+    }
+
+    /// `write_text` must not panic when a single cell renders to more
+    /// than `u16::MAX` characters. `std::fmt::rt::Argument::from_usize`
+    /// panics with "Formatting argument out of range" if a dynamic
+    /// `{:width$}` width parameter exceeds `u16::MAX`, which happens on
+    /// JOURNAL queries whose `balance` column holds inventories with
+    /// thousands of lots (see #1086 stress workloads). The fix in
+    /// `write_text` caps width at `u16::MAX`; cells wider than the cap
+    /// are still written verbatim because `write!` does not truncate
+    /// when content exceeds the requested width.
+    #[test]
+    fn test_write_text_does_not_panic_on_cells_wider_than_u16_max() {
+        use rustledger_query::QueryResult;
+
+        let mut result = QueryResult::new(vec!["wide".into()]);
+        // 70_000 chars > u16::MAX = 65_535
+        let wide = "x".repeat(70_000);
+        result.add_row(vec![Value::String(wide.clone())]);
+
+        let ctx = DisplayContext::new();
+        let mut buf: Vec<u8> = Vec::new();
+        write_text(&result, &mut buf, false, &ctx).expect("write_text must not panic on wide cell");
+
+        let text = String::from_utf8(buf).expect("utf8");
+        assert!(
+            text.contains(&wide),
+            "wide cell content must still appear verbatim in output"
         );
     }
 

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -463,7 +463,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
             use std::collections::HashMap;
 
             let mut aggregated: HashMap<(String, Option<String>), Position> = HashMap::new();
-            for pos in inv.positions().iter().filter(|p| !p.is_empty()) {
+            for pos in inv.positions().filter(|p| !p.is_empty()) {
                 let cost_key = pos.cost.as_ref().map(|c| {
                     format!(
                         "{}|{}|{:?}|{:?}",
@@ -587,7 +587,7 @@ fn value_to_json(value: &Value) -> serde_json::Value {
             })),
         }),
         Value::Inventory(inv) => serde_json::json!({
-            "positions": inv.positions().iter().map(|p| serde_json::json!({
+            "positions": inv.positions().map(|p| serde_json::json!({
                 "number": p.units.number.to_string(),
                 "currency": p.units.currency,
             })).collect::<Vec<_>>(),

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -420,6 +420,10 @@ criteria = "safe-to-deploy"
 version = "2.2.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.im]]
+version = "15.1.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.indexmap]]
 version = "2.14.0"
 criteria = "safe-to-deploy"
@@ -720,6 +724,10 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.rand_xoshiro]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.rawpointer]]
 version = "0.2.1"
 criteria = "safe-to-deploy"
@@ -850,6 +858,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.siphasher]]
 version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.sized-chunks]]
+version = "0.6.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.sprs]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1573,6 +1573,15 @@ criteria = "safe-to-deploy"
 delta = "2.10.0 -> 2.11.1"
 notes = "Minor updates, nothing awry here."
 
+[[audits.bytecode-alliance.audits.bitmaps]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.1.0"
+notes = """
+No ambient I/O. Minimal unsafe, purely related to simd ISA extensions and
+obviously correct with only local reasoning.
+"""
+
 [[audits.bytecode-alliance.audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

- Switches `Inventory.positions` from `Vec<Position>` to `im::Vector<Position>` so per-row balance snapshots in JOURNAL/SELECT cost O(1) (Arc bump on RRB-tree root) instead of O(M) per row.
- Eliminates O(N·M) memory blowup that crashes WASM on large-inventory JOURNAL queries.
- Comes with a measurable booking-mutation regression (O(log M) instead of O(1)) that scales with inventory size.

Closes #1086.

## The problem

PR #940 added a cumulative `balance` column to JOURNAL. Each row stores a clone of `cumulative_balance` at that point in the stream. With `Vec` backing, that's an O(M) clone per row, so memory scales O(N·M) — quadratic when each posting opens a unique lot.

Reproduced natively on a synthetic ledger (10k transactions, each opens a unique lot):

| N | RSS (pre-fix) | Elapsed |
|---|---------------|---------|
| 500 | 25 MB | 0.2s |
| 1000 | 63 MB | 0.9s |
| 2000 | 206 MB | 3.7s |
| 5000 | 1.2 GB | 12.7s |
| 10000 | **4.7 GB → panic** | 52s |

WASM has a 4 GB linear memory ceiling. It dies well before native does.

## The fix

`im::Vector` is a persistent RRB-tree. `.clone()` bumps an Arc on the root; subsequent mutations on either side path-copy only the affected nodes. Holding N snapshots that descend from a single base costs O(base + Σ deltas), not O(N · base).

Post-fix on the same workload:

| N | RSS (pre-fix) | RSS (post-fix) | Reduction |
|---|---|---|---|
| 500 | 25 MB | 19 MB | 24% |
| 1000 | 63 MB | 22 MB | 65% |
| 2000 | 206 MB | 31 MB | 85% |
| 5000 | 1.2 GB | 61 MB | 95% |
| 10000 | 4.7 GB (panic) | **108 MB** | **97.7%** |

Realistic active-trader workload (alternating buy/sell, FIFO booking):

| N | RSS (pre-fix) | RSS (post-fix) |
|---|---|---|
| 5000 | 1.2 GB | 58 MB |
| 20000 | **18.8 GB** | **196 MB** |

## Tradeoff

`im::Vector` mutations are O(log M) per op vs O(1) amortized for `Vec`. Booking benchmarks regress:

| benchmark | pre-fix | post-fix | delta | absolute per-op |
|-----------|---------|----------|-------|------------------|
| reduce_fifo/10 | 3.22 µs | 4.07 µs | +26% | +85 ns |
| reduce_fifo/100 | 189 µs | 352 µs | +86% | +1.6 µs |
| reduce_fifo/500 | 4.37 ms | 13.87 ms | +217% | +19 µs |

| benchmark | pre-fix | post-fix | delta |
|-----------|---------|----------|-------|
| inventory_clone/10 | 319 ns | 37 ns | **−88%** |
| inventory_clone/3 | 130 ns | 37 ns | −71% |

Per-op overhead scales with inventory size M. Users with large inventories pay the booking tax — but they're the same users who hit the JOURNAL OOM today, so net-positive for them. Typical users (M ≤ 10) eat ~85 ns/op; sub-millisecond impact on `rledger check`.

## Why not a hybrid (Vec for booking, im::Vector for JOURNAL only)?

Considered carefully. A clean implementation requires either:
1. Generic-over-backing on `Inventory` (substantial refactor — every method parameterized)
2. A delta-export API from every mutation (new public surface, replay logic in executor)

Either is a reasonable follow-up if the booking regression bites someone in real measurement. But pure-`Vec` snapshots fundamentally cannot avoid the O(N·M) memory shape — there is no structural sharing to amortize against.

## Surface changes

- `Inventory::positions()` now returns `impl Iterator<Item = &Position>` (was `&[Position]`) to abstract over the backing type.
- Added `Inventory::position_list() -> Vec<&Position>` for the handful of callers (BQL tests, FFI/WASM convert paths) that need slice-style access.
- Internal `self.positions.push(...)` → `push_back(...)` for the `im::Vector` API.
- `rkyv` derives removed from `Inventory`: `im::Vector` has no `rkyv` impl, and no code path archives an Inventory (verified during the SmallVec experiment for #1069). Serde wire format unchanged.

## Test plan

- [x] `cargo test -p rustledger-core -p rustledger-booking -p rustledger-validate -p rustledger-query --all-features` — 1046 tests, 0 failures
- [x] `cargo clippy -p ... -- -D warnings` — clean on all touched crates including rustledger-wasm, rustledger-ffi-wasi
- [x] `cargo fmt --all -- --check` — clean
- [x] Native stress test (adversarial unique-lot workload): 4.7 GB → 108 MB at N=10000
- [x] Native stress test (realistic FIFO trader): 18.8 GB → 196 MB at N=20000
- [ ] Manual WASM smoke test (would require building wasm-pack, not blocking)

## Known follow-up

`rustledger/src/cmd/query/output.rs:154` panics with `"Formatting argument out of range"` when a single rendered Inventory cell exceeds format-machinery limits (e.g., 5000+ positions in one cell). Pre-existing bug — was previously masked by the OOM. Will file a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)