### PR TITLE
feat(extract): wire up ML category suggestions via --suggest-categories

### DIFF
--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -35,6 +35,7 @@
 
 mod config;
 mod duplicate;
+mod suggest;
 
 use crate::cmd::completions::ShellType;
 use anyhow::{Context, Result, anyhow};
@@ -157,6 +158,13 @@ pub struct Args {
     /// Existing ledger file for duplicate detection
     #[arg(long, value_name = "FILE")]
     existing: Option<PathBuf>,
+
+    /// Use ML to suggest accounts for transactions the rules engine didn't
+    /// categorize. Trains a Naive Bayes model on the `--existing` ledger and
+    /// replaces `Expenses:Unknown` / `Income:Unknown` with the prediction.
+    /// Requires `--existing`.
+    #[arg(long, requires = "existing")]
+    suggest_categories: bool,
 
     /// Append a balance assertion with the given amount (e.g., "1234.56")
     #[arg(long, value_name = "AMOUNT")]
@@ -392,11 +400,13 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
         eprintln!("warning: {warning}");
     }
 
-    // Filter duplicates if --existing is specified
+    // Filter duplicates if --existing is specified, and optionally apply
+    // ML-based account suggestions for transactions the rules engine left
+    // pointing at a fallback account.
     let directives = if let Some(ref existing_path) = args.existing {
         let existing_txns = load_existing_transactions(existing_path)?;
         let before_count = result.directives.len();
-        let filtered: Vec<_> = result
+        let mut filtered: Vec<_> = result
             .directives
             .into_iter()
             .filter(|d| {
@@ -410,6 +420,9 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
         let dupes = before_count - filtered.len();
         if dupes > 0 {
             eprintln!("Filtered {dupes} duplicate transaction(s)");
+        }
+        if args.suggest_categories {
+            suggest::apply_ml_suggestions_with_summary(&mut filtered, &existing_txns)?;
         }
         filtered
     } else {

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -161,7 +161,9 @@ pub struct Args {
 
     /// Use ML to suggest accounts for transactions the rules engine didn't
     /// categorize. Trains a Naive Bayes model on the `--existing` ledger and
-    /// replaces `Expenses:Unknown` / `Income:Unknown` with the prediction.
+    /// replaces the configured fallback contra-accounts (the importer's
+    /// `default_expense` and `default_income`, defaulting to
+    /// `Expenses:Unknown` / `Income:Unknown`) with the prediction.
     /// Requires `--existing`.
     #[arg(long, requires = "existing")]
     suggest_categories: bool,
@@ -209,10 +211,15 @@ pub fn list_importers(args: &Args) -> Result<()> {
 
 /// Run the extract command with the given arguments.
 pub fn run(args: &Args, file: &Path) -> Result<()> {
-    // Detect OFX files and use appropriate importer
-    let result = if is_ofx_file(file) && args.importer.is_none() {
+    // Detect OFX files and use appropriate importer. Also captures the
+    // fallback contra-accounts (Expenses:Unknown / Income:Unknown by default,
+    // or `default_expense` / `default_income` from CsvConfig) so the
+    // optional --suggest-categories ML step knows which accounts to
+    // re-categorize.
+    let (result, fallback_accounts) = if is_ofx_file(file) && args.importer.is_none() {
         let ofx = OfxImporter::new(&args.account, &args.currency);
-        ofx.extract(file)?
+        // OFX importer hardcodes Expenses:Unknown as the only contra-account.
+        (ofx.extract(file)?, vec!["Expenses:Unknown".to_string()])
     } else {
         // Determine import config: --importer flag, explicit --config, or CLI args
         let config = if let Some(ref importer_name) = args.importer {
@@ -392,7 +399,16 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
             config
         };
 
-        config.extract(file)?
+        let rustledger_importer::config::ImporterType::Csv(csv) = &config.importer_type;
+        let fallbacks = vec![
+            csv.default_expense
+                .clone()
+                .unwrap_or_else(|| "Expenses:Unknown".to_string()),
+            csv.default_income
+                .clone()
+                .unwrap_or_else(|| "Income:Unknown".to_string()),
+        ];
+        (config.extract(file)?, fallbacks)
     };
 
     // Print warnings
@@ -422,7 +438,11 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
             eprintln!("Filtered {dupes} duplicate transaction(s)");
         }
         if args.suggest_categories {
-            suggest::apply_ml_suggestions_with_summary(&mut filtered, &existing_txns)?;
+            suggest::apply_ml_suggestions_with_summary(
+                &mut filtered,
+                &existing_txns,
+                &fallback_accounts,
+            )?;
         }
         filtered
     } else {

--- a/crates/rustledger/src/cmd/extract_cmd/suggest.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/suggest.rs
@@ -1,0 +1,206 @@
+//! ML-based account suggestion for `rledger extract --suggest-categories`.
+//!
+//! Trains a Multinomial Naive Bayes classifier on the user's existing ledger
+//! and replaces fallback contra-accounts (`Expenses:Unknown`, `Income:Unknown`)
+//! on imported transactions with the model's top prediction.
+//!
+//! This is the fallback path *after* the rules engine. Transactions with
+//! explicit rule matches keep their rule-assigned account; only unmatched
+//! transactions get ML treatment.
+//!
+//! Predictions are uncalibrated — see `rustledger_ops::ml::CategorizationModel`.
+
+use anyhow::{Context, Result, anyhow};
+use rustledger_core::{Directive, InternedStr, Transaction};
+use rustledger_ops::ml::CategorizationModel;
+use rustledger_plugin::convert::directives_to_wrappers;
+
+/// Default contra-accounts the CSV/OFX importers emit for unmatched rows.
+/// Transactions whose second posting matches one of these are candidates for
+/// ML re-categorization.
+const DEFAULT_FALLBACK_ACCOUNTS: &[&str] = &["Expenses:Unknown", "Income:Unknown"];
+
+/// Outcome of running ML suggestion over a batch of imported directives.
+#[derive(Debug, Default)]
+pub(super) struct SuggestStats {
+    /// Number of transactions whose contra-account was changed by ML.
+    pub modified: usize,
+    /// Number of transactions inspected (i.e., matched a fallback account).
+    pub inspected: usize,
+}
+
+/// Train a model from `existing_txns` and rewrite the contra-account on any
+/// transaction in `directives` whose second posting matches a fallback.
+///
+/// Returns counts of inspected / modified transactions. The caller is expected
+/// to print a summary line.
+///
+/// Returns an error only if training fails for non-recoverable reasons.
+/// `InsufficientData` is treated as a no-op (with a warning to stderr) since
+/// it's expected when the user has a small or new ledger.
+pub(super) fn apply_ml_suggestions(
+    directives: &mut [Directive],
+    existing_txns: &[Transaction],
+) -> Result<SuggestStats> {
+    // Wrap existing transactions as Directives for the wrapper-based ML API.
+    // Clone is unavoidable here — `existing_txns` is also used for duplicate
+    // detection in the calling path.
+    let training_directives: Vec<Directive> = existing_txns
+        .iter()
+        .cloned()
+        .map(Directive::Transaction)
+        .collect();
+    let training_wrappers = directives_to_wrappers(&training_directives);
+
+    let model = match CategorizationModel::train(&training_wrappers) {
+        Ok(m) => m,
+        Err(rustledger_ops::ml::MlError::InsufficientData(reason)) => {
+            eprintln!(
+                "warning: --suggest-categories: insufficient training data ({reason}); skipping ML suggestions"
+            );
+            return Ok(SuggestStats::default());
+        }
+        Err(e) => return Err(anyhow!("ML training failed: {e}")),
+    };
+
+    let mut stats = SuggestStats::default();
+
+    for directive in directives.iter_mut() {
+        let Directive::Transaction(txn) = directive else {
+            continue;
+        };
+
+        // Only re-categorize when the second posting is a fallback account.
+        // Transactions with explicit rule matches keep their rule-assigned
+        // contra-account.
+        let Some(contra) = txn.postings.get(1) else {
+            continue;
+        };
+        if !DEFAULT_FALLBACK_ACCOUNTS
+            .iter()
+            .any(|&fb| contra.account.as_str() == fb)
+        {
+            continue;
+        }
+        stats.inspected += 1;
+
+        let payee = txn.payee.as_ref().map(InternedStr::as_str);
+        let narration = txn.narration.as_str();
+        let predictions = model.predict(narration, payee);
+
+        if let Some((predicted, _conf)) = predictions.into_iter().next() {
+            // `predict` returns at most one prediction with non-zero
+            // confidence; if the predicted account differs from the
+            // fallback, rewrite it.
+            if predicted != contra.account.as_str() {
+                txn.postings[1].account = InternedStr::from(predicted);
+                stats.modified += 1;
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Convenience wrapper: prints a one-line summary to stderr.
+pub(super) fn apply_ml_suggestions_with_summary(
+    directives: &mut [Directive],
+    existing_txns: &[Transaction],
+) -> Result<()> {
+    let stats = apply_ml_suggestions(directives, existing_txns)
+        .context("applying ML category suggestions")?;
+    if stats.inspected > 0 {
+        eprintln!(
+            "ML suggestions: re-categorized {}/{} fallback transaction(s)",
+            stats.modified, stats.inspected
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::Decimal;
+    use rustledger_core::{Amount, Posting, Transaction, naive_date};
+
+    fn txn(payee: &str, narration: &str, contra_account: &str, amount: i64) -> Transaction {
+        let mut t = Transaction::new(naive_date(2025, 1, 15).unwrap(), narration);
+        t.payee = Some(payee.into());
+        t.with_posting(Posting::new(
+            "Assets:Bank",
+            Amount::new(Decimal::from(-amount), "USD"),
+        ))
+        .with_posting(Posting::auto(contra_account))
+    }
+
+    fn training_set() -> Vec<Transaction> {
+        vec![
+            txn("Whole Foods", "Groceries", "Expenses:Groceries", 50),
+            txn("Trader Joes", "Weekly food", "Expenses:Groceries", 60),
+            txn("Safeway", "Groceries", "Expenses:Groceries", 45),
+            txn("Kroger", "Food", "Expenses:Groceries", 70),
+            txn("Starbucks", "Coffee", "Expenses:Dining", 8),
+            txn("Chipotle", "Lunch", "Expenses:Dining", 12),
+            txn("McDonalds", "Lunch", "Expenses:Dining", 9),
+            txn("Shell", "Gas", "Expenses:Transport", 40),
+            txn("Chevron", "Fuel", "Expenses:Transport", 35),
+            txn("Uber", "Ride", "Expenses:Transport", 20),
+        ]
+    }
+
+    #[test]
+    fn rewrites_fallback_account() {
+        let existing = training_set();
+        let mut new_directives = vec![Directive::Transaction(txn(
+            "Whole Foods",
+            "Groceries",
+            "Expenses:Unknown",
+            55,
+        ))];
+        let stats = apply_ml_suggestions(&mut new_directives, &existing).unwrap();
+        assert_eq!(stats.inspected, 1);
+        assert_eq!(stats.modified, 1);
+        let Directive::Transaction(t) = &new_directives[0] else {
+            panic!()
+        };
+        assert_eq!(t.postings[1].account.as_str(), "Expenses:Groceries");
+    }
+
+    #[test]
+    fn skips_non_fallback_accounts() {
+        let existing = training_set();
+        let mut new_directives = vec![Directive::Transaction(txn(
+            "Whole Foods",
+            "Groceries",
+            "Expenses:Groceries", // already categorized; should not touch
+            55,
+        ))];
+        let stats = apply_ml_suggestions(&mut new_directives, &existing).unwrap();
+        assert_eq!(stats.inspected, 0);
+        assert_eq!(stats.modified, 0);
+        let Directive::Transaction(t) = &new_directives[0] else {
+            panic!()
+        };
+        assert_eq!(t.postings[1].account.as_str(), "Expenses:Groceries");
+    }
+
+    #[test]
+    fn insufficient_training_data_is_noop() {
+        // One existing txn isn't enough; should warn and return 0/0, not error.
+        let existing = vec![txn("Store", "Stuff", "Expenses:Misc", 10)];
+        let mut new_directives = vec![Directive::Transaction(txn(
+            "Whole Foods",
+            "Groceries",
+            "Expenses:Unknown",
+            55,
+        ))];
+        let stats = apply_ml_suggestions(&mut new_directives, &existing).unwrap();
+        assert_eq!(stats.modified, 0);
+        // Untouched.
+        let Directive::Transaction(t) = &new_directives[0] else {
+            panic!()
+        };
+        assert_eq!(t.postings[1].account.as_str(), "Expenses:Unknown");
+    }
+}

--- a/crates/rustledger/src/cmd/extract_cmd/suggest.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/suggest.rs
@@ -15,11 +15,6 @@ use rustledger_core::{Directive, InternedStr, Transaction};
 use rustledger_ops::ml::CategorizationModel;
 use rustledger_plugin::convert::directives_to_wrappers;
 
-/// Default contra-accounts the CSV/OFX importers emit for unmatched rows.
-/// Transactions whose second posting matches one of these are candidates for
-/// ML re-categorization.
-const DEFAULT_FALLBACK_ACCOUNTS: &[&str] = &["Expenses:Unknown", "Income:Unknown"];
-
 /// Outcome of running ML suggestion over a batch of imported directives.
 #[derive(Debug, Default)]
 pub(super) struct SuggestStats {
@@ -30,7 +25,11 @@ pub(super) struct SuggestStats {
 }
 
 /// Train a model from `existing_txns` and rewrite the contra-account on any
-/// transaction in `directives` whose second posting matches a fallback.
+/// transaction in `directives` whose second posting matches one of the
+/// `fallback_accounts`. The caller supplies the fallback list — for CSV
+/// imports this comes from `CsvConfig::default_expense` /
+/// `default_income` (defaulting to `Expenses:Unknown` / `Income:Unknown`);
+/// for OFX it's the importer's hardcoded `Expenses:Unknown`.
 ///
 /// Returns counts of inspected / modified transactions. The caller is expected
 /// to print a summary line.
@@ -41,6 +40,7 @@ pub(super) struct SuggestStats {
 pub(super) fn apply_ml_suggestions(
     directives: &mut [Directive],
     existing_txns: &[Transaction],
+    fallback_accounts: &[String],
 ) -> Result<SuggestStats> {
     // Wrap existing transactions as Directives for the wrapper-based ML API.
     // Clone is unavoidable here — `existing_txns` is also used for duplicate
@@ -76,9 +76,9 @@ pub(super) fn apply_ml_suggestions(
         let Some(contra) = txn.postings.get(1) else {
             continue;
         };
-        if !DEFAULT_FALLBACK_ACCOUNTS
+        if !fallback_accounts
             .iter()
-            .any(|&fb| contra.account.as_str() == fb)
+            .any(|fb| contra.account.as_str() == fb)
         {
             continue;
         }
@@ -106,8 +106,9 @@ pub(super) fn apply_ml_suggestions(
 pub(super) fn apply_ml_suggestions_with_summary(
     directives: &mut [Directive],
     existing_txns: &[Transaction],
+    fallback_accounts: &[String],
 ) -> Result<()> {
-    let stats = apply_ml_suggestions(directives, existing_txns)
+    let stats = apply_ml_suggestions(directives, existing_txns, fallback_accounts)
         .context("applying ML category suggestions")?;
     if stats.inspected > 0 {
         eprintln!(
@@ -149,6 +150,10 @@ mod tests {
         ]
     }
 
+    fn default_fallbacks() -> Vec<String> {
+        vec!["Expenses:Unknown".to_string(), "Income:Unknown".to_string()]
+    }
+
     #[test]
     fn rewrites_fallback_account() {
         let existing = training_set();
@@ -158,7 +163,8 @@ mod tests {
             "Expenses:Unknown",
             55,
         ))];
-        let stats = apply_ml_suggestions(&mut new_directives, &existing).unwrap();
+        let stats =
+            apply_ml_suggestions(&mut new_directives, &existing, &default_fallbacks()).unwrap();
         assert_eq!(stats.inspected, 1);
         assert_eq!(stats.modified, 1);
         let Directive::Transaction(t) = &new_directives[0] else {
@@ -176,7 +182,8 @@ mod tests {
             "Expenses:Groceries", // already categorized; should not touch
             55,
         ))];
-        let stats = apply_ml_suggestions(&mut new_directives, &existing).unwrap();
+        let stats =
+            apply_ml_suggestions(&mut new_directives, &existing, &default_fallbacks()).unwrap();
         assert_eq!(stats.inspected, 0);
         assert_eq!(stats.modified, 0);
         let Directive::Transaction(t) = &new_directives[0] else {
@@ -195,12 +202,34 @@ mod tests {
             "Expenses:Unknown",
             55,
         ))];
-        let stats = apply_ml_suggestions(&mut new_directives, &existing).unwrap();
+        let stats =
+            apply_ml_suggestions(&mut new_directives, &existing, &default_fallbacks()).unwrap();
         assert_eq!(stats.modified, 0);
         // Untouched.
         let Directive::Transaction(t) = &new_directives[0] else {
             panic!()
         };
         assert_eq!(t.postings[1].account.as_str(), "Expenses:Unknown");
+    }
+
+    #[test]
+    fn honors_custom_fallback() {
+        // A user configured `default_expense = "Expenses:Uncategorized"`.
+        // ML should re-categorize that account, not the hardcoded default.
+        let existing = training_set();
+        let mut new_directives = vec![Directive::Transaction(txn(
+            "Whole Foods",
+            "Groceries",
+            "Expenses:Uncategorized",
+            55,
+        ))];
+        let custom = vec!["Expenses:Uncategorized".to_string()];
+        let stats = apply_ml_suggestions(&mut new_directives, &existing, &custom).unwrap();
+        assert_eq!(stats.inspected, 1);
+        assert_eq!(stats.modified, 1);
+        let Directive::Transaction(t) = &new_directives[0] else {
+            panic!()
+        };
+        assert_eq!(t.postings[1].account.as_str(), "Expenses:Groceries");
     }
 }


### PR DESCRIPTION
## Summary

The `rustledger-ops::ml` module (Multinomial Naive Bayes classifier, ~440 lines) shipped in v0.15.0 with **zero callers**. This wires it into the import command so users can actually benefit from it before v1.0.

## What it does

```bash
rledger extract bank.csv \
    --account Assets:Bank \
    --existing ledger.beancount \
    --suggest-categories
```

When `--suggest-categories` is set:

1. The ML model trains on `--existing` (the user's historical ledger)
2. For each imported transaction whose contra-account is a fallback (`Expenses:Unknown` / `Income:Unknown`), the model predicts the most likely account based on payee + narration
3. Fallback accounts get rewritten with the prediction; rule-matched accounts are left alone
4. A summary line prints to stderr: `ML suggestions: re-categorized N/M fallback transaction(s)`

The flag requires `--existing` (no training data otherwise). Insufficient training data warns and no-ops rather than erroring — small / new ledgers degrade cleanly.

## Pipeline order

```
parse → dedup (--existing) → ML (--suggest-categories) → balance → write
```

ML runs *after* dedup so we don't spend cycles predicting for transactions about to be filtered, and *before* balance so the balance assertion sees the final accounts.

## Known issue (upstream)

`linfa-bayes 0.8.1` ships stray `dbg!()` macros in `multinomial_nb.rs:78` that pollute stderr during prediction. Stdout (the extracted ledger) is unaffected. Follow-up: file upstream issue, then pin a fixed linfa-bayes version. Tracking separately.

## Test plan

Three unit tests in `suggest.rs`:

- [x] Fallback account → rewritten to prediction
- [x] Non-fallback account → preserved (rules engine output respected)
- [x] Insufficient training data → no-op, not an error

End-to-end smoke (manual):

- [x] 9-transaction training ledger (Groceries x4, Dining x3, Transport x2)
- [x] 3-transaction CSV import (Whole Foods, Trader Joes, Starbucks)
- [x] Without flag: all 3 → `Expenses:Unknown`
- [x] With flag: Whole Foods → `Expenses:Groceries`, Trader Joes → `Expenses:Groceries`, Starbucks → `Expenses:Dining`. ✅

- [x] `cargo test -p rustledger --lib cmd::extract_cmd::suggest` → 3/3 pass
- [x] `cargo clippy -p rustledger --all-features -- -D warnings` clean

## Future follow-ups (not in this PR)

- Confidence threshold flag (currently model returns binary 0.8 / 0.0; once linfa supports calibrated probabilities, surface them)
- Handle Income fallbacks separately (current heuristic treats both Expense and Income fallbacks the same)
- Consider exposing alternative predictions (top-K) for interactive review

🤖 Generated with [Claude Code](https://claude.com/claude-code)