### PR TITLE
feat(importer): WasmImporter host loader (wave 2.3b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,10 +3271,17 @@ dependencies = [
  "jiff",
  "ofxy",
  "proptest",
+ "rmp-serde",
  "rust_decimal",
  "rustledger-core",
  "rustledger-ops",
+ "rustledger-plugin",
+ "rustledger-plugin-types",
+ "serde",
  "tempfile",
+ "thiserror 2.0.18",
+ "wasmtime",
+ "wat",
 ]
 
 [[package]]

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -18,12 +18,23 @@ bench = false
 [dependencies]
 rustledger-core.workspace = true
 rustledger-ops.workspace = true
+rustledger-plugin.workspace = true
+rustledger-plugin-types.workspace = true
 jiff.workspace = true
 rust_decimal.workspace = true
 anyhow.workspace = true
 format_num_pattern.workspace = true
 csv.workspace = true
 ofxy.workspace = true
+# WASM importer loader (wave 2.3b). Mirrors the sandboxing model used by
+# rustledger-plugin's directive-plugin runtime. We depend on
+# rustledger-plugin (not just -plugin-types) for `convert::wrapper_to_directive`
+# — the canonical wire-format → host-Directive converter, shared with the
+# directive plugin path.
+wasmtime = { workspace = true }
+rmp-serde = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 # `ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`, so
 # we need chrono in the dep tree to call its inherent `.format()` method.
 # IMPORTANT: chrono types must NOT leak into this crate's public API — they
@@ -35,6 +46,9 @@ chrono = "0.4"
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+# WAT (WebAssembly text format) — used by wasm.rs unit tests to author
+# tiny modules inline rather than shipping `.wasm` test fixtures.
+wat = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 [dependencies]
 rustledger-core.workspace = true
 rustledger-ops.workspace = true
-rustledger-plugin.workspace = true
+rustledger-plugin = { workspace = true, features = ["wasm-runtime"] }
 rustledger-plugin-types.workspace = true
 jiff.workspace = true
 rust_decimal.workspace = true

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -37,6 +37,7 @@ pub mod csv_importer;
 pub mod csv_inference;
 pub mod ofx_importer;
 pub mod registry;
+pub mod wasm;
 
 use anyhow::Result;
 use rustledger_core::Directive;
@@ -46,6 +47,7 @@ use std::path::Path;
 pub use config::ImporterConfig;
 pub use ofx_importer::OfxImporter;
 pub use registry::ImporterRegistry;
+pub use wasm::{WasmImporter, WasmImporterError, WasmRuntimeConfig};
 
 use rustledger_ops::fingerprint::Fingerprint;
 

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -37,16 +37,23 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rustledger_ops::fingerprint::Fingerprint;
-use rustledger_plugin::sandbox;
+use rustledger_plugin::sandbox::{self, StoreState};
 use rustledger_plugin_types::{
     EnrichedImporterOutput, IdentifyInput, IdentifyOutput, ImporterInput, ImporterOutput,
     MetadataOutput, PluginError, PluginErrorSeverity,
 };
 use serde::{Serialize, de::DeserializeOwned};
-use wasmtime::{Engine, Linker, Module, ResourceLimiter, Store};
+use wasmtime::{Engine, Linker, Module, Store};
 
 use crate::config::{CsvConfig, ImporterType};
 use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
+
+// NOTE on hardcoded caps below: `MAX_OUTPUT_BYTES` and `MAX_INPUT_BYTES`
+// are per-process constants, not per-importer config. They're sized
+// generously (64 MiB each) for any realistic bank-statement import.
+// Per-importer tunability is a v1.0 surface decision; for v0.16-pre the
+// caps are intentionally fixed so the security contract is uniform
+// across all loaded importers regardless of who configured them.
 
 /// Hard cap on the byte length a WASM importer can return from any
 /// entry point. Prevents a malicious or buggy module from triggering a
@@ -55,21 +62,11 @@ use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
 const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
 
 /// Hard cap on the byte length of input the host will marshal into the
-/// WASM module. Mirrors [`MAX_OUTPUT_BYTES`] on the input side:
+/// WASM module. Mirrors `MAX_OUTPUT_BYTES` on the input side:
 /// `wasm32` memory is `u32`-addressed, so anything over 4 GiB is
 /// fundamentally not addressable, but we cap much lower to avoid
 /// runaway allocations from accidentally-huge source files.
 const MAX_INPUT_BYTES: usize = 64 * 1024 * 1024;
-
-/// Hard cap on the number of elements in any single WASM table.
-/// Importers don't typically need indirect-call tables at all, let
-/// alone large ones. Each ref-typed slot is pointer-sized (8 bytes on
-/// 64-bit), so 1M elements = ~8 MiB worst case — well under the
-/// memory cap but enough headroom for any plausible indirect-dispatch
-/// pattern. Without this cap, `table.grow` would bypass the memory
-/// limiter (`Memory` and `Table` are separate resource classes in
-/// wasmtime's accounting).
-const MAX_TABLE_ELEMENTS: usize = 1024 * 1024;
 
 /// Configuration for the WASM importer runtime.
 #[derive(Debug, Clone, Copy)]
@@ -170,46 +167,11 @@ pub enum WasmImporterError {
     },
 }
 
-/// Per-store memory limiter. Wired into [`Store::limiter`] so wasmtime
-/// rejects `memory.grow` past `max_memory`. Without this, the
-/// [`WasmRuntimeConfig::max_memory`] field would be silently ignored —
-/// the sandbox would have unbounded heap, which defeats the
-/// "self-contained importer" guarantee.
-struct MemoryLimiter {
-    max_memory: usize,
-}
-
-impl ResourceLimiter for MemoryLimiter {
-    fn memory_growing(
-        &mut self,
-        _current: usize,
-        desired: usize,
-        _maximum: Option<usize>,
-    ) -> wasmtime::Result<bool> {
-        Ok(desired <= self.max_memory)
-    }
-
-    fn table_growing(
-        &mut self,
-        _current: usize,
-        desired: usize,
-        _maximum: Option<usize>,
-    ) -> wasmtime::Result<bool> {
-        // wasmtime accounts memory and tables separately — without
-        // this cap, `table.grow` would bypass the memory limiter.
-        // [`MAX_TABLE_ELEMENTS`] is conservative; bump it if a
-        // legitimate importer ever needs more.
-        Ok(desired <= MAX_TABLE_ELEMENTS)
-    }
-}
-
-/// Store user-data — just the [`MemoryLimiter`] today. Kept in a named
-/// struct so `Store::limiter`'s closure can return a stable reference
-/// and future additions (e.g. a host-side metrics counter) can land
-/// without changing the `Store<T>` type.
-struct StoreState {
-    limiter: MemoryLimiter,
-}
+// `MemoryLimiter`, `StoreState`, `MAX_TABLE_ELEMENTS`, and the
+// `make_sandboxed_store` helper live in `rustledger_plugin::sandbox`
+// so the per-call enforcement is identical between the WASM importer
+// host and the directive-plugin runtime. See sandbox.rs for the
+// rationale + tests.
 
 // Note: no manual `impl From<WasmImporterError> for anyhow::Error` — `anyhow`
 // has a blanket impl for any `std::error::Error + Send + Sync + 'static`,
@@ -244,6 +206,20 @@ pub struct WasmImporter {
     engine: Arc<Engine>,
     /// Per-call runtime limits.
     config: WasmRuntimeConfig,
+}
+
+impl std::fmt::Debug for WasmImporter {
+    /// Hand-rolled to avoid wasmtime's `Module`/`Engine` (whose `Debug`
+    /// outputs are noisy and version-dependent). Prints just the
+    /// host-side metadata that's useful for assertions and logging.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WasmImporter")
+            .field("path", &self.path)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WasmImporter {
@@ -378,35 +354,16 @@ impl WasmImporter {
     }
 }
 
-/// Create + configure a [`Store`] with both the memory limiter (so
-/// `WasmRuntimeConfig::max_memory` is actually enforced) and the fuel
-/// budget (so `max_time_secs` actually bounds execution).
-///
-/// `max_time_secs` is clamped to at least 1 so `max_time_secs = 0`
-/// doesn't immediately trap the WASM call on no-fuel.
+/// Build a [`Store`] with the workspace-shared sandbox enforcement
+/// (memory limiter + fuel budget). Thin wrapper over
+/// [`sandbox::make_sandboxed_store`] that adapts the wasmtime error
+/// to [`WasmImporterError`].
 fn make_store(
     engine: &Engine,
     config: WasmRuntimeConfig,
 ) -> Result<Store<StoreState>, WasmImporterError> {
-    let state = StoreState {
-        limiter: MemoryLimiter {
-            max_memory: config.max_memory,
-        },
-    };
-    let mut store = Store::new(engine, state);
-    store.limiter(|s| &mut s.limiter);
-    // 1M instructions per second is the same rough budget used by the
-    // directive-plugin runtime. `.max(1)` prevents zero-fuel starvation;
-    // `.saturating_mul` prevents u64 overflow on huge `max_time_secs`
-    // (panic in debug, silent wrap to a tiny number in release — both
-    // wrong, both prevented here).
-    let fuel = config.max_time_secs.max(1).saturating_mul(1_000_000);
-    // `set_fuel` only fails when `consume_fuel(false)` is configured
-    // on the Engine, and `sandbox::sandbox_config` always sets it true.
-    // The `?` propagation is defensive — if a future refactor flips
-    // that flag, we'd want to surface the error rather than panic.
-    store.set_fuel(fuel).map_err(runtime_err)?;
-    Ok(store)
+    sandbox::make_sandboxed_store(engine, config.max_memory, config.max_time_secs)
+        .map_err(runtime_err)
 }
 
 /// Cap input length before the lossy `as u32` cast — wasm32 memory
@@ -1126,26 +1083,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn memory_limiter_rejects_grow_above_max() {
-        // Pin the ResourceLimiter behavior directly. The full
-        // wasm.grow → trap path is wasmtime-internal and hard to
-        // observe without a custom module, so this test guards the
-        // bit we own: that memory_growing returns Ok(false) past the
-        // cap.
-        let mut limiter = MemoryLimiter { max_memory: 1024 };
-        assert!(
-            limiter
-                .memory_growing(0, 512, None)
-                .expect("under cap is Ok")
-        ); // under cap
-        assert!(limiter.memory_growing(0, 1024, None).expect("at cap is Ok")); // exactly at cap
-        assert!(
-            !limiter
-                .memory_growing(0, 1025, None)
-                .expect("over cap is Ok(false)")
-        ); // over cap
-    }
+    // Note: `memory_limiter_rejects_grow_above_max` and
+    // `table_limiter_rejects_grow_above_max` live in
+    // `rustledger_plugin::sandbox::tests` now that the limiter
+    // itself was hoisted there. The integration test below
+    // (`initial_memory_above_cap_is_rejected_via_limiter_wiring`)
+    // still proves the importer's load path wires it correctly.
 
     #[test]
     fn zero_max_time_secs_does_not_starve_fuel() {
@@ -1163,23 +1106,6 @@ mod tests {
         let importer = WasmImporter::load_from_bytes(PathBuf::from("test.wasm"), &bytes, config)
             .expect("zero max_time_secs is clamped, not starved");
         assert_eq!(importer.name(), "tst");
-    }
-
-    #[test]
-    fn table_limiter_rejects_grow_above_max() {
-        let mut limiter = MemoryLimiter {
-            max_memory: usize::MAX,
-        };
-        assert!(
-            limiter
-                .table_growing(0, MAX_TABLE_ELEMENTS, None)
-                .expect("at cap is Ok")
-        );
-        assert!(
-            !limiter
-                .table_growing(0, MAX_TABLE_ELEMENTS + 1, None)
-                .expect("over cap is Ok(false)")
-        );
     }
 
     #[test]
@@ -1478,6 +1404,55 @@ mod tests {
                 "error foo.csv:42: bad row".to_string(),
                 "warning: weird value".to_string(),
             ]
+        );
+    }
+
+    // ===== Accessor / constructor tests =====
+
+    #[test]
+    fn load_embedded_uses_name_as_path_and_default_config() {
+        let bytes = wat::parse_str(roundtrip_wat()).expect("WAT parses");
+        let importer =
+            WasmImporter::load_embedded("inline-test", &bytes).expect("embedded load succeeds");
+        // The diagnostic name flows through to `path()` so error
+        // messages and logs identify the embedded module.
+        assert_eq!(importer.path(), Path::new("inline-test"));
+        // Default config is used — caller didn't pass one.
+        assert_eq!(importer.runtime_config().max_memory, 256 * 1024 * 1024);
+        assert_eq!(importer.runtime_config().max_time_secs, 30);
+        // Metadata still cached as in the standard load path.
+        assert_eq!(importer.name(), "tst");
+    }
+
+    #[test]
+    fn runtime_config_returns_the_loaded_config() {
+        let custom = WasmRuntimeConfig {
+            max_memory: 128 * 1024 * 1024,
+            max_time_secs: 60,
+        };
+        let bytes = wat::parse_str(roundtrip_wat()).expect("WAT parses");
+        let importer = WasmImporter::load_from_bytes(PathBuf::from("custom.wasm"), &bytes, custom)
+            .expect("custom-config load succeeds");
+        assert_eq!(importer.runtime_config().max_memory, custom.max_memory);
+        assert_eq!(
+            importer.runtime_config().max_time_secs,
+            custom.max_time_secs
+        );
+    }
+
+    #[test]
+    fn debug_impl_does_not_panic_and_redacts_wasmtime_types() {
+        let bytes = wat::parse_str(roundtrip_wat()).expect("WAT parses");
+        let importer = WasmImporter::load_embedded("dbg-test", &bytes).expect("load succeeds");
+        let s = format!("{importer:?}");
+        // Includes host metadata...
+        assert!(s.contains("WasmImporter"));
+        assert!(s.contains("dbg-test"));
+        assert!(s.contains("tst")); // name + description
+        // ...but doesn't leak wasmtime Module/Engine internals.
+        assert!(
+            !s.contains("Module {"),
+            "Debug should not expand the wasmtime Module: {s}"
         );
     }
 }

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -53,6 +53,16 @@ use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
 /// well above any realistic importer output for a single statement.
 const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
 
+/// Hard cap on the number of elements in any single WASM table.
+/// Importers don't typically need indirect-call tables at all, let
+/// alone large ones. Each ref-typed slot is pointer-sized (8 bytes on
+/// 64-bit), so 1M elements = ~8 MiB worst case — well under the
+/// memory cap but enough headroom for any plausible indirect-dispatch
+/// pattern. Without this cap, `table.grow` would bypass the memory
+/// limiter (`Memory` and `Table` are separate resource classes in
+/// wasmtime's accounting).
+const MAX_TABLE_ELEMENTS: usize = 1024 * 1024;
+
 /// Configuration for the WASM importer runtime.
 #[derive(Debug, Clone, Copy)]
 pub struct WasmRuntimeConfig {
@@ -152,13 +162,14 @@ impl ResourceLimiter for MemoryLimiter {
     fn table_growing(
         &mut self,
         _current: usize,
-        _desired: usize,
+        desired: usize,
         _maximum: Option<usize>,
     ) -> wasmtime::Result<bool> {
-        // No per-table cap — importers don't typically need indirect
-        // call tables, and memory is the resource we actually care
-        // about for DoS.
-        Ok(true)
+        // wasmtime accounts memory and tables separately — without
+        // this cap, `table.grow` would bypass the memory limiter.
+        // [`MAX_TABLE_ELEMENTS`] is conservative; bump it if a
+        // legitimate importer ever needs more.
+        Ok(desired <= MAX_TABLE_ELEMENTS)
     }
 }
 
@@ -566,73 +577,88 @@ impl Importer for WasmImporter {
             .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
         let input = build_wasm_input(path, content, config);
         let output: EnrichedImporterOutput = self.call_msgpack("extract_enriched", &input)?;
-
-        // Bridge from wire-format EnrichedImporterOutput to the
-        // host-side EnrichedImportResult. We collect warnings as we
-        // go for the lossy paths (unknown method strings, malformed
-        // fingerprint hex) — these are recoverable but worth
-        // surfacing rather than silently degrading.
-        let mut entries = Vec::with_capacity(output.entries.len());
-        let mut bridge_warnings: Vec<String> = Vec::new();
-        for (wrapper, enr) in output.entries {
-            let dir = rustledger_plugin::convert::wrapper_to_directive(&wrapper)
-                .map_err(|e| anyhow::anyhow!("WASM importer returned invalid directive: {e:?}"))?;
-            let method = parse_method(&enr.method).unwrap_or_else(|unknown| {
-                bridge_warnings.push(format!(
-                    "warning: WASM importer used unknown categorization method `{unknown}`, falling back to Default"
-                ));
-                rustledger_ops::enrichment::CategorizationMethod::Default
-            });
-            let alternatives = enr
-                .alternatives
-                .into_iter()
-                .map(|a| {
-                    let alt_method = parse_method(&a.method).unwrap_or_else(|unknown| {
-                        bridge_warnings.push(format!(
-                            "warning: WASM importer used unknown categorization method `{unknown}` in alternative, falling back to Default"
-                        ));
-                        rustledger_ops::enrichment::CategorizationMethod::Default
-                    });
-                    rustledger_ops::enrichment::Alternative {
-                        account: a.account,
-                        confidence: a.confidence,
-                        method: alt_method,
-                    }
-                })
-                .collect();
-            let fingerprint = match enr.fingerprint {
-                Some(hex) => match Fingerprint::from_hex(&hex) {
-                    Ok(fp) => Some(fp),
-                    Err(e) => {
-                        bridge_warnings.push(format!(
-                            "warning: WASM importer returned malformed fingerprint hex `{hex}`: {e}"
-                        ));
-                        None
-                    }
-                },
-                None => None,
-            };
-            let enrichment = rustledger_ops::enrichment::Enrichment {
-                directive_index: enr.directive_index,
-                confidence: enr.confidence,
-                method,
-                alternatives,
-                fingerprint,
-            };
-            entries.push((dir, enrichment));
-        }
-        let mut enriched = EnrichedImportResult::new(entries);
-        for w in bridge_warnings {
-            enriched = enriched.with_warning(w);
-        }
-        for w in output.warnings {
-            enriched = enriched.with_warning(w);
-        }
-        for e in &output.errors {
-            enriched = enriched.with_warning(format_plugin_error(e));
-        }
-        Ok(enriched)
+        bridge_enriched_output(output)
     }
+}
+
+/// Bridge a wire-format [`EnrichedImporterOutput`] into the host's
+/// [`EnrichedImportResult`]. Extracted as a free function so the lossy
+/// paths (unknown method strings, malformed fingerprint hex) can be
+/// unit-tested without standing up wasmtime.
+///
+/// # Warning ordering
+///
+/// Warnings are emitted in this order, which is part of the contract
+/// for any downstream consumer that filters or surfaces them:
+///
+/// 1. **Bridge warnings** (per-entry lossy paths: unknown method,
+///    malformed fingerprint hex) — host-side issues with the wire
+///    data, surface first so the importer author sees them prominently.
+/// 2. **Output warnings** (importer's own informational warnings),
+///    forwarded verbatim from `output.warnings`.
+/// 3. **Output errors** (importer's structured errors), formatted via
+///    [`format_plugin_error`] which preserves severity prefix.
+fn bridge_enriched_output(output: EnrichedImporterOutput) -> anyhow::Result<EnrichedImportResult> {
+    let mut entries = Vec::with_capacity(output.entries.len());
+    let mut bridge_warnings: Vec<String> = Vec::new();
+    for (wrapper, enr) in output.entries {
+        let dir = rustledger_plugin::convert::wrapper_to_directive(&wrapper)
+            .map_err(|e| anyhow::anyhow!("WASM importer returned invalid directive: {e:?}"))?;
+        let method = parse_method(&enr.method).unwrap_or_else(|unknown| {
+            bridge_warnings.push(format!(
+                "warning: WASM importer used unknown categorization method `{unknown}`, falling back to Default"
+            ));
+            rustledger_ops::enrichment::CategorizationMethod::Default
+        });
+        let alternatives = enr
+            .alternatives
+            .into_iter()
+            .map(|a| {
+                let alt_method = parse_method(&a.method).unwrap_or_else(|unknown| {
+                    bridge_warnings.push(format!(
+                        "warning: WASM importer used unknown categorization method `{unknown}` in alternative, falling back to Default"
+                    ));
+                    rustledger_ops::enrichment::CategorizationMethod::Default
+                });
+                rustledger_ops::enrichment::Alternative {
+                    account: a.account,
+                    confidence: a.confidence,
+                    method: alt_method,
+                }
+            })
+            .collect();
+        let fingerprint = match enr.fingerprint {
+            Some(hex) => match Fingerprint::from_hex(&hex) {
+                Ok(fp) => Some(fp),
+                Err(e) => {
+                    bridge_warnings.push(format!(
+                        "warning: WASM importer returned malformed fingerprint hex `{hex}`: {e}"
+                    ));
+                    None
+                }
+            },
+            None => None,
+        };
+        let enrichment = rustledger_ops::enrichment::Enrichment {
+            directive_index: enr.directive_index,
+            confidence: enr.confidence,
+            method,
+            alternatives,
+            fingerprint,
+        };
+        entries.push((dir, enrichment));
+    }
+    let mut enriched = EnrichedImportResult::new(entries);
+    for w in bridge_warnings {
+        enriched = enriched.with_warning(w);
+    }
+    for w in output.warnings {
+        enriched = enriched.with_warning(w);
+    }
+    for e in &output.errors {
+        enriched = enriched.with_warning(format_plugin_error(e));
+    }
+    Ok(enriched)
 }
 
 /// Convert the wire-format method string (as emitted by
@@ -750,11 +776,7 @@ mod tests {
             let s = m.as_meta_value();
             let parsed = parse_method(s)
                 .unwrap_or_else(|u| panic!("as_meta_value `{u}` not handled by parse_method"));
-            assert_eq!(
-                std::mem::discriminant(&parsed),
-                std::mem::discriminant(&m),
-                "round-trip failed for {m:?}"
-            );
+            assert_eq!(parsed, m, "round-trip failed for {m:?}");
         }
     }
 
@@ -838,7 +860,13 @@ mod tests {
             ;; EnrichedImporterOutput { entries: [], warnings: [], errors: [] }
             (data (i32.const 32) "\93\90\90\90")
 
-            ;; bump allocator: hand out at $bump, advance by $size
+            ;; bump allocator: hand out at $bump, advance by $size.
+            ;; NOTE: real importers MUST bounds-check $bump+$size
+            ;; against current memory and call `memory.grow` (subject
+            ;; to MemoryLimiter approval). This test fixture skips
+            ;; that — inputs in the test are small and we declare 1
+            ;; full page (64 KiB), so the bump never crosses the
+            ;; boundary.
             (global $bump (mut i32) (i32.const 1024))
             (func (export "alloc") (param $size i32) (result i32)
                 (local $ret i32)
@@ -988,5 +1016,241 @@ mod tests {
         let importer = WasmImporter::load_from_bytes(PathBuf::from("test.wasm"), &bytes, config)
             .expect("zero max_time_secs is clamped, not starved");
         assert_eq!(importer.name(), "tst");
+    }
+
+    #[test]
+    fn table_limiter_rejects_grow_above_max() {
+        let mut limiter = MemoryLimiter {
+            max_memory: usize::MAX,
+        };
+        assert!(
+            limiter
+                .table_growing(0, MAX_TABLE_ELEMENTS, None)
+                .expect("at cap is Ok")
+        );
+        assert!(
+            !limiter
+                .table_growing(0, MAX_TABLE_ELEMENTS + 1, None)
+                .expect("over cap is Ok(false)")
+        );
+    }
+
+    #[test]
+    fn initial_memory_above_cap_is_rejected_via_limiter_wiring() {
+        // Pins the `store.limiter(|s| &mut s.limiter)` wiring against
+        // refactor regression. wasmtime calls `memory_growing` for
+        // both initial allocation and grow — a module declaring 5000
+        // pages (320 MiB) initial memory with a 64 MiB cap should
+        // fail to instantiate. If the limiter wiring breaks, this
+        // test catches it (the direct trait-method test above does
+        // not).
+        let wat = r#"
+            (module
+                (memory (export "memory") 5000)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "metadata") (result i64) i64.const 0)
+                (func (export "identify") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let config = WasmRuntimeConfig {
+            max_memory: 64 * 1024 * 1024,
+            max_time_secs: 30,
+        };
+        let Err(err) = WasmImporter::load_from_bytes(PathBuf::from("bigmem.wasm"), &bytes, config)
+        else {
+            panic!("module declaring 320 MiB initial memory should be rejected with 64 MiB cap");
+        };
+        // wasmtime turns Ok(false) at instantiation into an instantiate
+        // error, which the host maps to Runtime.
+        assert!(
+            matches!(err, WasmImporterError::Runtime(_)),
+            "expected Runtime (instantiate failed via limiter), got {err:?}"
+        );
+    }
+
+    // ===== bridge_enriched_output direct tests =====
+    //
+    // These exercise the lossy paths (unknown method, malformed
+    // fingerprint hex, valid fingerprint round-trip) without standing
+    // up wasmtime — the bridge logic is the testable piece, the
+    // wasmtime round-trip is covered by the end-to-end WAT test.
+
+    use rustledger_plugin_types::{
+        AlternativeWrapper, DirectiveData, DirectiveWrapper, EnrichmentWrapper, OpenData,
+    };
+
+    fn open_wrapper(account: &str) -> DirectiveWrapper {
+        DirectiveWrapper {
+            directive_type: String::new(),
+            date: "2024-01-01".to_string(),
+            filename: None,
+            lineno: None,
+            data: DirectiveData::Open(OpenData {
+                account: account.to_string(),
+                currencies: vec![],
+                booking: None,
+                metadata: vec![],
+            }),
+        }
+    }
+
+    fn enrichment_wrapper(method: &str, fingerprint: Option<String>) -> EnrichmentWrapper {
+        EnrichmentWrapper {
+            directive_index: 0,
+            confidence: 1.0,
+            method: method.to_string(),
+            alternatives: vec![],
+            fingerprint,
+        }
+    }
+
+    #[test]
+    fn bridge_round_trips_valid_fingerprint_hex() {
+        let fp = Fingerprint::compute("2024-01-01", Some("100"), "coffee");
+        let hex = fp.to_hex();
+        let out = EnrichedImporterOutput {
+            entries: vec![(
+                open_wrapper("Assets:Bank"),
+                enrichment_wrapper("rule", Some(hex)),
+            )],
+            warnings: vec![],
+            errors: vec![],
+        };
+        let bridged = bridge_enriched_output(out).expect("bridge succeeds");
+        assert_eq!(bridged.entries.len(), 1);
+        assert_eq!(
+            bridged.entries[0].1.fingerprint,
+            Some(fp),
+            "fingerprint should round-trip"
+        );
+        assert!(bridged.warnings.is_empty(), "no warnings expected");
+    }
+
+    #[test]
+    fn bridge_warns_on_malformed_fingerprint_hex_and_drops_to_none() {
+        let out = EnrichedImporterOutput {
+            entries: vec![(
+                open_wrapper("Assets:Bank"),
+                enrichment_wrapper("rule", Some("not-a-valid-hex".to_string())),
+            )],
+            warnings: vec![],
+            errors: vec![],
+        };
+        let bridged = bridge_enriched_output(out).expect("bridge succeeds");
+        assert_eq!(bridged.entries.len(), 1);
+        assert_eq!(bridged.entries[0].1.fingerprint, None);
+        // Warning text names the bad hex so the importer author can
+        // find the bug quickly.
+        assert_eq!(bridged.warnings.len(), 1);
+        assert!(
+            bridged.warnings[0].contains("not-a-valid-hex"),
+            "warning should name the bad hex: {}",
+            bridged.warnings[0]
+        );
+    }
+
+    #[test]
+    fn bridge_warns_on_unknown_method_and_falls_back_to_default() {
+        use rustledger_ops::enrichment::CategorizationMethod;
+        let out = EnrichedImporterOutput {
+            entries: vec![(
+                open_wrapper("Assets:Bank"),
+                enrichment_wrapper("merchant_dict", None), // underscore typo, exact #1130 bug shape
+            )],
+            warnings: vec![],
+            errors: vec![],
+        };
+        let bridged = bridge_enriched_output(out).expect("bridge succeeds");
+        assert_eq!(bridged.entries[0].1.method, CategorizationMethod::Default);
+        assert_eq!(bridged.warnings.len(), 1);
+        assert!(
+            bridged.warnings[0].contains("merchant_dict"),
+            "warning should name the unknown method: {}",
+            bridged.warnings[0]
+        );
+    }
+
+    #[test]
+    fn bridge_warns_on_unknown_method_in_alternative() {
+        use rustledger_ops::enrichment::CategorizationMethod;
+        let mut enr = enrichment_wrapper("rule", None);
+        enr.alternatives = vec![AlternativeWrapper {
+            account: "Expenses:Other".to_string(),
+            confidence: 0.3,
+            method: "future-method".to_string(),
+        }];
+        let out = EnrichedImporterOutput {
+            entries: vec![(open_wrapper("Assets:Bank"), enr)],
+            warnings: vec![],
+            errors: vec![],
+        };
+        let bridged = bridge_enriched_output(out).expect("bridge succeeds");
+        let alt = &bridged.entries[0].1.alternatives[0];
+        assert_eq!(alt.method, CategorizationMethod::Default);
+        assert_eq!(bridged.warnings.len(), 1);
+        assert!(bridged.warnings[0].contains("future-method"));
+        assert!(
+            bridged.warnings[0].contains("alternative"),
+            "warning should distinguish the alternative slot: {}",
+            bridged.warnings[0]
+        );
+    }
+
+    #[test]
+    fn bridge_warning_ordering_is_bridge_then_output_warnings_then_errors() {
+        // Pins the warning-emission order documented on
+        // `bridge_enriched_output`. Order matters for downstream
+        // consumers that filter or surface them.
+        let out = EnrichedImporterOutput {
+            entries: vec![(
+                open_wrapper("Assets:Bank"),
+                enrichment_wrapper("nonsense", None),
+            )],
+            warnings: vec!["informational warning".to_string()],
+            errors: vec![PluginError::error("structured error").at("foo.csv", 7)],
+        };
+        let bridged = bridge_enriched_output(out).expect("bridge succeeds");
+        assert_eq!(bridged.warnings.len(), 3);
+        assert!(
+            bridged.warnings[0].contains("nonsense"),
+            "first: bridge warning, got {}",
+            bridged.warnings[0]
+        );
+        assert_eq!(
+            bridged.warnings[1], "informational warning",
+            "second: output.warnings forwarded verbatim"
+        );
+        assert_eq!(
+            bridged.warnings[2], "error foo.csv:7: structured error",
+            "third: output.errors via format_plugin_error"
+        );
+    }
+
+    #[test]
+    fn output_to_import_result_uses_severity_aware_formatter() {
+        // Integration test: proves format_plugin_error is actually
+        // wired into the production path, not just unit-tested in
+        // isolation. A refactor that switches back to raw format!()
+        // would regress this.
+        let out = ImporterOutput {
+            directives: vec![],
+            warnings: vec!["plain warning".to_string()],
+            errors: vec![
+                PluginError::error("bad row").at("foo.csv", 42),
+                PluginError::warning("weird value"),
+            ],
+        };
+        let result = output_to_import_result(out).expect("succeeds");
+        assert_eq!(
+            result.warnings,
+            vec![
+                "plain warning".to_string(),
+                "error foo.csv:42: bad row".to_string(),
+                "warning: weird value".to_string(),
+            ]
+        );
     }
 }

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -135,8 +135,8 @@ pub enum WasmImporterError {
     #[error("failed to encode input for WASM importer: {0}")]
     Encode(#[source] rmp_serde::encode::Error),
     /// The WASM importer returned an `out_len` larger than the host's
-    /// allocation cap ([`MAX_OUTPUT_BYTES`]). Either the module is
-    /// buggy/malicious or `MAX_OUTPUT_BYTES` needs raising for a
+    /// allocation cap (`MAX_OUTPUT_BYTES`, currently 64 MiB). Either
+    /// the module is buggy/malicious or the cap needs raising for a
     /// genuinely huge import.
     #[error("WASM importer returned output of {len} bytes, exceeds cap of {max} bytes")]
     OutputTooLarge {
@@ -145,10 +145,10 @@ pub enum WasmImporterError {
         /// Host's enforced cap (`MAX_OUTPUT_BYTES`).
         max: usize,
     },
-    /// The input the host tried to marshal exceeds
-    /// [`MAX_INPUT_BYTES`]. The host caps before a lossy
-    /// `as u32` cast (wasm32 memory is `u32`-addressed, so >4 GiB
-    /// input would silently truncate).
+    /// The input the host tried to marshal exceeds the host's input
+    /// cap (`MAX_INPUT_BYTES`, currently 64 MiB). The host caps
+    /// before a lossy `as u32` cast (wasm32 memory is `u32`-addressed,
+    /// so >4 GiB input would silently truncate).
     #[error("input of {len} bytes exceeds cap of {max} bytes for WASM importer")]
     InputTooLarge {
         /// Length the host attempted to send.
@@ -534,7 +534,7 @@ fn build_wasm_input(path: &Path, content: Vec<u8>, config: &ImporterConfig) -> I
 ///
 /// - `date_format`, `delimiter`, `has_header`, `skip_rows`,
 ///   `invert_sign`, `skip_zero_amounts` — simple String/bool/number
-/// - `default_expense`, `default_income` — Option<String>
+/// - `default_expense`, `default_income` — `Option<String>`
 ///
 /// # Deferred to wave 2.3e+
 ///
@@ -750,7 +750,7 @@ fn bridge_enriched_output(output: EnrichedImporterOutput) -> anyhow::Result<Enri
 ///
 /// Returns `Err(unknown)` for strings the host doesn't recognize — the
 /// caller is expected to surface a warning and fall back to
-/// [`CategorizationMethod::Default`]. We don't silently absorb unknown
+/// `CategorizationMethod::Default`. We don't silently absorb unknown
 /// strings here: a typo like `"merchant_dict"` vs `"merchant-dict"`
 /// (the exact Copilot-flagged bug from #1130) would otherwise degrade
 /// data without any signal to the user.

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -36,15 +36,22 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use rustledger_ops::fingerprint::Fingerprint;
 use rustledger_plugin_types::{
     EnrichedImporterOutput, IdentifyInput, IdentifyOutput, ImporterInput, ImporterOutput,
-    MetadataOutput,
+    MetadataOutput, PluginError, PluginErrorSeverity,
 };
 use serde::{Serialize, de::DeserializeOwned};
-use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store};
 
 use crate::config::{CsvConfig, ImporterType};
 use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
+
+/// Hard cap on the byte length a WASM importer can return from any
+/// entry point. Prevents a malicious or buggy module from triggering a
+/// 4 GiB host allocation by returning `(any_ptr, u32::MAX)`. 64 MiB is
+/// well above any realistic importer output for a single statement.
+const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
 
 /// Configuration for the WASM importer runtime.
 #[derive(Debug, Clone, Copy)]
@@ -110,6 +117,57 @@ pub enum WasmImporterError {
     /// non-serializable state, which shouldn't.
     #[error("failed to encode input for WASM importer: {0}")]
     Encode(#[source] rmp_serde::encode::Error),
+    /// The WASM importer returned an `out_len` larger than the host's
+    /// allocation cap ([`MAX_OUTPUT_BYTES`]). Either the module is
+    /// buggy/malicious or `MAX_OUTPUT_BYTES` needs raising for a
+    /// genuinely huge import.
+    #[error("WASM importer returned output of {len} bytes, exceeds cap of {max} bytes")]
+    OutputTooLarge {
+        /// Length the module reported.
+        len: usize,
+        /// Host's enforced cap (`MAX_OUTPUT_BYTES`).
+        max: usize,
+    },
+}
+
+/// Per-store memory limiter. Wired into [`Store::limiter`] so wasmtime
+/// rejects `memory.grow` past `max_memory`. Without this, the
+/// [`WasmRuntimeConfig::max_memory`] field would be silently ignored —
+/// the sandbox would have unbounded heap, which defeats the
+/// "self-contained importer" guarantee.
+struct MemoryLimiter {
+    max_memory: usize,
+}
+
+impl ResourceLimiter for MemoryLimiter {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        Ok(desired <= self.max_memory)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        _desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        // No per-table cap — importers don't typically need indirect
+        // call tables, and memory is the resource we actually care
+        // about for DoS.
+        Ok(true)
+    }
+}
+
+/// Store user-data — just the [`MemoryLimiter`] today. Kept in a named
+/// struct so `Store::limiter`'s closure can return a stable reference
+/// and future additions (e.g. a host-side metrics counter) can land
+/// without changing the `Store<T>` type.
+struct StoreState {
+    limiter: MemoryLimiter,
 }
 
 // Note: no manual `impl From<WasmImporterError> for anyhow::Error` — `anyhow`
@@ -252,6 +310,56 @@ impl WasmImporter {
     }
 }
 
+/// Create + configure a [`Store`] with both the memory limiter (so
+/// `WasmRuntimeConfig::max_memory` is actually enforced) and the fuel
+/// budget (so `max_time_secs` actually bounds execution).
+///
+/// `max_time_secs` is clamped to at least 1 so `max_time_secs = 0`
+/// doesn't immediately trap the WASM call on no-fuel.
+fn make_store(
+    engine: &Engine,
+    config: WasmRuntimeConfig,
+) -> Result<Store<StoreState>, WasmImporterError> {
+    let state = StoreState {
+        limiter: MemoryLimiter {
+            max_memory: config.max_memory,
+        },
+    };
+    let mut store = Store::new(engine, state);
+    store.limiter(|s| &mut s.limiter);
+    // 1M instructions per second is the same rough budget used by the
+    // directive-plugin runtime.
+    let fuel = config.max_time_secs.max(1) * 1_000_000;
+    store.set_fuel(fuel).map_err(runtime_err)?;
+    Ok(store)
+}
+
+/// Read a packed `(out_ptr, out_len)` u64 from a WASM entry-point
+/// return, validate `out_len` against [`MAX_OUTPUT_BYTES`], and copy
+/// the bytes out of WASM memory.
+///
+/// Centralized so the cap is enforced uniformly across `metadata`,
+/// `identify`, `extract`, and `extract_enriched`.
+fn read_packed_output(
+    store: &Store<StoreState>,
+    memory: &wasmtime::Memory,
+    packed: u64,
+) -> Result<Vec<u8>, WasmImporterError> {
+    let out_ptr = (packed >> 32) as u32;
+    let out_len = (packed & 0xFFFF_FFFF) as u32 as usize;
+    if out_len > MAX_OUTPUT_BYTES {
+        return Err(WasmImporterError::OutputTooLarge {
+            len: out_len,
+            max: MAX_OUTPUT_BYTES,
+        });
+    }
+    let mut out_bytes = vec![0u8; out_len];
+    memory
+        .read(store, out_ptr as usize, &mut out_bytes)
+        .map_err(|e| WasmImporterError::Runtime(e.into()))?;
+    Ok(out_bytes)
+}
+
 /// Free-form wasmtime call helper. Extracted from `WasmImporter`'s
 /// methods so the load-time `metadata` call can use it before `self`
 /// is fully constructed.
@@ -264,11 +372,7 @@ fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
 ) -> Result<O, WasmImporterError> {
     let input_bytes = rmp_serde::to_vec(input).map_err(WasmImporterError::Encode)?;
 
-    let mut store = Store::new(engine, ());
-    // 1M instructions per second is the same rough budget used by the
-    // directive-plugin runtime.
-    let fuel = config.max_time_secs * 1_000_000;
-    store.set_fuel(fuel).map_err(runtime_err)?;
+    let mut store = make_store(engine, config)?;
 
     // No imports at all — full sandbox.
     let linker = Linker::new(engine);
@@ -299,14 +403,7 @@ fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
         .call(&mut store, (input_ptr, input_bytes.len() as u32))
         .map_err(runtime_err)?;
 
-    let out_ptr = (packed >> 32) as u32;
-    let out_len = (packed & 0xFFFF_FFFF) as u32;
-
-    let mut out_bytes = vec![0u8; out_len as usize];
-    memory
-        .read(&store, out_ptr as usize, &mut out_bytes)
-        .map_err(|e| WasmImporterError::Runtime(e.into()))?;
-
+    let out_bytes = read_packed_output(&store, &memory, packed)?;
     rmp_serde::from_slice(&out_bytes).map_err(WasmImporterError::Decode)
 }
 
@@ -318,9 +415,7 @@ fn call_metadata(
     module: &Module,
     config: WasmRuntimeConfig,
 ) -> Result<MetadataOutput, WasmImporterError> {
-    let mut store = Store::new(engine, ());
-    let fuel = config.max_time_secs * 1_000_000;
-    store.set_fuel(fuel).map_err(runtime_err)?;
+    let mut store = make_store(engine, config)?;
 
     let linker = Linker::new(engine);
     let instance = linker
@@ -336,15 +431,7 @@ fn call_metadata(
         .map_err(|_| WasmImporterError::MissingExport("metadata"))?;
 
     let packed = metadata.call(&mut store, ()).map_err(runtime_err)?;
-
-    let out_ptr = (packed >> 32) as u32;
-    let out_len = (packed & 0xFFFF_FFFF) as u32;
-
-    let mut out_bytes = vec![0u8; out_len as usize];
-    memory
-        .read(&store, out_ptr as usize, &mut out_bytes)
-        .map_err(|e| WasmImporterError::Runtime(e.into()))?;
-
+    let out_bytes = read_packed_output(&store, &memory, packed)?;
     rmp_serde::from_slice(&out_bytes).map_err(WasmImporterError::Decode)
 }
 
@@ -387,6 +474,29 @@ fn project_csv_config_into_options(
     }
 }
 
+/// Format a [`PluginError`] into a single human-readable line that
+/// preserves the severity ("error" vs "warning") and avoids orphan
+/// colons when location fields are absent.
+///
+/// Examples:
+/// - severity=Error, file="foo.csv", line=42 → `"error foo.csv:42: bad row"`
+/// - severity=Warning, file="foo.csv", line=None → `"warning foo.csv: weird value"`
+/// - severity=Warning, file=None, line=Some(7) → `"warning line 7: weird value"`
+/// - severity=Error, file=None, line=None → `"error: parser bug"`
+fn format_plugin_error(e: &PluginError) -> String {
+    let severity = match e.severity {
+        PluginErrorSeverity::Error => "error",
+        PluginErrorSeverity::Warning => "warning",
+    };
+    let location = match (&e.source_file, e.line_number) {
+        (Some(f), Some(n)) => format!(" {f}:{n}"),
+        (Some(f), None) => format!(" {f}"),
+        (None, Some(n)) => format!(" line {n}"),
+        (None, None) => String::new(),
+    };
+    format!("{severity}{location}: {}", e.message)
+}
+
 /// Materialize an [`ImporterOutput`] wire-format value back to the
 /// host-side [`ImportResult`]. Reuses
 /// `rustledger_plugin::convert::wrapper_to_directive` semantics —
@@ -406,16 +516,13 @@ fn output_to_import_result(out: ImporterOutput) -> anyhow::Result<ImportResult> 
     for w in out.warnings {
         result = result.with_warning(w);
     }
-    // Errors are non-fatal at this layer — surface them as warnings so
-    // the existing extract pipeline doesn't need a new error channel.
-    // The structured error path goes through LedgerError in the loader.
-    for e in out.errors {
-        result = result.with_warning(format!(
-            "{}{}: {}",
-            e.source_file.unwrap_or_default(),
-            e.line_number.map(|n| format!(":{n}")).unwrap_or_default(),
-            e.message
-        ));
+    // Errors and warnings flow through the same `warnings` channel,
+    // but the formatted string preserves the severity prefix so a
+    // fatal-but-recoverable importer error is still distinguishable
+    // from informational chatter. The structured error path
+    // (`LedgerError::location`) is reserved for the loader layer.
+    for e in &out.errors {
+        result = result.with_warning(format_plugin_error(e));
     }
     Ok(result)
 }
@@ -461,42 +568,68 @@ impl Importer for WasmImporter {
         let output: EnrichedImporterOutput = self.call_msgpack("extract_enriched", &input)?;
 
         // Bridge from wire-format EnrichedImporterOutput to the
-        // host-side EnrichedImportResult. The enrichment-wrapper →
-        // host-Enrichment conversion is intentionally lossy on
-        // `method` (string → enum): unknown methods fall back to
-        // `Default` rather than failing the whole import.
+        // host-side EnrichedImportResult. We collect warnings as we
+        // go for the lossy paths (unknown method strings, malformed
+        // fingerprint hex) — these are recoverable but worth
+        // surfacing rather than silently degrading.
         let mut entries = Vec::with_capacity(output.entries.len());
+        let mut bridge_warnings: Vec<String> = Vec::new();
         for (wrapper, enr) in output.entries {
             let dir = rustledger_plugin::convert::wrapper_to_directive(&wrapper)
                 .map_err(|e| anyhow::anyhow!("WASM importer returned invalid directive: {e:?}"))?;
+            let method = parse_method(&enr.method).unwrap_or_else(|unknown| {
+                bridge_warnings.push(format!(
+                    "warning: WASM importer used unknown categorization method `{unknown}`, falling back to Default"
+                ));
+                rustledger_ops::enrichment::CategorizationMethod::Default
+            });
+            let alternatives = enr
+                .alternatives
+                .into_iter()
+                .map(|a| {
+                    let alt_method = parse_method(&a.method).unwrap_or_else(|unknown| {
+                        bridge_warnings.push(format!(
+                            "warning: WASM importer used unknown categorization method `{unknown}` in alternative, falling back to Default"
+                        ));
+                        rustledger_ops::enrichment::CategorizationMethod::Default
+                    });
+                    rustledger_ops::enrichment::Alternative {
+                        account: a.account,
+                        confidence: a.confidence,
+                        method: alt_method,
+                    }
+                })
+                .collect();
+            let fingerprint = match enr.fingerprint {
+                Some(hex) => match Fingerprint::from_hex(&hex) {
+                    Ok(fp) => Some(fp),
+                    Err(e) => {
+                        bridge_warnings.push(format!(
+                            "warning: WASM importer returned malformed fingerprint hex `{hex}`: {e}"
+                        ));
+                        None
+                    }
+                },
+                None => None,
+            };
             let enrichment = rustledger_ops::enrichment::Enrichment {
                 directive_index: enr.directive_index,
                 confidence: enr.confidence,
-                method: parse_method(&enr.method),
-                alternatives: enr
-                    .alternatives
-                    .into_iter()
-                    .map(|a| rustledger_ops::enrichment::Alternative {
-                        account: a.account,
-                        confidence: a.confidence,
-                        method: parse_method(&a.method),
-                    })
-                    .collect(),
-                fingerprint: None, // Fingerprint round-trip via hex string is wave 2.3+
+                method,
+                alternatives,
+                fingerprint,
             };
             entries.push((dir, enrichment));
         }
         let mut enriched = EnrichedImportResult::new(entries);
+        for w in bridge_warnings {
+            enriched = enriched.with_warning(w);
+        }
         for w in output.warnings {
             enriched = enriched.with_warning(w);
         }
-        for e in output.errors {
-            enriched = enriched.with_warning(format!(
-                "{}{}: {}",
-                e.source_file.unwrap_or_default(),
-                e.line_number.map(|n| format!(":{n}")).unwrap_or_default(),
-                e.message
-            ));
+        for e in &output.errors {
+            enriched = enriched.with_warning(format_plugin_error(e));
         }
         Ok(enriched)
     }
@@ -504,17 +637,23 @@ impl Importer for WasmImporter {
 
 /// Convert the wire-format method string (as emitted by
 /// `CategorizationMethod::as_meta_value`) back into the host enum.
-/// Unknown strings fall back to `Default` so a future addition to the
-/// host enum doesn't break older WASM importers.
-fn parse_method(s: &str) -> rustledger_ops::enrichment::CategorizationMethod {
+///
+/// Returns `Err(unknown)` for strings the host doesn't recognize — the
+/// caller is expected to surface a warning and fall back to
+/// [`CategorizationMethod::Default`]. We don't silently absorb unknown
+/// strings here: a typo like `"merchant_dict"` vs `"merchant-dict"`
+/// (the exact Copilot-flagged bug from #1130) would otherwise degrade
+/// data without any signal to the user.
+fn parse_method(s: &str) -> Result<rustledger_ops::enrichment::CategorizationMethod, &str> {
     use rustledger_ops::enrichment::CategorizationMethod;
     match s {
-        "rule" => CategorizationMethod::Rule,
-        "merchant-dict" => CategorizationMethod::MerchantDict,
-        "ml" => CategorizationMethod::Ml,
-        "llm" => CategorizationMethod::Llm,
-        "manual" => CategorizationMethod::Manual,
-        _ => CategorizationMethod::Default,
+        "rule" => Ok(CategorizationMethod::Rule),
+        "merchant-dict" => Ok(CategorizationMethod::MerchantDict),
+        "ml" => Ok(CategorizationMethod::Ml),
+        "llm" => Ok(CategorizationMethod::Llm),
+        "manual" => Ok(CategorizationMethod::Manual),
+        "default" => Ok(CategorizationMethod::Default),
+        unknown => Err(unknown),
     }
 }
 
@@ -572,18 +711,282 @@ mod tests {
     }
 
     #[test]
-    fn parse_method_unknown_falls_back_to_default() {
+    fn parse_method_round_trips_known_values() {
         use rustledger_ops::enrichment::CategorizationMethod;
-        assert!(matches!(parse_method("rule"), CategorizationMethod::Rule));
+        assert!(matches!(
+            parse_method("rule"),
+            Ok(CategorizationMethod::Rule)
+        ));
         assert!(matches!(
             parse_method("merchant-dict"),
-            CategorizationMethod::MerchantDict
+            Ok(CategorizationMethod::MerchantDict)
         ));
-        // Forward-compat: a WASM importer emitting a method this host
-        // doesn't know about gets Default rather than a failed import.
+        assert!(matches!(parse_method("ml"), Ok(CategorizationMethod::Ml)));
+        assert!(matches!(parse_method("llm"), Ok(CategorizationMethod::Llm)));
         assert!(matches!(
-            parse_method("future-method"),
-            CategorizationMethod::Default
+            parse_method("manual"),
+            Ok(CategorizationMethod::Manual)
         ));
+        assert!(matches!(
+            parse_method("default"),
+            Ok(CategorizationMethod::Default)
+        ));
+    }
+
+    #[test]
+    fn parse_method_round_trips_via_as_meta_value() {
+        // Pin the contract: every `CategorizationMethod` round-trips
+        // through its `as_meta_value()` string. If a host variant is
+        // added without updating `parse_method`, this test fails.
+        use rustledger_ops::enrichment::CategorizationMethod;
+        for m in [
+            CategorizationMethod::Rule,
+            CategorizationMethod::MerchantDict,
+            CategorizationMethod::Ml,
+            CategorizationMethod::Llm,
+            CategorizationMethod::Manual,
+            CategorizationMethod::Default,
+        ] {
+            let s = m.as_meta_value();
+            let parsed = parse_method(s)
+                .unwrap_or_else(|u| panic!("as_meta_value `{u}` not handled by parse_method"));
+            assert_eq!(
+                std::mem::discriminant(&parsed),
+                std::mem::discriminant(&m),
+                "round-trip failed for {m:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_method_unknown_surfaces_the_unknown_string() {
+        // Previously: silently fell back to Default. Now: returns
+        // Err(unknown) so the caller can warn — protects against
+        // typos like `merchant_dict` (underscore) vs `merchant-dict`
+        // (hyphen, the actual wire encoding from
+        // `CategorizationMethod::as_meta_value`).
+        assert_eq!(parse_method("future-method"), Err("future-method"));
+        assert_eq!(parse_method("merchant_dict"), Err("merchant_dict"));
+        assert_eq!(parse_method(""), Err(""));
+    }
+
+    #[test]
+    fn format_plugin_error_with_full_location() {
+        let e = PluginError::error("bad row").at("foo.csv", 42);
+        assert_eq!(format_plugin_error(&e), "error foo.csv:42: bad row");
+    }
+
+    #[test]
+    fn format_plugin_error_warning_severity() {
+        let e = PluginError::warning("weird value").at("foo.csv", 42);
+        assert_eq!(format_plugin_error(&e), "warning foo.csv:42: weird value");
+    }
+
+    #[test]
+    fn format_plugin_error_no_location_no_orphan_colon() {
+        let e = PluginError::error("parser bug");
+        // Previously: ": parser bug" (orphan colon). Now: "error: parser bug".
+        assert_eq!(format_plugin_error(&e), "error: parser bug");
+    }
+
+    #[test]
+    fn format_plugin_error_file_only() {
+        let e = PluginError::warning("weird value");
+        let e = PluginError {
+            source_file: Some("foo.csv".to_string()),
+            ..e
+        };
+        assert_eq!(format_plugin_error(&e), "warning foo.csv: weird value");
+    }
+
+    #[test]
+    fn format_plugin_error_line_only_uses_human_phrasing() {
+        // Previously: ":42: weird" (orphan colon). Now: "warning line 42: weird".
+        let e = PluginError::warning("weird");
+        let e = PluginError {
+            line_number: Some(42),
+            ..e
+        };
+        assert_eq!(format_plugin_error(&e), "warning line 42: weird");
+    }
+
+    /// Build a WAT module that pre-loads `MessagePack` outputs for every
+    /// entry point in low memory and returns hardcoded packed
+    /// `(ptr, len)` u64s. `alloc` is a bump allocator starting at
+    /// offset 1024, so host-allocated input never overlaps the
+    /// pre-loaded data.
+    ///
+    /// Wire-format bytes are rmp-serde's default positional encoding
+    /// (struct → fixarray-N, fields in declaration order).
+    fn roundtrip_wat() -> &'static str {
+        r#"
+        (module
+            (memory (export "memory") 1)
+
+            ;; MetadataOutput { name: "tst", description: "tst" }
+            ;; 0x92 fixarray-2, 0xa3 fixstr-3 "tst", 0xa3 fixstr-3 "tst"
+            (data (i32.const 0) "\92\a3tst\a3tst")
+
+            ;; IdentifyOutput { matches: true }
+            ;; 0x91 fixarray-1, 0xc3 true
+            (data (i32.const 16) "\91\c3")
+
+            ;; ImporterOutput { directives: [], warnings: [], errors: [] }
+            ;; 0x93 fixarray-3, then three 0x90 fixarray-0
+            (data (i32.const 24) "\93\90\90\90")
+
+            ;; EnrichedImporterOutput { entries: [], warnings: [], errors: [] }
+            (data (i32.const 32) "\93\90\90\90")
+
+            ;; bump allocator: hand out at $bump, advance by $size
+            (global $bump (mut i32) (i32.const 1024))
+            (func (export "alloc") (param $size i32) (result i32)
+                (local $ret i32)
+                global.get $bump
+                local.set $ret
+                global.get $bump
+                local.get $size
+                i32.add
+                global.set $bump
+                local.get $ret)
+
+            ;; metadata: ptr=0, len=9 → (0<<32) | 9 = 9
+            (func (export "metadata") (result i64)
+                i64.const 9)
+
+            ;; identify: ptr=16, len=2 → (16<<32) | 2
+            (func (export "identify") (param i32 i32) (result i64)
+                i64.const 0x10_0000_0002)
+
+            ;; extract: ptr=24, len=4 → (24<<32) | 4
+            (func (export "extract") (param i32 i32) (result i64)
+                i64.const 0x18_0000_0004)
+
+            ;; extract_enriched: ptr=32, len=4 → (32<<32) | 4
+            (func (export "extract_enriched") (param i32 i32) (result i64)
+                i64.const 0x20_0000_0004)
+        )
+        "#
+    }
+
+    fn minimal_config() -> ImporterConfig {
+        ImporterConfig {
+            account: "Assets:Bank:Checking".to_string(),
+            currency: Some("USD".to_string()),
+            importer_type: ImporterType::Csv(CsvConfig::default()),
+        }
+    }
+
+    #[test]
+    fn end_to_end_wat_module_round_trips_all_entry_points() {
+        let bytes = wat::parse_str(roundtrip_wat()).expect("WAT parses");
+        let importer = WasmImporter::load_from_bytes(
+            PathBuf::from("test.wasm"),
+            &bytes,
+            WasmRuntimeConfig::default(),
+        )
+        .expect("module loads + metadata round-trips");
+
+        // metadata was decoded once at load and cached for these
+        // accessors — proves the MetadataOutput msgpack flowed end to
+        // end through the host.
+        assert_eq!(importer.name(), "tst");
+        assert_eq!(importer.description(), "tst");
+
+        // identify round-trip — input ignored, module hardcodes true.
+        assert!(importer.identify(Path::new("anything.csv")));
+
+        // extract + extract_enriched need a real file for std::fs::read.
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let config = minimal_config();
+
+        let result = importer
+            .extract(tmp.path(), &config)
+            .expect("extract round-trip");
+        assert!(result.directives.is_empty());
+        assert!(result.warnings.is_empty());
+
+        let enriched = importer
+            .extract_enriched(tmp.path(), &config)
+            .expect("extract_enriched round-trip");
+        assert!(enriched.entries.is_empty());
+        assert!(enriched.warnings.is_empty());
+    }
+
+    #[test]
+    fn oversized_output_is_rejected_before_allocation() {
+        // Module's metadata() returns out_len = u32::MAX. Without the
+        // MAX_OUTPUT_BYTES check, the host would attempt a ~4 GiB Vec
+        // allocation. The check should catch it during load.
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                ;; metadata: ptr=0, len=u32::MAX
+                (func (export "metadata") (result i64)
+                    i64.const 0x0000_0000_ffff_ffff)
+                (func (export "identify") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        // Can't use `.expect_err(...)` here — `WasmImporter` doesn't
+        // implement `Debug` (the wasmtime `Module`/`Engine` it holds
+        // aren't trivially debuggable), so we destructure manually.
+        let Err(err) = WasmImporter::load_from_bytes(
+            PathBuf::from("oversized.wasm"),
+            &bytes,
+            WasmRuntimeConfig::default(),
+        ) else {
+            panic!("oversized metadata output should have been rejected at load");
+        };
+        assert!(
+            matches!(
+                err,
+                WasmImporterError::OutputTooLarge { len, max }
+                    if len == u32::MAX as usize && max == MAX_OUTPUT_BYTES
+            ),
+            "expected OutputTooLarge, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn memory_limiter_rejects_grow_above_max() {
+        // Pin the ResourceLimiter behavior directly. The full
+        // wasm.grow → trap path is wasmtime-internal and hard to
+        // observe without a custom module, so this test guards the
+        // bit we own: that memory_growing returns Ok(false) past the
+        // cap.
+        let mut limiter = MemoryLimiter { max_memory: 1024 };
+        assert!(
+            limiter
+                .memory_growing(0, 512, None)
+                .expect("under cap is Ok")
+        ); // under cap
+        assert!(limiter.memory_growing(0, 1024, None).expect("at cap is Ok")); // exactly at cap
+        assert!(
+            !limiter
+                .memory_growing(0, 1025, None)
+                .expect("over cap is Ok(false)")
+        ); // over cap
+    }
+
+    #[test]
+    fn zero_max_time_secs_does_not_starve_fuel() {
+        // Regression: previously fuel = 0 * 1_000_000 = 0, causing
+        // immediate trap on first instruction. Now clamped via
+        // .max(1) so a 0 config still gets enough fuel to complete a
+        // trivial call.
+        let config = WasmRuntimeConfig {
+            max_memory: 256 * 1024 * 1024,
+            max_time_secs: 0,
+        };
+        let bytes = wat::parse_str(roundtrip_wat()).expect("WAT parses");
+        // Loading calls metadata(), which is a single i64.const +
+        // return — well under 1M instructions.
+        let importer = WasmImporter::load_from_bytes(PathBuf::from("test.wasm"), &bytes, config)
+            .expect("zero max_time_secs is clamped, not starved");
+        assert_eq!(importer.name(), "tst");
     }
 }

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -1,0 +1,589 @@
+//! Host loader for WASM-implemented importers (wave 2.3b).
+//!
+//! A [`WasmImporter`] wraps a `.wasm` module and implements the
+//! [`crate::Importer`] trait by serializing inputs to `MessagePack`,
+//! calling into the module via wasmtime, and deserializing outputs.
+//!
+//! # Sandbox model
+//!
+//! Mirrors the existing directive-plugin runtime in
+//! `rustledger-plugin/src/runtime.rs`:
+//!
+//! - No imports allowed (rejected at load time)
+//! - No WASI / filesystem / network / env / syscalls
+//! - Memory limit enforced (default 256 MiB)
+//! - Fuel-based execution time limit (default 30 s)
+//!
+//! The host reads the source file into memory and passes the bytes
+//! via [`ImporterInput::content`]; the WASM importer never opens the
+//! file itself.
+//!
+//! # Required WASM exports
+//!
+//! A WASM importer module must export:
+//!
+//! - `memory` — the standard linear memory
+//! - `alloc(size: u32) -> u32` — allocates `size` bytes, returns pointer
+//! - `metadata() -> u64` — packed `(ptr << 32) | len` of `MessagePack`
+//!   [`MetadataOutput`]. Called once at load.
+//! - `identify(ptr: u32, len: u32) -> u64` — input is msgpack
+//!   [`IdentifyInput`], output is msgpack [`IdentifyOutput`].
+//! - `extract(ptr: u32, len: u32) -> u64` — input is msgpack
+//!   [`ImporterInput`], output is msgpack [`ImporterOutput`].
+//! - `extract_enriched(ptr: u32, len: u32) -> u64` — input is msgpack
+//!   [`ImporterInput`], output is msgpack [`EnrichedImporterOutput`].
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rustledger_plugin_types::{
+    EnrichedImporterOutput, IdentifyInput, IdentifyOutput, ImporterInput, ImporterOutput,
+    MetadataOutput,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use wasmtime::{Config, Engine, Linker, Module, Store};
+
+use crate::config::{CsvConfig, ImporterType};
+use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
+
+/// Configuration for the WASM importer runtime.
+#[derive(Debug, Clone, Copy)]
+pub struct WasmRuntimeConfig {
+    /// Maximum memory in bytes (default 256 MiB).
+    pub max_memory: usize,
+    /// Maximum execution time in seconds (default 30). Converted to a
+    /// fuel budget at roughly 1M instructions per second.
+    pub max_time_secs: u64,
+}
+
+impl Default for WasmRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_memory: 256 * 1024 * 1024,
+            max_time_secs: 30,
+        }
+    }
+}
+
+/// Errors that can occur loading or invoking a WASM importer.
+#[derive(Debug, thiserror::Error)]
+pub enum WasmImporterError {
+    /// Failed to read the `.wasm` file from disk.
+    #[error("failed to read WASM file {path}: {source}")]
+    Io {
+        /// Path the host tried to read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+    /// The WASM module is malformed or uses unsupported features.
+    #[error("failed to compile WASM module {path}: {source}")]
+    Compile {
+        /// Path of the module that failed to compile.
+        path: PathBuf,
+        /// Underlying wasmtime compile error.
+        source: anyhow::Error,
+    },
+    /// The WASM module has imports — they're forbidden in the importer
+    /// sandbox. Importers must be self-contained.
+    #[error(
+        "WASM importer has forbidden import {module}::{name} — importers must be self-contained"
+    )]
+    ForbiddenImport {
+        /// Import module namespace (e.g. `env`, `wasi_snapshot_preview1`).
+        module: String,
+        /// Import item name within the module.
+        name: String,
+    },
+    /// A required export is missing.
+    #[error("WASM importer missing required export `{0}`")]
+    MissingExport(&'static str),
+    /// Runtime error during a wasmtime call (trap, fuel exhausted,
+    /// memory limit, etc.).
+    #[error("WASM importer runtime error: {0}")]
+    Runtime(#[source] anyhow::Error),
+    /// `MessagePack` decode error on the WASM-returned bytes.
+    #[error("WASM importer returned malformed MessagePack: {0}")]
+    Decode(#[source] rmp_serde::decode::Error),
+    /// `MessagePack` encode error on the input being sent to the WASM
+    /// importer. Practically only happens if `ImporterConfig` carries
+    /// non-serializable state, which shouldn't.
+    #[error("failed to encode input for WASM importer: {0}")]
+    Encode(#[source] rmp_serde::encode::Error),
+}
+
+// Note: no manual `impl From<WasmImporterError> for anyhow::Error` — `anyhow`
+// has a blanket impl for any `std::error::Error + Send + Sync + 'static`,
+// which thiserror's derive already satisfies. Adding our own would conflict.
+
+/// Wrap a `wasmtime::Error` in `WasmImporterError::Runtime`. Function form
+/// (not closure) so call sites stay terse: `.map_err(runtime_err)`.
+#[inline]
+fn runtime_err(e: wasmtime::Error) -> WasmImporterError {
+    WasmImporterError::Runtime(anyhow::Error::from(e))
+}
+
+/// A WASM-loaded importer. Implements [`Importer`] by dispatching to
+/// the loaded module's `extract` / `extract_enriched` entry points.
+///
+/// Cheap to clone — the underlying [`Engine`] and [`Module`] are
+/// shared via `Arc`. A fresh wasmtime [`Store`] is created per call,
+/// so concurrent extract calls don't share state.
+#[derive(Clone)]
+pub struct WasmImporter {
+    /// Filesystem path the module was loaded from (for diagnostics).
+    path: PathBuf,
+    /// Module's declared name (from the cached `metadata` call).
+    name: String,
+    /// Module's declared description (from the cached `metadata` call).
+    description: String,
+    /// Compiled module.
+    module: Arc<Module>,
+    /// Shared wasmtime engine.
+    engine: Arc<Engine>,
+    /// Per-call runtime limits.
+    config: WasmRuntimeConfig,
+}
+
+impl WasmImporter {
+    /// Load a WASM importer from a `.wasm` file with default runtime
+    /// limits.
+    pub fn load(path: impl Into<PathBuf>) -> Result<Self, WasmImporterError> {
+        Self::load_with_config(path, WasmRuntimeConfig::default())
+    }
+
+    /// Load a WASM importer with custom runtime limits.
+    pub fn load_with_config(
+        path: impl Into<PathBuf>,
+        config: WasmRuntimeConfig,
+    ) -> Result<Self, WasmImporterError> {
+        let path = path.into();
+        let bytes = std::fs::read(&path).map_err(|source| WasmImporterError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        Self::load_from_bytes(path, &bytes, config)
+    }
+
+    /// Load from in-memory WASM bytes — useful for tests and embedders
+    /// that ship the module inside their binary.
+    pub fn load_from_bytes(
+        path: impl Into<PathBuf>,
+        bytes: &[u8],
+        config: WasmRuntimeConfig,
+    ) -> Result<Self, WasmImporterError> {
+        let path = path.into();
+
+        let mut engine_config = Config::new();
+        engine_config.consume_fuel(true);
+        let engine =
+            Arc::new(
+                Engine::new(&engine_config).map_err(|e| WasmImporterError::Compile {
+                    path: path.clone(),
+                    source: anyhow::Error::from(e),
+                })?,
+            );
+
+        let module = Module::new(&engine, bytes).map_err(|e| WasmImporterError::Compile {
+            path: path.clone(),
+            source: anyhow::Error::from(e),
+        })?;
+
+        Self::validate_module(&module)?;
+
+        let module = Arc::new(module);
+
+        // Call `metadata` once and cache the result. Importers don't
+        // change name/description across calls; this avoids paying the
+        // wasmtime instantiation cost on every `name()` / `description()`.
+        let metadata = call_metadata(&engine, &module, config)?;
+
+        Ok(Self {
+            path,
+            name: metadata.name,
+            description: metadata.description,
+            module,
+            engine,
+            config,
+        })
+    }
+
+    /// The path the module was loaded from.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Reject imports (sandbox requirement) and check required exports.
+    fn validate_module(module: &Module) -> Result<(), WasmImporterError> {
+        if let Some(import) = module.imports().next() {
+            return Err(WasmImporterError::ForbiddenImport {
+                module: import.module().to_string(),
+                name: import.name().to_string(),
+            });
+        }
+
+        let exports: Vec<_> = module.exports().map(|e| e.name().to_string()).collect();
+        for required in &[
+            "memory",
+            "alloc",
+            "metadata",
+            "identify",
+            "extract",
+            "extract_enriched",
+        ] {
+            if !exports.iter().any(|n| n == required) {
+                return Err(WasmImporterError::MissingExport(required));
+            }
+        }
+        Ok(())
+    }
+
+    /// Wraps a wasmtime call that takes msgpack input and returns
+    /// msgpack output. The WASM module's entry-point convention:
+    /// `fn (ptr: u32, len: u32) -> u64` where the return packs
+    /// `(out_ptr << 32) | out_len`.
+    fn call_msgpack<I: Serialize, O: DeserializeOwned>(
+        &self,
+        entry: &'static str,
+        input: &I,
+    ) -> Result<O, WasmImporterError> {
+        call_msgpack_with(&self.engine, &self.module, self.config, entry, input)
+    }
+}
+
+/// Free-form wasmtime call helper. Extracted from `WasmImporter`'s
+/// methods so the load-time `metadata` call can use it before `self`
+/// is fully constructed.
+fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
+    engine: &Engine,
+    module: &Module,
+    config: WasmRuntimeConfig,
+    entry: &'static str,
+    input: &I,
+) -> Result<O, WasmImporterError> {
+    let input_bytes = rmp_serde::to_vec(input).map_err(WasmImporterError::Encode)?;
+
+    let mut store = Store::new(engine, ());
+    // 1M instructions per second is the same rough budget used by the
+    // directive-plugin runtime.
+    let fuel = config.max_time_secs * 1_000_000;
+    store.set_fuel(fuel).map_err(runtime_err)?;
+
+    // No imports at all — full sandbox.
+    let linker = Linker::new(engine);
+    let instance = linker
+        .instantiate(&mut store, module)
+        .map_err(runtime_err)?;
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .ok_or(WasmImporterError::MissingExport("memory"))?;
+
+    let alloc = instance
+        .get_typed_func::<u32, u32>(&mut store, "alloc")
+        .map_err(|_| WasmImporterError::MissingExport("alloc"))?;
+
+    let input_ptr = alloc
+        .call(&mut store, input_bytes.len() as u32)
+        .map_err(runtime_err)?;
+    memory
+        .write(&mut store, input_ptr as usize, &input_bytes)
+        .map_err(|e| WasmImporterError::Runtime(e.into()))?;
+
+    let func = instance
+        .get_typed_func::<(u32, u32), u64>(&mut store, entry)
+        .map_err(|_| WasmImporterError::MissingExport(entry))?;
+
+    let packed = func
+        .call(&mut store, (input_ptr, input_bytes.len() as u32))
+        .map_err(runtime_err)?;
+
+    let out_ptr = (packed >> 32) as u32;
+    let out_len = (packed & 0xFFFF_FFFF) as u32;
+
+    let mut out_bytes = vec![0u8; out_len as usize];
+    memory
+        .read(&store, out_ptr as usize, &mut out_bytes)
+        .map_err(|e| WasmImporterError::Runtime(e.into()))?;
+
+    rmp_serde::from_slice(&out_bytes).map_err(WasmImporterError::Decode)
+}
+
+/// Special-case helper for the no-input `metadata` entry point. The
+/// WASM convention is `fn metadata() -> u64` returning the packed
+/// `(ptr, len)` of msgpack-encoded [`MetadataOutput`].
+fn call_metadata(
+    engine: &Engine,
+    module: &Module,
+    config: WasmRuntimeConfig,
+) -> Result<MetadataOutput, WasmImporterError> {
+    let mut store = Store::new(engine, ());
+    let fuel = config.max_time_secs * 1_000_000;
+    store.set_fuel(fuel).map_err(runtime_err)?;
+
+    let linker = Linker::new(engine);
+    let instance = linker
+        .instantiate(&mut store, module)
+        .map_err(runtime_err)?;
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .ok_or(WasmImporterError::MissingExport("memory"))?;
+
+    let metadata = instance
+        .get_typed_func::<(), u64>(&mut store, "metadata")
+        .map_err(|_| WasmImporterError::MissingExport("metadata"))?;
+
+    let packed = metadata.call(&mut store, ()).map_err(runtime_err)?;
+
+    let out_ptr = (packed >> 32) as u32;
+    let out_len = (packed & 0xFFFF_FFFF) as u32;
+
+    let mut out_bytes = vec![0u8; out_len as usize];
+    memory
+        .read(&store, out_ptr as usize, &mut out_bytes)
+        .map_err(|e| WasmImporterError::Runtime(e.into()))?;
+
+    rmp_serde::from_slice(&out_bytes).map_err(WasmImporterError::Decode)
+}
+
+/// Flatten the host's [`ImporterConfig`] into the wire-format
+/// [`ImporterInput`] expected by the WASM module. CSV-specific config
+/// fields are serialized into the free-form `options` map.
+fn build_wasm_input(path: &Path, content: Vec<u8>, config: &ImporterConfig) -> ImporterInput {
+    let mut options = std::collections::HashMap::new();
+    let ImporterType::Csv(csv) = &config.importer_type;
+    project_csv_config_into_options(csv, &mut options);
+    ImporterInput {
+        path: path.to_string_lossy().into_owned(),
+        content,
+        account: config.account.clone(),
+        currency: config.currency.clone(),
+        options,
+    }
+}
+
+/// Project CSV-specific config into the wire-format `options` map.
+/// String-encoded per the ABI's String→String contract.
+fn project_csv_config_into_options(
+    csv: &CsvConfig,
+    options: &mut std::collections::HashMap<String, String>,
+) {
+    options.insert("date_format".to_string(), csv.date_format.clone());
+    options.insert("delimiter".to_string(), csv.delimiter.to_string());
+    options.insert("has_header".to_string(), csv.has_header.to_string());
+    options.insert("skip_rows".to_string(), csv.skip_rows.to_string());
+    options.insert("invert_sign".to_string(), csv.invert_sign.to_string());
+    options.insert(
+        "skip_zero_amounts".to_string(),
+        csv.skip_zero_amounts.to_string(),
+    );
+    if let Some(de) = &csv.default_expense {
+        options.insert("default_expense".to_string(), de.clone());
+    }
+    if let Some(di) = &csv.default_income {
+        options.insert("default_income".to_string(), di.clone());
+    }
+}
+
+/// Materialize an [`ImporterOutput`] wire-format value back to the
+/// host-side [`ImportResult`]. Reuses
+/// `rustledger_plugin::convert::wrapper_to_directive` semantics —
+/// duplicated here so this crate doesn't need to depend on the full
+/// `rustledger-plugin` graph just for the converter.
+fn output_to_import_result(out: ImporterOutput) -> anyhow::Result<ImportResult> {
+    let mut directives = Vec::with_capacity(out.directives.len());
+    for w in out.directives {
+        // Reuse the canonical conversion path. NOTE: this is the same
+        // converter the directive plugins use, so any improvements
+        // there land here too.
+        let d = rustledger_plugin::convert::wrapper_to_directive(&w)
+            .map_err(|e| anyhow::anyhow!("WASM importer returned invalid directive: {e:?}"))?;
+        directives.push(d);
+    }
+    let mut result = ImportResult::new(directives);
+    for w in out.warnings {
+        result = result.with_warning(w);
+    }
+    // Errors are non-fatal at this layer — surface them as warnings so
+    // the existing extract pipeline doesn't need a new error channel.
+    // The structured error path goes through LedgerError in the loader.
+    for e in out.errors {
+        result = result.with_warning(format!(
+            "{}{}: {}",
+            e.source_file.unwrap_or_default(),
+            e.line_number.map(|n| format!(":{n}")).unwrap_or_default(),
+            e.message
+        ));
+    }
+    Ok(result)
+}
+
+impl Importer for WasmImporter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn identify(&self, path: &Path) -> bool {
+        let input = IdentifyInput {
+            path: path.to_string_lossy().into_owned(),
+        };
+        // identify() failures (trap, decode error) conservatively return
+        // false — the registry treats this as "this importer doesn't
+        // handle the file" and falls back to the next candidate.
+        match self.call_msgpack::<_, IdentifyOutput>("identify", &input) {
+            Ok(out) => out.matches,
+            Err(_) => false,
+        }
+    }
+
+    fn extract(&self, path: &Path, config: &ImporterConfig) -> anyhow::Result<ImportResult> {
+        let content = std::fs::read(path)
+            .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+        let input = build_wasm_input(path, content, config);
+        let output: ImporterOutput = self.call_msgpack("extract", &input)?;
+        output_to_import_result(output)
+    }
+
+    fn extract_enriched(
+        &self,
+        path: &Path,
+        config: &ImporterConfig,
+    ) -> anyhow::Result<EnrichedImportResult> {
+        let content = std::fs::read(path)
+            .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+        let input = build_wasm_input(path, content, config);
+        let output: EnrichedImporterOutput = self.call_msgpack("extract_enriched", &input)?;
+
+        // Bridge from wire-format EnrichedImporterOutput to the
+        // host-side EnrichedImportResult. The enrichment-wrapper →
+        // host-Enrichment conversion is intentionally lossy on
+        // `method` (string → enum): unknown methods fall back to
+        // `Default` rather than failing the whole import.
+        let mut entries = Vec::with_capacity(output.entries.len());
+        for (wrapper, enr) in output.entries {
+            let dir = rustledger_plugin::convert::wrapper_to_directive(&wrapper)
+                .map_err(|e| anyhow::anyhow!("WASM importer returned invalid directive: {e:?}"))?;
+            let enrichment = rustledger_ops::enrichment::Enrichment {
+                directive_index: enr.directive_index,
+                confidence: enr.confidence,
+                method: parse_method(&enr.method),
+                alternatives: enr
+                    .alternatives
+                    .into_iter()
+                    .map(|a| rustledger_ops::enrichment::Alternative {
+                        account: a.account,
+                        confidence: a.confidence,
+                        method: parse_method(&a.method),
+                    })
+                    .collect(),
+                fingerprint: None, // Fingerprint round-trip via hex string is wave 2.3+
+            };
+            entries.push((dir, enrichment));
+        }
+        let mut enriched = EnrichedImportResult::new(entries);
+        for w in output.warnings {
+            enriched = enriched.with_warning(w);
+        }
+        for e in output.errors {
+            enriched = enriched.with_warning(format!(
+                "{}{}: {}",
+                e.source_file.unwrap_or_default(),
+                e.line_number.map(|n| format!(":{n}")).unwrap_or_default(),
+                e.message
+            ));
+        }
+        Ok(enriched)
+    }
+}
+
+/// Convert the wire-format method string (as emitted by
+/// `CategorizationMethod::as_meta_value`) back into the host enum.
+/// Unknown strings fall back to `Default` so a future addition to the
+/// host enum doesn't break older WASM importers.
+fn parse_method(s: &str) -> rustledger_ops::enrichment::CategorizationMethod {
+    use rustledger_ops::enrichment::CategorizationMethod;
+    match s {
+        "rule" => CategorizationMethod::Rule,
+        "merchant-dict" => CategorizationMethod::MerchantDict,
+        "ml" => CategorizationMethod::Ml,
+        "llm" => CategorizationMethod::Llm,
+        "manual" => CategorizationMethod::Manual,
+        _ => CategorizationMethod::Default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wasm_runtime_config_default_is_sensible() {
+        let c = WasmRuntimeConfig::default();
+        assert_eq!(c.max_memory, 256 * 1024 * 1024);
+        assert_eq!(c.max_time_secs, 30);
+    }
+
+    #[test]
+    fn validate_module_rejects_module_with_imports() {
+        // A WAT module with a single import — should be rejected.
+        let wat = r#"
+            (module
+                (import "env" "ext" (func $ext))
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "metadata") (result i64) i64.const 0)
+                (func (export "identify") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let mut engine_config = Config::new();
+        engine_config.consume_fuel(true);
+        let engine = Engine::new(&engine_config).unwrap();
+        let module = Module::new(&engine, &bytes).unwrap();
+        let err = WasmImporter::validate_module(&module).unwrap_err();
+        assert!(matches!(err, WasmImporterError::ForbiddenImport { .. }));
+    }
+
+    #[test]
+    fn validate_module_rejects_missing_export() {
+        // Has memory + alloc + metadata but missing identify/extract/extract_enriched.
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "metadata") (result i64) i64.const 0)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let mut engine_config = Config::new();
+        engine_config.consume_fuel(true);
+        let engine = Engine::new(&engine_config).unwrap();
+        let module = Module::new(&engine, &bytes).unwrap();
+        let err = WasmImporter::validate_module(&module).unwrap_err();
+        assert!(matches!(err, WasmImporterError::MissingExport(_)));
+    }
+
+    #[test]
+    fn parse_method_unknown_falls_back_to_default() {
+        use rustledger_ops::enrichment::CategorizationMethod;
+        assert!(matches!(parse_method("rule"), CategorizationMethod::Rule));
+        assert!(matches!(
+            parse_method("merchant-dict"),
+            CategorizationMethod::MerchantDict
+        ));
+        // Forward-compat: a WASM importer emitting a method this host
+        // doesn't know about gets Default rather than a failed import.
+        assert!(matches!(
+            parse_method("future-method"),
+            CategorizationMethod::Default
+        ));
+    }
+}

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -53,6 +53,13 @@ use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
 /// well above any realistic importer output for a single statement.
 const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
 
+/// Hard cap on the byte length of input the host will marshal into the
+/// WASM module. Mirrors [`MAX_OUTPUT_BYTES`] on the input side:
+/// `wasm32` memory is `u32`-addressed, so anything over 4 GiB is
+/// fundamentally not addressable, but we cap much lower to avoid
+/// runaway allocations from accidentally-huge source files.
+const MAX_INPUT_BYTES: usize = 64 * 1024 * 1024;
+
 /// Hard cap on the number of elements in any single WASM table.
 /// Importers don't typically need indirect-call tables at all, let
 /// alone large ones. Each ref-typed slot is pointer-sized (8 bytes on
@@ -137,6 +144,28 @@ pub enum WasmImporterError {
         len: usize,
         /// Host's enforced cap (`MAX_OUTPUT_BYTES`).
         max: usize,
+    },
+    /// The input the host tried to marshal exceeds
+    /// [`MAX_INPUT_BYTES`]. The host caps before a lossy
+    /// `as u32` cast (wasm32 memory is `u32`-addressed, so >4 GiB
+    /// input would silently truncate).
+    #[error("input of {len} bytes exceeds cap of {max} bytes for WASM importer")]
+    InputTooLarge {
+        /// Length the host attempted to send.
+        len: usize,
+        /// Host's enforced cap (`MAX_INPUT_BYTES`).
+        max: usize,
+    },
+    /// A required export exists but has the wrong signature. Distinct
+    /// from [`Self::MissingExport`] because `validate_module` already
+    /// proved presence at load time — a `get_typed_func` failure
+    /// thereafter is always a type mismatch, not absence.
+    #[error("WASM importer export `{name}` has wrong signature: {source}")]
+    ExportSignatureMismatch {
+        /// Name of the export.
+        name: &'static str,
+        /// Underlying wasmtime type-mismatch error.
+        source: anyhow::Error,
     },
 }
 
@@ -339,10 +368,28 @@ fn make_store(
     let mut store = Store::new(engine, state);
     store.limiter(|s| &mut s.limiter);
     // 1M instructions per second is the same rough budget used by the
-    // directive-plugin runtime.
-    let fuel = config.max_time_secs.max(1) * 1_000_000;
+    // directive-plugin runtime. `.max(1)` prevents zero-fuel starvation;
+    // `.saturating_mul` prevents u64 overflow on huge `max_time_secs`
+    // (panic in debug, silent wrap to a tiny number in release — both
+    // wrong, both prevented here).
+    let fuel = config.max_time_secs.max(1).saturating_mul(1_000_000);
     store.set_fuel(fuel).map_err(runtime_err)?;
     Ok(store)
+}
+
+/// Cap input length before the lossy `as u32` cast — wasm32 memory
+/// is u32-addressed, so >4 GiB input would silently truncate and
+/// corrupt the import. Returns the validated length as `u32` so
+/// callers don't need to repeat the cast.
+const fn validate_input_size(len: usize) -> Result<u32, WasmImporterError> {
+    if len > MAX_INPUT_BYTES {
+        return Err(WasmImporterError::InputTooLarge {
+            len,
+            max: MAX_INPUT_BYTES,
+        });
+    }
+    // Safe: `MAX_INPUT_BYTES` (64 MiB) fits in u32, and `len <= MAX_INPUT_BYTES`.
+    Ok(len as u32)
 }
 
 /// Read a packed `(out_ptr, out_len)` u64 from a WASM entry-point
@@ -382,6 +429,7 @@ fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
     input: &I,
 ) -> Result<O, WasmImporterError> {
     let input_bytes = rmp_serde::to_vec(input).map_err(WasmImporterError::Encode)?;
+    let input_len = validate_input_size(input_bytes.len())?;
 
     let mut store = make_store(engine, config)?;
 
@@ -391,27 +439,37 @@ fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
         .instantiate(&mut store, module)
         .map_err(runtime_err)?;
 
+    // For each `get_typed_func` below: `validate_module` already
+    // verified that the export exists at load time, so any error here
+    // is necessarily a signature mismatch (not absence). Surfacing it
+    // as `ExportSignatureMismatch` rather than `MissingExport` saves
+    // guest authors from chasing a misleading "export not found"
+    // error message.
     let memory = instance
         .get_memory(&mut store, "memory")
         .ok_or(WasmImporterError::MissingExport("memory"))?;
 
     let alloc = instance
         .get_typed_func::<u32, u32>(&mut store, "alloc")
-        .map_err(|_| WasmImporterError::MissingExport("alloc"))?;
+        .map_err(|e| WasmImporterError::ExportSignatureMismatch {
+            name: "alloc",
+            source: anyhow::Error::from(e),
+        })?;
 
-    let input_ptr = alloc
-        .call(&mut store, input_bytes.len() as u32)
-        .map_err(runtime_err)?;
+    let input_ptr = alloc.call(&mut store, input_len).map_err(runtime_err)?;
     memory
         .write(&mut store, input_ptr as usize, &input_bytes)
         .map_err(|e| WasmImporterError::Runtime(e.into()))?;
 
     let func = instance
         .get_typed_func::<(u32, u32), u64>(&mut store, entry)
-        .map_err(|_| WasmImporterError::MissingExport(entry))?;
+        .map_err(|e| WasmImporterError::ExportSignatureMismatch {
+            name: entry,
+            source: anyhow::Error::from(e),
+        })?;
 
     let packed = func
-        .call(&mut store, (input_ptr, input_bytes.len() as u32))
+        .call(&mut store, (input_ptr, input_len))
         .map_err(runtime_err)?;
 
     let out_bytes = read_packed_output(&store, &memory, packed)?;
@@ -437,9 +495,14 @@ fn call_metadata(
         .get_memory(&mut store, "memory")
         .ok_or(WasmImporterError::MissingExport("memory"))?;
 
+    // Same reasoning as in `call_msgpack_with`: validate_module
+    // proved presence, so a typed_func error is a signature mismatch.
     let metadata = instance
         .get_typed_func::<(), u64>(&mut store, "metadata")
-        .map_err(|_| WasmImporterError::MissingExport("metadata"))?;
+        .map_err(|e| WasmImporterError::ExportSignatureMismatch {
+            name: "metadata",
+            source: anyhow::Error::from(e),
+        })?;
 
     let packed = metadata.call(&mut store, ()).map_err(runtime_err)?;
     let out_bytes = read_packed_output(&store, &memory, packed)?;
@@ -447,8 +510,10 @@ fn call_metadata(
 }
 
 /// Flatten the host's [`ImporterConfig`] into the wire-format
-/// [`ImporterInput`] expected by the WASM module. CSV-specific config
-/// fields are serialized into the free-form `options` map.
+/// [`ImporterInput`] expected by the WASM module. A *subset* of
+/// CSV-specific config fields is serialized into the free-form
+/// `options` map — see [`project_csv_config_into_options`] for the
+/// list and what's deferred.
 fn build_wasm_input(path: &Path, content: Vec<u8>, config: &ImporterConfig) -> ImporterInput {
     let mut options = std::collections::HashMap::new();
     let ImporterType::Csv(csv) = &config.importer_type;
@@ -462,8 +527,30 @@ fn build_wasm_input(path: &Path, content: Vec<u8>, config: &ImporterConfig) -> I
     }
 }
 
-/// Project CSV-specific config into the wire-format `options` map.
-/// String-encoded per the ABI's String→String contract.
+/// Project a *subset* of [`CsvConfig`] into the wire-format `options`
+/// map. String-encoded per the ABI's String→String contract.
+///
+/// # Currently projected
+///
+/// - `date_format`, `delimiter`, `has_header`, `skip_rows`,
+///   `invert_sign`, `skip_zero_amounts` — simple String/bool/number
+/// - `default_expense`, `default_income` — Option<String>
+///
+/// # Deferred to wave 2.3e+
+///
+/// The richer fields — `date_column` / `narration_column` /
+/// `payee_column` / `amount_column` / `debit_column` /
+/// `credit_column` (`ColumnSpec` enum: name OR index), `amount_locale`
+/// / `amount_format`, `mappings` / `regex_mappings` (`Vec<(String,
+/// String)>`), `use_merchant_dict` — are not yet projected. Encoding
+/// them in a String→String map needs design decisions (key prefixes,
+/// JSON-in-string, parallel collections?) that are best driven by a
+/// real WASM CSV importer in wave 2.3e rather than guessed now.
+///
+/// A WASM importer in 2.3b can still extract from CSV files; it just
+/// has to implement its own column-spec discovery rather than
+/// inheriting the host's. Most non-CSV importers (OFX, MT940, …)
+/// don't need any of the deferred fields.
 fn project_csv_config_into_options(
     csv: &CsvConfig,
     options: &mut std::collections::HashMap<String, String>,
@@ -509,16 +596,13 @@ fn format_plugin_error(e: &PluginError) -> String {
 }
 
 /// Materialize an [`ImporterOutput`] wire-format value back to the
-/// host-side [`ImportResult`]. Reuses
-/// `rustledger_plugin::convert::wrapper_to_directive` semantics —
-/// duplicated here so this crate doesn't need to depend on the full
-/// `rustledger-plugin` graph just for the converter.
+/// host-side [`ImportResult`]. Delegates wrapper→directive conversion
+/// to `rustledger_plugin::convert::wrapper_to_directive` so the WASM
+/// importer path and the directive-plugin path share a single
+/// converter — improvements there land here for free.
 fn output_to_import_result(out: ImporterOutput) -> anyhow::Result<ImportResult> {
     let mut directives = Vec::with_capacity(out.directives.len());
     for w in out.directives {
-        // Reuse the canonical conversion path. NOTE: this is the same
-        // converter the directive plugins use, so any improvements
-        // there land here too.
         let d = rustledger_plugin::convert::wrapper_to_directive(&w)
             .map_err(|e| anyhow::anyhow!("WASM importer returned invalid directive: {e:?}"))?;
         directives.push(d);
@@ -1032,6 +1116,86 @@ mod tests {
             !limiter
                 .table_growing(0, MAX_TABLE_ELEMENTS + 1, None)
                 .expect("over cap is Ok(false)")
+        );
+    }
+
+    #[test]
+    fn validate_input_size_accepts_at_cap_and_rejects_above() {
+        // Exactly at the cap is fine.
+        assert_eq!(
+            validate_input_size(MAX_INPUT_BYTES).unwrap(),
+            MAX_INPUT_BYTES as u32
+        );
+        // One byte over is rejected, with the offending length surfaced
+        // in the error so the user can see how much they overshot.
+        let err = validate_input_size(MAX_INPUT_BYTES + 1).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                WasmImporterError::InputTooLarge { len, max }
+                    if len == MAX_INPUT_BYTES + 1 && max == MAX_INPUT_BYTES
+            ),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn fuel_calc_saturates_instead_of_overflowing() {
+        // Regression for Copilot #2: u64::MAX max_time_secs would have
+        // overflowed in release (silent wrap to a tiny number ⇒ fuel
+        // starvation) and panicked in debug. Saturating_mul caps at
+        // u64::MAX which set_fuel accepts.
+        let bytes = wat::parse_str(roundtrip_wat()).expect("WAT parses");
+        let config = WasmRuntimeConfig {
+            max_memory: 256 * 1024 * 1024,
+            max_time_secs: u64::MAX,
+        };
+        // Successful load proves the fuel calc didn't panic and the
+        // resulting saturated value is acceptable to set_fuel.
+        let importer = WasmImporter::load_from_bytes(PathBuf::from("test.wasm"), &bytes, config)
+            .expect("u64::MAX max_time_secs saturates, doesn't overflow");
+        assert_eq!(importer.name(), "tst");
+    }
+
+    #[test]
+    fn wrong_signature_export_surfaces_export_signature_mismatch() {
+        // `metadata` is declared but with the wrong signature
+        // (returns i32 instead of i64). `validate_module` checks
+        // presence-by-name only, so this passes validate. The
+        // signature error surfaces when `call_metadata` tries
+        // `get_typed_func::<(), u64>`.
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                ;; WRONG: should be (result i64), declared as (result i32)
+                (func (export "metadata") (result i32) i32.const 0)
+                (func (export "identify") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let Err(err) = WasmImporter::load_from_bytes(
+            PathBuf::from("badsig.wasm"),
+            &bytes,
+            WasmRuntimeConfig::default(),
+        ) else {
+            panic!("metadata with wrong signature should be rejected");
+        };
+        // Previously: silently surfaced as MissingExport("metadata"),
+        // which is misleading because the export DOES exist. Now:
+        // ExportSignatureMismatch names the export and includes the
+        // wasmtime type-mismatch error in the source chain.
+        assert!(
+            matches!(
+                err,
+                WasmImporterError::ExportSignatureMismatch {
+                    name: "metadata",
+                    ..
+                }
+            ),
+            "expected ExportSignatureMismatch for metadata, got {err:?}"
         );
     }
 

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -37,12 +37,13 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rustledger_ops::fingerprint::Fingerprint;
+use rustledger_plugin::sandbox;
 use rustledger_plugin_types::{
     EnrichedImporterOutput, IdentifyInput, IdentifyOutput, ImporterInput, ImporterOutput,
     MetadataOutput, PluginError, PluginErrorSeverity,
 };
 use serde::{Serialize, de::DeserializeOwned};
-use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store};
+use wasmtime::{Engine, Linker, Module, ResourceLimiter, Store};
 
 use crate::config::{CsvConfig, ImporterType};
 use crate::{EnrichedImportResult, ImportResult, Importer, ImporterConfig};
@@ -224,9 +225,10 @@ fn runtime_err(e: wasmtime::Error) -> WasmImporterError {
 /// A WASM-loaded importer. Implements [`Importer`] by dispatching to
 /// the loaded module's `extract` / `extract_enriched` entry points.
 ///
-/// Cheap to clone — the underlying [`Engine`] and [`Module`] are
-/// shared via `Arc`. A fresh wasmtime [`Store`] is created per call,
-/// so concurrent extract calls don't share state.
+/// Cheap to clone — the [`Module`] is shared via `Arc` and the
+/// [`Engine`] is process-wide (see [`rustledger_plugin::sandbox`]).
+/// A fresh wasmtime [`Store`] is created per call, so concurrent
+/// extract calls don't share state.
 #[derive(Clone)]
 pub struct WasmImporter {
     /// Filesystem path the module was loaded from (for diagnostics).
@@ -237,7 +239,8 @@ pub struct WasmImporter {
     description: String,
     /// Compiled module.
     module: Arc<Module>,
-    /// Shared wasmtime engine.
+    /// Shared wasmtime engine — one per process, sourced from the
+    /// workspace's shared sandbox config in `rustledger_plugin`.
     engine: Arc<Engine>,
     /// Per-call runtime limits.
     config: WasmRuntimeConfig,
@@ -263,8 +266,26 @@ impl WasmImporter {
         Self::load_from_bytes(path, &bytes, config)
     }
 
+    /// Load a WASM importer from in-memory bytes that aren't backed by
+    /// a real file. Use this when shipping `.wasm` modules embedded in
+    /// a binary or generated at runtime — `name_for_diagnostics`
+    /// surfaces in error messages and [`Self::path`] but doesn't have
+    /// to correspond to anything on disk.
+    pub fn load_embedded(
+        name_for_diagnostics: &str,
+        bytes: &[u8],
+    ) -> Result<Self, WasmImporterError> {
+        Self::load_from_bytes(
+            PathBuf::from(name_for_diagnostics),
+            bytes,
+            WasmRuntimeConfig::default(),
+        )
+    }
+
     /// Load from in-memory WASM bytes — useful for tests and embedders
-    /// that ship the module inside their binary.
+    /// that ship the module inside their binary. The `path` is used
+    /// only for diagnostics; see [`Self::load_embedded`] for an
+    /// embedder-friendly wrapper.
     pub fn load_from_bytes(
         path: impl Into<PathBuf>,
         bytes: &[u8],
@@ -272,15 +293,11 @@ impl WasmImporter {
     ) -> Result<Self, WasmImporterError> {
         let path = path.into();
 
-        let mut engine_config = Config::new();
-        engine_config.consume_fuel(true);
-        let engine =
-            Arc::new(
-                Engine::new(&engine_config).map_err(|e| WasmImporterError::Compile {
-                    path: path.clone(),
-                    source: anyhow::Error::from(e),
-                })?,
-            );
+        // Process-wide shared engine — amortizes the JIT/cache cost
+        // across all WASM-loaded modules in the workspace, and
+        // applies the same security-locked-down `Config` as the
+        // directive-plugin runtime.
+        let engine = sandbox::shared_engine();
 
         let module = Module::new(&engine, bytes).map_err(|e| WasmImporterError::Compile {
             path: path.clone(),
@@ -306,10 +323,21 @@ impl WasmImporter {
         })
     }
 
-    /// The path the module was loaded from.
+    /// The path the module was loaded from (or the
+    /// `name_for_diagnostics` passed to [`Self::load_embedded`]).
     #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// The per-call runtime caps this importer was loaded with. Useful
+    /// for diagnostics ("did I hit the host's cap?") — the values
+    /// surfaced in error variants like
+    /// [`WasmImporterError::InputTooLarge::max`] are the same ones
+    /// returned here.
+    #[must_use]
+    pub const fn runtime_config(&self) -> WasmRuntimeConfig {
+        self.config
     }
 
     /// Reject imports (sandbox requirement) and check required exports.
@@ -373,6 +401,10 @@ fn make_store(
     // (panic in debug, silent wrap to a tiny number in release — both
     // wrong, both prevented here).
     let fuel = config.max_time_secs.max(1).saturating_mul(1_000_000);
+    // `set_fuel` only fails when `consume_fuel(false)` is configured
+    // on the Engine, and `sandbox::sandbox_config` always sets it true.
+    // The `?` propagation is defensive — if a future refactor flips
+    // that flag, we'd want to surface the error rather than panic.
     store.set_fuel(fuel).map_err(runtime_err)?;
     Ok(store)
 }
@@ -445,9 +477,13 @@ fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
     // as `ExportSignatureMismatch` rather than `MissingExport` saves
     // guest authors from chasing a misleading "export not found"
     // error message.
+    // `validate_module` proved `memory` export presence at load time,
+    // so this `expect` documents an invariant rather than guarding a
+    // real failure path. (The variant `MissingExport("memory")` is
+    // reachable only via `validate_module` itself.)
     let memory = instance
         .get_memory(&mut store, "memory")
-        .ok_or(WasmImporterError::MissingExport("memory"))?;
+        .expect("validate_module verified `memory` export at load");
 
     let alloc = instance
         .get_typed_func::<u32, u32>(&mut store, "alloc")
@@ -491,9 +527,10 @@ fn call_metadata(
         .instantiate(&mut store, module)
         .map_err(runtime_err)?;
 
+    // Invariant: `validate_module` verified `memory` at load time.
     let memory = instance
         .get_memory(&mut store, "memory")
-        .ok_or(WasmImporterError::MissingExport("memory"))?;
+        .expect("validate_module verified `memory` export at load");
 
     // Same reasoning as in `call_msgpack_with`: validate_module
     // proved presence, so a typed_func error is a signature mismatch.
@@ -600,6 +637,18 @@ fn format_plugin_error(e: &PluginError) -> String {
 /// to `rustledger_plugin::convert::wrapper_to_directive` so the WASM
 /// importer path and the directive-plugin path share a single
 /// converter — improvements there land here for free.
+///
+/// # Warning ordering
+///
+/// Warnings are appended in this order:
+///
+/// 1. **Output warnings** — `output.warnings` forwarded verbatim.
+/// 2. **Output errors** — `output.errors`, formatted via
+///    [`format_plugin_error`] so the severity prefix is preserved.
+///
+/// (The enriched analogue [`bridge_enriched_output`] additionally
+/// emits *bridge warnings* first, for per-entry lossy paths that have
+/// no analogue here.)
 fn output_to_import_result(out: ImporterOutput) -> anyhow::Result<ImportResult> {
     let mut directives = Vec::with_capacity(out.directives.len());
     for w in out.directives {
@@ -635,18 +684,34 @@ impl Importer for WasmImporter {
         let input = IdentifyInput {
             path: path.to_string_lossy().into_owned(),
         };
-        // identify() failures (trap, decode error) conservatively return
-        // false — the registry treats this as "this importer doesn't
-        // handle the file" and falls back to the next candidate.
+        // The trait contract is `-> bool` (matches OFX/CSV), so we
+        // can't surface a structured error. But "wrong signature on
+        // `identify`" or "module trapped" are real bugs the guest
+        // author needs to see — emit to stderr so they get a signal
+        // instead of silently never matching. Successful identify
+        // calls are quiet.
         match self.call_msgpack::<_, IdentifyOutput>("identify", &input) {
             Ok(out) => out.matches,
-            Err(_) => false,
+            Err(e) => {
+                eprintln!(
+                    "warning: WASM importer `{}` identify({}) failed: {e}",
+                    self.name,
+                    path.display()
+                );
+                false
+            }
         }
     }
 
     fn extract(&self, path: &Path, config: &ImporterConfig) -> anyhow::Result<ImportResult> {
-        let content = std::fs::read(path)
-            .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+        // Use the typed `Io` variant before erasing to anyhow at the
+        // trait boundary — keeps load and extract symmetric on file-
+        // read failures, even though only the typed-error name is
+        // observable to crate-internal callers.
+        let content = std::fs::read(path).map_err(|source| WasmImporterError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
         let input = build_wasm_input(path, content, config);
         let output: ImporterOutput = self.call_msgpack("extract", &input)?;
         output_to_import_result(output)
@@ -657,8 +722,10 @@ impl Importer for WasmImporter {
         path: &Path,
         config: &ImporterConfig,
     ) -> anyhow::Result<EnrichedImportResult> {
-        let content = std::fs::read(path)
-            .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+        let content = std::fs::read(path).map_err(|source| WasmImporterError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
         let input = build_wasm_input(path, content, config);
         let output: EnrichedImporterOutput = self.call_msgpack("extract_enriched", &input)?;
         bridge_enriched_output(output)
@@ -793,9 +860,7 @@ mod tests {
             )
         "#;
         let bytes = wat::parse_str(wat).expect("WAT parses");
-        let mut engine_config = Config::new();
-        engine_config.consume_fuel(true);
-        let engine = Engine::new(&engine_config).unwrap();
+        let engine = sandbox::shared_engine();
         let module = Module::new(&engine, &bytes).unwrap();
         let err = WasmImporter::validate_module(&module).unwrap_err();
         assert!(matches!(err, WasmImporterError::ForbiddenImport { .. }));
@@ -812,9 +877,7 @@ mod tests {
             )
         "#;
         let bytes = wat::parse_str(wat).expect("WAT parses");
-        let mut engine_config = Config::new();
-        engine_config.consume_fuel(true);
-        let engine = Engine::new(&engine_config).unwrap();
+        let engine = sandbox::shared_engine();
         let module = Module::new(&engine, &bytes).unwrap();
         let err = WasmImporter::validate_module(&module).unwrap_err();
         assert!(matches!(err, WasmImporterError::MissingExport(_)));

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -354,18 +354,6 @@ impl WasmImporter {
     }
 }
 
-/// Build a [`Store`] with the workspace-shared sandbox enforcement
-/// (memory limiter + fuel budget). Thin wrapper over
-/// [`sandbox::make_sandboxed_store`] that adapts the wasmtime error
-/// to [`WasmImporterError`].
-fn make_store(
-    engine: &Engine,
-    config: WasmRuntimeConfig,
-) -> Result<Store<StoreState>, WasmImporterError> {
-    sandbox::make_sandboxed_store(engine, config.max_memory, config.max_time_secs)
-        .map_err(runtime_err)
-}
-
 /// Cap input length before the lossy `as u32` cast — wasm32 memory
 /// is u32-addressed, so >4 GiB input would silently truncate and
 /// corrupt the import. Returns the validated length as `u32` so
@@ -420,7 +408,8 @@ fn call_msgpack_with<I: Serialize, O: DeserializeOwned>(
     let input_bytes = rmp_serde::to_vec(input).map_err(WasmImporterError::Encode)?;
     let input_len = validate_input_size(input_bytes.len())?;
 
-    let mut store = make_store(engine, config)?;
+    let mut store = sandbox::make_sandboxed_store(engine, config.max_memory, config.max_time_secs)
+        .map_err(runtime_err)?;
 
     // No imports at all — full sandbox.
     let linker = Linker::new(engine);
@@ -477,7 +466,8 @@ fn call_metadata(
     module: &Module,
     config: WasmRuntimeConfig,
 ) -> Result<MetadataOutput, WasmImporterError> {
-    let mut store = make_store(engine, config)?;
+    let mut store = sandbox::make_sandboxed_store(engine, config.max_memory, config.max_time_secs)
+        .map_err(runtime_err)?;
 
     let linker = Linker::new(engine);
     let instance = linker

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -45,6 +45,8 @@ pub mod native;
 pub mod python;
 #[cfg(feature = "wasm-runtime")]
 pub mod runtime;
+#[cfg(feature = "wasm-runtime")]
+pub mod sandbox;
 pub mod test_helpers;
 pub mod types;
 

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -603,6 +603,7 @@ impl Default for WatchingPluginManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::PluginOptions;
 
     /// Test that a minimal valid WASM module passes validation.
     ///
@@ -1056,7 +1057,7 @@ mod tests {
         };
         let input = PluginInput {
             directives: vec![],
-            options: crate::types::PluginOptions {
+            options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
             },
@@ -1100,7 +1101,7 @@ mod tests {
             .expect("module loads (validate only checks presence by name)");
         let input = PluginInput {
             directives: vec![],
-            options: crate::types::PluginOptions {
+            options: PluginOptions {
                 operating_currencies: vec![],
                 title: None,
             },
@@ -1114,5 +1115,120 @@ mod tests {
             msg.contains("alloc") && msg.contains("wrong signature"),
             "expected `alloc` + `wrong signature` in error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn execute_surfaces_wrong_signature_on_process() {
+        // Symmetric to the `alloc` sibling: `process` is declared
+        // as `(i32, i32) -> i32` instead of `(u32, u32) -> u64`.
+        // Presence check passes; signature mismatch surfaces with
+        // the new "wrong signature" context.
+        let wasm = wat::parse_str(
+            r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "process") (param i32 i32) (result i32) i32.const 0)
+            )
+            "#,
+        )
+        .expect("WAT parses");
+        let plugin = Plugin::load_bytes("bad-process-sig", &wasm, &RuntimeConfig::default())
+            .expect("module loads (validate only checks presence by name)");
+        let input = PluginInput {
+            directives: vec![],
+            options: PluginOptions {
+                operating_currencies: vec![],
+                title: None,
+            },
+            config: None,
+        };
+        let err = plugin
+            .execute(&input, &RuntimeConfig::default())
+            .expect_err("wrong-sig process should fail execute");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("process") && msg.contains("wrong signature"),
+            "expected `process` + `wrong signature` in error, got: {msg}"
+        );
+    }
+
+    /// Minimal passthrough WAT used by the fuel-clamp tests below.
+    /// `process` returns `(ptr=0, len=0)` which deserializes to an
+    /// empty `PluginOutput` — enough to exercise the full fuel path.
+    fn passthrough_wat() -> &'static str {
+        r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "alloc") (param i32) (result i32) i32.const 0)
+            (func (export "process") (param i32 i32) (result i64) i64.const 0)
+        )
+        "#
+    }
+
+    fn empty_input() -> PluginInput {
+        PluginInput {
+            directives: vec![],
+            options: PluginOptions {
+                operating_currencies: vec![],
+                title: None,
+            },
+            config: None,
+        }
+    }
+
+    /// Assert that the error from a passthrough-WAT `execute` is the
+    /// expected msgpack-decode failure (the WAT returns
+    /// `(ptr=0, len=0)`, which can't parse as `PluginOutput`) and not
+    /// a fuel-exhaustion trap.
+    ///
+    /// Reaching the decode step proves WASM execution completed —
+    /// any fuel-starvation bug would have trapped before then.
+    fn assert_not_fuel_trap(err: &anyhow::Error) {
+        let msg = format!("{err:#}").to_ascii_lowercase();
+        assert!(
+            !msg.contains("fuel") && !msg.contains("trap"),
+            "expected msgpack decode error, got fuel/trap: {msg}"
+        );
+    }
+
+    #[test]
+    fn execute_with_zero_max_time_secs_clamps_to_min_fuel() {
+        // Regression for the fuel-calc bug fix that landed via
+        // `make_sandboxed_store`. Pre-PR, `max_time_secs = 0` caused
+        // immediate fuel-exhaustion trap on first instruction. Now
+        // clamped to ≥1 second of fuel by the shared helper.
+        // Proves the plugin runtime gets the fix, not just the
+        // importer.
+        let wasm = wat::parse_str(passthrough_wat()).expect("WAT parses");
+        let plugin =
+            Plugin::load_bytes("fuel-zero", &wasm, &RuntimeConfig::default()).expect("loads");
+        let zero_secs = RuntimeConfig {
+            max_memory: 256 * 1024 * 1024,
+            max_time_secs: 0,
+        };
+        let err = plugin
+            .execute(&empty_input(), &zero_secs)
+            .expect_err("passthrough WAT decode-fails by design");
+        assert_not_fuel_trap(&err);
+    }
+
+    #[test]
+    fn execute_with_max_max_time_secs_saturates_fuel() {
+        // Regression for the saturating_mul fix. Pre-PR, max_time_secs
+        // = u64::MAX would panic in debug and silently wrap in
+        // release. Now saturates to u64::MAX fuel via the shared
+        // helper.
+        let wasm = wat::parse_str(passthrough_wat()).expect("WAT parses");
+        let plugin =
+            Plugin::load_bytes("fuel-max", &wasm, &RuntimeConfig::default()).expect("loads");
+        let max_secs = RuntimeConfig {
+            max_memory: 256 * 1024 * 1024,
+            max_time_secs: u64::MAX,
+        };
+        let err = plugin
+            .execute(&empty_input(), &max_secs)
+            .expect_err("passthrough WAT decode-fails by design");
+        assert_not_fuel_trap(&err);
     }
 }

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result};
-use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime::{Engine, Linker, Module};
 
 use crate::sandbox;
 use crate::types::{DirectiveWrapper, PluginInput, PluginOp, PluginOutput};
@@ -178,12 +178,14 @@ impl Plugin {
 
     /// Execute the plugin with the given input.
     pub fn execute(&self, input: &PluginInput, config: &RuntimeConfig) -> Result<PluginOutput> {
-        // Create a store with fuel limit
-        let mut store = Store::new(&self.engine, ());
-
-        // Set fuel limit based on time (rough approximation: 1M instructions per second)
-        let fuel = config.max_time_secs * 1_000_000;
-        store.set_fuel(fuel)?;
+        // Workspace-shared sandboxed store: wires the MemoryLimiter
+        // (enforcing `config.max_memory` on initial allocation +
+        // `memory.grow`) and the fuel budget (clamped ≥1 + saturating
+        // to avoid zero-fuel starvation and u64 overflow). Mirrors the
+        // WASM importer host so per-call enforcement is consistent
+        // across the workspace.
+        let mut store =
+            sandbox::make_sandboxed_store(&self.engine, config.max_memory, config.max_time_secs)?;
 
         // Create linker with NO imports for full sandboxing
         // Plugins have no access to filesystem, network, or any system calls

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -58,11 +58,20 @@ fn materialize_ops(input: &[DirectiveWrapper], output: &PluginOutput) -> Vec<Dir
 }
 
 /// Configuration for the plugin runtime.
+///
+/// **Applied at `Plugin::execute` time, not at load.** `Plugin::load`
+/// and `Plugin::load_bytes` accept a `&RuntimeConfig` for API
+/// symmetry but ignore it — only the per-call execution caps
+/// (`max_memory`, `max_time_secs`) are meaningful, and those flow
+/// into the per-`Store` setup that `execute` builds.
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
-    /// Maximum memory in bytes (default: 256MB).
+    /// Maximum memory in bytes (default: 256MB). Enforced at
+    /// `Plugin::execute` via [`crate::sandbox::make_sandboxed_store`].
     pub max_memory: usize,
-    /// Maximum execution time in seconds (default: 30).
+    /// Maximum execution time in seconds (default: 30). Clamped to
+    /// `≥1` and `saturating_mul`'d to fuel units; see
+    /// [`crate::sandbox::make_sandboxed_store`].
     pub max_time_secs: u64,
 }
 
@@ -157,7 +166,7 @@ impl Plugin {
 
         let module = Module::new(&engine, &wasm_bytes)
             .map_err(anyhow::Error::from)
-            .with_context(|| format!("failed to compile {}", path.display()))?;
+            .with_context(|| format!("invalid plugin {}", path.display()))?;
 
         // Validate imports + required exports at load time so failures
         // surface here (with a clear "must export" message) rather than
@@ -180,7 +189,9 @@ impl Plugin {
     ) -> Result<Self> {
         let name = name.into();
         let engine = sandbox::shared_engine();
-        let module = Module::new(&engine, bytes)?;
+        let module = Module::new(&engine, bytes)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("invalid plugin `{name}`"))?;
         // Same load-time validation as `load` — see that method's
         // comment for rationale.
         validate_loaded_module(&module).with_context(|| format!("invalid plugin `{name}`"))?;
@@ -231,7 +242,10 @@ impl Plugin {
         let alloc = instance
             .get_typed_func::<u32, u32>(&mut store, "alloc")
             .map_err(anyhow::Error::from)
-            .context("plugin export `alloc` has wrong signature (expected fn(u32) -> u32)")?;
+            // wasmtime's error already names the expected vs found
+            // signature — our context just labels what was being
+            // looked up. Avoids drift if the ABI ever changes.
+            .context("plugin export `alloc` has wrong signature")?;
 
         // Allocate space for input
         let input_ptr = alloc.call(&mut store, input_bytes.len() as u32)?;
@@ -243,9 +257,7 @@ impl Plugin {
         let process = instance
             .get_typed_func::<(u32, u32), u64>(&mut store, "process")
             .map_err(anyhow::Error::from)
-            .context(
-                "plugin export `process` has wrong signature (expected fn(u32, u32) -> u64)",
-            )?;
+            .context("plugin export `process` has wrong signature")?;
 
         let result = process.call(&mut store, (input_ptr, input_bytes.len() as u32))?;
 
@@ -1053,13 +1065,54 @@ mod tests {
         let err = plugin
             .execute(&input, &tight_config)
             .expect_err("instantiation should fail when initial memory > cap");
-        // We don't pin the exact error message (wasmtime's wording
-        // varies across versions), just that it's an error and
-        // execution didn't silently succeed.
+        // Check for one of the keywords wasmtime uses when a
+        // ResourceLimiter rejects allocation. Wording varies across
+        // versions, but at least one of these tokens has appeared
+        // in every release we've targeted, so this catches a
+        // truly-silent failure (e.g. limiter not wired) while
+        // tolerating message rephrasings.
+        let msg = format!("{err:#}").to_ascii_lowercase();
+        assert!(
+            msg.contains("memory") || msg.contains("limit"),
+            "expected memory-limit error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn execute_surfaces_wrong_signature_on_alloc() {
+        // Plugin has `alloc(i64) -> i64` instead of the required
+        // `alloc(u32) -> u32`. Presence check (validate_loaded_module)
+        // passes — the export is there. The signature mismatch
+        // surfaces inside `execute()` with the new "wrong signature"
+        // context. Pre-PR this would have read "plugin must export
+        // 'alloc' function" — misleading, since it DOES export it.
+        let wasm = wat::parse_str(
+            r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i64) (result i64) i64.const 0)
+                (func (export "process") (param i32 i32) (result i64) i64.const 0)
+            )
+            "#,
+        )
+        .expect("WAT parses");
+        let plugin = Plugin::load_bytes("bad-alloc-sig", &wasm, &RuntimeConfig::default())
+            .expect("module loads (validate only checks presence by name)");
+        let input = PluginInput {
+            directives: vec![],
+            options: crate::types::PluginOptions {
+                operating_currencies: vec![],
+                title: None,
+            },
+            config: None,
+        };
+        let err = plugin
+            .execute(&input, &RuntimeConfig::default())
+            .expect_err("wrong-sig alloc should fail execute");
         let msg = format!("{err:#}");
         assert!(
-            !msg.is_empty(),
-            "expected non-empty error from over-cap instantiate"
+            msg.contains("alloc") && msg.contains("wrong signature"),
+            "expected `alloc` + `wrong signature` in error, got: {msg}"
         );
     }
 }

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -86,9 +86,21 @@ impl Default for RuntimeConfig {
 /// Returns an error if the module has forbidden imports or is missing
 /// required exports.
 pub fn validate_plugin_module(bytes: &[u8]) -> Result<()> {
-    let engine = Engine::default();
+    // Use the workspace sandbox config — same feature flags the
+    // runtime applies at load. Otherwise `validate_plugin_module`
+    // could say "Ok" against vanilla wasmtime features but the
+    // actual `Plugin::load_bytes` would reject the same module
+    // because (e.g.) it uses `wasm_threads`.
+    let engine = Engine::new(&sandbox::sandbox_config())?;
     let module = Module::new(&engine, bytes)?;
+    validate_loaded_module(&module)
+}
 
+/// Inner validator that operates on an already-compiled [`Module`].
+/// Used by both [`validate_plugin_module`] (the public bytes-taking
+/// helper) and `Plugin::load`/`load_bytes` so the module is only
+/// compiled once during load instead of twice.
+fn validate_loaded_module(module: &Module) -> Result<()> {
     // Check for forbidden imports (any imports are forbidden)
     if let Some(import) = module.imports().next() {
         anyhow::bail!(
@@ -147,6 +159,12 @@ impl Plugin {
             .map_err(anyhow::Error::from)
             .with_context(|| format!("failed to compile {}", path.display()))?;
 
+        // Validate imports + required exports at load time so failures
+        // surface here (with a clear "must export" message) rather than
+        // deeper in `execute()` where they look like signature mismatches.
+        validate_loaded_module(&module)
+            .with_context(|| format!("invalid plugin {}", path.display()))?;
+
         Ok(Self {
             name,
             module,
@@ -163,6 +181,9 @@ impl Plugin {
         let name = name.into();
         let engine = sandbox::shared_engine();
         let module = Module::new(&engine, bytes)?;
+        // Same load-time validation as `load` — see that method's
+        // comment for rationale.
+        validate_loaded_module(&module).with_context(|| format!("invalid plugin `{name}`"))?;
 
         Ok(Self {
             name,
@@ -197,16 +218,20 @@ impl Plugin {
         // Serialize input
         let input_bytes = rmp_serde::to_vec(input)?;
 
-        // Get memory and allocate space for input
+        // `validate_loaded_module` proved `memory` presence at load
+        // time — an absent export here is unreachable in practice.
         let memory = instance
             .get_memory(&mut store, "memory")
-            .ok_or_else(|| anyhow::anyhow!("plugin must export 'memory'"))?;
+            .expect("validate_loaded_module verified `memory` export at load");
 
-        // Get the alloc function to allocate space in WASM memory
+        // Same reasoning: presence is guaranteed by load-time
+        // validation, so any `get_typed_func` failure here is a
+        // signature mismatch (e.g. plugin declared `alloc(i64) -> i64`
+        // instead of `alloc(u32) -> u32`), not absence.
         let alloc = instance
             .get_typed_func::<u32, u32>(&mut store, "alloc")
             .map_err(anyhow::Error::from)
-            .context("plugin must export 'alloc' function")?;
+            .context("plugin export `alloc` has wrong signature (expected fn(u32) -> u32)")?;
 
         // Allocate space for input
         let input_ptr = alloc.call(&mut store, input_bytes.len() as u32)?;
@@ -218,7 +243,9 @@ impl Plugin {
         let process = instance
             .get_typed_func::<(u32, u32), u64>(&mut store, "process")
             .map_err(anyhow::Error::from)
-            .context("plugin must export 'process' function")?;
+            .context(
+                "plugin export `process` has wrong signature (expected fn(u32, u32) -> u64)",
+            )?;
 
         let result = process.call(&mut store, (input_ptr, input_bytes.len() as u32))?;
 
@@ -988,5 +1015,51 @@ mod tests {
         let empty: &[u8] = &[];
         let result = validate_plugin_module(empty);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn execute_rejects_initial_memory_above_max_memory_cap() {
+        // Plugin declares 5000 pages (320 MiB) initial memory.
+        // With max_memory = 64 MiB, instantiation inside execute()
+        // must fail via the MemoryLimiter wired by
+        // `sandbox::make_sandboxed_store`. Pins the equivalent of
+        // the importer's `initial_memory_above_cap_is_rejected_via_limiter_wiring`
+        // test for the plugin runtime path — proves the per-Store
+        // limiter is actually applied here, not just in the importer.
+        let wasm = wat::parse_str(
+            r#"
+            (module
+                (memory (export "memory") 5000)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "process") (param i32 i32) (result i64) i64.const 0)
+            )
+            "#,
+        )
+        .expect("WAT parses");
+        let plugin = Plugin::load_bytes("bigmem", &wasm, &RuntimeConfig::default())
+            .expect("module loads (declared memory size is checked at instantiate, not compile)");
+        let tight_config = RuntimeConfig {
+            max_memory: 64 * 1024 * 1024,
+            max_time_secs: 30,
+        };
+        let input = PluginInput {
+            directives: vec![],
+            options: crate::types::PluginOptions {
+                operating_currencies: vec![],
+                title: None,
+            },
+            config: None,
+        };
+        let err = plugin
+            .execute(&input, &tight_config)
+            .expect_err("instantiation should fail when initial memory > cap");
+        // We don't pin the exact error message (wasmtime's wording
+        // varies across versions), just that it's an error and
+        // execution didn't silently succeed.
+        let msg = format!("{err:#}");
+        assert!(
+            !msg.is_empty(),
+            "expected non-empty error from over-cap instantiate"
+        );
     }
 }

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -28,8 +28,9 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result};
-use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime::{Engine, Linker, Module, Store};
 
+use crate::sandbox;
 use crate::types::{DirectiveWrapper, PluginInput, PluginOp, PluginOutput};
 
 /// Materialize a plugin's `ops` against its input directive list,
@@ -132,11 +133,11 @@ impl Plugin {
             .unwrap_or("unknown")
             .to_string();
 
-        // Create engine with configuration
-        let mut engine_config = Config::new();
-        engine_config.consume_fuel(true); // Enable fuel for execution limits
-
-        let engine = Arc::new(Engine::new(&engine_config)?);
+        // Process-wide shared engine with the workspace's locked-down
+        // wasm-feature config (see `sandbox::sandbox_config` for the
+        // list). One Engine per process amortizes JIT/cache cost
+        // across all loaded plugins.
+        let engine = sandbox::shared_engine();
 
         // Load and compile the module
         let wasm_bytes =
@@ -160,11 +161,7 @@ impl Plugin {
         _config: &RuntimeConfig,
     ) -> Result<Self> {
         let name = name.into();
-
-        let mut engine_config = Config::new();
-        engine_config.consume_fuel(true);
-
-        let engine = Arc::new(Engine::new(&engine_config)?);
+        let engine = sandbox::shared_engine();
         let module = Module::new(&engine, bytes)?;
 
         Ok(Self {

--- a/crates/rustledger-plugin/src/sandbox.rs
+++ b/crates/rustledger-plugin/src/sandbox.rs
@@ -1,0 +1,168 @@
+//! Shared wasmtime sandbox configuration.
+//!
+//! Both the directive-plugin runtime ([`crate::runtime`]) and the WASM
+//! importer host (`rustledger-importer/src/wasm.rs`) load untrusted
+//! `.wasm` modules into wasmtime. They have the same security model
+//! and should agree on:
+//!
+//! - Which wasm proposals are enabled (attack surface)
+//! - Whether fuel metering is on (`DoS` bound)
+//! - The cost of `Engine` creation (compilation cache + thread pool)
+//!
+//! This module is the single source of truth for those decisions.
+//! Adding a feature flag here applies it to every WASM-loaded
+//! component in rustledger.
+//!
+//! # Why share the `Engine`?
+//!
+//! wasmtime's `Engine` owns the JIT compilation cache and the
+//! background-compilation thread pool. wasmtime documentation
+//! explicitly recommends one `Engine` per process — sharing it
+//! across all imported modules lets us amortize that cost. A
+//! per-call `Store` still provides isolation; the `Engine` only
+//! holds compiled-code state.
+
+use std::sync::{Arc, OnceLock};
+
+use wasmtime::{Config, Engine};
+
+/// Per-process shared wasmtime [`Engine`] with rustledger's security
+/// posture. Cheap to clone (`Arc`).
+///
+/// # Panics
+///
+/// Panics if wasmtime fails to construct an `Engine` with our config —
+/// this is a process-start invariant; if it fires, the binary is
+/// fundamentally broken, not a runtime condition worth handling.
+#[must_use]
+pub fn shared_engine() -> Arc<Engine> {
+    static ENGINE: OnceLock<Arc<Engine>> = OnceLock::new();
+    ENGINE
+        .get_or_init(|| {
+            let config = sandbox_config();
+            Arc::new(Engine::new(&config).expect("failed to build shared wasmtime engine"))
+        })
+        .clone()
+}
+
+/// Build a wasmtime [`Config`] with rustledger's locked-down security
+/// posture. Exposed for tests and embedders who need to construct an
+/// `Engine` with the same flags but different lifetimes.
+///
+/// # Enabled
+///
+/// - `consume_fuel(true)` — fuel metering for `DoS` bound. Every
+///   sandboxed call must `Store::set_fuel(...)` before invoking.
+///
+/// # Explicitly disabled (security)
+///
+/// - `wasm_threads` — atomics on shared memory bypass per-call `Store`
+///   isolation and enable contention-based `DoS`.
+/// - `wasm_shared_everything_threads` — extension of the above.
+/// - `wasm_multi_memory` — importers/plugins are designed for exactly
+///   one linear memory. Multiple memories would invalidate the single-
+///   memory accounting in `ResourceLimiter::memory_growing`.
+/// - `wasm_memory64` — our ABIs are u32-addressed. 64-bit memory would
+///   silently break offset math.
+/// - `wasm_component_model` (and the `_async`/`_threading`/`_gc`/etc.
+///   sub-flags) — we use a custom `MessagePack` ABI, not wasmtime
+///   components. Disabled to shrink attack surface.
+/// - `wasm_gc` / `wasm_function_references` — opt out of the GC and
+///   typed-references proposals; not used and add runtime complexity.
+/// - `wasm_stack_switching` / `wasm_tail_call` — control-flow features
+///   we don't use; disabled to shrink attack surface.
+///
+/// # Kept enabled (default + we rely on or tolerate)
+///
+/// - `wasm_simd` — vector instructions; useful for parsing,
+///   sandbox-safe.
+/// - `wasm_bulk_memory` — `memory.copy`/`memory.fill`; needed by
+///   compilers and harmless under our memory cap.
+/// - `wasm_reference_types` — `externref`/`funcref`; we cap table
+///   growth separately so unbounded ref tables aren't reachable.
+/// - `wasm_multi_value` — multi-return functions; sandbox-safe.
+#[must_use]
+pub fn sandbox_config() -> Config {
+    let mut c = Config::new();
+    c.consume_fuel(true);
+
+    // Concurrency / shared-state proposals — bypass our per-call
+    // `Store` isolation. Off.
+    c.wasm_threads(false);
+    c.wasm_shared_everything_threads(false);
+
+    // Multi-memory / 64-bit memory — invalidate our single-memory
+    // ResourceLimiter accounting and u32-based ABI offset math. Off.
+    c.wasm_multi_memory(false);
+    c.wasm_memory64(false);
+
+    // Component model — we use a custom MessagePack ABI, not
+    // components. Off (shrinks attack surface).
+    c.wasm_component_model(false);
+
+    // GC + typed function references — not used; runtime complexity
+    // without benefit. Off.
+    c.wasm_gc(false);
+    c.wasm_function_references(false);
+
+    // Control-flow features we don't use. Off.
+    c.wasm_stack_switching(false);
+    c.wasm_tail_call(false);
+
+    // Implicitly default-on and we tolerate them:
+    //   wasm_simd, wasm_bulk_memory, wasm_reference_types,
+    //   wasm_multi_value, wasm_extended_const, wasm_relaxed_simd.
+
+    c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_engine_is_idempotent() {
+        let a = shared_engine();
+        let b = shared_engine();
+        // Same Arc target (both clones of the OnceLock'd engine).
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "shared_engine must return the same Arc each call"
+        );
+    }
+
+    #[test]
+    fn sandbox_config_rejects_threads_module() {
+        // A module that declares a shared memory (requires
+        // `wasm_threads`) must fail to compile under our config.
+        let wat = r#"
+            (module
+                (memory (export "memory") 1 1 shared)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let engine = Engine::new(&sandbox_config()).unwrap();
+        let result = wasmtime::Module::new(&engine, &bytes);
+        assert!(
+            result.is_err(),
+            "shared-memory module should be rejected when wasm_threads=false"
+        );
+    }
+
+    #[test]
+    fn sandbox_config_rejects_multi_memory_module() {
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (memory (export "memory2") 1)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let engine = Engine::new(&sandbox_config()).unwrap();
+        let result = wasmtime::Module::new(&engine, &bytes);
+        assert!(
+            result.is_err(),
+            "multi-memory module should be rejected when wasm_multi_memory=false"
+        );
+    }
+}

--- a/crates/rustledger-plugin/src/sandbox.rs
+++ b/crates/rustledger-plugin/src/sandbox.rs
@@ -13,6 +13,18 @@
 //! Adding a feature flag here applies it to every WASM-loaded
 //! component in rustledger.
 //!
+//! # ⚠️ Breaking change for user WASM plugins
+//!
+//! As of the v0.16-pre reshape, [`sandbox_config`] explicitly
+//! disables a list of wasm proposals (see its docstring). A
+//! user-shipped `.wasm` plugin or importer that relies on any
+//! disabled proposal — most notably `wasm_threads`,
+//! `wasm_multi_memory`, `wasm_memory64`, `wasm_component_model`,
+//! or `wasm_gc` — will now fail to compile at load time with a
+//! wasmtime validation error. This is intentional security
+//! tightening, but plugin authors targeting earlier rustledger
+//! versions may need to recompile against the new sandbox profile.
+//!
 //! # Why share the `Engine`?
 //!
 //! wasmtime's `Engine` owns the JIT compilation cache and the
@@ -40,7 +52,11 @@ pub fn shared_engine() -> Arc<Engine> {
     ENGINE
         .get_or_init(|| {
             let config = sandbox_config();
-            Arc::new(Engine::new(&config).expect("failed to build shared wasmtime engine"))
+            // Bare `.expect` would swallow the wasmtime error detail —
+            // explicit panic preserves the cause for debugging.
+            Arc::new(
+                Engine::new(&config).unwrap_or_else(|e| panic!("wasmtime engine init failed: {e}")),
+            )
         })
         .clone()
 }
@@ -83,6 +99,14 @@ pub fn shared_engine() -> Arc<Engine> {
 /// - `wasm_multi_value` — multi-return functions; sandbox-safe.
 #[must_use]
 pub fn sandbox_config() -> Config {
+    // MAINTENANCE NOTE: wasmtime's `Config::new()` returns its
+    // current defaults, which evolve across versions — new
+    // proposals routinely land as default-on. On every wasmtime
+    // bump in Cargo.toml, re-audit this function: check
+    // wasmtime's release notes for new `wasm_*` features and
+    // decide whether to keep, disable, or leave at default.
+    // (wasmtime does not provide a "deny by default" mode, so the
+    // audit is structurally required.)
     let mut c = Config::new();
     c.consume_fuel(true);
 
@@ -163,6 +187,60 @@ mod tests {
         assert!(
             result.is_err(),
             "multi-memory module should be rejected when wasm_multi_memory=false"
+        );
+    }
+
+    #[test]
+    fn sandbox_config_rejects_memory64_module() {
+        // `(memory i64 1)` declares an i64-indexed (64-bit) memory,
+        // which requires `wasm_memory64`. Must be rejected.
+        let wat = r#"
+            (module
+                (memory (export "memory") i64 1)
+            )
+        "#;
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let engine = Engine::new(&sandbox_config()).unwrap();
+        let result = wasmtime::Module::new(&engine, &bytes);
+        assert!(
+            result.is_err(),
+            "memory64 module should be rejected when wasm_memory64=false"
+        );
+    }
+
+    #[test]
+    fn sandbox_config_rejects_component_module() {
+        // Component-model top-level `(component …)` requires
+        // `wasm_component_model`. We use a custom MessagePack ABI,
+        // not components, so this must be rejected.
+        let wat = r"(component)";
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let engine = Engine::new(&sandbox_config()).unwrap();
+        // Components compile via `Component::new`, not `Module::new`.
+        // `Module::new` on component bytes should fail outright.
+        let result = wasmtime::Module::new(&engine, &bytes);
+        assert!(
+            result.is_err(),
+            "component-model module should be rejected when wasm_component_model=false"
+        );
+    }
+
+    #[test]
+    fn sandbox_config_rejects_gc_module() {
+        // A `(struct …)` type definition requires the GC proposal
+        // (`wasm_gc` + `wasm_function_references` for typed refs).
+        // Must be rejected.
+        let wat = r"
+            (module
+                (type $point (struct (field i32) (field i32)))
+            )
+        ";
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let engine = Engine::new(&sandbox_config()).unwrap();
+        let result = wasmtime::Module::new(&engine, &bytes);
+        assert!(
+            result.is_err(),
+            "GC struct-type module should be rejected when wasm_gc=false"
         );
     }
 }

--- a/crates/rustledger-plugin/src/sandbox.rs
+++ b/crates/rustledger-plugin/src/sandbox.rs
@@ -7,6 +7,7 @@
 //!
 //! - Which wasm proposals are enabled (attack surface)
 //! - Whether fuel metering is on (`DoS` bound)
+//! - How per-call `Store` resource limits are enforced
 //! - The cost of `Engine` creation (compilation cache + thread pool)
 //!
 //! This module is the single source of truth for those decisions.
@@ -15,12 +16,18 @@
 //!
 //! # ⚠️ Breaking change for user WASM plugins
 //!
-//! As of the v0.16-pre reshape, [`sandbox_config`] explicitly
-//! disables a list of wasm proposals (see its docstring). A
-//! user-shipped `.wasm` plugin or importer that relies on any
-//! disabled proposal — most notably `wasm_threads`,
-//! `wasm_multi_memory`, `wasm_memory64`, `wasm_component_model`,
-//! or `wasm_gc` — will now fail to compile at load time with a
+//! As of the v0.16-pre reshape, [`sandbox_config`] explicitly disables
+//! these wasm proposals (full list — the rustdoc on `sandbox_config`
+//! explains the rationale for each):
+//!
+//! - `wasm_threads`, `wasm_shared_everything_threads`
+//! - `wasm_multi_memory`, `wasm_memory64`
+//! - `wasm_component_model` (and all sub-flags)
+//! - `wasm_gc`, `wasm_function_references`
+//! - `wasm_stack_switching`, `wasm_tail_call`
+//!
+//! A user-shipped `.wasm` plugin or importer that relies on any
+//! disabled proposal will now fail to compile at load time with a
 //! wasmtime validation error. This is intentional security
 //! tightening, but plugin authors targeting earlier rustledger
 //! versions may need to recompile against the new sandbox profile.
@@ -36,7 +43,18 @@
 
 use std::sync::{Arc, OnceLock};
 
-use wasmtime::{Config, Engine};
+use wasmtime::{Config, Engine, ResourceLimiter, Store};
+
+/// Hard cap on the number of elements in any single WASM table.
+///
+/// Importers/plugins don't typically need indirect-call tables at all,
+/// let alone large ones. Each ref-typed slot is pointer-sized (8 bytes
+/// on 64-bit), so 1M elements = ~8 MiB worst case — well under the
+/// memory cap but enough headroom for any plausible indirect-dispatch
+/// pattern. Without this cap, `table.grow` would bypass the memory
+/// limiter (`Memory` and `Table` are separate resource classes in
+/// wasmtime's accounting).
+pub const MAX_TABLE_ELEMENTS: usize = 1024 * 1024;
 
 /// Per-process shared wasmtime [`Engine`] with rustledger's security
 /// posture. Cheap to clone (`Arc`).
@@ -61,14 +79,120 @@ pub fn shared_engine() -> Arc<Engine> {
         .clone()
 }
 
+/// Per-store memory limiter.
+///
+/// Wired into [`Store::limiter`] so wasmtime rejects `memory.grow`
+/// past `max_memory`. Without this, configured memory caps would be
+/// silently ignored — the sandbox would have unbounded heap, which
+/// defeats the "self-contained module" guarantee.
+pub struct MemoryLimiter {
+    max_memory: usize,
+}
+
+impl MemoryLimiter {
+    /// Build a limiter that caps growth (and initial allocation) at
+    /// `max_memory` bytes.
+    #[must_use]
+    pub const fn new(max_memory: usize) -> Self {
+        Self { max_memory }
+    }
+}
+
+impl ResourceLimiter for MemoryLimiter {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        Ok(desired <= self.max_memory)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        // wasmtime accounts memory and tables separately — without
+        // this cap, `table.grow` would bypass the memory limiter.
+        // `MAX_TABLE_ELEMENTS` is conservative; bump it if a
+        // legitimate module ever needs more.
+        Ok(desired <= MAX_TABLE_ELEMENTS)
+    }
+}
+
+/// Store user-data — just the [`MemoryLimiter`] today.
+///
+/// Kept in a named struct so [`Store::limiter`]'s closure can return
+/// a stable reference and future additions (e.g. a host-side metrics
+/// counter) can land without changing the `Store<T>` type.
+pub struct StoreState {
+    limiter: MemoryLimiter,
+}
+
+impl StoreState {
+    /// Build a state initialized with the given memory cap.
+    #[must_use]
+    pub const fn new(max_memory: usize) -> Self {
+        Self {
+            limiter: MemoryLimiter::new(max_memory),
+        }
+    }
+}
+
+/// Create a [`Store`] with rustledger's sandbox enforcement wired in:
+///
+/// - [`MemoryLimiter`] enforcing `max_memory` on both initial
+///   allocation and `memory.grow`
+/// - Fuel budget computed from `max_time_secs` (clamped `≥1` to
+///   avoid zero-fuel starvation; `saturating_mul` to avoid overflow
+///   on absurd configurations)
+///
+/// Used by both the WASM importer host and the directive-plugin
+/// runtime so the per-call enforcement is identical across the
+/// workspace.
+///
+/// # Errors
+///
+/// Returns `wasmtime::Error` if `set_fuel` fails — which only happens
+/// when `consume_fuel(false)` is configured on the [`Engine`], and
+/// [`sandbox_config`] always sets it true. The `Result` is therefore
+/// defensive: a future refactor flipping the flag will surface the
+/// error rather than silently producing an unmetered Store.
+pub fn make_sandboxed_store(
+    engine: &Engine,
+    max_memory: usize,
+    max_time_secs: u64,
+) -> wasmtime::Result<Store<StoreState>> {
+    let mut store = Store::new(engine, StoreState::new(max_memory));
+    store.limiter(|s| &mut s.limiter);
+    // 1M instructions per second is the same rough budget used
+    // across the workspace.
+    let fuel = max_time_secs.max(1).saturating_mul(1_000_000);
+    store.set_fuel(fuel)?;
+    Ok(store)
+}
+
 /// Build a wasmtime [`Config`] with rustledger's locked-down security
 /// posture. Exposed for tests and embedders who need to construct an
 /// `Engine` with the same flags but different lifetimes.
 ///
+/// # Maintenance: re-audit on every wasmtime bump
+///
+/// wasmtime's `Config::new()` returns its *current* defaults, which
+/// evolve across versions — new proposals routinely land as
+/// default-on. On every wasmtime bump in `Cargo.toml`, re-audit this
+/// function: check wasmtime's release notes for new `wasm_*`
+/// features and decide whether to keep, disable, or leave at
+/// default. wasmtime does not provide a "deny by default" mode, so
+/// this audit is structurally required, not optional.
+///
 /// # Enabled
 ///
 /// - `consume_fuel(true)` — fuel metering for `DoS` bound. Every
-///   sandboxed call must `Store::set_fuel(...)` before invoking.
+///   sandboxed call must `Store::set_fuel(...)` before invoking
+///   (handled by [`make_sandboxed_store`]).
 ///
 /// # Explicitly disabled (security)
 ///
@@ -99,14 +223,6 @@ pub fn shared_engine() -> Arc<Engine> {
 /// - `wasm_multi_value` — multi-return functions; sandbox-safe.
 #[must_use]
 pub fn sandbox_config() -> Config {
-    // MAINTENANCE NOTE: wasmtime's `Config::new()` returns its
-    // current defaults, which evolve across versions — new
-    // proposals routinely land as default-on. On every wasmtime
-    // bump in Cargo.toml, re-audit this function: check
-    // wasmtime's release notes for new `wasm_*` features and
-    // decide whether to keep, disable, or leave at default.
-    // (wasmtime does not provide a "deny by default" mode, so the
-    // audit is structurally required.)
     let mut c = Config::new();
     c.consume_fuel(true);
 
@@ -153,6 +269,66 @@ mod tests {
             Arc::ptr_eq(&a, &b),
             "shared_engine must return the same Arc each call"
         );
+    }
+
+    #[test]
+    fn memory_limiter_rejects_grow_above_max() {
+        let mut limiter = MemoryLimiter::new(1024);
+        assert!(
+            limiter
+                .memory_growing(0, 512, None)
+                .expect("under cap is Ok")
+        );
+        assert!(limiter.memory_growing(0, 1024, None).expect("at cap is Ok"));
+        assert!(
+            !limiter
+                .memory_growing(0, 1025, None)
+                .expect("over cap is Ok(false)")
+        );
+    }
+
+    #[test]
+    fn table_limiter_rejects_grow_above_max() {
+        let mut limiter = MemoryLimiter::new(usize::MAX);
+        assert!(
+            limiter
+                .table_growing(0, MAX_TABLE_ELEMENTS, None)
+                .expect("at cap is Ok")
+        );
+        assert!(
+            !limiter
+                .table_growing(0, MAX_TABLE_ELEMENTS + 1, None)
+                .expect("over cap is Ok(false)")
+        );
+    }
+
+    #[test]
+    fn make_sandboxed_store_wires_fuel_and_limiter() {
+        let engine = shared_engine();
+        let store =
+            make_sandboxed_store(&engine, 1024 * 1024, 30).expect("default config builds a store");
+        // Fuel was set (wasmtime returns Some when set_fuel succeeded).
+        assert!(store.get_fuel().expect("get_fuel succeeds") > 0);
+    }
+
+    #[test]
+    fn make_sandboxed_store_clamps_zero_max_time_secs() {
+        // Regression: max_time_secs = 0 previously caused immediate
+        // fuel-exhaustion trap on first instruction.
+        let engine = shared_engine();
+        let store =
+            make_sandboxed_store(&engine, 1024 * 1024, 0).expect("zero secs clamps, not starves");
+        assert!(store.get_fuel().expect("get_fuel succeeds") > 0);
+    }
+
+    #[test]
+    fn make_sandboxed_store_saturates_huge_max_time_secs() {
+        // Regression: max_time_secs = u64::MAX would overflow the
+        // `* 1_000_000` calc (debug panic, release silent wrap).
+        let engine = shared_engine();
+        let store = make_sandboxed_store(&engine, 1024 * 1024, u64::MAX)
+            .expect("huge secs saturates, doesn't overflow");
+        assert_eq!(store.get_fuel().expect("get_fuel succeeds"), u64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wave 2.3b of the v0.16.0 reshape: host-side loader for `.wasm` importer modules. `WasmImporter` implements the `Importer` trait by serializing inputs to MessagePack, calling into the module via wasmtime, and deserializing outputs.

This is the runtime that lets future external importers (`rustledger-importer-mt940.wasm`, `rustledger-importer-fints.wasm`, etc.) plug into `ImporterRegistry` alongside the built-in CSV and OFX importers.

## ⚠️ Breaking changes for user WASM plugins / importers

This PR introduces `rustledger_plugin::sandbox` — a workspace-wide wasmtime engine config + per-Store enforcement now shared by both the directive-plugin runtime and the new WASM importer host. Two contract changes downstream consumers should know about:

### 1. Disabled wasm proposals (full list — see `sandbox::sandbox_config` rustdoc for rationale)

- `wasm_threads` / `wasm_shared_everything_threads`
- `wasm_multi_memory` / `wasm_memory64`
- `wasm_component_model` (+ all `_async`/`_threading`/`_gc`/etc. sub-flags)
- `wasm_gc` / `wasm_function_references`
- `wasm_stack_switching` / `wasm_tail_call`

Any user-shipped `.wasm` plugin or importer that relies on any of these proposals will now fail to compile at load time with a wasmtime validation error. This is intentional security tightening — `wasm_threads` in particular closes a real DoS vector — but plugin authors targeting earlier rustledger versions may need to recompile against the new sandbox profile.

### 2. `Plugin::execute` fuel calc now clamps + saturates

`Plugin::execute` previously computed `fuel = config.max_time_secs * 1_000_000`:

- `max_time_secs == 0` → fuel = 0 → immediate trap on first instruction
- `max_time_secs == u64::MAX` → panic in debug, silent wrap to a tiny number in release

Now uses `max(1).saturating_mul(1_000_000)`:

- `max_time_secs == 0` → fuel = 1M (~1s of work)
- `max_time_secs == u64::MAX` → fuel = `u64::MAX` (effectively unlimited)

Both are bug fixes, but if any downstream consumer was relying on `max_time_secs == 0` to test fuel-exhausted behavior, they'll need to set a small positive value instead.

## What changed

- **New** `crates/rustledger-plugin/src/sandbox.rs` — workspace-shared config + per-Store enforcement: `sandbox_config()`, `shared_engine()`, `MemoryLimiter`, `StoreState`, `make_sandboxed_store()`, `MAX_TABLE_ELEMENTS`. Adopted by both `rustledger-plugin/src/runtime.rs` and `rustledger-importer/src/wasm.rs`.
- **New** `crates/rustledger-importer/src/wasm.rs` (~1430 lines incl. 27 tests) — `WasmImporter` host loader implementing the `Importer` trait via MessagePack ABI.
- `validate_plugin_module` now uses `sandbox::sandbox_config()` (was `Engine::default()`) so validate + load agree on what's valid.
- `Plugin::load`/`load_bytes` auto-validate via a shared `validate_loaded_module(&Module)` helper, so missing exports surface at load time instead of looking like signature mismatches in `execute()`.
- `WasmImporter`, `WasmImporterError`, `WasmRuntimeConfig` re-exported from `rustledger_importer`.
- New deps: `wasmtime`, `rmp-serde`, `serde`, `thiserror` (importer); `wat` (importer dev-dep).

## Sandbox model

- All imports rejected at load time — no WASI, fs, net, env, syscalls
- `wasmtime::ResourceLimiter` enforces `max_memory` (default 256 MiB) on both initial allocation and `memory.grow`
- Table growth capped at 1M elements (`MAX_TABLE_ELEMENTS`) so `table.grow` can't bypass the memory limiter
- Output and input byte caps (64 MiB each) via `MAX_OUTPUT_BYTES`/`MAX_INPUT_BYTES` prevent ~4 GiB host allocations from malicious `(ptr, len)` returns or oversized inputs
- Fuel-based time limit (default 30 s, clamped `≥1s` and `saturating_mul` for overflow)
- Fresh `Store` per call — concurrent extracts don't share state
- Shared `Engine` per process (wasmtime-recommended pattern via `OnceLock`)
- Same `make_sandboxed_store` helper used by both `Plugin::execute` and `WasmImporter::extract` — per-Store enforcement is workspace-wide

## Wire protocol

WASM module exports: `memory`, `alloc(u32) -> u32`, `metadata() -> u64`, `identify(ptr,len) -> u64`, `extract(ptr,len) -> u64`, `extract_enriched(ptr,len) -> u64`. All u64 returns pack `(out_ptr << 32) | out_len`.

`ImporterConfig` projects a *subset* of CSV-specific fields into the wire format's free-form `options: HashMap<String, String>` (full projection of `ColumnSpec`/mappings/locale deferred to wave 2.3e when a real WASM CSV importer drives the format).

`extract_enriched` round-trips `EnrichmentWrapper`/`AlternativeWrapper`; the `method: String` field parses via `parse_method()` returning `Result<_, &str>` so unknown method strings surface as warnings rather than silently degrading. Fingerprint hex round-trips via `Fingerprint::from_hex`.

`metadata` is called once at load and cached for `name()`/`description()`.

Errors/warnings round-trip via `PluginError`; the `format_plugin_error` helper preserves severity ("error " vs "warning " prefix) when collapsing into the shared `warnings` channel.

## Error API surface

`WasmImporterError` variants:
- `Io`, `Compile`, `ForbiddenImport`, `MissingExport`, `Runtime`, `Decode`, `Encode` (basic load/runtime/wire failures)
- `OutputTooLarge { len, max }`, `InputTooLarge { len, max }` (size caps)
- `ExportSignatureMismatch { name, source }` (distinguishes "wrong type" from "missing")

## Test plan

- [x] 27 `wasm::tests::*` (validate, formatter, bridge, end-to-end WAT round-trip, oversized output, oversized input, signature mismatch, fuel saturation, initial-memory wiring, fingerprint round-trip, unknown-method warning, ordering, load_embedded, runtime_config, Debug redaction)
- [x] 11 `sandbox::tests::*` (shared engine idempotent, memory + table limiter, make_sandboxed_store fuel wiring, 5 module-rejection tests for threads/multi-memory/memory64/component-model/gc)
- [x] 116 `rustledger-plugin` lib tests (+1 `Plugin::execute` memory cap integration test)
- [x] 159 `rustledger-importer` tests pass
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` clean
- [ ] Reference sample importer + integration tests land in wave 2.3e

## What's next

- **2.3c**: registry discovery — `--wasm-importer <path>` flag + directory scan
- **2.3d**: guest macros re-exported from `rustledger-plugin-types` (per earlier agreement: no new crate)
- **2.3e**: reference sample importer + integration tests exercising the full host↔guest round trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)