### PR TITLE
chore(ci): drop dormant model-checking/kani-github-action wrapper

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -41,10 +41,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
-      - name: Install Kani
-        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
+      # Install Kani inline rather than via `model-checking/kani-github-action`.
+      # That action's repo HEAD hasn't moved since 2024-01-10 (~16 months at
+      # time of writing); its internal `action.yml` pulls in
+      # `actions/checkout@v3` and an unversioned `dtolnay/rust-toolchain@stable`,
+      # which is exactly the kind of unpinned/legacy dependency we audit out
+      # of every other workflow. The action's actual install step is just
+      # `cargo install --locked kani-verifier && cargo-kani setup` — inlining
+      # it lets us pin the toolchain explicitly and drop the third-party
+      # wrapper. Upstream Kani itself is healthy (latest 0.67.0 in
+      # 2026-01-16); only the action wrapper is dormant.
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
-          kani-version: 'latest'
+          toolchain: stable
+      - name: Install Kani
+        run: |
+          cargo install --locked kani-verifier
+          cargo-kani setup
       - name: Determine packages to verify
         id: packages
         run: |


### PR DESCRIPTION
## Summary

The Kani workflow was pinned to \`model-checking/kani-github-action@f8380966\` (v1.1) from **2024-01-10**. That action's repo hasn't received a single commit since — its HEAD is also 2024-01-10. So the audit finding "488 days behind HEAD" was technically false (the SHA matches an old-but-real release), but the deeper problem is real: the wrapper is dormant.

## Why retire the wrapper

Its \`action.yml\` internally does:

\`\`\`yaml
- uses: actions/checkout@v3              # legacy (we're on v6 elsewhere)
- uses: dtolnay/rust-toolchain@stable    # unpinned! (we SHA-pin elsewhere)
- run: install-kani.sh
\`\`\`

And \`install-kani.sh\` is just:

\`\`\`bash
cargo install --locked kani-verifier
cargo-kani setup
\`\`\`

We pin every action SHA in every other workflow. The wrapper pulling in legacy/unpinned transitives through its own \`action.yml\` quietly defeats that policy. And since the wrapper isn't being maintained, we're not getting "free updates" by depending on it.

## What changed

Inlined the two cargo commands and added an explicit \`dtolnay/rust-toolchain\` step pinned to the same SHA the rest of CI uses (\`3c5f7ea2\`).

## Not affected

- Kani itself is healthy — \`kani-verifier\` 0.67.0 shipped 2026-01-16. Only the GitHub Action wrapper is dormant.
- All other workflow logic in \`kani.yml\` (cron schedule, package selection, summary upload) is unchanged.

## Test plan

- [x] YAML still parses.
- [x] The only \`kani-github-action\` mention left in the file is the explanatory comment.
- [ ] The Kani job won't run on this PR (\`paths:\` gate doesn't match a workflow-only change), but next scheduled run will exercise the new install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)