### PR TITLE
docs: sweep import-system docs for accuracy post-wave-2.3e

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Config is searched in: current directory, `~/.config/rledger/importers.toml`, or
 A 3-tier pipeline automatically categorizes transactions:
 
 1. **Rules engine** — substring, regex, and exact match patterns from `importers.toml`
-2. **Merchant dictionary** — ~80 built-in patterns across 10 categories (grocery, dining, transport, subscriptions, etc.)
+2. **Merchant dictionary** — ~150 built-in patterns across 10 categories (grocery, dining, transport, subscriptions, etc.)
 3. **ML categorization** — TF-IDF + Naive Bayes classification via `linfa`
 
 ### Transfer Detection
@@ -252,6 +252,20 @@ Fuzzy matching on date + amount + payee/narration prevents importing the same tr
 
 The `--balance` flag appends a balance assertion directive matching your bank statement's ending balance, helping verify import accuracy.
 
+### Custom WASM Importers
+
+Beyond the built-in CSV and OFX importers, third parties can ship importers as sandboxed `.wasm` modules — no need to fork the workspace:
+
+```bash
+# Single file
+rledger extract --wasm-importer ./my-bank.wasm statement.dat -a Assets:Bank
+
+# Or scan a directory of .wasm modules (also configurable via importers.toml)
+rledger extract --wasm-importer-dir /etc/rledger/importers.d statement.dat -a Assets:Bank
+```
+
+WASM importers implement the same `Importer` trait as the built-ins via the [`wasm_importer_main!`](crates/rustledger-plugin-types/src/guest.rs) macro and run inside the same wasmtime sandbox as directive plugins (no FS / network / WASI; configurable memory + fuel caps). See [`examples/wasm-importer-csv-example`](examples/wasm-importer-csv-example/) for a reference implementation.
+
 ## Crates
 
 | Crate | Description |
@@ -265,7 +279,7 @@ The `--balance` flag appends a balance assertion directive matching your bank st
 | `rustledger-query` | BQL query engine |
 | `rustledger-plugin` | 30 built-in plugins + Python plugin support |
 | `rustledger-plugin-types` | Shared plugin type definitions |
-| `rustledger-importer` | CSV/OFX import framework with auto-detection, enrichment, and configurable importers |
+| `rustledger-importer` | Import framework: built-in CSV/OFX, plus a `WasmImporter` host loader for third-party `.wasm` importers |
 | `rustledger-ops` | Pure operations — ML categorization, LLM prompts, dedup, transfer detection, balance reconciliation, merchant dictionary |
 | `rustledger-lsp` | Language Server Protocol for editor integration |
 | `rustledger-wasm` | WebAssembly bindings for JavaScript/TypeScript |

--- a/crates/rustledger-importer/README.md
+++ b/crates/rustledger-importer/README.md
@@ -4,14 +4,29 @@ Import framework for rustledger - extract transactions from bank files.
 
 ## Overview
 
-This crate provides infrastructure for extracting Beancount transactions from bank statements, credit card statements, and other financial documents. It follows the design of Python beancount's `bean-extract`.
+This crate provides infrastructure for extracting Beancount transactions from
+bank statements, credit card statements, and other financial documents. It
+follows the design of Python beancount's `bean-extract`.
+
+Importers come in two flavors:
+
+- **Built-in importers** (CSV, OFX/QFX) — compiled into the crate.
+- **WASM importers** — third-party `.wasm` modules loaded at runtime through
+  the `WasmImporter` host loader. Sandboxed via wasmtime (no FS / network /
+  WASI), so untrusted modules are safe to load. See
+  [`examples/wasm-importer-csv-example`][csv-example] for a reference guest
+  implementation built with the `wasm_importer_main!` macro in
+  `rustledger-plugin-types`.
+
+[csv-example]: ../../examples/wasm-importer-csv-example/
 
 ## Supported Formats
 
-| Format | Description |
-|--------|-------------|
-| CSV | Configurable CSV importer with column mapping |
-| OFX/QFX | Open Financial Exchange format |
+| Format | Source | Description |
+|--------|--------|-------------|
+| CSV | built-in | Configurable CSV importer with column mapping |
+| OFX/QFX | built-in | Open Financial Exchange format |
+| _any_ | WASM | Any format a third-party `.wasm` module implements |
 
 ## Example
 
@@ -29,7 +44,9 @@ let config = ImporterConfig::csv()
     .build()?;
 
 // Dispatch through the registry — `identify()` picks OfxImporter for
-// .ofx/.qfx and CsvImporter for .csv.
+// .ofx/.qfx and CsvImporter for .csv. Add WASM importers via
+// `register_wasm_from_path` / `register_wasm_dir`; once registered, they
+// participate in the same identify-then-extract dispatch.
 let registry = ImporterRegistry::with_builtins();
 let result = registry.extract(Path::new("bank.csv"), &config)?;
 
@@ -48,41 +65,84 @@ The enrichment pipeline adds intelligence on top of basic CSV/OFX extraction:
 - **Confidence scores** on every enrichment decision
 
 ```rust
-use rustledger_importer::{auto_extract, CsvConfigBuilder};
+use rustledger_importer::auto_extract;
 use std::path::Path;
 
-// Zero-config: auto-detect format and enrich
-let result = auto_extract(Path::new("bank.csv"), "Assets:Bank:Checking")?;
+// Zero-config: auto-detect format and enrich. Signature is
+// `(path, account, currency)`.
+let result = auto_extract(
+    Path::new("bank.csv"),
+    "Assets:Bank:Checking",
+    "USD",
+)?;
 
-for entry in &result.enriched {
-    println!("{}: {} (confidence {:.0}%)",
-        entry.directive, entry.category, entry.confidence * 100.0);
+// `EnrichedImportResult.entries: Vec<(Directive, Enrichment)>`.
+for (directive, enrichment) in &result.entries {
+    println!(
+        "{:?}: method={:?} (confidence {:.0}%)",
+        directive,
+        enrichment.method,
+        enrichment.confidence * 100.0,
+    );
 }
 
-// Or opt-in to enrichment via the builder
-let config = CsvConfigBuilder::new()
+// Or opt-in to enrichment via the builder. `use_merchant_dict` takes a
+// bool — pass `true` to enable the built-in merchant dictionary fallback.
+use rustledger_importer::ImporterConfig;
+let config = ImporterConfig::csv()
     .account("Assets:Bank:Checking")
     .currency("USD")
-    .use_merchant_dict()
-    .build();
+    .use_merchant_dict(true)
+    .build()?;
 ```
+
+## WASM Importers
+
+Load a third-party importer at runtime from a `.wasm` file:
+
+```rust
+use rustledger_importer::ImporterRegistry;
+
+let mut registry = ImporterRegistry::with_builtins();
+
+// Single-file load (uses default sandbox: 256 MiB memory, 30 s fuel).
+let name = registry.register_wasm_from_path("/path/to/my-bank.wasm")?;
+println!("loaded WASM importer: {name}");
+
+// Or scan a directory — skip-and-collect: one broken module doesn't
+// prevent the rest from loading.
+let report = registry.register_wasm_dir("/etc/rustledger/importers.d")?;
+println!("loaded {} WASM importers", report.loaded.len());
+for (path, err) in &report.failures {
+    eprintln!("failed to load {}: {err}", path.display());
+}
+```
+
+To **author** a WASM importer, depend on `rustledger-plugin-types` with the
+`guest` feature and use the `wasm_importer_main!` macro. See
+[`examples/wasm-importer-csv-example`][csv-example] for a minimal but
+realistic implementation and the macro's docs in `rustledger-plugin-types`.
 
 ## Key Types
 
 | Type | Description |
 |------|-------------|
-| `Importer` | Trait for file importers |
-| `ImporterConfig` | Builder for configuring CSV imports |
+| `Importer` | Trait for file importers — implemented by built-ins and WASM |
+| `ImporterConfig` | Per-call configuration (target account, currency, format-specific) |
 | `ImportResult` | Result containing directives and warnings |
-| `ImporterRegistry` | Registry of available importers |
-| `OfxImporter` | OFX/QFX file importer |
-| `EnrichedImportResult` | Result with confidence scores and fingerprints |
-| `CsvConfigBuilder::use_merchant_dict()` | Enable built-in merchant dictionary |
-| `auto_extract()` | Zero-config import with auto-detection |
+| `EnrichedImportResult` | Result with `(Directive, Enrichment)` pairs and warnings |
+| `ImporterRegistry` | Registry; dispatches by `identify()`; loads WASM importers |
+| `OfxImporter` | Built-in OFX/QFX file importer |
+| `WasmImporter` | Host loader for WASM-implemented importers |
+| `WasmRuntimeConfig` | Per-call sandbox caps (memory, fuel) for `WasmImporter` |
+| `WasmDirScanReport` | Return type of `register_wasm_dir` — loaded names + failures |
+| `auto_extract()` | Zero-config import with format auto-detection |
 
 ## Importer Trait
 
-Implement the `Importer` trait to add support for new file formats:
+Implement the `Importer` trait to add support for new file formats from
+*inside* the workspace. (External authors should target the WASM ABI
+instead — `wasm_importer_main!` in `rustledger-plugin-types`.)
 
 ```rust
 use rustledger_importer::{Importer, ImportResult, ImporterConfig};
@@ -102,6 +162,10 @@ impl Importer for MyImporter {
         // Parse the file using `_config.account` / `_config.currency` and
         // return directives. Implementors should be stateless; per-call
         // configuration flows in via the `_config` parameter.
+        //
+        // `extract_enriched` has a default impl that wraps `extract` with
+        // a `Default` categorization method and computed fingerprints.
+        // Override it to surface real categorization confidence.
         Ok(ImportResult::empty())
     }
 }

--- a/crates/rustledger-plugin-types/README.md
+++ b/crates/rustledger-plugin-types/README.md
@@ -2,7 +2,22 @@
 
 WASM plugin interface types for [rustledger](https://github.com/rustledger/rustledger).
 
-This crate provides the canonical type definitions that plugins must use to communicate with the rustledger host. Using this crate ensures your plugin's types are always compatible with the host.
+This crate provides the canonical type definitions that plugins must use to
+communicate with the rustledger host. Using this crate ensures your plugin's
+types are always compatible with the host.
+
+There are **two distinct WASM plugin subsystems**, and this crate hosts the
+shared types for both:
+
+- **Directive plugins** transform the directive stream *after* parsing
+  (tagging, dedup, categorization). Required export: `process`. Host loader:
+  `rustledger-plugin`. See the "Directive Plugin Quick Start" section below.
+- **WASM importers** turn bank-statement files *into* directives (CSV, OFX,
+  custom formats). Required exports: `metadata`, `identify`, `extract`,
+  `extract_enriched`. Host loader: `rustledger-importer::WasmImporter`. See
+  the "WASM Importer Quick Start" section below, and use the
+  `wasm_importer_main!` macro (behind the `guest` feature) to skip writing
+  the export boilerplate yourself.
 
 ## Installation
 
@@ -17,13 +32,13 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-rustledger-plugin-types = "0.10"
+rustledger-plugin-types = "0.15"
 rmp-serde = "1"
 ```
 
-**Version compatibility**: Use the same minor version as your target rustledger host (e.g., `0.10.x` types for rustledger `0.10.x`).
+**Version compatibility**: Use the same minor version as your target rustledger host (e.g., `0.15.x` types for rustledger `0.15.x`).
 
-## Quick Start
+## Directive Plugin Quick Start
 
 ```rust
 use rustledger_plugin_types::*;
@@ -172,6 +187,91 @@ Plugins must export:
 Plugins may optionally export:
 
 - `dealloc(ptr: *mut u8, size: u32)` - Optional. For freeing memory within the plugin.
+
+## WASM Importer Quick Start
+
+Importers read source files (CSV, OFX, …) and emit directives. The host
+loader is in `rustledger-importer` (`WasmImporter::load`); the wire format
+lives in this crate.
+
+Use the `wasm_importer_main!` macro to generate the required exports.
+Enable it with the `guest` feature:
+
+```toml
+[dependencies]
+rustledger-plugin-types = { version = "0.15", features = ["guest"] }
+```
+
+```rust,ignore
+use rustledger_plugin_types::{
+    DirectiveData, DirectiveWrapper, ImporterInput, ImporterOutput,
+    OpenData, wasm_importer_main,
+};
+
+fn identify(path: &str) -> bool {
+    path.ends_with(".mybank")
+}
+
+fn extract(input: ImporterInput) -> ImporterOutput {
+    // Parse input.content (Vec<u8>) and emit DirectiveWrapper values.
+    // input.account / input.currency / input.options carry per-call config.
+    ImporterOutput::new(vec![DirectiveWrapper {
+        directive_type: String::new(),
+        date: "2024-01-01".into(),
+        filename: None,
+        lineno: None,
+        data: DirectiveData::Open(OpenData {
+            account: input.account,
+            currencies: input.currency.into_iter().collect(),
+            booking: None,
+            metadata: vec![],
+        }),
+    }])
+}
+
+wasm_importer_main! {
+    name: "my-bank",
+    description: "Importer for MyBank CSV statements",
+    identify: identify,
+    extract: extract,
+    // `extract_enriched` is auto-generated as a passthrough that wraps
+    // each directive with `CategorizationMethod::Default`. Add an
+    // `extract_enriched:` entry to override (and provide real
+    // categorization confidence + fingerprints).
+}
+```
+
+The macro emits the required exports (`memory`, `alloc`, `metadata`,
+`identify`, `extract`, `extract_enriched`) gated on
+`#[cfg_attr(target_arch = "wasm32", ...)]` so the host-target build of
+your crate (used by tests) doesn't collide with the WASM linker's symbol
+namespace.
+
+See [`examples/wasm-importer-csv-example`][csv-example] in the rustledger
+repo for a complete reference implementation.
+
+[csv-example]: https://github.com/rustledger/rustledger/tree/main/examples/wasm-importer-csv-example
+
+### Importer ABI types
+
+| Type | Description |
+|------|-------------|
+| `ImporterInput` | Input to `extract`/`extract_enriched`: path, content bytes, account, currency, options map |
+| `IdentifyInput` | Input to `identify`: path only (content isn't read until extract) |
+| `ImporterOutput` | Result of `extract`: directives + warnings + structured errors |
+| `EnrichedImporterOutput` | Result of `extract_enriched`: `(DirectiveWrapper, EnrichmentWrapper)` pairs |
+| `IdentifyOutput` | Result of `identify`: `bool` |
+| `MetadataOutput` | Result of `metadata`: name + description, called once at load |
+| `EnrichmentWrapper` | Per-directive categorization metadata (method, confidence, fingerprint, alternatives) |
+| `AlternativeWrapper` | Alternative account categorization with confidence |
+
+### Categorization method strings
+
+`EnrichmentWrapper::method` is a wire-format string that must match one of:
+`"rule"`, `"merchant-dict"` (hyphen, not underscore!), `"ml"`, `"llm"`,
+`"manual"`, `"default"`. Unknown strings cause the host to emit a warning
+and fall back to `Default`. The host pinning lives in
+`rustledger_ops::enrichment::CategorizationMethod::as_meta_value`.
 
 ## License
 

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -4,13 +4,27 @@
 //! Use it as a dependency in your plugin crate to ensure type compatibility with
 //! the rustledger host.
 //!
-//! # Quick Start
+//! # Two subsystems
+//!
+//! Rustledger has two distinct WASM plugin subsystems, and this crate hosts
+//! the shared types for both:
+//!
+//! - **Directive plugins** transform the directive stream *after* parsing
+//!   (tagging, dedup, categorization). Required export: `process`. Host
+//!   loader: `rustledger-plugin`. The Quick Start below covers this case.
+//! - **WASM importers** turn bank-statement files *into* directives.
+//!   Required exports: `metadata`, `identify`, `extract`, `extract_enriched`.
+//!   Host loader: `rustledger-importer::WasmImporter`. Use the
+//!   `wasm_importer_main!` macro (behind the `guest` feature) to generate
+//!   the boilerplate. See the [`guest`] module for details.
+//!
+//! # Directive-Plugin Quick Start
 //!
 //! Add this to your plugin's `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
-//! rustledger-plugin-types = "0.10"
+//! rustledger-plugin-types = "0.15"
 //! rmp-serde = "1"
 //! ```
 //!
@@ -71,7 +85,7 @@
 //!
 //! Plugin types are versioned with rustledger. For best compatibility, use the
 //! same minor version of `rustledger-plugin-types` as the rustledger host you're
-//! targeting (e.g., `0.10.x` for rustledger `0.10.x`).
+//! targeting (e.g., `0.15.x` for rustledger `0.15.x`).
 //!
 //! # Building
 //!
@@ -83,6 +97,54 @@
 //! ```
 //!
 //! The output will be in `target/wasm32-unknown-unknown/release/your_plugin.wasm`
+//!
+//! # WASM-Importer Quick Start
+//!
+//! Importers read source files (CSV, OFX, …) and emit directives. The host
+//! loader lives in `rustledger-importer`; the wire format and a
+//! boilerplate-eliminating macro live here.
+//!
+//! Enable the `guest` feature, then use `wasm_importer_main!`:
+//!
+//! ```toml
+//! [dependencies]
+//! rustledger-plugin-types = { version = "0.15", features = ["guest"] }
+//! ```
+//!
+//! ```rust,ignore
+//! use rustledger_plugin_types::{
+//!     DirectiveData, DirectiveWrapper, ImporterInput, ImporterOutput,
+//!     OpenData, wasm_importer_main,
+//! };
+//!
+//! fn identify(path: &str) -> bool {
+//!     path.ends_with(".mybank")
+//! }
+//!
+//! fn extract(input: ImporterInput) -> ImporterOutput {
+//!     // Parse input.content; emit DirectiveWrapper values.
+//!     ImporterOutput::new(vec![/* … */])
+//! }
+//!
+//! wasm_importer_main! {
+//!     name: "my-bank",
+//!     description: "MyBank CSV statements",
+//!     identify: identify,
+//!     extract: extract,
+//!     // `extract_enriched` is auto-generated as a Default-categorization
+//!     // passthrough. Add `extract_enriched: my_fn` to override.
+//! }
+//! ```
+//!
+//! Importer ABI types defined in this crate: [`ImporterInput`],
+//! [`IdentifyInput`], [`IdentifyOutput`], [`ImporterOutput`],
+//! [`EnrichedImporterOutput`], [`MetadataOutput`], [`EnrichmentWrapper`],
+//! [`AlternativeWrapper`].
+//!
+//! Wire-format method strings for `EnrichmentWrapper::method`: `"rule"`,
+//! `"merchant-dict"` (hyphen, not underscore), `"ml"`, `"llm"`, `"manual"`,
+//! `"default"`. Unknown values trigger a host warning and fall back to
+//! `Default`.
 
 #![warn(missing_docs)]
 

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -4,7 +4,7 @@ ______________________________________________________________________
 
 # rledger extract
 
-Import transactions from CSV and OFX bank statements.
+Import transactions from bank statements. Handles CSV and OFX/QFX out of the box; can also load third-party importers as sandboxed WASM modules via `--wasm-importer` / `--wasm-importer-dir`.
 
 ## Usage
 
@@ -53,6 +53,7 @@ rledger extract [OPTIONS] [FILE]
 | `--skip-rows <N>` | Number of header rows to skip [default: 0] |
 | `--invert-sign` | Invert sign of amounts |
 | `--no-header` | CSV has no header row |
+| `--include-zero-amounts` | Preserve rows whose amount is exactly zero (default drops them; bank "status filler" rows) |
 
 ### Output Options
 
@@ -60,7 +61,18 @@ rledger extract [OPTIONS] [FILE]
 |--------|-------------|
 | `-o, --output <FILE>` | Write output to file instead of stdout |
 | `--existing <FILE>` | Existing ledger file for duplicate detection |
-| `-P, --profile <PROFILE>` | Use a profile from config |
+| `--suggest-categories` | Use ML (Naive Bayes on the `--existing` ledger) to suggest accounts for transactions the rules engine didn't categorize. Requires `--existing`. |
+| `--balance <AMOUNT>` | Append a balance assertion directive with the given amount (e.g., `1234.56`) |
+| `--balance-date <DATE>` | Date for the balance assertion (defaults to today) |
+
+### WASM Importers
+
+Third-party importers ship as sandboxed `.wasm` modules. Flags below override `wasm_importer_dir` from `importers.toml`.
+
+| Option | Description |
+|--------|-------------|
+| `--wasm-importer <PATH>` | Register a specific `.wasm` importer ahead of built-ins. Repeatable. User-specified modules take precedence over discovered ones and built-ins. |
+| `--wasm-importer-dir <DIR>` | Scan a directory for `*.wasm` importer modules at startup. Repeatable. Subdirectories are not recursed into; non-`.wasm` files are silently skipped. |
 
 ## Examples
 
@@ -168,7 +180,7 @@ The importer library supports additional enrichment features via the
 
 | Builder Method | Description |
 |----------------|-------------|
-| `use_merchant_dict(true)` | Enable the built-in merchant dictionary (~60 common patterns) as a low-priority fallback for account categorization |
+| `use_merchant_dict(true)` | Enable the built-in merchant dictionary (~150 common patterns) as a low-priority fallback for account categorization |
 | `regex_mappings(vec)` | Add regex-based account mappings (case-insensitive, compiled at load time) |
 
 These options are available in the Rust library API but are not yet exposed as
@@ -204,9 +216,29 @@ rledger extract --config path/to/importers.toml --importer checking statement.cs
 
 ### List Available Importers
 
+Lists both TOML profiles (for `--importer <name>`) and registered importer engines (built-in CSV/OFX plus any WASM modules from `--wasm-importer`/`--wasm-importer-dir`):
+
 ```bash
 rledger extract --config importers.toml --list-importers
 ```
+
+### Using a WASM Importer
+
+```bash
+# One-off: register a single .wasm file
+rledger extract --wasm-importer ./my-bank.wasm statement.dat -a Assets:Bank
+
+# Or scan a whole directory at startup
+rledger extract --wasm-importer-dir ~/.config/rledger/importers.d statement.dat -a Assets:Bank
+```
+
+Persistent setup goes in `importers.toml`:
+
+```toml
+wasm_importer_dir = "/etc/rledger/importers.d"
+```
+
+WASM importers participate in the same `identify`-then-`extract` dispatch as the built-ins. See [`examples/wasm-importer-csv-example`](../../examples/wasm-importer-csv-example/) for how to write one.
 
 ### Direct CLI Import (No Config)
 

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -238,7 +238,7 @@ Persistent setup goes in `importers.toml`:
 wasm_importer_dir = "/etc/rledger/importers.d"
 ```
 
-WASM importers participate in the same `identify`-then-`extract` dispatch as the built-ins. See [`examples/wasm-importer-csv-example`](../../examples/wasm-importer-csv-example/) for how to write one.
+WASM importers participate in the same `identify`-then-`extract` dispatch as the built-ins. See [`examples/wasm-importer-csv-example`](https://github.com/rustledger/rustledger/tree/main/examples/wasm-importer-csv-example) for how to write one.
 
 ### Direct CLI Import (No Config)
 

--- a/docs/development/import-roadmap.md
+++ b/docs/development/import-roadmap.md
@@ -23,9 +23,9 @@
 | WASM Import Plugins | ✅ Done | Third-party importers as sandboxed `.wasm` modules ([`WasmImporter`][wasm-importer], [`wasm_importer_main!`][wasm-macro], [example][wasm-csv-example]) |
 | Source Archive | 🔮 Future | SQLite append-only store |
 
-[wasm-importer]: ../../crates/rustledger-importer/src/wasm.rs
-[wasm-macro]: ../../crates/rustledger-plugin-types/src/guest.rs
-[wasm-csv-example]: ../../examples/wasm-importer-csv-example/
+[wasm-importer]: https://github.com/rustledger/rustledger/blob/main/crates/rustledger-importer/src/wasm.rs
+[wasm-macro]: https://github.com/rustledger/rustledger/blob/main/crates/rustledger-plugin-types/src/guest.rs
+[wasm-csv-example]: https://github.com/rustledger/rustledger/tree/main/examples/wasm-importer-csv-example
 
 **Current version**: Enrichment pipeline (Phase 1 complete, Phase 4.1 partial)
 

--- a/docs/development/import-roadmap.md
+++ b/docs/development/import-roadmap.md
@@ -10,7 +10,7 @@
 | CSV Auto-Inference | ✅ Done | Delimiter, date format, column role detection (`--auto` flag) |
 | Ops Crate (`rustledger-ops`) | ✅ Done | Pure operations: dedup, categorize, fingerprint, reconcile, merchants, transfer |
 | Rules Engine | ✅ Done | Substring, regex, and exact match rules with priority ordering |
-| Merchant Dictionary | ✅ Done | ~60 built-in patterns (groceries, dining, transport, subscriptions, etc.) |
+| Merchant Dictionary | ✅ Done | ~150 built-in patterns (groceries, dining, transport, subscriptions, etc.) |
 | Transaction Fingerprinting | ✅ Done | Structural hashing via blake3 for stable dedup |
 | Enriched Import Results | ✅ Done | `EnrichedImportResult` with confidence scores and categorization method |
 | Institution Profiles | 🔮 Future | YAML-based bank definitions |
@@ -20,8 +20,12 @@
 | API Integration | 🔮 Future | SimpleFIN, Plaid |
 | ML Categorization | 🔮 Future | Learn from user's existing ledger |
 | LLM/MCP Categorization | 🔮 Future | LLM-assisted via MCP |
-| WASM Import Plugins | 🔮 Future | Custom importers as WASM plugins |
+| WASM Import Plugins | ✅ Done | Third-party importers as sandboxed `.wasm` modules ([`WasmImporter`][wasm-importer], [`wasm_importer_main!`][wasm-macro], [example][wasm-csv-example]) |
 | Source Archive | 🔮 Future | SQLite append-only store |
+
+[wasm-importer]: ../../crates/rustledger-importer/src/wasm.rs
+[wasm-macro]: ../../crates/rustledger-plugin-types/src/guest.rs
+[wasm-csv-example]: ../../examples/wasm-importer-csv-example/
 
 **Current version**: Enrichment pipeline (Phase 1 complete, Phase 4.1 partial)
 

--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -65,7 +65,7 @@ rledger extract --importer chase chase-statement.csv
 
 The `importers.toml` file is searched for automatically in these locations (first found wins):
 
-1. Path specified via `--importers-config path/to/importers.toml`
+1. Path specified via `--config path/to/importers.toml` (the legacy spelling `--importers-config` is still accepted as an alias)
 1. `importers.toml` in the current directory
 1. `~/.config/rledger/importers.toml`
 
@@ -101,6 +101,28 @@ rledger extract statement.ofx -a Assets:Bank:Checking
 ```
 
 OFX files contain structured data, so no column mapping is needed.
+
+## WASM Importers (custom formats)
+
+For bank formats CSV and OFX don't cover — proprietary `.dat` files, PDF, MT940, FinTS, vendor-specific JSON — you can load a sandboxed `.wasm` module that implements the `Importer` trait. WASM importers participate in the same `identify`-then-`extract` dispatch as the built-ins; they're indistinguishable to the CLI once loaded.
+
+```bash
+# Single .wasm file (highest precedence — overrides discovered + built-in)
+rledger extract --wasm-importer ./my-bank.wasm statement.dat -a Assets:Bank
+
+# Or scan a directory at startup
+rledger extract --wasm-importer-dir ~/.config/rledger/importers.d statement.dat -a Assets:Bank
+```
+
+Persistent setup goes in `importers.toml`:
+
+```toml
+# All `.wasm` files in this dir are loaded at startup. Subdirectories are
+# not recursed into. Override on the CLI with --wasm-importer-dir.
+wasm_importer_dir = "/etc/rledger/importers.d"
+```
+
+The sandbox is the same one used for directive plugins: no filesystem, no network, no WASI, with configurable memory (256 MiB default) and fuel (30 s default) caps. To **author** a WASM importer, depend on `rustledger-plugin-types` with the `guest` feature and use the `wasm_importer_main!` macro — see [`examples/wasm-importer-csv-example`](../../examples/wasm-importer-csv-example/) for a reference implementation.
 
 ## Multiple Accounts
 
@@ -139,7 +161,7 @@ rledger extract --importer credit_card chase-card.csv
 Or specify a custom config path:
 
 ```bash
-rledger extract --importers-config path/to/importers.toml --importer credit_card chase-card.csv
+rledger extract --config path/to/importers.toml --importer credit_card chase-card.csv
 ```
 
 ## Enriched Imports
@@ -148,7 +170,7 @@ The import pipeline can automatically enrich transactions beyond basic CSV/OFX
 extraction:
 
 - **Auto-inference**: Automatically detect CSV delimiter, date format, and column roles
-- **Merchant dictionary**: ~60 built-in merchant patterns (grocery, dining, transport, subscriptions, etc.) for automatic account categorization
+- **Merchant dictionary**: ~150 built-in merchant patterns (grocery, dining, transport, subscriptions, etc.) for automatic account categorization
 - **Transaction fingerprinting**: Stable structural hashes for deduplication against existing ledger entries
 - **Confidence scores**: Every enrichment decision carries a confidence value
 

--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -122,7 +122,7 @@ Persistent setup goes in `importers.toml`:
 wasm_importer_dir = "/etc/rledger/importers.d"
 ```
 
-The sandbox is the same one used for directive plugins: no filesystem, no network, no WASI, with configurable memory (256 MiB default) and fuel (30 s default) caps. To **author** a WASM importer, depend on `rustledger-plugin-types` with the `guest` feature and use the `wasm_importer_main!` macro — see [`examples/wasm-importer-csv-example`](../../examples/wasm-importer-csv-example/) for a reference implementation.
+The sandbox is the same one used for directive plugins: no filesystem, no network, no WASI, with configurable memory (256 MiB default) and fuel (30 s default) caps. To **author** a WASM importer, depend on `rustledger-plugin-types` with the `guest` feature and use the `wasm_importer_main!` macro — see [`examples/wasm-importer-csv-example`](https://github.com/rustledger/rustledger/tree/main/examples/wasm-importer-csv-example) for a reference implementation.
 
 ## Multiple Accounts
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -84,10 +84,10 @@ This document describes rustledger's crate structure and data flow.
 |-------|---------|-----------|
 | `rustledger-query` | BQL query engine | `Query`, `Executor`, `Table`, `Row` |
 | `rustledger-plugin` | Native + WASM + Python plugins | `NativePlugin`, `NativePluginRegistry`, `PluginManager` |
-| `rustledger-plugin-types` | WASM plugin interface types | `PluginInput`, `PluginOutput`, `DirectiveWrapper` |
+| `rustledger-plugin-types` | WASM plugin interface types (directive plugins **and** WASM importers) | `PluginInput`, `PluginOutput`, `DirectiveWrapper`, `ImporterInput`, `ImporterOutput`, `EnrichedImporterOutput`, `wasm_importer_main!` |
 | `rustledger-ops` | Pure operations on directives | `RulesEngine`, `find_structural_duplicates`, `structural_hash`, `Enrichment` |
 | `rustledger-lsp` | Language Server Protocol | LSP handlers for all standard features |
-| `rustledger-importer` | Bank statement import | `CsvImporter`, `OfxImporter`, `auto_extract`, `EnrichedImportResult` |
+| `rustledger-importer` | Bank statement import | `Importer` trait, `ImporterRegistry`, `CsvImporter`, `OfxImporter`, `WasmImporter`, `WasmRuntimeConfig`, `WasmDirScanReport`, `auto_extract`, `EnrichedImportResult` |
 
 ### Distribution Layer
 


### PR DESCRIPTION
## Summary

Audited every documentation file that mentions the importer subsystem against the current code on \`main\` and fixed ~15 stale claims. Wave 2 (PRs #1128–#1135) landed WASM importer support, but many docs were written assuming the pre-wave-2 world.

## Files changed

| File | Why |
|------|-----|
| \`README.md\` | merchant count \`~80\` → \`~150\`; added "Custom WASM Importers" subsection; updated importer crate description |
| \`crates/rustledger-importer/README.md\` | \`auto_extract\` signature wrong (3-arg, not 2); \`EnrichedImportResult\` example used non-existent \`result.enriched\` / \`entry.directive\` / \`entry.category\` fields; \`use_merchant_dict\` missing bool arg; Key Types table omitted every WASM-side type; added WASM Importers section |
| \`crates/rustledger-plugin-types/README.md\` + \`src/lib.rs\` | version pin \`0.10\` → \`0.15\`; both files documented only the directive-plugin ABI — never mentioned importer ABI types or the \`wasm_importer_main!\` macro behind the \`guest\` feature; added "WASM Importer Quick Start" sections |
| \`docs/development/import-roadmap.md\` | "WASM Import Plugins | Future" → "Done" with links; merchant count \`~60\` → \`~150\` |
| \`docs/commands/extract.md\` | missing flag rows: \`--include-zero-amounts\`, \`--suggest-categories\`, \`--balance\`, \`--balance-date\`, \`--wasm-importer\`, \`--wasm-importer-dir\`; merchant count \`~60\` → \`~150\`; \`--list-importers\` description clarified |
| \`docs/guides/importing.md\` | \`--importers-config\` → \`--config\` (primary; legacy alias still works); merchant count \`~60\` → \`~150\`; added "WASM Importers (custom formats)" section |
| \`docs/reference/architecture.md\` | extended exports rows for \`rustledger-importer\` (added \`Importer\`, \`ImporterRegistry\`, \`WasmImporter\`, \`WasmRuntimeConfig\`, \`WasmDirScanReport\`) and \`rustledger-plugin-types\` (now serves both directive-plugin AND importer ABIs) |

## Not changed (false alarm)

The audit flagged TOML field names \`skip_header\` and \`invert_amounts\` as wrong. They are *not* — those are the actual field names on \`ImporterEntry\` in \`extract_cmd/config.rs\`; the mapping to \`has_header\` (negated) / \`invert_sign\` happens at load time. Docs left as-is.

## Test plan

- [x] \`RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps\` — clean
- [x] Pre-push hooks pass (rustfmt, typos, gitleaks, commitizen)
- [ ] CI Documentation job passes (canary for intra-doc link breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)