### PR TITLE
fix(lsp): goto-definition for currency returns narrow token span + LineIndex

### DIFF
--- a/crates/rustledger-lsp/src/handlers/definition.rs
+++ b/crates/rustledger-lsp/src/handlers/definition.rs
@@ -8,9 +8,7 @@ use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Position
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 
-use super::utils::{
-    LineIndex, get_word_at_source_position, is_account_type, is_currency_like_simple,
-};
+use super::utils::{LineIndex, get_word_at_source_position, is_account_type, is_currency_like};
 
 /// Handle a go-to-definition request.
 pub fn handle_goto_definition(
@@ -39,8 +37,12 @@ pub fn handle_goto_definition(
         return Some(GotoDefinitionResponse::Scalar(location));
     }
 
-    // Check if it's a currency
-    if is_currency_like_simple(&word)
+    // Check if it's a currency. Use the AST-validating
+    // `is_currency_like` (not `_simple`) so words that look like
+    // currencies but don't actually appear as `Currency` tokens
+    // anywhere in the document short-circuit here instead of falling
+    // through to `find_currency_definition` and then returning None.
+    if is_currency_like(&word, parse_result)
         && let Some(location) = find_currency_definition(&word, parse_result, &line_index, uri)
     {
         return Some(GotoDefinitionResponse::Scalar(location));
@@ -64,9 +66,17 @@ fn find_account_definition(
 ) -> Option<Location> {
     for spanned_directive in &parse_result.directives {
         if let Directive::Open(open) = &spanned_directive.value {
-            let open_account = open.account.to_string();
-            // Match exact account or account prefix
-            if open_account == account || account.starts_with(&format!("{}:", open_account)) {
+            let open_account = open.account.as_ref();
+            // Match exact account or `Open:account:Sub`-style prefix.
+            // Pre-fix this branch did
+            // `account.starts_with(&format!("{}:", open_account))`,
+            // which allocated a new `String` per iteration. Using
+            // `strip_prefix` + a `b':'` check keeps it allocation-
+            // free.
+            let prefix_match = account
+                .strip_prefix(open_account)
+                .is_some_and(|rest| rest.starts_with(':'));
+            if account == open_account || prefix_match {
                 let (start_line, start_col) =
                     line_index.offset_to_position(spanned_directive.span.start);
                 let (end_line, end_col) = line_index.offset_to_position(spanned_directive.span.end);

--- a/crates/rustledger-lsp/src/handlers/definition.rs
+++ b/crates/rustledger-lsp/src/handlers/definition.rs
@@ -9,7 +9,7 @@ use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 
 use super::utils::{
-    byte_offset_to_position, get_word_at_source_position, is_account_type, is_currency_like_simple,
+    LineIndex, get_word_at_source_position, is_account_type, is_currency_like_simple,
 };
 
 /// Handle a go-to-definition request.
@@ -26,16 +26,22 @@ pub fn handle_goto_definition(
 
     tracing::debug!("Go-to-definition for word: {:?}", word);
 
+    // Build the line index once and share across both lookups.
+    // Each `byte_offset_to_position` call is O(n) (linear scan from
+    // byte 0); `LineIndex::offset_to_position` is O(log lines)
+    // after a one-shot O(n) build.
+    let line_index = LineIndex::new(source);
+
     // Check if it's an account name
     if (word.contains(':') || is_account_type(&word))
-        && let Some(location) = find_account_definition(&word, parse_result, source, uri)
+        && let Some(location) = find_account_definition(&word, parse_result, &line_index, uri)
     {
         return Some(GotoDefinitionResponse::Scalar(location));
     }
 
     // Check if it's a currency
     if is_currency_like_simple(&word)
-        && let Some(location) = find_currency_definition(&word, parse_result, source, uri)
+        && let Some(location) = find_currency_definition(&word, parse_result, &line_index, uri)
     {
         return Some(GotoDefinitionResponse::Scalar(location));
     }
@@ -44,10 +50,16 @@ pub fn handle_goto_definition(
 }
 
 /// Find the definition of an account (the Open directive).
+///
+/// Returns the whole Open directive's span. Most LSP clients
+/// position the cursor at the range start, so the practical UX is
+/// "jump to the start of `Open`". Narrowing to just the account-
+/// name token would require per-field spans on `Open`, which
+/// don't exist today.
 fn find_account_definition(
     account: &str,
     parse_result: &ParseResult,
-    source: &str,
+    line_index: &LineIndex,
     uri: &Uri,
 ) -> Option<Location> {
     for spanned_directive in &parse_result.directives {
@@ -56,9 +68,8 @@ fn find_account_definition(
             // Match exact account or account prefix
             if open_account == account || account.starts_with(&format!("{}:", open_account)) {
                 let (start_line, start_col) =
-                    byte_offset_to_position(source, spanned_directive.span.start);
-                let (end_line, end_col) =
-                    byte_offset_to_position(source, spanned_directive.span.end);
+                    line_index.offset_to_position(spanned_directive.span.start);
+                let (end_line, end_col) = line_index.offset_to_position(spanned_directive.span.end);
 
                 return Some(Location {
                     uri: uri.clone(),
@@ -73,29 +84,128 @@ fn find_account_definition(
     None
 }
 
-/// Find the definition of a currency (the Commodity directive).
+/// Find the definition of a currency (the declared `Currency` token
+/// inside its `Commodity` directive).
+///
+/// Returns a Range covering exactly the declared currency token, not
+/// the whole Commodity directive. With per-token precision the
+/// editor highlights just `USD` when the user invokes "go to
+/// definition" instead of a multi-line range (which is what we
+/// returned previously, because Commodity directives can have an
+/// indented metadata block).
+///
+/// The declared token is identified as the *first* `Currency` token
+/// within the Commodity directive's span. The parser is strictly
+/// forward-advancing and consumes the declared currency before the
+/// indented metadata block, so the first-within-span occurrence is
+/// unambiguously the declaration — same identification rule used by
+/// `commodity_declaration_spans` for the references / document-
+/// highlight handlers (see utils.rs).
 fn find_currency_definition(
     currency: &str,
     parse_result: &ParseResult,
-    source: &str,
+    line_index: &LineIndex,
     uri: &Uri,
 ) -> Option<Location> {
-    for spanned_directive in &parse_result.directives {
-        if let Directive::Commodity(comm) = &spanned_directive.value
-            && comm.currency.as_ref() == currency
-        {
-            let (start_line, start_col) =
-                byte_offset_to_position(source, spanned_directive.span.start);
-            let (end_line, end_col) = byte_offset_to_position(source, spanned_directive.span.end);
+    let commodity_directive = parse_result.directives.iter().find(|d| {
+        matches!(
+            &d.value,
+            Directive::Commodity(c) if c.currency.as_ref() == currency
+        )
+    })?;
 
-            return Some(Location {
-                uri: uri.clone(),
-                range: Range {
-                    start: Position::new(start_line, start_col),
-                    end: Position::new(end_line, end_col),
-                },
-            });
-        }
+    let declaration_token = parse_result.currency_occurrences.iter().find(|o| {
+        o.span.start >= commodity_directive.span.start && o.span.end <= commodity_directive.span.end
+    })?;
+
+    let (start_line, start_col) = line_index.offset_to_position(declaration_token.span.start);
+    let (end_line, end_col) = line_index.offset_to_position(declaration_token.span.end);
+
+    Some(Location {
+        uri: uri.clone(),
+        range: Range {
+            start: Position::new(start_line, start_col),
+            end: Position::new(end_line, end_col),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustledger_parser::parse;
+
+    /// Regression test: go-to-definition on a currency must return
+    /// a Range that covers exactly the declared currency token, not
+    /// the whole Commodity directive.
+    ///
+    /// The previous implementation returned the directive's whole
+    /// span, which for a Commodity with indented metadata spans
+    /// multiple lines and renders awkwardly in editors that
+    /// highlight the target range (e.g., a flash-highlight of the
+    /// whole multi-line block instead of just the `USD` token).
+    #[test]
+    fn test_goto_definition_currency_returns_token_span() {
+        let source = "\
+2024-01-01 commodity USD
+  name: \"United States Dollar\"
+2024-01-15 * \"Coffee\"
+  Assets:Bank  -5.00 USD
+";
+        let parse_result = parse(source);
+        assert!(
+            parse_result.errors.is_empty(),
+            "parse errors: {:?}",
+            parse_result.errors
+        );
+        let uri: Uri = "file:///test.beancount".parse().unwrap();
+
+        // Cursor on `USD` in `-5.00 USD` (line 3, col 21 — the `U`).
+        let params = GotoDefinitionParams {
+            text_document_position_params: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                position: Position::new(3, 21),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        let resp = handle_goto_definition(&params, source, &parse_result, &uri)
+            .expect("definition returns Some");
+        let loc = match resp {
+            GotoDefinitionResponse::Scalar(l) => l,
+            other => panic!("expected Scalar location; got {other:?}"),
+        };
+
+        // The declared `USD` token sits on line 0 at columns
+        // 21..24 (after `2024-01-01 commodity `).
+        // Pre-fix: range was the whole Commodity directive
+        // (lines 0..2 — multi-line because of the metadata block).
+        assert_eq!(loc.range.start, Position::new(0, 21));
+        assert_eq!(loc.range.end, Position::new(0, 24));
     }
-    None
+
+    /// `is_currency_like_simple` accepts anything matching
+    /// `[A-Z0-9]{2,5}` — so `USDX` would pass the format check
+    /// even if no commodity for it exists. The function must
+    /// return None when the currency isn't declared, not panic or
+    /// return a bogus location.
+    #[test]
+    fn test_goto_definition_currency_with_no_commodity_returns_none() {
+        let source = "2024-01-15 * \"Coffee\"\n  Assets:Bank  -5.00 USD\n";
+        let parse_result = parse(source);
+        let uri: Uri = "file:///test.beancount".parse().unwrap();
+
+        // Cursor on `USD`. There's no `commodity USD` directive.
+        let params = GotoDefinitionParams {
+            text_document_position_params: lsp_types::TextDocumentPositionParams {
+                text_document: lsp_types::TextDocumentIdentifier { uri: uri.clone() },
+                position: Position::new(1, 21),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        assert!(handle_goto_definition(&params, source, &parse_result, &uri).is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Two follow-up findings flagged but deferred from #1160:

1. **`find_currency_definition` returned the whole Commodity directive span as the goto-definition target.** For Commodity directives with indented metadata blocks, that was a multi-line range — editors that flash-highlight the destination would highlight the whole directive instead of just the declared `USD` token. Same root cause shape as the references / document-highlight bug fixed in #1160: Commodity directives carry indented metadata whose values can tokenize as `Currency`.

2. **`find_account_definition` and `find_currency_definition` both went through `byte_offset_to_position`,** which is O(n) per call (linear scan from byte 0). With many calls per LSP request, the goto-definition handler scaled quadratically on large files.

## Changes

- **Build a single `LineIndex` in `handle_goto_definition`** and thread it into both lookup helpers. Per-conversion cost: O(log lines) instead of O(n).
- **`find_currency_definition` now returns the declared-token span,** identified as the first `Currency` occurrence within the matching `Commodity` directive's span. The parser is strictly forward-advancing and consumes the declared currency before the indented metadata block, so the first-within-span occurrence is unambiguously the declaration — same rule used by `commodity_declaration_spans` in utils.rs.
- **`find_account_definition` continues to return the whole Open directive span.** Narrowing would require per-field spans on `Open`, which don't exist today (documented inline).

## Test plan

- [x] `cargo test -p rustledger-lsp --all-features` — **146 tests, 0 failures** (+2 new)
- [x] `RUSTFLAGS=-Dwarnings cargo build --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] **New `test_goto_definition_currency_returns_token_span`** — Commodity directive with indented metadata block, cursor on a `USD` use; asserts the returned `Range` is exactly the 3-byte declared token, not the whole multi-line directive. Would fail under the pre-fix implementation.
- [x] **New `test_goto_definition_currency_with_no_commodity_returns_none`** — pins behavior for a currency-shaped word with no declaration: returns None, not panic or bogus location.

Follow-up to #1160 (#552).
