### PR TITLE
chore(ci): refresh stale GitHub Action SHAs to current releases

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -76,7 +76,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install cargo-vet
-        uses: taiki-e/install-action@30791125b88ed3200de59e9b5edbf78d1949e41f # v2
+        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2
         with:
           tool: cargo-vet
       - name: Regenerate exemptions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install nextest
         if: matrix.install == 'nextest'
-        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
+        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
         with:
           tool: cargo-nextest
         continue-on-error: true

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -32,7 +32,7 @@ jobs:
             package.json
             package-lock.json
       - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v5
         with:
           node-version: 24
       - name: Install dependencies

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run opencode
-        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab # latest as of 2026-03-30
+        uses: anomalyco/opencode/github@2b92c5677e830e95d34fc3d5664a69297d2d0b51 # v1.15.4
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -65,7 +65,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run opencode (review and fix)
-        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
+        uses: anomalyco/opencode/github@2b92c5677e830e95d34fc3d5664a69297d2d0b51
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -107,7 +107,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run opencode (review only)
-        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
+        uses: anomalyco/opencode/github@2b92c5677e830e95d34fc3d5664a69297d2d0b51
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -144,7 +144,7 @@ jobs:
           persist-credentials: false
       - name: Run opencode (review and fix)
         if: inputs.action == 'review-and-fix'
-        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
+        uses: anomalyco/opencode/github@2b92c5677e830e95d34fc3d5664a69297d2d0b51
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -168,7 +168,7 @@ jobs:
                - Open a PR that closes the issue
       - name: Run opencode (review only)
         if: inputs.action == 'review-only'
-        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
+        uses: anomalyco/opencode/github@2b92c5677e830e95d34fc3d5664a69297d2d0b51
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:
@@ -221,7 +221,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run opencode on issue #${{ matrix.issue }}
-        uses: anomalyco/opencode/github@21d7a85e76983026bdd131b045f197386ef4c7ab
+        uses: anomalyco/opencode/github@2b92c5677e830e95d34fc3d5664a69297d2d0b51
         env:
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,7 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
-      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # cargo-deny
+      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        with:
+          tool: cargo-deny
       - name: Check advisories, licenses, and bans
         run: cargo deny check
   # Code coverage
@@ -51,7 +53,9 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # cargo-llvm-cov
+        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        with:
+          tool: cargo-llvm-cov
       - name: Generate coverage report
         run: |
           cargo llvm-cov --all-features --lcov --output-path lcov.info \

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
-      - uses: taiki-e/install-action@0fc09cf1c2f18a9f700d18b3d6eb8f7ee877c7a2 # cargo-deny
+      - uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # cargo-deny
       - name: Check advisories, licenses, and bans
         run: cargo deny check
   # Code coverage
@@ -51,7 +51,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@fb03c6692ef8fff8e8e84e2aa701f168d7ed3811 # cargo-llvm-cov
+        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # cargo-llvm-cov
       - name: Generate coverage report
         run: |
           cargo llvm-cov --all-features --lcov --output-path lcov.info \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -121,7 +121,7 @@ jobs:
           components: llvm-tools-preview
       - name: Install cross
         if: matrix.cross
-        uses: taiki-e/install-action@db5fe14d0f31ad3d2c6c8dbee23472867de1cc54 # cross
+        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # cross
       - name: Install cargo-pgo
         if: matrix.pgo
         run: cargo install cargo-pgo
@@ -400,7 +400,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -121,7 +121,9 @@ jobs:
           components: llvm-tools-preview
       - name: Install cross
         if: matrix.cross
-        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # cross
+        uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0
+        with:
+          tool: cross
       - name: Install cargo-pgo
         if: matrix.pgo
         run: cargo install cargo-pgo

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -215,7 +215,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -383,7 +383,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -436,7 +436,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Following up on the workflow audit, four pinned actions were trailing their latest released tag. Bumping them in one focused PR.

| Action | Old SHA | New SHA | Tag |
|---|---|---|---|
| \`actions/setup-node\` | a0853c24 | 48b55a01 | v6.4.0 |
| \`taiki-e/install-action\` (5 pins consolidated) | mixed | 7be9fd86 | v2.79.0 |
| \`anomalyco/opencode/github\` (6 call sites in one file) | 21d7a85e | 2b92c567 | v1.15.4 |
| \`actions/create-github-app-token\` | 1b10c78c | bcd2ba49 | v3.2.0 |

## Not in scope

Several other pins flagged "N days behind HEAD" in the audit but actually match their **current released tag**: \`peter-evans/repository-dispatch\` v4.0.1, \`actions/setup-java\`, \`actions/setup-python\`, \`Swatinem/rust-cache\` v2.9.1, \`rust-lang/crates-io-auth-action\`, \`docker/{setup-qemu,metadata,setup-buildx}-action\`, \`codecov/codecov-action\`, \`softprops/action-gh-release\`. Master commits past the last release tag aren't worth chasing.

## Workflows touched

ci.yml · quality.yml · cargo-vet-auto.yml · release-build.yml · release-publish.yml · docs-update.yml · docs-validate.yml · opencode.yml

## Test plan

- [x] All YAML still parses.
- [x] No leftover references to any of the old SHAs.
- [ ] CI for the bumped actions will exercise the new SHAs on this PR (most relevant: \`taiki-e/install-action\` runs in the \`Test\` job's nextest install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)