### PR TITLE
refactor(lsp,core): unify LSP and CLI formatters via format_posting

### DIFF
--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use directives::{
 };
 pub use helpers::escape_string;
 pub(crate) use helpers::format_meta_value;
+pub use transaction::format_posting;
 pub(crate) use transaction::{format_incomplete_amount, format_transaction};
 
 use crate::Directive;

--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -15,8 +15,8 @@ pub(crate) use directives::{
 };
 pub use helpers::escape_string;
 pub(crate) use helpers::format_meta_value;
-pub use transaction::format_posting;
 pub(crate) use transaction::{format_incomplete_amount, format_transaction};
+pub use transaction::{format_posting, format_posting_line};
 
 use crate::Directive;
 

--- a/crates/rustledger-core/src/format/transaction.rs
+++ b/crates/rustledger-core/src/format/transaction.rs
@@ -44,15 +44,12 @@ pub fn format_transaction(txn: &Transaction, config: &FormatConfig) -> String {
         for comment in &posting.comments {
             writeln!(out, "{}{}", &config.indent, comment).expect("write to String is infallible");
         }
-        // Output the posting line
-        let posting_line = format_posting(posting, config);
-        // Append trailing comment on same line if present (only first one)
-        if let Some(trailing) = posting.trailing_comments.first() {
-            writeln!(out, "{posting_line} {trailing}").expect("write to String is infallible");
-        } else {
-            out.push_str(&posting_line);
-            out.push('\n');
-        }
+        // Output the posting line (account + amount + first
+        // trailing comment, via the shared helper so the LSP path
+        // and on-disk output stay in lockstep).
+        let line_text = format_posting_line(posting, config);
+        out.push_str(&line_text);
+        out.push('\n');
         // Output any additional trailing comments on their own lines
         for trailing in posting.trailing_comments.iter().skip(1) {
             writeln!(out, "{}{}", &config.indent, trailing).expect("write to String is infallible");
@@ -69,6 +66,28 @@ pub fn format_transaction(txn: &Transaction, config: &FormatConfig) -> String {
     }
 
     out
+}
+
+/// Format the single-line representation of a posting.
+///
+/// Produces account + amount + cost + price + the first same-line
+/// trailing comment, if any. This is the unit `format_transaction`
+/// emits as one line, and it's also the unit the LSP edits when
+/// re-aligning a posting in place. Both call sites must agree on the
+/// canonical form, otherwise `rledger format` (on disk) and
+/// `textDocument/formatting` (in the editor) silently disagree.
+///
+/// Pre-line comments and subsequent trailing comments live on
+/// separate lines and are emitted by `format_transaction`; the LSP's
+/// per-line edit path doesn't touch them.
+#[must_use]
+pub fn format_posting_line(posting: &Posting, config: &FormatConfig) -> String {
+    let mut line = format_posting(posting, config);
+    if let Some(trailing) = posting.trailing_comments.first() {
+        line.push(' ');
+        line.push_str(trailing);
+    }
+    line
 }
 
 /// Format a posting with amount alignment.

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -70,7 +70,7 @@ pub use extract::{
     DEFAULT_CURRENCIES, extract_accounts, extract_accounts_iter, extract_currencies,
     extract_currencies_iter, extract_payees, extract_payees_iter,
 };
-pub use format::{FormatConfig, format_directive};
+pub use format::{FormatConfig, format_directive, format_posting};
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -70,7 +70,7 @@ pub use extract::{
     DEFAULT_CURRENCIES, extract_accounts, extract_accounts_iter, extract_currencies,
     extract_currencies_iter, extract_payees, extract_payees_iter,
 };
-pub use format::{FormatConfig, format_directive, format_posting};
+pub use format::{FormatConfig, format_directive, format_posting, format_posting_line};
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -5,11 +5,15 @@
 //! - rledger.sortTransactions: Sort transactions by date
 //! - rledger.alignAmounts: Align amounts in a region
 
-use lsp_types::{ExecuteCommandParams, TextEdit, Uri, WorkspaceEdit};
+use lsp_types::{
+    DocumentFormattingParams, ExecuteCommandParams, TextDocumentIdentifier, TextEdit, Uri,
+    WorkspaceEdit,
+};
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
+use super::formatting::handle_formatting;
 use super::utils::byte_offset_to_position;
 
 /// Available commands.
@@ -30,7 +34,7 @@ pub fn handle_execute_command(
     match params.command.as_str() {
         "rledger.insertDate" => handle_insert_date(),
         "rledger.sortTransactions" => handle_sort_transactions(source, parse_result, uri),
-        "rledger.alignAmounts" => handle_align_amounts(source, uri),
+        "rledger.alignAmounts" => handle_align_amounts(source, parse_result, uri),
         "rledger.showAccountBalance" => {
             handle_show_account_balance(&params.arguments, parse_result)
         }
@@ -117,65 +121,35 @@ fn handle_sort_transactions(
     serde_json::to_value(workspace_edit).ok()
 }
 
-/// Align amounts in the document.
-fn handle_align_amounts(source: &str, uri: &Uri) -> Option<serde_json::Value> {
-    let lines: Vec<&str> = source.lines().collect();
-    let mut edits: Vec<TextEdit> = Vec::new();
-
-    // Find posting lines and their amount positions
-    let mut posting_groups: Vec<Vec<(usize, usize, usize)>> = Vec::new(); // (line_idx, amount_start, amount_end)
-    let mut current_group: Vec<(usize, usize, usize)> = Vec::new();
-
-    for (line_idx, line) in lines.iter().enumerate() {
-        let trimmed = line.trim_start();
-
-        // Check if this is a posting line (indented, starts with account)
-        if (line.starts_with("  ") || line.starts_with('\t')) && is_posting_line(trimmed) {
-            if let Some((amount_start, amount_end)) = find_amount_position(line) {
-                current_group.push((line_idx, amount_start, amount_end));
-            }
-        } else if !current_group.is_empty() {
-            // End of transaction, save group
-            posting_groups.push(std::mem::take(&mut current_group));
-        }
-    }
-
-    // Don't forget the last group
-    if !current_group.is_empty() {
-        posting_groups.push(current_group);
-    }
-
-    // Process each group - align amounts to the rightmost position
-    for group in posting_groups {
-        if group.len() < 2 {
-            continue;
-        }
-
-        // Find the maximum column where amounts should start
-        let max_amount_col = group.iter().map(|(_, start, _)| *start).max().unwrap_or(0);
-
-        // Create edits to align
-        for (line_idx, amount_start, _amount_end) in group {
-            if amount_start < max_amount_col {
-                let padding = max_amount_col - amount_start;
-                let line = lines[line_idx];
-
-                // Find where the amount number starts (skip leading spaces)
-                if let Some(num_start) = line[..amount_start]
-                    .rfind(|c: char| !c.is_whitespace())
-                    .map(|i| i + 1)
-                {
-                    edits.push(TextEdit {
-                        range: lsp_types::Range {
-                            start: lsp_types::Position::new(line_idx as u32, num_start as u32),
-                            end: lsp_types::Position::new(line_idx as u32, amount_start as u32),
-                        },
-                        new_text: " ".repeat(padding + (amount_start - num_start)),
-                    });
-                }
-            }
-        }
-    }
+/// Align amounts in the document by delegating to the document
+/// formatter ([`handle_formatting`]).
+///
+/// The formatting handler is now the canonical alignment path: it
+/// looks up each posting's source line via its `Spanned<Posting>` span
+/// (so interleaved metadata is preserved — see #1142), aligns amounts
+/// to `AMOUNT_COLUMN`, and uses a single shared `LineIndex` for
+/// O(log lines) offset lookups. The previous bespoke logic here
+/// duplicated that pipeline with a regex-style line scanner and its
+/// own "max-existing-column" alignment heuristic, which produced
+/// different output than `rledger format` and the LSP's own
+/// `textDocument/formatting` request — exactly the kind of duplicate
+/// code path #1142 warned about.
+fn handle_align_amounts(
+    source: &str,
+    parse_result: &ParseResult,
+    uri: &Uri,
+) -> Option<serde_json::Value> {
+    // Synthesize the formatting params. `handle_formatting` ignores
+    // its `_params` argument today (everything it needs comes from
+    // `source` + `parse_result`), but we still construct a real
+    // `DocumentFormattingParams` so future option-driven behavior
+    // (e.g. tab size, alignment column) lands automatically.
+    let params = DocumentFormattingParams {
+        text_document: TextDocumentIdentifier { uri: uri.clone() },
+        options: Default::default(),
+        work_done_progress_params: Default::default(),
+    };
+    let edits: Vec<TextEdit> = handle_formatting(&params, source, parse_result).unwrap_or_default();
 
     if edits.is_empty() {
         return Some(serde_json::json!({
@@ -240,40 +214,6 @@ fn handle_show_account_balance(
     }))
 }
 
-/// Check if a line looks like a posting.
-fn is_posting_line(trimmed: &str) -> bool {
-    trimmed.starts_with("Assets")
-        || trimmed.starts_with("Liabilities")
-        || trimmed.starts_with("Equity")
-        || trimmed.starts_with("Income")
-        || trimmed.starts_with("Expenses")
-}
-
-/// Find the position of an amount in a posting line.
-fn find_amount_position(line: &str) -> Option<(usize, usize)> {
-    // Look for a number pattern (possibly negative)
-    let mut in_number = false;
-    let mut number_start = 0;
-
-    for (i, c) in line.char_indices() {
-        if !in_number {
-            if c == '-' || c.is_ascii_digit() {
-                in_number = true;
-                number_start = i;
-            }
-        } else if !c.is_ascii_digit() && c != '.' && c != ',' {
-            // End of number
-            return Some((number_start, i));
-        }
-    }
-
-    if in_number {
-        Some((number_start, line.len()))
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,19 +255,33 @@ mod tests {
     }
 
     #[test]
-    fn test_is_posting_line() {
-        assert!(is_posting_line("Assets:Bank  100 USD"));
-        assert!(is_posting_line("Expenses:Food"));
-        assert!(!is_posting_line("2024-01-15 * \"Coffee\""));
-        assert!(!is_posting_line("open Assets:Bank"));
-    }
+    fn test_align_amounts_delegates_to_formatter() {
+        // The command now reuses `handle_formatting`, so it inherits
+        // every fix the formatter has (per-posting span lookup,
+        // metadata preservation, etc.). Smoke-test the delegation
+        // returns a WorkspaceEdit shape on a misaligned source and the
+        // "no work" shape on already-aligned input.
+        use lsp_types::Uri;
 
-    #[test]
-    fn test_find_amount_position() {
-        let line = "  Assets:Bank  100.00 USD";
-        let pos = find_amount_position(line);
-        assert!(pos.is_some());
-        let (start, _end) = pos.unwrap();
-        assert!(line[start..].starts_with("100"));
+        let misaligned = "2024-01-15 * \"Coffee\"\n  Assets:Bank  -5.00 USD\n  Expenses:Food\n";
+        let result = parse(misaligned);
+        let uri: Uri = "file:///test.beancount".parse().unwrap();
+        let out =
+            handle_align_amounts(misaligned, &result, &uri).expect("align should return a value");
+        assert!(
+            out.get("changes").is_some(),
+            "misaligned input should produce a WorkspaceEdit with changes, got {out:?}"
+        );
+
+        // A canonically-aligned source should produce the "no edits"
+        // shape (the formatter sees nothing to change).
+        let aligned = "2024-01-15 open Assets:Bank USD\n";
+        let aligned_parsed = parse(aligned);
+        let out2 = handle_align_amounts(aligned, &aligned_parsed, &uri)
+            .expect("align should always return some value");
+        assert!(
+            out2.get("message").is_some(),
+            "no-op input should return a message-only shape, got {out2:?}"
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -124,15 +124,14 @@ fn handle_sort_transactions(
 /// Align amounts in the document by delegating to the document
 /// formatter ([`handle_formatting`]).
 ///
-/// The formatting handler is now the canonical alignment path: it
-/// looks up each posting's source line via its `Spanned<Posting>` span
-/// (so interleaved metadata is preserved — see #1142), aligns amounts
-/// to `AMOUNT_COLUMN`, and uses a single shared `LineIndex` for
-/// O(log lines) offset lookups. The previous bespoke logic here
-/// duplicated that pipeline with a regex-style line scanner and its
-/// own "max-existing-column" alignment heuristic, which produced
-/// different output than `rledger format` and the LSP's own
-/// `textDocument/formatting` request — exactly the kind of duplicate
+/// The formatting handler is the canonical alignment path now and it
+/// delegates further to [`rustledger_core::format_posting`], the same
+/// formatter `rledger format` uses on disk. So this command, the LSP's
+/// `textDocument/formatting` request, and the CLI all produce
+/// identical output for a given `FormatConfig`. The previous bespoke
+/// logic here ran its own regex-style line scanner with a
+/// "max-existing-column" alignment heuristic, which produced output
+/// that matched none of the canonical paths — the kind of duplicate
 /// code path #1142 warned about.
 fn handle_align_amounts(
     source: &str,
@@ -255,26 +254,49 @@ mod tests {
     }
 
     #[test]
-    fn test_align_amounts_delegates_to_formatter() {
-        // The command now reuses `handle_formatting`, so it inherits
-        // every fix the formatter has (per-posting span lookup,
-        // metadata preservation, etc.). Smoke-test the delegation
-        // returns a WorkspaceEdit shape on a misaligned source and the
-        // "no work" shape on already-aligned input.
+    fn test_align_amounts_produces_canonical_alignment() {
+        // Goes beyond a shape-only smoke test: applies the emitted
+        // edits to the source and asserts the resulting amount column
+        // matches `FormatConfig::default().amount_column` (the same
+        // value `rledger format` uses on disk). Pins the contract that
+        // `rledger.alignAmounts`, `textDocument/formatting`, and
+        // `rledger format` agree on the canonical alignment.
         use lsp_types::Uri;
+        use rustledger_core::FormatConfig;
 
         let misaligned = "2024-01-15 * \"Coffee\"\n  Assets:Bank  -5.00 USD\n  Expenses:Food\n";
         let result = parse(misaligned);
         let uri: Uri = "file:///test.beancount".parse().unwrap();
         let out =
             handle_align_amounts(misaligned, &result, &uri).expect("align should return a value");
-        assert!(
-            out.get("changes").is_some(),
-            "misaligned input should produce a WorkspaceEdit with changes, got {out:?}"
+
+        // The first posting line is misaligned (2-space gap between
+        // account and amount). After applying the edits, the amount
+        // number should start exactly at config.amount_column.
+        let changes = out.get("changes").and_then(|v| v.as_object()).unwrap();
+        let edits = changes.values().next().unwrap().as_array().unwrap();
+        assert!(!edits.is_empty(), "misaligned input must produce edits");
+
+        let expected_col = FormatConfig::default().amount_column;
+        let applied = apply_lsp_text_edits(misaligned, edits);
+        let bank_line = applied
+            .lines()
+            .find(|l| l.contains("Assets:Bank"))
+            .expect("Assets:Bank line should still exist after edit");
+        let dash_pos = bank_line.find("-5.00").expect("amount survived the edit");
+        // `amount_column` is the column the number starts at; in the
+        // formatter's math, "Assets:Bank" + indent ends at col 13, and
+        // padding fills out to (amount_column - amount.len()).
+        let amount_len = "-5.00 USD".len();
+        assert_eq!(
+            dash_pos,
+            expected_col - amount_len,
+            "amount should be aligned to FormatConfig::default().amount_column ({expected_col}); \
+             got line {bank_line:?}"
         );
 
-        // A canonically-aligned source should produce the "no edits"
-        // shape (the formatter sees nothing to change).
+        // No-op shape: a canonically-aligned source should return the
+        // "no work" message.
         let aligned = "2024-01-15 open Assets:Bank USD\n";
         let aligned_parsed = parse(aligned);
         let out2 = handle_align_amounts(aligned, &aligned_parsed, &uri)
@@ -283,5 +305,44 @@ mod tests {
             out2.get("message").is_some(),
             "no-op input should return a message-only shape, got {out2:?}"
         );
+    }
+
+    /// Apply a JSON array of LSP `TextEdit` objects to `source`,
+    /// returning the resulting text. Test-local helper — the LSP
+    /// production path applies edits client-side, so this just
+    /// mirrors what an editor would do, sorted bottom-to-top so each
+    /// replacement's offsets stay valid.
+    fn apply_lsp_text_edits(source: &str, edits: &[serde_json::Value]) -> String {
+        let mut typed: Vec<(u32, u32, u32, u32, String)> = edits
+            .iter()
+            .map(|e| {
+                let r = e.get("range").unwrap();
+                let s = r.get("start").unwrap();
+                let n = r.get("end").unwrap();
+                (
+                    s.get("line").and_then(|v| v.as_u64()).unwrap() as u32,
+                    s.get("character").and_then(|v| v.as_u64()).unwrap() as u32,
+                    n.get("line").and_then(|v| v.as_u64()).unwrap() as u32,
+                    n.get("character").and_then(|v| v.as_u64()).unwrap() as u32,
+                    e.get("newText")
+                        .and_then(|v| v.as_str())
+                        .unwrap()
+                        .to_string(),
+                )
+            })
+            .collect();
+        // Apply from the end so earlier edits' offsets don't shift.
+        typed.sort_by_key(|t| std::cmp::Reverse((t.0, t.1)));
+
+        let lines: Vec<String> = source.lines().map(str::to_string).collect();
+        let mut out = lines.clone();
+        for (sl, sc, el, ec, new_text) in typed {
+            // Only single-line edits exercised by this test.
+            assert_eq!(sl, el, "test helper only handles single-line edits");
+            let line = &mut out[sl as usize];
+            let (s, e) = (sc as usize, ec as usize);
+            line.replace_range(s..e, &new_text);
+        }
+        out.join("\n") + "\n"
     }
 }

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -5,16 +5,13 @@
 //! - rledger.sortTransactions: Sort transactions by date
 //! - rledger.alignAmounts: Align amounts in a region
 
-use lsp_types::{
-    DocumentFormattingParams, ExecuteCommandParams, TextDocumentIdentifier, TextEdit, Uri,
-    WorkspaceEdit,
-};
+use lsp_types::{ExecuteCommandParams, TextEdit, Uri, WorkspaceEdit};
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
-use super::formatting::handle_formatting;
-use super::utils::byte_offset_to_position;
+use super::formatting::format_document;
+use super::utils::{byte_offset_to_position, document_format_config};
 
 /// Available commands.
 pub const COMMANDS: &[&str] = &[
@@ -121,8 +118,8 @@ fn handle_sort_transactions(
     serde_json::to_value(workspace_edit).ok()
 }
 
-/// Align amounts in the document by delegating to the document
-/// formatter ([`handle_formatting`]).
+/// Align amounts in the document by delegating to the shared
+/// document formatter ([`format_document`]).
 ///
 /// The formatting handler is the canonical alignment path now and it
 /// delegates further to [`rustledger_core::format_posting`], the same
@@ -138,25 +135,15 @@ fn handle_align_amounts(
     parse_result: &ParseResult,
     uri: &Uri,
 ) -> Option<serde_json::Value> {
-    // Synthesize the formatting params. Today `handle_formatting`
-    // ignores its `_params` argument (everything it needs comes from
-    // `source` + `parse_result`) so the placeholder is harmless.
-    //
-    // Note: `workspace/executeCommand` does NOT carry the client's
-    // formatting preferences (tab size, insert-spaces, etc.) — those
-    // only travel with `textDocument/formatting`. If `handle_formatting`
-    // ever starts honoring `params.options`, this command will keep
-    // using server defaults and silently diverge from
-    // `textDocument/formatting`. When that day comes, plumb a
-    // server-wide `FormatConfig` through both handlers (or accept the
-    // options as command arguments) — don't paper over it by mirroring
-    // a client value we don't have.
-    let params = DocumentFormattingParams {
-        text_document: TextDocumentIdentifier { uri: uri.clone() },
-        options: Default::default(),
-        work_done_progress_params: Default::default(),
-    };
-    let edits: Vec<TextEdit> = handle_formatting(&params, source, parse_result).unwrap_or_default();
+    // `workspace/executeCommand` does NOT carry the client's
+    // formatting preferences — those only travel with
+    // `textDocument/formatting`. Express that explicitly by passing
+    // `None` to `document_format_config`: when that helper grows
+    // real options handling, the executeCommand path will fall back
+    // to server defaults rather than silently mirroring an absent
+    // client value.
+    let config = document_format_config(None);
+    let edits: Vec<TextEdit> = format_document(source, parse_result, &config).unwrap_or_default();
 
     if edits.is_empty() {
         return Some(serde_json::json!({

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -138,11 +138,19 @@ fn handle_align_amounts(
     parse_result: &ParseResult,
     uri: &Uri,
 ) -> Option<serde_json::Value> {
-    // Synthesize the formatting params. `handle_formatting` ignores
-    // its `_params` argument today (everything it needs comes from
-    // `source` + `parse_result`), but we still construct a real
-    // `DocumentFormattingParams` so future option-driven behavior
-    // (e.g. tab size, alignment column) lands automatically.
+    // Synthesize the formatting params. Today `handle_formatting`
+    // ignores its `_params` argument (everything it needs comes from
+    // `source` + `parse_result`) so the placeholder is harmless.
+    //
+    // Note: `workspace/executeCommand` does NOT carry the client's
+    // formatting preferences (tab size, insert-spaces, etc.) — those
+    // only travel with `textDocument/formatting`. If `handle_formatting`
+    // ever starts honoring `params.options`, this command will keep
+    // using server defaults and silently diverge from
+    // `textDocument/formatting`. When that day comes, plumb a
+    // server-wide `FormatConfig` through both handlers (or accept the
+    // options as command arguments) — don't paper over it by mirroring
+    // a client value we don't have.
     let params = DocumentFormattingParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         options: Default::default(),

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -6,7 +6,7 @@
 //! - Consistent spacing around operators
 
 use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
-use rustledger_core::{Directive, FormatConfig, SYNTHESIZED_FILE_ID, format_posting};
+use rustledger_core::{Directive, FormatConfig, SYNTHESIZED_FILE_ID, format_posting_line};
 use rustledger_parser::ParseResult;
 
 use super::utils::LineIndex;
@@ -49,7 +49,7 @@ pub fn handle_formatting(
                 let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
                     && let Some(edit) =
-                        format_posting_line(line, posting_line, spanned_posting, &config)
+                        posting_text_edit(line, posting_line, spanned_posting, &config)
                 {
                     edits.push(edit);
                 }
@@ -99,23 +99,23 @@ pub fn handle_formatting(
     if edits.is_empty() { None } else { Some(edits) }
 }
 
-/// Compute a posting-line edit by delegating to the canonical core
-/// formatter ([`rustledger_core::format_posting`]). The previous
-/// hand-rolled implementation lived here for historical reasons:
+/// Compute a posting-line `TextEdit` by delegating to the canonical
+/// core formatter ([`rustledger_core::format_posting_line`]). The
+/// previous hand-rolled implementation here had two latent problems
+/// fixed by the unification:
 ///
-/// - It hardcoded `AMOUNT_COLUMN = 50`, so the LSP's "Format Document"
-///   produced output one column shy of `rledger format`'s default 60.
-/// - It only formatted the account + units, silently dropping cost
-///   specs (`{...}`) and price annotations (`@`/`@@`) from the
-///   formatted line. The mismatch caused the surrounding heuristic to
-///   refuse to emit an edit for such postings, so the LSP never
-///   realigned them.
+/// - It hardcoded `AMOUNT_COLUMN = 50`, so the LSP produced output one
+///   column shy of `rledger format`'s default 60.
+/// - It only formatted account + units, silently dropping cost specs
+///   (`{...}`) and price annotations (`@`/`@@`).
 ///
-/// Routing through the core formatter fixes both, and means a future
-/// option-driven `FormatConfig` (tab size, column, indent) reaches
-/// `rledger format`, `textDocument/formatting`, and `rledger.alignAmounts`
-/// from a single place.
-fn format_posting_line(
+/// `format_posting_line` is also the unit the on-disk formatter emits
+/// (it's reused inside `format_transaction`), so any TextEdit we emit
+/// matches exactly what `rledger format` would write to disk —
+/// **including the first same-line trailing comment**. An earlier
+/// draft delegated to the lower-level `format_posting`, which omitted
+/// the comment and would have produced edits that silently dropped it.
+fn posting_text_edit(
     line: &str,
     line_num: u32,
     posting: &rustledger_core::Posting,
@@ -128,7 +128,7 @@ fn format_posting_line(
         return None;
     }
 
-    let formatted = format_posting(posting, config);
+    let formatted = format_posting_line(posting, config);
 
     // No edit needed when the source line already matches the canonical
     // form (ignoring trailing whitespace, which a separate pass strips).
@@ -257,6 +257,53 @@ mod tests {
                 .iter()
                 .any(|e| posting_lines.contains(&e.range.start.line)),
             "formatter emitted no edits for posting lines — alignment broken"
+        );
+    }
+
+    /// Regression test: the formatter must preserve a same-line
+    /// trailing comment on a posting. An earlier draft of the
+    /// unification (PR #1158, commit `e537755f`) delegated to
+    /// `format_posting`, which omits trailing comments — so the
+    /// formatter emitted edits that silently dropped them. The fix
+    /// is to route through `format_posting_line` (the helper that
+    /// `format_transaction` also uses on the on-disk path), which
+    /// appends `posting.trailing_comments[0]` to the line.
+    #[test]
+    fn test_formatting_preserves_trailing_comment_on_posting() {
+        // Indent is intentionally wrong (4-space) so the formatter
+        // *must* emit an edit; otherwise we'd be testing nothing.
+        let source = "\
+2024-01-15 * \"Coffee\"
+    Assets:Bank  -5.00 USD ; my comment
+    Expenses:Food
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = DocumentFormattingParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        };
+        let edits = handle_formatting(&params, source, &result).unwrap_or_default();
+
+        // Apply edits to the source and check the comment is still
+        // present on its original line.
+        let line1_edit = edits
+            .iter()
+            .find(|e| e.range.start.line == 1)
+            .expect("expected an edit on line 1 (the Assets:Bank posting)");
+        assert!(
+            line1_edit.new_text.contains("; my comment"),
+            "trailing comment dropped from canonical-formatted posting line; \
+             got new_text = {:?}",
+            line1_edit.new_text
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -9,13 +9,35 @@ use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
 use rustledger_core::{Directive, FormatConfig, SYNTHESIZED_FILE_ID, format_posting_line};
 use rustledger_parser::ParseResult;
 
-use super::utils::LineIndex;
+use super::utils::{LineIndex, document_format_config};
 
-/// Handle a document formatting request.
+/// Handle a `textDocument/formatting` request.
+///
+/// Thin LSP-shaped wrapper around [`format_document`]. The protocol
+/// passes client `FormattingOptions` here; this function feeds them
+/// to [`document_format_config`] for the actual `FormatConfig`.
 pub fn handle_formatting(
-    _params: &DocumentFormattingParams,
+    params: &DocumentFormattingParams,
     source: &str,
     parse_result: &ParseResult,
+) -> Option<Vec<TextEdit>> {
+    let config = document_format_config(Some(&params.options));
+    format_document(source, parse_result, &config)
+}
+
+/// Compute the document-format edits for a parsed source with a
+/// resolved [`FormatConfig`].
+///
+/// Both `textDocument/formatting` (via [`handle_formatting`]) and
+/// `rledger.alignAmounts` (via `handle_align_amounts`) call into
+/// this — separated from the LSP-shaped wrapper so the executeCommand
+/// path can express its config source explicitly (`None` → server
+/// defaults) rather than synthesizing a fake `DocumentFormattingParams`
+/// just to reach the formatter.
+pub fn format_document(
+    source: &str,
+    parse_result: &ParseResult,
+    config: &FormatConfig,
 ) -> Option<Vec<TextEdit>> {
     let mut edits = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
@@ -23,12 +45,6 @@ pub fn handle_formatting(
     // offset lookup. Without it, calling the naive O(n) scanner per
     // posting per transaction is quadratic on large files.
     let line_index = LineIndex::new(source);
-    // One canonical FormatConfig for the whole document, shared with
-    // `rledger format` (CLI) and `format_directive` (core). Previously
-    // the LSP had its own hardcoded `AMOUNT_COLUMN = 50` constant —
-    // amounts the user saw in the editor were one column shy of what
-    // `rledger format` produced on disk.
-    let config = FormatConfig::default();
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
@@ -49,7 +65,7 @@ pub fn handle_formatting(
                 let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
                     && let Some(edit) =
-                        posting_text_edit(line, posting_line, spanned_posting, &config)
+                        posting_text_edit(line, posting_line, spanned_posting, config)
                 {
                     edits.push(edit);
                 }

--- a/crates/rustledger-lsp/src/handlers/formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/formatting.rs
@@ -6,13 +6,10 @@
 //! - Consistent spacing around operators
 
 use lsp_types::{DocumentFormattingParams, Position, Range, TextEdit};
-use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
+use rustledger_core::{Directive, FormatConfig, SYNTHESIZED_FILE_ID, format_posting};
 use rustledger_parser::ParseResult;
 
 use super::utils::LineIndex;
-
-/// Default column for amount alignment.
-const AMOUNT_COLUMN: usize = 50;
 
 /// Handle a document formatting request.
 pub fn handle_formatting(
@@ -26,6 +23,12 @@ pub fn handle_formatting(
     // offset lookup. Without it, calling the naive O(n) scanner per
     // posting per transaction is quadratic on large files.
     let line_index = LineIndex::new(source);
+    // One canonical FormatConfig for the whole document, shared with
+    // `rledger format` (CLI) and `format_directive` (core). Previously
+    // the LSP had its own hardcoded `AMOUNT_COLUMN = 50` constant —
+    // amounts the user saw in the editor were one column shy of what
+    // `rledger format` produced on disk.
+    let config = FormatConfig::default();
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
@@ -45,7 +48,8 @@ pub fn handle_formatting(
                 }
                 let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
                 if let Some(line) = lines.get(posting_line as usize)
-                    && let Some(edit) = format_posting_line(line, posting_line, spanned_posting)
+                    && let Some(edit) =
+                        format_posting_line(line, posting_line, spanned_posting, &config)
                 {
                     edits.push(edit);
                 }
@@ -95,11 +99,27 @@ pub fn handle_formatting(
     if edits.is_empty() { None } else { Some(edits) }
 }
 
-/// Format a posting line for alignment.
+/// Compute a posting-line edit by delegating to the canonical core
+/// formatter ([`rustledger_core::format_posting`]). The previous
+/// hand-rolled implementation lived here for historical reasons:
+///
+/// - It hardcoded `AMOUNT_COLUMN = 50`, so the LSP's "Format Document"
+///   produced output one column shy of `rledger format`'s default 60.
+/// - It only formatted the account + units, silently dropping cost
+///   specs (`{...}`) and price annotations (`@`/`@@`) from the
+///   formatted line. The mismatch caused the surrounding heuristic to
+///   refuse to emit an edit for such postings, so the LSP never
+///   realigned them.
+///
+/// Routing through the core formatter fixes both, and means a future
+/// option-driven `FormatConfig` (tab size, column, indent) reaches
+/// `rledger format`, `textDocument/formatting`, and `rledger.alignAmounts`
+/// from a single place.
 fn format_posting_line(
     line: &str,
     line_num: u32,
     posting: &rustledger_core::Posting,
+    config: &FormatConfig,
 ) -> Option<TextEdit> {
     let trimmed = line.trim();
 
@@ -108,67 +128,21 @@ fn format_posting_line(
         return None;
     }
 
-    // Parse the line to find account and amount positions
-    let account = posting.account.to_string();
+    let formatted = format_posting(posting, config);
 
-    // Check if line starts with proper indentation
-    let current_indent = line.len() - line.trim_start().len();
-    let expected_indent = 2;
-
-    // Build the formatted line
-    let mut formatted = String::new();
-
-    // Add indentation
-    formatted.push_str(&" ".repeat(expected_indent));
-
-    // Add account
-    formatted.push_str(&account);
-
-    // Add amount if present
-    if let Some(ref units) = posting.units
-        && let (Some(num), Some(curr)) = (units.number(), units.currency())
-    {
-        let num_str = num.to_string();
-        let curr_str = curr.to_string();
-        let amount_str = format!("{} {}", num_str, curr_str);
-
-        // Calculate padding to align amount at AMOUNT_COLUMN
-        let current_len = expected_indent + account.len();
-        let padding = if current_len < AMOUNT_COLUMN - amount_str.len() {
-            AMOUNT_COLUMN - amount_str.len() - current_len
-        } else {
-            2 // Minimum 2 spaces
-        };
-
-        formatted.push_str(&" ".repeat(padding));
-        formatted.push_str(&amount_str);
+    // No edit needed when the source line already matches the canonical
+    // form (ignoring trailing whitespace, which a separate pass strips).
+    if formatted.trim_end() == line.trim_end() {
+        return None;
     }
 
-    // Check if formatting changed anything significant
-    let line_trimmed_end = line.trim_end();
-    if formatted.trim_end() != line_trimmed_end
-        && (current_indent != expected_indent || needs_alignment(line, &formatted))
-    {
-        Some(TextEdit {
-            range: Range {
-                start: Position::new(line_num, 0),
-                end: Position::new(line_num, line.len() as u32),
-            },
-            new_text: formatted,
-        })
-    } else {
-        None
-    }
-}
-
-/// Check if line needs amount alignment.
-fn needs_alignment(original: &str, formatted: &str) -> bool {
-    // Simple heuristic: if the formatted version has different spacing, align
-    let orig_parts: Vec<&str> = original.split_whitespace().collect();
-    let fmt_parts: Vec<&str> = formatted.split_whitespace().collect();
-
-    // If content is the same but spacing is different, we need alignment
-    orig_parts == fmt_parts && original.trim() != formatted.trim()
+    Some(TextEdit {
+        range: Range {
+            start: Position::new(line_num, 0),
+            end: Position::new(line_num, line.len() as u32),
+        },
+        new_text: formatted,
+    })
 }
 
 #[cfg(test)]

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -3,9 +3,36 @@
 //! This module contains common utilities used across multiple handlers,
 //! including position conversion, word extraction, and type checking.
 
-use lsp_types::Position;
-use rustledger_core::Directive;
+use lsp_types::{FormattingOptions, Position};
+use rustledger_core::{Directive, FormatConfig};
 use rustledger_parser::ParseResult;
+
+/// Resolve the `FormatConfig` the LSP server uses for a given request.
+///
+/// Today both `textDocument/formatting` (which has client-supplied
+/// `FormattingOptions`) and the `rledger.alignAmounts`
+/// `workspace/executeCommand` (which does NOT — the LSP protocol
+/// doesn't pass formatting preferences with commands) come through
+/// this single function. That keeps the two paths producing identical
+/// edits even though their inputs differ.
+///
+/// When the LSP server gains real config plumbing (server-wide
+/// settings via initializationOptions, or per-document settings via
+/// `workspace/configuration`), update this one function: derive
+/// `amount_column` / `indent` from the client `tab_size`,
+/// `insert_spaces`, and any `properties.amount_column` extension; for
+/// the executeCommand path (`opts == None`), fall back to the
+/// server-wide configured value rather than `FormatConfig::default()`.
+/// Both call sites then benefit automatically.
+#[must_use]
+pub fn document_format_config(_opts: Option<&FormattingOptions>) -> FormatConfig {
+    // Intentionally ignores the supplied options for now: the LSP
+    // server has no config layer yet, so honoring `tab_size` /
+    // `insert_spaces` would mean the executeCommand path (which
+    // can't see them) diverged from `textDocument/formatting` for
+    // no upside. Wire both at once when the config layer lands.
+    FormatConfig::default()
+}
 
 /// A line index for efficient offset-to-position conversion.
 ///


### PR DESCRIPTION
## Summary

Unifies the LSP and CLI formatters around `rustledger_core::format_posting_line`, the single canonical "what does a posting line look like" function. The LSP previously had its own hand-rolled formatter with three latent problems that are now gone.

## What this PR fixes

### Column mismatch (LSP=50, CLI=60)

`crates/rustledger-lsp/src/handlers/formatting.rs:15` hardcoded `AMOUNT_COLUMN = 50`; `FormatConfig::default()` in core defaults to 60. `rledger format` on disk and the editor's "Format Document" produced amounts in different columns. They now agree — both use the core default.

### Silent cost/price drop

The old LSP formatter only handled account + units. For a posting like

```
Assets:Brokerage  10 AAPL {150 USD} @ 155 USD
```

the formatted output dropped `{150 USD} @ 155 USD`. The surrounding tokenization heuristic noticed the mismatch and bailed, so the LSP **silently never realigned cost-bearing or priced postings**. Routing through `format_posting_line` (which handles cost + price + units uniformly) fixes it.

### Trailing-comment data loss (caught mid-review)

An earlier draft of this PR delegated to `format_posting` directly. That function omits trailing comments — so a source line like `Assets:Bank  -50.00 USD  ; my comment` would have had the `; my comment` silently dropped on format. The pre-unification code accidentally avoided this via its `needs_alignment` token-compare heuristic. The fix (commit `73e1f5d9`) extracts a `format_posting_line` helper in core that wraps `format_posting` + appends the first trailing comment, so the on-disk path (`format_transaction`) and the LSP edit path call the same helper. Regression test in `test_formatting_preserves_trailing_comment_on_posting` — verified to FAIL against the broken version.

## Architecture after this PR

```
rustledger_core::format_posting_line(posting, config)
            │
            ├── format_transaction (on-disk, via rledger format)
            └── posting_text_edit (LSP)
                       │
                       ├── format_document (pure body)
                       │      ├── handle_formatting (textDocument/formatting)
                       │      │       └── document_format_config(Some(&opts))
                       │      └── handle_align_amounts (rledger.alignAmounts)
                       │              └── document_format_config(None)
```

One canonical posting-line renderer; one canonical `FormatConfig` resolver; both LSP entrypoints share both. The on-disk and editor paths produce **identical output** for any given config.

## User-visible behavior changes

**Amount column moves from 50 → 60.** Anyone using the LSP's "Format Document" or "Align Amounts" command will see their amounts shift one column right. This matches the column `rledger format` already produces on disk — and means saving via the editor and saving via the CLI produce the same file. Users who want column 50 back will need server-config plumbing (see next section).

**Cost-bearing and priced postings now realign.** Previously the LSP formatter silently skipped them; now they format like any other posting.

## Known limitation, with explicit deferred fix

`workspace/executeCommand` does not carry the client's `FormattingOptions` (tab size, etc.) — those only travel with `textDocument/formatting`. The `rledger.alignAmounts` command therefore always uses server defaults, while `textDocument/formatting` *could* honor client options.

Today both paths produce identical output because `document_format_config` ignores its argument and returns `FormatConfig::default()`. When the LSP server gains real config plumbing (server-wide settings via `initializationOptions`, or per-document via `workspace/configuration`), that helper is the single point to update — both call sites benefit automatically, and the executeCommand path will fall back to server defaults (via the explicit `None`) rather than silently mirroring an absent client value.

This is documented in the code on both `document_format_config` and at the `handle_align_amounts` call site.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets`
- [x] `RUSTFLAGS=-Dwarnings cargo build --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `cargo test -p rustledger-lsp -p rustledger-core --all-features` — **134 LSP + 305 core, 0 failures**
- [x] `cargo fmt --all -- --check`
- [x] `test_align_amounts_produces_canonical_alignment` — applies emitted edits, asserts the amount column equals `FormatConfig::default().amount_column`.
- [x] `test_formatting_preserves_trailing_comment_on_posting` — verified to fail against the data-loss-prone version.

Refs #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
