### PR TITLE
fix(lsp): use posting.span in formatters, preserving metadata (closes #1142)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -9,7 +9,7 @@ use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Default column for amount alignment.
 const AMOUNT_COLUMN: usize = 50;
@@ -22,6 +22,10 @@ pub fn handle_formatting(
 ) -> Option<Vec<TextEdit>> {
     let mut edits = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
+    // Build the line index once: O(n) up front, O(log lines) per
+    // offset lookup. Without it, calling the naive O(n) scanner per
+    // posting per transaction is quadratic on large files.
+    let line_index = LineIndex::new(source);
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
@@ -39,7 +43,7 @@ pub fn handle_formatting(
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
-                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
+                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
                     && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
                 {
@@ -245,8 +249,11 @@ mod tests {
 
         let edits = handle_formatting(&params, source, &result).unwrap_or_default();
 
-        // Identify the metadata-line indices in the source: lines that
-        // start with the `effective_date:` key after four-space indent.
+        // Identify the metadata-line indices in the source: lines whose
+        // first non-whitespace content is the `effective_date:` key.
+        // (The canonical form uses four-space indent, but the check
+        // accepts any indentation so a future test fixture variation
+        // doesn't silently start matching the wrong lines.)
         let metadata_lines: Vec<u32> = source
             .lines()
             .enumerate()

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -32,8 +32,10 @@ pub fn handle_formatting(
             // the formatter then overwrote with posting content — see
             // issue #1142.
             for spanned_posting in &txn.postings {
-                // Skip plugin-synthesized postings: they have no source
-                // location to format.
+                // Defensive: the LSP formats parser-derived directives,
+                // which always carry real spans. Guard against
+                // `Spanned::synthesized` entries in case a future
+                // integration feeds loader/plugin output through here.
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
@@ -255,6 +257,7 @@ mod tests {
             })
             .collect();
         assert_eq!(metadata_lines, vec![2, 4], "test source layout assumption");
+        let posting_lines: [u32; 2] = [1, 3];
 
         // No emitted edit should touch a metadata line. Pre-fix, the
         // line-arithmetic bug produced a posting-shaped edit at line 2
@@ -265,5 +268,14 @@ mod tests {
                 "edit targets a metadata line — issue #1142 regressed: {edit:?}"
             );
         }
+        // Positive assertion: the formatter must still do its job on
+        // the real posting lines (otherwise a degenerate "emit zero
+        // edits" implementation would silently pass the test).
+        assert!(
+            edits
+                .iter()
+                .any(|e| posting_lines.contains(&e.range.start.line)),
+            "formatter emitted no edits for posting lines — alignment broken"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -6,7 +6,7 @@
 //! - Consistent spacing around operators
 
 use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::byte_offset_to_position;
@@ -25,14 +25,21 @@ pub fn handle_formatting(
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
-
-            // Format each posting
-            for (i, posting) in txn.postings.iter().enumerate() {
-                let posting_line = start_line + 1 + i as u32;
-
+            // Format each posting using its own source span, not a
+            // line-arithmetic guess from the directive's start_line.
+            // Interleaved posting-level metadata (e.g., `effective_date:`)
+            // makes `start_line + 1 + i` point at metadata lines, which
+            // the formatter then overwrote with posting content — see
+            // issue #1142.
+            for spanned_posting in &txn.postings {
+                // Skip plugin-synthesized postings: they have no source
+                // location to format.
+                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                    continue;
+                }
+                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
-                    && let Some(edit) = format_posting_line(line, posting_line, posting)
+                    && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
                 {
                     edits.push(edit);
                 }
@@ -197,5 +204,66 @@ mod tests {
         let edits = edits.unwrap();
         // Should have edit to replace tab
         assert!(edits.iter().any(|e| e.new_text.contains("  ")));
+    }
+
+    /// Regression test for issue #1142.
+    ///
+    /// When a transaction has posting-level metadata interleaved between
+    /// postings (e.g., `effective_date:`), the previous formatter
+    /// computed each posting's line as `txn_start_line + 1 + posting_idx`
+    /// and so produced TextEdits targeting metadata lines instead of
+    /// posting lines. Applying those edits overwrote the metadata. This
+    /// test pins the post-fix behavior: emitted edits target only the
+    /// posting lines and never the metadata lines between them.
+    #[test]
+    fn test_formatting_preserves_interleaved_metadata_1142() {
+        // Note the two-space indentation on postings vs four-space on
+        // metadata — this is the canonical effective_date format.
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -50.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food  50.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edits = handle_formatting(&params, source, &result).unwrap_or_default();
+
+        // Identify the metadata-line indices in the source: lines that
+        // start with the `effective_date:` key after four-space indent.
+        let metadata_lines: Vec<u32> = source
+            .lines()
+            .enumerate()
+            .filter_map(|(i, line)| {
+                line.trim_start()
+                    .starts_with("effective_date:")
+                    .then_some(i as u32)
+            })
+            .collect();
+        assert_eq!(metadata_lines, vec![2, 4], "test source layout assumption");
+
+        // No emitted edit should touch a metadata line. Pre-fix, the
+        // line-arithmetic bug produced a posting-shaped edit at line 2
+        // (the first metadata line), overwriting it.
+        for edit in &edits {
+            assert!(
+                !metadata_lines.contains(&edit.range.start.line),
+                "edit targets a metadata line — issue #1142 regressed: {edit:?}"
+            );
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -65,6 +65,10 @@ pub fn handle_range_formatting(
             }
 
             for spanned_posting in &txn.postings {
+                // Defensive: the LSP formats parser-derived directives,
+                // which always carry real spans. Guard against
+                // `Spanned::synthesized` entries in case a future
+                // integration feeds loader/plugin output through here.
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
@@ -213,5 +217,60 @@ mod tests {
                 "edit targets a metadata line — issue #1142 regressed: {edit:?}"
             );
         }
+        // No positive "must produce an edit" assertion here: range
+        // formatting only emits edits when something actually needs
+        // changing, and this source is already correctly formatted.
+        // Emitting zero edits IS the right outcome — see the
+        // `_misindented` variant below for the positive case.
+    }
+
+    /// Companion to the regression test above: with a *misindented*
+    /// posting interleaved with metadata, range formatting should
+    /// produce a fix for the posting and still leave the metadata
+    /// alone. Catches a future regression that silently short-circuits
+    /// the formatter (the all-correct test above can't tell those
+    /// apart from a working fix).
+    #[test]
+    fn test_range_formatting_fixes_misindented_posting_without_touching_metadata() {
+        // Note: posting 1 has 4-space indent (should be 2).
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -50.00 USD
+    effective_date: 2024-01-20
+    Expenses:Food  50.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentRangeFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(5, 0),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edits = handle_range_formatting(&params, source, &result).unwrap_or_default();
+        let metadata_lines = [2u32, 4u32];
+
+        for edit in &edits {
+            assert!(
+                !metadata_lines.contains(&edit.range.start.line),
+                "edit targets a metadata line — issue #1142 regressed: {edit:?}"
+            );
+        }
+        assert!(
+            edits.iter().any(|e| e.range.start.line == 3),
+            "expected an edit at the misindented posting (line 3); got {edits:?}"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -6,7 +6,7 @@ use lsp_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Handle a range formatting request.
 pub fn handle_range_formatting(
@@ -17,6 +17,10 @@ pub fn handle_range_formatting(
     let range = params.range;
     let mut edits = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
+    // Build the line index once so per-posting offset→line lookups are
+    // O(log lines) instead of O(n). On a large file with many
+    // transactions, the naive scanner would otherwise dominate.
+    let line_index = LineIndex::new(source);
 
     // Process lines within the range
     for line_num in range.start.line..=range.end.line {
@@ -57,7 +61,7 @@ pub fn handle_range_formatting(
     // assumption and caused #1142.
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
             // Check if transaction overlaps with range
             if start_line > range.end.line {
@@ -72,7 +76,7 @@ pub fn handle_range_formatting(
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
-                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
+                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
 
                 // Check if posting is within range
                 if posting_line >= range.start.line

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -3,7 +3,7 @@
 //! Formats only the selected range of the document.
 
 use lsp_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::byte_offset_to_position;
@@ -50,7 +50,11 @@ pub fn handle_range_formatting(
         }
     }
 
-    // Format postings within transactions in the range
+    // Format postings within transactions in the range. Look up each
+    // posting's line from its own source span, not via line arithmetic
+    // off the transaction header — interleaved posting-level metadata
+    // (e.g., `effective_date:`) breaks the `start_line + 1 + i`
+    // assumption and caused #1142.
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
             let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
@@ -60,14 +64,17 @@ pub fn handle_range_formatting(
                 continue;
             }
 
-            for (i, posting) in txn.postings.iter().enumerate() {
-                let posting_line = start_line + 1 + i as u32;
+            for spanned_posting in &txn.postings {
+                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                    continue;
+                }
+                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
 
                 // Check if posting is within range
                 if posting_line >= range.start.line
                     && posting_line <= range.end.line
                     && let Some(line) = lines.get(posting_line as usize)
-                    && let Some(edit) = format_posting_line(line, posting_line, posting)
+                    && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
                 {
                     // Don't duplicate edits
                     if !edits.iter().any(|e| e.range.start.line == posting_line) {
@@ -150,5 +157,61 @@ mod tests {
 
         let edits = handle_range_formatting(&params, source, &result);
         assert!(edits.is_some());
+    }
+
+    /// Regression test for issue #1142 (range-formatting variant).
+    ///
+    /// Pre-fix, `posting_line = start_line + 1 + i` pointed at the
+    /// metadata lines between postings, and the formatter emitted
+    /// posting-shaped edits that overwrote them. See the matching test
+    /// on `formatting.rs` for the full reasoning.
+    #[test]
+    fn test_range_formatting_preserves_interleaved_metadata_1142() {
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -50.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food  50.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentRangeFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            // Cover the full transaction.
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(5, 0),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edits = handle_range_formatting(&params, source, &result).unwrap_or_default();
+
+        let metadata_lines: Vec<u32> = source
+            .lines()
+            .enumerate()
+            .filter_map(|(i, line)| {
+                line.trim_start()
+                    .starts_with("effective_date:")
+                    .then_some(i as u32)
+            })
+            .collect();
+        assert_eq!(metadata_lines, vec![2, 4], "test source layout assumption");
+
+        for edit in &edits {
+            assert!(
+                !metadata_lines.contains(&edit.range.start.line),
+                "edit targets a metadata line — issue #1142 regressed: {edit:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1142.

The LSP's document-formatting and range-formatting handlers computed each posting's source line as `txn_start_line + 1 + posting_idx`. That works only when postings sit on consecutive lines — and breaks the moment a transaction has posting-level metadata interleaved between postings, as the `effective_date:` plugin convention does:

```beancount
2024-01-15 * "Test"
  Assets:Bank  -50.00 USD
    effective_date: 2024-01-20
  Expenses:Food  50.00 USD
    effective_date: 2024-01-21
```

The second posting is on line 3, not line 2. The handlers emitted a posting-shaped `TextEdit` targeting line 2, **overwriting the metadata line with formatted posting content**. The reporter saw the file silently mangled every time their editor (nvim, VS Code, etc.) ran format-on-save.

The fix uses the per-posting source span landed by #1151 (`Vec<Spanned<Posting>>`): look up each posting's line directly from `spanned.span.start`. The line-arithmetic assumption is gone.

## What changed

- `handlers/formatting.rs` and `handlers/range_formatting.rs` now iterate `txn.postings` as `&[Spanned<Posting>]`, derive each posting's line via `byte_offset_to_position(source, p.span.start)`, and skip plugin-synthesized postings (`file_id == SYNTHESIZED_FILE_ID`) which have no source location.

## Regression tests pin the contract

- Both handlers get a `test_*_preserves_interleaved_metadata_1142` test that builds the canonical `effective_date:` source, runs the handler, and asserts no emitted edit targets a metadata line.
- I verified the test correctly **fails** against the pre-fix code (applied the new test alone against the buggy implementation — it caught the bug at the exact location reported).

## Out of scope (audit-identified follow-ups)

The same `start_line + 1 + i` anti-pattern lives in 11 other LSP handlers:

`call_hierarchy.rs`, `document_highlight.rs`, `selection_range.rs`, `linked_editing.rs`, `code_actions.rs`, `inlay_hints.rs`, `document_color.rs`, `execute_command.rs`, `references.rs`, `on_type_formatting.rs`, `symbols.rs`.

These handlers are **read-only** — they produce wrong highlights / hovers / navigation targets in the same scenarios but cannot corrupt files. Each warrants its own audit + tests + PR rather than a blind sweep here.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `cargo test -p rustledger-lsp --all-features` — **130 tests, 0 failures** (incl. 2 new regression tests)
- [x] `cargo fmt --all -- --check`
- [x] Verified new tests fail against pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
