### PR TITLE
refactor(core): visitor pattern for currency + account enumeration

### DIFF
--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -1,8 +1,14 @@
 //! Extract unique accounts, currencies, and payees from directives.
 //!
 //! These functions are used by both the WASM editor and LSP for completions.
+//! The currency and account walks delegate to [`crate::visit`] for
+//! exhaustive position coverage; that module is the single
+//! enumeration point — any new directive variant or new currency/
+//! account-bearing position is added there and every consumer
+//! (extract, hover, completion, …) benefits.
 
-use crate::{Directive, MetaValue, Metadata, PriceAnnotation};
+use crate::Directive;
+use crate::visit::{visit_accounts, visit_currencies};
 
 /// Common default currencies included in completions.
 pub const DEFAULT_CURRENCIES: &[&str] = &["USD", "EUR", "GBP"];
@@ -20,94 +26,18 @@ pub fn extract_accounts(directives: &[Directive]) -> Vec<String> {
 /// ```
 /// Extract unique account names from an iterator of directive references.
 ///
-/// Covers every position an account name can appear in source:
-/// - `Open.account` / `Close.account`
-/// - `Balance.account`
-/// - `Pad.account` and `Pad.source_account`
-/// - `Note.account`
-/// - `Document.account`
-/// - `Posting.account` (transactions)
-/// - `MetaValue::Account` values inside the metadata block of any
-///   directive or posting
-/// - `MetaValue::Account` inside `Custom.values`
-///
-/// Earlier iterations of this function covered only Open / Close /
-/// Balance / Pad / Transaction.postings — accounts mentioned only
-/// on a Note, Document, in metadata, or in a Custom directive were
-/// silently absent from completion suggestions in both the LSP and
-/// the WASM editor.
+/// Delegates to [`visit_accounts`] for exhaustive position coverage
+/// (Open / Close / Balance / Pad / Note / Document / Posting,
+/// metadata, Custom values, …). See that function for the
+/// authoritative position list.
 pub fn extract_accounts_iter<'a>(directives: impl Iterator<Item = &'a Directive>) -> Vec<String> {
     let mut accounts = Vec::new();
-
     for directive in directives {
-        match directive {
-            Directive::Open(open) => {
-                accounts.push(open.account.to_string());
-                extract_meta_accounts(&open.meta, &mut accounts);
-            }
-            Directive::Close(close) => {
-                accounts.push(close.account.to_string());
-                extract_meta_accounts(&close.meta, &mut accounts);
-            }
-            Directive::Balance(bal) => {
-                accounts.push(bal.account.to_string());
-                extract_meta_accounts(&bal.meta, &mut accounts);
-            }
-            Directive::Pad(pad) => {
-                accounts.push(pad.account.to_string());
-                accounts.push(pad.source_account.to_string());
-                extract_meta_accounts(&pad.meta, &mut accounts);
-            }
-            Directive::Note(note) => {
-                accounts.push(note.account.to_string());
-                extract_meta_accounts(&note.meta, &mut accounts);
-            }
-            Directive::Document(doc) => {
-                accounts.push(doc.account.to_string());
-                extract_meta_accounts(&doc.meta, &mut accounts);
-            }
-            Directive::Transaction(txn) => {
-                extract_meta_accounts(&txn.meta, &mut accounts);
-                for posting in &txn.postings {
-                    accounts.push(posting.account.to_string());
-                    extract_meta_accounts(&posting.meta, &mut accounts);
-                }
-            }
-            Directive::Custom(custom) => {
-                for v in &custom.values {
-                    if let MetaValue::Account(a) = v {
-                        accounts.push(a.clone());
-                    }
-                }
-                extract_meta_accounts(&custom.meta, &mut accounts);
-            }
-            Directive::Commodity(comm) => {
-                extract_meta_accounts(&comm.meta, &mut accounts);
-            }
-            Directive::Price(price) => {
-                extract_meta_accounts(&price.meta, &mut accounts);
-            }
-            Directive::Event(event) => {
-                extract_meta_accounts(&event.meta, &mut accounts);
-            }
-            Directive::Query(query) => {
-                extract_meta_accounts(&query.meta, &mut accounts);
-            }
-        }
+        visit_accounts(directive, &mut |a| accounts.push(a.to_string()));
     }
-
     accounts.sort();
     accounts.dedup();
     accounts
-}
-
-/// Push any account literal embedded in a metadata block onto `out`.
-fn extract_meta_accounts(meta: &Metadata, out: &mut Vec<String>) {
-    for v in meta.values() {
-        if let MetaValue::Account(a) = v {
-            out.push(a.clone());
-        }
-    }
 }
 
 /// Extract unique currencies from directives (sorted, deduplicated).
@@ -119,134 +49,24 @@ pub fn extract_currencies(directives: &[Directive]) -> Vec<String> {
 
 /// Extract unique currencies from an iterator of directive references.
 ///
-/// Covers every position a `Currency` token can appear in source:
-/// - `Open.currencies` (constraint list)
-/// - `Commodity.currency` (declaration)
-/// - `Balance.amount.currency`
-/// - `Price` directive (both base `currency` and `amount.currency`)
-/// - `Posting.units.currency()` (units side, incl. `CurrencyOnly`)
-/// - `Posting.cost.currency` (cost spec)
-/// - `Posting.price` (`@`/`@@` annotation, all 6 variants)
-/// - `MetaValue::Currency` / `MetaValue::Amount` values inside the
-///   metadata block of any directive or posting
-/// - `Custom.values` entries that are `MetaValue::Currency` or
-///   `MetaValue::Amount` (Custom directives can carry arbitrary
-///   `MetaValue`s as positional arguments)
+/// Delegates to [`visit_currencies`] for exhaustive position coverage
+/// (Open / Commodity / Balance / Price / Posting units+cost+price,
+/// metadata `Currency`/`Amount` values, Custom values, …). See that
+/// function for the authoritative position list.
 ///
-/// Earlier iterations of this function covered only `Open`,
-/// `Commodity`, `Balance`, and `Posting.units` — any currency that
-/// reached the parser through the other positions silently
-/// disappeared from completion suggestions in both the LSP and
-/// the WASM editor.
+/// Always appends [`DEFAULT_CURRENCIES`] so completion can suggest
+/// the common codes even in a fresh document with nothing typed yet.
 pub fn extract_currencies_iter<'a>(directives: impl Iterator<Item = &'a Directive>) -> Vec<String> {
     let mut currencies = Vec::new();
-
     for directive in directives {
-        match directive {
-            Directive::Open(open) => {
-                for currency in &open.currencies {
-                    currencies.push(currency.to_string());
-                }
-                extract_meta_currencies(&open.meta, &mut currencies);
-            }
-            Directive::Commodity(comm) => {
-                currencies.push(comm.currency.to_string());
-                extract_meta_currencies(&comm.meta, &mut currencies);
-            }
-            Directive::Balance(bal) => {
-                currencies.push(bal.amount.currency.to_string());
-                extract_meta_currencies(&bal.meta, &mut currencies);
-            }
-            Directive::Price(price) => {
-                currencies.push(price.currency.to_string());
-                currencies.push(price.amount.currency.to_string());
-                extract_meta_currencies(&price.meta, &mut currencies);
-            }
-            Directive::Transaction(txn) => {
-                extract_meta_currencies(&txn.meta, &mut currencies);
-                for posting in &txn.postings {
-                    if let Some(ref units) = posting.units
-                        && let Some(currency) = units.currency()
-                    {
-                        currencies.push(currency.to_string());
-                    }
-                    if let Some(ref cost) = posting.cost
-                        && let Some(ref c) = cost.currency
-                    {
-                        currencies.push(c.to_string());
-                    }
-                    if let Some(ref price) = posting.price {
-                        extract_price_currency(price, &mut currencies);
-                    }
-                    extract_meta_currencies(&posting.meta, &mut currencies);
-                }
-            }
-            Directive::Custom(custom) => {
-                for v in &custom.values {
-                    match v {
-                        MetaValue::Currency(s) => currencies.push(s.clone()),
-                        MetaValue::Amount(a) => currencies.push(a.currency.to_string()),
-                        _ => {}
-                    }
-                }
-                extract_meta_currencies(&custom.meta, &mut currencies);
-            }
-            Directive::Note(note) => {
-                extract_meta_currencies(&note.meta, &mut currencies);
-            }
-            Directive::Document(doc) => {
-                extract_meta_currencies(&doc.meta, &mut currencies);
-            }
-            Directive::Close(close) => {
-                extract_meta_currencies(&close.meta, &mut currencies);
-            }
-            Directive::Pad(pad) => {
-                extract_meta_currencies(&pad.meta, &mut currencies);
-            }
-            Directive::Event(event) => {
-                extract_meta_currencies(&event.meta, &mut currencies);
-            }
-            Directive::Query(query) => {
-                extract_meta_currencies(&query.meta, &mut currencies);
-            }
-        }
+        visit_currencies(directive, &mut |c| currencies.push(c.to_string()));
     }
-
     for currency in DEFAULT_CURRENCIES {
         currencies.push((*currency).to_string());
     }
-
     currencies.sort();
     currencies.dedup();
     currencies
-}
-
-/// Push any currency literal embedded in a metadata block onto `out`.
-fn extract_meta_currencies(meta: &Metadata, out: &mut Vec<String>) {
-    for v in meta.values() {
-        match v {
-            MetaValue::Currency(s) => out.push(s.clone()),
-            MetaValue::Amount(a) => out.push(a.currency.to_string()),
-            _ => {}
-        }
-    }
-}
-
-/// Push the currency carried by a `PriceAnnotation` (`@` or `@@`)
-/// onto `out`, if it has one. `UnitEmpty` / `TotalEmpty` annotations
-/// (the user typed `@`/`@@` without an amount) have no currency.
-fn extract_price_currency(price: &PriceAnnotation, out: &mut Vec<String>) {
-    match price {
-        PriceAnnotation::Unit(a) | PriceAnnotation::Total(a) => {
-            out.push(a.currency.to_string());
-        }
-        PriceAnnotation::UnitIncomplete(ia) | PriceAnnotation::TotalIncomplete(ia) => {
-            if let Some(c) = ia.currency() {
-                out.push(c.to_string());
-            }
-        }
-        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => {}
-    }
 }
 
 /// Extract unique payees from transactions (sorted, deduplicated).
@@ -275,7 +95,7 @@ pub fn extract_payees_iter<'a>(directives: impl Iterator<Item = &'a Directive>) 
 mod tests {
     use super::*;
     use crate::NaiveDate;
-    use crate::{Amount, Balance, Commodity, Open, Pad, Posting, Transaction};
+    use crate::{Amount, Balance, Commodity, MetaValue, Metadata, Open, Pad, Posting, Transaction};
 
     fn date(y: i32, m: u32, d: u32) -> NaiveDate {
         crate::naive_date(y, m, d).unwrap()

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod inventory;
 pub mod position;
 pub mod span;
 pub mod synthetic;
+pub mod visit;
 
 // Kani formal verification proofs (only compiled with Kani)
 #[cfg(kani)]
@@ -78,6 +79,7 @@ pub use inventory::{
 };
 pub use position::Position;
 pub use span::{SYNTHESIZED_FILE_ID, Span, Spanned};
+pub use visit::{visit_accounts, visit_currencies};
 
 // Re-export commonly used external types
 /// Calendar date without timezone. Alias for `jiff::civil::Date`.

--- a/crates/rustledger-core/src/visit.rs
+++ b/crates/rustledger-core/src/visit.rs
@@ -1,0 +1,498 @@
+//! Visitors for AST positions that carry a currency or an account name.
+//!
+//! These exist because hand-rolled "for each currency / for each
+//! account" walks across the AST kept missing positions. The earlier
+//! pattern was: every consumer (LSP completion, hover usage count,
+//! WASM editor extraction, etc.) wrote its own walk over `Directive`
+//! variants, and silently dropped any position the author happened
+//! not to remember (`Note.account`, `Posting.cost.currency`,
+//! `MetaValue::Account` metadata values, `Custom.values`, …).
+//! Fixing it in five different files left the underlying problem
+//! intact: the next contributor writing a "for each X" walk will
+//! reach for the same shape and reintroduce the same bug class.
+//!
+//! These visitors are the canonical answer. Every position that
+//! carries a currency or an account name is enumerated exactly once
+//! here, with no `_ => {}` catch-all on the `Directive` match — so
+//! a future `Directive` variant added to the enum forces a compile
+//! error at THIS file, which is the only place that needs to be
+//! updated. Downstream consumers calling `visit_*` benefit
+//! automatically.
+//!
+//! Spans of source tokens are intentionally NOT exposed here:
+//! source positions are parser-only metadata published via
+//! `ParseResult::currency_occurrences` (the parser is the canonical
+//! owner of source-position data). Value-level consumers (extract,
+//! hover usage count, completion suggestions) want the strings;
+//! source-position consumers (LSP rename / references /
+//! document-highlight / linked-editing / goto-definition) consume
+//! the parser's index. Separating the concerns keeps the AST
+//! value types pure.
+
+use crate::{Directive, MetaValue, Metadata, PriceAnnotation};
+
+/// Walk every position a currency name can appear in this directive,
+/// invoking `visit` once per occurrence.
+///
+/// Positions covered:
+/// - `Open.currencies` (each constraint entry)
+/// - `Commodity.currency` (the declared currency)
+/// - `Balance.amount.currency`
+/// - `Price` directive (base `currency` and `amount.currency`)
+/// - `Posting.units.currency()` (units side, including `CurrencyOnly`)
+/// - `Posting.cost.currency` (cost spec)
+/// - `Posting.price` (all 6 `PriceAnnotation` variants)
+/// - `MetaValue::Currency` / `MetaValue::Amount` in any directive's
+///   or posting's metadata block
+/// - `Custom.values` entries that are `MetaValue::Currency` or
+///   `MetaValue::Amount`
+///
+/// The visit order within a directive is the order tokens appear in
+/// source for the parser-generated AST, except for metadata (which
+/// is a `HashMap` and has unspecified iteration order).
+pub fn visit_currencies<'a>(directive: &'a Directive, visit: &mut impl FnMut(&'a str)) {
+    match directive {
+        Directive::Open(open) => {
+            for currency in &open.currencies {
+                visit(currency.as_str());
+            }
+            visit_meta_currencies(&open.meta, visit);
+        }
+        Directive::Commodity(comm) => {
+            visit(comm.currency.as_str());
+            visit_meta_currencies(&comm.meta, visit);
+        }
+        Directive::Balance(bal) => {
+            visit(bal.amount.currency.as_str());
+            visit_meta_currencies(&bal.meta, visit);
+        }
+        Directive::Price(price) => {
+            visit(price.currency.as_str());
+            visit(price.amount.currency.as_str());
+            visit_meta_currencies(&price.meta, visit);
+        }
+        Directive::Transaction(txn) => {
+            visit_meta_currencies(&txn.meta, visit);
+            for posting in &txn.postings {
+                if let Some(units) = &posting.units
+                    && let Some(c) = units.currency()
+                {
+                    visit(c);
+                }
+                if let Some(cost) = &posting.cost
+                    && let Some(c) = &cost.currency
+                {
+                    visit(c.as_str());
+                }
+                if let Some(price) = &posting.price {
+                    visit_price_currency(price, visit);
+                }
+                visit_meta_currencies(&posting.meta, visit);
+            }
+        }
+        Directive::Custom(custom) => {
+            for v in &custom.values {
+                match v {
+                    MetaValue::Currency(s) => visit(s.as_str()),
+                    MetaValue::Amount(a) => visit(a.currency.as_str()),
+                    _ => {}
+                }
+            }
+            visit_meta_currencies(&custom.meta, visit);
+        }
+        Directive::Note(note) => visit_meta_currencies(&note.meta, visit),
+        Directive::Document(doc) => visit_meta_currencies(&doc.meta, visit),
+        Directive::Close(close) => visit_meta_currencies(&close.meta, visit),
+        Directive::Pad(pad) => visit_meta_currencies(&pad.meta, visit),
+        Directive::Event(event) => visit_meta_currencies(&event.meta, visit),
+        Directive::Query(query) => visit_meta_currencies(&query.meta, visit),
+    }
+}
+
+/// Walk every position an account name can appear in this directive,
+/// invoking `visit` once per occurrence.
+///
+/// Positions covered:
+/// - `Open.account`, `Close.account`
+/// - `Balance.account`
+/// - `Pad.account`, `Pad.source_account`
+/// - `Note.account`, `Document.account`
+/// - `Posting.account` (transactions)
+/// - `MetaValue::Account` in any directive's or posting's metadata
+/// - `Custom.values` entries that are `MetaValue::Account`
+///
+/// Visit order matches the source order of the parser-generated
+/// AST, except for metadata (unspecified iteration order).
+pub fn visit_accounts<'a>(directive: &'a Directive, visit: &mut impl FnMut(&'a str)) {
+    match directive {
+        Directive::Open(open) => {
+            visit(open.account.as_str());
+            visit_meta_accounts(&open.meta, visit);
+        }
+        Directive::Close(close) => {
+            visit(close.account.as_str());
+            visit_meta_accounts(&close.meta, visit);
+        }
+        Directive::Balance(bal) => {
+            visit(bal.account.as_str());
+            visit_meta_accounts(&bal.meta, visit);
+        }
+        Directive::Pad(pad) => {
+            visit(pad.account.as_str());
+            visit(pad.source_account.as_str());
+            visit_meta_accounts(&pad.meta, visit);
+        }
+        Directive::Note(note) => {
+            visit(note.account.as_str());
+            visit_meta_accounts(&note.meta, visit);
+        }
+        Directive::Document(doc) => {
+            visit(doc.account.as_str());
+            visit_meta_accounts(&doc.meta, visit);
+        }
+        Directive::Transaction(txn) => {
+            visit_meta_accounts(&txn.meta, visit);
+            for posting in &txn.postings {
+                visit(posting.account.as_str());
+                visit_meta_accounts(&posting.meta, visit);
+            }
+        }
+        Directive::Custom(custom) => {
+            for v in &custom.values {
+                if let MetaValue::Account(a) = v {
+                    visit(a.as_str());
+                }
+            }
+            visit_meta_accounts(&custom.meta, visit);
+        }
+        Directive::Commodity(comm) => visit_meta_accounts(&comm.meta, visit),
+        Directive::Price(price) => visit_meta_accounts(&price.meta, visit),
+        Directive::Event(event) => visit_meta_accounts(&event.meta, visit),
+        Directive::Query(query) => visit_meta_accounts(&query.meta, visit),
+    }
+}
+
+fn visit_meta_currencies<'a>(meta: &'a Metadata, visit: &mut impl FnMut(&'a str)) {
+    for v in meta.values() {
+        match v {
+            MetaValue::Currency(s) => visit(s.as_str()),
+            MetaValue::Amount(a) => visit(a.currency.as_str()),
+            _ => {}
+        }
+    }
+}
+
+fn visit_meta_accounts<'a>(meta: &'a Metadata, visit: &mut impl FnMut(&'a str)) {
+    for v in meta.values() {
+        if let MetaValue::Account(a) = v {
+            visit(a.as_str());
+        }
+    }
+}
+
+fn visit_price_currency<'a>(price: &'a PriceAnnotation, visit: &mut impl FnMut(&'a str)) {
+    match price {
+        PriceAnnotation::Unit(a) | PriceAnnotation::Total(a) => visit(a.currency.as_str()),
+        PriceAnnotation::UnitIncomplete(ia) | PriceAnnotation::TotalIncomplete(ia) => {
+            if let Some(c) = ia.currency() {
+                visit(c);
+            }
+        }
+        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Amount, Balance, Close, Commodity, CostSpec, Custom, Document, MetaValue, Metadata,
+        NaiveDate, Note, Open, Pad, Posting, Price, Spanned, Transaction,
+    };
+    use rust_decimal_macros::dec;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        crate::naive_date(y, m, d).unwrap()
+    }
+
+    fn collect_currencies(directives: &[Directive]) -> Vec<String> {
+        let mut out = Vec::new();
+        for d in directives {
+            visit_currencies(d, &mut |c| out.push(c.to_string()));
+        }
+        out
+    }
+
+    fn collect_accounts(directives: &[Directive]) -> Vec<String> {
+        let mut out = Vec::new();
+        for d in directives {
+            visit_accounts(d, &mut |a| out.push(a.to_string()));
+        }
+        out
+    }
+
+    /// `visit_currencies` must surface every Currency-bearing
+    /// position. This test seeds USD into all 11 positions and
+    /// asserts the visitor reaches each one.
+    #[test]
+    fn test_visit_currencies_reaches_every_position() {
+        let mut commodity_meta: Metadata = Default::default();
+        commodity_meta.insert("note".into(), MetaValue::Currency("USD".into()));
+
+        let mut txn_meta: Metadata = Default::default();
+        txn_meta.insert(
+            "settled".into(),
+            MetaValue::Amount(Amount::new(dec!(1), "USD")),
+        );
+
+        let directives = vec![
+            // Open.currencies + meta
+            Directive::Open(Open {
+                date: date(2024, 1, 1),
+                account: "Assets:Cash".into(),
+                currencies: vec!["USD".into()],
+                booking: None,
+                meta: Default::default(),
+            }),
+            // Commodity.currency + meta
+            Directive::Commodity(Commodity {
+                date: date(2024, 1, 2),
+                currency: "USD".into(),
+                meta: commodity_meta,
+            }),
+            // Balance.amount.currency
+            Directive::Balance(Balance {
+                date: date(2024, 1, 3),
+                account: "Assets:Cash".into(),
+                amount: Amount::new(dec!(100), "USD"),
+                tolerance: None,
+                meta: Default::default(),
+            }),
+            // Price (both halves)
+            Directive::Price(Price {
+                date: date(2024, 1, 4),
+                currency: "USD".into(),
+                amount: Amount::new(dec!(1), "USD"),
+                meta: Default::default(),
+            }),
+            // Transaction with: txn meta (Amount::USD), posting units,
+            // cost, price annotation, posting meta.
+            Directive::Transaction(Transaction {
+                date: date(2024, 1, 5),
+                flag: '*',
+                payee: None,
+                narration: "".into(),
+                tags: vec![],
+                links: vec![],
+                meta: txn_meta,
+                postings: vec![Spanned::synthesized(Posting {
+                    account: "Assets:Stock".into(),
+                    units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "USD"))),
+                    cost: Some(CostSpec {
+                        number_per: Some(dec!(1)),
+                        number_total: None,
+                        currency: Some("USD".into()),
+                        date: None,
+                        label: None,
+                        merge: false,
+                    }),
+                    price: Some(PriceAnnotation::Unit(Amount::new(dec!(1), "USD"))),
+                    flag: None,
+                    meta: Default::default(),
+                    comments: vec![],
+                    trailing_comments: vec![],
+                })],
+                trailing_comments: vec![],
+            }),
+            // Custom.values with Currency and Amount variants.
+            Directive::Custom(Custom {
+                date: date(2024, 1, 6),
+                custom_type: "test".into(),
+                values: vec![
+                    MetaValue::Currency("USD".into()),
+                    MetaValue::Amount(Amount::new(dec!(1), "USD")),
+                ],
+                meta: Default::default(),
+            }),
+        ];
+
+        let currencies = collect_currencies(&directives);
+        let usd_count = currencies.iter().filter(|c| *c == "USD").count();
+
+        // Expected USD visits:
+        //   1. Open.currencies[0]
+        //   2. Commodity.currency
+        //   3. Commodity.meta (`note: USD`)
+        //   4. Balance.amount.currency
+        //   5. Price.currency
+        //   6. Price.amount.currency
+        //   7. Transaction.meta (`settled: 1 USD` → Amount.currency)
+        //   8. Posting.units (Amount.currency)
+        //   9. Posting.cost.currency
+        //  10. Posting.price.amount.currency
+        //  11. Custom.values[0] (Currency variant)
+        //  12. Custom.values[1] (Amount variant)
+        assert_eq!(
+            usd_count, 12,
+            "expected USD visited 12 times across all positions; got {usd_count} in {currencies:?}"
+        );
+    }
+
+    /// `visit_accounts` must surface every Account-bearing position.
+    /// Seeds `Assets:X` into all reachable positions and asserts the
+    /// visitor reaches each one.
+    #[test]
+    fn test_visit_accounts_reaches_every_position() {
+        let mut meta_with_account: Metadata = Default::default();
+        meta_with_account.insert("see_also".into(), MetaValue::Account("Assets:X".into()));
+
+        let directives = vec![
+            Directive::Open(Open {
+                date: date(2024, 1, 1),
+                account: "Assets:X".into(),
+                currencies: vec![],
+                booking: None,
+                meta: meta_with_account.clone(),
+            }),
+            Directive::Close(Close {
+                date: date(2024, 1, 2),
+                account: "Assets:X".into(),
+                meta: Default::default(),
+            }),
+            Directive::Balance(Balance {
+                date: date(2024, 1, 3),
+                account: "Assets:X".into(),
+                amount: Amount::new(dec!(0), "USD"),
+                tolerance: None,
+                meta: Default::default(),
+            }),
+            Directive::Pad(Pad {
+                date: date(2024, 1, 4),
+                account: "Assets:X".into(),
+                source_account: "Assets:X".into(),
+                meta: Default::default(),
+            }),
+            Directive::Note(Note {
+                date: date(2024, 1, 5),
+                account: "Assets:X".into(),
+                comment: String::new(),
+                meta: Default::default(),
+            }),
+            Directive::Document(Document {
+                date: date(2024, 1, 6),
+                account: "Assets:X".into(),
+                path: String::new(),
+                tags: vec![],
+                links: vec![],
+                meta: Default::default(),
+            }),
+            Directive::Transaction(Transaction {
+                date: date(2024, 1, 7),
+                flag: '*',
+                payee: None,
+                narration: "".into(),
+                tags: vec![],
+                links: vec![],
+                meta: meta_with_account,
+                postings: vec![Spanned::synthesized(Posting::auto("Assets:X"))],
+                trailing_comments: vec![],
+            }),
+            Directive::Custom(Custom {
+                date: date(2024, 1, 8),
+                custom_type: "test".into(),
+                values: vec![MetaValue::Account("Assets:X".into())],
+                meta: Default::default(),
+            }),
+        ];
+
+        let accounts = collect_accounts(&directives);
+        let count = accounts.iter().filter(|a| *a == "Assets:X").count();
+
+        // Expected `Assets:X` visits:
+        //   1. Open.account
+        //   2. Open.meta (`see_also: Assets:X`)
+        //   3. Close.account
+        //   4. Balance.account
+        //   5. Pad.account
+        //   6. Pad.source_account
+        //   7. Note.account
+        //   8. Document.account
+        //   9. Transaction.meta (`see_also: Assets:X`)
+        //  10. Posting.account
+        //  11. Custom.values[0]
+        assert_eq!(
+            count, 11,
+            "expected `Assets:X` visited 11 times; got {count} in {accounts:?}"
+        );
+    }
+
+    /// `PriceAnnotation` has six variants. The visitor must handle
+    /// all of them: Unit / Total emit one currency, the Incomplete
+    /// variants emit one if their `IncompleteAmount` has a currency
+    /// (`Complete` or `CurrencyOnly`), the Empty variants emit nothing.
+    #[test]
+    fn test_visit_currencies_handles_all_price_annotation_variants() {
+        let txn = |price| Transaction {
+            date: date(2024, 1, 1),
+            flag: '*',
+            payee: None,
+            narration: "".into(),
+            tags: vec![],
+            links: vec![],
+            meta: Default::default(),
+            postings: vec![Spanned::synthesized(Posting {
+                account: "Assets:X".into(),
+                units: Some(crate::IncompleteAmount::from(Amount::new(dec!(1), "AAPL"))),
+                cost: None,
+                price: Some(price),
+                flag: None,
+                meta: Default::default(),
+                comments: vec![],
+                trailing_comments: vec![],
+            })],
+            trailing_comments: vec![],
+        };
+
+        // Unit + Total: each surface one currency.
+        let unit = Directive::Transaction(txn(PriceAnnotation::Unit(Amount::new(dec!(1), "USD"))));
+        let total =
+            Directive::Transaction(txn(PriceAnnotation::Total(Amount::new(dec!(1), "EUR"))));
+        // Incomplete-Complete + Incomplete-CurrencyOnly both have a
+        // currency; Incomplete-NumberOnly does not.
+        let inc_complete = Directive::Transaction(txn(PriceAnnotation::UnitIncomplete(
+            crate::IncompleteAmount::Complete(Amount::new(dec!(1), "GBP")),
+        )));
+        let inc_curr = Directive::Transaction(txn(PriceAnnotation::TotalIncomplete(
+            crate::IncompleteAmount::CurrencyOnly("JPY".into()),
+        )));
+        let inc_num = Directive::Transaction(txn(PriceAnnotation::UnitIncomplete(
+            crate::IncompleteAmount::NumberOnly(dec!(1)),
+        )));
+        // Empty variants surface nothing.
+        let unit_empty = Directive::Transaction(txn(PriceAnnotation::UnitEmpty));
+        let total_empty = Directive::Transaction(txn(PriceAnnotation::TotalEmpty));
+
+        let directives = vec![
+            unit,
+            total,
+            inc_complete,
+            inc_curr,
+            inc_num,
+            unit_empty,
+            total_empty,
+        ];
+
+        let currencies = collect_currencies(&directives);
+
+        // Each transaction's units side contributes AAPL, so 7×AAPL.
+        // Price annotation adds USD/EUR/GBP/JPY for the four non-
+        // empty variants; UnitEmpty/TotalEmpty add nothing;
+        // NumberOnly adds nothing for its price side.
+        let by_curr = |code: &str| currencies.iter().filter(|c| *c == code).count();
+        assert_eq!(by_curr("AAPL"), 7);
+        assert_eq!(by_curr("USD"), 1);
+        assert_eq!(by_curr("EUR"), 1);
+        assert_eq!(by_curr("GBP"), 1);
+        assert_eq!(by_curr("JPY"), 1);
+    }
+}

--- a/crates/rustledger-core/src/visit.rs
+++ b/crates/rustledger-core/src/visit.rs
@@ -13,11 +13,19 @@
 //!
 //! These visitors are the canonical answer. Every position that
 //! carries a currency or an account name is enumerated exactly once
-//! here, with no `_ => {}` catch-all on the `Directive` match — so
-//! a future `Directive` variant added to the enum forces a compile
-//! error at THIS file, which is the only place that needs to be
-//! updated. Downstream consumers calling `visit_*` benefit
-//! automatically.
+//! here, with no `_ => {}` catch-all — at any layer of the match.
+//! That means:
+//!
+//! - A future `Directive` variant added to the enum forces a
+//!   compile error at the top-level `visit_*` match.
+//! - A future `MetaValue` variant forces a compile error at
+//!   `visit_meta_value_currency` and `visit_meta_value_account`.
+//! - A future `PriceAnnotation` variant forces a compile error at
+//!   `visit_price_currency`.
+//!
+//! This file is the ONE place that needs to be updated when new
+//! variants are added to any of those enums. Downstream consumers
+//! calling `visit_*` benefit automatically.
 //!
 //! Spans of source tokens are intentionally NOT exposed here:
 //! source positions are parser-only metadata published via
@@ -92,11 +100,7 @@ pub fn visit_currencies<'a>(directive: &'a Directive, visit: &mut impl FnMut(&'a
         }
         Directive::Custom(custom) => {
             for v in &custom.values {
-                match v {
-                    MetaValue::Currency(s) => visit(s.as_str()),
-                    MetaValue::Amount(a) => visit(a.currency.as_str()),
-                    _ => {}
-                }
+                visit_meta_value_currency(v, visit);
             }
             visit_meta_currencies(&custom.meta, visit);
         }
@@ -159,9 +163,7 @@ pub fn visit_accounts<'a>(directive: &'a Directive, visit: &mut impl FnMut(&'a s
         }
         Directive::Custom(custom) => {
             for v in &custom.values {
-                if let MetaValue::Account(a) = v {
-                    visit(a.as_str());
-                }
+                visit_meta_value_account(v, visit);
             }
             visit_meta_accounts(&custom.meta, visit);
         }
@@ -174,19 +176,56 @@ pub fn visit_accounts<'a>(directive: &'a Directive, visit: &mut impl FnMut(&'a s
 
 fn visit_meta_currencies<'a>(meta: &'a Metadata, visit: &mut impl FnMut(&'a str)) {
     for v in meta.values() {
-        match v {
-            MetaValue::Currency(s) => visit(s.as_str()),
-            MetaValue::Amount(a) => visit(a.currency.as_str()),
-            _ => {}
-        }
+        visit_meta_value_currency(v, visit);
     }
 }
 
 fn visit_meta_accounts<'a>(meta: &'a Metadata, visit: &mut impl FnMut(&'a str)) {
     for v in meta.values() {
-        if let MetaValue::Account(a) = v {
-            visit(a.as_str());
-        }
+        visit_meta_value_account(v, visit);
+    }
+}
+
+/// Per-`MetaValue` currency extractor. Used both by metadata-block
+/// walks and by `Custom.values` walks (Custom directives carry a
+/// `Vec<MetaValue>` as positional args; the same per-variant logic
+/// applies). The match is exhaustive with no `_ => {}` catch-all —
+/// a future `MetaValue` variant added to the enum forces a compile
+/// error here and at `visit_meta_value_account`, so the visitor
+/// stays in lockstep with the type definition. Mirrors the no-
+/// catch-all guarantee already enforced on the `Directive` match
+/// at the top of this module.
+fn visit_meta_value_currency<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a str)) {
+    match v {
+        MetaValue::Currency(s) => visit(s.as_str()),
+        MetaValue::Amount(a) => visit(a.currency.as_str()),
+        // Variants that cannot carry a currency.
+        MetaValue::String(_)
+        | MetaValue::Account(_)
+        | MetaValue::Tag(_)
+        | MetaValue::Link(_)
+        | MetaValue::Date(_)
+        | MetaValue::Number(_)
+        | MetaValue::Bool(_)
+        | MetaValue::None => {}
+    }
+}
+
+/// Per-`MetaValue` account extractor. See `visit_meta_value_currency`
+/// for the no-`_ => {}`-catch-all rationale.
+fn visit_meta_value_account<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a str)) {
+    match v {
+        MetaValue::Account(a) => visit(a.as_str()),
+        // Variants that cannot carry an account name.
+        MetaValue::String(_)
+        | MetaValue::Currency(_)
+        | MetaValue::Tag(_)
+        | MetaValue::Link(_)
+        | MetaValue::Date(_)
+        | MetaValue::Number(_)
+        | MetaValue::Bool(_)
+        | MetaValue::Amount(_)
+        | MetaValue::None => {}
     }
 }
 


### PR DESCRIPTION
## Summary

Architecture follow-up to the #1160 / #1161 arc.

The underlying problem wasn't string-search-vs-AST — it was **manual AST walks silently dropping positions.** Every consumer that wrote `for d in directives { match &d.value { Directive::Open(_) => ..., _ => {} } }` was at risk of omitting an arm (`Note.account`, `Posting.cost.currency`, metadata values, `Custom.values`, …), and the bug class kept recurring across files. Fixing eight separate hand-rolled walks in #1160 left the *underlying* issue intact: the next contributor writing a "for each currency" walk would reach for the same shape and reintroduce the same bug.

This PR makes the architecture **structural rather than reactive**:

- New `rustledger_core::visit` module with `visit_currencies` and `visit_accounts`.
- Both enumerate exactly one position per source occurrence with **no `_ => {}` catch-all** on the `Directive` match. A future Directive variant added to the enum forces a compile error AT this file — the single enumeration point — and every consumer benefits automatically.
- `extract_currencies_iter` and `extract_accounts_iter` collapse to ~6 lines each, delegating to the visitor. The previous ~90-line hand-rolled walks (with `extract_meta_currencies`, `extract_meta_accounts`, `extract_price_currency` helpers) are absorbed into the visitor module.

## Why a visitor instead of just keeping the exhaustive arms?

The `_ => {}` → explicit-arms-for-every-variant pattern from #1160 was a band-aid: it caught omissions in the *existing* extractor functions, but the next person writing a new "for each currency" walk would start with `match` and the catch-all by default. Promoting the enumeration to a named module function (`visit_currencies`) means future code that needs to enumerate calls the visitor instead of writing its own walk. Coverage gains are sustained.

## What's NOT changed

- **Source-position queries.** `ParseResult.currency_occurrences` (the parser-published side index) is the correct API for LSP rename / references / document-highlight / linked-editing / goto-definition — they need exact byte spans, not values. Not touched.
- **Domain-specific walks.** Validators, balance reports, booking, etc. walk directives for domain-specific purposes (not "enumerate all currencies"). Not touched.

## Test plan

- [x] `cargo test -p rustledger-core --all-features` — **310 tests, 0 failures** (+3 new in `visit.rs`)
- [x] `cargo test -p rustledger-lsp --all-features` — **146 tests, 0 failures**
- [x] `RUSTFLAGS=-Dwarnings cargo build --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] **`test_visit_currencies_reaches_every_position`** — seeds USD into all 11 currency-bearing positions, asserts 12 visits (one position contributes twice: txn-meta `Amount` and posting-cost both surface USD).
- [x] **`test_visit_accounts_reaches_every_position`** — seeds `Assets:X` into all 11 account-bearing positions, asserts 11 visits.
- [x] **`test_visit_currencies_handles_all_price_annotation_variants`** — pins behavior across all 6 `PriceAnnotation` variants (Unit / Total / UnitIncomplete-with-CurrencyOnly / UnitIncomplete-with-Complete / UnitIncomplete-with-NumberOnly / TotalIncomplete / UnitEmpty / TotalEmpty).
