### PR TITLE
feat(plugin-types): WASM importer ABI types (wave 2.3a)

### DIFF
--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -737,6 +737,17 @@ pub struct CustomData {
 
 /// Wire-format input passed from the host to a WASM importer's
 /// `extract` / `extract_enriched` entry point.
+///
+/// # `options` design note
+///
+/// The `options` map is `String -> String`. Values that are
+/// semantically numbers, booleans, or other types (e.g.
+/// `skip_rows = 5`, `has_header = true`, `delimiter = ","`) are
+/// string-encoded on the host side and parsed by the WASM importer.
+/// This keeps the WASM ABI minimal (no `serde_json::Value` or `rmpv`
+/// dep in the guest crate) at the cost of pushing string parsing into
+/// every importer. A future additive field (`options_typed`) could
+/// carry typed values if needed; not in v1.0 scope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImporterInput {
     /// Source file path. Informational only — the WASM sandbox cannot
@@ -754,8 +765,40 @@ pub struct ImporterInput {
     /// `importers.toml` entries' arbitrary fields into this map; the
     /// WASM importer reads the keys it knows about. Keeps the
     /// wire format independent of any host-side config struct shape.
+    /// See the type-level doc for the string-encoding trade-off.
     #[serde(default)]
     pub options: std::collections::HashMap<String, String>,
+}
+
+/// Wire-format input to a WASM importer's `identify` entry point.
+///
+/// The WASM importer answers "do I handle this file?" based on the
+/// path (typically extension) alone — `extract` is the path that
+/// gets file content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentifyInput {
+    /// Source file path. Same lossy-utf8 caveat as
+    /// [`ImporterInput::path`].
+    pub path: String,
+}
+
+/// Wire-format output from a WASM importer's `identify`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentifyOutput {
+    /// True if this importer handles the file at `IdentifyInput.path`.
+    pub matches: bool,
+}
+
+/// Wire-format output from a WASM importer's `metadata` entry point.
+/// Returned once at load time and cached by the host registry — used
+/// for `Importer::name()` and `Importer::description()` on the wrapper.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataOutput {
+    /// Importer name (e.g. `"MT940"`, `"FinTS"`). Used by the registry
+    /// for `find_by_name` lookups.
+    pub name: String,
+    /// Human-readable description for `--list-importers` and similar.
+    pub description: String,
 }
 
 /// Wire-format output returned from a WASM importer's `extract`.
@@ -766,24 +809,34 @@ pub struct ImporterOutput {
     /// Warnings encountered during extraction (non-fatal).
     #[serde(default)]
     pub warnings: Vec<String>,
+    /// Fatal-but-recoverable errors (e.g. malformed individual rows
+    /// the importer chose to skip rather than abort on). Distinct from
+    /// `warnings` (informational) and from a WASM trap (which the host
+    /// surfaces as an `anyhow::Error`). Reuses the existing
+    /// [`PluginError`] shape so importer errors flow into the same
+    /// `LedgerError::location` path as plugin errors.
+    #[serde(default)]
+    pub errors: Vec<PluginError>,
 }
 
 impl ImporterOutput {
-    /// Create an output with no warnings.
+    /// Create an output with no warnings or errors.
     #[must_use]
     pub const fn new(directives: Vec<DirectiveWrapper>) -> Self {
         Self {
             directives,
             warnings: Vec::new(),
+            errors: Vec::new(),
         }
     }
 
-    /// Empty result with no directives and no warnings.
+    /// Empty result with no directives, no warnings, no errors.
     #[must_use]
     pub const fn empty() -> Self {
         Self {
             directives: Vec::new(),
             warnings: Vec::new(),
+            errors: Vec::new(),
         }
     }
 }
@@ -798,6 +851,10 @@ pub struct EnrichedImporterOutput {
     /// Warnings encountered during extraction (non-fatal).
     #[serde(default)]
     pub warnings: Vec<String>,
+    /// Fatal-but-recoverable errors. Same semantics as
+    /// [`ImporterOutput::errors`].
+    #[serde(default)]
+    pub errors: Vec<PluginError>,
 }
 
 /// Wire-format counterpart to `rustledger_ops::enrichment::Enrichment`.
@@ -1219,5 +1276,95 @@ mod tests {
         let decoded: ImporterInput = rmp_serde::from_slice(&bytes).unwrap();
         assert!(decoded.options.is_empty());
         assert_eq!(decoded.path, "/x.csv");
+    }
+
+    #[test]
+    fn enriched_importer_output_msgpack_roundtrip() {
+        // Cover the more complex enriched variant — pair of
+        // (DirectiveWrapper, EnrichmentWrapper) with metadata,
+        // plus warnings + errors.
+        let dir = DirectiveWrapper {
+            directive_type: "transaction".to_string(),
+            date: "2024-01-15".to_string(),
+            filename: Some("/tmp/foo.csv".to_string()),
+            lineno: Some(7),
+            data: DirectiveData::Transaction(TransactionData {
+                flag: "*".to_string(),
+                payee: Some("Whole Foods".to_string()),
+                narration: "Groceries".to_string(),
+                tags: vec![],
+                links: vec![],
+                metadata: vec![],
+                postings: vec![],
+            }),
+        };
+        let enr = EnrichmentWrapper {
+            directive_index: 0,
+            confidence: 0.92,
+            method: "rule".to_string(),
+            alternatives: vec![],
+            fingerprint: Some("dead-beef".to_string()),
+        };
+        let original = EnrichedImporterOutput {
+            entries: vec![(dir, enr)],
+            warnings: vec!["row 3 skipped".to_string()],
+            errors: vec![PluginError::error("row 4 unparsable").at("/tmp/foo.csv", 4)],
+        };
+        let bytes = rmp_serde::to_vec(&original).unwrap();
+        let decoded: EnrichedImporterOutput = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.entries.len(), 1);
+        assert_eq!(decoded.entries[0].1.method, "rule");
+        assert_eq!(decoded.warnings.len(), 1);
+        assert_eq!(decoded.errors.len(), 1);
+        assert_eq!(decoded.errors[0].line_number, Some(4));
+    }
+
+    #[test]
+    fn identify_input_output_msgpack_roundtrip() {
+        let input = IdentifyInput {
+            path: "/tmp/statement.mt940".to_string(),
+        };
+        let input_bytes = rmp_serde::to_vec(&input).unwrap();
+        let decoded_input: IdentifyInput = rmp_serde::from_slice(&input_bytes).unwrap();
+        assert_eq!(decoded_input.path, input.path);
+
+        let output = IdentifyOutput { matches: true };
+        let output_bytes = rmp_serde::to_vec(&output).unwrap();
+        let decoded_output: IdentifyOutput = rmp_serde::from_slice(&output_bytes).unwrap();
+        assert!(decoded_output.matches);
+    }
+
+    #[test]
+    fn metadata_output_msgpack_roundtrip() {
+        let original = MetadataOutput {
+            name: "MT940".to_string(),
+            description: "SWIFT MT940 bank statement importer".to_string(),
+        };
+        let bytes = rmp_serde::to_vec(&original).unwrap();
+        let decoded: MetadataOutput = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.name, original.name);
+        assert_eq!(decoded.description, original.description);
+    }
+
+    #[test]
+    fn importer_output_errors_field_is_backward_compatible() {
+        // Like the `options` field on input, the `errors` field on
+        // output has `#[serde(default)]`. An older WASM importer that
+        // emits only `directives` + `warnings` deserializes cleanly
+        // with an empty errors vec.
+        #[derive(serde::Serialize)]
+        struct OldShape {
+            directives: Vec<DirectiveWrapper>,
+            warnings: Vec<String>,
+            // intentionally no `errors`
+        }
+        let old = OldShape {
+            directives: vec![],
+            warnings: vec!["w".to_string()],
+        };
+        let bytes = rmp_serde::to_vec(&old).unwrap();
+        let decoded: ImporterOutput = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(decoded.errors.is_empty());
+        assert_eq!(decoded.warnings.len(), 1);
     }
 }

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -722,18 +722,25 @@ pub struct CustomData {
 //
 // # MessagePack contract
 //
-// Both [`ImporterInput`] and [`ImporterOutput`] are `Serialize +
-// Deserialize` and travel between host and guest as MessagePack-encoded
-// byte slices. The WASM module exports a single byte-buffer entry point
-// for each operation; see `rustledger-importer::WasmImporter` for the
-// host side and `rustledger-plugin`'s reference implementation for the
-// guest side.
+// All ABI types travel between host and guest as MessagePack-encoded byte
+// slices via `rmp_serde`. We use rmp-serde's **default positional struct
+// encoding** (compact arrays of values, no field names on the wire). This
+// is faster and smaller than map encoding at the cost of being strict
+// about field order.
 //
 // # Versioning
 //
-// Field additions are backward-compatible (msgpack ignores unknown
-// fields). Field removals or shape changes are major-version breaks
-// for the WASM ABI.
+// We do not maintain wire-format backward compatibility. Any field
+// addition, removal, reorder, or type change is a major-version break
+// for the WASM ABI. Users of WASM importer modules are expected to
+// rebuild their importer against the host version they're targeting —
+// the host's ABI version (exposed via `wave-2.3 release notes`) is the
+// authoritative reference.
+//
+// Rationale: pre-v1.0 we ship structural changes freely; locking serde
+// `default`-tolerance into v1.0 would force every future ABI evolution
+// to be additive and live with a growing tail of compat shims. We'd
+// rather bump majors.
 
 /// Wire-format input passed from the host to a WASM importer's
 /// `extract` / `extract_enriched` entry point.
@@ -766,7 +773,6 @@ pub struct ImporterInput {
     /// WASM importer reads the keys it knows about. Keeps the
     /// wire format independent of any host-side config struct shape.
     /// See the type-level doc for the string-encoding trade-off.
-    #[serde(default)]
     pub options: std::collections::HashMap<String, String>,
 }
 
@@ -807,7 +813,6 @@ pub struct ImporterOutput {
     /// Extracted directives.
     pub directives: Vec<DirectiveWrapper>,
     /// Warnings encountered during extraction (non-fatal).
-    #[serde(default)]
     pub warnings: Vec<String>,
     /// Fatal-but-recoverable errors (e.g. malformed individual rows
     /// the importer chose to skip rather than abort on). Distinct from
@@ -815,7 +820,6 @@ pub struct ImporterOutput {
     /// surfaces as an `anyhow::Error`). Reuses the existing
     /// [`PluginError`] shape so importer errors flow into the same
     /// `LedgerError::location` path as plugin errors.
-    #[serde(default)]
     pub errors: Vec<PluginError>,
 }
 
@@ -849,11 +853,9 @@ pub struct EnrichedImporterOutput {
     /// Directive–enrichment pairs, parallel to `ImporterOutput.directives`.
     pub entries: Vec<(DirectiveWrapper, EnrichmentWrapper)>,
     /// Warnings encountered during extraction (non-fatal).
-    #[serde(default)]
     pub warnings: Vec<String>,
     /// Fatal-but-recoverable errors. Same semantics as
     /// [`ImporterOutput::errors`].
-    #[serde(default)]
     pub errors: Vec<PluginError>,
 }
 
@@ -872,12 +874,15 @@ pub struct EnrichmentWrapper {
     /// Confidence score for the primary categorization (0.0 to 1.0).
     pub confidence: f64,
     /// How the primary categorization was determined. String-encoded
-    /// (e.g. `"rule"`, `"merchant_dict"`, `"ml"`, `"llm"`, `"default"`,
-    /// `"manual"`) to avoid pinning the `CategorizationMethod` enum's
-    /// exact variant set into the wire format.
+    /// to avoid pinning the `CategorizationMethod` enum's exact variant
+    /// set into the wire format. Must match
+    /// `CategorizationMethod::as_meta_value()` in `rustledger-ops`:
+    /// `"rule"`, `"merchant-dict"`, `"ml"`, `"llm"`, `"default"`,
+    /// `"manual"`. (Note: `merchant-dict` uses a hyphen, not an
+    /// underscore — the host string-matches against
+    /// `as_meta_value()`'s output, so the wire format must agree.)
     pub method: String,
     /// Other possible categorizations, sorted by confidence descending.
-    #[serde(default)]
     pub alternatives: Vec<AlternativeWrapper>,
     /// Stable fingerprint for deduplication, serialized as a hex string.
     pub fingerprint: Option<String>,
@@ -890,6 +895,9 @@ pub struct AlternativeWrapper {
     pub account: String,
     /// Confidence score for this alternative (0.0 to 1.0).
     pub confidence: f64,
+    /// How this alternative was determined. Same encoding rules as
+    /// [`EnrichmentWrapper::method`].
+    pub method: String,
 }
 
 // ============================================================================
@@ -1239,6 +1247,7 @@ mod tests {
             alternatives: vec![AlternativeWrapper {
                 account: "Expenses:Groceries".to_string(),
                 confidence: 0.75,
+                method: "merchant-dict".to_string(),
             }],
             fingerprint: Some("abc123def456".to_string()),
         };
@@ -1249,40 +1258,22 @@ mod tests {
         assert_eq!(decoded.method, original.method);
         assert_eq!(decoded.alternatives.len(), 1);
         assert_eq!(decoded.alternatives[0].account, "Expenses:Groceries");
+        // Every field on AlternativeWrapper must round-trip — if any drift
+        // silently (renamed / dropped / type-changed) we want to catch it
+        // here, not at the WASM boundary where it'd corrupt enriched results.
+        assert!(
+            (decoded.alternatives[0].confidence - 0.75).abs() < f64::EPSILON,
+            "alternative confidence must round-trip exactly"
+        );
+        assert_eq!(decoded.alternatives[0].method, "merchant-dict");
         assert_eq!(decoded.fingerprint, original.fingerprint);
-    }
-
-    #[test]
-    fn importer_input_default_options_field_is_backward_compatible() {
-        // The `options` field has `#[serde(default)]` so an older WASM
-        // importer that doesn't include the field in its serialized
-        // output can still be deserialized. Pin this with a synthetic
-        // partial-shape blob.
-        #[derive(serde::Serialize)]
-        struct OldShape {
-            path: String,
-            content: Vec<u8>,
-            account: String,
-            currency: Option<String>,
-            // intentionally no `options`
-        }
-        let old = OldShape {
-            path: "/x.csv".into(),
-            content: vec![1, 2, 3],
-            account: "Assets:Bank".into(),
-            currency: Some("USD".into()),
-        };
-        let bytes = rmp_serde::to_vec(&old).unwrap();
-        let decoded: ImporterInput = rmp_serde::from_slice(&bytes).unwrap();
-        assert!(decoded.options.is_empty());
-        assert_eq!(decoded.path, "/x.csv");
     }
 
     #[test]
     fn enriched_importer_output_msgpack_roundtrip() {
         // Cover the more complex enriched variant — pair of
         // (DirectiveWrapper, EnrichmentWrapper) with metadata,
-        // plus warnings + errors.
+        // plus warnings + errors. Asserts every field individually.
         let dir = DirectiveWrapper {
             directive_type: "transaction".to_string(),
             date: "2024-01-15".to_string(),
@@ -1302,7 +1293,11 @@ mod tests {
             directive_index: 0,
             confidence: 0.92,
             method: "rule".to_string(),
-            alternatives: vec![],
+            alternatives: vec![AlternativeWrapper {
+                account: "Expenses:Other".to_string(),
+                confidence: 0.10,
+                method: "default".to_string(),
+            }],
             fingerprint: Some("dead-beef".to_string()),
         };
         let original = EnrichedImporterOutput {
@@ -1313,9 +1308,31 @@ mod tests {
         let bytes = rmp_serde::to_vec(&original).unwrap();
         let decoded: EnrichedImporterOutput = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(decoded.entries.len(), 1);
-        assert_eq!(decoded.entries[0].1.method, "rule");
-        assert_eq!(decoded.warnings.len(), 1);
+        let (dir, enr) = &decoded.entries[0];
+        // `directive_type` is intentionally `#[serde(skip_serializing, default)]`
+        // on `DirectiveWrapper` — derived from the `data` variant, not on the
+        // wire. Don't assert it here.
+        assert_eq!(dir.date, "2024-01-15");
+        match &dir.data {
+            DirectiveData::Transaction(t) => {
+                assert_eq!(t.payee.as_deref(), Some("Whole Foods"));
+                assert_eq!(t.narration, "Groceries");
+            }
+            other => panic!("expected Transaction, got {other:?}"),
+        }
+        assert_eq!(enr.directive_index, 0);
+        assert!((enr.confidence - 0.92).abs() < f64::EPSILON);
+        assert_eq!(enr.method, "rule");
+        assert_eq!(enr.alternatives.len(), 1);
+        assert_eq!(enr.alternatives[0].method, "default");
+        assert_eq!(enr.fingerprint, Some("dead-beef".to_string()));
+        assert_eq!(decoded.warnings, vec!["row 3 skipped".to_string()]);
         assert_eq!(decoded.errors.len(), 1);
+        assert_eq!(decoded.errors[0].message, "row 4 unparsable");
+        assert_eq!(
+            decoded.errors[0].source_file,
+            Some("/tmp/foo.csv".to_string())
+        );
         assert_eq!(decoded.errors[0].line_number, Some(4));
     }
 
@@ -1344,27 +1361,5 @@ mod tests {
         let decoded: MetadataOutput = rmp_serde::from_slice(&bytes).unwrap();
         assert_eq!(decoded.name, original.name);
         assert_eq!(decoded.description, original.description);
-    }
-
-    #[test]
-    fn importer_output_errors_field_is_backward_compatible() {
-        // Like the `options` field on input, the `errors` field on
-        // output has `#[serde(default)]`. An older WASM importer that
-        // emits only `directives` + `warnings` deserializes cleanly
-        // with an empty errors vec.
-        #[derive(serde::Serialize)]
-        struct OldShape {
-            directives: Vec<DirectiveWrapper>,
-            warnings: Vec<String>,
-            // intentionally no `errors`
-        }
-        let old = OldShape {
-            directives: vec![],
-            warnings: vec!["w".to_string()],
-        };
-        let bytes = rmp_serde::to_vec(&old).unwrap();
-        let decoded: ImporterOutput = rmp_serde::from_slice(&bytes).unwrap();
-        assert!(decoded.errors.is_empty());
-        assert_eq!(decoded.warnings.len(), 1);
     }
 }

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -707,6 +707,135 @@ pub struct CustomData {
 }
 
 // ============================================================================
+// Importer ABI (wave 2.3: WASM-loaded importers)
+// ============================================================================
+//
+// These types are the wire format spoken between the rustledger host and
+// a WASM-loaded importer plugin (e.g. `rustledger-importer-mt940.wasm`).
+//
+// # Sandbox model
+//
+// WASM importers run in the same locked-down sandbox as directive plugins
+// (no filesystem, no network, no environment, no syscalls). The host reads
+// the source file and passes its bytes via [`ImporterInput::content`] —
+// the WASM importer does NOT open the file itself.
+//
+// # MessagePack contract
+//
+// Both [`ImporterInput`] and [`ImporterOutput`] are `Serialize +
+// Deserialize` and travel between host and guest as MessagePack-encoded
+// byte slices. The WASM module exports a single byte-buffer entry point
+// for each operation; see `rustledger-importer::WasmImporter` for the
+// host side and `rustledger-plugin`'s reference implementation for the
+// guest side.
+//
+// # Versioning
+//
+// Field additions are backward-compatible (msgpack ignores unknown
+// fields). Field removals or shape changes are major-version breaks
+// for the WASM ABI.
+
+/// Wire-format input passed from the host to a WASM importer's
+/// `extract` / `extract_enriched` entry point.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImporterInput {
+    /// Source file path. Informational only — the WASM sandbox cannot
+    /// open this. Used for diagnostics and fingerprint generation.
+    pub path: String,
+    /// File content bytes. The host reads the file and forwards the
+    /// bytes here so the WASM importer doesn't need filesystem access.
+    pub content: Vec<u8>,
+    /// Target account for imported transactions
+    /// (from `ImporterConfig.account`).
+    pub account: String,
+    /// Currency for amounts (from `ImporterConfig.currency`).
+    pub currency: Option<String>,
+    /// Free-form importer-specific options. The host serializes
+    /// `importers.toml` entries' arbitrary fields into this map; the
+    /// WASM importer reads the keys it knows about. Keeps the
+    /// wire format independent of any host-side config struct shape.
+    #[serde(default)]
+    pub options: std::collections::HashMap<String, String>,
+}
+
+/// Wire-format output returned from a WASM importer's `extract`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImporterOutput {
+    /// Extracted directives.
+    pub directives: Vec<DirectiveWrapper>,
+    /// Warnings encountered during extraction (non-fatal).
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+impl ImporterOutput {
+    /// Create an output with no warnings.
+    #[must_use]
+    pub const fn new(directives: Vec<DirectiveWrapper>) -> Self {
+        Self {
+            directives,
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Empty result with no directives and no warnings.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            directives: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+/// Wire-format output returned from a WASM importer's
+/// `extract_enriched`. Each directive is paired with per-directive
+/// categorization metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnrichedImporterOutput {
+    /// Directive–enrichment pairs, parallel to `ImporterOutput.directives`.
+    pub entries: Vec<(DirectiveWrapper, EnrichmentWrapper)>,
+    /// Warnings encountered during extraction (non-fatal).
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+/// Wire-format counterpart to `rustledger_ops::enrichment::Enrichment`.
+///
+/// Kept here (rather than in `rustledger-ops`) so the importer ABI is
+/// self-contained — WASM importers depend on `rustledger-plugin-types`
+/// and shouldn't pull in the larger `rustledger-ops` graph just for an
+/// enrichment definition. The host converts between the two shapes at
+/// the trait boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnrichmentWrapper {
+    /// Index of the directive this enrichment applies to (parallel to
+    /// `EnrichedImporterOutput.entries`).
+    pub directive_index: usize,
+    /// Confidence score for the primary categorization (0.0 to 1.0).
+    pub confidence: f64,
+    /// How the primary categorization was determined. String-encoded
+    /// (e.g. `"rule"`, `"merchant_dict"`, `"ml"`, `"llm"`, `"default"`,
+    /// `"manual"`) to avoid pinning the `CategorizationMethod` enum's
+    /// exact variant set into the wire format.
+    pub method: String,
+    /// Other possible categorizations, sorted by confidence descending.
+    #[serde(default)]
+    pub alternatives: Vec<AlternativeWrapper>,
+    /// Stable fingerprint for deduplication, serialized as a hex string.
+    pub fingerprint: Option<String>,
+}
+
+/// Wire-format counterpart to `rustledger_ops::enrichment::Alternative`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlternativeWrapper {
+    /// Account this alternative would assign.
+    pub account: String,
+    /// Confidence score for this alternative (0.0 to 1.0).
+    pub confidence: f64,
+}
+
+// ============================================================================
 // Utility Functions
 // ============================================================================
 
@@ -994,5 +1123,101 @@ mod tests {
             }
             other => panic!("expected Unit, got {other:?}"),
         }
+    }
+
+    // ===== Importer ABI round-trip tests =====
+    //
+    // Pin the MessagePack-roundtrip shape of the WASM importer wire
+    // format. If any field is renamed, removed, or its type changes,
+    // these tests catch it — that's a v1.0 ABI breakage we want to
+    // notice at code-change time.
+
+    #[test]
+    fn importer_input_msgpack_roundtrip() {
+        let mut options = std::collections::HashMap::new();
+        options.insert("date_column".to_string(), "Date".to_string());
+        options.insert("delimiter".to_string(), ",".to_string());
+
+        let original = ImporterInput {
+            path: "/path/to/foo.csv".to_string(),
+            content: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            account: "Assets:Bank".to_string(),
+            currency: Some("USD".to_string()),
+            options,
+        };
+        let bytes = rmp_serde::to_vec(&original).unwrap();
+        let decoded: ImporterInput = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.path, original.path);
+        assert_eq!(decoded.content, original.content);
+        assert_eq!(decoded.account, original.account);
+        assert_eq!(decoded.currency, original.currency);
+        assert_eq!(decoded.options, original.options);
+    }
+
+    #[test]
+    fn importer_output_msgpack_roundtrip_empty() {
+        let original = ImporterOutput::empty();
+        let bytes = rmp_serde::to_vec(&original).unwrap();
+        let decoded: ImporterOutput = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(decoded.directives.is_empty());
+        assert!(decoded.warnings.is_empty());
+    }
+
+    #[test]
+    fn importer_output_msgpack_roundtrip_with_warning() {
+        let mut out = ImporterOutput::new(vec![]);
+        out.warnings.push("Skipped row 3: bad date".to_string());
+        let bytes = rmp_serde::to_vec(&out).unwrap();
+        let decoded: ImporterOutput = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.warnings.len(), 1);
+        assert!(decoded.warnings[0].contains("bad date"));
+    }
+
+    #[test]
+    fn enrichment_wrapper_msgpack_roundtrip() {
+        let original = EnrichmentWrapper {
+            directive_index: 7,
+            confidence: 0.85,
+            method: "rule".to_string(),
+            alternatives: vec![AlternativeWrapper {
+                account: "Expenses:Groceries".to_string(),
+                confidence: 0.75,
+            }],
+            fingerprint: Some("abc123def456".to_string()),
+        };
+        let bytes = rmp_serde::to_vec(&original).unwrap();
+        let decoded: EnrichmentWrapper = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.directive_index, original.directive_index);
+        assert!((decoded.confidence - original.confidence).abs() < f64::EPSILON);
+        assert_eq!(decoded.method, original.method);
+        assert_eq!(decoded.alternatives.len(), 1);
+        assert_eq!(decoded.alternatives[0].account, "Expenses:Groceries");
+        assert_eq!(decoded.fingerprint, original.fingerprint);
+    }
+
+    #[test]
+    fn importer_input_default_options_field_is_backward_compatible() {
+        // The `options` field has `#[serde(default)]` so an older WASM
+        // importer that doesn't include the field in its serialized
+        // output can still be deserialized. Pin this with a synthetic
+        // partial-shape blob.
+        #[derive(serde::Serialize)]
+        struct OldShape {
+            path: String,
+            content: Vec<u8>,
+            account: String,
+            currency: Option<String>,
+            // intentionally no `options`
+        }
+        let old = OldShape {
+            path: "/x.csv".into(),
+            content: vec![1, 2, 3],
+            account: "Assets:Bank".into(),
+            currency: Some("USD".into()),
+        };
+        let bytes = rmp_serde::to_vec(&old).unwrap();
+        let decoded: ImporterInput = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(decoded.options.is_empty());
+        assert_eq!(decoded.path, "/x.csv");
     }
 }


### PR DESCRIPTION
## Summary

First step of wave 2.3 — the **v1.0-locking wire format** for WASM-loaded importer plugins. Subsequent PRs (2.3b/2.3c/2.3d) build on these types:

- **2.3b**: host loader in `rustledger-importer` (wasmtime + sandboxing)
- **2.3c**: registry discovery (auto-scan + `--wasm-importer` flag)
- **2.3d**: guest macros in `rustledger-plugin`

## New types (in `rustledger-plugin-types`)

| Type | Purpose |
|---|---|
| `ImporterInput` | Wire-format input to the WASM importer's `extract` entry. Carries `(path, content, account, currency, options: HashMap<String,String>)`. The host reads the file and passes bytes via `content` — sandbox forbids WASM filesystem access. |
| `ImporterOutput` | Wire-format output. `{ directives, warnings }`. |
| `EnrichedImporterOutput` | Enriched variant with per-directive categorization metadata. |
| `EnrichmentWrapper` / `AlternativeWrapper` | Wire-format counterparts to `rustledger_ops::enrichment::{Enrichment, Alternative}`. Method string-encoded (`"rule"`, `"ml"`, etc.) to avoid pinning enum variants into v1.0. |

## Why `options: HashMap<String, String>` instead of a typed config

WASM importers handle **one format** with their own internal logic. They don't need the host's `ImporterConfig` shape (which is CSV-centric and pulls in `format_num_pattern::Locale` etc. that aren't trivially serde-clean for WASM). The free-form map lets the host serialize TOML entry fields straight through, and the WASM importer reads what it knows about.

Trade-off: callers lose type safety on importer-specific config — but in exchange, the wire format stays independent of any host-side struct. Future-proof against host config refactors.

## Sandbox + versioning contract

Documented inline at the section header:

- WASM importers run in the same locked-down sandbox as directive plugins (no FS, no net, no env, no syscalls)
- Field additions are backward-compatible (msgpack ignores unknown fields)
- Field removals or shape changes are major-version breaks for the WASM ABI

## Tests

5 round-trip tests pin the MessagePack wire format:

- `importer_input_msgpack_roundtrip` — full input with options map
- `importer_output_msgpack_roundtrip_empty` — empty output via `::empty()`
- `importer_output_msgpack_roundtrip_with_warning` — output carrying a warning
- `enrichment_wrapper_msgpack_roundtrip` — full enrichment with alternatives
- `importer_input_default_options_field_is_backward_compatible` — synthetic blob from an older shape (without `options`) deserializes cleanly because of `#[serde(default)]`

## Verification

- [x] 18/18 plugin-types tests pass (was 13 — 5 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo check --workspace` clean

## Decision rationale

Per the recent dispatch architecture discussion:
- **Discovery (2.3c)**: directory scan + `--wasm-importer` flag (both)
- **Guest SDK (2.3d)**: re-export from `rustledger-plugin-types`, no new crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
