### PR TITLE
fix: box BQL expression parser to avoid Apple linker crash

### DIFF
--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -514,9 +514,9 @@ fn at_function<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<'a>
 
 /// Parse an expression (with precedence climbing).
 #[allow(clippy::large_stack_frames)]
-fn expr<'a>() -> impl Parser<'a, ParserInput<'a>, Expr, ParserExtra<'a>> + Clone {
+fn expr<'a>() -> Boxed<'a, 'a, ParserInput<'a>, Expr, ParserExtra<'a>> {
     recursive(|expr| {
-        let primary = primary_expr(expr.clone());
+        let primary = primary_expr(expr.clone()).boxed();
 
         // Unary minus
         let unary = just('-')
@@ -529,32 +529,39 @@ fn expr<'a>() -> impl Parser<'a, ParserInput<'a>, Expr, ParserExtra<'a>> + Clone
                 } else {
                     e
                 }
-            });
+            })
+            .boxed();
 
         // Multiplicative: * / %
-        let multiplicative = unary.clone().foldl(
-            ws().ignore_then(choice((
-                just('*').to(BinaryOperator::Mul),
-                just('/').to(BinaryOperator::Div),
-                just('%').to(BinaryOperator::Mod),
-            )))
-            .then_ignore(ws())
-            .then(unary)
-            .repeated(),
-            |left, (op, right)| Expr::binary(left, op, right),
-        );
+        let multiplicative = unary
+            .clone()
+            .foldl(
+                ws().ignore_then(choice((
+                    just('*').to(BinaryOperator::Mul),
+                    just('/').to(BinaryOperator::Div),
+                    just('%').to(BinaryOperator::Mod),
+                )))
+                .then_ignore(ws())
+                .then(unary)
+                .repeated(),
+                |left, (op, right)| Expr::binary(left, op, right),
+            )
+            .boxed();
 
         // Additive: + -
-        let additive = multiplicative.clone().foldl(
-            ws().ignore_then(choice((
-                just('+').to(BinaryOperator::Add),
-                just('-').to(BinaryOperator::Sub),
-            )))
-            .then_ignore(ws())
-            .then(multiplicative)
-            .repeated(),
-            |left, (op, right)| Expr::binary(left, op, right),
-        );
+        let additive = multiplicative
+            .clone()
+            .foldl(
+                ws().ignore_then(choice((
+                    just('+').to(BinaryOperator::Add),
+                    just('-').to(BinaryOperator::Sub),
+                )))
+                .then_ignore(ws())
+                .then(multiplicative)
+                .repeated(),
+                |left, (op, right)| Expr::binary(left, op, right),
+            )
+            .boxed();
 
         // Comparison: = != < <= > >= ~ !~ IN NOT IN BETWEEN IS NULL
         let comparison = additive
@@ -629,7 +636,8 @@ fn expr<'a>() -> impl Parser<'a, ParserInput<'a>, Expr, ParserExtra<'a>> + Clone
                 } else {
                     expr
                 }
-            });
+            })
+            .boxed();
 
         // NOT
         let not_expr = kw("NOT")
@@ -640,17 +648,21 @@ fn expr<'a>() -> impl Parser<'a, ParserInput<'a>, Expr, ParserExtra<'a>> + Clone
             .map(|(nots, e)| {
                 nots.into_iter()
                     .fold(e, |acc, ()| Expr::unary(UnaryOperator::Not, acc))
-            });
+            })
+            .boxed();
 
         // AND
-        let and_expr = not_expr.clone().foldl(
-            ws1()
-                .ignore_then(kw("AND"))
-                .ignore_then(ws1())
-                .ignore_then(not_expr)
-                .repeated(),
-            |left, right| Expr::binary(left, BinaryOperator::And, right),
-        );
+        let and_expr = not_expr
+            .clone()
+            .foldl(
+                ws1()
+                    .ignore_then(kw("AND"))
+                    .ignore_then(ws1())
+                    .ignore_then(not_expr)
+                    .repeated(),
+                |left, right| Expr::binary(left, BinaryOperator::And, right),
+            )
+            .boxed();
 
         // OR (lowest precedence)
         and_expr.clone().foldl(
@@ -662,6 +674,7 @@ fn expr<'a>() -> impl Parser<'a, ParserInput<'a>, Expr, ParserExtra<'a>> + Clone
             |left, right| Expr::binary(left, BinaryOperator::Or, right),
         )
     })
+    .boxed()
 }
 
 /// Parse comparison operators (excluding IN/NOT IN which are handled specially).

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -621,11 +621,13 @@ pub fn run(args: &Args) -> Result<ExitCode> {
             error_count += 1;
         }
     }
-    let mut warning_count = ledger
+    let warning_count = ledger
         .errors
         .iter()
         .filter(|e| matches!(e.severity, rustledger_loader::ErrorSeverity::Warning))
         .count();
+    #[cfg(feature = "python-plugin-wasm")]
+    let mut warning_count = warning_count;
 
     // === Run CLI-specified WASM plugins as post-processing ===
     // File-declared plugins (native, WASM, Python) are all handled by


### PR DESCRIPTION
## Summary

Original work by @sciyoshi (Samuel Cormier-Iijima) in #1075. Re-opened here with the conformant branch name (`fix/apple-ld-query-parser` instead of `fix-apple-ld-query-parser`) and `cargo fmt` applied so CI runs cleanly. Author preserved on the cherry-picked commit; co-authored trailer added for the rebase/fmt cleanup.

- Box the Chumsky BQL expression parser and major precedence layers so the enormous concrete parser type doesn't produce multi-megabyte Rust symbols that crash Apple's `ld`.
- Keep parser behavior unchanged while allowing Apple `ld` to link the CLI.
- Avoid an `unused_mut` warning when `python-plugin-wasm` is disabled.

## Verification

- `cargo build -p rustledger --no-default-features` ✅
- `cargo build -p rustledger --all-features` ✅
- `cargo test -p rustledger-query` ✅ (137 + 370 + 13 + 3 tests, all passing)
- `cargo clippy -p rustledger-query --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅ (the formatting deltas from the original PR are now applied)

## Why a new PR

The original #1075 had two non-content blockers:

1. Branch name `fix-apple-ld-query-parser` (hyphen) violated the repo's `<type>/<description>` (slash) policy enforced by the Validate branch name workflow.
2. The original commit hadn't been run through `rustfmt` and tripped the Format check.

Both are fixed here. The actual code is byte-identical to sciyoshi's commit before fmt (the diff shows pure rustfmt reflows of the `.foldl(...)` calls after `.boxed()` was added).

The two CI infrastructure failures on #1075 (gitleaks license, fork-PR comment posting) have since been resolved on main via #1094 and #1096.

Closes #1075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)