### PR TITLE
chore(tsconfig): adjust both packages for TS 6 conventions

### DIFF
--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2024",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2022"],
+    "lib": ["ES2024"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -2,13 +2,25 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
+    // Explicit `node10` (the historical default for `module: commonjs`).
+    // TS 6 deprecates this name but still accepts it under
+    // `ignoreDeprecations: "6.0"` — kept here because VS Code's extension
+    // publisher tooling (`@vscode/vsce`) hasn't sanctioned the
+    // `nodenext`/`bundler` migration path for extensions yet. Revisit
+    // before adopting TS 7.
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2020"],
     "outDir": "./out",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    // Lock in what was previously auto-included. TS 6 changes the
+    // default to `[]`; pinning explicitly avoids a silent regression
+    // when we eventually drop `ignoreDeprecations`.
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "out"]


### PR DESCRIPTION
## Summary

Two small tsconfig.json tweaks now that we're on TS 6 (PR #1146):

### \`packages/mcp-server\`

\`target\`/\`lib\` \`ES2022\` → \`ES2024\`. Node 24 is pinned via \`.nvmrc\` (#1144), so we can use ES2024 built-ins (\`Object.groupBy\`, \`Promise.withResolvers\`, etc.) without runtime-availability concerns. Deliberately stopping short of ES2025 to avoid tying us to APIs that need the very latest Node minor.

### \`packages/vscode\`

- Add explicit \`moduleResolution: "node10"\` + \`ignoreDeprecations: "6.0"\`. TS 6 deprecates the implicit \`node10\` resolution. Can't migrate to \`nodenext\`/\`bundler\` yet because \`@vscode/vsce\` (the extension publisher tooling) hasn't sanctioned that path. Comment in-line documents when to revisit (TS 7 adoption).
- Add explicit \`types: ["node"]\`. TS 6 changes the default from \`[<all auto-included>]\` to \`[]\`. Locking it explicitly avoids a silent type-loss regression when we eventually drop \`ignoreDeprecations\`.

## Skipped (no payoff in our code)

The flashy TS 6 features don't have natural insertion points:

| Feature | Why not |
|---|---|
| Subpath imports (\`#/\`) | 8 sibling files in mcp-server; no deep \`../../\` patterns. |
| \`Map.getOrInsert\` / \`RegExp.escape\` / Temporal | No natural insertion points found; would be speculative refactor. |
| \`--stableTypeOrdering\` flag | TS 7 prep with ~25% type-check overhead; not worth it until we're actively migrating. |

## Test plan

- [x] mcp-server: \`tsc\` clean; **166/166 vitest tests pass**
- [x] vscode: \`tsc\` clean; \`npm run package\` produces \`rustledger-vscode.vsix\` (105 KB) without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)