### PR TITLE
chore(deps): bump TypeScript 5 -> 6 in mcp-server + vscode

### DIFF
--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.0",
         "vitest": "^4.0.17"
       },
       "engines": {
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.0",
     "vitest": "^4.0.17"
   },
   "engines": {

--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -16,7 +16,7 @@
         "@types/vscode": "^1.82.0",
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",
-        "typescript": "^5.5.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "vscode": "^1.82.0"
@@ -4251,9 +4251,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -99,7 +99,7 @@
     "@types/vscode": "^1.82.0",
     "@vscode/vsce": "^3.0.0",
     "esbuild": "^0.25.0",
-    "typescript": "^5.5.0"
+    "typescript": "^6.0.0"
   },
   "overrides": {
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Summary

Last item from the dep-audit menu (D→E→F). TypeScript major-version bump in both Node packages.

## Bumps

| Package | Before | After |
|---|---|---|
| \`packages/mcp-server\` | \`typescript ^5.7.0\` | \`typescript ^6.0.0\` |
| \`packages/vscode\` | \`typescript ^5.5.0\` | \`typescript ^6.0.0\` |

## Not bumped

- \`@types/node\` in mcp-server stays \`^24.0.0\` (matches \`.nvmrc\` Node 24 LTS from PR #1144). The original audit suggested \`^25\`, but that targets the *current-but-non-LTS* Node 25 line — would mismatch our pinned runtime.
- \`@types/node\` in vscode stays \`^22.0.0\` (matches VS Code's extension-host runtime, also from PR #1144).

## Test plan

- [x] mcp-server: \`tsc\` clean, **166/166 vitest tests pass**
- [x] vscode: \`tsc\` clean, \`npm run package\` produces \`rustledger-vscode.vsix\` (105 KB) without errors

Surprisingly clean — TypeScript 6 didn't surface any breaking changes in either codebase. No source code edits required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)