### PR TITLE
ci: make PR-comment posting best-effort to fix fork PR red Xs (closes #1093)

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -167,6 +167,13 @@ jobs:
             echo "Could not fetch baseline history"
           fi
       - name: Post PR comment
+        # GITHUB_TOKEN is read-only on `pull_request` workflows from forks
+        # (a GitHub security guarantee; `permissions: pull-requests: write`
+        # above does not override it). Make comment-posting best-effort so
+        # the job's success/failure reflects the actual benchmark result,
+        # not whether we could leave a comment. Fork PRs silently skip with
+        # a log line; non-fork PRs continue to receive the comment. (#1093)
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -908,8 +908,19 @@ jobs:
 
           *Real-world: Downloaded from 10+ beancount repositories. Synthetic: Generated edge cases and proptest fixtures.*
           EOF
-      - name: Post PR comment (release PRs only)
+      - name: Post PR comment
         if: github.event_name == 'pull_request'
+        # GITHUB_TOKEN is read-only on `pull_request` workflows from forks
+        # (a GitHub security guarantee; `permissions: pull-requests: write`
+        # above does not override it). Make comment-posting best-effort so
+        # the job's success/failure reflects the compatibility-test result,
+        # not whether we could leave a comment. Fork PRs silently skip with
+        # a log line; non-fork PRs continue to receive the comment. (#1093)
+        #
+        # The previous step name was `Post PR comment (release PRs only)`
+        # but the `if:` above runs on every `pull_request`, not just release
+        # PRs — renamed to match actual behavior. (#1093)
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the `Post PR comment` step in `bench-pr.yml` and `compat.yml`.
- Renames compat.yml's misleading `Post PR comment (release PRs only)` to `Post PR comment` (the `if:` guard already runs on every PR, not just release PRs).

Closes #1093.

## Why

`GITHUB_TOKEN` is [read-only on `pull_request` workflows from forks](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) by GitHub design. Setting `permissions: pull-requests: write` in the workflow does not override that — it's a GitHub security guarantee.

As a result, the `Post PR comment` step in both workflows fails every fork PR with:

```
HttpError: Resource not accessible by integration
https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

The underlying work — benchmark, compatibility scan — succeeds. Only the comment-posting plumbing fails, but it takes the whole job down with it. External contributors see two red Xs on a PR that's actually fine. Last hit: PR #1075 ([bench-pr log](https://github.com/rustledger/rustledger/actions/runs/25648039121/job/75281093923), [compat log](https://github.com/rustledger/rustledger/actions/runs/25648039131/job/75281094055)).

## What this changes

| Scenario | Before | After |
|----------|--------|-------|
| Maintainer PR | Comment posted, job green | Comment posted, job green (no change) |
| Fork PR | Comment fails, job red ❌ | Comment fails silently with a log line, job green ✅ |
| Transient API issue on maintainer PR | Job red | Comment fails with a log line, job green |

The trade is: if comment-posting fails on a non-fork PR (transient API hiccup, etc.), we now get a logged warning instead of a job failure. That's the desired behavior — the comment is a convenience, not a correctness gate.

## What this doesn't do

This is Option A from #1093. It doesn't give fork contributors the benchmark / compat comment on the PR thread itself — for that we'd want Option C (restructure with `workflow_run` + elevated permissions). That's filed under #1093 as a possible future enhancement; this PR unblocks the red-X problem now without the restructure.

## Verification

Both YAMLs parse cleanly. The `Post PR comment` steps now have `continue-on-error: true`; compat.yml's `if:` is unchanged (still `github.event_name == 'pull_request'`); the misleading step-name suffix is dropped.

```
$ python3 -c "
import yaml
for f in ['.github/workflows/bench-pr.yml', '.github/workflows/compat.yml']:
    d = yaml.safe_load(open(f))
    for job in d['jobs'].values():
        for step in job.get('steps', []):
            if step.get('name', '').startswith('Post PR comment'):
                print(f, step['name'], 'coe=', step.get('continue-on-error'), 'if=', step.get('if'))
"
.github/workflows/bench-pr.yml Post PR comment coe= True if= None
.github/workflows/compat.yml   Post PR comment coe= True if= github.event_name == 'pull_request'
```

## Test plan

- [x] YAML parses correctly
- [x] Both `Post PR comment` steps have `continue-on-error: true`
- [x] compat.yml step renamed to drop misleading "(release PRs only)" suffix
- [ ] Confirm on next maintainer PR: comment still appears, job still green
- [ ] Confirm on next fork PR (e.g. once #1075 is rebased): job goes green even though comment is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)