### PR TITLE
refactor(plugin): extract shared wasm-dir scanner (closes parity-work duplication)

### DIFF
--- a/crates/rustledger-importer/src/registry.rs
+++ b/crates/rustledger-importer/src/registry.rs
@@ -101,47 +101,34 @@ impl ImporterRegistry {
         dir: impl AsRef<Path>,
     ) -> Result<WasmDirScanReport, WasmImporterError> {
         let dir = dir.as_ref();
-        let entries = std::fs::read_dir(dir).map_err(|source| WasmImporterError::Io {
-            path: dir.to_path_buf(),
-            source,
+        // Listing/filtering/sorting is shared with
+        // `PluginManager::register_wasm_dir` — see
+        // `rustledger_plugin::wasm_dir_scan` for the common helper.
+        // Caller-side: dir-level error wrapping + per-file load fn +
+        // per-entry error wrapping (importer uses the typed `DirEntry`
+        // variant, plugin uses `anyhow::Error::new`).
+        let scan = rustledger_plugin::wasm_dir_scan::collect_wasm_paths(dir).map_err(|source| {
+            WasmImporterError::Io {
+                path: dir.to_path_buf(),
+                source,
+            }
         })?;
         let mut report = WasmDirScanReport::default();
-        let mut wasm_paths: Vec<PathBuf> = Vec::new();
-        for entry in entries {
-            // Per-entry I/O errors (rare — permission denied on a
-            // single inode, broken symlink) flow into `failures` so
-            // a user debugging a missing importer can see they
-            // existed but couldn't be enumerated. The dir path
-            // itself is used as the failure path since we don't
-            // know the inode's name.
-            match entry {
-                Ok(e) => {
-                    let path = e.path();
-                    if path.is_file()
-                        && path
-                            .extension()
-                            .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
-                    {
-                        wasm_paths.push(path);
-                    }
-                }
-                Err(source) => {
-                    // `read_dir().next()` can return Err for a
-                    // single entry without us knowing its name —
-                    // surface as `DirEntry` (typed for this case)
-                    // tagged with the dir path.
-                    report.failures.push((
-                        dir.to_path_buf(),
-                        WasmImporterError::DirEntry {
-                            dir: dir.to_path_buf(),
-                            source,
-                        },
-                    ));
-                }
-            }
+        // Per-entry I/O errors → the typed `DirEntry` variant so a
+        // user debugging a missing importer can distinguish them from
+        // file-read errors. The path on the report entry is the dir
+        // itself because the per-entry error doesn't expose the
+        // offending inode's name.
+        for (entry_path, source) in scan.entry_failures {
+            report.failures.push((
+                entry_path,
+                WasmImporterError::DirEntry {
+                    dir: dir.to_path_buf(),
+                    source,
+                },
+            ));
         }
-        wasm_paths.sort();
-        for path in wasm_paths {
+        for path in scan.sorted_paths {
             match self.register_wasm_from_path(&path) {
                 Ok(name) => report.loaded.push(name),
                 Err(e) => report.failures.push((path, e)),

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -49,6 +49,8 @@ pub mod runtime;
 pub mod sandbox;
 pub mod test_helpers;
 pub mod types;
+#[cfg(feature = "wasm-runtime")]
+pub mod wasm_dir_scan;
 
 pub use convert::{
     ConversionError, directive_to_wrapper, directive_to_wrapper_with_location,

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -366,33 +366,18 @@ impl PluginManager {
     /// caller can surface them without aborting the rest of the scan.
     pub fn register_wasm_dir(&mut self, dir: impl AsRef<Path>) -> Result<WasmPluginDirScanReport> {
         let dir = dir.as_ref();
-        let entries = std::fs::read_dir(dir)
+        // Listing/filtering/sorting is shared with `ImporterRegistry::register_wasm_dir`
+        // in `rustledger-importer` — see `crate::wasm_dir_scan` for the
+        // common helper. Caller-side: dir-level error context + the
+        // per-file load fn + the per-entry error wrapping.
+        let scan = crate::wasm_dir_scan::collect_wasm_paths(dir)
             .with_context(|| format!("failed to read plugin dir {}", dir.display()))?;
         let mut report = WasmPluginDirScanReport::default();
-        let mut wasm_paths: Vec<PathBuf> = Vec::new();
-        for entry in entries {
-            match entry {
-                Ok(e) => {
-                    let path = e.path();
-                    if path.is_file()
-                        && path
-                            .extension()
-                            .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
-                    {
-                        wasm_paths.push(path);
-                    }
-                }
-                Err(source) => {
-                    // Per-entry I/O error without a known inode name —
-                    // tag with the dir path so the user can debug.
-                    report
-                        .failures
-                        .push((dir.to_path_buf(), anyhow::Error::new(source)));
-                }
-            }
+        // Forward per-entry I/O failures wrapped in anyhow.
+        for (path, source) in scan.entry_failures {
+            report.failures.push((path, anyhow::Error::new(source)));
         }
-        wasm_paths.sort();
-        for path in wasm_paths {
+        for path in scan.sorted_paths {
             match self.load(&path) {
                 Ok(index) => {
                     // Read the name back from the registered Plugin so

--- a/crates/rustledger-plugin/src/wasm_dir_scan.rs
+++ b/crates/rustledger-plugin/src/wasm_dir_scan.rs
@@ -1,0 +1,153 @@
+//! Shared `.wasm` directory scanner.
+//!
+//! Both [`crate::PluginManager::register_wasm_dir`] and
+//! `rustledger_importer::ImporterRegistry::register_wasm_dir` walk a
+//! directory looking for `.wasm` files to register. (The latter isn't
+//! an intra-doc link because that crate sits downstream of this one
+//! in the dep graph — link from text on the importer side instead.)
+//! The two used to
+//! be near-copies — same listing, filtering, sorting, and per-entry
+//! error handling logic, only the error wrapping and per-file load fn
+//! differed. This module factors out the shared listing-and-filtering
+//! step.
+//!
+//! # What's shared
+//!
+//! - `read_dir` + iteration
+//! - `is_file()` + case-insensitive `.wasm` extension filter
+//! - Per-entry I/O errors collected (not propagated, so a single
+//!   permission-denied inode doesn't abort the scan)
+//! - Lexicographic sort by path so load order is deterministic across
+//!   filesystems and platforms
+//!
+//! # What stays caller-side
+//!
+//! - **Dir-level `read_dir` error wrapping**: each caller has its own
+//!   error type and preferred context message ("failed to read plugin
+//!   dir ..." vs `WasmImporterError::Io`).
+//! - **Per-file load**: the importer calls
+//!   `register_wasm_from_path`, the plugin manager calls `load`.
+//!   Their return values and error shapes are different (importer
+//!   returns the module's declared name; plugin returns an index +
+//!   uses the registered Plugin's `name()`).
+//!
+//! Both kept caller-side because forcing them through a generic
+//! adapter would add more code than it saved.
+
+use std::path::{Path, PathBuf};
+
+/// Outcome of [`collect_wasm_paths`].
+///
+/// `sorted_paths` is what callers iterate to do the actual loading;
+/// `entry_failures` carries per-entry I/O errors (broken-during-iter
+/// inodes) that callers fold into their own failure-tracking shape.
+#[derive(Debug, Default)]
+pub struct WasmDirScan {
+    /// `.wasm` files found in the directory, sorted lexicographically
+    /// by full path. Sorting at this layer means callers don't have
+    /// to think about deterministic load order.
+    pub sorted_paths: Vec<PathBuf>,
+    /// Per-entry I/O errors from the `read_dir` iterator (rare —
+    /// permission denied on a single inode, broken symlinks the
+    /// dirent-read step caught). Paired with the dir path because
+    /// the per-entry `Err` doesn't carry the inode's name.
+    pub entry_failures: Vec<(PathBuf, std::io::Error)>,
+}
+
+/// Collect `.wasm` files from `dir` (one level, no recursion) and
+/// sort them lexicographically.
+///
+/// Filter rules:
+/// - Skips subdirectories (matches `path.is_file()`).
+/// - Skips files whose `path.is_file()` returns false for any reason
+///   — broken symlinks, transient metadata errors, etc. (`is_file`
+///   swallows the underlying I/O error; this is a documented
+///   limitation, not a bug.)
+/// - Extension matching is case-insensitive: `foo.wasm`, `BAR.WASM`,
+///   and `mixed.Wasm` all match.
+/// - Per-entry I/O errors (where the `read_dir` iterator itself
+///   returns an `Err`) are collected into
+///   [`WasmDirScan::entry_failures`] rather than aborting the scan.
+///
+/// # Errors
+///
+/// Returns the dir-level `read_dir` error verbatim. Callers wrap it
+/// with whatever context they need ("failed to read importer dir ...",
+/// `WasmImporterError::Io { path, source }`, etc.).
+pub fn collect_wasm_paths(dir: &Path) -> std::io::Result<WasmDirScan> {
+    let entries = std::fs::read_dir(dir)?;
+    let mut scan = WasmDirScan::default();
+    for entry in entries {
+        match entry {
+            Ok(e) => {
+                let path = e.path();
+                if path.is_file()
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
+                {
+                    scan.sorted_paths.push(path);
+                }
+            }
+            Err(source) => {
+                // Per-entry I/O error — the `read_dir` iterator's
+                // `next()` can return `Err` for a single inode (rare;
+                // usually permission denied or a broken symlink)
+                // without exposing the entry name. Tag with the dir
+                // path so the caller's report is useful for debugging.
+                scan.entry_failures.push((dir.to_path_buf(), source));
+            }
+        }
+    }
+    scan.sorted_paths.sort();
+    Ok(scan)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn touch(path: &Path) {
+        std::fs::write(path, b"placeholder").expect("write fixture");
+    }
+
+    #[test]
+    fn collects_only_top_level_wasm_files_in_sorted_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path();
+        touch(&p.join("b_second.wasm"));
+        touch(&p.join("a_first.wasm"));
+        touch(&p.join("README.md")); // wrong extension
+        touch(&p.join(".gitignore")); // no extension
+        // Subdir with a .wasm inside — should NOT be picked up.
+        std::fs::create_dir(p.join("sub")).expect("subdir");
+        touch(&p.join("sub").join("recursed.wasm"));
+
+        let scan = collect_wasm_paths(p).expect("scan succeeds");
+        let names: Vec<_> = scan
+            .sorted_paths
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["a_first.wasm", "b_second.wasm"]);
+        assert!(scan.entry_failures.is_empty());
+    }
+
+    #[test]
+    fn extension_match_is_case_insensitive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        touch(&dir.path().join("upper.WASM"));
+        touch(&dir.path().join("mixed.Wasm"));
+        let scan = collect_wasm_paths(dir.path()).expect("scan succeeds");
+        assert_eq!(scan.sorted_paths.len(), 2);
+    }
+
+    #[test]
+    fn missing_dir_propagates_read_dir_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nonexistent = dir.path().join("does-not-exist");
+        let err = collect_wasm_paths(&nonexistent)
+            .expect_err("missing dir should error at the read_dir step, not in entry_failures");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

PR #1137 shipped `PluginManager::register_wasm_dir` as a near-copy of `ImporterRegistry::register_wasm_dir` from PR #1132. Both did identical listing/filtering/sorting work, differing only in error-wrapping shape and per-file load fn. This PR DRYs the shared piece into a small helper module.

## What's extracted

New `rustledger_plugin::wasm_dir_scan::collect_wasm_paths(dir) -> io::Result<WasmDirScan>`:
- `read_dir` + iteration
- `is_file()` + case-insensitive `.wasm` extension filter
- Per-entry I/O errors collected into `WasmDirScan::entry_failures` (not propagated)
- Lexicographic sort of the resulting paths

Both `register_wasm_dir` call sites collapse from ~50 lines to ~20.

## What's caller-side (and why)

- **Dir-level error wrapping** — importer uses `WasmImporterError::Io { path, source }`, plugin uses anyhow `with_context(\"failed to read plugin dir ...\")`. Forcing this through a generic adapter would add more code than it removed.
- **Per-file load fn** — importer's `register_wasm_from_path` returns the module's declared name; plugin's `load` returns an index and the caller reads `plugins[i].name()`. Different shapes; not worth abstracting.
- **Per-entry error wrapping** — importer wraps in the typed `DirEntry { dir, source }` variant; plugin wraps in `anyhow::Error::new`. Two-line difference each.

The helper's doc comment calls out this split explicitly so future contributors don't try to "DRY harder".

## Design notes

- Helper lives in `rustledger-plugin` because both crates already depend on it (for `sandbox`). Putting it in a new shared crate or in plugin-types would have been heavier than the problem warranted.
- Returns a struct rather than a generic-over-error-type wrapper. Tried the generic approach first; the trait bounds on the two error types added more code than the duplication.
- Three new unit tests on the helper cover happy path, case-insensitive extension matching, and missing-dir error propagation. The existing tests on both `register_wasm_dir` impls remain unchanged and still pass — they cover the integration paths.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo check --all-features --all-targets\`
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps\`
- [x] \`cargo test -p rustledger-plugin --all-features\` (143 tests pass, including 3 new wasm_dir_scan tests + existing register_wasm_dir tests)
- [x] \`cargo test -p rustledger-importer --all-features\` (existing register_wasm_dir tests still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)