### PR TITLE
fix(lsp): sweep read-only handlers to use posting.span (refs #1142)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
+++ b/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
@@ -11,7 +11,7 @@ use lsp_types::{
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     Position, Range, SymbolKind, Uri,
 };
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
@@ -102,11 +102,18 @@ pub fn handle_incoming_calls(
             // Build transaction description
             let description = format!("{} {} \"{}\"", txn.date, txn.flag, txn.narration.as_ref());
 
-            // Find the ranges where this account appears in the transaction
+            // Find the ranges where this account appears in the
+            // transaction. Per-posting span lookup (see #1142): the
+            // prior `txn_line + 1 + idx` arithmetic broke for
+            // transactions with interleaved posting-level metadata.
             let from_ranges: Vec<Range> = posting_indices
                 .iter()
                 .filter_map(|&idx| {
-                    let posting_line = txn_line + 1 + idx as u32;
+                    let sp = txn.postings.get(idx)?;
+                    if sp.file_id == SYNTHESIZED_FILE_ID {
+                        return None;
+                    }
+                    let (posting_line, _) = byte_offset_to_position(source, sp.span.start);
                     let line_text = source.lines().nth(posting_line as usize)?;
                     let col = line_text.find(account)?;
                     Some(Range {
@@ -120,6 +127,12 @@ pub fn handle_incoming_calls(
                 continue;
             }
 
+            // Compute the transaction's full source range from the
+            // outer directive span. The prior heuristic of
+            // `txn_line + postings.len() + 1` under-counted lines
+            // whenever the transaction had interleaved metadata or
+            // pre-posting comments (same root cause as #1142).
+            let (txn_end_line, _) = byte_offset_to_position(source, spanned.span.end);
             let txn_item = CallHierarchyItem {
                 name: description,
                 kind: SymbolKind::EVENT, // Use Event for transactions
@@ -128,7 +141,7 @@ pub fn handle_incoming_calls(
                 uri: uri.clone(),
                 range: Range {
                     start: Position::new(txn_line, 0),
-                    end: Position::new(txn_line + txn.postings.len() as u32 + 1, 0),
+                    end: Position::new(txn_end_line.saturating_add(1), 0),
                 },
                 selection_range: Range {
                     start: Position::new(txn_line, 0),
@@ -195,8 +208,13 @@ pub fn handle_outgoing_calls(
                     let (_acc_line, acc_range) = match account_location {
                         Some(loc) => loc,
                         None => {
-                            // Fallback: use first posting location
-                            let posting_line = line + 1 + indices[0] as u32;
+                            // Fallback: use first posting location, looked
+                            // up via its span (see #1142).
+                            let sp = txn.postings.get(indices[0])?;
+                            if sp.file_id == SYNTHESIZED_FILE_ID {
+                                return None;
+                            }
+                            let (posting_line, _) = byte_offset_to_position(source, sp.span.start);
                             let line_text = source.lines().nth(posting_line as usize)?;
                             let col = line_text.find(&account)?;
                             (
@@ -209,11 +227,17 @@ pub fn handle_outgoing_calls(
                         }
                     };
 
-                    // Ranges where this account is "called" from the transaction
+                    // Ranges where this account is "called" from the
+                    // transaction (per-posting span lookup, see #1142).
+                    let _ = line; // formerly used in the arithmetic
                     let from_ranges: Vec<Range> = indices
                         .iter()
                         .filter_map(|&idx| {
-                            let posting_line = line + 1 + idx as u32;
+                            let sp = txn.postings.get(idx)?;
+                            if sp.file_id == SYNTHESIZED_FILE_ID {
+                                return None;
+                            }
+                            let (posting_line, _) = byte_offset_to_position(source, sp.span.start);
                             let line_text = source.lines().nth(posting_line as usize)?;
                             let col = line_text.find(&account)?;
                             Some(Range {

--- a/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
+++ b/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
@@ -132,7 +132,19 @@ pub fn handle_incoming_calls(
             // `txn_line + postings.len() + 1` under-counted lines
             // whenever the transaction had interleaved metadata or
             // pre-posting comments (same root cause as #1142).
-            let (txn_end_line, _) = byte_offset_to_position(source, spanned.span.end);
+            //
+            // `spanned.span.end` is an *exclusive* byte offset that
+            // typically already points at the start of the next line
+            // (the parser consumes the trailing newline). Use the
+            // resulting (line, col) directly; only normalize to the
+            // next line when the end column is non-zero (i.e. the
+            // span ends mid-line and the LSP range needs to round up).
+            let (txn_end_line, txn_end_col) = byte_offset_to_position(source, spanned.span.end);
+            let normalized_end_line = if txn_end_col == 0 {
+                txn_end_line
+            } else {
+                txn_end_line.saturating_add(1)
+            };
             let txn_item = CallHierarchyItem {
                 name: description,
                 kind: SymbolKind::EVENT, // Use Event for transactions
@@ -141,7 +153,7 @@ pub fn handle_incoming_calls(
                 uri: uri.clone(),
                 range: Range {
                     start: Position::new(txn_line, 0),
-                    end: Position::new(txn_end_line.saturating_add(1), 0),
+                    end: Position::new(normalized_end_line, 0),
                 },
                 selection_range: Range {
                     start: Position::new(txn_line, 0),
@@ -229,7 +241,6 @@ pub fn handle_outgoing_calls(
 
                     // Ranges where this account is "called" from the
                     // transaction (per-posting span lookup, see #1142).
-                    let _ = line; // formerly used in the arithmetic
                     let from_ranges: Vec<Range> = indices
                         .iter()
                         .filter_map(|&idx| {

--- a/crates/rustledger-lsp/src/handlers/document_color.rs
+++ b/crates/rustledger-lsp/src/handlers/document_color.rs
@@ -9,10 +9,10 @@ use lsp_types::{
     Color, ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
     Position, Range,
 };
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Red color for negative amounts.
 const COLOR_NEGATIVE: Color = Color {
@@ -45,18 +45,26 @@ pub fn handle_document_color(
     parse_result: &ParseResult,
 ) -> Option<Vec<ColorInformation>> {
     let mut colors = Vec::new();
+    let line_index = LineIndex::new(source);
+    let lines: Vec<&str> = source.lines().collect();
 
     for spanned in &parse_result.directives {
         match &spanned.value {
             Directive::Transaction(txn) => {
-                let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
-
-                for (i, posting) in txn.postings.iter().enumerate() {
+                // Per-posting span lookup (see #1142): the prior
+                // `start_line + 1 + i` arithmetic broke whenever a
+                // transaction had interleaved posting-level metadata.
+                for spanned_posting in &txn.postings {
+                    if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                        continue;
+                    }
+                    let posting = &**spanned_posting;
                     if let Some(units) = &posting.units
                         && let Some(number) = units.number()
                     {
-                        let posting_line = start_line + 1 + i as u32;
-                        let line_text = source.lines().nth(posting_line as usize).unwrap_or("");
+                        let (posting_line, _) =
+                            line_index.offset_to_position(spanned_posting.span.start);
+                        let line_text = lines.get(posting_line as usize).copied().unwrap_or("");
 
                         // Find the amount in the line
                         let amount_str = number.to_string();
@@ -76,7 +84,7 @@ pub fn handle_document_color(
                 }
             }
             Directive::Balance(bal) => {
-                let (line, _) = byte_offset_to_position(source, spanned.span.start);
+                let (line, _) = line_index.offset_to_position(spanned.span.start);
                 let line_text = source.lines().nth(line as usize).unwrap_or("");
 
                 let amount_str = bal.amount.number.to_string();
@@ -93,7 +101,7 @@ pub fn handle_document_color(
                 }
             }
             Directive::Price(price) => {
-                let (line, _) = byte_offset_to_position(source, spanned.span.start);
+                let (line, _) = line_index.offset_to_position(spanned.span.start);
                 let line_text = source.lines().nth(line as usize).unwrap_or("");
 
                 let amount_str = price.amount.number.to_string();

--- a/crates/rustledger-lsp/src/handlers/document_highlight.rs
+++ b/crates/rustledger-lsp/src/handlers/document_highlight.rs
@@ -8,7 +8,7 @@
 use lsp_types::{
     DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams, Position, Range,
 };
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::{
@@ -143,9 +143,16 @@ fn collect_account_highlights(
                 }
             }
             Directive::Transaction(txn) => {
-                for (i, posting) in txn.postings.iter().enumerate() {
-                    if posting.account.as_ref() == account {
-                        let posting_line = start_line + 1 + i as u32;
+                // Per-posting span lookup (see #1142): the prior
+                // `start_line + 1 + i` arithmetic broke whenever a
+                // transaction had interleaved posting-level metadata.
+                for spanned_posting in &txn.postings {
+                    if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                        continue;
+                    }
+                    if spanned_posting.account.as_ref() == account {
+                        let (posting_line, _) =
+                            byte_offset_to_position(source, spanned_posting.span.start);
                         if let Some(range) = find_in_line(source, posting_line, account) {
                             highlights.push(DocumentHighlight {
                                 range,
@@ -340,5 +347,59 @@ mod tests {
         let highlights = highlights.unwrap();
         // Should find USD in: open, posting 1, posting 2 = 3
         assert_eq!(highlights.len(), 3);
+    }
+
+    /// Regression test for the read-only sibling of #1142.
+    ///
+    /// Pre-fix, `posting_line = txn_start_line + 1 + i` put the second
+    /// posting's highlight on the metadata line between the postings.
+    /// Per-posting span lookup must put each highlight on the actual
+    /// posting line.
+    #[test]
+    fn test_highlight_account_with_interleaved_metadata_1142() {
+        let source = "\
+2024-01-01 open Assets:Bank USD
+2024-01-15 * \"Test\"
+  Assets:Bank  -5.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food  5.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let uri: lsp_types::Uri = "file:///test.beancount".parse().unwrap();
+        let params = DocumentHighlightParams {
+            text_document_position_params: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri },
+                position: Position::new(0, 16), // on "Assets:Bank" in open
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        let highlights = handle_document_highlight(&params, source, &result)
+            .expect("Assets:Bank has at least the Open + 1 posting");
+
+        // Lines 3 and 5 contain `effective_date:`; the posting is on
+        // line 2 (after the Open + transaction header). No highlight
+        // should land on a metadata line.
+        let metadata_lines = [3u32, 5u32];
+        for h in &highlights {
+            assert!(
+                !metadata_lines.contains(&h.range.start.line),
+                "highlight landed on metadata line: {h:?}"
+            );
+        }
+        // Positive assertion: the Assets:Bank posting on line 2 must be
+        // highlighted (the bug used to point at line 3 instead).
+        assert!(
+            highlights.iter().any(|h| h.range.start.line == 2),
+            "Assets:Bank posting on line 2 should be highlighted; got {highlights:?}"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/document_highlight.rs
+++ b/crates/rustledger-lsp/src/handlers/document_highlight.rs
@@ -11,9 +11,7 @@ use lsp_types::{
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::{
-    byte_offset_to_position, get_word_at_position, is_account_like, is_currency_like,
-};
+use super::utils::{LineIndex, get_word_at_position, is_account_like, is_currency_like};
 
 /// Handle a document highlight request.
 pub fn handle_document_highlight(
@@ -30,18 +28,22 @@ pub fn handle_document_highlight(
     let (word, _, _) = get_word_at_position(line, position.character as usize)?;
 
     let mut highlights = Vec::new();
+    // Build the line index once and share it across collectors: each
+    // directive (and posting) used to trigger an O(n) byte→line scan,
+    // which scales quadratically on large files.
+    let line_index = LineIndex::new(source);
 
     // Check if it's an account
     if is_account_like(&word) {
-        collect_account_highlights(source, parse_result, &word, &mut highlights);
+        collect_account_highlights(source, parse_result, &line_index, &word, &mut highlights);
     }
     // Check if it's a currency
     else if is_currency_like(&word, parse_result) {
-        collect_currency_highlights(source, parse_result, &word, &mut highlights);
+        collect_currency_highlights(source, parse_result, &line_index, &word, &mut highlights);
     }
     // Check if it's a payee (inside quotes)
     else if is_in_quotes(line, position.character as usize) {
-        collect_payee_highlights(source, parse_result, &word, &mut highlights);
+        collect_payee_highlights(source, parse_result, &line_index, &word, &mut highlights);
     }
 
     if highlights.is_empty() {
@@ -55,11 +57,12 @@ pub fn handle_document_highlight(
 fn collect_account_highlights(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     account: &str,
     highlights: &mut Vec<DocumentHighlight>,
 ) {
     for spanned in &parse_result.directives {
-        let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
         match &spanned.value {
             Directive::Open(open) => {
@@ -152,7 +155,7 @@ fn collect_account_highlights(
                     }
                     if spanned_posting.account.as_ref() == account {
                         let (posting_line, _) =
-                            byte_offset_to_position(source, spanned_posting.span.start);
+                            line_index.offset_to_position(spanned_posting.span.start);
                         if let Some(range) = find_in_line(source, posting_line, account) {
                             highlights.push(DocumentHighlight {
                                 range,
@@ -171,12 +174,13 @@ fn collect_account_highlights(
 fn collect_currency_highlights(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     currency: &str,
     highlights: &mut Vec<DocumentHighlight>,
 ) {
     for spanned in &parse_result.directives {
         let directive_text = &source[spanned.span.start..spanned.span.end];
-        let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
         let is_declaration =
             matches!(&spanned.value, Directive::Commodity(c) if c.currency.as_ref() == currency);
@@ -236,6 +240,7 @@ fn collect_currency_highlights(
 fn collect_payee_highlights(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     payee: &str,
     highlights: &mut Vec<DocumentHighlight>,
 ) {
@@ -244,7 +249,7 @@ fn collect_payee_highlights(
             && let Some(ref txn_payee) = txn.payee
             && txn_payee.as_ref() == payee
         {
-            let (line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (line, _) = line_index.offset_to_position(spanned.span.start);
             let line_text = source.lines().nth(line as usize).unwrap_or("");
 
             if let Some(start) = line_text.find(&format!("\"{}\"", payee)) {

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -9,7 +9,7 @@ use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Default column for amount alignment.
 const AMOUNT_COLUMN: usize = 50;
@@ -22,6 +22,10 @@ pub fn handle_formatting(
 ) -> Option<Vec<TextEdit>> {
     let mut edits = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
+    // Build the line index once: O(n) up front, O(log lines) per
+    // offset lookup. Without it, calling the naive O(n) scanner per
+    // posting per transaction is quadratic on large files.
+    let line_index = LineIndex::new(source);
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
@@ -39,7 +43,7 @@ pub fn handle_formatting(
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
-                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
+                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
                     && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
                 {
@@ -245,8 +249,11 @@ mod tests {
 
         let edits = handle_formatting(&params, source, &result).unwrap_or_default();
 
-        // Identify the metadata-line indices in the source: lines that
-        // start with the `effective_date:` key after four-space indent.
+        // Identify the metadata-line indices in the source: lines whose
+        // first non-whitespace content is the `effective_date:` key.
+        // (The canonical form uses four-space indent, but the check
+        // accepts any indentation so a future test fixture variation
+        // doesn't silently start matching the wrong lines.)
         let metadata_lines: Vec<u32> = source
             .lines()
             .enumerate()

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -32,8 +32,10 @@ pub fn handle_formatting(
             // the formatter then overwrote with posting content — see
             // issue #1142.
             for spanned_posting in &txn.postings {
-                // Skip plugin-synthesized postings: they have no source
-                // location to format.
+                // Defensive: the LSP formats parser-derived directives,
+                // which always carry real spans. Guard against
+                // `Spanned::synthesized` entries in case a future
+                // integration feeds loader/plugin output through here.
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
@@ -255,6 +257,7 @@ mod tests {
             })
             .collect();
         assert_eq!(metadata_lines, vec![2, 4], "test source layout assumption");
+        let posting_lines: [u32; 2] = [1, 3];
 
         // No emitted edit should touch a metadata line. Pre-fix, the
         // line-arithmetic bug produced a posting-shaped edit at line 2
@@ -265,5 +268,14 @@ mod tests {
                 "edit targets a metadata line — issue #1142 regressed: {edit:?}"
             );
         }
+        // Positive assertion: the formatter must still do its job on
+        // the real posting lines (otherwise a degenerate "emit zero
+        // edits" implementation would silently pass the test).
+        assert!(
+            edits
+                .iter()
+                .any(|e| posting_lines.contains(&e.range.start.line)),
+            "formatter emitted no edits for posting lines — alignment broken"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -6,7 +6,7 @@
 //! - Consistent spacing around operators
 
 use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::byte_offset_to_position;
@@ -25,14 +25,21 @@ pub fn handle_formatting(
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
-
-            // Format each posting
-            for (i, posting) in txn.postings.iter().enumerate() {
-                let posting_line = start_line + 1 + i as u32;
-
+            // Format each posting using its own source span, not a
+            // line-arithmetic guess from the directive's start_line.
+            // Interleaved posting-level metadata (e.g., `effective_date:`)
+            // makes `start_line + 1 + i` point at metadata lines, which
+            // the formatter then overwrote with posting content — see
+            // issue #1142.
+            for spanned_posting in &txn.postings {
+                // Skip plugin-synthesized postings: they have no source
+                // location to format.
+                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                    continue;
+                }
+                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
-                    && let Some(edit) = format_posting_line(line, posting_line, posting)
+                    && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
                 {
                     edits.push(edit);
                 }
@@ -197,5 +204,66 @@ mod tests {
         let edits = edits.unwrap();
         // Should have edit to replace tab
         assert!(edits.iter().any(|e| e.new_text.contains("  ")));
+    }
+
+    /// Regression test for issue #1142.
+    ///
+    /// When a transaction has posting-level metadata interleaved between
+    /// postings (e.g., `effective_date:`), the previous formatter
+    /// computed each posting's line as `txn_start_line + 1 + posting_idx`
+    /// and so produced TextEdits targeting metadata lines instead of
+    /// posting lines. Applying those edits overwrote the metadata. This
+    /// test pins the post-fix behavior: emitted edits target only the
+    /// posting lines and never the metadata lines between them.
+    #[test]
+    fn test_formatting_preserves_interleaved_metadata_1142() {
+        // Note the two-space indentation on postings vs four-space on
+        // metadata — this is the canonical effective_date format.
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -50.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food  50.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edits = handle_formatting(&params, source, &result).unwrap_or_default();
+
+        // Identify the metadata-line indices in the source: lines that
+        // start with the `effective_date:` key after four-space indent.
+        let metadata_lines: Vec<u32> = source
+            .lines()
+            .enumerate()
+            .filter_map(|(i, line)| {
+                line.trim_start()
+                    .starts_with("effective_date:")
+                    .then_some(i as u32)
+            })
+            .collect();
+        assert_eq!(metadata_lines, vec![2, 4], "test source layout assumption");
+
+        // No emitted edit should touch a metadata line. Pre-fix, the
+        // line-arithmetic bug produced a posting-shaped edit at line 2
+        // (the first metadata line), overwriting it.
+        for edit in &edits {
+            assert!(
+                !metadata_lines.contains(&edit.range.start.line),
+                "edit targets a metadata line — issue #1142 regressed: {edit:?}"
+            );
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -11,7 +11,7 @@ use rustledger_core::{Decimal, Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Handle an inlay hints request.
 pub fn handle_inlay_hints(
@@ -23,10 +23,14 @@ pub fn handle_inlay_hints(
     let uri = params.text_document.uri.as_str();
     let mut hints = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
+    // Build the line index once: O(n) up front, O(log lines) per
+    // offset lookup. Without it the per-directive + per-posting
+    // lookups below scale quadratically with file size.
+    let line_index = LineIndex::new(source);
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
             // Skip if transaction is outside the requested range
             if start_line > range.end.line {
@@ -44,7 +48,7 @@ pub fn handle_inlay_hints(
                     continue;
                 }
                 let posting = &**spanned_posting;
-                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
+                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
 
                 // Skip if outside range
                 if posting_line < range.start.line || posting_line > range.end.line {

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -7,7 +7,7 @@
 //! Supports resolve for lazy-loading rich tooltips with account details.
 
 use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Position};
-use rustledger_core::{Decimal, Directive};
+use rustledger_core::{Decimal, Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
@@ -36,8 +36,15 @@ pub fn handle_inlay_hints(
             // Calculate the inferred amount for postings without amounts
             let inferred = calculate_inferred_amount(txn);
 
-            for (i, posting) in txn.postings.iter().enumerate() {
-                let posting_line = start_line + 1 + i as u32;
+            // Per-posting span lookup (see #1142): the prior
+            // `start_line + 1 + i` arithmetic put hints on the wrong
+            // line for transactions with interleaved metadata.
+            for spanned_posting in &txn.postings {
+                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                    continue;
+                }
+                let posting = &**spanned_posting;
+                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
 
                 // Skip if outside range
                 if posting_line < range.start.line || posting_line > range.end.line {
@@ -329,5 +336,50 @@ mod tests {
         // This proves server logic is correct.
         // If hints linger in editor after typing, it's a CLIENT issue
         // (client not re-requesting textDocument/inlayHint after didChange)
+    }
+
+    /// Regression test for the read-only sibling of #1142.
+    ///
+    /// Pre-fix, the inferred-amount hint for the amountless posting
+    /// landed on the wrong line whenever the prior posting had
+    /// `effective_date:` (or any other) metadata between them. With
+    /// per-posting span lookup, the hint sits on the posting line
+    /// itself.
+    #[test]
+    fn test_inlay_hint_lands_on_correct_line_with_interleaved_metadata_1142() {
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -5.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = InlayHintParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            range: lsp_types::Range {
+                start: Position::new(0, 0),
+                end: Position::new(10, 0),
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        let hints = handle_inlay_hints(&params, source, &result).unwrap_or_default();
+        assert_eq!(hints.len(), 1, "exactly one inferred-amount hint expected");
+
+        // Expenses:Food is on line 3 (after Assets:Bank on line 1 and
+        // its metadata on line 2). Pre-fix arithmetic would have put
+        // the hint on line 2 (the metadata line).
+        assert_eq!(
+            hints[0].position.line, 3,
+            "inferred-amount hint should be on the posting line, not the metadata line"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/linked_editing.rs
+++ b/crates/rustledger-lsp/src/handlers/linked_editing.rs
@@ -5,7 +5,7 @@
 //! - Currency names: edit all occurrences simultaneously
 
 use lsp_types::{LinkedEditingRangeParams, LinkedEditingRanges, Position, Range};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::{
@@ -121,9 +121,16 @@ fn collect_account_ranges(
                 }
             }
             Directive::Transaction(txn) => {
-                for (i, posting) in txn.postings.iter().enumerate() {
-                    if posting.account.as_ref() == account {
-                        let posting_line = start_line + 1 + i as u32;
+                // Per-posting span lookup (see #1142): the prior
+                // `start_line + 1 + i` arithmetic broke whenever a
+                // transaction had interleaved posting-level metadata.
+                for spanned_posting in &txn.postings {
+                    if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                        continue;
+                    }
+                    if spanned_posting.account.as_ref() == account {
+                        let (posting_line, _) =
+                            byte_offset_to_position(source, spanned_posting.span.start);
                         if let Some(range) = find_in_line(source, posting_line, account) {
                             ranges.push(range);
                         }

--- a/crates/rustledger-lsp/src/handlers/linked_editing.rs
+++ b/crates/rustledger-lsp/src/handlers/linked_editing.rs
@@ -8,9 +8,7 @@ use lsp_types::{LinkedEditingRangeParams, LinkedEditingRanges, Position, Range};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::{
-    byte_offset_to_position, get_word_at_position, is_account_like, is_currency_like,
-};
+use super::utils::{LineIndex, get_word_at_position, is_account_like, is_currency_like};
 
 /// Handle a linked editing range request.
 pub fn handle_linked_editing_range(
@@ -27,14 +25,17 @@ pub fn handle_linked_editing_range(
     let (word, _, _) = get_word_at_position(line, position.character as usize)?;
 
     let mut ranges = Vec::new();
+    // Build the line index once and share it across collectors —
+    // otherwise each posting/directive lookup is an O(n) scan.
+    let line_index = LineIndex::new(source);
 
     // Check if it's an account
     if is_account_like(&word) {
-        collect_account_ranges(source, parse_result, &word, &mut ranges);
+        collect_account_ranges(source, parse_result, &line_index, &word, &mut ranges);
     }
     // Check if it's a currency
     else if is_currency_like(&word, parse_result) {
-        collect_currency_ranges(source, parse_result, &word, &mut ranges);
+        collect_currency_ranges(source, parse_result, &line_index, &word, &mut ranges);
     }
 
     if ranges.is_empty() {
@@ -58,11 +59,12 @@ pub fn handle_linked_editing_range(
 fn collect_account_ranges(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     account: &str,
     ranges: &mut Vec<Range>,
 ) {
     for spanned in &parse_result.directives {
-        let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
         match &spanned.value {
             Directive::Open(open) => {
@@ -130,7 +132,7 @@ fn collect_account_ranges(
                     }
                     if spanned_posting.account.as_ref() == account {
                         let (posting_line, _) =
-                            byte_offset_to_position(source, spanned_posting.span.start);
+                            line_index.offset_to_position(spanned_posting.span.start);
                         if let Some(range) = find_in_line(source, posting_line, account) {
                             ranges.push(range);
                         }
@@ -146,12 +148,13 @@ fn collect_account_ranges(
 fn collect_currency_ranges(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     currency: &str,
     ranges: &mut Vec<Range>,
 ) {
     for spanned in &parse_result.directives {
         let directive_text = &source[spanned.span.start..spanned.span.end];
-        let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
         for (line_offset, line) in directive_text.lines().enumerate() {
             let mut search_start = 0;

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -65,6 +65,10 @@ pub fn handle_range_formatting(
             }
 
             for spanned_posting in &txn.postings {
+                // Defensive: the LSP formats parser-derived directives,
+                // which always carry real spans. Guard against
+                // `Spanned::synthesized` entries in case a future
+                // integration feeds loader/plugin output through here.
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
@@ -213,5 +217,60 @@ mod tests {
                 "edit targets a metadata line — issue #1142 regressed: {edit:?}"
             );
         }
+        // No positive "must produce an edit" assertion here: range
+        // formatting only emits edits when something actually needs
+        // changing, and this source is already correctly formatted.
+        // Emitting zero edits IS the right outcome — see the
+        // `_misindented` variant below for the positive case.
+    }
+
+    /// Companion to the regression test above: with a *misindented*
+    /// posting interleaved with metadata, range formatting should
+    /// produce a fix for the posting and still leave the metadata
+    /// alone. Catches a future regression that silently short-circuits
+    /// the formatter (the all-correct test above can't tell those
+    /// apart from a working fix).
+    #[test]
+    fn test_range_formatting_fixes_misindented_posting_without_touching_metadata() {
+        // Note: posting 1 has 4-space indent (should be 2).
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -50.00 USD
+    effective_date: 2024-01-20
+    Expenses:Food  50.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentRangeFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(5, 0),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edits = handle_range_formatting(&params, source, &result).unwrap_or_default();
+        let metadata_lines = [2u32, 4u32];
+
+        for edit in &edits {
+            assert!(
+                !metadata_lines.contains(&edit.range.start.line),
+                "edit targets a metadata line — issue #1142 regressed: {edit:?}"
+            );
+        }
+        assert!(
+            edits.iter().any(|e| e.range.start.line == 3),
+            "expected an edit at the misindented posting (line 3); got {edits:?}"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -6,7 +6,7 @@ use lsp_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Handle a range formatting request.
 pub fn handle_range_formatting(
@@ -17,6 +17,10 @@ pub fn handle_range_formatting(
     let range = params.range;
     let mut edits = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
+    // Build the line index once so per-posting offset→line lookups are
+    // O(log lines) instead of O(n). On a large file with many
+    // transactions, the naive scanner would otherwise dominate.
+    let line_index = LineIndex::new(source);
 
     // Process lines within the range
     for line_num in range.start.line..=range.end.line {
@@ -57,7 +61,7 @@ pub fn handle_range_formatting(
     // assumption and caused #1142.
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
             // Check if transaction overlaps with range
             if start_line > range.end.line {
@@ -72,7 +76,7 @@ pub fn handle_range_formatting(
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
-                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
+                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
 
                 // Check if posting is within range
                 if posting_line >= range.start.line

--- a/crates/rustledger-lsp/src/handlers/range_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/range_formatting.rs
@@ -3,7 +3,7 @@
 //! Formats only the selected range of the document.
 
 use lsp_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::byte_offset_to_position;
@@ -50,7 +50,11 @@ pub fn handle_range_formatting(
         }
     }
 
-    // Format postings within transactions in the range
+    // Format postings within transactions in the range. Look up each
+    // posting's line from its own source span, not via line arithmetic
+    // off the transaction header — interleaved posting-level metadata
+    // (e.g., `effective_date:`) breaks the `start_line + 1 + i`
+    // assumption and caused #1142.
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
             let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
@@ -60,14 +64,17 @@ pub fn handle_range_formatting(
                 continue;
             }
 
-            for (i, posting) in txn.postings.iter().enumerate() {
-                let posting_line = start_line + 1 + i as u32;
+            for spanned_posting in &txn.postings {
+                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                    continue;
+                }
+                let (posting_line, _) = byte_offset_to_position(source, spanned_posting.span.start);
 
                 // Check if posting is within range
                 if posting_line >= range.start.line
                     && posting_line <= range.end.line
                     && let Some(line) = lines.get(posting_line as usize)
-                    && let Some(edit) = format_posting_line(line, posting_line, posting)
+                    && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
                 {
                     // Don't duplicate edits
                     if !edits.iter().any(|e| e.range.start.line == posting_line) {
@@ -150,5 +157,61 @@ mod tests {
 
         let edits = handle_range_formatting(&params, source, &result);
         assert!(edits.is_some());
+    }
+
+    /// Regression test for issue #1142 (range-formatting variant).
+    ///
+    /// Pre-fix, `posting_line = start_line + 1 + i` pointed at the
+    /// metadata lines between postings, and the formatter emitted
+    /// posting-shaped edits that overwrote them. See the matching test
+    /// on `formatting.rs` for the full reasoning.
+    #[test]
+    fn test_range_formatting_preserves_interleaved_metadata_1142() {
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank  -50.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food  50.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentRangeFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            // Cover the full transaction.
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(5, 0),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edits = handle_range_formatting(&params, source, &result).unwrap_or_default();
+
+        let metadata_lines: Vec<u32> = source
+            .lines()
+            .enumerate()
+            .filter_map(|(i, line)| {
+                line.trim_start()
+                    .starts_with("effective_date:")
+                    .then_some(i as u32)
+            })
+            .collect();
+        assert_eq!(metadata_lines, vec![2, 4], "test source layout assumption");
+
+        for edit in &edits {
+            assert!(
+                !metadata_lines.contains(&edit.range.start.line),
+                "edit targets a metadata line — issue #1142 regressed: {edit:?}"
+            );
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -5,9 +5,7 @@
 //! - Currency names (all usages across directives)
 //! - Payees (all transactions with same payee)
 
-use super::utils::{
-    byte_offset_to_position, get_word_at_position, is_account_like, is_currency_like,
-};
+use super::utils::{LineIndex, get_word_at_position, is_account_like, is_currency_like};
 use lsp_types::{Location, Position, Range, ReferenceParams, Uri};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
@@ -30,12 +28,16 @@ pub fn handle_references(
     let (word, _, _) = get_word_at_position(line, position.character as usize)?;
 
     let mut locations = Vec::new();
+    // Build the line index once and share it across collectors —
+    // otherwise each posting/directive lookup is an O(n) scan.
+    let line_index = LineIndex::new(source);
 
     // Check if it's an account
     if is_account_like(&word) {
         collect_account_references(
             source,
             parse_result,
+            &line_index,
             &word,
             uri,
             include_declaration,
@@ -47,6 +49,7 @@ pub fn handle_references(
         collect_currency_references(
             source,
             parse_result,
+            &line_index,
             &word,
             uri,
             include_declaration,
@@ -55,7 +58,14 @@ pub fn handle_references(
     }
     // Check if it's a payee (inside quotes on a transaction line)
     else if is_in_quotes(line, position.character as usize) {
-        collect_payee_references(source, parse_result, &word, uri, &mut locations);
+        collect_payee_references(
+            source,
+            parse_result,
+            &line_index,
+            &word,
+            uri,
+            &mut locations,
+        );
     }
 
     if locations.is_empty() {
@@ -69,6 +79,7 @@ pub fn handle_references(
 fn collect_account_references(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     account: &str,
     uri: &Uri,
     include_declaration: bool,
@@ -81,6 +92,7 @@ fn collect_account_references(
                     && include_declaration
                     && let Some(loc) = find_in_directive(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         account,
@@ -94,6 +106,7 @@ fn collect_account_references(
                 if close.account.as_ref() == account
                     && let Some(loc) = find_in_directive(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         account,
@@ -107,6 +120,7 @@ fn collect_account_references(
                 if bal.account.as_ref() == account
                     && let Some(loc) = find_in_directive(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         account,
@@ -120,6 +134,7 @@ fn collect_account_references(
                 if pad.account.as_ref() == account
                     && let Some(loc) = find_in_directive(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         account,
@@ -135,7 +150,7 @@ fn collect_account_references(
                         let after_first = first_pos + account.len();
                         if let Some(second_pos) = directive_text[after_first..].find(account) {
                             let actual_pos = after_first + second_pos;
-                            let (line, _) = byte_offset_to_position(source, spanned.span.start);
+                            let (line, _) = line_index.offset_to_position(spanned.span.start);
                             locations.push(Location {
                                 uri: uri.clone(),
                                 range: Range {
@@ -151,6 +166,7 @@ fn collect_account_references(
                 if note.account.as_ref() == account
                     && let Some(loc) = find_in_directive(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         account,
@@ -164,6 +180,7 @@ fn collect_account_references(
                 if doc.account.as_ref() == account
                     && let Some(loc) = find_in_directive(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         account,
@@ -183,7 +200,7 @@ fn collect_account_references(
                     }
                     if spanned_posting.account.as_ref() == account {
                         let (posting_line, _) =
-                            byte_offset_to_position(source, spanned_posting.span.start);
+                            line_index.offset_to_position(spanned_posting.span.start);
                         if let Some(line_text) = source.lines().nth(posting_line as usize)
                             && let Some(col) = line_text.find(account)
                         {
@@ -207,6 +224,7 @@ fn collect_account_references(
 fn collect_currency_references(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     currency: &str,
     uri: &Uri,
     include_declaration: bool,
@@ -214,7 +232,7 @@ fn collect_currency_references(
 ) {
     for spanned in &parse_result.directives {
         let directive_text = &source[spanned.span.start..spanned.span.end];
-        let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
+        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
 
         // Check if directive contains this currency
         let is_declaration =
@@ -275,6 +293,7 @@ fn collect_currency_references(
 fn collect_payee_references(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     payee: &str,
     uri: &Uri,
     locations: &mut Vec<Location>,
@@ -284,7 +303,7 @@ fn collect_payee_references(
             && let Some(ref txn_payee) = txn.payee
             && txn_payee.as_ref() == payee
         {
-            let (line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (line, _) = line_index.offset_to_position(spanned.span.start);
             let line_text = source.lines().nth(line as usize).unwrap_or("");
 
             // Find the payee in quotes
@@ -304,13 +323,14 @@ fn collect_payee_references(
 /// Find a string in a directive and create a location.
 fn find_in_directive(
     source: &str,
+    line_index: &LineIndex,
     start_offset: usize,
     end_offset: usize,
     needle: &str,
     uri: &Uri,
 ) -> Option<Location> {
     let directive_text = &source[start_offset..end_offset];
-    let (start_line, start_col) = byte_offset_to_position(source, start_offset);
+    let (start_line, start_col) = line_index.offset_to_position(start_offset);
 
     for (line_offset, line) in directive_text.lines().enumerate() {
         if let Some(col) = line.find(needle) {

--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -75,8 +75,6 @@ fn collect_account_references(
     locations: &mut Vec<Location>,
 ) {
     for spanned in &parse_result.directives {
-        let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
-
         match &spanned.value {
             Directive::Open(open) => {
                 if open.account.as_ref() == account

--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -9,7 +9,7 @@ use super::utils::{
     byte_offset_to_position, get_word_at_position, is_account_like, is_currency_like,
 };
 use lsp_types::{Location, Position, Range, ReferenceParams, Uri};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 /// Handle a find references request.
@@ -176,9 +176,16 @@ fn collect_account_references(
                 }
             }
             Directive::Transaction(txn) => {
-                for (i, posting) in txn.postings.iter().enumerate() {
-                    if posting.account.as_ref() == account {
-                        let posting_line = start_line + 1 + i as u32;
+                // Per-posting span lookup (see #1142): the prior
+                // `start_line + 1 + i` arithmetic broke whenever a
+                // transaction had interleaved posting-level metadata.
+                for spanned_posting in &txn.postings {
+                    if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                        continue;
+                    }
+                    if spanned_posting.account.as_ref() == account {
+                        let (posting_line, _) =
+                            byte_offset_to_position(source, spanned_posting.span.start);
                         if let Some(line_text) = source.lines().nth(posting_line as usize)
                             && let Some(col) = line_text.find(account)
                         {
@@ -410,5 +417,60 @@ mod tests {
         let refs = refs.unwrap();
         // Should find USD in: open, posting 1, posting 2 = 3 references
         assert_eq!(refs.len(), 3);
+    }
+
+    /// Regression test for the read-only sibling of #1142.
+    ///
+    /// Pre-fix, the reference range for the second posting landed on
+    /// the metadata line between postings. With per-posting span
+    /// lookup, every reference points at its actual posting line.
+    #[test]
+    fn test_find_account_references_with_interleaved_metadata_1142() {
+        let source = "\
+2024-01-01 open Assets:Bank USD
+2024-01-15 * \"Test\"
+  Assets:Bank  -5.00 USD
+    effective_date: 2024-01-20
+  Expenses:Food  5.00 USD
+    effective_date: 2024-01-21
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let uri: Uri = "file:///test.beancount".parse().unwrap();
+        let params = ReferenceParams {
+            text_document_position: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                position: Position::new(0, 16), // on "Assets:Bank" in open
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            context: lsp_types::ReferenceContext {
+                include_declaration: true,
+            },
+        };
+
+        let refs = handle_references(&params, source, &result, &uri)
+            .expect("at least the Open definition + 1 posting reference");
+
+        let metadata_lines = [3u32, 5u32];
+        for r in &refs {
+            assert!(
+                !metadata_lines.contains(&r.range.start.line),
+                "reference range landed on a metadata line: {r:?}"
+            );
+        }
+        // The Assets:Bank posting is on line 2 (the second posting,
+        // Expenses:Food, is on line 4 and isn't a reference to
+        // Assets:Bank, so we only verify the positive lines we expect).
+        let lines: Vec<u32> = refs.iter().map(|r| r.range.start.line).collect();
+        assert!(
+            lines.contains(&2),
+            "Assets:Bank posting on line 2 should appear in refs; got {lines:?}"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/selection_range.rs
+++ b/crates/rustledger-lsp/src/handlers/selection_range.rs
@@ -77,7 +77,6 @@ fn compute_selection_range(
             // the prior `dir_start_line + 1 + i` arithmetic broke
             // whenever a transaction had interleaved posting-level
             // metadata, putting the cursor-test on the wrong row.
-            let _ = dir_range;
             for spanned_posting in &txn.postings {
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;

--- a/crates/rustledger-lsp/src/handlers/selection_range.rs
+++ b/crates/rustledger-lsp/src/handlers/selection_range.rs
@@ -5,7 +5,7 @@
 //! - Word -> Amount -> Posting -> Transaction
 
 use lsp_types::{Position, Range, SelectionRange, SelectionRangeParams};
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::{LineIndex, is_word_char};
@@ -73,11 +73,17 @@ fn compute_selection_range(
     // Build the selection hierarchy
     match containing_directive {
         Some((dir_range, Directive::Transaction(txn))) => {
-            // Check if we're in a posting
-            let (dir_start_line, _) = (dir_range.start.line, dir_range.start.character);
-
-            for (i, posting) in txn.postings.iter().enumerate() {
-                let posting_line = dir_start_line + 1 + i as u32;
+            // Resolve each posting's line from its own span (see #1142):
+            // the prior `dir_start_line + 1 + i` arithmetic broke
+            // whenever a transaction had interleaved posting-level
+            // metadata, putting the cursor-test on the wrong row.
+            let _ = dir_range;
+            for spanned_posting in &txn.postings {
+                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
+                    continue;
+                }
+                let posting = &**spanned_posting;
+                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
 
                 if position.line == posting_line {
                     // We're in a posting line

--- a/crates/rustledger-lsp/src/handlers/symbols.rs
+++ b/crates/rustledger-lsp/src/handlers/symbols.rs
@@ -9,7 +9,7 @@
 use lsp_types::{
     DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, Position, Range, SymbolKind,
 };
-use rustledger_core::Directive;
+use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
 use super::utils::LineIndex;
@@ -77,12 +77,17 @@ fn directive_to_symbol(
                 Some(txn.narration.to_string())
             };
 
-            // Create child symbols for postings
+            // Create child symbols for postings. Look up each posting's
+            // line from its own source span instead of the prior
+            // `start_line + 1 + i` arithmetic (see #1142): with
+            // interleaved metadata, that pointed at metadata lines and
+            // produced wrong symbol ranges in the outline view.
             let children: Vec<DocumentSymbol> = txn
                 .postings
                 .iter()
-                .enumerate()
-                .map(|(i, posting)| {
+                .filter(|spanned_posting| spanned_posting.file_id != SYNTHESIZED_FILE_ID)
+                .map(|spanned_posting| {
+                    let posting = &**spanned_posting;
                     let posting_name = posting.account.to_string();
                     let posting_detail = posting.units.as_ref().map(|u| {
                         if let (Some(num), Some(curr)) = (u.number(), u.currency()) {
@@ -94,8 +99,8 @@ fn directive_to_symbol(
                         }
                     });
 
-                    // Estimate posting position (simplified)
-                    let posting_line = start_line + 1 + i as u32;
+                    let (posting_line, _) =
+                        line_index.offset_to_position(spanned_posting.span.start);
                     let posting_range = Range {
                         start: Position::new(posting_line, 2),
                         end: Position::new(posting_line, 50),


### PR DESCRIPTION
## Summary

Follow-up to #1156. Extends the per-posting-span lookup pattern to the seven remaining LSP handlers that had the same `txn_start_line + 1 + posting_idx` anti-pattern. These handlers don't corrupt files (#1156 covered those), but they produce wrong line numbers whenever a transaction has posting-level metadata interleaved between postings.

> *Based on `feat/lsp-handlers-posting-span` (#1156). Rebases onto main automatically once #1156 lands via auto-merge.*

## Symptoms per handler, pre-fix

| Handler | Wrong-line manifestation |
|---|---|
| `document_highlight` | Account highlight on the second posting landed on its metadata line |
| `references` | "Find references" range pointed at metadata; jumping scrolled to wrong row |
| `inlay_hints` | Inferred-amount overlay sat one row too high |
| `selection_range` | Cursor-expand selected the metadata line as the posting body |
| `symbols` | Outline-view ranges for postings pointed at metadata |
| `call_hierarchy` | Incoming/outgoing call ranges pointed at metadata; transaction outer range under-counted lines |
| `document_color` | Amount color decorations rendered on the wrong row |
| `linked_editing` | Rename-linked ranges pointed at metadata lines |

## What changed

- Each handler iterates `&[Spanned<Posting>]` and resolves the posting's line from `byte_offset_to_position(source, p.span.start)` (or `LineIndex::offset_to_position` where one was already in scope).
- Plugin-synthesized postings (`file_id == SYNTHESIZED_FILE_ID`) are skipped — defensive, consistent with the formatters.
- `call_hierarchy`'s transaction outer range now derives from `spanned.span.end` instead of the `txn_line + postings.len() + 1` heuristic.

## Tests

Three new regression tests cover the highest-impact handlers using the canonical `effective_date:` fixture from #1142:

- `document_highlight::tests::test_highlight_account_with_interleaved_metadata_1142`
- `references::tests::test_find_account_references_with_interleaved_metadata_1142`
- `inlay_hints::tests::test_inlay_hint_lands_on_correct_line_with_interleaved_metadata_1142`

Each asserts both:
1. **No result lands on a metadata line** (the #1142 contract).
2. **The real posting line IS surfaced** (catches a future short-circuit that emits empty results).

The other handlers ride on the same mechanical pattern; tests can be added incrementally if a specific handler regresses.

## Out of scope (audit false positives)

- `code_actions.rs` — the only grep hit was a window-search heuristic (`range.start.line + 10`), not posting arithmetic.
- `on_type_formatting.rs` / `execute_command.rs` — matches were `is_posting_line()` content classifiers, not line indexing.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `cargo test -p rustledger-lsp --all-features` — **134 tests, 0 failures** (3 new + 131 pre-existing)
- [x] `cargo fmt --all -- --check`

Refs #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
