### PR TITLE
fix(buildrs): capture sub-cargo stderr + extend env scrub

### DIFF
--- a/crates/rustledger-importer/build.rs
+++ b/crates/rustledger-importer/build.rs
@@ -82,18 +82,30 @@ fn main() {
     //   wasm32 runtime support and aborts the fixture compile with a
     //   linker error. Scrubbing also prevents the host's `-Dwarnings`
     //   from breaking the fixture on a future plugin-types deprecation.
-    // - `CARGO_BUILD_TARGET`: would override `--target` (rare, but
-    //   propagates from `cargo-llvm-cov` and from some Nix shells).
-    // - `CARGO_BUILD_RUSTFLAGS`: same shape, same risk.
+    // - `CARGO_BUILD_TARGET` / `CARGO_BUILD_RUSTFLAGS`: same shape, same risk.
+    // - `RUSTDOCFLAGS`: cargo-llvm-cov sets this in tandem with
+    //   `RUSTFLAGS`; harmless for `cargo build` but cleaner not to inherit.
+    // - `CARGO_INCREMENTAL`: cargo-llvm-cov forces 0; we want the
+    //   fixture's own default.
+    // - `LLVM_PROFILE_FILE`: runtime profile output path; doesn't apply
+    //   to compilation, but scrubbing keeps the sub-build deterministic.
     //
     // Don't scrub `CARGO_TARGET_DIR` — `--target-dir` on the command
     // line takes precedence anyway, and clearing it would defeat
     // caching.
-    let status = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+    //
+    // Capture (rather than inherit) stdout/stderr so the actual
+    // compile errors from the sub-cargo surface as `cargo:warning=`
+    // lines on failure. Cargo's default build-script protocol swallows
+    // inherited stderr; we explicitly re-emit it below.
+    let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
         .env_remove("RUSTFLAGS")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("CARGO_BUILD_RUSTFLAGS")
         .env_remove("CARGO_BUILD_TARGET")
+        .env_remove("RUSTDOCFLAGS")
+        .env_remove("CARGO_INCREMENTAL")
+        .env_remove("LLVM_PROFILE_FILE")
         .args([
             "build",
             "--release",
@@ -104,10 +116,10 @@ fn main() {
         .arg(fixture_dir.join("Cargo.toml"))
         .arg("--target-dir")
         .arg(&target_dir)
-        .status();
+        .output();
 
-    match status {
-        Ok(s) if s.success() => {
+    match output {
+        Ok(out) if out.status.success() => {
             let built = target_dir
                 .join("wasm32-unknown-unknown")
                 .join("release")
@@ -121,13 +133,18 @@ fn main() {
             }
             std::fs::copy(&built, &sentinel).expect("copy stub wasm to OUT_DIR");
         }
-        Ok(s) => {
+        Ok(out) => {
             // Non-zero exit. Common cause locally: wasm32 target not
-            // installed. Other causes (compile error, ABI break) are
-            // real bugs — surfaced to the user via CI's panic path
-            // when the e2e test sees a missing sentinel.
+            // installed. Other causes (compile error, ABI break,
+            // env-leak from coverage tooling) are real bugs — surface
+            // the sub-cargo's actual stderr so reviewers can debug
+            // without re-running locally.
+            for line in String::from_utf8_lossy(&out.stderr).lines() {
+                println!("cargo:warning=sample_stub stderr: {line}");
+            }
             println!(
-                "cargo:warning=cargo build for sample_stub fixture exited {s}; e2e test will skip (local) or panic (CI)"
+                "cargo:warning=cargo build for sample_stub fixture exited {}; e2e test will skip (local) or panic (CI)",
+                out.status
             );
         }
         Err(e) => {

--- a/crates/rustledger-importer/build.rs
+++ b/crates/rustledger-importer/build.rs
@@ -106,7 +106,19 @@ fn main() {
         .env_remove("RUSTDOCFLAGS")
         .env_remove("CARGO_INCREMENTAL")
         .env_remove("LLVM_PROFILE_FILE")
+        // `cargo-llvm-cov` v0.6+ injects coverage rustflags via cargo's
+        // `--config 'build.rustflags=[...]'` arg, which propagates to
+        // sub-cargos through cargo's config merging (NOT via env vars
+        // we scrubbed above). The wasm32 stable toolchain ships no
+        // `profiler_builtins` crate, so `-Cinstrument-coverage` leaking
+        // through produces `error[E0463]: can't find crate for
+        // 'profiler_builtins'`. Counter it at maximum priority: pass
+        // our own `--config` that empties the rustflags for the wasm32
+        // target. Command-line `--config` beats env beats config file
+        // in cargo's merge order.
         .args([
+            "--config",
+            "target.wasm32-unknown-unknown.rustflags=[]",
             "build",
             "--release",
             "--target",

--- a/crates/rustledger-plugin/build.rs
+++ b/crates/rustledger-plugin/build.rs
@@ -66,23 +66,21 @@ fn main() {
 
     let target_dir = out_dir.join("sample_stub_target");
 
-    // Scrub env vars that don't make sense for the inner wasm32 build:
+    // Scrub env vars that don't make sense for the inner wasm32 build.
+    // Mirrors `rustledger-importer/build.rs`; see that file for the
+    // full rationale.
     //
-    // - `RUSTFLAGS` / `CARGO_ENCODED_RUSTFLAGS`: under `cargo-llvm-cov`
-    //   the outer build sets `-C instrument-coverage`, which has no
-    //   wasm32 runtime support and aborts the fixture compile with a
-    //   linker error.
-    // - `CARGO_BUILD_TARGET` / `CARGO_BUILD_RUSTFLAGS`: same shape,
-    //   same risk.
-    //
-    // Don't scrub `CARGO_TARGET_DIR` — `--target-dir` on the command
-    // line takes precedence anyway, and clearing it would defeat
-    // caching.
-    let status = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+    // Capture (rather than inherit) stdout/stderr so the actual
+    // compile errors from the sub-cargo surface as `cargo:warning=`
+    // lines on failure.
+    let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
         .env_remove("RUSTFLAGS")
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("CARGO_BUILD_RUSTFLAGS")
         .env_remove("CARGO_BUILD_TARGET")
+        .env_remove("RUSTDOCFLAGS")
+        .env_remove("CARGO_INCREMENTAL")
+        .env_remove("LLVM_PROFILE_FILE")
         .args([
             "build",
             "--release",
@@ -93,10 +91,10 @@ fn main() {
         .arg(fixture_dir.join("Cargo.toml"))
         .arg("--target-dir")
         .arg(&target_dir)
-        .status();
+        .output();
 
-    match status {
-        Ok(s) if s.success() => {
+    match output {
+        Ok(out) if out.status.success() => {
             let built = target_dir
                 .join("wasm32-unknown-unknown")
                 .join("release")
@@ -110,9 +108,13 @@ fn main() {
             }
             std::fs::copy(&built, &sentinel).expect("copy stub wasm to OUT_DIR");
         }
-        Ok(s) => {
+        Ok(out) => {
+            for line in String::from_utf8_lossy(&out.stderr).lines() {
+                println!("cargo:warning=sample_stub plugin stderr: {line}");
+            }
             println!(
-                "cargo:warning=cargo build for sample_stub plugin fixture exited {s}; e2e test will skip (local) or panic (CI)"
+                "cargo:warning=cargo build for sample_stub plugin fixture exited {}; e2e test will skip (local) or panic (CI)",
+                out.status
             );
         }
         Err(e) => {

--- a/crates/rustledger-plugin/build.rs
+++ b/crates/rustledger-plugin/build.rs
@@ -81,7 +81,13 @@ fn main() {
         .env_remove("RUSTDOCFLAGS")
         .env_remove("CARGO_INCREMENTAL")
         .env_remove("LLVM_PROFILE_FILE")
+        // See `rustledger-importer/build.rs` for the full rationale:
+        // cargo-llvm-cov injects coverage rustflags via cargo's
+        // `--config` which propagates to sub-cargos. Override it
+        // explicitly at command-line priority.
         .args([
+            "--config",
+            "target.wasm32-unknown-unknown.rustflags=[]",
             "build",
             "--release",
             "--target",


### PR DESCRIPTION
## Summary

Code Coverage on main has been failing since #1141 merged. The \`wasm_importer_e2e\` / \`wasm_plugin_e2e\` tests panic with "sentinel missing" because the fixture's sub-cargo \`build.rs\` exits 101 — but the sub-cargo's stderr was being swallowed, so we couldn't see *why*.

## Two changes

**1. Capture stderr.** Switch from \`Command::status()\` to \`Command::output()\` and explicitly re-emit captured stderr as \`cargo:warning=sample_stub stderr: ...\` lines on failure. Next failed run surfaces the actual compile error inline in CI logs.

**2. Extend the env-scrub list defensively** in both \`build.rs\` files:
- \`RUSTDOCFLAGS\` (cargo-llvm-cov sets in tandem with \`RUSTFLAGS\`)
- \`CARGO_INCREMENTAL\` (cargo-llvm-cov forces 0)
- \`LLVM_PROFILE_FILE\` (runtime profile path)

If one of these three was the culprit, this PR alone resolves Code Coverage. If not, the captured stderr from change #1 will diagnose it on the next CI run.

## Test plan

- [x] Local \`cargo check -p rustledger-importer -p rustledger-plugin --all-features\` clean.
- [ ] CI's Code Coverage job: either passes (defensive scrub fixed it) or surfaces the actual compile error in its logs (diagnostic worked).

## Context

Files: \`crates/rustledger-importer/build.rs\` + \`crates/rustledger-plugin/build.rs\` (sibling files; identical shape). Memory entry: \`feedback_buildrs_sub_cargo_gotchas\` documents the four guards we already had — this extends the env-scrub guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)