### PR TITLE
refactor(query): drop pub use ast::* glob, fix Query/Directive::Query collision

### DIFF
--- a/crates/rustledger-query/src/lib.rs
+++ b/crates/rustledger-query/src/lib.rs
@@ -33,7 +33,11 @@ pub mod executor;
 pub mod parser;
 pub mod price;
 
-pub use ast::*;
+// AST types are accessed via `rustledger_query::ast::*` rather than re-exported
+// at the crate root. The previous `pub use ast::*;` glob exposed 22 names —
+// none used by external crates, and one (`Query`) collided with
+// `rustledger_core::Directive::Query`. Power users still reach AST types via
+// the `ast` module.
 pub use error::{ParseError, QueryError};
 pub use executor::{Executor, Interval, IntervalUnit, QueryResult, Value};
 pub use parser::parse;

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -101,43 +101,43 @@ fn execute_query(query_str: &str, directives: &[Directive]) -> QueryResult {
 #[test]
 fn test_parse_simple_select() {
     let query = parse("SELECT account, number").expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]
 fn test_parse_select_with_where() {
     let query = parse(r#"SELECT account WHERE account ~ "Expenses""#).expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]
 fn test_parse_select_with_group_by() {
     let query = parse("SELECT account, SUM(number) GROUP BY account").expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]
 fn test_parse_select_with_order_by() {
     let query = parse("SELECT account, number ORDER BY number DESC").expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]
 fn test_parse_journal_query() {
     let query = parse(r#"JOURNAL "Assets:Bank""#).expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Journal(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Journal(_)));
 }
 
 #[test]
 fn test_parse_balances_query() {
     let query = parse("BALANCES").expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Balances(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Balances(_)));
 }
 
 #[test]
 fn test_parse_balances_where_query() {
     let query = parse(r#"BALANCES WHERE account ~ "Assets:""#).expect("should parse");
-    if let rustledger_query::Query::Balances(b) = query {
+    if let rustledger_query::ast::Query::Balances(b) = query {
         assert!(b.where_clause.is_some());
     } else {
         panic!("Expected BALANCES query");
@@ -147,7 +147,7 @@ fn test_parse_balances_where_query() {
 #[test]
 fn test_parse_balances_at_cost_where_query() {
     let query = parse(r#"BALANCES AT cost WHERE account ~ "Assets:""#).expect("should parse");
-    if let rustledger_query::Query::Balances(b) = query {
+    if let rustledger_query::ast::Query::Balances(b) = query {
         assert_eq!(b.at_function, Some("cost".to_string()));
         assert!(b.where_clause.is_some());
     } else {
@@ -173,7 +173,7 @@ fn test_execute_balances_where() {
 #[test]
 fn test_parse_print_query() {
     let query = parse("PRINT").expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Print(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Print(_)));
 }
 
 #[test]
@@ -1669,7 +1669,7 @@ fn test_parse_pivot_by_two_columns() {
          ORDER BY account PIVOT BY YEAR(date), account",
     )
     .expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]
@@ -1930,14 +1930,14 @@ fn test_pivot_by_with_order_by_on_hidden_column_works() {
 #[test]
 fn test_parse_window_function_row_number() {
     let query = parse("SELECT account, ROW_NUMBER() OVER (ORDER BY date)").expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]
 fn test_parse_window_function_with_partition() {
     let query = parse("SELECT account, ROW_NUMBER() OVER (PARTITION BY account ORDER BY date)")
         .expect("should parse");
-    assert!(matches!(query, rustledger_query::Query::Select(_)));
+    assert!(matches!(query, rustledger_query::ast::Query::Select(_)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`rustledger_query::lib.rs` re-exported 22 AST type names at the crate root via `pub use ast::*;`. Workspace audit confirmed:

- **Zero external uses** of any of the 22 names from any other workspace crate or package (`rustledger`, `rustledger-wasm`, `rustledger-ffi-wasi`, `rustledger-lsp`, `rustledger-ops`, `rustledger-importer`, `mcp-server`)
- One name (`Query`) **collided** with `rustledger_core::Directive::Query` (the Beancount `query` directive variant), forcing tests to write `rustledger_query::Query::Select` to disambiguate

This drops the glob. Power users still get every AST type via the explicit `ast` namespace.

## What changed

**Before:**
```rust
pub use ast::*;  // 22 names: Query, SelectQuery, Expr, Literal, BinaryOp, ...
```

**After:**
```rust
// AST types via `rustledger_query::ast::*` rather than re-exported.
// Power users still reach AST types via the `ast` module.
```

Crate-root surface now matches what external callers actually use:

| Name | External callers |
|---|---|
| `Executor` | rustledger CLI, wasm, ffi-wasi |
| `parse` | rustledger CLI, wasm, ffi-wasi |
| `Value` | rustledger CLI, wasm, ffi-wasi |
| `QueryResult` | rustledger CLI |
| `IntervalUnit`, `Interval` | wasm, rustledger CLI |
| `ParseError`, `QueryError` | (error consumers) |
| `PriceDatabase` | (price-fetching) |

## Migration

The only code touching the AST type names was the internal integration test (`bql_integration_test.rs`). Updated mechanically — `rustledger_query::Query` → `rustledger_query::ast::Query` at 12 sites.

External downstreams unaffected (verified no external uses).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p rustledger-query --test bql_integration_test` — **370/370 pass**
- [x] Confirmed zero external references via workspace-wide grep

## Why now

Pre-v1.0 surface ratchet. Adding new public re-exports later is non-breaking; removing them would be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)