### PR TITLE
chore(docker): bump Dockerfile rust base 1.83-alpine -> 1.95-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Produces a minimal image with static musl binaries
 
 # Build stage
-FROM rust:1.83-alpine AS builder
+FROM rust:1.95-alpine AS builder
 
 RUN apk add --no-cache musl-dev
 


### PR DESCRIPTION
## Summary

One-line bump: 12 minor versions of Rust behind.

## Scope

This is the **dev-convenience** \`Dockerfile\` at repo root, for local \`docker build .\` workflows. Release Docker images are built via an inline \`FROM scratch\` Dockerfile generated in \`release-publish.yml\` that just copies pre-built musl binaries — those are **not** affected by this bump.

## Risk

Low. Tag verified available on Docker Hub. No \`Dockerfile\`-using CI job to run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)