### PR TITLE
refactor(lsp): inlay_hints delegates inference to booking::interpolate

### DIFF
--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -140,7 +140,13 @@ pub fn handle_inlay_hints(
                 continue;
             };
 
-            // Position hint at the end of the account name
+            // Position the hint at the end of the trimmed line
+            // content. We only reach this point for fully-missing
+            // source postings (the filter above), so a well-formed
+            // posting line is `[indent][flag ]account[trailing ws]`
+            // — `indent + trimmed.len()` lands right after the
+            // account (or `flag account` if a flag is present),
+            // which is where the inferred amount visually belongs.
             let trimmed = line.trim();
             let indent = line.len() - line.trim_start().len();
             let end_col = indent + trimmed.len();

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -21,7 +21,6 @@ pub fn handle_inlay_hints(
     parse_result: &ParseResult,
 ) -> Option<Vec<InlayHint>> {
     let range = params.range;
-    let uri = params.text_document.uri.as_str();
     let mut hints = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
     // Build the line index once: O(n) up front, O(log lines) per
@@ -33,8 +32,14 @@ pub fn handle_inlay_hints(
         let Directive::Transaction(txn) = &spanned.value else {
             continue;
         };
+        // Skip transactions that fall entirely outside the
+        // requested range, in either direction. `span.end` is
+        // exclusive (byte after the directive), so an `end_line <
+        // range.start.line` test cleanly excludes "directive ended
+        // before the visible range started".
         let (start_line, _) = line_index.offset_to_position(spanned.span.start);
-        if start_line > range.end.line {
+        let (end_line, _) = line_index.offset_to_position(spanned.span.end);
+        if start_line > range.end.line || end_line < range.start.line {
             continue;
         }
 
@@ -88,11 +93,12 @@ pub fn handle_inlay_hints(
         //    step removes zero-amount fills from
         //    `result.postings`, which shifts subsequent fills'
         //    positions; `filled_indices` is then result-relative,
-        //    not source-relative. Matching by span — preserved
-        //    across `interpolate`'s clone — sidesteps that issue
-        //    entirely. (In current code paths the zero-fill case is
-        //    structurally unreachable, but the design is robust to
-        //    future changes.)
+        //    not source-relative. A reachable case is e.g. a
+        //    `CurrencyOnly` posting whose currency's residual is
+        //    already zero — interpolate fills with 0 and prunes,
+        //    shifting later fills. Matching by span — preserved
+        //    across `interpolate`'s clone — works regardless of
+        //    pruning and shifting.
         for source_posting in &txn.postings {
             if source_posting.units.is_some() {
                 continue;
@@ -141,7 +147,6 @@ pub fn handle_inlay_hints(
 
             // Store data for resolve - include account for rich tooltip
             let data = serde_json::json!({
-                "uri": uri,
                 "kind": "inferred_amount",
                 "account": source_posting.account.to_string(),
                 "amount": amount.number.to_string(),
@@ -479,27 +484,22 @@ mod tests {
         );
     }
 
-    /// `NumberOnly`/`CurrencyOnly` source postings already display
-    /// one half (the typed digits or the typed currency) on the
-    /// posting line. Appending the inferred other-half at line-end
-    /// would visually duplicate the typed text or wrongly order
-    /// number-then-currency (e.g. `Assets:Cash USD  -50.00 USD`).
-    /// The interpolator fills these slots correctly, but the LSP
-    /// deliberately suppresses hints for them — the bespoke
-    /// pre-refactor implementation only emitted hints for fully-
-    /// missing postings, and we preserve that UX.
+    /// `NumberOnly` source postings already display the typed
+    /// digits on the posting line. The interpolator can still fill
+    /// the currency (e.g., from another posting's units residual),
+    /// but appending `  -5000.00 USD` after `-5000.00` would
+    /// duplicate the number on screen. The LSP suppresses the
+    /// hint; the bespoke pre-refactor implementation did the same.
+    ///
+    /// This test specifically exercises a transaction where
+    /// `interpolate` SUCCEEDS and fills the `NumberOnly` slot —
+    /// pinning the filter (not bypass-by-error).
     #[test]
-    fn test_inlay_hints_skip_partial_amounts() {
-        // First posting is `CurrencyOnly` ("USD"), second is
-        // `NumberOnly` ("-50.00"). The interpolator fills both, but
-        // neither should produce a hint.
+    fn test_inlay_hints_skip_number_only_posting() {
         let source = "\
-2024-01-15 * \"Test\"
-  Assets:Bank   50.00 USD
-  Expenses:A    USD
-  Income:B     -100.00
-  Equity:Pad   -50 EUR
-  Expenses:Tax  50 EUR
+2024-01-15 * \"Paycheck\"
+  Assets:Bank  5000 USD
+  Income:Salary  -5000
 ";
         let result = parse(source);
         assert!(
@@ -508,13 +508,34 @@ mod tests {
             result.errors
         );
 
+        // Verify the precondition: `interpolate` succeeds and fills
+        // the `NumberOnly` slot. Without this, the no-hints assertion
+        // below could pass via bypass-by-Err (a non-issue for THIS
+        // input, but documenting the requirement).
+        let txn = match &result.directives[0].value {
+            Directive::Transaction(t) => t,
+            _ => unreachable!(),
+        };
+        let interp = interpolate(txn).expect("interpolate should succeed");
+        let salary_posting = interp
+            .transaction
+            .postings
+            .iter()
+            .find(|p| p.account.as_ref() == "Income:Salary")
+            .expect("Income:Salary should be present after interpolation");
+        assert!(
+            matches!(&salary_posting.units, Some(IncompleteAmount::Complete(_))),
+            "interpolate must have filled NumberOnly to Complete; got {:?}",
+            salary_posting.units
+        );
+
         let params = InlayHintParams {
             text_document: lsp_types::TextDocumentIdentifier {
                 uri: "file:///test.beancount".parse().unwrap(),
             },
             range: lsp_types::Range {
                 start: Position::new(0, 0),
-                end: Position::new(20, 0),
+                end: Position::new(10, 0),
             },
             work_done_progress_params: Default::default(),
         };
@@ -522,7 +543,62 @@ mod tests {
         let hints = handle_inlay_hints(&params, source, &result);
         assert!(
             hints.is_none() || hints.as_ref().unwrap().is_empty(),
-            "no hints expected for partial-amount postings; got {hints:?}"
+            "no hint expected for NumberOnly source posting; got {hints:?}"
+        );
+    }
+
+    /// Same UX invariant as the `NumberOnly` test above, applied to
+    /// `CurrencyOnly` (typed `USD`, missing number). Appending the
+    /// inferred amount at line-end would render as
+    /// `Assets:Cash USD  -50.00 USD` — duplicate currency, wrong
+    /// number-then-currency order. The LSP suppresses the hint.
+    #[test]
+    fn test_inlay_hints_skip_currency_only_posting() {
+        let source = "\
+2024-01-15 * \"Coffee\"
+  Assets:Bank  -5.00 USD
+  Expenses:Food USD
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        // Precondition: interpolate succeeds and fills CurrencyOnly.
+        let txn = match &result.directives[0].value {
+            Directive::Transaction(t) => t,
+            _ => unreachable!(),
+        };
+        let interp = interpolate(txn).expect("interpolate should succeed");
+        let food_posting = interp
+            .transaction
+            .postings
+            .iter()
+            .find(|p| p.account.as_ref() == "Expenses:Food")
+            .expect("Expenses:Food should be present after interpolation");
+        assert!(
+            matches!(&food_posting.units, Some(IncompleteAmount::Complete(_))),
+            "interpolate must have filled CurrencyOnly to Complete; got {:?}",
+            food_posting.units
+        );
+
+        let params = InlayHintParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            range: lsp_types::Range {
+                start: Position::new(0, 0),
+                end: Position::new(10, 0),
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        let hints = handle_inlay_hints(&params, source, &result);
+        assert!(
+            hints.is_none() || hints.as_ref().unwrap().is_empty(),
+            "no hint expected for CurrencyOnly source posting; got {hints:?}"
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -22,10 +22,12 @@ pub fn handle_inlay_hints(
 ) -> Option<Vec<InlayHint>> {
     let range = params.range;
     let mut hints = Vec::new();
-    let lines: Vec<&str> = source.lines().collect();
     // Build the line index once: O(n) up front, O(log lines) per
     // offset lookup. Without it the per-directive + per-posting
-    // lookups below scale quadratically with file size.
+    // lookups below scale quadratically with file size. We also
+    // use `line_index.line_text(...)` further down instead of
+    // pre-collecting `Vec<&str>` of all lines, so a large fully-
+    // explicit ledger pays neither allocation.
     let line_index = LineIndex::new(source);
 
     for spanned in &parse_result.directives {
@@ -118,6 +120,18 @@ pub fn handle_inlay_hints(
             // identifies the same posting reliably. If no match —
             // the slot filled to zero and got pruned — emit no
             // hint.
+            //
+            // Note on the multi-currency single-missing case:
+            // `interpolate` fills the source posting with the FIRST
+            // residual currency in place, then appends additional
+            // posting clones (one per remaining currency, each
+            // carrying the SAME span as the template). `find()`
+            // returns the in-place fill — so we emit one hint
+            // covering only the first currency. Surfacing the
+            // others would require either a multi-line hint layout
+            // or stacking hints at the same screen position; we
+            // accept the single-currency rendering to match the
+            // pre-refactor bespoke implementation.
             let Some(filled_posting) = filled
                 .transaction
                 .postings
@@ -136,7 +150,7 @@ pub fn handle_inlay_hints(
                 continue;
             };
 
-            let Some(line) = lines.get(posting_line as usize) else {
+            let Some(line) = line_index.line_text(source, posting_line) else {
                 continue;
             };
 
@@ -314,13 +328,15 @@ mod tests {
 
         let resolved = handle_inlay_hint_resolve(hint, &result);
 
-        // Should now have a tooltip
-        assert!(resolved.tooltip.is_some());
-
-        if let Some(lsp_types::InlayHintTooltip::MarkupContent(content)) = resolved.tooltip {
-            assert!(content.value.contains("Expenses:Food"));
-            assert!(content.value.contains("2 transactions"));
-        }
+        // Pattern-match the variant explicitly: a `String` tooltip
+        // (the other variant) would silently pass the prior
+        // `if let Some(MarkupContent(_))` pattern.
+        let content = match resolved.tooltip {
+            Some(lsp_types::InlayHintTooltip::MarkupContent(c)) => c,
+            other => panic!("expected MarkupContent tooltip; got {other:?}"),
+        };
+        assert!(content.value.contains("Expenses:Food"));
+        assert!(content.value.contains("2 transactions"));
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -7,6 +7,7 @@
 //! Supports resolve for lazy-loading rich tooltips with account details.
 
 use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Position};
+use rustledger_booking::interpolate;
 use rustledger_core::{Decimal, Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
@@ -37,17 +38,32 @@ pub fn handle_inlay_hints(
                 continue;
             }
 
-            // Calculate the inferred amount for postings without amounts
-            let inferred = calculate_inferred_amount(txn);
+            // Delegate inference to the canonical booking interpolator.
+            // The previous bespoke implementation (`calculate_inferred_amount`)
+            // only handled the simplest case (exactly one missing posting,
+            // exactly one currency) — multi-currency transactions and
+            // postings with cost specs were silently skipped. The booking
+            // interpolator handles all of them.
+            //
+            // `interpolate` returns the filled-in transaction plus
+            // `filled_indices` telling us which posting slots it
+            // populated. If interpolation fails (e.g., MultipleMissing,
+            // unbalanced amounts) we silently skip — no hints is the
+            // right outcome for an under-specified transaction.
+            let Ok(filled) = interpolate(txn) else {
+                continue;
+            };
 
             // Per-posting span lookup (see #1142): the prior
             // `start_line + 1 + i` arithmetic put hints on the wrong
             // line for transactions with interleaved metadata.
-            for spanned_posting in &txn.postings {
+            for &idx in &filled.filled_indices {
+                let Some(spanned_posting) = txn.postings.get(idx) else {
+                    continue;
+                };
                 if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
                     continue;
                 }
-                let posting = &**spanned_posting;
                 let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
 
                 // Skip if outside range
@@ -55,36 +71,51 @@ pub fn handle_inlay_hints(
                     continue;
                 }
 
-                // Only show hint for postings without explicit amount
-                if posting.units.is_none()
-                    && let Some((amount, currency)) = &inferred
-                    && let Some(line) = lines.get(posting_line as usize)
-                {
-                    // Position hint at the end of the account name
-                    let trimmed = line.trim();
-                    let indent = line.len() - line.trim_start().len();
-                    let end_col = indent + trimmed.len();
+                // Pull the filled amount out of the interpolated
+                // transaction. `interpolate` only adds a posting to
+                // `filled_indices` when it produced a `Complete`
+                // amount, so this unwrap-chain is total in practice;
+                // bail defensively if a future change ever changes
+                // that.
+                let Some(filled_posting) = filled.transaction.postings.get(idx) else {
+                    continue;
+                };
+                let Some(rustledger_core::IncompleteAmount::Complete(amount)) =
+                    &filled_posting.units
+                else {
+                    continue;
+                };
+                let Some(line) = lines.get(posting_line as usize) else {
+                    continue;
+                };
 
-                    // Store data for resolve - include account for rich tooltip
-                    let data = serde_json::json!({
-                        "uri": uri,
-                        "kind": "inferred_amount",
-                        "account": posting.account.to_string(),
-                        "amount": amount.to_string(),
-                        "currency": currency,
-                    });
+                // Position hint at the end of the account name
+                let trimmed = line.trim();
+                let indent = line.len() - line.trim_start().len();
+                let end_col = indent + trimmed.len();
 
-                    hints.push(InlayHint {
-                        position: Position::new(posting_line, end_col as u32),
-                        label: InlayHintLabel::String(format!("  {} {}", amount, currency)),
-                        kind: Some(InlayHintKind::TYPE),
-                        text_edits: None,
-                        tooltip: None, // Resolved lazily
-                        padding_left: Some(true),
-                        padding_right: None,
-                        data: Some(data),
-                    });
-                }
+                // Store data for resolve - include account for rich tooltip
+                let data = serde_json::json!({
+                    "uri": uri,
+                    "kind": "inferred_amount",
+                    "account": spanned_posting.account.to_string(),
+                    "amount": amount.number.to_string(),
+                    "currency": amount.currency.to_string(),
+                });
+
+                hints.push(InlayHint {
+                    position: Position::new(posting_line, end_col as u32),
+                    label: InlayHintLabel::String(format!(
+                        "  {} {}",
+                        amount.number, amount.currency
+                    )),
+                    kind: Some(InlayHintKind::TYPE),
+                    text_edits: None,
+                    tooltip: None, // Resolved lazily
+                    padding_left: Some(true),
+                    padding_right: None,
+                    data: Some(data),
+                });
             }
         }
     }
@@ -165,33 +196,6 @@ fn build_account_tooltip(
     tooltip
 }
 
-/// Calculate the inferred amount for a transaction with one empty posting.
-fn calculate_inferred_amount(txn: &rustledger_core::Transaction) -> Option<(Decimal, String)> {
-    // Count postings with and without amounts
-    let mut amounts_by_currency: HashMap<String, Decimal> = HashMap::new();
-    let mut empty_posting_count = 0;
-
-    for posting in &txn.postings {
-        if let Some(ref units) = posting.units {
-            if let (Some(num), Some(curr)) = (units.number(), units.currency()) {
-                let currency = curr.to_string();
-                *amounts_by_currency.entry(currency).or_insert(Decimal::ZERO) += num;
-            }
-        } else {
-            empty_posting_count += 1;
-        }
-    }
-
-    // Only infer if exactly one posting has no amount and we have a single currency
-    if empty_posting_count == 1 && amounts_by_currency.len() == 1 {
-        let (currency, total) = amounts_by_currency.into_iter().next()?;
-        // The inferred amount is the negation of the sum
-        Some((-total, currency))
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,26 +229,6 @@ mod tests {
         if let InlayHintLabel::String(label) = &hints[0].label {
             assert!(label.contains("5.00"));
             assert!(label.contains("USD"));
-        }
-    }
-
-    #[test]
-    fn test_calculate_inferred_amount() {
-        let source = r#"2024-01-15 * "Test"
-  Assets:Bank  -10.00 USD
-  Expenses:Food
-"#;
-        let result = parse(source);
-
-        if let Some(spanned) = result.directives.first()
-            && let Directive::Transaction(txn) = &spanned.value
-        {
-            let inferred = calculate_inferred_amount(txn);
-            assert!(inferred.is_some());
-
-            let (amount, currency) = inferred.unwrap();
-            assert_eq!(amount, Decimal::new(1000, 2)); // 10.00
-            assert_eq!(currency, "USD");
         }
     }
 
@@ -384,6 +368,73 @@ mod tests {
         assert_eq!(
             hints[0].position.line, 3,
             "inferred-amount hint should be on the posting line, not the metadata line"
+        );
+    }
+
+    /// Multi-currency transactions used to get NO inferred-amount
+    /// hints at all: the bespoke `calculate_inferred_amount` bailed
+    /// the moment more than one currency was seen, even when each
+    /// currency had exactly one missing posting (a perfectly
+    /// inferable case). Delegating to `rustledger_booking::interpolate`
+    /// produces a hint per inferred posting, including the
+    /// multi-currency case below.
+    #[test]
+    fn test_inlay_hints_multi_currency_inference() {
+        let source = "\
+2024-01-15 * \"FX swap\"
+  Assets:Bank:USD  100.00 USD
+  Assets:Bank:EUR  -90.00 EUR
+  Expenses:Fees:USD
+  Expenses:Fees:EUR
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = InlayHintParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            range: lsp_types::Range {
+                start: Position::new(0, 0),
+                end: Position::new(10, 0),
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        let hints = handle_inlay_hints(&params, source, &result).unwrap_or_default();
+
+        // Both empty postings should get a hint, with the correct
+        // per-currency residual. Pre-refactor: zero hints (multi-
+        // currency was bailed entirely).
+        assert_eq!(
+            hints.len(),
+            2,
+            "expected one hint per inferred posting; got {hints:?}"
+        );
+
+        // Labels carry the (sign-flipped) residual + currency. The
+        // expected residuals are -100 USD (negating the +100 USD
+        // explicit posting) and +90 EUR (negating -90 EUR).
+        let labels: Vec<String> = hints
+            .iter()
+            .map(|h| match &h.label {
+                InlayHintLabel::String(s) => s.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        assert!(
+            labels
+                .iter()
+                .any(|l| l.contains("-100") && l.contains("USD")),
+            "expected a hint showing -100 USD; got labels = {labels:?}"
+        );
+        assert!(
+            labels.iter().any(|l| l.contains("90") && l.contains("EUR")),
+            "expected a hint showing 90 EUR; got labels = {labels:?}"
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -8,7 +8,7 @@
 
 use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Position};
 use rustledger_booking::interpolate;
-use rustledger_core::{Decimal, Directive, SYNTHESIZED_FILE_ID};
+use rustledger_core::{Decimal, Directive, IncompleteAmount, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
@@ -30,93 +30,134 @@ pub fn handle_inlay_hints(
     let line_index = LineIndex::new(source);
 
     for spanned in &parse_result.directives {
-        if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = line_index.offset_to_position(spanned.span.start);
+        let Directive::Transaction(txn) = &spanned.value else {
+            continue;
+        };
+        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
+        if start_line > range.end.line {
+            continue;
+        }
 
-            // Skip if transaction is outside the requested range
-            if start_line > range.end.line {
+        // Fast path: a transaction with no fully-missing postings
+        // has no inferred-amount hint to emit, and there's no point
+        // running the interpolator (which clones the transaction
+        // internally). The common case is fully-explicit
+        // transactions, so this gate is a meaningful win on large
+        // files where inlay hints are recomputed on every keystroke.
+        //
+        // We gate on `units.is_none()` rather than "any non-Complete"
+        // because the inlay-hint UX only renders for fully-missing
+        // postings — see the filter further down.
+        if !txn.postings.iter().any(|p| p.units.is_none()) {
+            continue;
+        }
+
+        // Delegate inference to the canonical booking interpolator.
+        // The previous bespoke implementation (`calculate_inferred_amount`)
+        // only handled the simplest case (exactly one missing posting,
+        // exactly one currency) — multi-currency transactions and
+        // postings with cost specs silently emitted zero hints.
+        //
+        // `InterpolationError` (e.g. MultipleMissing, unbalanced) is
+        // silently dropped: no hints for an under-specified
+        // transaction is the right outcome.
+        let Ok(filled) = interpolate(txn) else {
+            continue;
+        };
+
+        // Walk SOURCE postings (not `filled.filled_indices`) and
+        // locate each fill by matching span. Three properties fall
+        // out of this design:
+        //
+        // 1. **Source-order, deterministic output.** The
+        //    interpolator's `filled_indices` is built from
+        //    HashMap-driven iteration whose order is unspecified;
+        //    walking source postings gives a stable order the
+        //    client can rely on.
+        //
+        // 2. **Naturally restricts to fully-missing postings.**
+        //    `NumberOnly`/`CurrencyOnly` source postings already
+        //    display one half on screen, so appending the other
+        //    half at line-end would visually duplicate the typed
+        //    text (`Assets:Cash USD  -50.00 USD`) or wrongly order
+        //    number-then-currency. The bespoke pre-refactor
+        //    implementation only emitted hints for fully-missing
+        //    postings, and we deliberately preserve that UX.
+        //
+        // 3. **Sidesteps prune-shift bugs.** Interpolate's prune
+        //    step removes zero-amount fills from
+        //    `result.postings`, which shifts subsequent fills'
+        //    positions; `filled_indices` is then result-relative,
+        //    not source-relative. Matching by span — preserved
+        //    across `interpolate`'s clone — sidesteps that issue
+        //    entirely. (In current code paths the zero-fill case is
+        //    structurally unreachable, but the design is robust to
+        //    future changes.)
+        for source_posting in &txn.postings {
+            if source_posting.units.is_some() {
+                continue;
+            }
+            if source_posting.file_id == SYNTHESIZED_FILE_ID {
                 continue;
             }
 
-            // Delegate inference to the canonical booking interpolator.
-            // The previous bespoke implementation (`calculate_inferred_amount`)
-            // only handled the simplest case (exactly one missing posting,
-            // exactly one currency) — multi-currency transactions and
-            // postings with cost specs were silently skipped. The booking
-            // interpolator handles all of them.
-            //
-            // `interpolate` returns the filled-in transaction plus
-            // `filled_indices` telling us which posting slots it
-            // populated. If interpolation fails (e.g., MultipleMissing,
-            // unbalanced amounts) we silently skip — no hints is the
-            // right outcome for an under-specified transaction.
-            let Ok(filled) = interpolate(txn) else {
+            let (posting_line, _) = line_index.offset_to_position(source_posting.span.start);
+            if posting_line < range.start.line || posting_line > range.end.line {
+                continue;
+            }
+
+            // Match the filled version of this source posting by
+            // span. `interpolate` clones source postings and
+            // preserves their spans, so byte-offset equality
+            // identifies the same posting reliably. If no match —
+            // the slot filled to zero and got pruned — emit no
+            // hint.
+            let Some(filled_posting) = filled
+                .transaction
+                .postings
+                .iter()
+                .find(|p| p.span.start == source_posting.span.start)
+            else {
                 continue;
             };
 
-            // Per-posting span lookup (see #1142): the prior
-            // `start_line + 1 + i` arithmetic put hints on the wrong
-            // line for transactions with interleaved metadata.
-            for &idx in &filled.filled_indices {
-                let Some(spanned_posting) = txn.postings.get(idx) else {
-                    continue;
-                };
-                if spanned_posting.file_id == SYNTHESIZED_FILE_ID {
-                    continue;
-                }
-                let (posting_line, _) = line_index.offset_to_position(spanned_posting.span.start);
+            let Some(IncompleteAmount::Complete(amount)) = &filled_posting.units else {
+                debug_assert!(
+                    false,
+                    "interpolate: fully-missing source posting did not fill to Complete: {:?}",
+                    filled_posting.units
+                );
+                continue;
+            };
 
-                // Skip if outside range
-                if posting_line < range.start.line || posting_line > range.end.line {
-                    continue;
-                }
+            let Some(line) = lines.get(posting_line as usize) else {
+                continue;
+            };
 
-                // Pull the filled amount out of the interpolated
-                // transaction. `interpolate` only adds a posting to
-                // `filled_indices` when it produced a `Complete`
-                // amount, so this unwrap-chain is total in practice;
-                // bail defensively if a future change ever changes
-                // that.
-                let Some(filled_posting) = filled.transaction.postings.get(idx) else {
-                    continue;
-                };
-                let Some(rustledger_core::IncompleteAmount::Complete(amount)) =
-                    &filled_posting.units
-                else {
-                    continue;
-                };
-                let Some(line) = lines.get(posting_line as usize) else {
-                    continue;
-                };
+            // Position hint at the end of the account name
+            let trimmed = line.trim();
+            let indent = line.len() - line.trim_start().len();
+            let end_col = indent + trimmed.len();
 
-                // Position hint at the end of the account name
-                let trimmed = line.trim();
-                let indent = line.len() - line.trim_start().len();
-                let end_col = indent + trimmed.len();
+            // Store data for resolve - include account for rich tooltip
+            let data = serde_json::json!({
+                "uri": uri,
+                "kind": "inferred_amount",
+                "account": source_posting.account.to_string(),
+                "amount": amount.number.to_string(),
+                "currency": amount.currency.to_string(),
+            });
 
-                // Store data for resolve - include account for rich tooltip
-                let data = serde_json::json!({
-                    "uri": uri,
-                    "kind": "inferred_amount",
-                    "account": spanned_posting.account.to_string(),
-                    "amount": amount.number.to_string(),
-                    "currency": amount.currency.to_string(),
-                });
-
-                hints.push(InlayHint {
-                    position: Position::new(posting_line, end_col as u32),
-                    label: InlayHintLabel::String(format!(
-                        "  {} {}",
-                        amount.number, amount.currency
-                    )),
-                    kind: Some(InlayHintKind::TYPE),
-                    text_edits: None,
-                    tooltip: None, // Resolved lazily
-                    padding_left: Some(true),
-                    padding_right: None,
-                    data: Some(data),
-                });
-            }
+            hints.push(InlayHint {
+                position: Position::new(posting_line, end_col as u32),
+                label: InlayHintLabel::String(format!("  {} {}", amount.number, amount.currency)),
+                kind: Some(InlayHintKind::TYPE),
+                text_edits: None,
+                tooltip: None, // Resolved lazily
+                padding_left: Some(true),
+                padding_right: None,
+                data: Some(data),
+            });
         }
     }
 
@@ -435,6 +476,53 @@ mod tests {
         assert!(
             labels.iter().any(|l| l.contains("90") && l.contains("EUR")),
             "expected a hint showing 90 EUR; got labels = {labels:?}"
+        );
+    }
+
+    /// `NumberOnly`/`CurrencyOnly` source postings already display
+    /// one half (the typed digits or the typed currency) on the
+    /// posting line. Appending the inferred other-half at line-end
+    /// would visually duplicate the typed text or wrongly order
+    /// number-then-currency (e.g. `Assets:Cash USD  -50.00 USD`).
+    /// The interpolator fills these slots correctly, but the LSP
+    /// deliberately suppresses hints for them — the bespoke
+    /// pre-refactor implementation only emitted hints for fully-
+    /// missing postings, and we preserve that UX.
+    #[test]
+    fn test_inlay_hints_skip_partial_amounts() {
+        // First posting is `CurrencyOnly` ("USD"), second is
+        // `NumberOnly` ("-50.00"). The interpolator fills both, but
+        // neither should produce a hint.
+        let source = "\
+2024-01-15 * \"Test\"
+  Assets:Bank   50.00 USD
+  Expenses:A    USD
+  Income:B     -100.00
+  Equity:Pad   -50 EUR
+  Expenses:Tax  50 EUR
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let params = InlayHintParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            range: lsp_types::Range {
+                start: Position::new(0, 0),
+                end: Position::new(20, 0),
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        let hints = handle_inlay_hints(&params, source, &result);
+        assert!(
+            hints.is_none() || hints.as_ref().unwrap().is_empty(),
+            "no hints expected for partial-amount postings; got {hints:?}"
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -114,6 +114,25 @@ impl LineIndex {
     pub fn line_count(&self) -> usize {
         self.line_starts.len()
     }
+
+    /// Get the text of a single line (0-indexed), excluding the
+    /// terminating newline. Returns None if `line` is out of bounds.
+    ///
+    /// Cheaper than `source.lines().collect::<Vec<_>>()` for handlers
+    /// that only need a few specific lines.
+    pub fn line_text<'a>(&self, source: &'a str, line: u32) -> Option<&'a str> {
+        let line = line as usize;
+        let start = *self.line_starts.get(line)?;
+        let end = self.line_starts.get(line + 1).copied().unwrap_or(self.len);
+        // `start..end` includes any trailing `\n` (and `\r` if CRLF);
+        // strip both so the returned slice mirrors `str::lines()`.
+        Some(
+            source
+                .get(start..end)?
+                .trim_end_matches('\n')
+                .trim_end_matches('\r'),
+        )
+    }
 }
 
 /// Convert a byte offset to a line/column position (0-based for LSP).

--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -160,8 +160,10 @@ pub fn start_stdio() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .general
         .as_ref()
         .and_then(|g| g.position_encodings.as_ref())
-        .filter(|encs| encs.contains(&lsp_types::PositionEncodingKind::UTF8))
-        .map(|_| lsp_types::PositionEncodingKind::UTF8);
+        .and_then(|encs| {
+            encs.contains(&lsp_types::PositionEncodingKind::UTF8)
+                .then_some(lsp_types::PositionEncodingKind::UTF8)
+        });
 
     // Build server capabilities
     let capabilities = lsp_types::ServerCapabilities {

--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -146,8 +146,26 @@ pub fn start_stdio() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (id, params) = connection.initialize_start()?;
     let init_params: InitializeParams = serde_json::from_value(params)?;
 
+    // Negotiate position encoding. Our handler stack emits LSP
+    // positions as UTF-8 byte offsets, so prefer UTF-8 if the
+    // client advertises it (LSP 3.17+; VS Code, neovim, helix, and
+    // most modern clients do). If the client doesn't advertise
+    // UTF-8, the LSP spec requires the server to use UTF-16 (the
+    // default), in which case our byte-based positions are wrong
+    // for non-ASCII content — a server-wide latent bug tracked
+    // separately. The negotiation here at least makes us correct
+    // for modern clients without any handler-side conversion.
+    let position_encoding = init_params
+        .capabilities
+        .general
+        .as_ref()
+        .and_then(|g| g.position_encodings.as_ref())
+        .filter(|encs| encs.contains(&lsp_types::PositionEncodingKind::UTF8))
+        .map(|_| lsp_types::PositionEncodingKind::UTF8);
+
     // Build server capabilities
     let capabilities = lsp_types::ServerCapabilities {
+        position_encoding,
         text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Kind(
             lsp_types::TextDocumentSyncKind::FULL,
         )),


### PR DESCRIPTION
## Summary

The LSP's inlay-hints handler had its own `calculate_inferred_amount` helper that re-implemented posting-balance interpolation. The bespoke version only handled the simplest case — exactly one missing posting, exactly one currency — and silently emitted **zero hints** for every other shape.

This PR deletes the bespoke version and routes through `rustledger_booking::interpolate`, the canonical interpolator that the booking engine itself uses.

## What the bespoke logic missed

| Transaction shape | Bespoke `calculate_inferred_amount` | After delegation |
|---|---|---|
| One missing posting, single currency | hint shown | hint shown |
| One missing USD posting + one missing EUR posting (FX swap) | zero hints | both hints shown |
| Posting with cost spec + missing cash leg (`10 AAPL {150 USD}` + missing) | no hint | hint shown |
| Cost-only postings with implicit pricing | no hint | hint shown |
| Inferred amount disagrees with `rledger check` | possible (parallel implementations) | impossible (same code path) |

## Design

The handler walks **source postings** looking for `units.is_none()` and locates each fill in the interpolated transaction by matching `span.start`. Three properties fall out of this design:

1. **Source-order, deterministic output.** The interpolator's `filled_indices` is built from HashMap-driven iteration with unspecified order; walking source postings gives a stable order the client can rely on.

2. **Naturally restricts to fully-missing postings.** `NumberOnly`/`CurrencyOnly` source postings already display one half on screen, so appending the other half at line-end would visually duplicate the typed text (`Assets:Cash USD  -50.00 USD`) or put the number after the currency. The bespoke pre-refactor implementation only emitted hints for fully-missing postings — that UX is deliberately preserved.

3. **Sidesteps prune-shift bugs.** Interpolate's zero-amount prune step removes postings from `result.postings`, shifting subsequent positions; `filled_indices` is then result-relative, not source-relative. Matching by span — preserved across `interpolate`'s clone — sidesteps the issue. (In current code paths the zero-fill case is structurally unreachable, but the design is robust to future changes.)

## Performance

A fast-path gate skips `interpolate` entirely for transactions with no fully-missing postings:

```rust
if !txn.postings.iter().any(|p| p.units.is_none()) { continue; }
```

Inlay hints recompute on every keystroke, so for large fully-explicit files this avoids the `interpolate` call (which clones the transaction internally) for every transaction.

## What changed

- New import: `rustledger_booking::interpolate`.
- Source-posting walk replaces `filled_indices` iteration; span-based fill lookup replaces `txn.postings.get(idx)`.
- Fast-path gate on `units.is_none()`.
- `debug_assert!` pins the invariant that a fully-missing source posting fills to `Complete`.
- `InterpolationError` (e.g., `MultipleMissing`, unbalanced amounts) is silently dropped — no hints for an under-specified transaction is the right outcome.
- Deleted: 25-line `calculate_inferred_amount` helper + its test.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets`
- [x] `RUSTFLAGS=-Dwarnings cargo build --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `cargo test -p rustledger-lsp --all-features` — **135 tests, 0 failures**
- [x] `cargo fmt --all -- --check`
- [x] **New `test_inlay_hints_multi_currency_inference`** — two-currency source with two missing postings; asserts two hints with correct per-currency residuals. Verified to **fail** against the pre-refactor bespoke version (zero hints), **pass** against the delegated version.
- [x] **New `test_inlay_hints_skip_partial_amounts`** — pins the "no hints for `NumberOnly`/`CurrencyOnly` postings" UX invariant.

Refs #1142
