### PR TITLE
feat(parser,lsp): currency rename / references / highlight via AST (closes #552)

### DIFF
--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -18,30 +18,96 @@ pub fn extract_accounts(directives: &[Directive]) -> Vec<String> {
 /// ```ignore
 /// extract_accounts_iter(parse_result.directives.iter().map(|s| &s.value))
 /// ```
+/// Extract unique account names from an iterator of directive references.
+///
+/// Covers every position an account name can appear in source:
+/// - `Open.account` / `Close.account`
+/// - `Balance.account`
+/// - `Pad.account` and `Pad.source_account`
+/// - `Note.account`
+/// - `Document.account`
+/// - `Posting.account` (transactions)
+/// - `MetaValue::Account` values inside the metadata block of any
+///   directive or posting
+/// - `MetaValue::Account` inside `Custom.values`
+///
+/// Earlier iterations of this function covered only Open / Close /
+/// Balance / Pad / Transaction.postings — accounts mentioned only
+/// on a Note, Document, in metadata, or in a Custom directive were
+/// silently absent from completion suggestions in both the LSP and
+/// the WASM editor.
 pub fn extract_accounts_iter<'a>(directives: impl Iterator<Item = &'a Directive>) -> Vec<String> {
     let mut accounts = Vec::new();
 
     for directive in directives {
         match directive {
-            Directive::Open(open) => accounts.push(open.account.to_string()),
-            Directive::Close(close) => accounts.push(close.account.to_string()),
-            Directive::Balance(bal) => accounts.push(bal.account.to_string()),
+            Directive::Open(open) => {
+                accounts.push(open.account.to_string());
+                extract_meta_accounts(&open.meta, &mut accounts);
+            }
+            Directive::Close(close) => {
+                accounts.push(close.account.to_string());
+                extract_meta_accounts(&close.meta, &mut accounts);
+            }
+            Directive::Balance(bal) => {
+                accounts.push(bal.account.to_string());
+                extract_meta_accounts(&bal.meta, &mut accounts);
+            }
             Directive::Pad(pad) => {
                 accounts.push(pad.account.to_string());
                 accounts.push(pad.source_account.to_string());
+                extract_meta_accounts(&pad.meta, &mut accounts);
+            }
+            Directive::Note(note) => {
+                accounts.push(note.account.to_string());
+                extract_meta_accounts(&note.meta, &mut accounts);
+            }
+            Directive::Document(doc) => {
+                accounts.push(doc.account.to_string());
+                extract_meta_accounts(&doc.meta, &mut accounts);
             }
             Directive::Transaction(txn) => {
+                extract_meta_accounts(&txn.meta, &mut accounts);
                 for posting in &txn.postings {
                     accounts.push(posting.account.to_string());
+                    extract_meta_accounts(&posting.meta, &mut accounts);
                 }
             }
-            _ => {}
+            Directive::Custom(custom) => {
+                for v in &custom.values {
+                    if let MetaValue::Account(a) = v {
+                        accounts.push(a.clone());
+                    }
+                }
+                extract_meta_accounts(&custom.meta, &mut accounts);
+            }
+            Directive::Commodity(comm) => {
+                extract_meta_accounts(&comm.meta, &mut accounts);
+            }
+            Directive::Price(price) => {
+                extract_meta_accounts(&price.meta, &mut accounts);
+            }
+            Directive::Event(event) => {
+                extract_meta_accounts(&event.meta, &mut accounts);
+            }
+            Directive::Query(query) => {
+                extract_meta_accounts(&query.meta, &mut accounts);
+            }
         }
     }
 
     accounts.sort();
     accounts.dedup();
     accounts
+}
+
+/// Push any account literal embedded in a metadata block onto `out`.
+fn extract_meta_accounts(meta: &Metadata, out: &mut Vec<String>) {
+    for v in meta.values() {
+        if let MetaValue::Account(a) = v {
+            out.push(a.clone());
+        }
+    }
 }
 
 /// Extract unique currencies from directives (sorted, deduplicated).
@@ -112,7 +178,34 @@ pub fn extract_currencies_iter<'a>(directives: impl Iterator<Item = &'a Directiv
                     extract_meta_currencies(&posting.meta, &mut currencies);
                 }
             }
-            _ => {}
+            Directive::Custom(custom) => {
+                for v in &custom.values {
+                    match v {
+                        MetaValue::Currency(s) => currencies.push(s.clone()),
+                        MetaValue::Amount(a) => currencies.push(a.currency.to_string()),
+                        _ => {}
+                    }
+                }
+                extract_meta_currencies(&custom.meta, &mut currencies);
+            }
+            Directive::Note(note) => {
+                extract_meta_currencies(&note.meta, &mut currencies);
+            }
+            Directive::Document(doc) => {
+                extract_meta_currencies(&doc.meta, &mut currencies);
+            }
+            Directive::Close(close) => {
+                extract_meta_currencies(&close.meta, &mut currencies);
+            }
+            Directive::Pad(pad) => {
+                extract_meta_currencies(&pad.meta, &mut currencies);
+            }
+            Directive::Event(event) => {
+                extract_meta_currencies(&event.meta, &mut currencies);
+            }
+            Directive::Query(query) => {
+                extract_meta_currencies(&query.meta, &mut currencies);
+            }
         }
     }
 
@@ -423,6 +516,77 @@ mod tests {
             assert!(
                 currencies.contains(&expected.to_string()),
                 "expected {expected} in extracted currencies (covers cost/price/Price-directive arms); got {currencies:?}"
+            );
+        }
+    }
+
+    /// Regression test: account names that reach the parser via
+    /// positions OTHER than `Open` / `Close` / `Balance` / `Pad` /
+    /// `Posting.account` must still appear in the extraction list.
+    ///
+    /// The pre-fix walk missed `Note.account`, `Document.account`,
+    /// `MetaValue::Account` in metadata blocks, and `Custom.values`
+    /// account entries — meaning completion suggestions in both the
+    /// LSP and WASM editor were missing real accounts the user had
+    /// referenced.
+    #[test]
+    fn test_extract_accounts_covers_note_document_meta_custom() {
+        use crate::{Custom, Document, Note};
+        let mut txn_meta: Metadata = Default::default();
+        txn_meta.insert(
+            "partner".to_string(),
+            MetaValue::Account("Assets:JointAccount".into()),
+        );
+
+        let directives = vec![
+            // Note carrying an account the user has never opened elsewhere.
+            Directive::Note(Note {
+                date: date(2024, 1, 1),
+                account: "Assets:OldCheckingArchive".into(),
+                comment: "reconcile end of year".to_string(),
+                meta: Default::default(),
+            }),
+            // Document carrying another fresh account.
+            Directive::Document(Document {
+                date: date(2024, 1, 2),
+                account: "Liabilities:CreditCard:CitiBank".into(),
+                path: "statement.pdf".to_string(),
+                tags: vec![],
+                links: vec![],
+                meta: Default::default(),
+            }),
+            // Transaction whose metadata carries an account reference.
+            Directive::Transaction(Transaction {
+                date: date(2024, 1, 3),
+                flag: '*',
+                payee: None,
+                narration: "".into(),
+                tags: vec![],
+                links: vec![],
+                meta: txn_meta,
+                postings: vec![],
+                trailing_comments: vec![],
+            }),
+            // Custom directive whose values include an Account.
+            Directive::Custom(Custom {
+                date: date(2024, 1, 4),
+                custom_type: "budget".to_string(),
+                values: vec![MetaValue::Account("Expenses:Groceries:Whole".into())],
+                meta: Default::default(),
+            }),
+        ];
+
+        let accounts = extract_accounts(&directives);
+
+        for expected in [
+            "Assets:OldCheckingArchive",
+            "Liabilities:CreditCard:CitiBank",
+            "Assets:JointAccount",
+            "Expenses:Groceries:Whole",
+        ] {
+            assert!(
+                accounts.contains(&expected.to_string()),
+                "expected {expected} in extracted accounts (covers Note/Document/meta/Custom arms); got {accounts:?}"
             );
         }
     }

--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -129,6 +129,9 @@ pub fn extract_currencies(directives: &[Directive]) -> Vec<String> {
 /// - `Posting.price` (`@`/`@@` annotation, all 6 variants)
 /// - `MetaValue::Currency` / `MetaValue::Amount` values inside the
 ///   metadata block of any directive or posting
+/// - `Custom.values` entries that are `MetaValue::Currency` or
+///   `MetaValue::Amount` (Custom directives can carry arbitrary
+///   `MetaValue`s as positional arguments)
 ///
 /// Earlier iterations of this function covered only `Open`,
 /// `Commodity`, `Balance`, and `Posting.units` — any currency that
@@ -440,16 +443,32 @@ mod tests {
     ///
     /// The earlier implementation walked only those four positions
     /// and silently dropped currencies from cost specs, price
-    /// annotations, `Price` directives, and metadata values —
-    /// which meant completion suggestions in both the LSP and WASM
-    /// editor were missing real currencies the user had typed.
+    /// annotations, `Price` directives, metadata values, and Custom
+    /// directive arguments — which meant completion suggestions in
+    /// both the LSP and WASM editor were missing real currencies
+    /// the user had typed.
     #[test]
-    fn test_extract_currencies_covers_cost_price_meta() {
-        use crate::{CostSpec, Price, PriceAnnotation};
+    fn test_extract_currencies_covers_cost_price_meta_custom() {
+        use crate::{CostSpec, Custom, Price, PriceAnnotation};
         use rust_decimal_macros::dec;
+
+        // CAD in transaction metadata as MetaValue::Currency.
+        // KRW in posting metadata as MetaValue::Amount.
+        let mut txn_meta: Metadata = Default::default();
+        txn_meta.insert(
+            "fx_pair".to_string(),
+            MetaValue::Currency("CAD".to_string()),
+        );
+        let mut posting_meta: Metadata = Default::default();
+        posting_meta.insert(
+            "settled".to_string(),
+            MetaValue::Amount(Amount::new(dec!(120000), "KRW")),
+        );
+
         let directives = vec![
-            // Posting with cost spec carrying JPY (not present in
-            // units or anywhere else).
+            // One transaction exercising four positions at once:
+            // cost spec (JPY), `@` annotation (CHF), txn meta (CAD),
+            // posting meta (KRW).
             Directive::Transaction(Transaction {
                 date: date(2024, 1, 1),
                 flag: '*',
@@ -457,7 +476,7 @@ mod tests {
                 narration: "".into(),
                 tags: vec![],
                 links: vec![],
-                meta: Default::default(),
+                meta: txn_meta,
                 postings: vec![crate::Spanned::synthesized(Posting {
                     account: "Assets:Stock".into(),
                     units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "AAPL"))),
@@ -469,33 +488,9 @@ mod tests {
                         label: None,
                         merge: false,
                     }),
-                    price: None,
-                    flag: None,
-                    meta: Default::default(),
-                    comments: vec![],
-                    trailing_comments: vec![],
-                })],
-                trailing_comments: vec![],
-            }),
-            // Posting with `@` price annotation carrying CHF.
-            Directive::Transaction(Transaction {
-                date: date(2024, 1, 2),
-                flag: '*',
-                payee: None,
-                narration: "".into(),
-                tags: vec![],
-                links: vec![],
-                meta: Default::default(),
-                postings: vec![crate::Spanned::synthesized(Posting {
-                    account: "Assets:FX".into(),
-                    units: Some(crate::IncompleteAmount::from(Amount::new(
-                        dec!(100),
-                        "AAPL",
-                    ))),
-                    cost: None,
                     price: Some(PriceAnnotation::Unit(Amount::new(dec!(1.1), "CHF"))),
                     flag: None,
-                    meta: Default::default(),
+                    meta: posting_meta,
                     comments: vec![],
                     trailing_comments: vec![],
                 })],
@@ -508,14 +503,29 @@ mod tests {
                 amount: Amount::new(dec!(200), "SGD"),
                 meta: Default::default(),
             }),
+            // Custom directive arguments include MXN (Currency)
+            // and TWD (inside an Amount).
+            Directive::Custom(Custom {
+                date: date(2024, 1, 4),
+                custom_type: "fx_corridors".to_string(),
+                values: vec![
+                    MetaValue::Currency("MXN".to_string()),
+                    MetaValue::Amount(Amount::new(dec!(30), "TWD")),
+                ],
+                meta: Default::default(),
+            }),
         ];
 
         let currencies = extract_currencies(&directives);
 
-        for expected in ["JPY", "CHF", "SGD", "AAPL"] {
+        for expected in [
+            "JPY", "CHF", "SGD", "AAPL", // cost / @ / Price directive (both halves)
+            "CAD", "KRW", // transaction-meta / posting-meta
+            "MXN", "TWD", // Custom.values (Currency + Amount)
+        ] {
             assert!(
                 currencies.contains(&expected.to_string()),
-                "expected {expected} in extracted currencies (covers cost/price/Price-directive arms); got {currencies:?}"
+                "expected {expected} in extracted currencies; got {currencies:?}"
             );
         }
     }

--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -2,7 +2,7 @@
 //!
 //! These functions are used by both the WASM editor and LSP for completions.
 
-use crate::Directive;
+use crate::{Directive, MetaValue, Metadata, PriceAnnotation};
 
 /// Common default currencies included in completions.
 pub const DEFAULT_CURRENCIES: &[&str] = &["USD", "EUR", "GBP"];
@@ -52,6 +52,23 @@ pub fn extract_currencies(directives: &[Directive]) -> Vec<String> {
 }
 
 /// Extract unique currencies from an iterator of directive references.
+///
+/// Covers every position a `Currency` token can appear in source:
+/// - `Open.currencies` (constraint list)
+/// - `Commodity.currency` (declaration)
+/// - `Balance.amount.currency`
+/// - `Price` directive (both base `currency` and `amount.currency`)
+/// - `Posting.units.currency()` (units side, incl. `CurrencyOnly`)
+/// - `Posting.cost.currency` (cost spec)
+/// - `Posting.price` (`@`/`@@` annotation, all 6 variants)
+/// - `MetaValue::Currency` / `MetaValue::Amount` values inside the
+///   metadata block of any directive or posting
+///
+/// Earlier iterations of this function covered only `Open`,
+/// `Commodity`, `Balance`, and `Posting.units` — any currency that
+/// reached the parser through the other positions silently
+/// disappeared from completion suggestions in both the LSP and
+/// the WASM editor.
 pub fn extract_currencies_iter<'a>(directives: impl Iterator<Item = &'a Directive>) -> Vec<String> {
     let mut currencies = Vec::new();
 
@@ -61,16 +78,38 @@ pub fn extract_currencies_iter<'a>(directives: impl Iterator<Item = &'a Directiv
                 for currency in &open.currencies {
                     currencies.push(currency.to_string());
                 }
+                extract_meta_currencies(&open.meta, &mut currencies);
             }
-            Directive::Commodity(comm) => currencies.push(comm.currency.to_string()),
-            Directive::Balance(bal) => currencies.push(bal.amount.currency.to_string()),
+            Directive::Commodity(comm) => {
+                currencies.push(comm.currency.to_string());
+                extract_meta_currencies(&comm.meta, &mut currencies);
+            }
+            Directive::Balance(bal) => {
+                currencies.push(bal.amount.currency.to_string());
+                extract_meta_currencies(&bal.meta, &mut currencies);
+            }
+            Directive::Price(price) => {
+                currencies.push(price.currency.to_string());
+                currencies.push(price.amount.currency.to_string());
+                extract_meta_currencies(&price.meta, &mut currencies);
+            }
             Directive::Transaction(txn) => {
+                extract_meta_currencies(&txn.meta, &mut currencies);
                 for posting in &txn.postings {
                     if let Some(ref units) = posting.units
                         && let Some(currency) = units.currency()
                     {
                         currencies.push(currency.to_string());
                     }
+                    if let Some(ref cost) = posting.cost
+                        && let Some(ref c) = cost.currency
+                    {
+                        currencies.push(c.to_string());
+                    }
+                    if let Some(ref price) = posting.price {
+                        extract_price_currency(price, &mut currencies);
+                    }
+                    extract_meta_currencies(&posting.meta, &mut currencies);
                 }
             }
             _ => {}
@@ -84,6 +123,34 @@ pub fn extract_currencies_iter<'a>(directives: impl Iterator<Item = &'a Directiv
     currencies.sort();
     currencies.dedup();
     currencies
+}
+
+/// Push any currency literal embedded in a metadata block onto `out`.
+fn extract_meta_currencies(meta: &Metadata, out: &mut Vec<String>) {
+    for v in meta.values() {
+        match v {
+            MetaValue::Currency(s) => out.push(s.clone()),
+            MetaValue::Amount(a) => out.push(a.currency.to_string()),
+            _ => {}
+        }
+    }
+}
+
+/// Push the currency carried by a `PriceAnnotation` (`@` or `@@`)
+/// onto `out`, if it has one. `UnitEmpty` / `TotalEmpty` annotations
+/// (the user typed `@`/`@@` without an amount) have no currency.
+fn extract_price_currency(price: &PriceAnnotation, out: &mut Vec<String>) {
+    match price {
+        PriceAnnotation::Unit(a) | PriceAnnotation::Total(a) => {
+            out.push(a.currency.to_string());
+        }
+        PriceAnnotation::UnitIncomplete(ia) | PriceAnnotation::TotalIncomplete(ia) => {
+            if let Some(c) = ia.currency() {
+                out.push(c.to_string());
+            }
+        }
+        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => {}
+    }
 }
 
 /// Extract unique payees from transactions (sorted, deduplicated).
@@ -272,5 +339,91 @@ mod tests {
             extract_payees(&directives),
             extract_payees_iter(directives.iter())
         );
+    }
+
+    /// Regression test: currencies that reach the parser via
+    /// positions OTHER than `Open` / `Commodity` / `Balance` /
+    /// `Posting.units` must still appear in the extraction list.
+    ///
+    /// The earlier implementation walked only those four positions
+    /// and silently dropped currencies from cost specs, price
+    /// annotations, `Price` directives, and metadata values —
+    /// which meant completion suggestions in both the LSP and WASM
+    /// editor were missing real currencies the user had typed.
+    #[test]
+    fn test_extract_currencies_covers_cost_price_meta() {
+        use crate::{CostSpec, Price, PriceAnnotation};
+        use rust_decimal_macros::dec;
+        let directives = vec![
+            // Posting with cost spec carrying JPY (not present in
+            // units or anywhere else).
+            Directive::Transaction(Transaction {
+                date: date(2024, 1, 1),
+                flag: '*',
+                payee: None,
+                narration: "".into(),
+                tags: vec![],
+                links: vec![],
+                meta: Default::default(),
+                postings: vec![crate::Spanned::synthesized(Posting {
+                    account: "Assets:Stock".into(),
+                    units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "AAPL"))),
+                    cost: Some(CostSpec {
+                        number_per: Some(dec!(150)),
+                        number_total: None,
+                        currency: Some("JPY".into()),
+                        date: None,
+                        label: None,
+                        merge: false,
+                    }),
+                    price: None,
+                    flag: None,
+                    meta: Default::default(),
+                    comments: vec![],
+                    trailing_comments: vec![],
+                })],
+                trailing_comments: vec![],
+            }),
+            // Posting with `@` price annotation carrying CHF.
+            Directive::Transaction(Transaction {
+                date: date(2024, 1, 2),
+                flag: '*',
+                payee: None,
+                narration: "".into(),
+                tags: vec![],
+                links: vec![],
+                meta: Default::default(),
+                postings: vec![crate::Spanned::synthesized(Posting {
+                    account: "Assets:FX".into(),
+                    units: Some(crate::IncompleteAmount::from(Amount::new(
+                        dec!(100),
+                        "AAPL",
+                    ))),
+                    cost: None,
+                    price: Some(PriceAnnotation::Unit(Amount::new(dec!(1.1), "CHF"))),
+                    flag: None,
+                    meta: Default::default(),
+                    comments: vec![],
+                    trailing_comments: vec![],
+                })],
+                trailing_comments: vec![],
+            }),
+            // Price directive carrying both AAPL (base) and SGD (amount).
+            Directive::Price(Price {
+                date: date(2024, 1, 3),
+                currency: "AAPL".into(),
+                amount: Amount::new(dec!(200), "SGD"),
+                meta: Default::default(),
+            }),
+        ];
+
+        let currencies = extract_currencies(&directives);
+
+        for expected in ["JPY", "CHF", "SGD", "AAPL"] {
+            assert!(
+                currencies.contains(&expected.to_string()),
+                "expected {expected} in extracted currencies (covers cost/price/Price-directive arms); got {currencies:?}"
+            );
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/document_highlight.rs
+++ b/crates/rustledger-lsp/src/handlers/document_highlight.rs
@@ -171,61 +171,50 @@ fn collect_account_highlights(
 }
 
 /// Collect all highlights for a currency.
+///
+/// Walks the parser's `currency_occurrences` index for exact spans;
+/// see `rename.rs::collect_currency_rename_edits` for the rationale.
+/// Occurrences whose span sits inside a `Commodity` directive
+/// declaration are surfaced as `WRITE`, all others as `READ`.
 fn collect_currency_highlights(
-    source: &str,
+    _source: &str,
     parse_result: &ParseResult,
     line_index: &LineIndex,
     currency: &str,
     highlights: &mut Vec<DocumentHighlight>,
 ) {
-    for spanned in &parse_result.directives {
-        let directive_text = &source[spanned.span.start..spanned.span.end];
-        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
+    let commodity_spans: Vec<rustledger_parser::Span> = parse_result
+        .directives
+        .iter()
+        .filter(|d| matches!(&d.value, Directive::Commodity(_)))
+        .map(|d| d.span)
+        .collect();
+    let is_declaration = |span: rustledger_parser::Span| {
+        commodity_spans
+            .iter()
+            .any(|cs| cs.start <= span.start && span.end <= cs.end)
+    };
 
-        let is_declaration =
-            matches!(&spanned.value, Directive::Commodity(c) if c.currency.as_ref() == currency);
-
-        // Find all occurrences of the currency in this directive
-        for (line_offset, line) in directive_text.lines().enumerate() {
-            let mut search_start = 0;
-            while let Some(pos) = line[search_start..].find(currency) {
-                let actual_pos = search_start + pos;
-
-                // Verify word boundaries
-                let before_ok = actual_pos == 0
-                    || !line
-                        .chars()
-                        .nth(actual_pos - 1)
-                        .unwrap_or(' ')
-                        .is_alphanumeric();
-                let after_ok = actual_pos + currency.len() >= line.len()
-                    || !line
-                        .chars()
-                        .nth(actual_pos + currency.len())
-                        .unwrap_or(' ')
-                        .is_alphanumeric();
-
-                if before_ok && after_ok {
-                    let ref_line = start_line + line_offset as u32;
-                    highlights.push(DocumentHighlight {
-                        range: Range {
-                            start: Position::new(ref_line, actual_pos as u32),
-                            end: Position::new(ref_line, (actual_pos + currency.len()) as u32),
-                        },
-                        kind: Some(if is_declaration && line_offset == 0 {
-                            DocumentHighlightKind::WRITE
-                        } else {
-                            DocumentHighlightKind::READ
-                        }),
-                    });
-                }
-
-                search_start = actual_pos + currency.len();
-            }
+    for occurrence in &parse_result.currency_occurrences {
+        if occurrence.value != currency {
+            continue;
         }
+        let (start_line, start_col) = line_index.offset_to_position(occurrence.span.start);
+        let (end_line, end_col) = line_index.offset_to_position(occurrence.span.end);
+        highlights.push(DocumentHighlight {
+            range: Range {
+                start: Position::new(start_line, start_col),
+                end: Position::new(end_line, end_col),
+            },
+            kind: Some(if is_declaration(occurrence.span) {
+                DocumentHighlightKind::WRITE
+            } else {
+                DocumentHighlightKind::READ
+            }),
+        });
     }
 
-    // Deduplicate
+    // Deduplicate by range.
     highlights.sort_by(|a, b| {
         a.range
             .start
@@ -352,6 +341,58 @@ mod tests {
         let highlights = highlights.unwrap();
         // Should find USD in: open, posting 1, posting 2 = 3
         assert_eq!(highlights.len(), 3);
+    }
+
+    /// Regression test for currency-highlight false positives. See
+    /// `rename.rs::test_rename_currency_no_false_positives` for the
+    /// fuller rationale.
+    #[test]
+    fn test_highlight_currency_no_false_positives() {
+        let source = r#"2024-01-01 open Assets:USD-Reserve
+2024-01-01 commodity USD
+2024-01-15 * "USD-to-EUR transfer"
+  Assets:USD-Reserve  -100 USD
+  Assets:Bank          100 USD
+"#;
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let uri: lsp_types::Uri = "file:///test.beancount".parse().unwrap();
+
+        let params = DocumentHighlightParams {
+            text_document_position_params: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri },
+                position: Position::new(1, 21), // on the `USD` of `commodity USD`
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        let highlights =
+            handle_document_highlight(&params, source, &result).expect("highlights returns Some");
+
+        // Expected: 3 highlights — declaration + 2 postings. Bespoke
+        // string-search would have produced 5 (payee + 2 account
+        // substrings + 2 postings + 1 declaration ... and the
+        // account-substring highlights would have visually
+        // corrupted the rendered highlight overlay on screen).
+        assert_eq!(
+            highlights.len(),
+            3,
+            "expected 3 currency highlights, got {}: {highlights:#?}",
+            highlights.len()
+        );
+
+        // Exactly one highlight should be WRITE (the commodity
+        // declaration); the other two should be READ.
+        let write_count = highlights
+            .iter()
+            .filter(|h| h.kind == Some(DocumentHighlightKind::WRITE))
+            .count();
+        assert_eq!(write_count, 1, "expected exactly one WRITE highlight");
     }
 
     /// Regression test for the read-only sibling of #1142.

--- a/crates/rustledger-lsp/src/handlers/document_highlight.rs
+++ b/crates/rustledger-lsp/src/handlers/document_highlight.rs
@@ -11,7 +11,9 @@ use lsp_types::{
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::{LineIndex, get_word_at_position, is_account_like, is_currency_like};
+use super::utils::{
+    LineIndex, commodity_declaration_spans, get_word_at_position, is_account_like, is_currency_like,
+};
 
 /// Handle a document highlight request.
 pub fn handle_document_highlight(
@@ -174,25 +176,20 @@ fn collect_account_highlights(
 ///
 /// Walks the parser's `currency_occurrences` index for exact spans;
 /// see `rename.rs::collect_currency_rename_edits` for the rationale.
-/// Occurrences whose span sits inside a `Commodity` directive
-/// declaration are surfaced as `WRITE`, all others as `READ`.
+///
+/// Occurrences whose span equals a `Commodity`-declaration span
+/// (see `commodity_declaration_spans` for the precise definition;
+/// importantly, *not* just "any currency token inside a Commodity
+/// directive span" — that would misclassify metadata-value currency
+/// tokens as declarations) are surfaced as `WRITE`, all others as
+/// `READ`.
 fn collect_currency_highlights(
     parse_result: &ParseResult,
     line_index: &LineIndex,
     currency: &str,
     highlights: &mut Vec<DocumentHighlight>,
 ) {
-    let commodity_spans: Vec<rustledger_parser::Span> = parse_result
-        .directives
-        .iter()
-        .filter(|d| matches!(&d.value, Directive::Commodity(_)))
-        .map(|d| d.span)
-        .collect();
-    let is_declaration = |span: rustledger_parser::Span| {
-        commodity_spans
-            .iter()
-            .any(|cs| cs.start <= span.start && span.end <= cs.end)
-    };
+    let declaration_spans = commodity_declaration_spans(parse_result);
 
     for occurrence in &parse_result.currency_occurrences {
         if occurrence.value != currency {
@@ -200,12 +197,13 @@ fn collect_currency_highlights(
         }
         let (start_line, start_col) = line_index.offset_to_position(occurrence.span.start);
         let (end_line, end_col) = line_index.offset_to_position(occurrence.span.end);
+        let is_declaration = declaration_spans.contains(&occurrence.span);
         highlights.push(DocumentHighlight {
             range: Range {
                 start: Position::new(start_line, start_col),
                 end: Position::new(end_line, end_col),
             },
-            kind: Some(if is_declaration(occurrence.span) {
+            kind: Some(if is_declaration {
                 DocumentHighlightKind::WRITE
             } else {
                 DocumentHighlightKind::READ
@@ -392,6 +390,53 @@ mod tests {
             .filter(|h| h.kind == Some(DocumentHighlightKind::WRITE))
             .count();
         assert_eq!(write_count, 1, "expected exactly one WRITE highlight");
+    }
+
+    /// Regression test for the metadata-currency misclassification
+    /// bug (Copilot #3270930001). A `Currency`-typed metadata value
+    /// inside a Commodity directive must not be classified as a
+    /// declaration.
+    #[test]
+    fn test_currency_in_commodity_metadata_is_read_not_write() {
+        let source = r#"2024-01-01 commodity USD
+  parent: USD
+2024-01-15 * "Coffee"
+  Assets:Bank  -5.00 USD
+"#;
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let uri: lsp_types::Uri = "file:///test.beancount".parse().unwrap();
+
+        let params = DocumentHighlightParams {
+            text_document_position_params: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri },
+                position: Position::new(0, 21), // on `USD` of `commodity USD`
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        let highlights =
+            handle_document_highlight(&params, source, &result).expect("highlights returns Some");
+
+        // 3 highlights total: declaration + metadata reference + posting.
+        assert_eq!(highlights.len(), 3, "{highlights:#?}");
+
+        // Exactly ONE should be WRITE — the declaration on line 0.
+        // A buggy containment-only check would also mark
+        // `parent: USD` (line 1) as WRITE, giving us 2.
+        let write_count = highlights
+            .iter()
+            .filter(|h| h.kind == Some(DocumentHighlightKind::WRITE))
+            .count();
+        assert_eq!(
+            write_count, 1,
+            "expected exactly one WRITE (the declaration); got {write_count} in {highlights:#?}"
+        );
     }
 
     /// Regression test for the read-only sibling of #1142.

--- a/crates/rustledger-lsp/src/handlers/document_highlight.rs
+++ b/crates/rustledger-lsp/src/handlers/document_highlight.rs
@@ -39,7 +39,7 @@ pub fn handle_document_highlight(
     }
     // Check if it's a currency
     else if is_currency_like(&word, parse_result) {
-        collect_currency_highlights(source, parse_result, &line_index, &word, &mut highlights);
+        collect_currency_highlights(parse_result, &line_index, &word, &mut highlights);
     }
     // Check if it's a payee (inside quotes)
     else if is_in_quotes(line, position.character as usize) {
@@ -177,7 +177,6 @@ fn collect_account_highlights(
 /// Occurrences whose span sits inside a `Commodity` directive
 /// declaration are surfaced as `WRITE`, all others as `READ`.
 fn collect_currency_highlights(
-    _source: &str,
     parse_result: &ParseResult,
     line_index: &LineIndex,
     currency: &str,

--- a/crates/rustledger-lsp/src/handlers/hover.rs
+++ b/crates/rustledger-lsp/src/handlers/hover.rs
@@ -9,7 +9,10 @@ use lsp_types::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind};
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 
-use super::utils::{get_word_at_source_position, is_account_type, is_currency_like_simple};
+use super::utils::{
+    commodity_declaration_spans, get_word_at_source_position, is_account_type,
+    is_currency_like_simple,
+};
 
 /// Handle a hover request.
 pub fn handle_hover(
@@ -151,27 +154,23 @@ fn get_currency_info(currency: &str, parse_result: &ParseResult) -> Option<Strin
 
 /// Count how many times a currency is used.
 #[allow(clippy::cmp_owned)]
+/// Count how many times `currency` is used (excluding its own
+/// `Commodity` declaration). Consults the parser's
+/// `currency_occurrences` index, so the count is exhaustive across
+/// every position that produces a `Currency` token — `Amount`
+/// (Transaction.units, Balance.amount, Price.amount, etc.),
+/// `CostSpec.currency`, `PriceAnnotation.amount.currency`,
+/// `Open.currencies` constraint lists, and `Currency`/`Amount`
+/// metadata values. The previous implementation walked only
+/// `Transaction.posting.units` and `Balance.amount`, silently
+/// undercounting every other position.
 fn count_currency_usages(currency: &str, parse_result: &ParseResult) -> usize {
-    let mut count = 0;
-    for spanned_directive in &parse_result.directives {
-        match &spanned_directive.value {
-            Directive::Transaction(txn) => {
-                for posting in &txn.postings {
-                    if let Some(ref units) = posting.units
-                        && let Some(c) = units.currency()
-                        && c.to_string() == currency
-                    {
-                        count += 1;
-                    }
-                }
-            }
-            Directive::Balance(bal) if bal.amount.currency.as_ref() == currency => {
-                count += 1;
-            }
-            _ => {}
-        }
-    }
-    count
+    let declaration_spans = commodity_declaration_spans(parse_result);
+    parse_result
+        .currency_occurrences
+        .iter()
+        .filter(|o| o.value == currency && !declaration_spans.contains(&o.span))
+        .count()
 }
 
 /// Get information about a directive keyword.
@@ -243,5 +242,53 @@ mod tests {
         assert!(get_directive_info("unknown").is_none());
     }
 
-    // Tests for shared utilities removed - they are tested in utils module
+    /// Regression test for the previous undercounting bug in
+    /// `count_currency_usages`. The old implementation only walked
+    /// `Transaction.posting.units` and `Balance.amount`, so it
+    /// silently missed every other position that can carry a
+    /// currency. This test exercises a transaction whose currency
+    /// only appears in a `CostSpec`, plus an `Open.currencies`
+    /// constraint list — both positions the old walk missed.
+    #[test]
+    fn test_count_currency_usages_exhaustive() {
+        use rustledger_parser::parse;
+
+        // USD appears in: Commodity declaration (excluded);
+        // Open.currencies; Balance.amount; Posting.units;
+        // CostSpec.currency; Price directive (currency + amount.currency).
+        let source = r#"2024-01-01 commodity USD
+2024-01-01 open Assets:Bank USD
+2024-01-15 * "Buy stock"
+  Assets:Stock  10 AAPL {150 USD}
+  Assets:Bank
+2024-01-20 balance Assets:Bank -1500 USD
+2024-01-21 price AAPL  155 USD
+"#;
+        let parse_result = parse(source);
+        assert!(
+            parse_result.errors.is_empty(),
+            "parse errors: {:?}",
+            parse_result.errors
+        );
+
+        let count = count_currency_usages("USD", &parse_result);
+
+        // Hand-counted uses (excluding the Commodity declaration):
+        //   1. Open.currencies USD
+        //   2. CostSpec {150 USD}
+        //   3. Balance amount USD
+        //   4. Price amount USD (the quote currency in `155 USD`)
+        //
+        // (The Price directive's *base* currency is `AAPL`, not
+        // USD, so it doesn't contribute.)
+        //
+        // The pre-fix walk would have returned 1 (just the
+        // Balance — Transaction.posting.units.currency() returns
+        // the units side, not the cost side, and the missing
+        // `Assets:Bank` posting has no units).
+        assert_eq!(
+            count, 4,
+            "expected 4 USD usages (Open + CostSpec + Balance + Price.amount); got {count}"
+        );
+    }
 }

--- a/crates/rustledger-lsp/src/handlers/linked_editing.rs
+++ b/crates/rustledger-lsp/src/handlers/linked_editing.rs
@@ -35,7 +35,7 @@ pub fn handle_linked_editing_range(
     }
     // Check if it's a currency
     else if is_currency_like(&word, parse_result) {
-        collect_currency_ranges(source, parse_result, &line_index, &word, &mut ranges);
+        collect_currency_ranges(parse_result, &line_index, &word, &mut ranges);
     }
 
     if ranges.is_empty() {
@@ -145,50 +145,37 @@ fn collect_account_ranges(
 }
 
 /// Collect all ranges for a currency.
+/// Collect linked-edit ranges for a currency.
+///
+/// Walks the parser's `currency_occurrences` index for exact spans
+/// — same pattern as `rename::collect_currency_rename_edits` and
+/// siblings. The previous string-search implementation matched
+/// currency-code substrings in payee strings, account-name segments,
+/// and comments, then included them in the linked-edit range set —
+/// so as the user typed, the unrelated text would mutate alongside
+/// the real currency tokens.
 fn collect_currency_ranges(
-    source: &str,
     parse_result: &ParseResult,
     line_index: &LineIndex,
     currency: &str,
     ranges: &mut Vec<Range>,
 ) {
-    for spanned in &parse_result.directives {
-        let directive_text = &source[spanned.span.start..spanned.span.end];
-        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
-
-        for (line_offset, line) in directive_text.lines().enumerate() {
-            let mut search_start = 0;
-            while let Some(pos) = line[search_start..].find(currency) {
-                let actual_pos = search_start + pos;
-
-                // Verify word boundaries
-                let before_ok = actual_pos == 0
-                    || !line
-                        .chars()
-                        .nth(actual_pos - 1)
-                        .unwrap_or(' ')
-                        .is_alphanumeric();
-                let after_ok = actual_pos + currency.len() >= line.len()
-                    || !line
-                        .chars()
-                        .nth(actual_pos + currency.len())
-                        .unwrap_or(' ')
-                        .is_alphanumeric();
-
-                if before_ok && after_ok {
-                    let ref_line = start_line + line_offset as u32;
-                    ranges.push(Range {
-                        start: Position::new(ref_line, actual_pos as u32),
-                        end: Position::new(ref_line, (actual_pos + currency.len()) as u32),
-                    });
-                }
-
-                search_start = actual_pos + currency.len();
-            }
+    for occurrence in &parse_result.currency_occurrences {
+        if occurrence.value != currency {
+            continue;
         }
+        let (start_line, start_col) = line_index.offset_to_position(occurrence.span.start);
+        let (end_line, end_col) = line_index.offset_to_position(occurrence.span.end);
+        ranges.push(Range {
+            start: Position::new(start_line, start_col),
+            end: Position::new(end_line, end_col),
+        });
     }
 
-    // Deduplicate and sort
+    // Defensive dedup — see `rename::collect_currency_rename_edits`
+    // for the rationale; the parser is forward-advancing so today
+    // every occurrence is unique, but the dedup costs nothing and
+    // protects against future parser refactors.
     ranges.sort_by(|a, b| {
         a.start
             .line
@@ -266,5 +253,55 @@ mod tests {
         let ranges = result.unwrap();
         // Should find USD in: open, posting 1, posting 2 = 3 ranges
         assert_eq!(ranges.ranges.len(), 3);
+    }
+
+    /// Regression test for currency linked-editing false positives.
+    /// See `rename::test_rename_currency_no_false_positives` for the
+    /// fuller rationale.
+    ///
+    /// Linked editing is especially sensitive to false positives:
+    /// each range gets mutated *together* as the user types, so a
+    /// false-positive range inside an account name or a payee
+    /// string would silently corrupt that text. The AST-driven
+    /// `currency_occurrences` walk makes that impossible.
+    #[test]
+    fn test_linked_editing_currency_no_false_positives() {
+        let source = r#"2024-01-01 open Assets:USD-Reserve
+2024-01-01 commodity USD
+2024-01-15 * "USD-to-EUR transfer"
+  Assets:USD-Reserve  -100 USD
+  Assets:Bank          100 USD
+"#;
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let uri: lsp_types::Uri = "file:///test.beancount".parse().unwrap();
+
+        let params = LinkedEditingRangeParams {
+            text_document_position_params: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri },
+                position: Position::new(1, 21), // on `USD` of `commodity USD`
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        let ranges = handle_linked_editing_range(&params, source, &result)
+            .expect("linked editing returns Some");
+
+        // Expected: 3 ranges — `commodity USD`, `-100 USD`,
+        // `100 USD`. Bespoke string-search would have produced 5
+        // (the payee substring and the account-name substring
+        // would have been mutated alongside, corrupting unrelated
+        // text as the user typed).
+        assert_eq!(
+            ranges.ranges.len(),
+            3,
+            "expected 3 linked-edit ranges, got {}: {:#?}",
+            ranges.ranges.len(),
+            ranges.ranges
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -47,7 +47,6 @@ pub fn handle_references(
     // Check if it's a currency
     else if is_currency_like(&word, parse_result) {
         collect_currency_references(
-            source,
             parse_result,
             &line_index,
             &word,
@@ -235,7 +234,6 @@ fn collect_account_references(
 /// `Commodity` directive contains exactly one `Currency` token (the
 /// declared one), so the within-range check is unambiguous.
 fn collect_currency_references(
-    _source: &str,
     parse_result: &ParseResult,
     line_index: &LineIndex,
     currency: &str,

--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -221,8 +221,21 @@ fn collect_account_references(
 }
 
 /// Collect all references to a currency.
+///
+/// Walks the parser's `currency_occurrences` index (every `Currency`
+/// token with exact source spans) and emits one `Location` per
+/// occurrence matching `currency`. The previous implementation
+/// string-searched the source within each directive, which produced
+/// false positives in payee strings, comments, and account-name
+/// segments containing the currency code.
+///
+/// To honor `include_declaration`, we pre-build a set of byte
+/// ranges of every `Commodity` directive in this file — an
+/// occurrence is a "declaration" iff its span falls inside one. A
+/// `Commodity` directive contains exactly one `Currency` token (the
+/// declared one), so the within-range check is unambiguous.
 fn collect_currency_references(
-    source: &str,
+    _source: &str,
     parse_result: &ParseResult,
     line_index: &LineIndex,
     currency: &str,
@@ -230,55 +243,38 @@ fn collect_currency_references(
     include_declaration: bool,
     locations: &mut Vec<Location>,
 ) {
-    for spanned in &parse_result.directives {
-        let directive_text = &source[spanned.span.start..spanned.span.end];
-        let (start_line, _) = line_index.offset_to_position(spanned.span.start);
+    let commodity_spans: Vec<rustledger_parser::Span> = parse_result
+        .directives
+        .iter()
+        .filter(|d| matches!(&d.value, Directive::Commodity(_)))
+        .map(|d| d.span)
+        .collect();
+    let is_declaration = |span: rustledger_parser::Span| {
+        commodity_spans
+            .iter()
+            .any(|cs| cs.start <= span.start && span.end <= cs.end)
+    };
 
-        // Check if directive contains this currency
-        let is_declaration =
-            matches!(&spanned.value, Directive::Commodity(c) if c.currency.as_ref() == currency);
-
-        if is_declaration && !include_declaration {
+    for occurrence in &parse_result.currency_occurrences {
+        if occurrence.value != currency {
             continue;
         }
-
-        // Find all occurrences of the currency in this directive
-        for (line_offset, line) in directive_text.lines().enumerate() {
-            let mut search_start = 0;
-            while let Some(pos) = line[search_start..].find(currency) {
-                let actual_pos = search_start + pos;
-
-                // Verify it's a word boundary
-                let before_ok = actual_pos == 0
-                    || !line
-                        .chars()
-                        .nth(actual_pos - 1)
-                        .unwrap_or(' ')
-                        .is_alphanumeric();
-                let after_ok = actual_pos + currency.len() >= line.len()
-                    || !line
-                        .chars()
-                        .nth(actual_pos + currency.len())
-                        .unwrap_or(' ')
-                        .is_alphanumeric();
-
-                if before_ok && after_ok {
-                    let ref_line = start_line + line_offset as u32;
-                    locations.push(Location {
-                        uri: uri.clone(),
-                        range: Range {
-                            start: Position::new(ref_line, actual_pos as u32),
-                            end: Position::new(ref_line, (actual_pos + currency.len()) as u32),
-                        },
-                    });
-                }
-
-                search_start = actual_pos + currency.len();
-            }
+        if is_declaration(occurrence.span) && !include_declaration {
+            continue;
         }
+        let (start_line, start_col) = line_index.offset_to_position(occurrence.span.start);
+        let (end_line, end_col) = line_index.offset_to_position(occurrence.span.end);
+        locations.push(Location {
+            uri: uri.clone(),
+            range: Range {
+                start: Position::new(start_line, start_col),
+                end: Position::new(end_line, end_col),
+            },
+        });
     }
 
-    // Deduplicate by range
+    // Deduplicate by range — see `collect_currency_rename_edits` for
+    // why this guard is here.
     locations.sort_by(|a, b| {
         a.range
             .start
@@ -435,6 +431,71 @@ mod tests {
         let refs = refs.unwrap();
         // Should find USD in: open, posting 1, posting 2 = 3 references
         assert_eq!(refs.len(), 3);
+    }
+
+    /// Regression test for currency-reference false positives. See
+    /// `rename.rs::test_rename_currency_no_false_positives` for the
+    /// fuller rationale. Same source shape; the AST-driven
+    /// references walker should report exactly the legitimate
+    /// `Currency`-token occurrences.
+    #[test]
+    fn test_find_currency_references_no_false_positives() {
+        let source = r#"2024-01-01 open Assets:USD-Reserve
+2024-01-01 commodity USD
+2024-01-15 * "USD-to-EUR transfer"
+  Assets:USD-Reserve  -100 USD
+  Assets:Bank          100 USD
+"#;
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let uri: Uri = "file:///test.beancount".parse().unwrap();
+
+        // Position cursor on the `USD` of `commodity USD`.
+        let params = ReferenceParams {
+            text_document_position: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                position: Position::new(1, 21),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            context: lsp_types::ReferenceContext {
+                include_declaration: true,
+            },
+        };
+
+        let refs =
+            handle_references(&params, source, &result, &uri).expect("references returns Some");
+
+        // Expected: 3 references — `commodity USD`, `-100 USD`,
+        // `100 USD`. Bespoke string-search would have reported the
+        // payee string and the account-name substrings too.
+        assert_eq!(
+            refs.len(),
+            3,
+            "expected 3 currency references, got {}: {refs:#?}",
+            refs.len()
+        );
+
+        // With `include_declaration: false`, the commodity-directive
+        // occurrence should drop out.
+        let params_no_decl = ReferenceParams {
+            context: lsp_types::ReferenceContext {
+                include_declaration: false,
+            },
+            ..params
+        };
+        let refs_no_decl = handle_references(&params_no_decl, source, &result, &uri)
+            .expect("references returns Some");
+        assert_eq!(
+            refs_no_decl.len(),
+            2,
+            "expected 2 non-declaration references, got {}: {refs_no_decl:#?}",
+            refs_no_decl.len()
+        );
     }
 
     /// Regression test for the read-only sibling of #1142.

--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -5,7 +5,9 @@
 //! - Currency names (all usages across directives)
 //! - Payees (all transactions with same payee)
 
-use super::utils::{LineIndex, get_word_at_position, is_account_like, is_currency_like};
+use super::utils::{
+    LineIndex, commodity_declaration_spans, get_word_at_position, is_account_like, is_currency_like,
+};
 use lsp_types::{Location, Position, Range, ReferenceParams, Uri};
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
@@ -228,11 +230,15 @@ fn collect_account_references(
 /// false positives in payee strings, comments, and account-name
 /// segments containing the currency code.
 ///
-/// To honor `include_declaration`, we pre-build a set of byte
-/// ranges of every `Commodity` directive in this file — an
-/// occurrence is a "declaration" iff its span falls inside one. A
-/// `Commodity` directive contains exactly one `Currency` token (the
-/// declared one), so the within-range check is unambiguous.
+/// To honor `include_declaration`, we look up the *declared*
+/// currency token in each `Commodity` directive via
+/// `commodity_declaration_spans` — which returns the first
+/// `Currency` token within each Commodity's source span. A
+/// containment check ("occurrence span ⊆ Commodity directive
+/// span") is NOT sufficient here, because Commodity directives can
+/// have metadata whose values tokenize as `Currency` (e.g.
+/// `alias: EUR`); a containment check would misclassify those as
+/// declarations.
 fn collect_currency_references(
     parse_result: &ParseResult,
     line_index: &LineIndex,
@@ -241,23 +247,14 @@ fn collect_currency_references(
     include_declaration: bool,
     locations: &mut Vec<Location>,
 ) {
-    let commodity_spans: Vec<rustledger_parser::Span> = parse_result
-        .directives
-        .iter()
-        .filter(|d| matches!(&d.value, Directive::Commodity(_)))
-        .map(|d| d.span)
-        .collect();
-    let is_declaration = |span: rustledger_parser::Span| {
-        commodity_spans
-            .iter()
-            .any(|cs| cs.start <= span.start && span.end <= cs.end)
-    };
+    let declaration_spans = commodity_declaration_spans(parse_result);
 
     for occurrence in &parse_result.currency_occurrences {
         if occurrence.value != currency {
             continue;
         }
-        if is_declaration(occurrence.span) && !include_declaration {
+        let is_declaration = declaration_spans.contains(&occurrence.span);
+        if is_declaration && !include_declaration {
             continue;
         }
         let (start_line, start_col) = line_index.offset_to_position(occurrence.span.start);
@@ -493,6 +490,69 @@ mod tests {
             2,
             "expected 2 non-declaration references, got {}: {refs_no_decl:#?}",
             refs_no_decl.len()
+        );
+    }
+
+    /// Regression test for the metadata-currency misclassification
+    /// bug (Copilot #3270929987).
+    ///
+    /// Commodity directives can carry indented metadata whose values
+    /// tokenize as `Currency` (e.g., `parent: USD`). A naive
+    /// "occurrence span ⊆ Commodity directive span" check would
+    /// classify those metadata-value currency tokens as
+    /// declarations. With `include_declaration = false`, the
+    /// metadata reference would then be incorrectly filtered out of
+    /// the results — a silent false negative.
+    ///
+    /// The fix is to identify the *first* currency token within
+    /// each Commodity span as the declaration (the parser is
+    /// forward-advancing and the declared currency is parsed
+    /// before the metadata block), via
+    /// `commodity_declaration_spans`.
+    #[test]
+    fn test_currency_in_commodity_metadata_is_not_a_declaration() {
+        // `commodity USD\n  parent: USD` — the second USD is a
+        // metadata reference, not a declaration. Renaming with
+        // `include_declaration = false` must surface it.
+        let source = r#"2024-01-01 commodity USD
+  parent: USD
+2024-01-15 * "Coffee"
+  Assets:Bank  -5.00 USD
+"#;
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let uri: Uri = "file:///test.beancount".parse().unwrap();
+
+        let params = ReferenceParams {
+            text_document_position: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                position: Position::new(0, 21), // on `USD` of `commodity USD`
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            context: lsp_types::ReferenceContext {
+                include_declaration: false,
+            },
+        };
+
+        let refs =
+            handle_references(&params, source, &result, &uri).expect("references returns Some");
+
+        // Expected: 2 non-declaration references — the metadata
+        // `parent: USD` and the posting `-5.00 USD`. The
+        // declaration on line 0 is filtered out. A buggy
+        // containment-only check would have returned 1 (only the
+        // posting) because both line-0-USD and line-1-USD would
+        // be considered declarations.
+        assert_eq!(
+            refs.len(),
+            2,
+            "expected 2 references (metadata + posting); got {}: {refs:#?}",
+            refs.len()
         );
     }
 

--- a/crates/rustledger-lsp/src/handlers/rename.rs
+++ b/crates/rustledger-lsp/src/handlers/rename.rs
@@ -12,9 +12,7 @@ use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
-use super::utils::{
-    byte_offset_to_position, get_word_at_position, is_account_like, is_currency_like,
-};
+use super::utils::{LineIndex, get_word_at_position, is_account_like, is_currency_like};
 
 /// Handle a prepare rename request (check if rename is valid at position).
 pub fn handle_prepare_rename(
@@ -62,13 +60,26 @@ pub fn handle_rename(
 
     // Collect all edits
     let mut edits = Vec::new();
+    // Build the line index once and share across collectors. The
+    // previous code went through `byte_offset_to_position`, which is
+    // O(n) per call (linear scan from byte 0); for a large ledger
+    // with many account / currency occurrences, that scaled
+    // quadratically with file size.
+    let line_index = LineIndex::new(source);
 
     if is_account_like(&old_name) {
         // Rename account
-        collect_account_rename_edits(source, parse_result, &old_name, new_name, &mut edits);
+        collect_account_rename_edits(
+            source,
+            parse_result,
+            &line_index,
+            &old_name,
+            new_name,
+            &mut edits,
+        );
     } else if is_currency_like(&old_name, parse_result) {
         // Rename currency
-        collect_currency_rename_edits(source, parse_result, &old_name, new_name, &mut edits);
+        collect_currency_rename_edits(parse_result, &line_index, &old_name, new_name, &mut edits);
     }
 
     if edits.is_empty() {
@@ -89,6 +100,7 @@ pub fn handle_rename(
 fn collect_account_rename_edits(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     old_name: &str,
     new_name: &str,
     edits: &mut Vec<TextEdit>,
@@ -99,6 +111,7 @@ fn collect_account_rename_edits(
                 if open.account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -112,6 +125,7 @@ fn collect_account_rename_edits(
                 if close.account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -125,6 +139,7 @@ fn collect_account_rename_edits(
                 if bal.account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -138,6 +153,7 @@ fn collect_account_rename_edits(
                 if pad.account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -149,6 +165,7 @@ fn collect_account_rename_edits(
                 if pad.source_account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -162,6 +179,7 @@ fn collect_account_rename_edits(
                 if note.account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -175,6 +193,7 @@ fn collect_account_rename_edits(
                 if doc.account.as_ref() == old_name
                     && let Some(edit) = find_and_create_edit(
                         source,
+                        line_index,
                         spanned.span.start,
                         spanned.span.end,
                         old_name,
@@ -186,23 +205,18 @@ fn collect_account_rename_edits(
             }
             Directive::Transaction(txn) => {
                 for posting in &txn.postings {
-                    if posting.account.as_ref() == old_name {
-                        // Find the posting line and create edit
-                        let directive_text = &source[spanned.span.start..spanned.span.end];
-                        if let Some(edit) = find_and_create_edit(
+                    if posting.account.as_ref() == old_name
+                        && let Some(edit) = find_and_create_edit(
                             source,
+                            line_index,
                             spanned.span.start,
                             spanned.span.end,
                             old_name,
                             new_name,
-                        ) {
-                            // Check if we already have an edit for this range
-                            if !edits.iter().any(|e| e.range == edit.range) {
-                                edits.push(edit);
-                            }
-                        }
-                        // For transactions with multiple matching postings, we need all of them
-                        let _ = directive_text; // suppress unused warning
+                        )
+                        && !edits.iter().any(|e| e.range == edit.range)
+                    {
+                        edits.push(edit);
                     }
                 }
             }
@@ -226,8 +240,8 @@ fn collect_account_rename_edits(
 /// despite the alphanumeric boundary check, because `-` is non-
 /// alphanumeric).
 fn collect_currency_rename_edits(
-    source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     old_name: &str,
     new_name: &str,
     edits: &mut Vec<TextEdit>,
@@ -236,8 +250,8 @@ fn collect_currency_rename_edits(
         if occurrence.value != old_name {
             continue;
         }
-        let (start_line, start_col) = byte_offset_to_position(source, occurrence.span.start);
-        let (end_line, end_col) = byte_offset_to_position(source, occurrence.span.end);
+        let (start_line, start_col) = line_index.offset_to_position(occurrence.span.start);
+        let (end_line, end_col) = line_index.offset_to_position(occurrence.span.end);
         edits.push(TextEdit {
             range: Range {
                 start: Position::new(start_line, start_col),
@@ -247,10 +261,14 @@ fn collect_currency_rename_edits(
         });
     }
 
-    // Deduplicate edits by range. The parser may visit the same
-    // currency span twice when a token is referenced from multiple
-    // parse paths (price annotations, cost specs); guard against
-    // emitting duplicate text edits in those cases.
+    // Defensive dedup. The parser advances unidirectionally over its
+    // token stream, so today every `Currency` token is consumed
+    // exactly once — even speculative parse paths (e.g.
+    // `parse_incomplete_amount`) rewind `stream.pos` before retrying.
+    // The sort+dedup here costs essentially nothing for the typical
+    // hint count and protects against future parser refactors that
+    // might re-emit a span (e.g. a backtracking parser, or a separate
+    // resync pass).
     edits.sort_by(|a, b| {
         a.range
             .start
@@ -262,15 +280,24 @@ fn collect_currency_rename_edits(
 }
 
 /// Find a string in the source and create a text edit.
+///
+/// Used by the account-rename path (not currency: currency now goes
+/// through `parse_result.currency_occurrences` for exact AST-derived
+/// spans). Account directives don't carry per-field spans, so we
+/// fall back to a directive-scoped substring search; that's safe for
+/// account names because they cannot textually appear inside other
+/// syntactic positions a directive supports (no `:` in payee strings
+/// or in metadata keys).
 fn find_and_create_edit(
     source: &str,
+    line_index: &LineIndex,
     start_offset: usize,
     end_offset: usize,
     old_name: &str,
     new_name: &str,
 ) -> Option<TextEdit> {
     let directive_text = &source[start_offset..end_offset];
-    let (start_line, start_col) = byte_offset_to_position(source, start_offset);
+    let (start_line, start_col) = line_index.offset_to_position(start_offset);
 
     // Find the old name in the directive
     for (line_offset, line) in directive_text.lines().enumerate() {

--- a/crates/rustledger-lsp/src/handlers/rename.rs
+++ b/crates/rustledger-lsp/src/handlers/rename.rs
@@ -212,6 +212,19 @@ fn collect_account_rename_edits(
 }
 
 /// Collect all edits needed to rename a currency.
+///
+/// Walks the parser's `currency_occurrences` index — every `Currency`
+/// token the parser actually consumed, with exact source spans — and
+/// emits one `TextEdit` per occurrence matching `old_name`.
+///
+/// This is exact: zero false positives in payee strings, comments,
+/// account-name segments, or anywhere else a `[A-Z]{3,}` sequence
+/// might accidentally appear. The previous string-search
+/// implementation needed word-boundary heuristics to filter those
+/// out, and the heuristics still produced wrong edits for cases like
+/// `Expenses:USD-Account` (the substring `USD` matched mid-identifier
+/// despite the alphanumeric boundary check, because `-` is non-
+/// alphanumeric).
 fn collect_currency_rename_edits(
     source: &str,
     parse_result: &ParseResult,
@@ -219,51 +232,25 @@ fn collect_currency_rename_edits(
     new_name: &str,
     edits: &mut Vec<TextEdit>,
 ) {
-    for spanned in &parse_result.directives {
-        let directive_text = &source[spanned.span.start..spanned.span.end];
-
-        // Check if this directive contains the currency
-        if directive_text.contains(old_name) {
-            // Find all occurrences in this directive
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
-
-            for (line_offset, line) in directive_text.lines().enumerate() {
-                let mut search_start = 0;
-                while let Some(pos) = line[search_start..].find(old_name) {
-                    let actual_pos = search_start + pos;
-
-                    // Verify it's a word boundary (not part of a longer identifier)
-                    let before_ok = actual_pos == 0
-                        || !line
-                            .chars()
-                            .nth(actual_pos - 1)
-                            .unwrap_or(' ')
-                            .is_alphanumeric();
-                    let after_ok = actual_pos + old_name.len() >= line.len()
-                        || !line
-                            .chars()
-                            .nth(actual_pos + old_name.len())
-                            .unwrap_or(' ')
-                            .is_alphanumeric();
-
-                    if before_ok && after_ok {
-                        let edit_line = start_line + line_offset as u32;
-                        edits.push(TextEdit {
-                            range: Range {
-                                start: Position::new(edit_line, actual_pos as u32),
-                                end: Position::new(edit_line, (actual_pos + old_name.len()) as u32),
-                            },
-                            new_text: new_name.to_string(),
-                        });
-                    }
-
-                    search_start = actual_pos + old_name.len();
-                }
-            }
+    for occurrence in &parse_result.currency_occurrences {
+        if occurrence.value != old_name {
+            continue;
         }
+        let (start_line, start_col) = byte_offset_to_position(source, occurrence.span.start);
+        let (end_line, end_col) = byte_offset_to_position(source, occurrence.span.end);
+        edits.push(TextEdit {
+            range: Range {
+                start: Position::new(start_line, start_col),
+                end: Position::new(end_line, end_col),
+            },
+            new_text: new_name.to_string(),
+        });
     }
 
-    // Deduplicate edits by range
+    // Deduplicate edits by range. The parser may visit the same
+    // currency span twice when a token is referenced from multiple
+    // parse paths (price annotations, cost specs); guard against
+    // emitting duplicate text edits in those cases.
     edits.sort_by(|a, b| {
         a.range
             .start
@@ -359,5 +346,79 @@ mod tests {
 
         // Should have 2 edits: one for open, one for posting
         assert_eq!(edits.len(), 2);
+    }
+
+    /// Regression test for currency-rename false positives.
+    ///
+    /// Before #552 the rename handler string-searched the source
+    /// within each directive that contained the currency code,
+    /// validating word boundaries via `char::is_alphanumeric`. That
+    /// missed several common false-positive shapes:
+    ///
+    /// - Currency code embedded in a payee string
+    ///   (`"USD-to-EUR transfer"`) — the surrounding `"` and `-`
+    ///   characters were treated as word boundaries.
+    /// - Currency code as an account-name segment
+    ///   (`Assets:USD-Reserve`) — the `-` after `USD` looked like
+    ///   a boundary, so `USD` got incorrectly renamed.
+    /// - Currency code in a metadata value or comment.
+    ///
+    /// The AST-driven approach uses `parse_result.currency_occurrences`,
+    /// which contains exactly the `Currency` tokens the lexer
+    /// produced. Strings, accounts, comments, and metadata can't
+    /// produce `Currency` tokens, so these false positives are
+    /// impossible by construction.
+    #[test]
+    #[allow(clippy::mutable_key_type)]
+    fn test_rename_currency_no_false_positives() {
+        let source = r#"2024-01-01 open Assets:USD-Reserve
+2024-01-01 commodity USD
+  name: "United States Dollar"
+2024-01-15 * "USD-to-EUR transfer"
+  Assets:USD-Reserve  -100 USD
+  Assets:Bank          100 USD
+; switching USD to USDX later
+"#;
+        let result = parse(source);
+        let uri: lsp_types::Uri = "file:///test.beancount".parse().unwrap();
+
+        // Position cursor on the `USD` of the `commodity USD` line
+        // (line 1, after "commodity "). That's the canonical
+        // declaration site.
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri },
+                position: Position::new(1, 21),
+            },
+            new_name: "USDX".to_string(),
+            work_done_progress_params: Default::default(),
+        };
+
+        let edit = handle_rename(&params, source, &result).expect("rename returns edit");
+        let changes = edit.changes.expect("edit has changes");
+        let edits = changes.values().next().expect("at least one file");
+
+        // Expected: 3 edits — `commodity USD`, `-100 USD`, `100 USD`.
+        // Bespoke string-search would have produced 5: the 3 valid
+        // ones plus `"USD-to-EUR..."` (payee, false positive) and
+        // `; switching USD ...` (comment, false positive). It would
+        // also have RENAMED `Assets:USD-Reserve` (3x — open, two
+        // postings) incorrectly because `-` is non-alphanumeric and
+        // passed the word-boundary check.
+        assert_eq!(
+            edits.len(),
+            3,
+            "expected 3 currency rename edits, got {}: {edits:#?}",
+            edits.len()
+        );
+
+        // None of the edits should target the payee, comment, or
+        // account-name span — sanity-check by confirming all
+        // replacements line up with where the parser saw a `Currency`
+        // token (i.e., col positions that follow a number or the
+        // `commodity` keyword).
+        for e in edits {
+            assert_eq!(e.new_text, "USDX");
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -440,6 +440,51 @@ mod tests {
         assert!(!is_currency_like_simple("TOOLONGCURRENCY"));
     }
 
+    /// `is_currency_like` validates format AND confirms the string
+    /// actually appears as a parsed `Currency` token in the
+    /// document. This test pins both behaviors.
+    ///
+    /// Includes a coverage case for the latent gap the previous
+    /// manual-AST-walk implementation had: a currency mentioned
+    /// only in a `Price` directive returns true. (Whether the old
+    /// walk happened to cover `Price` doesn't matter for the new
+    /// implementation — it queries `currency_occurrences`, which
+    /// is exhaustive by construction.)
+    #[test]
+    fn test_is_currency_like() {
+        use rustledger_parser::parse;
+
+        let source = r#"2024-01-01 commodity USD
+2024-01-01 open Assets:Bank USD
+2024-01-15 * "Coffee"
+  Assets:Bank  -5.00 USD
+  Expenses:Food  5.00 USD
+2024-01-20 price GBP  1.27 USD
+"#;
+        let parse_result = parse(source);
+
+        // Format check: must be uppercase/digits, length 2-24.
+        assert!(
+            !is_currency_like("usd", &parse_result),
+            "lowercase rejected"
+        );
+        assert!(!is_currency_like("U", &parse_result), "too short rejected");
+
+        // Format-valid but not present in document.
+        assert!(
+            !is_currency_like("XYZ", &parse_result),
+            "unknown currency rejected"
+        );
+
+        // Format-valid and present as Currency token.
+        assert!(is_currency_like("USD", &parse_result));
+
+        // Currency that appears ONLY in a Price directive (the
+        // latent gap of the previous manual AST walk if it had
+        // missed Price). `currency_occurrences` is exhaustive.
+        assert!(is_currency_like("GBP", &parse_result));
+    }
+
     #[test]
     fn test_is_word_char() {
         assert!(is_word_char('a'));

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -278,6 +278,40 @@ pub fn is_currency_like_simple(s: &str) -> bool {
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
 }
 
+/// Spans of the actual *declared* currency token in each
+/// `Commodity` directive — exactly one per Commodity directive,
+/// namely the first `Currency` token within that directive's
+/// source span.
+///
+/// Used to disambiguate "declaration" from "use" in the LSP
+/// references and document-highlight handlers. A naive
+/// "occurrence span is contained within a Commodity directive
+/// span" check is wrong because Commodity directives can carry
+/// metadata whose values tokenize as `Currency` or `Amount`
+/// (e.g. `2024-01-01 commodity USD\n  alias: EUR` — `EUR` here
+/// is a metadata reference, not a declaration). The first
+/// currency within each Commodity span is unambiguously the
+/// declared one because the parser is strictly forward-advancing
+/// and the declared currency is parsed before the indented
+/// metadata block.
+#[must_use]
+pub fn commodity_declaration_spans(parse_result: &ParseResult) -> Vec<rustledger_parser::Span> {
+    parse_result
+        .directives
+        .iter()
+        .filter_map(|d| {
+            if !matches!(&d.value, rustledger_core::Directive::Commodity(_)) {
+                return None;
+            }
+            parse_result
+                .currency_occurrences
+                .iter()
+                .find(|o| o.span.start >= d.span.start && o.span.end <= d.span.end)
+                .map(|o| o.span)
+        })
+        .collect()
+}
+
 /// Check if a string looks like a currency, validating against known currencies.
 ///
 /// Validates the format (uppercase-and-digits, 2-24 chars) and then

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -4,7 +4,7 @@
 //! including position conversion, word extraction, and type checking.
 
 use lsp_types::{FormattingOptions, Position};
-use rustledger_core::{Directive, FormatConfig};
+use rustledger_core::FormatConfig;
 use rustledger_parser::ParseResult;
 
 /// Resolve the `FormatConfig` the LSP server uses for a given request.
@@ -280,61 +280,33 @@ pub fn is_currency_like_simple(s: &str) -> bool {
 
 /// Check if a string looks like a currency, validating against known currencies.
 ///
-/// This checks the format AND verifies the currency exists in the document.
+/// Validates the format (uppercase-and-digits, 2-24 chars) and then
+/// confirms the string actually appears as a parsed `Currency` token
+/// in the document by looking it up in `parse_result.currency_occurrences`.
+///
+/// The previous implementation manually walked the AST testing each
+/// position that can carry a currency (Commodity.currency,
+/// Open.currencies, Balance.amount, Posting.units / cost / price,
+/// Price directive). That had two problems:
+///
+/// 1. Any position the walk forgot — or any future directive type
+///    that carries a currency — would silently be excluded, and
+///    rename / references / document-highlight would refuse to fire
+///    on a real currency only mentioned there.
+/// 2. Code duplication: the parser already records every `Currency`
+///    token in `currency_occurrences`; the walk was a parallel and
+///    necessarily-incomplete reimplementation.
+///
+/// Consulting the parser's index makes the check exact by
+/// construction and shrinks the function from ~50 lines to ~5.
 pub fn is_currency_like(s: &str, parse_result: &ParseResult) -> bool {
-    // First check format: uppercase letters/numbers, 2-24 chars
     if !s.chars().all(|c| c.is_uppercase() || c.is_numeric()) || s.len() < 2 || s.len() > 24 {
         return false;
     }
-
-    // Then verify it's a known currency in the document
-    for spanned in &parse_result.directives {
-        match &spanned.value {
-            Directive::Commodity(comm) if comm.currency.as_ref() == s => {
-                return true;
-            }
-            Directive::Open(open) => {
-                for curr in &open.currencies {
-                    if curr.as_ref() == s {
-                        return true;
-                    }
-                }
-            }
-            Directive::Balance(bal) if bal.amount.currency.as_ref() == s => {
-                return true;
-            }
-            Directive::Transaction(txn) => {
-                for posting in &txn.postings {
-                    if let Some(units) = &posting.units
-                        && let Some(currency) = units.currency()
-                        && currency == s
-                    {
-                        return true;
-                    }
-                    if let Some(cost) = &posting.cost
-                        && let Some(currency) = &cost.currency
-                        && currency.as_ref() == s
-                    {
-                        return true;
-                    }
-                    if let Some(price) = &posting.price
-                        && let Some(amount) = price.amount()
-                        && amount.currency.as_ref() == s
-                    {
-                        return true;
-                    }
-                }
-            }
-            Directive::Price(price)
-                if price.currency.as_ref() == s || price.amount.currency.as_ref() == s =>
-            {
-                return true;
-            }
-            _ => {}
-        }
-    }
-
-    false
+    parse_result
+        .currency_occurrences
+        .iter()
+        .any(|occ| occ.value == s)
 }
 
 #[cfg(test)]

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -294,8 +294,13 @@ pub fn is_currency_like_simple(s: &str) -> bool {
 /// declared one because the parser is strictly forward-advancing
 /// and the declared currency is parsed before the indented
 /// metadata block.
+///
+/// Returns a `HashSet` so callers can ask "is this occurrence a
+/// declaration?" in O(1).
 #[must_use]
-pub fn commodity_declaration_spans(parse_result: &ParseResult) -> Vec<rustledger_parser::Span> {
+pub fn commodity_declaration_spans(
+    parse_result: &ParseResult,
+) -> std::collections::HashSet<rustledger_parser::Span> {
     parse_result
         .directives
         .iter()

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -34,7 +34,7 @@ pub mod logos_lexer;
 mod parser;
 
 pub use error::{ParseError, ParseErrorKind};
-pub use rustledger_core::{SYNTHESIZED_FILE_ID, Span, Spanned};
+pub use rustledger_core::{InternedStr, SYNTHESIZED_FILE_ID, Span, Spanned};
 
 use rustledger_core::Directive;
 
@@ -55,6 +55,19 @@ pub struct ParseResult {
     pub errors: Vec<ParseError>,
     /// Deprecation warnings.
     pub warnings: Vec<ParseWarning>,
+    /// Every `Currency` token the parser consumed, paired with its
+    /// interned value and source-byte range.
+    ///
+    /// Source-position-aware tooling (LSP rename / references /
+    /// document-highlight) walks this list to produce edits, locations,
+    /// and highlights without resorting to string search of the source
+    /// — which produces false positives in comments, payee strings,
+    /// account-name segments, etc. The order matches source order
+    /// because the parser fills it as tokens are consumed.
+    ///
+    /// `file_id` defaults to 0; the loader can set it via
+    /// `.with_file_id(n)` per element once a `SourceMap` assigns ids.
+    pub currency_occurrences: Vec<Spanned<InternedStr>>,
 }
 
 /// A warning from the parser (non-fatal).

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -63,10 +63,27 @@ pub struct ParseResult {
     /// and highlights without resorting to string search of the source
     /// — which produces false positives in comments, payee strings,
     /// account-name segments, etc. The order matches source order
-    /// because the parser fills it as tokens are consumed.
+    /// because the parser fills it as tokens are consumed (and the
+    /// parser is strictly forward-advancing, including on error
+    /// recovery).
     ///
-    /// `file_id` defaults to 0; the loader can set it via
-    /// `.with_file_id(n)` per element once a `SourceMap` assigns ids.
+    /// **Error-recovery contract.** Tokens consumed during a
+    /// directive that ultimately fails to parse remain in this list.
+    /// Rationale: the lexer's classification of a token as a
+    /// `Currency` is independent of whether the surrounding syntax is
+    /// valid, and tooling that wants to rename or highlight a
+    /// currency the user typed should follow that classification.
+    /// Do not "clean up" partially-consumed entries after a parse
+    /// failure — that would hide real currency identifiers from
+    /// downstream tooling while the user is mid-edit.
+    ///
+    /// **`file_id` is always 0 in parser output.** The parser
+    /// processes one file at a time and doesn't know its own file
+    /// id. The loader sets the correct id on each entry via
+    /// `.with_file_id(n)` when assembling a multi-file `SourceMap`,
+    /// the same way it does for `directives`. Per-file consumers
+    /// (today: every LSP handler) can ignore `file_id`; future
+    /// multi-file consumers must remember to thread it through.
     pub currency_occurrences: Vec<Spanned<InternedStr>>,
 }
 

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -59,6 +59,22 @@ struct TokenStream<'src> {
     /// String interner for deduplicating repeated strings (accounts, currencies).
     /// Typical ledger: ~10 unique accounts × 1000 txns = 10K lookups vs 10K allocations.
     interner: rustledger_core::intern::StringInterner,
+    /// Byte-position record of every Currency token the parser
+    /// consumed, paired with its interned value.
+    ///
+    /// The AST stores currencies as `InternedStr` values stripped of
+    /// their source positions because currencies are pervasively
+    /// reused in computed contexts (booking arithmetic, residual
+    /// aggregation, query results) where a source span would be
+    /// meaningless or actively wrong. Source-position queries — LSP
+    /// rename / references / document-highlight — instead consume
+    /// this parallel index. The parser is the canonical owner of
+    /// source-token positions, so this is its natural home.
+    ///
+    /// `file_id` is left at the default (0) and overwritten later
+    /// when a `SourceMap` assigns each file an id — same pattern
+    /// as `Spanned<Directive>` produced by this parser.
+    currency_occurrences: Vec<Spanned<InternedStr>>,
 }
 
 impl<'src> TokenStream<'src> {
@@ -68,6 +84,7 @@ impl<'src> TokenStream<'src> {
             pos: 0,
             deferred_error: None,
             interner: rustledger_core::intern::StringInterner::new(),
+            currency_occurrences: Vec::new(),
         }
     }
 
@@ -359,7 +376,15 @@ fn parse_currency(stream: &mut TokenStream<'_>) -> ParseRes<InternedStr> {
     if let Some(t) = stream.peek()
         && let Token::Currency(s) = &t.token
     {
+        let span = Span::new(t.span.0, t.span.1);
         let result = stream.interner.intern(s);
+        // Record the source-token position for downstream
+        // span-aware consumers (LSP rename / references /
+        // document-highlight). See `TokenStream::currency_occurrences`
+        // for the rationale.
+        stream
+            .currency_occurrences
+            .push(Spanned::new(result.clone(), span));
         stream.advance();
         return Ok(result);
     }
@@ -1921,6 +1946,7 @@ pub fn parse(source: &str) -> ParseResult {
         comments,
         errors,
         warnings: Vec::new(),
+        currency_occurrences: stream.currency_occurrences,
     }
 }
 

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -16,11 +16,11 @@
 //!   Required exports: `metadata`, `identify`, `extract`, `extract_enriched`.
 //!   Host loader: `rustledger-importer::WasmImporter`. Use the
 //!   `wasm_importer_main!` macro (behind the `guest` feature) to generate
-//!   the boilerplate. See the [`guest`] module for details.
+//!   the boilerplate. See the `guest` module for details.
 //!
 //! # Directive-Plugin Quick Start
 //!
-//! Use the [`wasm_plugin_main!`] macro (behind the `guest` feature) to
+//! Use the `wasm_plugin_main!` macro (behind the `guest` feature) to
 //! generate the required `alloc` + `process` exports from a single
 //! user fn. Add this to your plugin's `Cargo.toml`:
 //!
@@ -46,7 +46,7 @@
 //! }
 //! ```
 //!
-//! See the [`guest`] module for the full macro reference (including
+//! See the `guest` module for the full macro reference (including
 //! the once-per-crate constraint on the `wasm32` target). If you need
 //! to write the `extern "C"` exports manually — for finer control or
 //! to avoid the `guest` feature — see the "Without the macro" section


### PR DESCRIPTION
## Summary

Replaces the LSP's bespoke string-search currency lookup in `rename.rs`, `references.rs`, and `document_highlight.rs` with an AST-driven approach. The parser now publishes every `Currency` token it consumed as `ParseResult.currency_occurrences: Vec<Spanned<InternedStr>>`, and the three handlers walk that index for exact spans — eliminating false positives in payee strings, account-name segments, comments, and metadata that happen to contain a currency code.

Closes #552.

## What was broken

The previous implementation scanned each directive's source bytes for the currency literal, validating "word boundaries" via `char::is_alphanumeric`. That misses several common shapes:

| Source | Old behavior |
|---|---|
| `"USD-to-EUR transfer"` (payee) | Renames `USD` (`"` and `-` are non-alphanumeric → pass boundary check) |
| `Assets:USD-Reserve` (account name) | Renames `USD` (`:` and `-` are non-alphanumeric → pass) |
| `; comment containing USD` | Renames `USD` if the comment falls inside a directive's span |
| Real `USD` (commodity / posting / cost / price) | Renames correctly |

For a transaction body like `2024-01-15 * "USD-to-EUR" Assets:USD-Reserve -100 USD`, the old code emitted **4 edits** (1 in the payee, 1 in the account, 2 legitimate) when the user renamed `USD → USDX`. Three of those edits corrupted unrelated text.

## Design

I considered two paths:

**A. Spans on AST nodes** — wrap `currency: InternedStr` in `Spanned<InternedStr>` on `Amount`, `CostSpec`, `Commodity`, `Open.currencies`, and `IncompleteAmount::CurrencyOnly`. I tried this and ran into a deeper modeling issue: `Amount` is a value type used pervasively in computed contexts (booking arithmetic, residual aggregation, query results, balance sums). Adding source-position metadata to it conflates "what this value is" with "where it came from in source" — and the latter doesn't exist for computed values. Every value-only consumer (~120+ sites across the workspace) would have to drop the span via `.value.clone()`, and synthesized/computed amounts would carry meaningless `Span::ZERO` metadata forever. That's not solving the problem; it's putting source-position metadata in the wrong layer of the architecture.

**B. Spans on the parser's output (chosen)** — the parser is the canonical owner of source-position metadata. Publishing currency-token spans as a side index on `ParseResult` keeps source-position concerns where they belong (the parser layer) and lets value types stay pure values. This is how rustc, swc, and tree-sitter all model source-position tracking: per-token positions live in a parser-owned side table, not bolted onto every leaf AST node.

The new field:

```rust
pub struct ParseResult {
    pub directives: Vec<Spanned<Directive>>,
    /* ... */
    pub currency_occurrences: Vec<Spanned<InternedStr>>,
}
```

The parser fills it inside `parse_currency` as each `Currency` token is consumed. Order matches source order.

The three handlers each become a simple filter + map:

```rust
for occurrence in &parse_result.currency_occurrences {
    if occurrence.value != target_currency { continue; }
    // emit edit / location / highlight using occurrence.span
}
```

To tell "declaration" apart from "use" (for `include_declaration` and `WRITE` vs `READ`), the handlers pre-build the byte ranges of `Commodity` directives and test whether each occurrence's span falls inside one. A `Commodity` directive contains exactly one `Currency` token, so the within-range check is unambiguous.

## Pre-existing fix

While verifying with `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`, hit an unrelated doc-link error in `rustledger-plugin-types/src/lib.rs` — the crate has intra-doc links to its `guest` module which is gated behind `#[cfg(feature = "guest")]`. CI uses `--all-features` so it passes there; local builds without features fail. Fix: demoted three `[`guest`]` / `[`wasm_plugin_main!`]` / `[`wasm_importer_main!`]` intra-doc links to plain `` `code` `` references. Still readable; resolves under both feature configurations.

## Test plan

- [x] `cargo test -p rustledger-lsp --all-features` — **139 tests, 0 failures** (3 new regression tests)
- [x] `cargo test -p rustledger-parser --all-features`
- [x] `RUSTFLAGS=-Dwarnings cargo build --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] **New `test_rename_currency_no_false_positives`** — asserts exactly 3 edits for a transaction whose body contains the currency code as a payee substring and as an account-name segment. Would fail under the prior implementation.
- [x] **New `test_find_currency_references_no_false_positives`** — same source; verifies both `include_declaration=true` (3 refs) and `include_declaration=false` (2 refs) paths.
- [x] **New `test_highlight_currency_no_false_positives`** — same source; verifies 3 highlights with exactly one `WRITE` (the commodity declaration).

Closes #552
