### PR TITLE
chore: release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "im",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "jiff",
  "rustc-hash",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "glob",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "crossbeam-channel",
  "jiff",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.94"
 license = "GPL-3.0-only"
@@ -145,16 +145,16 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.14.1", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.14.1", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.14.1", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.14.1", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.14.1", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.14.1", path = "crates/rustledger-query" }
-rustledger-plugin = { version = "0.14.1", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.14.1", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.14.1", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.14.1", path = "crates/rustledger-ops" }
+rustledger-core = { version = "0.15.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.15.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.15.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.15.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.15.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.15.0", path = "crates/rustledger-query" }
+rustledger-plugin = { version = "0.15.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.15.0", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.15.0", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.15.0", path = "crates/rustledger-ops" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Rustledger FFI via WASI - JSON API for embedding in any language"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.14.1"
+    "@rustledger/wasm": "^0.15.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.14.1
+Version:        0.15.0
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.14.1.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.15.0.tar.gz
 
 # Must match `workspace.package.rust-version` in Cargo.toml.
 # Edition 2024 stabilized in 1.85, so older toolchains fail at parse
@@ -24,7 +24,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.14.1
+%setup -q -n rustledger-0.15.0
 
 %build
 cargo build --release


### PR DESCRIPTION
## Summary

Bump to v0.15.0. Minor version per SemVer (pre-1.0) because of PR #1116's breaking API changes — see "Breaking changes" below for the migration story.

## Versions bumped

Per [`RELEASING.md`](../blob/main/RELEASING.md):

- [x] `Cargo.toml` — `[workspace.package].version` + 10 `[workspace.dependencies]` path-pinned siblings.
- [x] 14 crate `Cargo.toml` files under `crates/`.
- [x] `Cargo.lock` regenerated via `cargo check --workspace`.
- [x] `packages/mcp-server/package.json` — `version` and `@rustledger/wasm` dep.
- [x] `packaging/rpm/rustledger.spec` — `Version`, `Source0`, `%setup` directory.
- [x] `BuildRequires: rust >= 1.94` already matches `workspace.package.rust-version` — no change.

## Pre-flight smoke checks (per RELEASING.md §3)

- [x] `cargo check --workspace --all-features --all-targets` — clean.
- [x] `cd packages/mcp-server && npm ci && npm run build` — clean. Temporarily reverted `@rustledger/wasm` to `^0.14.1` during the build (`^0.15.0` isn't on npm yet during the bump PR); restored to `^0.15.0` before commit.
- [x] `cd crates/rustledger-wasm && wasm-pack build --target web --release` — clean.

## Breaking changes since v0.14.1

PR #1116 reshaped two public protocols and removed several shortcut entry points. Migration paths for each:

### `rustledger_validate`

The free-function shortcuts are gone. Use `ValidationSession`:

```rust
// Before (v0.14.x)
let errors = rustledger_validate::validate(&directives);
let errors = rustledger_validate::validate_with_options(&directives, opts);

// After (v0.15.0)
use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
use rustledger_core::naive_date;

let today = naive_date(2030, 1, 1).unwrap();
let mut session = ValidationSession::new(ValidationOptions::default());
let mut errors = session.run_phase(&directives, Phase::Early, today);
errors.extend(session.run_phase(&directives, Phase::Late, today));
errors.extend(session.finalize());
```

### `rustledger_plugin_types`

`PluginOutput.directives: Vec<DirectiveWrapper>` is replaced with `ops: Vec<PluginOp>`:

```rust
// Before
PluginOutput { directives: vec![...], errors: vec![] }

// After
use rustledger_plugin_types::{PluginOp, PluginOutput};

PluginOutput {
    ops: vec![
        PluginOp::Keep(0),                       // reuse input[0] (preserves span)
        PluginOp::Modify(1, new_wrapper),        // new content, input[1]'s identity
        PluginOp::Insert(synthesized_wrapper),   // fresh directive
        PluginOp::Delete(2),                     // drop input[2]
    ],
    errors: vec![],
}
// Or, for pure validators:
PluginOutput::passthrough(input.directives.len())
```

Every input index must appear in EXACTLY ONE op across `{Keep, Modify, Delete}` — the loader validates and emits a `PLUGIN` error on violations.

### `rustledger_plugin::NativePlugin`

New `is_synth()` trait method (default `false`). Override to `true` if your plugin synthesizes directives that the Early validator depends on (e.g., `auto_accounts`).

### `rustledger_loader`

- New `PluginPass { PreBookingSynth | PostBooking | All }` enum. `pub fn run_plugins` takes an extra `pass: PluginPass` parameter. Standalone callers (LSP, FFI, tests on already-booked input) pass `PluginPass::All`.
- `run_booking` now returns `(Vec<Spanned<Directive>>, Vec<Spanned<Directive>>)` partitioned into (booked, failed) instead of `Vec<usize>` of failed indices.

### `rustledger_booking`

- `INTERPOLATED_MARKER` const removed. The marker-based zero-elided posting preservation from #1114 was replaced by the validate phase split — Early validation now runs before booking prunes.

## Highlights since v0.14.1

- **Phase-split validation** (#1116) — type-checked Early/Late phases via `ValidationSession`, replacing the `INTERPOLATED_MARKER` metadata side-channel from #1114.
- **PluginOp transformation-record protocol** (#1116) — span fidelity preserved by construction across plugin round-trips.
- **Loader pipeline restructure** (#1116) — synth/regular plugin split, partition-based failed-booking handling, single canonical sort.
- **Plugin error source-location propagation** (#1116) — `PluginError::source_file` + `line_number` now flow into `LedgerError::location`.
- **Bug fixes**: duplicate-Open suppression across five plugins (#1116), multi-currency pad regression (#1116), future-dated pad leak (#1116), duplicate same-day Close double-emit (#1116), Nix sandbox test build (#1120 → #1119).
- **Doc + example refresh** — every README, spec doc, ADR, and example plugin updated for the new APIs (#1116).

## Post-merge

Follow RELEASING.md §5 to tag and trigger release-build + release-publish:

```bash
git switch main
git pull --ff-only origin main
gh release create v0.15.0 --target "$(git rev-parse HEAD)" --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
