### PR TITLE
refactor(core): Currency domain newtype (refs #1163)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -63,7 +63,7 @@ pub struct CapitalGain {
     /// The account holding the asset.
     pub account: InternedStr,
     /// The currency of the asset.
-    pub currency: InternedStr,
+    pub currency: rustledger_core::Currency,
     /// The gain amount (positive) or loss (negative).
     pub amount: Amount,
     /// Cost basis of the sold lot.

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -4,7 +4,7 @@
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
-use rustledger_core::{Amount, IncompleteAmount, InternedStr, Transaction};
+use rustledger_core::{Amount, Currency, IncompleteAmount, InternedStr, Transaction};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -26,7 +26,7 @@ pub enum InterpolationError {
     )]
     MultipleMissing {
         /// The currency group with too many unknowns.
-        currency: InternedStr,
+        currency: Currency,
         /// Total count of unknowns: missing-amount postings plus
         /// empty-cost-spec postings whose weight is deferred to
         /// booking-time lot matching.
@@ -36,7 +36,8 @@ pub enum InterpolationError {
     /// Cannot infer currency for a posting.
     #[error("cannot infer currency for posting to account {account}")]
     CannotInferCurrency {
-        /// The account of the posting.
+        /// The account of the posting. Account migration is a
+        /// follow-up — see issue #1163.
         account: InternedStr,
     },
 
@@ -44,7 +45,7 @@ pub enum InterpolationError {
     #[error("transaction does not balance: residual {residual} {currency}")]
     DoesNotBalance {
         /// The unbalanced currency.
-        currency: InternedStr,
+        currency: Currency,
         /// The residual amount.
         residual: Decimal,
     },
@@ -58,7 +59,7 @@ pub struct InterpolationResult {
     /// Which posting indices were filled in.
     pub filled_indices: Vec<usize>,
     /// Residuals after interpolation (should all be near zero).
-    pub residuals: HashMap<InternedStr, Decimal>,
+    pub residuals: HashMap<Currency, Decimal>,
 }
 
 /// Round an interpolated amount to match existing scale, but never round
@@ -125,8 +126,8 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     let mut filled_indices = Vec::new();
 
     // Lazily compute inferred currency only when needed (most transactions don't need it)
-    let mut inferred_cost_currency: Option<Option<InternedStr>> = None;
-    let get_inferred_currency = |cache: &mut Option<Option<InternedStr>>| -> Option<InternedStr> {
+    let mut inferred_cost_currency: Option<Option<Currency>> = None;
+    let get_inferred_currency = |cache: &mut Option<Option<Currency>>| -> Option<Currency> {
         cache
             .get_or_insert_with(|| crate::infer_cost_currency_from_postings(transaction))
             .clone()
@@ -135,8 +136,8 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Calculate initial residuals from postings with amounts
     // Pre-allocate for typical case (1-2 currencies per transaction)
     let num_postings = transaction.postings.len();
-    let mut residuals: HashMap<InternedStr, Decimal> = HashMap::with_capacity(num_postings.min(4));
-    let mut missing_by_currency: HashMap<InternedStr, Vec<usize>> = HashMap::with_capacity(2);
+    let mut residuals: HashMap<Currency, Decimal> = HashMap::with_capacity(num_postings.min(4));
+    let mut missing_by_currency: HashMap<Currency, Vec<usize>> = HashMap::with_capacity(2);
     let mut unassigned_missing: Vec<usize> = Vec::with_capacity(2);
 
     // Track maximum scale (decimal places) per currency for rounding interpolated amounts.
@@ -166,7 +167,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     //   the cash side `336.73 USD` gives USD scale=2; the residual gets
     //   quantized to 2dp instead of inheriting the lot's derived 26-digit
     //   per_unit precision.
-    let mut max_scale_by_currency: HashMap<InternedStr, u32> = HashMap::with_capacity(4);
+    let mut max_scale_by_currency: HashMap<Currency, u32> = HashMap::with_capacity(4);
 
     // Track per-currency count of postings whose weight contribution is unknown
     // because the cost spec is empty (e.g., `{}`) and resolution is deferred to
@@ -176,7 +177,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // rledger would silently use a fallback weight (price annotation, if
     // present) and accept transactions with more unknowns than the
     // interpolation rule allows.
-    let mut cost_unknowns_by_currency: HashMap<InternedStr, usize> = HashMap::with_capacity(2);
+    let mut cost_unknowns_by_currency: HashMap<Currency, usize> = HashMap::with_capacity(2);
 
     for (i, posting) in transaction.postings.iter().enumerate() {
         match &posting.units {
@@ -384,7 +385,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // deterministic for the same input. HashMap iteration order is
     // unspecified, so picking "the first failing currency" without
     // sorting would produce non-reproducible test output.
-    let mut currencies_with_unknowns: Vec<&InternedStr> = missing_by_currency
+    let mut currencies_with_unknowns: Vec<&Currency> = missing_by_currency
         .keys()
         .chain(cost_unknowns_by_currency.keys())
         .collect();
@@ -424,7 +425,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Pick the lexicographically-smallest cost-unknown currency for the
     // error so the message is reproducible across runs.
     if !unassigned_missing.is_empty() {
-        let mut cost_unknown_keys: Vec<&InternedStr> = cost_unknowns_by_currency.keys().collect();
+        let mut cost_unknown_keys: Vec<&Currency> = cost_unknowns_by_currency.keys().collect();
         cost_unknown_keys.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         if let Some(curr) = cost_unknown_keys.first() {
             let count = cost_unknowns_by_currency.get(*curr).copied().unwrap_or(0);
@@ -457,7 +458,7 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // Each one absorbs one or more currencies' residuals
     if !unassigned_missing.is_empty() {
         // Get currencies with non-zero residuals
-        let non_zero_residuals: Vec<(InternedStr, Decimal)> = residuals
+        let non_zero_residuals: Vec<(Currency, Decimal)> = residuals
             .iter()
             .filter(|&(_, v)| !v.is_zero())
             .map(|(k, v)| (k.clone(), *v))
@@ -1530,7 +1531,7 @@ mod tests {
         let cost_spec = CostSpec {
             number_per: Some(dec!(170.16734)),
             number_total: None,
-            currency: Some(InternedStr::from("USD")),
+            currency: Some(Currency::from("USD")),
             date: None,
             label: None,
             merge: false,
@@ -1599,7 +1600,7 @@ mod tests {
                     CostSpec {
                         number_per: None,
                         number_total: Some(dec!(300.00)),
-                        currency: Some(InternedStr::from("USD")),
+                        currency: Some(Currency::from("USD")),
                         date: None,
                         label: None,
                         merge: false,

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -33,17 +33,16 @@ pub use pad::{PadError, PadResult, expand_pads, merge_with_padding, process_pads
 use bigdecimal::BigDecimal;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
-use rustledger_core::{Amount, IncompleteAmount, InternedStr, Transaction};
+use rustledger_core::{Amount, Currency, IncompleteAmount, InternedStr, Transaction};
 use std::collections::HashMap;
 
 /// Calculate the tolerance for a set of amounts.
 ///
 /// Tolerance is the maximum of all individual amount tolerances.
 #[must_use]
-pub fn calculate_tolerance(amounts: &[&Amount]) -> HashMap<InternedStr, Decimal> {
+pub fn calculate_tolerance(amounts: &[&Amount]) -> HashMap<Currency, Decimal> {
     // Pre-allocate for typical case (1-3 currencies per transaction)
-    let mut tolerances: HashMap<InternedStr, Decimal> =
-        HashMap::with_capacity(amounts.len().min(4));
+    let mut tolerances: HashMap<Currency, Decimal> = HashMap::with_capacity(amounts.len().min(4));
 
     for amount in amounts {
         let tol = amount.inferred_tolerance();
@@ -64,7 +63,7 @@ pub fn calculate_tolerance(amounts: &[&Amount]) -> HashMap<InternedStr, Decimal>
 /// interpolation to look up a posting's price-side currency without
 /// duplicating the match in three places.
 #[must_use]
-pub(crate) fn price_currency_of(posting: &rustledger_core::Posting) -> Option<InternedStr> {
+pub(crate) fn price_currency_of(posting: &rustledger_core::Posting) -> Option<Currency> {
     posting.price.as_ref().and_then(|p| match p {
         rustledger_core::PriceAnnotation::Unit(a) | rustledger_core::PriceAnnotation::Total(a) => {
             Some(a.currency.clone())
@@ -89,7 +88,7 @@ pub(crate) fn price_currency_of(posting: &rustledger_core::Posting) -> Option<In
 /// 3. The currency of other simple postings (units or currency-only amounts).
 /// 4. The currency from a cost spec (e.g., `{0 USD}` for zero-cost items).
 #[must_use]
-pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Option<InternedStr> {
+pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Option<Currency> {
     // First pass: look for simple postings (no cost spec) - these take priority
     for posting in &transaction.postings {
         // Skip postings with cost specs in first pass
@@ -156,14 +155,14 @@ pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Op
 ///
 /// See: `spec/tla/DoubleEntry.tla`
 #[must_use]
-pub fn calculate_residual(transaction: &Transaction) -> HashMap<InternedStr, Decimal> {
+pub fn calculate_residual(transaction: &Transaction) -> HashMap<Currency, Decimal> {
     // Pre-allocate for typical case (1-2 currencies per transaction)
-    let mut residuals: HashMap<InternedStr, Decimal> =
+    let mut residuals: HashMap<Currency, Decimal> =
         HashMap::with_capacity(transaction.postings.len().min(4));
 
     // Lazily compute inferred currency only when needed (most transactions don't need it)
-    let mut inferred_cost_currency: Option<Option<InternedStr>> = None;
-    let get_inferred_currency = |cache: &mut Option<Option<InternedStr>>| -> Option<InternedStr> {
+    let mut inferred_cost_currency: Option<Option<Currency>> = None;
+    let get_inferred_currency = |cache: &mut Option<Option<Currency>>| -> Option<Currency> {
         cache
             .get_or_insert_with(|| infer_cost_currency_from_postings(transaction))
             .clone()
@@ -285,12 +284,12 @@ fn to_big(d: Decimal) -> BigDecimal {
 /// when amounts have near-28-digit precision. `rust_decimal` is limited to 28-29
 /// significant digits; this function handles arbitrary precision correctly.
 #[must_use]
-pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<InternedStr, BigDecimal> {
-    let mut residuals: HashMap<InternedStr, BigDecimal> =
+pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Currency, BigDecimal> {
+    let mut residuals: HashMap<Currency, BigDecimal> =
         HashMap::with_capacity(transaction.postings.len().min(4));
 
-    let mut inferred_cost_currency: Option<Option<InternedStr>> = None;
-    let get_inferred_currency = |cache: &mut Option<Option<InternedStr>>| -> Option<InternedStr> {
+    let mut inferred_cost_currency: Option<Option<Currency>> = None;
+    let get_inferred_currency = |cache: &mut Option<Option<Currency>>| -> Option<Currency> {
         cache
             .get_or_insert_with(|| infer_cost_currency_from_postings(transaction))
             .clone()
@@ -383,7 +382,7 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Interned
 /// Check if a transaction is balanced within tolerance.
 #[must_use]
 #[allow(clippy::implicit_hasher)]
-pub fn is_balanced(transaction: &Transaction, tolerances: &HashMap<InternedStr, Decimal>) -> bool {
+pub fn is_balanced(transaction: &Transaction, tolerances: &HashMap<Currency, Decimal>) -> bool {
     let residuals = calculate_residual(transaction);
 
     for (currency, residual) in residuals {

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -33,7 +33,7 @@ pub use pad::{PadError, PadResult, expand_pads, merge_with_padding, process_pads
 use bigdecimal::BigDecimal;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
-use rustledger_core::{Amount, Currency, IncompleteAmount, InternedStr, Transaction};
+use rustledger_core::{Amount, Currency, IncompleteAmount, Transaction};
 use std::collections::HashMap;
 
 /// Calculate the tolerance for a set of amounts.

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -24,7 +24,8 @@
 
 use rust_decimal::Decimal;
 use rustledger_core::{
-    Amount, Directive, InternedStr, Inventory, NaiveDate, Pad, Position, Posting, Transaction,
+    Amount, Currency, Directive, InternedStr, Inventory, NaiveDate, Pad, Position, Posting,
+    Transaction,
 };
 use std::collections::HashMap;
 use std::ops::Neg;
@@ -76,7 +77,7 @@ struct PendingPad {
     /// Whether this pad has been used (has at least one balance assertion).
     used: bool,
     /// Currencies that have already been padded (each currency can only be padded once per pad).
-    padded_currencies: std::collections::HashSet<InternedStr>,
+    padded_currencies: std::collections::HashSet<Currency>,
 }
 
 /// Process pad directives and generate synthetic transactions.

--- a/crates/rustledger-core/src/amount.rs
+++ b/crates/rustledger-core/src/amount.rs
@@ -10,9 +10,8 @@ use std::fmt;
 use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 use crate::Currency;
-use crate::intern::InternedStr;
 #[cfg(feature = "rkyv")]
-use crate::intern::{AsDecimal, AsInternedStr};
+use crate::intern::AsDecimal;
 
 /// An amount is a quantity paired with a currency.
 ///

--- a/crates/rustledger-core/src/amount.rs
+++ b/crates/rustledger-core/src/amount.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
+use crate::Currency;
 use crate::intern::InternedStr;
 #[cfg(feature = "rkyv")]
 use crate::intern::{AsDecimal, AsInternedStr};
@@ -40,14 +41,13 @@ pub struct Amount {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))]
     pub number: Decimal,
     /// The currency code (e.g., "USD", "EUR", "AAPL")
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub currency: InternedStr,
+    pub currency: Currency,
 }
 
 impl Amount {
     /// Create a new amount.
     #[must_use]
-    pub fn new(number: Decimal, currency: impl Into<InternedStr>) -> Self {
+    pub fn new(number: Decimal, currency: impl Into<Currency>) -> Self {
         Self {
             number,
             currency: currency.into(),
@@ -56,7 +56,7 @@ impl Amount {
 
     /// Create a zero amount with the given currency.
     #[must_use]
-    pub fn zero(currency: impl Into<InternedStr>) -> Self {
+    pub fn zero(currency: impl Into<Currency>) -> Self {
         Self {
             number: Decimal::ZERO,
             currency: currency.into(),
@@ -300,13 +300,13 @@ pub enum IncompleteAmount {
     /// Only number specified, currency to be inferred from context (cost, price, or other postings)
     NumberOnly(#[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))] Decimal),
     /// Only currency specified, number to be interpolated to balance the transaction
-    CurrencyOnly(#[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))] InternedStr),
+    CurrencyOnly(Currency),
 }
 
 impl IncompleteAmount {
     /// Create a complete amount.
     #[must_use]
-    pub fn complete(number: Decimal, currency: impl Into<InternedStr>) -> Self {
+    pub fn complete(number: Decimal, currency: impl Into<Currency>) -> Self {
         Self::Complete(Amount::new(number, currency))
     }
 
@@ -318,7 +318,7 @@ impl IncompleteAmount {
 
     /// Create a currency-only incomplete amount.
     #[must_use]
-    pub fn currency_only(currency: impl Into<InternedStr>) -> Self {
+    pub fn currency_only(currency: impl Into<Currency>) -> Self {
         Self::CurrencyOnly(currency.into())
     }
 

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::Amount;
-use crate::intern::InternedStr;
 
 // Note: We no longer auto-quantize calculated values during cost storage.
 // Python beancount preserves full precision during booking and only rounds
@@ -21,7 +20,7 @@ use crate::intern::InternedStr;
 // For example: 300.00 / 1.763 = 170.16505... should NOT be rounded to 170.17,
 // because 1.763 * 170.17 = 300.00971 ≠ 300.00.
 #[cfg(feature = "rkyv")]
-use crate::intern::{AsDecimal, AsInternedStr, AsNaiveDate};
+use crate::intern::{AsDecimal, AsNaiveDate};
 
 /// A cost represents the acquisition cost of a position (lot).
 ///

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -54,8 +54,7 @@ pub struct Cost {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))]
     pub number: Decimal,
     /// Currency of the cost
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub currency: InternedStr,
+    pub currency: crate::Currency,
     /// Acquisition date (optional, for lot identification)
     #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsNaiveDate>))]
     pub date: Option<NaiveDate>,
@@ -69,7 +68,7 @@ impl Cost {
     /// Create a new cost with exact precision.
     /// Use this for user-specified values that should preserve their precision.
     #[must_use]
-    pub fn new(number: Decimal, currency: impl Into<InternedStr>) -> Self {
+    pub fn new(number: Decimal, currency: impl Into<crate::Currency>) -> Self {
         Self {
             number,
             currency: currency.into(),
@@ -83,7 +82,7 @@ impl Cost {
     /// Previously this auto-quantized, but we now preserve full precision
     /// to avoid cost basis errors. Rounding should only happen at display time.
     #[must_use]
-    pub fn new_calculated(number: Decimal, currency: impl Into<InternedStr>) -> Self {
+    pub fn new_calculated(number: Decimal, currency: impl Into<crate::Currency>) -> Self {
         Self::new(number, currency)
     }
 
@@ -202,8 +201,7 @@ pub struct CostSpec {
     #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsDecimal>))]
     pub number_total: Option<Decimal>,
     /// Currency of the cost (if specified)
-    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsInternedStr>))]
-    pub currency: Option<InternedStr>,
+    pub currency: Option<crate::Currency>,
     /// Acquisition date (if specified)
     #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsNaiveDate>))]
     pub date: Option<NaiveDate>,
@@ -236,7 +234,7 @@ impl CostSpec {
 
     /// Set the currency.
     #[must_use]
-    pub fn with_currency(mut self, currency: impl Into<InternedStr>) -> Self {
+    pub fn with_currency(mut self, currency: impl Into<crate::Currency>) -> Self {
         self.currency = Some(currency.into());
         self
     }

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -830,8 +830,7 @@ pub struct Open {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
     pub account: InternedStr,
     /// Allowed currencies (empty = any currency allowed)
-    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsInternedStr>))]
-    pub currencies: Vec<InternedStr>,
+    pub currencies: Vec<crate::Currency>,
     /// Booking method for this account
     pub booking: Option<String>,
     /// Metadata
@@ -853,7 +852,7 @@ impl Open {
 
     /// Set allowed currencies.
     #[must_use]
-    pub fn with_currencies(mut self, currencies: Vec<InternedStr>) -> Self {
+    pub fn with_currencies(mut self, currencies: Vec<crate::Currency>) -> Self {
         self.currencies = currencies;
         self
     }
@@ -877,7 +876,11 @@ impl fmt::Display for Open {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} open {}", self.date, self.account)?;
         if !self.currencies.is_empty() {
-            let currencies: Vec<&str> = self.currencies.iter().map(InternedStr::as_str).collect();
+            let currencies: Vec<&str> = self
+                .currencies
+                .iter()
+                .map(crate::Currency::as_str)
+                .collect();
             write!(f, " {}", currencies.join(","))?;
         }
         if let Some(booking) = &self.booking {
@@ -944,8 +947,7 @@ pub struct Commodity {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Currency/commodity code (e.g., "USD", "AAPL")
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub currency: InternedStr,
+    pub currency: crate::Currency,
     /// Metadata
     pub meta: Metadata,
 }
@@ -953,7 +955,7 @@ pub struct Commodity {
 impl Commodity {
     /// Create a new commodity declaration.
     #[must_use]
-    pub fn new(date: NaiveDate, currency: impl Into<InternedStr>) -> Self {
+    pub fn new(date: NaiveDate, currency: impl Into<crate::Currency>) -> Self {
         Self {
             date,
             currency: currency.into(),
@@ -1273,8 +1275,7 @@ pub struct Price {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Currency being priced
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub currency: InternedStr,
+    pub currency: crate::Currency,
     /// Price amount (in another currency)
     pub amount: Amount,
     /// Metadata
@@ -1284,7 +1285,7 @@ pub struct Price {
 impl Price {
     /// Create a new price directive.
     #[must_use]
-    pub fn new(date: NaiveDate, currency: impl Into<InternedStr>, amount: Amount) -> Self {
+    pub fn new(date: NaiveDate, currency: impl Into<crate::Currency>, amount: Amount) -> Self {
         Self {
             date,
             currency: currency.into(),

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -102,7 +102,7 @@ macro_rules! domain_newtype {
             /// `Arc` after merging directives from multiple files —
             /// the value semantics don't change, but the storage is
             /// re-pointed at the workspace-wide interner's copy.
-            pub fn as_interned_mut(&mut self) -> &mut InternedStr {
+            pub const fn as_interned_mut(&mut self) -> &mut InternedStr {
                 &mut self.0
             }
         }

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -41,16 +41,23 @@
 //!
 //! # When to use which
 //!
-//! - [`Account`]: `Open.account`, `Close.account`, `Balance.account`,
-//!   `Pad.account` / `source_account`, `Note.account`,
-//!   `Document.account`, `Posting.account`, and `MetaValue::Account`.
-//! - [`Currency`]: `Commodity.currency`, `Open.currencies` entries,
-//!   `Amount.currency`, `CostSpec.currency`, `Price.currency`,
-//!   `IncompleteAmount::CurrencyOnly`, and `MetaValue::Currency`.
-//! - [`Tag`]: `Transaction.tags` entries, `pushtag`/`poptag`,
-//!   `Document.tags`, and `MetaValue::Tag`.
-//! - [`Link`]: `Transaction.links` entries, `Document.links`, and
-//!   `MetaValue::Link`.
+//! [`Currency`] is fully plumbed through the AST; the other three
+//! are defined but not yet wired up (planned slices of #1163):
+//!
+//! - [`Currency`] *(in use)*: `Commodity.currency`, `Open.currencies`
+//!   entries, `Amount.currency`, `CostSpec.currency`, `Price.currency`,
+//!   `IncompleteAmount::CurrencyOnly`.
+//! - [`Account`] *(planned)*: `Open.account`, `Close.account`,
+//!   `Balance.account`, `Pad.account` / `source_account`,
+//!   `Note.account`, `Document.account`, `Posting.account`.
+//! - [`Tag`] *(planned)*: `Transaction.tags` entries,
+//!   `pushtag`/`poptag`, `Document.tags`.
+//! - [`Link`] *(planned)*: `Transaction.links` entries,
+//!   `Document.links`.
+//!
+//! `MetaValue::{Account, Currency, Tag, Link}` are still `String`
+//! pending a separate decision on how meta values cross the typed
+//! boundary.
 
 use crate::InternedStr;
 #[cfg(feature = "rkyv")]
@@ -64,6 +71,7 @@ macro_rules! domain_newtype {
             feature = "rkyv",
             derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
         )]
+        #[repr(transparent)]
         pub struct $name(
             #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))] InternedStr,
         );

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -1,0 +1,347 @@
+//! Domain-typed identifiers: [`Account`], [`Currency`], [`Tag`], [`Link`].
+//!
+//! These newtype wrappers around [`InternedStr`] give the type system
+//! enough vocabulary to distinguish the different kinds of identifier
+//! the beancount AST carries. Pre-newtype, every identifier was just
+//! an `InternedStr` — passing an account where a currency was
+//! expected (or vice versa) compiled fine, and the bug surfaced
+//! only at runtime via wrong-but-validly-shaped string matching.
+//! Now the same mistake is a type error.
+//!
+//! # Design
+//!
+//! Each newtype is a transparent wrapper:
+//!
+//! - `Deref<Target = str>` so calls like `account.starts_with("Assets:")`
+//!   work without `.as_str()` everywhere.
+//! - `AsRef<str>` and [`Borrow<str>`](std::borrow::Borrow) so `HashMap` lookups by `&str`
+//!   keep working (`some_map.get("Assets:Bank")` where the map is
+//!   keyed by [`Account`]).
+//! - `PartialEq` against `str` / `&str` / `String` / `InternedStr` /
+//!   the newtype's own type, so `account == "Assets:Bank"` keeps
+//!   reading naturally without coercion.
+//! - `From<&str>`, `From<String>`, `From<InternedStr>` for
+//!   construction at call sites that have a string and need the
+//!   typed form.
+//! - `Hash` delegates to the inner `InternedStr`'s hash, so
+//!   `HashMap<Account, V>` and `HashMap<InternedStr, V>` produce
+//!   the same bucketing for the same underlying string.
+//!
+//! What you DON'T get for free is cross-newtype assignment:
+//!
+//! ```compile_fail
+//! # use rustledger_core::{Account, Currency};
+//! fn want_currency(_: Currency) {}
+//! let acct = Account::from("Assets:Bank");
+//! want_currency(acct); // ← type error
+//! ```
+//!
+//! Conversions between newtypes are deliberate (`Currency::from(account.into_interned())`)
+//! so the compiler can flag accidental crossings.
+//!
+//! # When to use which
+//!
+//! - [`Account`]: `Open.account`, `Close.account`, `Balance.account`,
+//!   `Pad.account` / `source_account`, `Note.account`,
+//!   `Document.account`, `Posting.account`, and `MetaValue::Account`.
+//! - [`Currency`]: `Commodity.currency`, `Open.currencies` entries,
+//!   `Amount.currency`, `CostSpec.currency`, `Price.currency`,
+//!   `IncompleteAmount::CurrencyOnly`, and `MetaValue::Currency`.
+//! - [`Tag`]: `Transaction.tags` entries, `pushtag`/`poptag`,
+//!   `Document.tags`, and `MetaValue::Tag`.
+//! - [`Link`]: `Transaction.links` entries, `Document.links`, and
+//!   `MetaValue::Link`.
+
+use crate::InternedStr;
+#[cfg(feature = "rkyv")]
+use crate::intern::AsInternedStr;
+
+macro_rules! domain_newtype {
+    ($name:ident, $kind:literal) => {
+        #[doc = concat!("Domain-typed identifier for a ", $kind, ". See the [module docs](crate::identifiers) for rationale.")]
+        #[derive(Debug, Clone, Eq)]
+        #[cfg_attr(
+            feature = "rkyv",
+            derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+        )]
+        pub struct $name(
+            #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))] InternedStr,
+        );
+
+        impl $name {
+            /// Construct from anything that can become an `InternedStr`.
+            #[must_use]
+            pub fn new(s: impl Into<InternedStr>) -> Self {
+                Self(s.into())
+            }
+
+            /// Borrow the underlying string slice.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
+
+            /// Borrow the underlying `InternedStr`. Useful when interfacing
+            /// with APIs that still take untyped interned strings.
+            #[must_use]
+            pub const fn as_interned(&self) -> &InternedStr {
+                &self.0
+            }
+
+            /// Unwrap to the underlying `InternedStr`, discarding the
+            /// domain tag. Use deliberately — this is the explicit
+            /// "I'm crossing types on purpose" escape hatch.
+            #[must_use]
+            pub fn into_interned(self) -> InternedStr {
+                self.0
+            }
+
+            /// Mutable access to the underlying `InternedStr`.
+            /// Used by the loader's cross-file interning pass
+            /// (`rustledger_loader::dedup`) to canonicalize the
+            /// `Arc` after merging directives from multiple files —
+            /// the value semantics don't change, but the storage is
+            /// re-pointed at the workspace-wide interner's copy.
+            pub fn as_interned_mut(&mut self) -> &mut InternedStr {
+                &mut self.0
+            }
+        }
+
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == **other
+            }
+        }
+
+        impl PartialEq<String> for $name {
+            fn eq(&self, other: &String) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<InternedStr> for $name {
+            fn eq(&self, other: &InternedStr) -> bool {
+                self.0 == *other
+            }
+        }
+
+        impl PartialEq<$name> for &str {
+            fn eq(&self, other: &$name) -> bool {
+                other.0 == **self
+            }
+        }
+
+        impl PartialEq<$name> for str {
+            fn eq(&self, other: &$name) -> bool {
+                other.0 == *self
+            }
+        }
+
+        impl PartialEq<$name> for InternedStr {
+            fn eq(&self, other: &$name) -> bool {
+                *self == other.0
+            }
+        }
+
+        impl std::hash::Hash for $name {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.0.hash(state);
+            }
+        }
+
+        impl std::cmp::PartialOrd for $name {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl std::cmp::Ord for $name {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                self.0.cmp(&other.0)
+            }
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = str;
+            fn deref(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl std::borrow::Borrow<str> for $name {
+            fn borrow(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(InternedStr::from(s))
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(InternedStr::from(s))
+            }
+        }
+
+        impl From<&String> for $name {
+            fn from(s: &String) -> Self {
+                Self(InternedStr::from(s.as_str()))
+            }
+        }
+
+        impl From<InternedStr> for $name {
+            fn from(s: InternedStr) -> Self {
+                Self(s)
+            }
+        }
+
+        impl From<&InternedStr> for $name {
+            fn from(s: &InternedStr) -> Self {
+                Self(s.clone())
+            }
+        }
+
+        impl From<&$name> for $name {
+            fn from(s: &$name) -> Self {
+                s.clone()
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self(InternedStr::default())
+            }
+        }
+
+        impl serde::Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                self.0.serialize(serializer)
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(
+                deserializer: D,
+            ) -> Result<Self, D::Error> {
+                Ok(Self(InternedStr::deserialize(deserializer)?))
+            }
+        }
+
+        // rkyv archive is `#[derive]`'d above using the field
+        // attribute `#[rkyv(with = AsInternedStr)]` — same wrapper
+        // pattern `Posting.account` (and every other `InternedStr`
+        // field) uses. That goes through `ArchivedString` via the
+        // `AsInternedStr` adapter, picking up bytecheck/CheckBytes
+        // for free.
+    };
+}
+
+domain_newtype!(Account, "beancount account name (e.g. `Assets:Cash:USD`)");
+domain_newtype!(Currency, "currency code (e.g. `USD`, `EUR`, `AAPL`)");
+domain_newtype!(Tag, "beancount tag (e.g. `#travel`)");
+domain_newtype!(Link, "beancount link (e.g. `^invoice-2024-01`)");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_construction_from_str() {
+        let a = Account::from("Assets:Bank");
+        let c = Currency::from("USD");
+        assert_eq!(a, "Assets:Bank");
+        assert_eq!(c, "USD");
+    }
+
+    #[test]
+    fn test_eq_against_str_in_both_directions() {
+        let a = Account::from("Assets:Bank");
+        assert_eq!(a, "Assets:Bank");
+        assert_eq!("Assets:Bank", a);
+        assert_ne!(a, "Assets:Other");
+    }
+
+    #[test]
+    fn test_eq_against_self_kind() {
+        let a1 = Account::from("Assets:Bank");
+        let a2 = Account::from("Assets:Bank");
+        let a3 = Account::from("Assets:Other");
+        assert_eq!(a1, a2);
+        assert_ne!(a1, a3);
+    }
+
+    #[test]
+    fn test_hash_borrow_str() {
+        use std::collections::HashMap;
+        let mut m: HashMap<Account, u32> = HashMap::new();
+        m.insert(Account::from("Assets:Bank"), 1);
+        // Look up by &str via Borrow<str> impl.
+        assert_eq!(m.get("Assets:Bank"), Some(&1));
+        assert_eq!(m.get("Assets:Other"), None);
+    }
+
+    #[test]
+    fn test_deref_str_methods() {
+        let a = Account::from("Assets:Bank:Checking");
+        assert!(a.starts_with("Assets:"));
+        assert!(a.contains(':'));
+        assert_eq!(a.len(), 20);
+    }
+
+    #[test]
+    fn test_round_trip_interned() {
+        let i = InternedStr::from("USD");
+        let c = Currency::from(i.clone());
+        assert_eq!(c.as_interned(), &i);
+        assert_eq!(c.into_interned(), i);
+    }
+
+    #[test]
+    fn test_different_newtypes_dont_cross() {
+        // This test is structural — uncommenting either of the
+        // assignment lines below MUST cause a compile error
+        // (verified by the doc-comment compile_fail block on the
+        // module). Here we just confirm the runtime types are
+        // distinct via a function signature.
+        fn want_account(_: Account) {}
+        fn want_currency(_: Currency) {}
+        want_account(Account::from("Assets:X"));
+        want_currency(Currency::from("USD"));
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let a = Account::from("Assets:Bank");
+        let json = serde_json::to_string(&a).unwrap();
+        assert_eq!(json, "\"Assets:Bank\"");
+        let back: Account = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -9,7 +9,7 @@ use rust_decimal::prelude::Signed;
 use smallvec::{SmallVec, smallvec};
 
 use super::{BookingError, BookingMethod, BookingResult, Inventory, MatchedLots};
-use crate::{Amount, Cost, CostSpec, InternedStr, Position};
+use crate::{Amount, Cost, CostSpec, Currency, Position};
 
 /// Compute weighted-average cost from a set of positions.
 ///
@@ -18,9 +18,9 @@ use crate::{Amount, Cost, CostSpec, InternedStr, Position};
 fn average_cost_from_positions(
     positions: &[&Position],
     total_units: Decimal,
-) -> Result<Option<(Decimal, InternedStr)>, BookingError> {
+) -> Result<Option<(Decimal, Currency)>, BookingError> {
     let mut total_cost = Decimal::ZERO;
-    let mut cost_currency: Option<InternedStr> = None;
+    let mut cost_currency: Option<Currency> = None;
     let mut has_any_cost = false;
 
     for pos in positions {

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -136,19 +136,19 @@ pub enum BookingError {
         /// Number of lots that matched.
         num_matches: usize,
         /// The currency being reduced.
-        currency: InternedStr,
+        currency: crate::Currency,
     },
     /// No lots match the cost specification.
     NoMatchingLot {
         /// The currency being reduced.
-        currency: InternedStr,
+        currency: crate::Currency,
         /// The cost spec that didn't match.
         cost_spec: CostSpec,
     },
     /// Not enough units in matching lots.
     InsufficientUnits {
         /// The currency being reduced.
-        currency: InternedStr,
+        currency: crate::Currency,
         /// Units requested.
         requested: Decimal,
         /// Units available.
@@ -157,9 +157,9 @@ pub enum BookingError {
     /// Currency mismatch between reduction and inventory.
     CurrencyMismatch {
         /// Expected currency.
-        expected: InternedStr,
+        expected: crate::Currency,
         /// Got currency.
-        got: InternedStr,
+        got: crate::Currency,
     },
 }
 
@@ -326,12 +326,12 @@ pub struct Inventory {
     /// Maps currency to position index in the `positions` vector.
     /// Not serialized - rebuilt on demand.
     #[serde(skip)]
-    simple_index: FxHashMap<InternedStr, usize>,
+    simple_index: FxHashMap<crate::Currency, usize>,
     /// Cache of total units per currency for O(1) `units()` lookups.
     /// Updated incrementally on `add()` and `reduce()`.
     /// Not serialized - rebuilt on demand.
     #[serde(skip)]
-    units_cache: FxHashMap<InternedStr, Decimal>,
+    units_cache: FxHashMap<crate::Currency, Decimal>,
 }
 
 impl PartialEq for Inventory {
@@ -462,8 +462,8 @@ impl Inventory {
     ///
     /// Returns the sum of all cost bases for positions of the given currency.
     #[must_use]
-    pub fn book_value(&self, units_currency: &str) -> FxHashMap<InternedStr, Decimal> {
-        let mut totals: FxHashMap<InternedStr, Decimal> = FxHashMap::default();
+    pub fn book_value(&self, units_currency: &str) -> FxHashMap<crate::Currency, Decimal> {
+        let mut totals: FxHashMap<crate::Currency, Decimal> = FxHashMap::default();
 
         for pos in &self.positions {
             if pos.units.currency == units_currency

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod directive;
 pub mod display_context;
 pub mod extract;
 pub mod format;
+pub mod identifiers;
 pub mod implicit_prices;
 pub mod intern;
 pub mod inventory;
@@ -71,6 +72,7 @@ pub use extract::{
     extract_currencies_iter, extract_payees, extract_payees_iter,
 };
 pub use format::{FormatConfig, format_directive, format_posting, format_posting_line};
+pub use identifiers::{Account, Currency, Link, Tag};
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{

--- a/crates/rustledger-core/tests/property_tests.rs
+++ b/crates/rustledger-core/tests/property_tests.rs
@@ -208,7 +208,7 @@ proptest! {
     #[test]
     fn prop_inventory_units_consistency(positions in prop::collection::vec(arb_position(), 1..5)) {
         let mut inv = Inventory::new();
-        let mut expected_units: std::collections::HashMap<InternedStr, Decimal> = std::collections::HashMap::new();
+        let mut expected_units: std::collections::HashMap<rustledger_core::Currency, Decimal> = std::collections::HashMap::new();
 
         for pos in &positions {
             inv.add(pos.clone());

--- a/crates/rustledger-core/tests/property_tests.rs
+++ b/crates/rustledger-core/tests/property_tests.rs
@@ -7,7 +7,7 @@
 use proptest::prelude::*;
 use rust_decimal::Decimal;
 use rustledger_core::NaiveDate;
-use rustledger_core::{Amount, BookingMethod, Cost, CostSpec, InternedStr, Inventory, Position};
+use rustledger_core::{Amount, BookingMethod, Cost, CostSpec, Inventory, Position};
 
 // ============================================================================
 // Arbitrary generators

--- a/crates/rustledger-loader/src/dedup.rs
+++ b/crates/rustledger-loader/src/dedup.rs
@@ -83,6 +83,22 @@ fn intern_vec(v: &mut [InternedStr], interner: &mut StringInterner, dedup_count:
     }
 }
 
+/// Same as [`intern_vec`] but for slices of domain-typed identifiers
+/// (e.g., `Currency`, `Account`, `Tag`, `Link`). Calls
+/// `.as_interned_mut()` to reach the underlying `InternedStr`.
+fn intern_typed_vec<T>(
+    v: &mut [T],
+    interner: &mut StringInterner,
+    dedup_count: &mut usize,
+    get_inner: fn(&mut T) -> &mut InternedStr,
+) {
+    for s in v.iter_mut() {
+        if do_intern(get_inner(s), interner) {
+            *dedup_count += 1;
+        }
+    }
+}
+
 /// Re-intern all `InternedStr` fields in a single directive,
 /// deduplicating identical strings to share a single `Arc<str>`
 /// allocation. Returns the count of strings that were already present
@@ -115,12 +131,12 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
                 if let Some(ref mut units) = posting.units {
                     match units {
                         IncompleteAmount::Complete(amt) => {
-                            if do_intern(&mut amt.currency, interner) {
+                            if do_intern(amt.currency.as_interned_mut(), interner) {
                                 dedup_count += 1;
                             }
                         }
                         IncompleteAmount::CurrencyOnly(cur) => {
-                            if do_intern(cur, interner) {
+                            if do_intern(cur.as_interned_mut(), interner) {
                                 dedup_count += 1;
                             }
                         }
@@ -130,7 +146,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
                 // Cost spec
                 if let Some(ref mut cost) = posting.cost
                     && let Some(ref mut cur) = cost.currency
-                    && do_intern(cur, interner)
+                    && do_intern(cur.as_interned_mut(), interner)
                 {
                     dedup_count += 1;
                 }
@@ -138,19 +154,19 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
                 if let Some(ref mut price) = posting.price {
                     match price {
                         PriceAnnotation::Unit(amt) | PriceAnnotation::Total(amt) => {
-                            if do_intern(&mut amt.currency, interner) {
+                            if do_intern(amt.currency.as_interned_mut(), interner) {
                                 dedup_count += 1;
                             }
                         }
                         PriceAnnotation::UnitIncomplete(inc)
                         | PriceAnnotation::TotalIncomplete(inc) => match inc {
                             IncompleteAmount::Complete(amt) => {
-                                if do_intern(&mut amt.currency, interner) {
+                                if do_intern(amt.currency.as_interned_mut(), interner) {
                                     dedup_count += 1;
                                 }
                             }
                             IncompleteAmount::CurrencyOnly(cur) => {
-                                if do_intern(cur, interner) {
+                                if do_intern(cur.as_interned_mut(), interner) {
                                     dedup_count += 1;
                                 }
                             }
@@ -165,7 +181,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             if do_intern(&mut bal.account, interner) {
                 dedup_count += 1;
             }
-            if do_intern(&mut bal.amount.currency, interner) {
+            if do_intern(bal.amount.currency.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
         }
@@ -173,7 +189,12 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             if do_intern(&mut open.account, interner) {
                 dedup_count += 1;
             }
-            intern_vec(&mut open.currencies, interner, &mut dedup_count);
+            intern_typed_vec(
+                &mut open.currencies,
+                interner,
+                &mut dedup_count,
+                rustledger_core::Currency::as_interned_mut,
+            );
         }
         Directive::Close(close) => {
             if do_intern(&mut close.account, interner) {
@@ -181,7 +202,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             }
         }
         Directive::Commodity(comm) => {
-            if do_intern(&mut comm.currency, interner) {
+            if do_intern(comm.currency.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
         }
@@ -207,10 +228,10 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             intern_vec(&mut doc.links, interner, &mut dedup_count);
         }
         Directive::Price(price) => {
-            if do_intern(&mut price.currency, interner) {
+            if do_intern(price.currency.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
-            if do_intern(&mut price.amount.currency, interner) {
+            if do_intern(price.amount.currency.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
         }

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -84,7 +84,7 @@ pub struct ParseResult {
     /// the same way it does for `directives`. Per-file consumers
     /// (today: every LSP handler) can ignore `file_id`; future
     /// multi-file consumers must remember to thread it through.
-    pub currency_occurrences: Vec<Spanned<InternedStr>>,
+    pub currency_occurrences: Vec<Spanned<rustledger_core::Currency>>,
 }
 
 /// A warning from the parser (non-fatal).

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -74,7 +74,7 @@ struct TokenStream<'src> {
     /// `file_id` is left at the default (0) and overwritten later
     /// when a `SourceMap` assigns each file an id — same pattern
     /// as `Spanned<Directive>` produced by this parser.
-    currency_occurrences: Vec<Spanned<InternedStr>>,
+    currency_occurrences: Vec<Spanned<rustledger_core::Currency>>,
 }
 
 impl<'src> TokenStream<'src> {
@@ -384,7 +384,7 @@ fn parse_currency(stream: &mut TokenStream<'_>) -> ParseRes<InternedStr> {
         // for the rationale.
         stream
             .currency_occurrences
-            .push(Spanned::new(result.clone(), span));
+            .push(Spanned::new(result.clone().into(), span));
         stream.advance();
         return Ok(result);
     }
@@ -650,7 +650,7 @@ fn parse_incomplete_amount(stream: &mut TokenStream<'_>) -> ParseRes<IncompleteA
     // Reset and try just currency
     stream.pos = start_pos;
     if let Ok(currency) = parse_currency(stream) {
-        return Ok(IncompleteAmount::CurrencyOnly(currency));
+        return Ok(IncompleteAmount::CurrencyOnly(currency.into()));
     }
 
     Err(())
@@ -746,7 +746,7 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
                 if let Ok(total) = parse_expr(stream) {
                     spec.number_total = Some(total);
                     if let Ok(c) = parse_currency(stream) {
-                        spec.currency = Some(c);
+                        spec.currency = Some(c.into());
                     }
                     continue;
                 }
@@ -760,7 +760,7 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
 
             // Optional currency
             if let Ok(c) = parse_currency(stream) {
-                spec.currency = Some(c);
+                spec.currency = Some(c.into());
             }
         } else {
             // Unknown component, skip
@@ -805,7 +805,7 @@ fn parse_price_annotation(stream: &mut TokenStream<'_>) -> ParseRes<PriceAnnotat
 
     // Try just currency (incomplete price - number missing)
     if let Ok(currency) = parse_currency(stream) {
-        let incomplete = IncompleteAmount::CurrencyOnly(currency);
+        let incomplete = IncompleteAmount::CurrencyOnly(currency.into());
         return Ok(if is_total {
             PriceAnnotation::TotalIncomplete(incomplete)
         } else {
@@ -1412,7 +1412,7 @@ fn parse_open_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedItem> {
     let open = Open {
         date,
         account,
-        currencies,
+        currencies: currencies.into_iter().map(Into::into).collect(),
         booking,
         meta,
     };
@@ -1452,7 +1452,7 @@ fn parse_commodity_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedIte
 
     let commodity = Commodity {
         date,
-        currency,
+        currency: currency.into(),
         meta,
     };
 
@@ -1598,7 +1598,7 @@ fn parse_price_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedItem> {
 
     let price = Price {
         date,
-        currency,
+        currency: currency.into(),
         amount,
         meta,
     };

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -1,7 +1,7 @@
 //! Position and inventory function implementations for the BQL executor.
 
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, InternedStr, Inventory, Position};
+use rustledger_core::{Amount, Inventory, Position};
 
 use crate::ast::FunctionCall;
 use crate::error::QueryError;

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -211,7 +211,7 @@ impl Executor<'_> {
             Value::Amount(a) => Ok(Value::Amount(a)),
             Value::Inventory(inv) => {
                 let mut total = Decimal::ZERO;
-                let mut currency: Option<InternedStr> = None;
+                let mut currency: Option<rustledger_core::Currency> = None;
                 for pos in inv.positions() {
                     if let Some(cost) = &pos.cost {
                         total += pos.units.number * cost.number;

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -813,7 +813,7 @@ impl<'a> Executor<'a> {
                     Value::Amount(a) => Ok(Value::Amount(a.clone())),
                     Value::Inventory(inv) => {
                         let mut total = Decimal::ZERO;
-                        let mut currency: Option<InternedStr> = None;
+                        let mut currency: Option<rustledger_core::Currency> = None;
                         for pos in inv.positions() {
                             if let Some(cost) = &pos.cost {
                                 total += pos.units.number * cost.number;

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -4,9 +4,7 @@
 //! and allows looking up prices for currency conversions.
 
 use rust_decimal::Decimal;
-use rustledger_core::{
-    Amount, Directive, InternedStr, NaiveDate, Price as PriceDirective, Transaction,
-};
+use rustledger_core::{Amount, Directive, NaiveDate, Price as PriceDirective, Transaction};
 use std::collections::HashMap;
 
 /// A price entry.

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -22,7 +22,7 @@ pub struct PriceEntry {
     /// Price amount.
     pub price: Decimal,
     /// Quote currency.
-    pub currency: InternedStr,
+    pub currency: rustledger_core::Currency,
     /// `true` if sourced from an explicit `Price` directive (or a
     /// plugin-emitted one — same shape after plugin runs); `false` if
     /// derived from a transaction posting in the executor's pass-2
@@ -43,7 +43,7 @@ pub struct PriceEntry {
 pub struct PriceDatabase {
     /// Prices indexed by base currency.
     /// Each base currency maps to a list of price entries sorted by date.
-    prices: HashMap<InternedStr, Vec<PriceEntry>>,
+    prices: HashMap<rustledger_core::Currency, Vec<PriceEntry>>,
 }
 
 impl PriceDatabase {
@@ -159,7 +159,11 @@ impl PriceDatabase {
     /// [`from_directives`] for the protocol.
     pub(crate) fn snapshot_keys(
         &self,
-    ) -> std::collections::HashSet<(InternedStr, InternedStr, NaiveDate)> {
+    ) -> std::collections::HashSet<(
+        rustledger_core::Currency,
+        rustledger_core::Currency,
+        NaiveDate,
+    )> {
         self.prices
             .iter()
             .flat_map(|(base, entries)| {
@@ -190,7 +194,11 @@ impl PriceDatabase {
     pub(crate) fn add_implicit_prices_from_transaction(
         &mut self,
         txn: &Transaction,
-        explicit: &std::collections::HashSet<(InternedStr, InternedStr, NaiveDate)>,
+        explicit: &std::collections::HashSet<(
+            rustledger_core::Currency,
+            rustledger_core::Currency,
+            NaiveDate,
+        )>,
     ) {
         for posting in &txn.postings {
             let Some(units) = posting.amount() else {
@@ -242,9 +250,9 @@ impl PriceDatabase {
     fn add_implicit_price(
         &mut self,
         date: NaiveDate,
-        base_currency: &InternedStr,
+        base_currency: &rustledger_core::Currency,
         price: Decimal,
-        quote_currency: &InternedStr,
+        quote_currency: &rustledger_core::Currency,
     ) {
         let entry = PriceEntry {
             date,
@@ -301,15 +309,16 @@ impl PriceDatabase {
     /// For A→C, try to find A→B and B→C for some intermediate B.
     fn get_chained_price(&self, base: &str, quote: &str, date: NaiveDate) -> Option<Decimal> {
         // Collect all currencies that have prices from 'base'
-        let intermediates: Vec<InternedStr> = if let Some(entries) = self.prices.get(base) {
-            entries
-                .iter()
-                .filter(|e| e.date <= date)
-                .map(|e| e.currency.clone())
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let intermediates: Vec<rustledger_core::Currency> =
+            if let Some(entries) = self.prices.get(base) {
+                entries
+                    .iter()
+                    .filter(|e| e.date <= date)
+                    .map(|e| e.currency.clone())
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
         // Try each intermediate currency
         for intermediate in intermediates {
@@ -397,11 +406,12 @@ impl PriceDatabase {
     /// For A→C, try to find A→B and B→C for some intermediate B.
     fn get_chained_latest_price(&self, base: &str, quote: &str) -> Option<Decimal> {
         // Collect all currencies that have prices from 'base'
-        let intermediates: Vec<InternedStr> = if let Some(entries) = self.prices.get(base) {
-            entries.iter().map(|e| e.currency.clone()).collect()
-        } else {
-            Vec::new()
-        };
+        let intermediates: Vec<rustledger_core::Currency> =
+            if let Some(entries) = self.prices.get(base) {
+                entries.iter().map(|e| e.currency.clone()).collect()
+            } else {
+                Vec::new()
+            };
 
         // Try each intermediate currency
         for intermediate in intermediates {
@@ -471,7 +481,7 @@ impl PriceDatabase {
 
     /// Get all currencies that have prices defined.
     pub fn currencies(&self) -> impl Iterator<Item = &str> {
-        self.prices.keys().map(InternedStr::as_str)
+        self.prices.keys().map(rustledger_core::Currency::as_str)
     }
 
     /// Check if a currency has any prices defined.

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -116,7 +116,7 @@ struct AccountState {
     /// Date closed (if closed).
     closed: Option<NaiveDate>,
     /// Allowed currencies (empty = any).
-    currencies: FxHashSet<InternedStr>,
+    currencies: FxHashSet<rustledger_core::Currency>,
     /// Booking method for this account (from `open` directive).
     /// Used by `update_inventories()` for lot matching during validation.
     booking: BookingMethod,
@@ -246,7 +246,7 @@ struct PendingPad {
     /// → balance EUR`), so we track per-currency rather than a single
     /// `used` flag. Empty set = no balance has consumed this pad yet
     /// (drives E2003 in `check_unused_pads`).
-    padded_currencies: FxHashSet<InternedStr>,
+    padded_currencies: FxHashSet<rustledger_core::Currency>,
 }
 
 /// Ledger state for validation.
@@ -257,7 +257,7 @@ pub struct LedgerState {
     /// Account inventories.
     inventories: FxHashMap<InternedStr, Inventory>,
     /// Declared commodities.
-    commodities: FxHashSet<InternedStr>,
+    commodities: FxHashSet<rustledger_core::Currency>,
     /// Pending pad directives (account -> list of pads).
     pending_pads: FxHashMap<InternedStr, Vec<PendingPad>>,
     /// Validation options.

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -21,7 +21,7 @@ const BALANCE_TOLERANCE_MULTIPLIER: Decimal = Decimal::TWO;
 fn sum_account_and_subaccounts(
     inventories: &FxHashMap<InternedStr, Inventory>,
     account: &InternedStr,
-    currency: &InternedStr,
+    currency: &rustledger_core::Currency,
 ) -> Decimal {
     let account_str = account.as_str();
     let mut total = Decimal::ZERO;

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -115,7 +115,8 @@ pub fn validate_transaction_structure(
     // is ambiguous. We detect this by looking at postings where `amount()` is
     // None AND the posting has no units at all (fully elided amount).
     {
-        let mut missing_count: FxHashMap<Option<&InternedStr>, u32> = FxHashMap::default();
+        let mut missing_count: FxHashMap<Option<&rustledger_core::Currency>, u32> =
+            FxHashMap::default();
         for posting in &txn.postings {
             if posting.amount().is_none() {
                 // Group by the currency hint from partial units, or None for fully elided
@@ -252,7 +253,7 @@ pub fn validate_posting_currency(
 ///    `tolerance = units_quantum * cost_per_unit * tolerance_multiplier`
 pub fn validate_transaction_balance(
     txn: &Transaction,
-    tolerances: &HashMap<InternedStr, Decimal>,
+    tolerances: &HashMap<rustledger_core::Currency, Decimal>,
     errors: &mut Vec<ValidationError>,
 ) {
     // Skip balance checking if there are any empty cost specs (e.g., `{}`).
@@ -331,9 +332,9 @@ pub fn decimal_quantum(value: Decimal) -> Decimal {
 pub fn calculate_tolerances(
     txn: &Transaction,
     options: &ValidationOptions,
-) -> HashMap<InternedStr, Decimal> {
+) -> HashMap<rustledger_core::Currency, Decimal> {
     // Pre-allocate for typical case (1-2 currencies)
-    let mut tolerances: HashMap<InternedStr, Decimal> =
+    let mut tolerances: HashMap<rustledger_core::Currency, Decimal> =
         HashMap::with_capacity(txn.postings.len().min(4));
 
     // Default tolerance based on quantum of amounts in postings.
@@ -361,7 +362,7 @@ pub fn calculate_tolerances(
     // across postings, then max'd with the existing tolerance per currency.
     if options.infer_tolerance_from_cost {
         // Accumulated cost/price tolerances per currency
-        let mut cost_tolerances: HashMap<InternedStr, Decimal> = HashMap::new();
+        let mut cost_tolerances: HashMap<rustledger_core::Currency, Decimal> = HashMap::new();
 
         for posting in &txn.postings {
             if let Some(units) = posting.amount() {
@@ -433,7 +434,7 @@ pub fn calculate_tolerances(
             if currency_str == "*" {
                 continue;
             }
-            let currency = InternedStr::new(currency_str.as_str());
+            let currency = rustledger_core::Currency::from(currency_str.as_str());
             tolerances
                 .entry(currency)
                 .and_modify(|t| *t = (*t).max(*default_tol))

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -2,9 +2,7 @@
 
 use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;
-use rustledger_core::{
-    Amount, BookingMethod, InternedStr, Inventory, Posting, ReductionScope, Transaction,
-};
+use rustledger_core::{Amount, BookingMethod, Inventory, Posting, ReductionScope, Transaction};
 use std::collections::HashMap;
 
 use crate::error::{ErrorCode, ValidationError};

--- a/crates/rustledger/src/cmd/doctor/stats.rs
+++ b/crates/rustledger/src/cmd/doctor/stats.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rustledger_core::{Directive, InternedStr, NaiveDate};
+use rustledger_core::{Currency, Directive, NaiveDate};
 use rustledger_loader::Loader;
 use std::collections::BTreeSet;
 use std::io::Write;
@@ -14,7 +14,7 @@ pub(super) fn cmd_stats<W: Write>(file: &PathBuf, writer: &mut W) -> Result<()> 
     let mut transactions = 0;
     let mut postings = 0;
     let mut accounts = 0;
-    let mut commodities_set: BTreeSet<InternedStr> = BTreeSet::new();
+    let mut commodities_set: BTreeSet<Currency> = BTreeSet::new();
     let mut balance_assertions = 0;
     let mut prices = 0;
     let mut first_date: Option<NaiveDate> = None;

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -51,8 +51,8 @@ pub(super) fn report_balsheet<W: Write>(
     // Helper to sum inventory by currency (uses InternedStr to avoid allocations)
     fn sum_by_currency(
         balances: &BTreeMap<InternedStr, Inventory>,
-    ) -> BTreeMap<InternedStr, Decimal> {
-        let mut totals: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
+    ) -> BTreeMap<rustledger_core::Currency, Decimal> {
+        let mut totals: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
         for inv in balances.values() {
             for pos in inv.positions() {
                 *totals.entry(pos.units.currency.clone()).or_default() += pos.units.number;
@@ -91,7 +91,7 @@ pub(super) fn report_balsheet<W: Write>(
     // Net worth = Assets - Liabilities
     let asset_totals = sum_by_currency(&assets);
     let liability_totals = sum_by_currency(&liabilities);
-    let mut net_worth: BTreeMap<InternedStr, Decimal> = asset_totals;
+    let mut net_worth: BTreeMap<rustledger_core::Currency, Decimal> = asset_totals;
     for (currency, amount) in &liability_totals {
         *net_worth.entry(currency.clone()).or_default() += amount;
     }
@@ -144,7 +144,7 @@ pub(super) fn report_balsheet<W: Write>(
                 writer: &mut W,
                 title: &str,
                 balances: &BTreeMap<InternedStr, Inventory>,
-            ) -> Result<BTreeMap<InternedStr, Decimal>> {
+            ) -> Result<BTreeMap<rustledger_core::Currency, Decimal>> {
                 writeln!(writer, "{title}")?;
                 writeln!(writer, "{}", "-".repeat(60))?;
                 for (account, inventory) in balances {
@@ -159,7 +159,7 @@ pub(super) fn report_balsheet<W: Write>(
                         )?;
                     }
                 }
-                let mut totals: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
+                let mut totals: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
                 for inv in balances.values() {
                     for pos in inv.positions() {
                         *totals.entry(pos.units.currency.clone()).or_default() += pos.units.number;

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -39,8 +39,8 @@ pub(super) fn report_income<W: Write>(
 
     fn sum_by_currency(
         balances: &BTreeMap<InternedStr, Inventory>,
-    ) -> BTreeMap<InternedStr, Decimal> {
-        let mut totals: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
+    ) -> BTreeMap<rustledger_core::Currency, Decimal> {
+        let mut totals: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
         for inv in balances.values() {
             for pos in inv.positions() {
                 *totals.entry(pos.units.currency.clone()).or_default() += pos.units.number;
@@ -77,7 +77,7 @@ pub(super) fn report_income<W: Write>(
     // Net income = -(Income) - Expenses (income is negative in double-entry)
     let income_totals = sum_by_currency(&income);
     let expense_totals = sum_by_currency(&expenses);
-    let mut net_income: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
+    let mut net_income: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
     for (currency, amount) in &income_totals {
         *net_income.entry(currency.clone()).or_default() -= amount;
     }
@@ -132,7 +132,7 @@ pub(super) fn report_income<W: Write>(
                 writer: &mut W,
                 title: &str,
                 balances: &BTreeMap<InternedStr, Inventory>,
-            ) -> Result<BTreeMap<InternedStr, Decimal>> {
+            ) -> Result<BTreeMap<rustledger_core::Currency, Decimal>> {
                 writeln!(writer, "{title}")?;
                 writeln!(writer, "{}", "-".repeat(60))?;
                 for (account, inventory) in balances {
@@ -147,7 +147,7 @@ pub(super) fn report_income<W: Write>(
                         )?;
                     }
                 }
-                let mut totals: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
+                let mut totals: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
                 for inv in balances.values() {
                     for pos in inv.positions() {
                         *totals.entry(pos.units.currency.clone()).or_default() += pos.units.number;

--- a/crates/rustledger/src/cmd/report_cmd/networth.rs
+++ b/crates/rustledger/src/cmd/report_cmd/networth.rs
@@ -3,7 +3,7 @@
 use super::OutputFormat;
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, InternedStr};
+use rustledger_core::Directive;
 use std::collections::BTreeMap;
 use std::io::Write;
 

--- a/crates/rustledger/src/cmd/report_cmd/networth.rs
+++ b/crates/rustledger/src/cmd/report_cmd/networth.rs
@@ -48,9 +48,10 @@ pub(super) fn report_networth<W: Write>(
         return Ok(());
     }
 
-    let mut asset_balance: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
-    let mut liability_balance: BTreeMap<InternedStr, Decimal> = BTreeMap::new();
-    let mut period_results: Vec<(String, BTreeMap<InternedStr, Decimal>)> = Vec::new();
+    let mut asset_balance: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
+    let mut liability_balance: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
+    let mut period_results: Vec<(String, BTreeMap<rustledger_core::Currency, Decimal>)> =
+        Vec::new();
 
     let format_period = |date: rustledger_core::NaiveDate, period: &str| -> String {
         match period {
@@ -83,7 +84,7 @@ pub(super) fn report_networth<W: Write>(
         let txn_period = format_period(txn.date, period);
 
         if txn_period != current_period && !current_period.is_empty() {
-            let mut net_worth: BTreeMap<InternedStr, Decimal> = asset_balance.clone();
+            let mut net_worth: BTreeMap<rustledger_core::Currency, Decimal> = asset_balance.clone();
             for (currency, amount) in &liability_balance {
                 *net_worth.entry(currency.clone()).or_default() += amount;
             }
@@ -115,7 +116,7 @@ pub(super) fn report_networth<W: Write>(
     }
 
     if !current_period.is_empty() {
-        let mut net_worth: BTreeMap<InternedStr, Decimal> = asset_balance.clone();
+        let mut net_worth: BTreeMap<rustledger_core::Currency, Decimal> = asset_balance.clone();
         for (currency, amount) in &liability_balance {
             *net_worth.entry(currency.clone()).or_default() += amount;
         }


### PR DESCRIPTION
## Summary

First slice of [#1163](https://github.com/rustledger/rustledger/issues/1163) — wraps the `currency: InternedStr` field that appears on `Amount`, `Cost`, `CostSpec`, `Commodity`, `Open`, `Price`, and related types behind a `Currency` newtype. Account / Tag / Link migrations will follow in separate PRs.

## What changed

- New `crates/rustledger-core/src/identifiers.rs` with a macro that generates `Account`, `Currency`, `Tag`, `Link` newtypes. Only `Currency` is plumbed end-to-end in this PR; the other three are defined but unused (they ride along so the macro and `rkyv` derive get exercised before the next slice).
- All `currency: InternedStr` fields on `Amount`, `IncompleteAmount::CurrencyOnly`, `Cost`, `CostSpec`, `Commodity`, `Open.currencies: Vec<…>`, `Price`, `BookingError::*`, `Inventory::{simple_index, units_cache}`, etc. now use `Currency`.
- Hot maps switched in tandem (no per-op conversion): `HashMap<Currency, Decimal>` for tolerances/residuals in `rustledger-booking`, `HashMap<Currency, Vec<PriceEntry>>` in `rustledger-query::price`, currency-keyed `BTreeMap` totals in the report commands, etc.
- Loader's `dedup` pass uses `currency.as_interned_mut()` (no allocation) to feed the workspace-wide interner — added a `intern_typed_vec` helper for slices of typed identifiers.
- Constructors use `impl Into<Currency>` so existing call sites with bare `"USD"` literals continue to compile.

## Why

`Amount::new(dec!(100), "USD")` was indistinguishable from `Amount::new(dec!(100), some_account_name)` at the type level. Currency-position vs account-position bugs (the implicit-prices doubling regression in #1006 had a near miss of this shape) had to be caught by tests rather than the compiler. The newtype makes the boundary load-bearing — passing an account-derived string where a currency is expected won't compile.

## Performance

Verified zero conversion in hot paths:
- `Currency` is `#[repr(transparent)]` over `InternedStr` (no extra indirection)
- `PartialEq` / `Hash` delegate to `InternedStr` (`Arc::ptr_eq` fast path preserved across the workspace-wide dedup pass)
- HashMap keys migrated in tandem — no `String::from(currency.as_str())` re-interning anywhere
- `Borrow<str>` impl preserved so `map.get("USD")` still works for ergonomic lookup

## What's deferred

- `Account` migration — `Open/Close/Balance/Pad/Note/Document/Posting.account` (next PR)
- `Tag` / `Link` migration — `Transaction.{tags, links}`, `Document.{tags, links}`, pushtag/poptag stack
- `MetaValue::{Account, Currency, Tag, Link}` — currently `String`, design decision deferred
- LSP / plugin / wasm / ffi ripples for the above

## Test plan

- [x] `cargo check --workspace --all-features --all-targets` — clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test -p rustledger-core -p rustledger-booking -p rustledger-validate -p rustledger-query -p rustledger-loader -p rustledger-parser --all-features` — all pass
- [ ] CI full workspace test + compat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)