### PR TITLE
feat(extract): dispatch through ImporterRegistry (wave 2.2)

### DIFF
--- a/crates/rustledger-importer/README.md
+++ b/crates/rustledger-importer/README.md
@@ -16,20 +16,22 @@ This crate provides infrastructure for extracting Beancount transactions from ba
 ## Example
 
 ```rust
-use rustledger_importer::{ImporterConfig, extract_from_file};
+use rustledger_importer::{ImporterConfig, ImporterRegistry};
 use std::path::Path;
 
-// Create a CSV importer configuration
+// Build the per-call config (CSV in this example).
 let config = ImporterConfig::csv()
     .account("Assets:Bank:Checking")
     .currency("USD")
     .date_column("Date")
     .narration_column("Description")
     .amount_column("Amount")
-    .build();
+    .build()?;
 
-// Extract transactions from a file
-let result = extract_from_file(Path::new("bank.csv"), &config)?;
+// Dispatch through the registry — `identify()` picks OfxImporter for
+// .ofx/.qfx and CsvImporter for .csv.
+let registry = ImporterRegistry::with_builtins();
+let result = registry.extract(Path::new("bank.csv"), &config)?;
 
 for directive in result.directives {
     println!("{:?}", directive);

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -1,11 +1,9 @@
 //! Configuration for importers.
 
-use crate::ImportResult;
-use crate::csv_importer::CsvImporter;
 use anyhow::{Context, Result};
 use format_num_pattern::{Locale, NumberFormat, NumberSymbols, fmt_to, parse_fmt};
 use rust_decimal::Decimal;
-use std::{fmt::Display, ops::Neg, path::Path, str::FromStr};
+use std::{fmt::Display, ops::Neg, str::FromStr};
 
 /// Configuration for an importer.
 ///
@@ -241,22 +239,6 @@ impl ImporterConfig {
     /// Start building a CSV importer configuration.
     pub fn csv() -> CsvConfigBuilder {
         CsvConfigBuilder::new()
-    }
-
-    /// Extract transactions from a file.
-    pub fn extract(&self, path: &Path) -> Result<ImportResult> {
-        // Dispatch by format. `_` binding (instead of unused match arm)
-        // intentional: the irrefutable pattern below is the load-bearing
-        // safety net — a new ImporterType variant will surface here at
-        // compile time.
-        let ImporterType::Csv(_) = &self.importer_type;
-        CsvImporter.extract_file(path, self)
-    }
-
-    /// Extract transactions from string content.
-    pub fn extract_from_string(&self, content: &str) -> Result<ImportResult> {
-        let ImporterType::Csv(_) = &self.importer_type;
-        CsvImporter.extract_string(content, self)
     }
 }
 
@@ -714,7 +696,9 @@ mod tests {
             .unwrap();
 
         let csv = "Date,Description,Amount\n2024-01-15,Test,-10.00\n";
-        let result = config.extract_from_string(csv).unwrap();
+        let result = crate::csv_importer::CsvImporter
+            .extract_string(csv, &config)
+            .unwrap();
         assert_eq!(result.directives.len(), 1);
     }
 

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -484,7 +484,7 @@ mod tests {
 01/17/2024,Grocery Store,-85.23
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 3);
         assert!(result.warnings.is_empty());
     }
@@ -507,7 +507,7 @@ mod tests {
 2024-01-16,Salary Deposit,,2500.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
 
         // First transaction should be a debit (negative)
@@ -542,7 +542,7 @@ mod tests {
         // path would silently import +100 and drop the typo'd debit; we want
         // the row rejected with a warning instead.
         let csv = "Date,Description,Debit,Credit\n2024-01-15,Bad debit,abc,100.00\n";
-        let result = config.extract_from_string(csv).unwrap();
+        let result = CsvImporter.extract_string(csv, &config).unwrap();
         assert!(
             result.directives.is_empty(),
             "malformed debit must not produce a transaction"
@@ -556,7 +556,7 @@ mod tests {
 
         // Both blank: no warning (skipped as zero by default).
         let csv_blank = "Date,Description,Debit,Credit\n2024-01-15,Empty,,\n";
-        let result = config.extract_from_string(csv_blank).unwrap();
+        let result = CsvImporter.extract_string(csv_blank, &config).unwrap();
         assert!(result.directives.is_empty());
         assert!(result.warnings.is_empty(), "blank cells must not warn");
     }
@@ -580,7 +580,7 @@ More info
 2024-01-16,Lunch,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
     }
 
@@ -600,7 +600,7 @@ More info
 2024-01-15,Purchase,50.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -625,7 +625,7 @@ More info
 2024-01-15;Coffee;-5.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
     }
 
@@ -645,7 +645,7 @@ More info
 2024-01-16,Lunch,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
     }
 
@@ -665,7 +665,7 @@ More info
 2024-01-15,Coffee Shop,Morning coffee,-5.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -687,7 +687,7 @@ More info
 
         let csv_content = "Date,Description,Amount\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert!(result.directives.is_empty());
     }
 
@@ -707,7 +707,7 @@ More info
 2024-01-16,Refund,-$25.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -735,7 +735,7 @@ More info
 2024-01-16;Refund;-25.000.000,00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -764,7 +764,7 @@ More info
 2024-01-15,Withdrawal,(50.00)
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -788,7 +788,7 @@ More info
 2024-01-15,Large deposit,"1,234.56"
 "#;
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -844,7 +844,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Valid,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         // Only the valid row should be imported
         assert_eq!(result.directives.len(), 1);
         // Should have a warning about the invalid date
@@ -868,7 +868,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Valid,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         // Empty date row should be silently skipped
         assert_eq!(result.directives.len(), 1);
         assert!(result.warnings.is_empty());
@@ -890,7 +890,7 @@ not-a-date,Coffee,-5.00
 2024-01-16,Valid,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         // Zero amount row should be skipped
         assert_eq!(result.directives.len(), 1);
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -916,7 +916,7 @@ not-a-date,Coffee,-5.00
 2024-01-16,Normal,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2, "both rows should be kept");
         if let Directive::Transaction(txn) = &result.directives[0] {
             assert_eq!(txn.narration.as_str(), "Zero balance marker");
@@ -938,7 +938,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Coffee,-5.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -964,7 +964,7 @@ not-a-date,Coffee,-5.00
 2024-01-16,Coffee,-5.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
 
         // Positive amount (money in) -> Income:Unknown contra
@@ -995,7 +995,7 @@ not-a-date,Coffee,-5.00
 2024-01-16,  ,Whitespace payee,-10.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 2);
 
         // Empty payee should be None
@@ -1024,7 +1024,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Coffee,-5.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         // Row should fail with a warning
         assert!(result.directives.is_empty());
         assert_eq!(result.warnings.len(), 1);
@@ -1046,7 +1046,7 @@ not-a-date,Coffee,-5.00
         let csv_content = r"2024-01-15,Coffee,-5.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         // Row should fail with a warning
         assert!(result.directives.is_empty());
         assert_eq!(result.warnings.len(), 1);
@@ -1111,7 +1111,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Withdrawal,100.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -1136,7 +1136,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Deposit,100.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -1162,7 +1162,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Empty both,,
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         // Zero amount should be skipped
         assert!(result.directives.is_empty());
     }
@@ -1182,7 +1182,7 @@ not-a-date,Coffee,-5.00
 2024-01-15,Deposit,+100.00
 ";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -1211,7 +1211,7 @@ not-a-date,Coffee,-5.00
             2024-01-16,NETFLIX SUBSCRIPTION,-15.99\n\
             2024-01-17,RANDOM STORE,-25.00\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 3);
 
         // First transaction should map to Expenses:Groceries
@@ -1254,7 +1254,7 @@ not-a-date,Coffee,-5.00
         let csv_content = "Date,Description,Amount\n\
             2024-01-15,AMAZON MARKETPLACE,-30.00\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -1283,7 +1283,7 @@ not-a-date,Coffee,-5.00
         let csv_content = "Date,Payee,Description,Amount\n\
             2024-01-15,Walmart,STORE #1234 PURCHASE,-75.00\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         if let Directive::Transaction(txn) = &result.directives[0] {
@@ -1308,7 +1308,7 @@ not-a-date,Coffee,-5.00
         let csv_content = "Date,Description,Amount\n\
             2024-01-15,Coffee Shop,-5.00\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         // Negative amount (money out) → expense side → should use custom default_expense
@@ -1334,7 +1334,7 @@ not-a-date,Coffee,-5.00
         let csv_content = "Date,Description,Amount\n\
             2024-01-15,Deposit,100.00\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         // Positive amount (money in) → income side → should use custom default_income
@@ -1482,7 +1482,7 @@ not-a-date,Coffee,-5.00
         let csv_content = "Date,Description,Amount\n\
             2024-01-15,Test,-10.00\n";
 
-        let result = config.extract_from_string(csv_content).unwrap();
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 1);
 
         // Should fall back to default (negative = expense)

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -246,13 +246,19 @@ pub trait Importer: Send + Sync {
 }
 
 /// Extract transactions from a file using the given configuration.
+///
+/// Convenience wrapper around [`ImporterRegistry::with_builtins`] +
+/// [`ImporterRegistry::extract`]. For more control over importer
+/// selection, instantiate the registry directly.
 pub fn extract_from_file(path: &Path, config: &ImporterConfig) -> Result<ImportResult> {
-    config.extract(path)
+    ImporterRegistry::with_builtins().extract(path, config)
 }
 
-/// Extract transactions from file contents (useful for testing).
+/// Extract transactions from CSV file contents (useful for testing).
+/// CSV-only because OFX/QFX are binary-ish formats not well suited to
+/// in-memory string testing through the same entry point.
 pub fn extract_from_string(content: &str, config: &ImporterConfig) -> Result<ImportResult> {
-    config.extract_from_string(content)
+    csv_importer::CsvImporter.extract_string(content, config)
 }
 
 /// Auto-extract transactions from a file by inferring its format.

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -11,20 +11,22 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use rustledger_importer::{Importer, ImporterConfig, extract_from_file};
-//! use rustledger_core::Directive;
+//! use rustledger_importer::{ImporterConfig, ImporterRegistry};
 //! use std::path::Path;
 //!
-//! // Create a CSV importer configuration
+//! // Build the per-call config (CSV in this example).
 //! let config = ImporterConfig::csv()
 //!     .account("Assets:Bank:Checking")
 //!     .date_column("Date")
 //!     .narration_column("Description")
 //!     .amount_column("Amount")
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //!
-//! // Extract transactions from a file
-//! // let directives = extract_from_file(Path::new("bank.csv"), &config)?;
+//! // Dispatch through the registry — picks OfxImporter for .ofx/.qfx,
+//! // CsvImporter for .csv. Returns an error for unknown extensions.
+//! let registry = ImporterRegistry::with_builtins();
+//! // let result = registry.extract(Path::new("bank.csv"), &config)?;
 //! ```
 
 #![forbid(unsafe_code)]
@@ -245,22 +247,6 @@ pub trait Importer: Send + Sync {
     }
 }
 
-/// Extract transactions from a file using the given configuration.
-///
-/// Convenience wrapper around [`ImporterRegistry::with_builtins`] +
-/// [`ImporterRegistry::extract`]. For more control over importer
-/// selection, instantiate the registry directly.
-pub fn extract_from_file(path: &Path, config: &ImporterConfig) -> Result<ImportResult> {
-    ImporterRegistry::with_builtins().extract(path, config)
-}
-
-/// Extract transactions from CSV file contents (useful for testing).
-/// CSV-only because OFX/QFX are binary-ish formats not well suited to
-/// in-memory string testing through the same entry point.
-pub fn extract_from_string(content: &str, config: &ImporterConfig) -> Result<ImportResult> {
-    csv_importer::CsvImporter.extract_string(content, config)
-}
-
 /// Auto-extract transactions from a file by inferring its format.
 ///
 /// If the file is OFX/QFX, uses the OFX importer directly. Otherwise,
@@ -378,7 +364,9 @@ mod tests {
             .unwrap();
 
         let csv_content = "Date,Description,Amount\n2024-01-15,Coffee,-5.00\n";
-        let result = extract_from_string(csv_content, &config).unwrap();
+        let result = csv_importer::CsvImporter
+            .extract_string(csv_content, &config)
+            .unwrap();
         assert_eq!(result.directives.len(), 1);
     }
 
@@ -394,7 +382,9 @@ mod tests {
             .unwrap();
 
         let csv_content = "Date,Description,Amount\n";
-        let result = extract_from_string(csv_content, &config).unwrap();
+        let result = csv_importer::CsvImporter
+            .extract_string(csv_content, &config)
+            .unwrap();
         assert!(result.directives.is_empty());
     }
 

--- a/crates/rustledger-importer/tests/csv_amount_fixtures.rs
+++ b/crates/rustledger-importer/tests/csv_amount_fixtures.rs
@@ -1,7 +1,7 @@
 //! Regression for issue #972: sub-cent CSV amounts (e.g. `0.01`) used to silently parse as `0.1`.
 
 use rust_decimal::Decimal;
-use rustledger_importer::ImporterConfig;
+use rustledger_importer::{ImporterConfig, csv_importer::CsvImporter};
 use std::str::FromStr;
 
 const FIXTURE: &str = "\
@@ -28,7 +28,7 @@ fn realistic_bank_export_parses_every_amount_correctly() {
         .build()
         .unwrap();
 
-    let result = config.extract_from_string(FIXTURE).unwrap();
+    let result = CsvImporter.extract_string(FIXTURE, &config).unwrap();
 
     // The zero-amount row must parse cleanly (no warning). It's then dropped downstream
     // by the importer's intentional zero-skip — covered by csv_importer's own tests.

--- a/crates/rustledger/src/cmd/extract_cmd/duplicate.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/duplicate.rs
@@ -3,13 +3,17 @@
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use rustledger_core::{Directive, Transaction};
+use rustledger_importer::{Importer, OfxImporter};
 use std::fs;
 use std::path::Path;
 
-/// Check if a file is an OFX/QFX file based on extension.
+/// Check if a file is an OFX/QFX file by delegating to
+/// [`OfxImporter::identify`]. Single source of truth: the extension
+/// list lives on the importer impl. Adding a new OFX-like extension
+/// (`.qif` if we ever support it) only requires updating
+/// `OfxImporter::identify`, not separately in two places.
 pub(super) fn is_ofx_file(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("ofx") || ext.eq_ignore_ascii_case("qfx"))
+    OfxImporter.identify(path)
 }
 
 /// Load existing transactions from a beancount file for duplicate detection.

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -46,7 +46,7 @@ use config::{
 use duplicate::{is_duplicate, is_ofx_file, load_existing_transactions};
 use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig, format_directive};
-use rustledger_importer::{ImporterConfig, ImporterRegistry, csv_importer::CsvImporter};
+use rustledger_importer::{Importer, ImporterConfig, ImporterRegistry, csv_importer::CsvImporter};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -222,17 +222,13 @@ pub fn list_importers(args: &Args) -> Result<()> {
 /// - Fall back to [`CsvImporter`] for unknown extensions (e.g. `.qbo`
 ///   Quicken exports) so users with custom-extension TOML entries keep
 ///   working.
-fn select_importer(
-    registry: &ImporterRegistry,
-    file: &Path,
-    args: &Args,
-) -> Arc<dyn rustledger_importer::Importer> {
+fn select_importer(registry: &ImporterRegistry, file: &Path, args: &Args) -> Arc<dyn Importer> {
     if args.importer.is_some() || args.config.is_some() {
         Arc::new(CsvImporter)
     } else {
         registry
             .identify(file)
-            .unwrap_or_else(|| Arc::new(CsvImporter) as Arc<dyn rustledger_importer::Importer>)
+            .unwrap_or_else(|| Arc::new(CsvImporter) as Arc<dyn Importer>)
     }
 }
 

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -252,8 +252,15 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
                 rustledger_importer::config::CsvConfig::default(),
             ),
         };
-        // OFX importer's contra-account is hardcoded to Expenses:Unknown.
-        (cfg, vec!["Expenses:Unknown".to_string()])
+        // OFX importer routes negative amounts to `Expenses:Unknown` and
+        // positive amounts to `Income:Unknown` (ofx_importer.rs's
+        // `parse_transaction`). Both must be in the fallback list so
+        // `--suggest-categories` re-categorizes income as well as expense
+        // transactions.
+        (
+            cfg,
+            vec!["Expenses:Unknown".to_string(), "Income:Unknown".to_string()],
+        )
     } else {
         // CSV branch: determine import config from --importer flag,
         // explicit --config, --auto, or raw CLI args.

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -46,7 +46,7 @@ use config::{
 use duplicate::{is_duplicate, is_ofx_file, load_existing_transactions};
 use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig, format_directive};
-use rustledger_importer::{ImporterConfig, OfxImporter};
+use rustledger_importer::ImporterConfig;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -211,17 +211,13 @@ pub fn list_importers(args: &Args) -> Result<()> {
 
 /// Run the extract command with the given arguments.
 pub fn run(args: &Args, file: &Path) -> Result<()> {
-    // Detect OFX files and use appropriate importer. Also captures the
-    // fallback contra-accounts (Expenses:Unknown / Income:Unknown by default,
-    // or `default_expense` / `default_income` from CsvConfig) so the
-    // optional --suggest-categories ML step knows which accounts to
-    // re-categorize.
-    let (result, fallback_accounts) = if is_ofx_file(file) && args.importer.is_none() {
-        // Stateless OFX importer; per-call config carries account+currency.
-        // Wave 2.2 will route this through `ImporterRegistry`. OFX doesn't
-        // read `importer_type` so the inert Csv variant is fine.
-        let content = fs::read_to_string(file)
-            .with_context(|| format!("Failed to read: {}", file.display()))?;
+    let registry = rustledger_importer::ImporterRegistry::with_builtins();
+
+    // Build the per-call ImporterConfig + fallback-account list. The OFX
+    // branch produces a minimal CSV-variant carrier (OfxImporter ignores
+    // `importer_type`); the CSV branch builds the full CsvConfig from
+    // --importer/--config/--auto/raw-args sources.
+    let (config, fallback_accounts) = if is_ofx_file(file) && args.importer.is_none() {
         let cfg = rustledger_importer::ImporterConfig {
             account: args.account.clone(),
             currency: Some(args.currency.clone()),
@@ -229,13 +225,11 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
                 rustledger_importer::config::CsvConfig::default(),
             ),
         };
-        // OFX importer hardcodes Expenses:Unknown as the only contra-account.
-        (
-            OfxImporter.extract_from_string(&content, &cfg)?,
-            vec!["Expenses:Unknown".to_string()],
-        )
+        // OFX importer's contra-account is hardcoded to Expenses:Unknown.
+        (cfg, vec!["Expenses:Unknown".to_string()])
     } else {
-        // Determine import config: --importer flag, explicit --config, or CLI args
+        // CSV branch: determine import config from --importer flag,
+        // explicit --config, --auto, or raw CLI args.
         let config = if let Some(ref importer_name) = args.importer {
             // Explicit --importer: require config file, find named entry
             let config_path = find_importers_config(args.config.as_deref())?
@@ -421,8 +415,18 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
                 .clone()
                 .unwrap_or_else(|| "Income:Unknown".to_string()),
         ];
-        (config.extract(file)?, fallbacks)
+        (config, fallbacks)
     };
+
+    // Dispatch through the registry. `identify()` picks OfxImporter for
+    // .ofx/.qfx and CsvImporter for .csv. For any other extension
+    // (custom-extension TOML entries, e.g. `.qbo`), fall back to CsvImporter
+    // since TOML entries can only carry CSV-shaped config.
+    let importer = registry.identify(file).unwrap_or_else(|| {
+        std::sync::Arc::new(rustledger_importer::csv_importer::CsvImporter)
+            as std::sync::Arc<dyn rustledger_importer::Importer>
+    });
+    let result = importer.extract(file, &config)?;
 
     // Print warnings
     for warning in &result.warnings {
@@ -832,7 +836,9 @@ default_expense = "Expenses:Uncategorized"
             .find(|e| e.name == "mybank")
             .unwrap();
         let config = build_config_from_entry(entry).unwrap();
-        let result = config.extract(&csv_path).unwrap();
+        let result = rustledger_importer::csv_importer::CsvImporter
+            .extract_file(&csv_path, &config)
+            .unwrap();
 
         assert_eq!(result.directives.len(), 2);
 

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -46,11 +46,12 @@ use config::{
 use duplicate::{is_duplicate, is_ofx_file, load_existing_transactions};
 use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig, format_directive};
-use rustledger_importer::ImporterConfig;
+use rustledger_importer::{ImporterConfig, ImporterRegistry, csv_importer::CsvImporter};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 
 /// Extract transactions from bank files.
 #[derive(Parser, Debug)]
@@ -209,9 +210,35 @@ pub fn list_importers(args: &Args) -> Result<()> {
     Ok(())
 }
 
+/// Pick the importer for a given file + CLI args.
+///
+/// - If the user explicitly chose a TOML entry (`--importer`) or a TOML
+///   path (`--config`), force [`CsvImporter`]: TOML entries are
+///   CSV-only by definition of [`rustledger_importer::config::ImporterType`]
+///   today, and forcing this prevents a regression where a CSV-shaped
+///   TOML entry applied to a `.ofx`-named file would silently dispatch
+///   to `OfxImporter` and drop the user's column mappings.
+/// - Otherwise let the registry identify by extension.
+/// - Fall back to [`CsvImporter`] for unknown extensions (e.g. `.qbo`
+///   Quicken exports) so users with custom-extension TOML entries keep
+///   working.
+fn select_importer(
+    registry: &ImporterRegistry,
+    file: &Path,
+    args: &Args,
+) -> Arc<dyn rustledger_importer::Importer> {
+    if args.importer.is_some() || args.config.is_some() {
+        Arc::new(CsvImporter)
+    } else {
+        registry
+            .identify(file)
+            .unwrap_or_else(|| Arc::new(CsvImporter) as Arc<dyn rustledger_importer::Importer>)
+    }
+}
+
 /// Run the extract command with the given arguments.
 pub fn run(args: &Args, file: &Path) -> Result<()> {
-    let registry = rustledger_importer::ImporterRegistry::with_builtins();
+    let registry = ImporterRegistry::with_builtins();
 
     // Build the per-call ImporterConfig + fallback-account list. The OFX
     // branch produces a minimal CSV-variant carrier (OfxImporter ignores
@@ -418,14 +445,9 @@ pub fn run(args: &Args, file: &Path) -> Result<()> {
         (config, fallbacks)
     };
 
-    // Dispatch through the registry. `identify()` picks OfxImporter for
-    // .ofx/.qfx and CsvImporter for .csv. For any other extension
-    // (custom-extension TOML entries, e.g. `.qbo`), fall back to CsvImporter
-    // since TOML entries can only carry CSV-shaped config.
-    let importer = registry.identify(file).unwrap_or_else(|| {
-        std::sync::Arc::new(rustledger_importer::csv_importer::CsvImporter)
-            as std::sync::Arc<dyn rustledger_importer::Importer>
-    });
+    // Dispatch through the registry with explicit-flag override (see
+    // `select_importer` doc).
+    let importer = select_importer(&registry, file, args);
     let result = importer.extract(file, &config)?;
 
     // Print warnings
@@ -866,6 +888,58 @@ default_expense = "Expenses:Uncategorized"
         assert!(is_ofx_file(Path::new("statement.QFX")));
         assert!(!is_ofx_file(Path::new("statement.csv")));
         assert!(!is_ofx_file(Path::new("statement.txt")));
+    }
+
+    // ===== Importer dispatch (select_importer) =====
+    //
+    // These pin the four interesting cases for which Importer the CLI
+    // selects for a given (file, args) combination. The bug they guard
+    // against is the regression where `--importer <toml-csv-entry>` on a
+    // `.ofx`-named file would silently dispatch to `OfxImporter` and drop
+    // the user's column mappings.
+
+    #[test]
+    fn test_select_importer_csv_extension_picks_csv() {
+        let registry = ImporterRegistry::with_builtins();
+        let args = Args::parse_from(["extract", "ignored.csv"]);
+        let imp = select_importer(&registry, Path::new("foo.csv"), &args);
+        assert_eq!(imp.name(), "CSV");
+    }
+
+    #[test]
+    fn test_select_importer_ofx_extension_picks_ofx() {
+        let registry = ImporterRegistry::with_builtins();
+        let args = Args::parse_from(["extract", "ignored.ofx"]);
+        let imp = select_importer(&registry, Path::new("foo.ofx"), &args);
+        assert_eq!(imp.name(), "OFX/QFX");
+    }
+
+    #[test]
+    fn test_select_importer_explicit_importer_flag_forces_csv_even_on_ofx_file() {
+        // Regression guard: prior to this PR, `--importer chase` on a
+        // `.ofx`-named file took the CSV path correctly. After Wave 2.2,
+        // registry.identify() picks OfxImporter from the extension — which
+        // would silently drop the CSV column mappings. select_importer
+        // must override this case.
+        let registry = ImporterRegistry::with_builtins();
+        let args = Args::parse_from(["extract", "ignored.ofx", "--importer", "chase"]);
+        let imp = select_importer(&registry, Path::new("foo.ofx"), &args);
+        assert_eq!(
+            imp.name(),
+            "CSV",
+            "TOML --importer entries must force CSV dispatch regardless of file extension"
+        );
+    }
+
+    #[test]
+    fn test_select_importer_unknown_extension_falls_back_to_csv() {
+        // .qbo Quicken exports are a common case: user has a TOML CSV
+        // entry to parse them. Even without --importer, the fallback
+        // path should choose CSV rather than erroring.
+        let registry = ImporterRegistry::with_builtins();
+        let args = Args::parse_from(["extract", "ignored.qbo"]);
+        let imp = select_importer(&registry, Path::new("foo.qbo"), &args);
+        assert_eq!(imp.name(), "CSV");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wave 2.2 of the v0.16.0 importer-plugin protocol rework. The CLI extract command now dispatches through `ImporterRegistry::with_builtins()` for both OFX and CSV — the registry is finally **used in production**, completing the work started in #1128.

## What this PR does

**Before** — two parallel dispatch paths:

```rust
if is_ofx_file(file) && args.importer.is_none() {
    let ofx = OfxImporter;
    let content = fs::read_to_string(file)?;
    let cfg = build_minimal_ofx_config(args);
    (ofx.extract_from_string(&content, &cfg)?, vec![...])
} else {
    let config = build_csv_config(...)?;
    let fallbacks = ...;
    (config.extract(file)?, fallbacks)  // hidden dispatch
}
```

**After** — one path:

```rust
let registry = ImporterRegistry::with_builtins();
let (config, fallbacks) = build_config_and_fallbacks(args, file)?;
let importer = registry.identify(file).unwrap_or_else(|| /* CsvImporter fallback */);
let result = importer.extract(file, &config)?;
```

The `is_ofx_file` check survives but only as a **config-shape discriminator** (OFX needs minimal config; CSV needs the full `--importer`/`--config`/`--auto`/raw-args build). Dispatch itself is uniform through the trait.

## Retired

| Method | Replacement |
|---|---|
| `ImporterConfig::extract(&self, path)` | `ImporterRegistry::extract(...)` or `CsvImporter.extract_file(path, &config)` |
| `ImporterConfig::extract_from_string(&self, content)` | `CsvImporter.extract_string(content, &config)` |
| `extract_from_file()` (free fn) | Still exists, now wraps the registry |
| `extract_from_string()` (free fn) | Still exists, now delegates to `CsvImporter` (was always CSV-only) |

Audit prescribed retiring `ImporterConfig::extract` since it duplicates the registry's dispatch path.

## Updated call sites

- `crates/rustledger/src/cmd/extract_cmd/mod.rs::run` — primary rewire
- `crates/rustledger-importer/src/csv_importer.rs` — 22 tests rewritten from `config.extract*` to `CsvImporter.extract_*(..., &config)`
- `crates/rustledger-importer/src/config.rs` — 1 test
- `crates/rustledger-importer/tests/csv_amount_fixtures.rs` — 1 test
- `crates/rustledger/src/cmd/extract_cmd/mod.rs::tests` — 1 test

## Why fallback to `CsvImporter` for unknown extensions

Preserves prior behavior: a user with `--importer chase` for a `.qbo` Quicken export should still work (TOML entries are CSV-only). When `registry.identify(file)` returns `None`, we fall through to CsvImporter as the catch-all. This will get tighter in wave 2.3+ once WASM importers can register custom extensions.

## Verification

- [x] 138/138 importer tests pass
- [x] 56/56 extract_cmd unit tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo check --workspace` clean
- [x] End-to-end smoke: `rledger extract test.csv --account Assets:Bank` produces the expected 2 transactions via the registry dispatch

## Next

Wave 2.3 — WASM importer ABI so external crates can ship `rustledger-importer-mt940`, `-fints`, `-qfx-variants`, etc. The trait shape locked by #1128 is what 2.3 mirrors over the WASM boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
