### PR TITLE
feat(lint): wire up TransferDetector — `rledger lint transfers` + `check --lint`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -25,3 +25,5 @@ commoditiy = "commoditiy"
 qurey = "qurey"
 qeury = "qeury"
 cusotm = "cusotm"
+# Intentional typo for testing --lint argument validation (#1099 / #1111)
+tranfsers = "tranfsers"

--- a/crates/rustledger-ops/src/transfer.rs
+++ b/crates/rustledger-ops/src/transfer.rs
@@ -123,8 +123,10 @@ pub fn find_transfers(
 /// when you have one combined ledger and want all internal transfers
 /// detected without manually splitting by file.
 ///
-/// Directives without a determinable account (non-transactions, or
-/// transactions whose first posting lacks units) are silently dropped.
+/// Non-transaction directives (Open, Balance, Pad, etc.) are skipped at
+/// grouping time. Transactions whose first posting has no units are still
+/// grouped (by that posting's account), but they can never match — the
+/// per-pair predicate requires units on both sides.
 ///
 /// Idempotent: pairs whose transactions already share at least one `^link:`
 /// tag are skipped.

--- a/crates/rustledger-ops/src/transfer.rs
+++ b/crates/rustledger-ops/src/transfer.rs
@@ -8,11 +8,17 @@
 //! - Opposite-sign amounts (within tolerance)
 //! - Same currency
 //! - Dates within a configurable window
-//! - Optional narration keyword boosting (TRANSFER, XFER, ACH, etc.)
+//! - Narration keyword boosting (strong: TRANSFER/XFER/INTERNAL/SWEEP/MOVE;
+//!   weak: PAYMENT/ACH/WIRE — these only boost on same-date matches because
+//!   they alone are too eager: every credit-card payment, every direct
+//!   deposit, etc.)
+//!
+//! Pairs that already share a `^link:` tag are skipped — re-running the
+//! detector against an already-linked ledger is a no-op (idempotent).
 
 use rust_decimal::Decimal;
 use rustledger_plugin_types::{DirectiveData, DirectiveWrapper};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::str::FromStr;
 
 /// Configuration for transfer matching.
@@ -40,22 +46,40 @@ pub struct TransferMatch {
     pub from_group: usize,
     /// Index within that group's directives.
     pub from_index: usize,
+    /// Account name of the debit side (if available).
+    pub from_account: Option<String>,
+    /// Source file of the debit side (if available).
+    pub from_filename: Option<String>,
+    /// Source line number of the debit side (if available).
+    pub from_lineno: Option<u32>,
     /// Index of the destination transaction (credit side) in the second group.
     pub to_group: usize,
     /// Index within that group's directives.
     pub to_index: usize,
+    /// Account name of the credit side (if available).
+    pub to_account: Option<String>,
+    /// Source file of the credit side (if available).
+    pub to_filename: Option<String>,
+    /// Source line number of the credit side (if available).
+    pub to_lineno: Option<u32>,
     /// The matched amount (absolute value).
     pub amount: Decimal,
     /// The matched currency.
     pub currency: String,
     /// Confidence score (0.0 to 1.0).
     pub confidence: f64,
+    /// Date of the debit (from) side, in YYYY-MM-DD form.
+    pub date: String,
 }
 
 /// Find transfer pairs across multiple account import groups.
 ///
-/// Each group is a `(account_name, directives)` pair from a separate import.
-/// Returns matches between groups (never within a single group).
+/// Each group is a `(account_name, directives)` pair. Returns matches between
+/// groups (never within a single group). For "match all transfers across this
+/// ledger regardless of file boundaries," use `find_transfers_in_ledger`.
+///
+/// Idempotent: pairs whose transactions already share at least one `^link:`
+/// tag are skipped.
 #[must_use]
 pub fn find_transfers(
     groups: &[(String, Vec<DirectiveWrapper>)],
@@ -65,6 +89,8 @@ pub fn find_transfers(
     // Track all matched directives globally so a directive in one group
     // cannot be matched by multiple other groups.
     let mut globally_matched: HashSet<(usize, usize)> = HashSet::new();
+
+    let group_accounts: Vec<&str> = groups.iter().map(|(a, _)| a.as_str()).collect();
 
     // Compare each pair of groups
     for (g1, (_, directives1)) in groups.iter().enumerate() {
@@ -78,6 +104,7 @@ pub fn find_transfers(
                 directives1,
                 g2,
                 directives2,
+                &group_accounts,
                 config,
                 &mut matches,
                 &mut globally_matched,
@@ -88,12 +115,46 @@ pub fn find_transfers(
     matches
 }
 
+/// Find transfer pairs across all accounts in a flat directive list.
+///
+/// Groups directives by the **first posting's account** (the "owning"
+/// account of an imported transaction is conventionally the first posting)
+/// and runs the same cross-group matching as `find_transfers`. Use this
+/// when you have one combined ledger and want all internal transfers
+/// detected without manually splitting by file.
+///
+/// Directives without a determinable account (non-transactions, or
+/// transactions whose first posting lacks units) are silently dropped.
+///
+/// Idempotent: pairs whose transactions already share at least one `^link:`
+/// tag are skipped.
+#[must_use]
+pub fn find_transfers_in_ledger(
+    directives: &[DirectiveWrapper],
+    config: &TransferConfig,
+) -> Vec<TransferMatch> {
+    // BTreeMap for deterministic group ordering by account name.
+    let mut by_account: BTreeMap<String, Vec<DirectiveWrapper>> = BTreeMap::new();
+    for d in directives {
+        if let Some(account) = first_posting_account(d) {
+            by_account
+                .entry(account.to_string())
+                .or_default()
+                .push(d.clone());
+        }
+    }
+    let groups: Vec<(String, Vec<DirectiveWrapper>)> = by_account.into_iter().collect();
+    find_transfers(&groups, config)
+}
+
 /// Find matching transactions between two directive lists.
+#[allow(clippy::too_many_arguments)]
 fn find_matches_between(
     g1: usize,
     directives1: &[DirectiveWrapper],
     g2: usize,
     directives2: &[DirectiveWrapper],
+    group_accounts: &[&str],
     config: &TransferConfig,
     matches: &mut Vec<TransferMatch>,
     globally_matched: &mut HashSet<(usize, usize)>,
@@ -132,36 +193,63 @@ fn find_matches_between(
                 continue;
             }
 
-            // Compute confidence
-            let mut confidence: f64 = 0.7; // Base confidence for amount + date match
+            // Idempotency: skip if both txns already share a link. Mark both
+            // as "used" so they can't pair with a third party and produce a
+            // redundant match.
+            if shares_link(d1, d2) {
+                globally_matched.insert((g1, i));
+                globally_matched.insert((g2, j));
+                break;
+            }
 
-            // Boost for transfer-related keywords in narration
-            if has_transfer_keywords(d1) || has_transfer_keywords(d2) {
+            let same_date = d1.date == d2.date;
+
+            // Compute confidence.
+            let mut confidence: f64 = 0.7; // Base for amount + date match
+
+            let kw1 = classify_keywords(d1);
+            let kw2 = classify_keywords(d2);
+            let strong = kw1.strong || kw2.strong;
+            let weak = kw1.weak || kw2.weak;
+            if strong || (weak && same_date) {
                 confidence += 0.2;
             }
 
-            // Boost for exact date match
-            if d1.date == d2.date {
+            if same_date {
                 confidence += 0.1;
             }
 
             let confidence = confidence.min(1.0);
 
             // Determine from/to based on sign
-            let (from_group, from_index, to_group, to_index) = if amount1.is_sign_negative() {
-                (g1, i, g2, j)
-            } else {
-                (g2, j, g1, i)
-            };
+            let (from_group, from_index, to_group, to_index, from, to) =
+                if amount1.is_sign_negative() {
+                    (g1, i, g2, j, d1, d2)
+                } else {
+                    (g2, j, g1, i, d2, d1)
+                };
 
             matches.push(TransferMatch {
                 from_group,
                 from_index,
+                from_account: group_accounts
+                    .get(from_group)
+                    .map(|s| (*s).to_string())
+                    .filter(|s| !s.is_empty()),
+                from_filename: from.filename.clone(),
+                from_lineno: from.lineno,
                 to_group,
                 to_index,
+                to_account: group_accounts
+                    .get(to_group)
+                    .map(|s| (*s).to_string())
+                    .filter(|s| !s.is_empty()),
+                to_filename: to.filename.clone(),
+                to_lineno: to.lineno,
                 amount: amount1.abs(),
                 currency: currency1.to_string(),
                 confidence,
+                date: from.date.clone(),
             });
 
             globally_matched.insert((g1, i));
@@ -183,6 +271,32 @@ fn first_posting_amount_currency(d: &DirectiveWrapper) -> Option<(Decimal, &str)
     None
 }
 
+/// Extract the first posting's account name from a directive.
+fn first_posting_account(d: &DirectiveWrapper) -> Option<&str> {
+    if let DirectiveData::Transaction(txn) = &d.data
+        && let Some(posting) = txn.postings.first()
+    {
+        return Some(posting.account.as_str());
+    }
+    None
+}
+
+/// True if both transactions share at least one `^link:` tag.
+///
+/// `link` strings in `TransactionData::links` are stored without the `^`
+/// sigil, so we compare them directly.
+fn shares_link(a: &DirectiveWrapper, b: &DirectiveWrapper) -> bool {
+    let (DirectiveData::Transaction(txn_a), DirectiveData::Transaction(txn_b)) = (&a.data, &b.data)
+    else {
+        return false;
+    };
+    if txn_a.links.is_empty() || txn_b.links.is_empty() {
+        return false;
+    }
+    let set: HashSet<&str> = txn_a.links.iter().map(String::as_str).collect();
+    txn_b.links.iter().any(|l| set.contains(l.as_str()))
+}
+
 /// Check if two date strings are within a given window (in days).
 fn within_date_window(date1: &str, date2: &str, days: i64) -> bool {
     // Simple date comparison for YYYY-MM-DD format
@@ -201,29 +315,35 @@ fn within_date_window(date1: &str, date2: &str, days: i64) -> bool {
     i64::from(diff) <= days
 }
 
-/// Transfer-related keywords that boost matching confidence.
-const TRANSFER_KEYWORDS: &[&str] = &[
-    "transfer", "xfer", "ach", "wire", "payment", "internal", "move", "sweep",
-];
+/// Strong transfer keywords: explicit transfer language. Boost unconditionally.
+const STRONG_KEYWORDS: &[&str] = &["transfer", "xfer", "internal", "sweep", "move"];
 
-/// Check if a directive's narration contains transfer-related keywords.
-fn has_transfer_keywords(d: &DirectiveWrapper) -> bool {
-    if let DirectiveData::Transaction(txn) = &d.data {
-        let narration_lower = txn.narration.to_lowercase();
-        if TRANSFER_KEYWORDS
+/// Weak keywords: appear on transfers but also on many non-transfers (every
+/// credit-card payment has "payment"; every direct-deposit paycheck is an
+/// ACH credit). Boost only when the two sides also match on date.
+const WEAK_KEYWORDS: &[&str] = &["payment", "ach", "wire"];
+
+#[derive(Default, Clone, Copy)]
+struct KeywordHit {
+    strong: bool,
+    weak: bool,
+}
+
+fn classify_keywords(d: &DirectiveWrapper) -> KeywordHit {
+    let DirectiveData::Transaction(txn) = &d.data else {
+        return KeywordHit::default();
+    };
+    let mut hit = KeywordHit::default();
+    let narration_lower = txn.narration.to_lowercase();
+    let payee_lower = txn.payee.as_deref().unwrap_or("").to_lowercase();
+    let scan = |needles: &[&str]| -> bool {
+        needles
             .iter()
-            .any(|kw| narration_lower.contains(kw))
-        {
-            return true;
-        }
-        if let Some(ref payee) = txn.payee {
-            let payee_lower = payee.to_lowercase();
-            if TRANSFER_KEYWORDS.iter().any(|kw| payee_lower.contains(kw)) {
-                return true;
-            }
-        }
-    }
-    false
+            .any(|kw| narration_lower.contains(kw) || payee_lower.contains(kw))
+    };
+    hit.strong = scan(STRONG_KEYWORDS);
+    hit.weak = scan(WEAK_KEYWORDS);
+    hit
 }
 
 #[cfg(test)]
@@ -232,6 +352,17 @@ mod tests {
     use rustledger_plugin_types::{AmountData, PostingData, TransactionData};
 
     fn make_txn(date: &str, narration: &str, amount: &str, currency: &str) -> DirectiveWrapper {
+        make_txn_with(date, narration, amount, currency, "Assets:Bank", vec![])
+    }
+
+    fn make_txn_with(
+        date: &str,
+        narration: &str,
+        amount: &str,
+        currency: &str,
+        account: &str,
+        links: Vec<String>,
+    ) -> DirectiveWrapper {
         DirectiveWrapper {
             directive_type: "transaction".to_string(),
             date: date.to_string(),
@@ -242,10 +373,10 @@ mod tests {
                 payee: None,
                 narration: narration.to_string(),
                 tags: vec![],
-                links: vec![],
+                links,
                 metadata: vec![],
                 postings: vec![PostingData {
-                    account: "Assets:Bank".to_string(),
+                    account: account.to_string(),
                     units: Some(AmountData {
                         number: amount.to_string(),
                         currency: currency.to_string(),
@@ -257,6 +388,21 @@ mod tests {
                 }],
             }),
         }
+    }
+
+    fn make_txn_loc(
+        date: &str,
+        narration: &str,
+        amount: &str,
+        currency: &str,
+        account: &str,
+        filename: &str,
+        lineno: u32,
+    ) -> DirectiveWrapper {
+        let mut d = make_txn_with(date, narration, amount, currency, account, vec![]);
+        d.filename = Some(filename.to_string());
+        d.lineno = Some(lineno);
+        d
     }
 
     #[test]
@@ -284,7 +430,7 @@ mod tests {
         let matches = find_transfers(&groups, &TransferConfig::default());
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].amount, Decimal::new(50000, 2));
-        assert!(matches[0].confidence > 0.8); // Transfer keywords + exact date
+        assert!(matches[0].confidence > 0.8); // Strong keyword + exact date
     }
 
     #[test]
@@ -391,7 +537,7 @@ mod tests {
         ];
         let matches = find_transfers(&groups, &TransferConfig::default());
         assert_eq!(matches.len(), 1);
-        // Both sides have keywords + exact date = max confidence
+        // Strong keyword + exact date = max
         assert!(matches[0].confidence >= 0.9);
     }
 
@@ -409,7 +555,7 @@ mod tests {
         ];
         let matches = find_transfers(&groups, &TransferConfig::default());
         assert_eq!(matches.len(), 1);
-        // No keywords, different dates = base confidence only
+        // No keywords, different dates = base only
         assert!(matches[0].confidence < 0.8);
     }
 
@@ -437,7 +583,7 @@ mod tests {
 
     #[test]
     fn one_to_one_matching() {
-        // Same amount appears twice — should not double-match
+        // Same amount twice — single savings entry only matches one of them.
         let groups = vec![
             (
                 "Assets:Checking".to_string(),
@@ -452,7 +598,6 @@ mod tests {
             ),
         ];
         let matches = find_transfers(&groups, &TransferConfig::default());
-        // Only one match — the single savings entry can only match one checking entry
         assert_eq!(matches.len(), 1);
     }
 
@@ -473,7 +618,7 @@ mod tests {
             ),
         ];
         let matches = find_transfers(&groups, &TransferConfig::default());
-        // Checking→Savings matches; CreditCard has no opposite-sign match
+        // Checking↔Savings matches; CreditCard has no opposite-sign match
         assert_eq!(matches.len(), 1);
     }
 
@@ -482,5 +627,220 @@ mod tests {
         let groups: Vec<(String, Vec<DirectiveWrapper>)> = vec![];
         let matches = find_transfers(&groups, &TransferConfig::default());
         assert!(matches.is_empty());
+    }
+
+    // ─── Phase 0 — new behavior ────────────────────────────────────────────
+
+    #[test]
+    fn in_ledger_groups_by_first_posting_account() {
+        // Single flat list, transfers between accounts inside it.
+        let directives = vec![
+            make_txn_with(
+                "2024-01-15",
+                "Transfer to savings",
+                "-500.00",
+                "USD",
+                "Assets:Checking",
+                vec![],
+            ),
+            make_txn_with(
+                "2024-01-15",
+                "Transfer from checking",
+                "500.00",
+                "USD",
+                "Assets:Savings",
+                vec![],
+            ),
+        ];
+        let matches = find_transfers_in_ledger(&directives, &TransferConfig::default());
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].from_account.as_deref(), Some("Assets:Checking"));
+        assert_eq!(matches[0].to_account.as_deref(), Some("Assets:Savings"));
+    }
+
+    #[test]
+    fn in_ledger_does_not_match_within_same_account() {
+        // Two txns on the same account can't be a transfer between accounts.
+        let directives = vec![
+            make_txn_with(
+                "2024-01-15",
+                "Out",
+                "-500.00",
+                "USD",
+                "Assets:Checking",
+                vec![],
+            ),
+            make_txn_with(
+                "2024-01-15",
+                "In",
+                "500.00",
+                "USD",
+                "Assets:Checking",
+                vec![],
+            ),
+        ];
+        let matches = find_transfers_in_ledger(&directives, &TransferConfig::default());
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn transfer_match_carries_filename_and_lineno() {
+        let groups = vec![
+            (
+                "Assets:Checking".to_string(),
+                vec![make_txn_loc(
+                    "2024-01-15",
+                    "Transfer",
+                    "-500.00",
+                    "USD",
+                    "Assets:Checking",
+                    "checking.bean",
+                    42,
+                )],
+            ),
+            (
+                "Assets:Savings".to_string(),
+                vec![make_txn_loc(
+                    "2024-01-15",
+                    "Transfer",
+                    "500.00",
+                    "USD",
+                    "Assets:Savings",
+                    "savings.bean",
+                    18,
+                )],
+            ),
+        ];
+        let matches = find_transfers(&groups, &TransferConfig::default());
+        assert_eq!(matches.len(), 1);
+        let m = &matches[0];
+        assert_eq!(m.from_filename.as_deref(), Some("checking.bean"));
+        assert_eq!(m.from_lineno, Some(42));
+        assert_eq!(m.to_filename.as_deref(), Some("savings.bean"));
+        assert_eq!(m.to_lineno, Some(18));
+    }
+
+    #[test]
+    fn already_linked_pair_is_skipped() {
+        let groups = vec![
+            (
+                "Assets:Checking".to_string(),
+                vec![make_txn_with(
+                    "2024-01-15",
+                    "Transfer",
+                    "-500.00",
+                    "USD",
+                    "Assets:Checking",
+                    vec!["xfer-001".to_string()],
+                )],
+            ),
+            (
+                "Assets:Savings".to_string(),
+                vec![make_txn_with(
+                    "2024-01-15",
+                    "Transfer",
+                    "500.00",
+                    "USD",
+                    "Assets:Savings",
+                    vec!["xfer-001".to_string()],
+                )],
+            ),
+        ];
+        let matches = find_transfers(&groups, &TransferConfig::default());
+        assert!(
+            matches.is_empty(),
+            "already-linked pair must not be re-detected; got {matches:?}"
+        );
+    }
+
+    #[test]
+    fn unrelated_links_do_not_block_match() {
+        let groups = vec![
+            (
+                "Assets:Checking".to_string(),
+                vec![make_txn_with(
+                    "2024-01-15",
+                    "Transfer",
+                    "-500.00",
+                    "USD",
+                    "Assets:Checking",
+                    vec!["batch-import-A".to_string()],
+                )],
+            ),
+            (
+                "Assets:Savings".to_string(),
+                vec![make_txn_with(
+                    "2024-01-15",
+                    "Transfer",
+                    "500.00",
+                    "USD",
+                    "Assets:Savings",
+                    vec!["batch-import-B".to_string()],
+                )],
+            ),
+        ];
+        let matches = find_transfers(&groups, &TransferConfig::default());
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn weak_keyword_does_not_boost_when_dates_differ() {
+        let groups = vec![
+            (
+                "Assets:Checking".to_string(),
+                vec![make_txn("2024-01-15", "PAYMENT", "-200.00", "USD")],
+            ),
+            (
+                "Liabilities:Card".to_string(),
+                vec![make_txn("2024-01-17", "PAYMENT", "200.00", "USD")],
+            ),
+        ];
+        let matches = find_transfers(&groups, &TransferConfig::default());
+        assert_eq!(matches.len(), 1);
+        assert!(
+            (matches[0].confidence - 0.7).abs() < 1e-9,
+            "weak keyword + different dates must stay at base 0.7; got {}",
+            matches[0].confidence
+        );
+    }
+
+    #[test]
+    fn weak_keyword_boosts_on_same_date() {
+        let groups = vec![
+            (
+                "Assets:Checking".to_string(),
+                vec![make_txn("2024-01-15", "PAYMENT", "-200.00", "USD")],
+            ),
+            (
+                "Liabilities:Card".to_string(),
+                vec![make_txn("2024-01-15", "PAYMENT", "200.00", "USD")],
+            ),
+        ];
+        let matches = find_transfers(&groups, &TransferConfig::default());
+        assert_eq!(matches.len(), 1);
+        // 0.7 base + 0.2 weak + 0.1 same-date = 1.0
+        assert!(matches[0].confidence > 0.95);
+    }
+
+    #[test]
+    fn strong_keyword_boosts_even_on_different_dates() {
+        let groups = vec![
+            (
+                "Assets:Checking".to_string(),
+                vec![make_txn("2024-01-15", "TRANSFER", "-500.00", "USD")],
+            ),
+            (
+                "Assets:Savings".to_string(),
+                vec![make_txn("2024-01-17", "TRANSFER", "500.00", "USD")],
+            ),
+        ];
+        let matches = find_transfers(&groups, &TransferConfig::default());
+        assert_eq!(matches.len(), 1);
+        // 0.7 base + 0.2 strong = 0.9 (no same-date bonus)
+        assert!(
+            (matches[0].confidence - 0.9).abs() < 1e-9,
+            "strong keyword + different dates: expect 0.9, got {}",
+            matches[0].confidence
+        );
     }
 }

--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -131,6 +131,12 @@ enum Commands {
         action: CompatAction,
     },
 
+    /// Non-fatal advisory passes — e.g., detect inter-account transfer pairs
+    Lint {
+        #[command(flatten)]
+        args: rustledger::cmd::lint::Args,
+    },
+
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for
@@ -431,6 +437,13 @@ fn main() -> ExitCode {
                 }
             }
         }
+        Commands::Lint { args } => match rustledger::cmd::lint::run(&args) {
+            Ok(code) => code,
+            Err(e) => {
+                eprintln!("error: {e:#}");
+                ExitCode::from(1)
+            }
+        },
         Commands::Compat { action } => match action {
             CompatAction::Install { prefix } => {
                 match rustledger::cmd::compat::install(prefix.as_deref()) {

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -28,6 +28,17 @@ pub enum OutputFormat {
     Json,
 }
 
+/// Advisory lints that can be run alongside `check`.
+///
+/// Modeled as an enum (not a free-form `String`) so unknown names like
+/// `--lint tranfsers` fail at argument parsing time instead of silently
+/// no-op'ing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LintName {
+    /// Detect likely unlinked inter-account transfer pairs.
+    Transfers,
+}
+
 /// A diagnostic message in JSON format.
 #[derive(Debug, Serialize)]
 pub struct JsonDiagnostic {
@@ -141,11 +152,10 @@ pub struct Args {
 
     /// Run non-fatal advisory lints alongside validation.
     ///
-    /// Supported names: `transfers` (detect unlinked inter-account transfer
-    /// pairs). Repeatable to enable multiple lints. Findings are emitted as
+    /// Repeatable to enable multiple lints. Findings are emitted as
     /// warnings, never errors — exit code is unaffected.
-    #[arg(long = "lint", value_name = "NAME")]
-    pub lints: Vec<String>,
+    #[arg(long = "lint", value_enum, value_name = "NAME")]
+    pub lints: Vec<LintName>,
 
     /// Minimum confidence (0.0 - 1.0) for `--lint transfers` matches to be
     /// reported. Default 0.8 silences the noisy 0.7 floor.
@@ -751,11 +761,7 @@ pub fn run(args: &Args) -> Result<ExitCode> {
     // here only for the other cfg branch.
     #[cfg(not(feature = "python-plugin-wasm"))]
     let mut warning_count = warning_count;
-    if args
-        .lints
-        .iter()
-        .any(|l| l.eq_ignore_ascii_case("transfers"))
-    {
+    if args.lints.contains(&LintName::Transfers) {
         let mut wrappers: Vec<rustledger_plugin::types::DirectiveWrapper> =
             Vec::with_capacity(spanned_directives.len());
         for spanned in &spanned_directives {

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -138,6 +138,19 @@ pub struct Args {
     /// Output format (text or json)
     #[arg(long, short = 'f', value_enum, default_value = "text")]
     pub format: OutputFormat,
+
+    /// Run non-fatal advisory lints alongside validation.
+    ///
+    /// Supported names: `transfers` (detect unlinked inter-account transfer
+    /// pairs). Repeatable to enable multiple lints. Findings are emitted as
+    /// warnings, never errors — exit code is unaffected.
+    #[arg(long = "lint", value_name = "NAME")]
+    pub lints: Vec<String>,
+
+    /// Minimum confidence (0.0 - 1.0) for `--lint transfers` matches to be
+    /// reported. Default 0.8 silences the noisy 0.7 floor.
+    #[arg(long, default_value_t = 0.8)]
+    pub lint_min_confidence: f64,
 }
 
 /// Run the check command with the given arguments.
@@ -711,7 +724,7 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                     let msg = format!("WASM plugin execution failed: {e}");
                     if json_mode {
                         diagnostics.push(JsonDiagnostic {
-                            file: main_file_str,
+                            file: main_file_str.clone(),
                             line: 1,
                             column: 1,
                             end_line: 1,
@@ -729,6 +742,81 @@ pub fn run(args: &Args) -> Result<ExitCode> {
                     error_count += 1;
                 }
             }
+        }
+    }
+
+    // === Non-fatal advisory lints (--lint NAME) ===
+    // Lint findings are warnings, never errors. They never affect exit code.
+    // Under `python-plugin-wasm` the binding above is already `mut`; rebind
+    // here only for the other cfg branch.
+    #[cfg(not(feature = "python-plugin-wasm"))]
+    let mut warning_count = warning_count;
+    if args
+        .lints
+        .iter()
+        .any(|l| l.eq_ignore_ascii_case("transfers"))
+    {
+        let mut wrappers: Vec<rustledger_plugin::types::DirectiveWrapper> =
+            Vec::with_capacity(spanned_directives.len());
+        for spanned in &spanned_directives {
+            let (filename, lineno) = if let Some(file) = source_map.get(spanned.file_id as usize) {
+                let (line, _col) = file.line_col(spanned.span.start);
+                (
+                    Some(file.path.to_string_lossy().into_owned()),
+                    u32::try_from(line).ok(),
+                )
+            } else {
+                (None, None)
+            };
+            wrappers.push(rustledger_plugin::directive_to_wrapper_with_location(
+                &spanned.value,
+                filename,
+                lineno,
+            ));
+        }
+        let config = rustledger_ops::transfer::TransferConfig::default();
+        let matches: Vec<_> =
+            rustledger_ops::transfer::find_transfers_in_ledger(&wrappers, &config)
+                .into_iter()
+                .filter(|m| m.confidence >= args.lint_min_confidence)
+                .collect();
+        for m in &matches {
+            let msg = format!(
+                "likely transfer pair: {} {} {} → {} (confidence {:.2}); link with ^xfer-... to silence",
+                m.amount,
+                m.currency,
+                m.from_account.as_deref().unwrap_or("?"),
+                m.to_account.as_deref().unwrap_or("?"),
+                m.confidence,
+            );
+            if json_mode {
+                diagnostics.push(JsonDiagnostic {
+                    file: m
+                        .from_filename
+                        .clone()
+                        .unwrap_or_else(|| main_file_str.clone()),
+                    line: m.from_lineno.map_or(1, |n| n as usize),
+                    column: 1,
+                    end_line: m.from_lineno.map_or(1, |n| n as usize),
+                    end_column: 1,
+                    severity: "warning".to_string(),
+                    phase: "lint".to_string(),
+                    code: "LINT-XFER".to_string(),
+                    message: msg,
+                    hint: Some(
+                        "run `rledger lint transfers --apply <files>` to add links".to_string(),
+                    ),
+                    context: None,
+                });
+            } else if !args.quiet {
+                let loc = format!(
+                    "{}:{}",
+                    m.from_filename.as_deref().unwrap_or("?"),
+                    m.from_lineno.map_or_else(|| "?".into(), |n| n.to_string()),
+                );
+                writeln!(stdout, "{loc}: warning[LINT-XFER]: {msg}")?;
+            }
+            warning_count += 1;
         }
     }
 

--- a/crates/rustledger/src/cmd/lint/mod.rs
+++ b/crates/rustledger/src/cmd/lint/mod.rs
@@ -1,0 +1,38 @@
+//! Non-fatal advisory passes — lints.
+//!
+//! `rledger lint <NAME> <ARGS...>` runs a named lint over the given inputs and
+//! reports issues without failing the build. The first lint is `transfers`,
+//! which finds likely inter-account transfer pairs and (optionally) links
+//! them with `^link:` tags.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::process::ExitCode;
+
+pub mod transfers;
+
+/// Run non-fatal advisory passes over one or more beancount files.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// The specific lint to run.
+    #[command(subcommand)]
+    pub lint: LintKind,
+}
+
+/// Available lints.
+#[derive(Subcommand, Debug)]
+pub enum LintKind {
+    /// Detect inter-account transfer pairs.
+    Transfers(transfers::Args),
+}
+
+/// Dispatch to the requested lint.
+///
+/// # Errors
+/// Propagates errors from the underlying lint implementation.
+pub fn run(args: &Args) -> Result<ExitCode> {
+    match &args.lint {
+        LintKind::Transfers(t_args) => transfers::run(t_args),
+    }
+}

--- a/crates/rustledger/src/cmd/lint/transfers.rs
+++ b/crates/rustledger/src/cmd/lint/transfers.rs
@@ -1,0 +1,651 @@
+//! `rledger lint transfers` — detect and (optionally) link inter-account
+//! transfer pairs across one or more beancount files.
+//!
+//! Default behavior is read-only: emit a report of detected pairs plus the
+//! exact `^link:` lines that `--apply` would write. With `--apply`, the
+//! tool edits the source files in place, appending a deterministic
+//! `^xfer-YYYYMMDD-<hash>` link to both sides of each match. Re-running
+//! `--apply` is a no-op because the detector skips pairs that already
+//! share a link.
+
+use anyhow::{Context, Result, anyhow};
+use clap::{Parser, ValueEnum};
+use rust_decimal::Decimal;
+use rustledger_loader::Loader;
+use rustledger_ops::transfer::{TransferConfig, TransferMatch, find_transfers_in_ledger};
+use rustledger_plugin::convert::directive_to_wrapper_with_location;
+use rustledger_plugin::types::DirectiveWrapper;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::str::FromStr;
+
+/// Output format for the report.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable text (default).
+    #[default]
+    Text,
+    /// JSON, one object per detected match.
+    Json,
+}
+
+/// Detect inter-account transfer pairs across imported beancount files.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Beancount files to scan. At least one is required.
+    #[arg(value_name = "FILE", required = true)]
+    pub files: Vec<PathBuf>,
+
+    /// Minimum confidence (0.0 - 1.0) for a match to be reported.
+    ///
+    /// Default 0.8 filters out the bare 0.7 floor (amount + date window only,
+    /// no keyword and not same-date), which tends to be noisy. Pass 0.7 to
+    /// see every match.
+    #[arg(long, default_value_t = 0.8)]
+    pub min_confidence: f64,
+
+    /// Maximum number of days between matched transactions.
+    #[arg(long, default_value_t = 3)]
+    pub date_window: i64,
+
+    /// Amount tolerance for matching (in the transaction currency).
+    #[arg(long, default_value = "0.01")]
+    pub amount_tolerance: String,
+
+    /// Write `^xfer-YYYYMMDD-<hash>` links to source files instead of just
+    /// previewing them.
+    #[arg(long)]
+    pub apply: bool,
+
+    /// Output format.
+    #[arg(long, short = 'f', value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+/// Run the lint.
+///
+/// Exit code: `0` if no matches above the threshold, `0` if matches were
+/// found and reported (this is a lint, not a check — finding matches is not
+/// a failure). Returns a non-zero `ExitCode` only on hard errors (file not
+/// found, parse failure, etc., propagated via `anyhow::Error`).
+///
+/// # Errors
+/// - Fails if any input file does not exist or cannot be parsed.
+/// - Fails if `--apply` is set and a file edit can't be written.
+pub fn run(args: &Args) -> Result<ExitCode> {
+    let tolerance = Decimal::from_str(&args.amount_tolerance)
+        .with_context(|| format!("invalid --amount-tolerance: {}", args.amount_tolerance))?;
+    let config = TransferConfig {
+        date_window_days: args.date_window,
+        amount_tolerance: tolerance,
+    };
+
+    // Load every input file separately so we can attach the file's path to
+    // each directive's `filename`/`lineno` before merging into one flat list.
+    let mut wrappers: Vec<DirectiveWrapper> = Vec::new();
+    for path in &args.files {
+        let resolved = canonicalize_for_report(path)?;
+        let mut loader = Loader::new();
+        let result = loader
+            .load(path)
+            .with_context(|| format!("failed to load {}", path.display()))?;
+
+        for spanned in &result.directives {
+            let (filename, lineno) =
+                if let Some(file) = result.source_map.get(spanned.file_id as usize) {
+                    let (line, _col) = file.line_col(spanned.span.start);
+                    (
+                        Some(file.path.to_string_lossy().into_owned()),
+                        u32::try_from(line).ok(),
+                    )
+                } else {
+                    (Some(resolved.clone()), None)
+                };
+            wrappers.push(directive_to_wrapper_with_location(
+                &spanned.value,
+                filename,
+                lineno,
+            ));
+        }
+    }
+
+    // Run detection. Phase 0's `find_transfers_in_ledger` groups by the
+    // first posting's account and skips pairs that already share a link.
+    let all_matches = find_transfers_in_ledger(&wrappers, &config);
+    let matches: Vec<TransferMatch> = all_matches
+        .into_iter()
+        .filter(|m| m.confidence >= args.min_confidence)
+        .collect();
+
+    if args.apply {
+        apply_links(&matches)?;
+    }
+
+    match args.format {
+        OutputFormat::Text => print_text_report(&matches, args.apply)?,
+        OutputFormat::Json => print_json_report(&matches, args.apply)?,
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Canonicalize a path for stable display in the report. Falls back to the
+/// raw path if canonicalization fails (e.g. file doesn't exist yet during
+/// argument validation).
+fn canonicalize_for_report(path: &std::path::Path) -> Result<String> {
+    if let Ok(canon) = path.canonicalize() {
+        Ok(canon.to_string_lossy().into_owned())
+    } else {
+        Ok(path.to_string_lossy().into_owned())
+    }
+}
+
+// ─── Link-name generation ────────────────────────────────────────────────
+
+/// Build a deterministic, idempotent link name for a match.
+///
+/// Form: `xfer-YYYYMMDD-<hash>` where `<hash>` is a 6-hex-char prefix of
+/// `sha256(from_filename ++ from_lineno ++ to_filename ++ to_lineno ++
+/// amount ++ currency)`. Same conceptual pair → same name across runs, so
+/// re-applying is a no-op (the Phase 0 idempotency filter will then skip
+/// it on the next detection).
+fn link_name_for(m: &TransferMatch) -> String {
+    let date_compact = m.date.replace('-', "");
+    let mut h = Sha256::new();
+    h.update(m.from_filename.as_deref().unwrap_or("").as_bytes());
+    h.update(b"\0");
+    h.update(m.from_lineno.unwrap_or(0).to_le_bytes());
+    h.update(b"\0");
+    h.update(m.to_filename.as_deref().unwrap_or("").as_bytes());
+    h.update(b"\0");
+    h.update(m.to_lineno.unwrap_or(0).to_le_bytes());
+    h.update(b"\0");
+    h.update(m.amount.to_string().as_bytes());
+    h.update(b"\0");
+    h.update(m.currency.as_bytes());
+    let digest = h.finalize();
+    let mut suffix = String::with_capacity(6);
+    for b in digest.iter().take(3) {
+        write!(suffix, "{b:02x}").expect("writing to String never fails");
+    }
+    format!("xfer-{date_compact}-{suffix}")
+}
+
+// ─── File mutation (`--apply`) ───────────────────────────────────────────
+
+/// Apply detected links to source files in place. Each match adds the same
+/// `^xfer-…` link to both the from-side and to-side transaction header
+/// lines. Multiple edits per file are batched into a single read/write
+/// cycle.
+fn apply_links(matches: &[TransferMatch]) -> Result<()> {
+    // Group edits by filename: `filename -> {lineno -> link_name}`.
+    // BTreeMap on the outer key for stable iteration order in tests.
+    let mut edits: BTreeMap<String, BTreeMap<u32, String>> = BTreeMap::new();
+    for m in matches {
+        let name = link_name_for(m);
+        for (file, line) in [
+            (m.from_filename.as_deref(), m.from_lineno),
+            (m.to_filename.as_deref(), m.to_lineno),
+        ] {
+            let (Some(file), Some(line)) = (file, line) else {
+                continue;
+            };
+            edits
+                .entry(file.to_string())
+                .or_default()
+                .insert(line, name.clone());
+        }
+    }
+
+    for (file, line_edits) in edits {
+        apply_file_edits(&file, &line_edits)?;
+    }
+    Ok(())
+}
+
+fn apply_file_edits(path: &str, edits: &BTreeMap<u32, String>) -> Result<()> {
+    let original = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {path} for --apply"))?;
+
+    // Split into lines preserving trailing newline state — we keep the
+    // original line terminators when writing back.
+    let mut lines: Vec<String> = original.split_inclusive('\n').map(String::from).collect();
+
+    for (&lineno, link_name) in edits {
+        let idx = lineno
+            .checked_sub(1)
+            .ok_or_else(|| anyhow!("invalid 0 lineno in {path}"))? as usize;
+        let Some(line) = lines.get_mut(idx) else {
+            return Err(anyhow!(
+                "line {lineno} out of range in {path} ({} total)",
+                lines.len()
+            ));
+        };
+        *line = insert_link_into_header(line, link_name);
+    }
+
+    let new = lines.concat();
+    if new != original {
+        std::fs::write(path, new).with_context(|| format!("failed to write {path}"))?;
+    }
+    Ok(())
+}
+
+/// Append ` ^link_name` to a transaction header line, preserving the
+/// original trailing newline. If the line already contains `^link_name`,
+/// the line is returned unchanged (defensive; the Phase 0 detector should
+/// already filter these out).
+fn insert_link_into_header(line: &str, link_name: &str) -> String {
+    let needle = format!("^{link_name}");
+    let (body, term) = split_terminator(line);
+    if body.split_whitespace().any(|tok| tok == needle) {
+        return line.to_string();
+    }
+    let trimmed = body.trim_end_matches([' ', '\t']);
+    format!("{trimmed} {needle}{term}")
+}
+
+/// Split a line into its body and its trailing newline (`\n`, `\r\n`, or
+/// none).
+fn split_terminator(line: &str) -> (&str, &str) {
+    if let Some(body) = line.strip_suffix("\r\n") {
+        (body, "\r\n")
+    } else if let Some(body) = line.strip_suffix('\n') {
+        (body, "\n")
+    } else {
+        (line, "")
+    }
+}
+
+// ─── Reporting ───────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct JsonMatch<'a> {
+    confidence: f64,
+    date: &'a str,
+    amount: String,
+    currency: &'a str,
+    from: JsonSide<'a>,
+    to: JsonSide<'a>,
+    link_name: String,
+}
+
+#[derive(Serialize)]
+struct JsonSide<'a> {
+    account: Option<&'a str>,
+    filename: Option<&'a str>,
+    lineno: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct JsonReport<'a> {
+    matches: Vec<JsonMatch<'a>>,
+    applied: bool,
+}
+
+fn print_json_report(matches: &[TransferMatch], applied: bool) -> Result<()> {
+    use std::io::Write;
+    let report = JsonReport {
+        matches: matches
+            .iter()
+            .map(|m| JsonMatch {
+                confidence: round_to(m.confidence, 3),
+                date: &m.date,
+                amount: m.amount.to_string(),
+                currency: &m.currency,
+                from: JsonSide {
+                    account: m.from_account.as_deref(),
+                    filename: m.from_filename.as_deref(),
+                    lineno: m.from_lineno,
+                },
+                to: JsonSide {
+                    account: m.to_account.as_deref(),
+                    filename: m.to_filename.as_deref(),
+                    lineno: m.to_lineno,
+                },
+                link_name: link_name_for(m),
+            })
+            .collect(),
+        applied,
+    };
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer_pretty(&mut handle, &report).context("write JSON report")?;
+    writeln!(handle).ok();
+    Ok(())
+}
+
+fn print_text_report(matches: &[TransferMatch], applied: bool) -> Result<()> {
+    use std::io::Write;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    if matches.is_empty() {
+        writeln!(out, "No transfer pairs detected.").ok();
+        return Ok(());
+    }
+
+    writeln!(
+        out,
+        "{} likely transfer{} detected:\n",
+        matches.len(),
+        if matches.len() == 1 { "" } else { "s" }
+    )
+    .ok();
+
+    for m in matches {
+        let link = link_name_for(m);
+        let from_acct = m.from_account.as_deref().unwrap_or("?");
+        let to_acct = m.to_account.as_deref().unwrap_or("?");
+        writeln!(
+            out,
+            "  {} {} {} → {}    confidence {:.2}",
+            m.amount, m.currency, from_acct, to_acct, m.confidence
+        )
+        .ok();
+        writeln!(
+            out,
+            "    from: {}:{}  {}",
+            m.from_filename.as_deref().unwrap_or("?"),
+            m.from_lineno.map_or_else(|| "?".into(), |n| n.to_string()),
+            m.date,
+        )
+        .ok();
+        writeln!(
+            out,
+            "    to:   {}:{}",
+            m.to_filename.as_deref().unwrap_or("?"),
+            m.to_lineno.map_or_else(|| "?".into(), |n| n.to_string()),
+        )
+        .ok();
+        writeln!(
+            out,
+            "    {} ^{link}",
+            if applied { "applied:" } else { "would add:" }
+        )
+        .ok();
+        writeln!(out).ok();
+    }
+
+    if !applied {
+        writeln!(out, "Run with --apply to write these links.").ok();
+    }
+    Ok(())
+}
+
+fn round_to(x: f64, places: u32) -> f64 {
+    let mult = 10f64.powi(places as i32);
+    (x * mult).round() / mult
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustledger_plugin::types::{AmountData, DirectiveData, PostingData, TransactionData};
+
+    fn match_with(
+        date: &str,
+        from_file: &str,
+        from_line: u32,
+        to_file: &str,
+        to_line: u32,
+    ) -> TransferMatch {
+        TransferMatch {
+            from_group: 0,
+            from_index: 0,
+            from_account: Some("Assets:Checking".into()),
+            from_filename: Some(from_file.into()),
+            from_lineno: Some(from_line),
+            to_group: 1,
+            to_index: 0,
+            to_account: Some("Assets:Savings".into()),
+            to_filename: Some(to_file.into()),
+            to_lineno: Some(to_line),
+            amount: Decimal::new(50000, 2),
+            currency: "USD".into(),
+            confidence: 0.95,
+            date: date.into(),
+        }
+    }
+
+    #[test]
+    fn link_name_is_deterministic() {
+        let m = match_with("2024-01-15", "a.bean", 10, "b.bean", 20);
+        let n1 = link_name_for(&m);
+        let n2 = link_name_for(&m);
+        assert_eq!(n1, n2, "same match must produce same link name");
+        assert!(n1.starts_with("xfer-20240115-"));
+        assert_eq!(n1.len(), "xfer-YYYYMMDD-XXXXXX".len());
+    }
+
+    #[test]
+    fn link_name_differs_for_different_pairs() {
+        let m1 = match_with("2024-01-15", "a.bean", 10, "b.bean", 20);
+        let m2 = match_with("2024-01-15", "a.bean", 11, "b.bean", 20);
+        assert_ne!(link_name_for(&m1), link_name_for(&m2));
+    }
+
+    #[test]
+    fn insert_link_appends_to_header_preserving_newline() {
+        let line = "2024-01-15 * \"Transfer\"\n";
+        let out = insert_link_into_header(line, "xfer-20240115-abcdef");
+        assert_eq!(out, "2024-01-15 * \"Transfer\" ^xfer-20240115-abcdef\n");
+    }
+
+    #[test]
+    fn insert_link_handles_crlf() {
+        let line = "2024-01-15 * \"Transfer\"\r\n";
+        let out = insert_link_into_header(line, "xfer-20240115-abcdef");
+        assert_eq!(out, "2024-01-15 * \"Transfer\" ^xfer-20240115-abcdef\r\n");
+    }
+
+    #[test]
+    fn insert_link_strips_trailing_whitespace_before_appending() {
+        let line = "2024-01-15 * \"Transfer\"   \n";
+        let out = insert_link_into_header(line, "xfer-20240115-abcdef");
+        assert_eq!(out, "2024-01-15 * \"Transfer\" ^xfer-20240115-abcdef\n");
+    }
+
+    #[test]
+    fn insert_link_is_idempotent_when_already_present() {
+        let line = "2024-01-15 * \"Transfer\" ^xfer-20240115-abcdef\n";
+        let out = insert_link_into_header(line, "xfer-20240115-abcdef");
+        assert_eq!(out, line, "already-present link must not be duplicated");
+    }
+
+    #[test]
+    fn insert_link_adds_alongside_existing_unrelated_link() {
+        let line = "2024-01-15 * \"Transfer\" ^batch-import-A\n";
+        let out = insert_link_into_header(line, "xfer-20240115-abcdef");
+        assert_eq!(
+            out,
+            "2024-01-15 * \"Transfer\" ^batch-import-A ^xfer-20240115-abcdef\n"
+        );
+    }
+
+    #[test]
+    fn insert_link_handles_no_terminator() {
+        let line = "2024-01-15 * \"Transfer\"";
+        let out = insert_link_into_header(line, "xfer-20240115-abcdef");
+        assert_eq!(out, "2024-01-15 * \"Transfer\" ^xfer-20240115-abcdef");
+    }
+
+    /// Integration test: write two beancount files representing a transfer
+    /// pair, run the lint end-to-end with `--apply`, and verify the files
+    /// now contain matching `^xfer-…` links and that re-running is a no-op.
+    #[test]
+    fn end_to_end_apply_writes_and_is_idempotent() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let checking = dir.path().join("checking.bean");
+        let savings = dir.path().join("savings.bean");
+        std::fs::write(
+            &checking,
+            "2024-01-01 open Assets:Checking USD\n\
+             \n\
+             2024-01-15 * \"Transfer to savings\"\n  \
+             Assets:Checking  -500.00 USD\n  \
+             Assets:Savings    500.00 USD\n",
+        )?;
+        std::fs::write(
+            &savings,
+            "2024-01-01 open Assets:Savings USD\n\
+             \n\
+             2024-01-15 * \"Transfer from checking\"\n  \
+             Assets:Savings    500.00 USD\n  \
+             Assets:Checking  -500.00 USD\n",
+        )?;
+
+        let args = Args {
+            files: vec![checking.clone(), savings.clone()],
+            min_confidence: 0.8,
+            date_window: 3,
+            amount_tolerance: "0.01".to_string(),
+            apply: true,
+            format: OutputFormat::Json,
+        };
+
+        // First run: should apply links.
+        let _ = run(&args)?;
+        let after_checking = std::fs::read_to_string(&checking)?;
+        let after_savings = std::fs::read_to_string(&savings)?;
+        assert!(
+            after_checking.contains("^xfer-20240115-"),
+            "checking file should have a link: {after_checking}"
+        );
+        assert!(
+            after_savings.contains("^xfer-20240115-"),
+            "savings file should have a link: {after_savings}"
+        );
+
+        // Second run: idempotent — files unchanged.
+        let _ = run(&args)?;
+        let final_checking = std::fs::read_to_string(&checking)?;
+        let final_savings = std::fs::read_to_string(&savings)?;
+        assert_eq!(
+            after_checking, final_checking,
+            "second --apply run must not modify the checking file"
+        );
+        assert_eq!(
+            after_savings, final_savings,
+            "second --apply run must not modify the savings file"
+        );
+
+        Ok(())
+    }
+
+    /// Verify --min-confidence actually filters.
+    #[test]
+    fn min_confidence_filters_low_confidence_matches() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let a = dir.path().join("a.bean");
+        let b = dir.path().join("b.bean");
+        // No keyword, dates 2 days apart → confidence 0.7 (base only).
+        std::fs::write(
+            &a,
+            "2024-01-01 open Assets:A USD\n\
+             2024-01-15 * \"Something\"\n  \
+             Assets:A  -100.00 USD\n  \
+             Assets:Other  100.00 USD\n",
+        )?;
+        std::fs::write(
+            &b,
+            "2024-01-01 open Assets:B USD\n\
+             2024-01-17 * \"Something else\"\n  \
+             Assets:B   100.00 USD\n  \
+             Assets:Other  -100.00 USD\n",
+        )?;
+
+        // At default 0.8, no match should be reported.
+        let args = Args {
+            files: vec![a.clone(), b],
+            min_confidence: 0.8,
+            date_window: 3,
+            amount_tolerance: "0.01".to_string(),
+            apply: false,
+            format: OutputFormat::Json,
+        };
+        // run() returns ExitCode::SUCCESS regardless; we instead verify that
+        // re-running with --apply doesn't add any links (because filtered).
+        let apply_args = Args {
+            apply: true,
+            ..clone_args(&args)
+        };
+        let _ = run(&apply_args)?;
+        let after_a = std::fs::read_to_string(&a)?;
+        assert!(
+            !after_a.contains("^xfer-"),
+            "0.7-confidence match must be filtered by default min_confidence 0.8; got {after_a}"
+        );
+
+        // At 0.7, the same match should now be applied.
+        let permissive = Args {
+            min_confidence: 0.7,
+            apply: true,
+            ..clone_args(&args)
+        };
+        let _ = run(&permissive)?;
+        let after_a2 = std::fs::read_to_string(&a)?;
+        assert!(
+            after_a2.contains("^xfer-"),
+            "with min_confidence 0.7 the 0.7-confidence match should be applied; got {after_a2}"
+        );
+        Ok(())
+    }
+
+    fn clone_args(a: &Args) -> Args {
+        Args {
+            files: a.files.clone(),
+            min_confidence: a.min_confidence,
+            date_window: a.date_window,
+            amount_tolerance: a.amount_tolerance.clone(),
+            apply: a.apply,
+            format: a.format,
+        }
+    }
+
+    #[test]
+    fn no_match_within_same_account() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let f = dir.path().join("single.bean");
+        // Two transactions on the same account — algorithm shouldn't pair them.
+        std::fs::write(
+            &f,
+            "2024-01-01 open Assets:Single USD\n\
+             2024-01-15 * \"Out\"\n  \
+             Assets:Single  -500.00 USD\n  \
+             Equity:Misc  500.00 USD\n\
+             2024-01-15 * \"In\"\n  \
+             Assets:Single   500.00 USD\n  \
+             Equity:Misc  -500.00 USD\n",
+        )?;
+        let args = Args {
+            files: vec![f.clone()],
+            min_confidence: 0.7, // permissive so we'd see the match if it existed
+            date_window: 3,
+            amount_tolerance: "0.01".to_string(),
+            apply: true,
+            format: OutputFormat::Json,
+        };
+        let _ = run(&args)?;
+        let after = std::fs::read_to_string(&f)?;
+        assert!(
+            !after.contains("^xfer-"),
+            "same-account transactions must not be paired"
+        );
+        Ok(())
+    }
+
+    // Silence unused import warning when not building this module.
+    #[allow(dead_code)]
+    fn _unused_imports() {
+        let _: DirectiveData;
+        let _: TransactionData;
+        let _: PostingData;
+        let _: AmountData;
+    }
+}

--- a/crates/rustledger/src/cmd/lint/transfers.rs
+++ b/crates/rustledger/src/cmd/lint/transfers.rs
@@ -29,7 +29,7 @@ pub enum OutputFormat {
     /// Human-readable text (default).
     #[default]
     Text,
-    /// JSON, one object per detected match.
+    /// JSON: a single object with a `matches` array and an `applied` flag.
     Json,
 }
 

--- a/crates/rustledger/src/cmd/mod.rs
+++ b/crates/rustledger/src/cmd/mod.rs
@@ -11,6 +11,7 @@ pub mod config_cmd;
 pub mod doctor;
 pub mod extract_cmd;
 pub mod format;
+pub mod lint;
 pub mod price;
 pub mod price_cmd;
 pub mod query;

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -333,12 +333,17 @@ fn test_lint_transfers_apply_is_idempotent() {
 
     let bin = require_rledger!();
     // First apply.
-    let _ = Command::new(&bin)
+    let first = Command::new(&bin)
         .args(["lint", "transfers", "--apply"])
         .arg(&checking)
         .arg(&savings)
         .output()
         .expect("first --apply");
+    assert!(
+        first.status.success(),
+        "first --apply must exit 0. stderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
     let after_first = std::fs::read_to_string(&checking).unwrap();
     assert!(
         after_first.contains("^xfer-20240115-"),
@@ -346,12 +351,17 @@ fn test_lint_transfers_apply_is_idempotent() {
     );
 
     // Second apply must be a no-op.
-    let _ = Command::new(&bin)
+    let second = Command::new(&bin)
         .args(["lint", "transfers", "--apply"])
         .arg(&checking)
         .arg(&savings)
         .output()
         .expect("second --apply");
+    assert!(
+        second.status.success(),
+        "second --apply must exit 0. stderr: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
     let after_second = std::fs::read_to_string(&checking).unwrap();
     assert_eq!(
         after_first, after_second,
@@ -362,6 +372,24 @@ fn test_lint_transfers_apply_is_idempotent() {
 // =============================================================================
 // rledger check --lint transfers tests (Phase 2)
 // =============================================================================
+
+#[test]
+fn test_check_with_lint_unknown_name_rejected_at_parse_time() {
+    // ValueEnum should reject typos at clap parse time, not silently no-op.
+    let output = Command::new(require_rledger!())
+        .args(["check", "--lint", "tranfsers", "/tmp/whatever.bean"])
+        .output()
+        .expect("Failed to run rledger check --lint tranfsers");
+    assert!(
+        !output.status.success(),
+        "unknown lint name must fail at argument parsing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("tranfsers") || stderr.contains("invalid value"),
+        "expected clap to flag the typo, got stderr: {stderr}"
+    );
+}
 
 #[test]
 fn test_check_with_lint_transfers_emits_warning_but_succeeds() {

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -246,8 +246,159 @@ fn test_check_ambiguous_lot_match_reports_once() {
 }
 
 // =============================================================================
-// rledger query tests
+// rledger lint transfers tests
 // =============================================================================
+
+#[test]
+fn test_lint_transfers_help() {
+    let output = Command::new(require_rledger!())
+        .args(["lint", "transfers", "--help"])
+        .output()
+        .expect("Failed to run rledger lint transfers --help");
+    assert!(output.status.success(), "Help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("min-confidence") || stdout.contains("min_confidence"),
+        "help should mention --min-confidence flag: {stdout}"
+    );
+}
+
+#[test]
+fn test_lint_transfers_detects_pair_across_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checking = dir.path().join("checking.bean");
+    let savings = dir.path().join("savings.bean");
+    std::fs::write(
+        &checking,
+        "2024-01-01 open Assets:Checking USD\n\
+         \n\
+         2024-01-15 * \"Transfer to savings\"\n  \
+         Assets:Checking  -500.00 USD\n  \
+         Assets:Savings    500.00 USD\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &savings,
+        "2024-01-01 open Assets:Savings USD\n\
+         \n\
+         2024-01-15 * \"Transfer from checking\"\n  \
+         Assets:Savings    500.00 USD\n  \
+         Assets:Checking  -500.00 USD\n",
+    )
+    .unwrap();
+
+    let output = Command::new(require_rledger!())
+        .args(["lint", "transfers", "--format", "json"])
+        .arg(&checking)
+        .arg(&savings)
+        .output()
+        .expect("Failed to run rledger lint transfers");
+    assert!(
+        output.status.success(),
+        "lint should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("xfer-20240115-"),
+        "expected link_name in JSON output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"applied\": false") || stdout.contains("\"applied\":false"),
+        "without --apply, JSON should show applied=false: {stdout}"
+    );
+}
+
+#[test]
+fn test_lint_transfers_apply_is_idempotent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let checking = dir.path().join("checking.bean");
+    let savings = dir.path().join("savings.bean");
+    std::fs::write(
+        &checking,
+        "2024-01-01 open Assets:Checking USD\n\
+         2024-01-15 * \"Transfer to savings\"\n  \
+         Assets:Checking  -500.00 USD\n  \
+         Assets:Savings    500.00 USD\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &savings,
+        "2024-01-01 open Assets:Savings USD\n\
+         2024-01-15 * \"Transfer from checking\"\n  \
+         Assets:Savings    500.00 USD\n  \
+         Assets:Checking  -500.00 USD\n",
+    )
+    .unwrap();
+
+    let bin = require_rledger!();
+    // First apply.
+    let _ = Command::new(&bin)
+        .args(["lint", "transfers", "--apply"])
+        .arg(&checking)
+        .arg(&savings)
+        .output()
+        .expect("first --apply");
+    let after_first = std::fs::read_to_string(&checking).unwrap();
+    assert!(
+        after_first.contains("^xfer-20240115-"),
+        "first --apply should add link: {after_first}"
+    );
+
+    // Second apply must be a no-op.
+    let _ = Command::new(&bin)
+        .args(["lint", "transfers", "--apply"])
+        .arg(&checking)
+        .arg(&savings)
+        .output()
+        .expect("second --apply");
+    let after_second = std::fs::read_to_string(&checking).unwrap();
+    assert_eq!(
+        after_first, after_second,
+        "second --apply must not modify the file (idempotency); got:\n{after_second}"
+    );
+}
+
+// =============================================================================
+// rledger check --lint transfers tests (Phase 2)
+// =============================================================================
+
+#[test]
+fn test_check_with_lint_transfers_emits_warning_but_succeeds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let combined = dir.path().join("combined.bean");
+    std::fs::write(
+        &combined,
+        "option \"operating_currency\" \"USD\"\n\
+         2024-01-01 open Assets:Checking USD\n\
+         2024-01-01 open Assets:Savings USD\n\
+         \n\
+         2024-01-15 * \"Transfer to savings\"\n  \
+         Assets:Checking  -500.00 USD\n  \
+         Assets:Savings    500.00 USD\n\
+         \n\
+         2024-01-15 * \"Transfer from checking\"\n  \
+         Assets:Savings    500.00 USD\n  \
+         Assets:Checking  -500.00 USD\n",
+    )
+    .unwrap();
+
+    let output = Command::new(require_rledger!())
+        .args(["check", "--lint", "transfers", "-f", "json"])
+        .arg(&combined)
+        .output()
+        .expect("Failed to run rledger check --lint transfers");
+    assert!(
+        output.status.success(),
+        "check --lint should still exit 0 — lint is non-fatal. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("LINT-XFER"),
+        "expected LINT-XFER diagnostic, got: {stdout}"
+    );
+}
 
 #[test]
 fn test_query_version() {


### PR DESCRIPTION
## Summary

Implements all three actionable phases of #1099 in a single PR:

- **Phase 0**: Reshape `rustledger-ops::transfer` API so the detector groups by account (not by file), carries source location through `TransferMatch`, is idempotent against already-linked pairs, and uses a tightened keyword list.
- **Phase 1**: New `rledger lint <NAME>` subcommand with `transfers` as the first lint. Default dry-run shows the exact `^xfer-YYYYMMDD-HEX` diff each match would write; `--apply` mutates files in place.
- **Phase 2**: New `--lint NAME` flag on `rledger check` that surfaces transfer findings as `LINT-XFER` warnings without affecting exit code.

Phase 3 (MCP tool) is intentionally deferred per the plan in #1099 — adding speculative WASM re-exports for one lint is not worth the bundle bloat.

Closes #1099.

## What changed

### `crates/rustledger-ops/src/transfer.rs`

- **`find_transfers_in_ledger(directives, config)`** — new entry point that groups directives by their first posting's account internally, then runs the existing cross-group matching. Original `find_transfers(groups, config)` is preserved for callers who already have groups.
- **Filename / lineno / date / account** propagated through `TransferMatch` (was `(group_idx, dir_idx)` pairs, which need the original input arrays to be useful).
- **Idempotency built into the detector**: `shares_link()` filter skips pairs whose transactions share any `^link:`. Re-running against a linked ledger is a true no-op.
- **Tightened keyword tiers**: `STRONG` (`transfer`, `xfer`, `internal`, `sweep`, `move`) always boosts +0.2; `WEAK` (`payment`, `ach`, `wire`) only boosts when the pair is also same-date. The old list flat-boosted "payment" / "ach", which falsely matched every CC payment and direct deposit.
- 8 new unit tests on top of the existing 12; all 20 pass.

### `crates/rustledger/src/cmd/lint/` (new)

- `mod.rs` — subcommand dispatcher (extensible to future lints).
- `transfers.rs` — the lint implementation. Loads each input file via `rustledger_loader::Loader`, plumbs filename + line number from the source map into the directive wrappers, runs `find_transfers_in_ledger`, filters by `--min-confidence` (default 0.8), and either reports or applies.
- Apply path: per file, batch all line edits, append `^xfer-YYYYMMDD-HEX` to the transaction header line (CRLF/LF aware, alongside any existing unrelated `^link`s, no-op if the link is already present).
- Link names are 6-hex-char sha256-derived — same conceptual pair always gets the same name, so re-applying converges to the exact same file content.
- 8 new unit tests covering link generation, header-line mutation, end-to-end apply + idempotency, and `--min-confidence` filtering.

### `crates/rustledger/src/cmd/check.rs`

- New `--lint NAME` (repeatable) and `--lint-min-confidence` flags.
- After validation and plugins, if `transfers` was requested, run the detector and emit one `phase="lint"`, `code="LINT-XFER"` warning per match. Exit code is unchanged — these are advisory.

### `crates/rustledger/src/bin/rledger.rs` + `cmd/mod.rs`

- Register the new `Lint` subcommand and module.

### `crates/rustledger/tests/cli_commands_test.rs`

- 4 new end-to-end CLI tests:
  - `rledger lint transfers --help` shows the flags
  - `rledger lint transfers --format json` detects a cross-file pair and emits the expected link name
  - `rledger lint transfers --apply` is idempotent across repeated runs
  - `rledger check --lint transfers` emits `LINT-XFER` warnings and still exits 0

## Why this shape

Per the deep-design discussion in #1099:

1. **Group by account, not by file** — the old API took `(account_name, directives)` groups but never actually read the `account_name`. The file/group correspondence was incidental, and forcing the CLI caller to pre-split inputs by file was friction. Grouping by `posting.account` inside the detector makes single-file workflows and the validation pass work without any extra plumbing.
2. **Dry-run with diff preview as the default v1** — a read-only "here are the matches" report is just a fancier `grep`. The slow half of the manual workflow is editing two transactions per pair. Showing the proposed edits inline addresses that.
3. **Idempotency in the detector, not in callers** — every caller would need the same "are these already linked?" filter otherwise; building it in once at the algorithm boundary is cheaper and safer.
4. **Tighter keywords** — "payment" / "ach" were flat-boosting confidence by +0.2 even though they fire on every CC payment and direct deposit. Now they only boost on same-date pairs, which is when they're informative.

## Test plan

- [x] `cargo test -p rustledger-ops --all-features` — 96 tests pass (20 in `transfer::tests`, including 8 new for Phase 0 behaviors)
- [x] `cargo test -p rustledger --all-features` — all crate tests pass, including 12 new (8 lint unit + 4 CLI integration)
- [x] `cargo clippy -p rustledger-ops -p rustledger --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Pre-push workspace-wide `cargo check --all-features --all-targets` passed

## Notes

- The `--format yaml` option mentioned in #1099 is not included; adding a yaml dependency for one CLI flag wasn't worth it. `text` and `json` are supported. Easy to add if anyone asks.
- The `find_transfers(groups, ...)` API is preserved for backwards compatibility — `find_transfers_in_ledger` is just a wrapper that builds groups internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
