### PR TITLE
fix(test): make build work in Nix hermetic sandboxes (closes #1119)

### DIFF
--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -2762,6 +2762,15 @@ mod tests {
         );
     }
 
+    // These `#[should_panic]` tests assert the `debug_assert!` calls in
+    // `ValidationSession::check_phase_ordering` fire on misuse. Since
+    // `debug_assert!` is a no-op in release builds, gate the tests on
+    // `cfg(debug_assertions)` so `cargo test --release` (Nix builds via
+    // crane, packagers, etc.) doesn't see a `should_panic` test that
+    // can't panic. The phase-ordering check still no-ops correctly in
+    // release builds — that's the documented "release builds gracefully
+    // ignore the violation" behavior on `ValidationSession`.
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "called twice for Late")]
     fn test_run_phase_duplicate_late_panics_in_debug() {
@@ -2773,6 +2782,7 @@ mod tests {
         let _ = session.run_phase(&directives, Phase::Late, date(2030, 1, 1));
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "Phase::Late) called before Phase::Early")]
     fn test_run_phase_late_before_early_panics_in_debug() {

--- a/crates/rustledger/tests/price_clobber_post_fetch.rs
+++ b/crates/rustledger/tests/price_clobber_post_fetch.rs
@@ -9,24 +9,31 @@
 
 #![cfg(unix)]
 
-use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
 use std::process::Command;
-use tempfile::{NamedTempFile, TempDir};
+use tempfile::NamedTempFile;
+#[cfg(target_os = "linux")]
+use tempfile::TempDir;
 
-fn stub_emitting_date(date: &str) -> (TempDir, PathBuf) {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("stub-source.sh");
-    // Beancount-form output: `<date> price <ticker> <amount> <currency>`.
-    // The source-cmd parser picks up the date from this line. Args (ticker,
-    // currency) are ignored — we always emit the same line so we can assert
-    // the dedup behavior is driven by the *response* date.
-    let body = format!("#!/usr/bin/env bash\necho '{date} price AAPL 150.00 USD'\n");
-    std::fs::write(&path, body).unwrap();
-    let mut perms = std::fs::metadata(&path).unwrap().permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&path, perms).unwrap();
-    (dir, path)
+/// Build a `--source-cmd` invocation that emits the given date in
+/// beancount price form.
+///
+/// We invoke `sh -c '<body>'` directly rather than writing an
+/// executable shell script with a `#!/usr/bin/env bash` shebang
+/// because hermetic build sandboxes (Nix in particular — see
+/// rustledger#1119) don't expose `/usr/bin/env`. Without it the
+/// kernel's shebang resolution fails, `Command::spawn` returns ENOENT,
+/// the fetch silently errors, and the test sees empty stdout.
+/// Resolving `sh` via `$PATH` works on every Unix the test suite
+/// targets, including Nix's stdenv.
+///
+/// Output is `<date> price <ticker> <amount> <currency>` — beancount
+/// form. The source-cmd parser keys off the date in this line. The
+/// script ignores its positional args; we always emit the same line
+/// so the dedup assertions are driven by the *response* date, not the
+/// requested date.
+fn stub_cmd_emitting_date(date: &str) -> String {
+    let body = format!("echo '{date} price AAPL 150.00 USD'");
+    format!("sh -c {}", shell_words::quote(&body))
 }
 
 fn write_fixture(content: &str) -> NamedTempFile {
@@ -60,8 +67,7 @@ fn clobber_post_fetch_skips_when_response_date_matches_existing() {
 2024-01-10 price AAPL 150.00 USD
 ";
     let f = write_fixture(fixture);
-    let (_dir, stub_path) = stub_emitting_date("2024-01-10");
-    let stub_arg = shell_words::quote(stub_path.to_str().unwrap()).into_owned();
+    let stub_cmd = stub_cmd_emitting_date("2024-01-10");
 
     let out = Command::new(env!("CARGO_BIN_EXE_rledger"))
         .args([
@@ -70,7 +76,7 @@ fn clobber_post_fetch_skips_when_response_date_matches_existing() {
             f.path().to_str().unwrap(),
             "--beancount",
             "--source-cmd",
-            &stub_arg,
+            &stub_cmd,
             "--date",
             "2024-01-15",
         ])
@@ -111,8 +117,7 @@ fn clobber_post_fetch_emits_duplicate_when_clobber_is_set() {
 2024-01-10 price AAPL 150.00 USD
 ";
     let f = write_fixture(fixture);
-    let (_dir, stub_path) = stub_emitting_date("2024-01-10");
-    let stub_arg = shell_words::quote(stub_path.to_str().unwrap()).into_owned();
+    let stub_cmd = stub_cmd_emitting_date("2024-01-10");
 
     let out = Command::new(env!("CARGO_BIN_EXE_rledger"))
         .args([
@@ -121,7 +126,7 @@ fn clobber_post_fetch_emits_duplicate_when_clobber_is_set() {
             f.path().to_str().unwrap(),
             "--beancount",
             "--source-cmd",
-            &stub_arg,
+            &stub_cmd,
             "--date",
             "2024-01-15",
             "--clobber",


### PR DESCRIPTION
## Summary

Closes #1119.

Two Nix-sandbox / release-mode build issues, both surfaced by hermetic-sandbox testing.

### 1. `/usr/bin/env` shebang in test stub

`crates/rustledger/tests/price_clobber_post_fetch.rs` wrote a shell script with `#!/usr/bin/env bash`. Hermetic sandboxes that don't expose `/usr/bin` — Nix in particular — fail kernel shebang resolution: `Command::spawn` returns ENOENT, `ExternalCommandSource::fetch_price` returns `Err`, and `run_with_external_command` silently logs to stderr while returning `Ok(())`. Net effect: exit code 0 + empty stdout.

That single failure mode produced asymmetric behavior:

- `clobber_post_fetch_emits_duplicate_when_clobber_is_set` — expects non-empty stdout. **Fails on Nix** (the symptom in #1119).
- `clobber_post_fetch_skips_when_response_date_matches_existing` — expects zero `price AAPL` lines. **Passes for the wrong reason** (empty stdout matches its zero-count expectation).

**Fix.** Pass `sh -c '<body>'` directly via `--source-cmd` instead of writing an executable shell script. Resolves through `$PATH` (Nix stdenv provides `sh`); no `/usr/bin/env`, no `chmod`, no shebang.

### 2. `#[should_panic]` on `debug_assert!` paths in release builds

`crates/rustledger-validate/src/lib.rs` had two `#[should_panic]` tests targeting `debug_assert!` calls in `ValidationSession::check_phase_ordering`. `debug_assert!` is a no-op in release builds, so the tests fail under `cargo test --release` with "test did not panic as expected". Nix package builds (via crane) compile with `--release`, so they hit this.

**Fix.** Gate both tests on `#[cfg(debug_assertions)]`. The phase-ordering check still works correctly in release (it returns `false` and no-ops the misuse, as documented on `ValidationSession`); only the panic-assertion test is debug-only.

## Deeper verification

In addition to running the failing test directly:

- **Reproduced the bug locally** via `unshare --user --map-root-user --mount sh -c "mount --bind /tmp /usr ..."` — same panic, same stack trace as the issue report.
- **Verified the fix locally** in the same simulated sandbox: all 3 `price_clobber_post_fetch` tests pass.
- **Audited for similar shebang fragility** — `bean_price_compat.rs` uses the same pattern but skips entirely when `bean-price` isn't on PATH (which it isn't in the Nix sandbox), so it never reaches the stub-script code.
- **Ran `nix build .#rustledger` end-to-end** — checkPhase passes, all tests + doctests green, binary builds and installs.

## How to test

```bash
# Reproduces the original failure if /usr/bin/env is missing:
unshare --user --map-root-user --mount sh -c "mount --bind /tmp /usr && cargo test -p rustledger --test price_clobber_post_fetch --release"

# Verifies the release-mode test gating:
cargo test -p rustledger-validate --lib --release
cargo test -p rustledger-validate --lib  # also exercises the debug-only tests

# End-to-end Nix build:
nix build .#rustledger
```

## Verification

- [x] `cargo test --workspace --all-features` clean (debug).
- [x] `cargo test --workspace --all-features --release` clean.
- [x] `cargo clippy -p rustledger --tests -- -D warnings` clean.
- [x] Mount-namespace simulation of Nix sandbox: all 3 `price_clobber_post_fetch` tests pass.
- [x] `nix build .#rustledger --no-link --print-build-logs` — full checkPhase passes, binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
