### PR TITLE
fix(query): split format vs format_amount semantics — recover BQL compat (refs #1112)

### DIFF
--- a/crates/rustledger-core/src/display_context.rs
+++ b/crates/rustledger-core/src/display_context.rs
@@ -451,9 +451,64 @@ impl DisplayContext {
     }
 
     /// Format an amount (number + currency) using the tracked precision.
+    ///
+    /// Unlike [`Self::format`] (which preserves over-scale arithmetic
+    /// precision to match Python `bean-query`'s `DecimalRenderer` for
+    /// scalar `Value::Number` results), this method always *quantizes* to
+    /// the currency's tracked dp — matching bean-query's `AmountRenderer`
+    /// for Amounts, Positions, and Inventory entries.
+    ///
+    /// Python uses two distinct renderers for the two semantic kinds of
+    /// output:
+    ///
+    /// - `DecimalRenderer` for naked decimals (preserves scale, since
+    ///   Python `decimal` carries scale through arithmetic).
+    /// - `AmountRenderer` for amount-typed values (uses the ledger's
+    ///   display context per-currency dp, which is the user-facing
+    ///   "how many decimal places does this currency render at" setting).
+    ///
+    /// Rust used to conflate the two through a single `format` call,
+    /// which is why #1103's fix (preserving scale in `format`) inadvertently
+    /// regressed the BQL compat suite by ~7pp on queries that produce
+    /// `Value::Inventory` — the position amounts inside the inventory now
+    /// render with raw arithmetic scale instead of the currency's display
+    /// dp. See #1112 for the regression analysis.
     #[must_use]
     pub fn format_amount(&self, number: Decimal, currency: &str) -> String {
-        format!("{} {}", self.format(number, currency), currency)
+        format!("{} {}", self.format_quantized(number, currency), currency)
+    }
+
+    /// Format the number portion of an Amount/Position (no currency
+    /// suffix), quantized to the tracked dp.
+    ///
+    /// Used by the BQL `numberify` rendering path that strips the
+    /// currency from positions/inventories — same semantics as
+    /// [`Self::format_amount`] but without the trailing ` <CURRENCY>`.
+    #[must_use]
+    pub fn format_amount_number(&self, number: Decimal, currency: &str) -> String {
+        self.format_quantized(number, currency)
+    }
+
+    /// Internal: quantize `number` to `currency`'s tracked dp (rounding
+    /// and padding) and stringify. Falls back to natural representation
+    /// when the currency is untracked.
+    fn format_quantized(&self, number: Decimal, currency: &str) -> String {
+        let raw = match self.get_precision(currency) {
+            Some(dp) => {
+                let mut rounded = number.round_dp(dp);
+                // `round_dp` leaves a smaller scale than `dp` when the
+                // input had fewer dp; `rescale` pads with trailing zeros
+                // to exactly `dp`.
+                rounded.rescale(dp);
+                rounded.to_string()
+            }
+            None => number.normalize().to_string(),
+        };
+        if self.render_commas {
+            Self::add_commas(&raw)
+        } else {
+            raw
+        }
     }
 
     /// Format a Decimal that has no associated currency.
@@ -892,6 +947,55 @@ mod tests {
         // Value scale ≤ tracked dp → pad up (unchanged from #988 fix).
         assert_eq!(ctx.format(dec!(7.5), "USD"), "7.50");
         assert_eq!(ctx.format(dec!(0), "USD"), "0.00");
+    }
+
+    /// Pins the post-#1112 fix: `format` and `format_amount` must NOT share
+    /// rounding behavior.
+    ///
+    /// `format` (used for scalar `Value::Number`) preserves the Decimal's
+    /// arithmetic scale — matches Python `DecimalRenderer`. `format_amount`
+    /// (used for Amounts/Positions/Inventory) quantizes to the currency's
+    /// tracked dp — matches Python `AmountRenderer`. Conflating them is
+    /// what caused the 7pp BQL compat regression on main since #1106.
+    #[test]
+    fn test_format_vs_format_amount_split_semantics() {
+        let mut ctx = DisplayContext::new();
+        ctx.update(dec!(100.00), "USD");
+        ctx.update(dec!(50.25), "USD");
+        assert_eq!(ctx.get_precision("USD"), Some(2));
+
+        // `format`: scalar Number → preserve arithmetic scale (over and under).
+        assert_eq!(ctx.format(dec!(-1202.00896), "USD"), "-1202.00896");
+        assert_eq!(ctx.format(dec!(7.5), "USD"), "7.50");
+
+        // `format_amount`: Amount → quantize to tracked dp (over and under).
+        assert_eq!(ctx.format_amount(dec!(-1202.00896), "USD"), "-1202.01 USD");
+        assert_eq!(ctx.format_amount(dec!(7.5), "USD"), "7.50 USD");
+        // Cost-spec interpolation can produce 26-digit per-unit values; the
+        // Amount renderer must clamp those to the currency's display dp.
+        assert_eq!(
+            ctx.format_amount(dec!(170.16449234259784458309699376), "USD"),
+            "170.16 USD"
+        );
+
+        // `format_amount_number`: same quantize semantics, no currency suffix.
+        assert_eq!(
+            ctx.format_amount_number(dec!(-1202.00896), "USD"),
+            "-1202.01"
+        );
+        assert_eq!(ctx.format_amount_number(dec!(7.5), "USD"), "7.50");
+    }
+
+    /// Untracked currencies fall through to natural rendering in both
+    /// `format` and `format_amount`. Trailing zeros are stripped because
+    /// there's no display-precision target to pad against.
+    #[test]
+    fn test_format_amount_untracked_currency_uses_natural_scale() {
+        let ctx = DisplayContext::new();
+        // No prior `update` calls — get_precision("USD") returns None.
+        assert_eq!(ctx.format_amount(dec!(170.164), "USD"), "170.164 USD");
+        assert_eq!(ctx.format_amount(dec!(7.5), "USD"), "7.5 USD");
+        assert_eq!(ctx.format_amount(dec!(100), "USD"), "100 USD");
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -476,7 +476,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
         }
         Value::Position(p) => {
             if numberify {
-                ctx.format(p.units.number, p.units.currency.as_str())
+                ctx.format_amount_number(p.units.number, p.units.currency.as_str())
             } else {
                 let mut s = ctx.format_amount(p.units.number, p.units.currency.as_str());
                 if let Some(ref cost) = p.cost {
@@ -547,7 +547,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
                 .filter(|p| !position_renders_as_zero(p, ctx))
                 .map(|p| {
                     if numberify {
-                        ctx.format(p.units.number, p.units.currency.as_str())
+                        ctx.format_amount_number(p.units.number, p.units.currency.as_str())
                     } else {
                         let mut s = ctx.format_amount(p.units.number, p.units.currency.as_str());
                         if let Some(ref cost) = p.cost {

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -469,7 +469,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
         Value::Boolean(b) => b.to_string(),
         Value::Amount(a) => {
             if numberify {
-                ctx.format(a.number, a.currency.as_str())
+                ctx.format_amount_number(a.number, a.currency.as_str())
             } else {
                 ctx.format_amount(a.number, a.currency.as_str())
             }
@@ -800,6 +800,33 @@ mod tests {
             rendered.contains("-0.01"),
             "-0.01 USD is exactly at USD precision; must still render. Got {rendered:?}"
         );
+    }
+
+    /// Pins post-#1113 fix: all three amount-typed values (`Value::Amount`,
+    /// `Value::Position`, `Value::Inventory`) must quantize to the
+    /// currency's tracked dp under `--numberify`, not preserve raw
+    /// arithmetic scale. Was a Copilot-review catch on #1113 — the
+    /// `Value::Amount` arm had been left on `format` while the other two
+    /// were moved to `format_amount_number`.
+    #[test]
+    fn test_numberify_quantizes_all_amount_kinds_consistently() {
+        let mut ctx = DisplayContext::new();
+        // USD tracked at 2dp.
+        ctx.update(dec!(100.00), "USD");
+        ctx.update(dec!(50.25), "USD");
+
+        let over_scale = dec!(-1202.00896);
+
+        // Each of Amount, Position, Inventory wraps the same scale-5 value.
+        let amount_val = Value::Amount(Amount::new(over_scale, "USD"));
+        let pos_val = Value::Position(Box::new(Position::simple(Amount::new(over_scale, "USD"))));
+        let mut inv = Inventory::new();
+        inv.add(Position::simple(Amount::new(over_scale, "USD")));
+        let inv_val = Value::Inventory(Box::new(inv));
+
+        assert_eq!(format_value(&amount_val, true, &ctx), "-1202.01");
+        assert_eq!(format_value(&pos_val, true, &ctx), "-1202.01");
+        assert_eq!(format_value(&inv_val, true, &ctx), "-1202.01");
     }
 
     /// Issue #1104 cross-format coverage: the zero-position suppression


### PR DESCRIPTION
## Summary

Recovers most of the 7pp BQL compat regression introduced in #1106 by splitting `DisplayContext::format` (scalar Number — preserve scale) from `format_amount` (Amount/Position/Inventory — quantize to tracked dp). Python `bean-query` uses two distinct renderers for these two semantic kinds; we used to route both through one path.

Refs #1112. Does not fully close it — see "Out of scope" below.

## The problem

#1106 changed `DisplayContext::format` from "always quantize to currency's tracked dp" to "preserve over-scale arithmetic precision." That fix is correct for scalar `Value::Number` results (Python's `DecimalRenderer` carries scale through SUM and Rust now matches it — closes #1103).

But the same function was also reached by `format_amount` (used by Amount, Position, and Inventory text rendering). Python uses a *different* renderer (`AmountRenderer`) there, which quantizes to the currency's display dp. After #1106, Rust started emitting Inventory contents with raw arithmetic scale where Python rendered at 2dp:

```
SELECT account, SUM(position) GROUP BY account ...

before #1106 (correct):  Equity:Opening-Balances -1202.01 USD
after #1106  (broken):   Equity:Opening-Balances -1202.00896 USD
Python (target):         Equity:Opening-Balances -1202.01 USD
```

Same shape for cost-spec values:

```
before #1106:  1.763 VIIIX { 170.16 USD}
after #1106:   1.763 VIIIX { 170.16449234259784458309699376 USD}
Python:        1.763 VIIIX { 170.16 USD}
```

## What this PR changes

### `crates/rustledger-core/src/display_context.rs`

- `format_amount(n, ccy)` no longer calls `format`. It goes through a new private `format_quantized(n, ccy)` helper that does the pre-#1106 quantize-and-pad: `round_dp(dp).rescale(dp)` then stringify.
- New public `format_amount_number(n, ccy)`: same quantize semantics as `format_amount` but returns just the number with no currency suffix. Used by the BQL `numberify` rendering path.
- `format(n, ccy)` is unchanged. Scalar `Value::Number` still preserves over-scale arithmetic precision — the #1103 fix stays intact.

### `crates/rustledger/src/cmd/query/output.rs`

- `Value::Position` and `Value::Inventory` `numberify` branches call `format_amount_number` instead of `format`. So when the user strips the currency suffix, the number still quantizes to the same dp it would have shown with the suffix.

### Tests

Two new unit tests in `display_context.rs`:

- `test_format_vs_format_amount_split_semantics` — pins that `format` preserves scale and `format_amount` quantizes, both on the canonical -1202.00896 case and the 26-digit cost-spec case (170.16449...).
- `test_format_amount_untracked_currency_uses_natural_scale` — pins the fallback path for currencies without tracked precision.

## Verification

Local reproduction of the failing fixtures (build with `--no-default-features` to match CI compat-test build):

| Fixture / query | Before | After (this PR) | Python target |
|---|---|---|---|
| `ofx_cleared_0_journal sum-position-by-account` | `-1202.00896 USD` | `-1202.01 USD` | `-1202.01 USD` |
| `healthequity_invalid_journal sum-position-by-account` | `185.58392… USD` | `185.58 USD` | `185.58 USD` |
| `vanguard_with_cash_… balances-by-account` | `0.00000 USD` | `0.00 USD` | `0.00 USD` |
| `ofx_cleared_0_journal SUM(number) GROUP BY currency` | `-1202.00896 USD` | `-1202.00896 USD` | `-1202.00896 USD` (#1103 fix intact) |

## Out of scope

Two non-scale failures remain after this fix, with different root causes:

1. **`cost_only.beancount first-balance-by-month`** and similar `first-balance-by-month` queries — Rust shows an extra residual posting (e.g. ` -5200 USD`) that Python doesn't. Different bug, separate fix.
2. **`healthequity sum-number-by-currency`** — Rust's *intermediate* SUM produces scale 2 where Python's produces scale 3. The `format` path is correct (preserve whatever scale arrives); the issue is upstream in arithmetic. Continuation of #1108's "fix Rust pipeline scale propagation" work.

Both tracked under #1112.

## Test plan

- [x] `cargo test -p rustledger-core --all-features` — 335 tests pass
- [x] `cargo test -p rustledger --all-features --lib output` — 31 output tests pass
- [x] `cargo clippy -p rustledger-core -p rustledger --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Pre-push workspace-wide `cargo check` passed
- [x] Manual: each canonical Bucket B / Bucket C fixture from #1112 now matches Python output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
