### PR TITLE
refactor(importer): seal chrono behind ofxy boundary; fix stale core docs

### DIFF
--- a/crates/rustledger-core/README.md
+++ b/crates/rustledger-core/README.md
@@ -17,15 +17,14 @@ Core types for the rustledger Beancount implementation.
 ## Example
 
 ```rust
-use rustledger_core::{Amount, Cost, Position, Inventory, BookingMethod};
+use rustledger_core::{Amount, Cost, Position, Inventory, BookingMethod, naive_date};
 use rust_decimal_macros::dec;
-use chrono::NaiveDate;
 
 let mut inv = Inventory::new();
 
 // Add a stock position
 let cost = Cost::new(dec!(150.00), "USD")
-    .with_date(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap());
+    .with_date(naive_date(2024, 1, 15).unwrap());
 inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost));
 
 // Sell using FIFO

--- a/crates/rustledger-core/src/intern.rs
+++ b/crates/rustledger-core/src/intern.rs
@@ -535,7 +535,8 @@ mod rkyv_decimal {
     }
 }
 
-// rkyv wrapper for chrono::NaiveDate - serialize as i32 (days from CE)
+// rkyv wrapper for jiff::civil::Date (re-exported as NaiveDate) - serialize
+// as i32 (days since Unix epoch). 4 bytes instead of 10+ for ISO string.
 #[cfg(feature = "rkyv")]
 pub use rkyv_date::AsNaiveDate;
 

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -24,7 +24,13 @@ anyhow.workspace = true
 format_num_pattern.workspace = true
 csv.workspace = true
 ofxy.workspace = true
-chrono = "0.4"                      # ofxy exposes chrono::DateTime; needed for DateTime::format()
+# `ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`, so
+# we need chrono in the dep tree to call its inherent `.format()` method.
+# IMPORTANT: chrono types must NOT leak into this crate's public API — they
+# are converted to `jiff::civil::Date` inside ofx_importer.rs at the boundary.
+# When v1.0 ships, dropping ofxy or replacing it with a jiff-native OFX
+# parser would let us remove chrono entirely.
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/rustledger-importer/src/ofx_importer.rs
+++ b/crates/rustledger-importer/src/ofx_importer.rs
@@ -2,6 +2,15 @@
 //!
 //! This module implements importing transactions from OFX (Open Financial Exchange)
 //! and QFX (Quicken Financial Exchange) files commonly exported by banks.
+//!
+//! # Chrono boundary
+//!
+//! `ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`, but
+//! the rest of the workspace uses `jiff::civil::Date`. The chrono → jiff
+//! conversion happens inside `extract_transaction` via a `format("%Y-%m-%d")
+//! .parse()` round-trip. No `chrono` type appears in any `pub` signature in
+//! this crate — `chrono` is an internal, ofxy-only seal. If we ever drop or
+//! replace ofxy, the chrono dependency can go away with it.
 
 use crate::{EnrichedImportResult, ImportResult, Importer};
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary

Item **G** of the v0.16.0 plan. The chrono boundary in `rustledger-importer` is already correct — no `chrono::*` appears in any `pub` signature; the conversion to `jiff::civil::Date` happens inside the private `extract_transaction`. This PR makes the policy **explicit**, documents the path to eliminate chrono entirely post-v1.0, and fixes two stale chrono references that survived the workspace's prior jiff migration.

## Why chrono can't go away yet

`ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`. Calling `.format()` on the value (an inherent method on chrono's `DateTime`) requires chrono be a **direct** dependency of `rustledger-importer` — transitively-via-ofxy is not enough. Removing the dep silently breaks the OFX importer at compile time.

The seal already in place:
- `chrono::DateTime<Utc>` from ofxy is converted to `jiff::civil::Date` inside `extract_transaction` via a `.format("%Y-%m-%d").parse()` round-trip
- Workspace-wide grep confirms **zero `chrono::` types** in any `pub` signature in the importer
- The chrono dep is invisible to anyone using `rustledger_importer` from the outside

## What this PR changes

1. **`crates/rustledger-importer/Cargo.toml`** — the one-line `# ofxy exposes chrono::DateTime` comment is elevated to an explicit invariant: *"chrono types must NOT leak into this crate's public API."*

2. **`crates/rustledger-importer/src/ofx_importer.rs`** — module-level docstring section titled "Chrono boundary" documenting where the conversion happens and what would let us drop chrono entirely (replace ofxy or fork it to expose jiff types).

3. **`crates/rustledger-core/README.md`** — example code used `use chrono::NaiveDate; NaiveDate::from_ymd_opt(...)`. Stale since the jiff migration; copy-paste users would add a dead chrono dep and use a confusingly-named type. Fixed to use the existing `rustledger_core::naive_date()` helper.

4. **`crates/rustledger-core/src/intern.rs:538`** — leftover `// rkyv wrapper for chrono::NaiveDate` comment on code that actually wraps `jiff::civil::Date`. Fixed.

## Verification

- [x] `cargo check -p rustledger-importer` clean
- [x] `cargo test --doc -p rustledger-core` — 10/10 pass
- [x] Workspace-wide grep: no `chrono::` in any pub signature

## Future follow-up (not in this PR)

Replace ofxy (or fork it to expose jiff types) so chrono can leave the workspace entirely. Out of scope for v0.16.0; the seal is sufficient for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)