### PR TITLE
perf(lsp): finish LineIndex sweep across remaining handlers (refs #1157)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
+++ b/crates/rustledger-lsp/src/handlers/call_hierarchy.rs
@@ -15,7 +15,7 @@ use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
-use super::utils::{byte_offset_to_position, get_word_at_position, is_account_like};
+use super::utils::{LineIndex, get_word_at_position, is_account_like};
 
 /// Handle a prepare call hierarchy request.
 /// Returns the account at the cursor position as a CallHierarchyItem.
@@ -80,6 +80,7 @@ pub fn handle_incoming_calls(
         .unwrap_or(&params.item.name);
 
     let mut calls: Vec<CallHierarchyIncomingCall> = Vec::new();
+    let line_index = LineIndex::new(source);
 
     // Find all transactions that reference this account
     for spanned in &parse_result.directives {
@@ -97,7 +98,7 @@ pub fn handle_incoming_calls(
             }
 
             // Get transaction location
-            let (txn_line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (txn_line, _) = line_index.offset_to_position(spanned.span.start);
 
             // Build transaction description
             let description = format!("{} {} \"{}\"", txn.date, txn.flag, txn.narration.as_ref());
@@ -113,8 +114,8 @@ pub fn handle_incoming_calls(
                     if sp.file_id == SYNTHESIZED_FILE_ID {
                         return None;
                     }
-                    let (posting_line, _) = byte_offset_to_position(source, sp.span.start);
-                    let line_text = source.lines().nth(posting_line as usize)?;
+                    let (posting_line, _) = line_index.offset_to_position(sp.span.start);
+                    let line_text = line_index.line_text(source, posting_line)?;
                     let col = line_text.find(account)?;
                     Some(Range {
                         start: Position::new(posting_line, col as u32),
@@ -139,7 +140,7 @@ pub fn handle_incoming_calls(
             // resulting (line, col) directly; only normalize to the
             // next line when the end column is non-zero (i.e. the
             // span ends mid-line and the LSP range needs to round up).
-            let (txn_end_line, txn_end_col) = byte_offset_to_position(source, spanned.span.end);
+            let (txn_end_line, txn_end_col) = line_index.offset_to_position(spanned.span.end);
             let normalized_end_line = if txn_end_col == 0 {
                 txn_end_line
             } else {
@@ -194,11 +195,12 @@ pub fn handle_outgoing_calls(
     }
 
     let txn_line = data.get("line").and_then(|v| v.as_u64())? as u32;
+    let line_index = LineIndex::new(source);
 
     // Find the transaction at this line
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (line, _) = line_index.offset_to_position(spanned.span.start);
 
             if line != txn_line {
                 continue;
@@ -216,7 +218,8 @@ pub fn handle_outgoing_calls(
                 .into_iter()
                 .filter_map(|(account, indices)| {
                     // Find where this account is defined (open directive)
-                    let account_location = find_account_definition(source, parse_result, &account);
+                    let account_location =
+                        find_account_definition(source, parse_result, &line_index, &account);
                     let (_acc_line, acc_range) = match account_location {
                         Some(loc) => loc,
                         None => {
@@ -226,8 +229,8 @@ pub fn handle_outgoing_calls(
                             if sp.file_id == SYNTHESIZED_FILE_ID {
                                 return None;
                             }
-                            let (posting_line, _) = byte_offset_to_position(source, sp.span.start);
-                            let line_text = source.lines().nth(posting_line as usize)?;
+                            let (posting_line, _) = line_index.offset_to_position(sp.span.start);
+                            let line_text = line_index.line_text(source, posting_line)?;
                             let col = line_text.find(&account)?;
                             (
                                 posting_line,
@@ -248,8 +251,8 @@ pub fn handle_outgoing_calls(
                             if sp.file_id == SYNTHESIZED_FILE_ID {
                                 return None;
                             }
-                            let (posting_line, _) = byte_offset_to_position(source, sp.span.start);
-                            let line_text = source.lines().nth(posting_line as usize)?;
+                            let (posting_line, _) = line_index.offset_to_position(sp.span.start);
+                            let line_text = line_index.line_text(source, posting_line)?;
                             let col = line_text.find(&account)?;
                             Some(Range {
                                 start: Position::new(posting_line, col as u32),
@@ -287,14 +290,15 @@ pub fn handle_outgoing_calls(
 fn find_account_definition(
     source: &str,
     parse_result: &ParseResult,
+    line_index: &LineIndex,
     account: &str,
 ) -> Option<(u32, Range)> {
     for spanned in &parse_result.directives {
         if let Directive::Open(open) = &spanned.value
             && open.account.as_ref() == account
         {
-            let (line, _) = byte_offset_to_position(source, spanned.span.start);
-            let line_text = source.lines().nth(line as usize)?;
+            let (line, _) = line_index.offset_to_position(spanned.span.start);
+            let line_text = line_index.line_text(source, line)?;
             let col = line_text.find(account)?;
             return Some((
                 line,

--- a/crates/rustledger-lsp/src/handlers/code_actions.rs
+++ b/crates/rustledger-lsp/src/handlers/code_actions.rs
@@ -15,7 +15,7 @@ use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::collections::{HashMap, HashSet};
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Handle a code action request.
 pub fn handle_code_actions(
@@ -27,6 +27,7 @@ pub fn handle_code_actions(
 
     let range = params.range;
     let uri = params.text_document.uri.clone();
+    let line_index = LineIndex::new(source);
 
     // Collect all defined accounts
     let defined_accounts = collect_defined_accounts(parse_result);
@@ -43,14 +44,14 @@ pub fn handle_code_actions(
     // If there are undefined accounts, offer to create open directives
     for account in undefined_accounts {
         // Check if this account is on or near the selected range
-        if is_account_in_range(source, &account, range, parse_result) {
+        if is_account_in_range(source, &line_index, &account, range, parse_result) {
             let action = create_open_directive_action(&uri, &account);
             actions.push(action);
         }
     }
 
     // Check for unbalanced transactions in range
-    if let Some(action) = check_unbalanced_transactions(params, source, parse_result) {
+    if let Some(action) = check_unbalanced_transactions(params, &line_index, parse_result) {
         actions.push(action);
     }
 
@@ -118,6 +119,7 @@ fn collect_used_accounts(parse_result: &ParseResult) -> HashSet<String> {
 /// Check if an account is mentioned in or near the given range.
 fn is_account_in_range(
     source: &str,
+    line_index: &LineIndex,
     account: &str,
     range: Range,
     parse_result: &ParseResult,
@@ -138,8 +140,8 @@ fn is_account_in_range(
     // Also check if we're inside a transaction that uses this account
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (dir_line, _) = byte_offset_to_position(source, spanned.span.start);
-            let (end_line, _) = byte_offset_to_position(source, spanned.span.end);
+            let (dir_line, _) = line_index.offset_to_position(spanned.span.start);
+            let (end_line, _) = line_index.offset_to_position(spanned.span.end);
 
             // Check if range overlaps with transaction
             if (range.start.line <= end_line) && (range.end.line >= dir_line) {
@@ -192,9 +194,10 @@ pub fn handle_code_action_resolve(
         && data.get("kind").and_then(|v| v.as_str()) == Some("add_open_directive")
         && let Some(account) = data.get("account").and_then(|v| v.as_str())
     {
+        let line_index = LineIndex::new(source);
         resolved.edit = Some(compute_open_directive_edit(
             uri,
-            source,
+            &line_index,
             account,
             parse_result,
         ));
@@ -207,7 +210,7 @@ pub fn handle_code_action_resolve(
 #[allow(clippy::mutable_key_type)] // Uri is required as key by LSP WorkspaceEdit API
 fn compute_open_directive_edit(
     uri: &Uri,
-    source: &str,
+    line_index: &LineIndex,
     account: &str,
     parse_result: &ParseResult,
 ) -> WorkspaceEdit {
@@ -216,7 +219,7 @@ fn compute_open_directive_edit(
         find_earliest_date(parse_result).unwrap_or_else(|| "2000-01-01".to_string());
 
     // Find where to insert the open directive
-    let insert_position = find_open_directive_position(source, parse_result);
+    let insert_position = find_open_directive_position(line_index, parse_result);
 
     let new_text = format!("{} open {}\n", earliest_date, account);
 
@@ -268,7 +271,7 @@ fn find_earliest_date(parse_result: &ParseResult) -> Option<String> {
 }
 
 /// Find the position to insert new open directives.
-fn find_open_directive_position(source: &str, parse_result: &ParseResult) -> Position {
+fn find_open_directive_position(line_index: &LineIndex, parse_result: &ParseResult) -> Position {
     // Find the last open directive and insert after it
     let mut last_open_end: Option<usize> = None;
 
@@ -279,7 +282,7 @@ fn find_open_directive_position(source: &str, parse_result: &ParseResult) -> Pos
     }
 
     if let Some(offset) = last_open_end {
-        let (line, _) = byte_offset_to_position(source, offset);
+        let (line, _) = line_index.offset_to_position(offset);
         // Insert on the next line
         Position::new(line + 1, 0)
     } else {
@@ -291,15 +294,15 @@ fn find_open_directive_position(source: &str, parse_result: &ParseResult) -> Pos
 /// Check for unbalanced transactions and offer to add a balancing posting.
 fn check_unbalanced_transactions(
     params: &CodeActionParams,
-    source: &str,
+    line_index: &LineIndex,
     parse_result: &ParseResult,
 ) -> Option<CodeAction> {
     let range = params.range;
 
     for spanned in &parse_result.directives {
         if let Directive::Transaction(txn) = &spanned.value {
-            let (start_line, _) = byte_offset_to_position(source, spanned.span.start);
-            let (end_line, _) = byte_offset_to_position(source, spanned.span.end);
+            let (start_line, _) = line_index.offset_to_position(spanned.span.start);
+            let (end_line, _) = line_index.offset_to_position(spanned.span.end);
 
             // Check if selection is within this transaction
             if range.start.line >= start_line && range.start.line <= end_line {

--- a/crates/rustledger-lsp/src/handlers/code_actions.rs
+++ b/crates/rustledger-lsp/src/handlers/code_actions.rs
@@ -124,13 +124,14 @@ fn is_account_in_range(
     range: Range,
     parse_result: &ParseResult,
 ) -> bool {
-    // Find the line at the range start
-    let lines: Vec<&str> = source.lines().collect();
-    let start_line = range.start.line as usize;
-
-    // Check a few lines around the selection
-    for line_idx in start_line.saturating_sub(3)..=(start_line + 10).min(lines.len() - 1) {
-        if let Some(line) = lines.get(line_idx)
+    // Check a few lines around the selection. Fetch each line via
+    // LineIndex so we don't re-split the whole source on every
+    // undefined-account check (called once per undefined account).
+    let start_line = range.start.line;
+    let window_start = start_line.saturating_sub(3);
+    let window_end = start_line.saturating_add(10);
+    for line_idx in window_start..=window_end {
+        if let Some(line) = line_index.line_text(source, line_idx)
             && line.contains(account)
         {
             return true;

--- a/crates/rustledger-lsp/src/handlers/document_links.rs
+++ b/crates/rustledger-lsp/src/handlers/document_links.rs
@@ -11,7 +11,7 @@ use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::path::Path;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Handle a document links request.
 pub fn handle_document_links(
@@ -24,14 +24,19 @@ pub fn handle_document_links(
 
     // Get the base directory from the document URI
     let base_dir = get_base_directory(base_uri);
+    let line_index = LineIndex::new(source);
 
     for spanned in &parse_result.directives {
         if let Directive::Document(doc) = &spanned.value {
             // Create link for document path
             let path_str = doc.path.to_string();
-            if let Some(link) =
-                create_document_link(source, spanned.span.start, &path_str, &base_dir)
-            {
+            if let Some(link) = create_document_link(
+                source,
+                &line_index,
+                spanned.span.start,
+                &path_str,
+                &base_dir,
+            ) {
                 links.push(link);
             }
         }
@@ -123,15 +128,15 @@ fn get_base_directory(uri: &Uri) -> Option<String> {
 /// The target is deferred to the resolve phase for lazy verification.
 fn create_document_link(
     source: &str,
+    line_index: &LineIndex,
     directive_start: usize,
     path: &str,
     base_dir: &Option<String>,
 ) -> Option<DocumentLink> {
-    let (start_line, _) = byte_offset_to_position(source, directive_start);
+    let (start_line, _) = line_index.offset_to_position(directive_start);
 
     // Find the path in the directive line
-    let lines: Vec<&str> = source.lines().collect();
-    let line = lines.get(start_line as usize)?;
+    let line = line_index.line_text(source, start_line)?;
 
     // Find the quoted path
     let quote_start = line.find('"')?;

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -11,7 +11,7 @@ use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
 use super::formatting::format_document;
-use super::utils::{byte_offset_to_position, document_format_config};
+use super::utils::{LineIndex, document_format_config};
 
 /// Available commands.
 pub const COMMANDS: &[&str] = &[
@@ -94,8 +94,9 @@ fn handle_sort_transactions(
         .join("\n\n");
 
     // Create workspace edit
-    let (start_line, start_col) = byte_offset_to_position(source, first_start);
-    let (end_line, end_col) = byte_offset_to_position(source, last_end);
+    let line_index = LineIndex::new(source);
+    let (start_line, start_col) = line_index.offset_to_position(first_start);
+    let (end_line, end_col) = line_index.offset_to_position(last_end);
 
     let edit = TextEdit {
         range: lsp_types::Range {

--- a/crates/rustledger-lsp/src/handlers/semantic_tokens.rs
+++ b/crates/rustledger-lsp/src/handlers/semantic_tokens.rs
@@ -19,7 +19,7 @@ use rustledger_parser::ParseResult;
 use rustledger_parser::logos_lexer::{Token, tokenize};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Token types we support.
 pub const TOKEN_TYPES: &[SemanticTokenType] = &[
@@ -253,10 +253,11 @@ fn collect_lexer_tokens_in_range(source: &str, range: &Range) -> Vec<RawToken> {
 fn apply_directive_modifiers(
     raw_tokens: &mut [RawToken],
     source: &str,
+    line_index: &LineIndex,
     parse_result: &ParseResult,
 ) {
     for spanned in &parse_result.directives {
-        let (dir_line, _) = byte_offset_to_position(source, spanned.span.start);
+        let (dir_line, _) = line_index.offset_to_position(spanned.span.start);
 
         match &spanned.value {
             Directive::Open(open) => {
@@ -344,7 +345,8 @@ pub fn handle_semantic_tokens(
     parse_result: &ParseResult,
 ) -> Option<SemanticTokensResult> {
     let mut raw_tokens = collect_lexer_tokens(source);
-    apply_directive_modifiers(&mut raw_tokens, source, parse_result);
+    let line_index = LineIndex::new(source);
+    apply_directive_modifiers(&mut raw_tokens, source, &line_index, parse_result);
 
     // Tokens are already in source order from the lexer
     let tokens = encode_tokens(&raw_tokens);
@@ -367,7 +369,8 @@ pub fn handle_semantic_tokens_delta(
     previous_tokens: Option<&[SemanticToken]>,
 ) -> Option<SemanticTokensFullDeltaResult> {
     let mut raw_tokens = collect_lexer_tokens(source);
-    apply_directive_modifiers(&mut raw_tokens, source, parse_result);
+    let line_index = LineIndex::new(source);
+    apply_directive_modifiers(&mut raw_tokens, source, &line_index, parse_result);
     let current_tokens = encode_tokens(&raw_tokens);
 
     // If tokens unchanged, return empty delta
@@ -429,7 +432,8 @@ pub fn handle_semantic_tokens_range(
     let range = params.range;
 
     let mut raw_tokens = collect_lexer_tokens_in_range(source, &range);
-    apply_directive_modifiers(&mut raw_tokens, source, parse_result);
+    let line_index = LineIndex::new(source);
+    apply_directive_modifiers(&mut raw_tokens, source, &line_index, parse_result);
 
     let tokens = encode_tokens(&raw_tokens);
 

--- a/crates/rustledger-lsp/src/handlers/type_hierarchy.rs
+++ b/crates/rustledger-lsp/src/handlers/type_hierarchy.rs
@@ -12,7 +12,7 @@ use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::collections::HashSet;
 
-use super::utils::{byte_offset_to_position, get_word_at_position, is_account_like};
+use super::utils::{LineIndex, get_word_at_position, is_account_like};
 
 /// Handle a prepare type hierarchy request.
 /// Returns the account at the cursor position as a TypeHierarchyItem.
@@ -79,7 +79,8 @@ pub fn handle_supertypes(
     let parent = get_parent_account(account)?;
 
     // Find where this parent account is defined or used
-    let location = find_account_location(source, parse_result, &parent)?;
+    let line_index = LineIndex::new(source);
+    let location = find_account_location(source, &line_index, parse_result, &parent)?;
 
     let item = TypeHierarchyItem {
         name: parent.clone(),
@@ -117,10 +118,11 @@ pub fn handle_subtypes(
         return None;
     }
 
+    let line_index = LineIndex::new(source);
     let items: Vec<TypeHierarchyItem> = children
         .into_iter()
         .filter_map(|child| {
-            let location = find_account_location(source, parse_result, &child)?;
+            let location = find_account_location(source, &line_index, parse_result, &child)?;
             Some(TypeHierarchyItem {
                 name: child.clone(),
                 kind: SymbolKind::CLASS,
@@ -204,14 +206,19 @@ fn account_exists(account: &str, parse_result: &ParseResult) -> bool {
 }
 
 /// Find the location where an account is defined or first used.
-fn find_account_location(source: &str, parse_result: &ParseResult, account: &str) -> Option<Range> {
+fn find_account_location(
+    source: &str,
+    line_index: &LineIndex,
+    parse_result: &ParseResult,
+    account: &str,
+) -> Option<Range> {
     // First try to find an open directive
     for spanned in &parse_result.directives {
         if let Directive::Open(open) = &spanned.value
             && open.account.as_ref() == account
         {
-            let (line, _) = byte_offset_to_position(source, spanned.span.start);
-            let line_text = source.lines().nth(line as usize)?;
+            let (line, _) = line_index.offset_to_position(spanned.span.start);
+            let line_text = line_index.line_text(source, line)?;
             if let Some(col) = line_text.find(account) {
                 return Some(Range {
                     start: Position::new(line, col as u32),
@@ -225,7 +232,7 @@ fn find_account_location(source: &str, parse_result: &ParseResult, account: &str
     for spanned in &parse_result.directives {
         let accounts = get_accounts_from_directive(&spanned.value);
         if accounts.iter().any(|a| a == account) {
-            let (line, _) = byte_offset_to_position(source, spanned.span.start);
+            let (line, _) = line_index.offset_to_position(spanned.span.start);
             let directive_text = &source[spanned.span.start..spanned.span.end];
 
             for (line_offset, line_content) in directive_text.lines().enumerate() {

--- a/crates/rustledger-lsp/src/handlers/workspace_symbols.rs
+++ b/crates/rustledger-lsp/src/handlers/workspace_symbols.rs
@@ -14,7 +14,7 @@ use rustledger_parser::ParseResult;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::utils::byte_offset_to_position;
+use super::utils::LineIndex;
 
 /// Handle a workspace symbol request.
 pub fn handle_workspace_symbols(
@@ -57,8 +57,9 @@ fn collect_symbols_from_document(
     seen_accounts: &mut HashSet<String>,
     seen_currencies: &mut HashSet<String>,
 ) {
+    let line_index = LineIndex::new(source);
     for spanned in &parse_result.directives {
-        let (line, col) = byte_offset_to_position(source, spanned.span.start);
+        let (line, col) = line_index.offset_to_position(spanned.span.start);
         let location = Location {
             uri: uri.clone(),
             range: Range {


### PR DESCRIPTION
## Summary

Finishes the LineIndex sweep that started in PRs #1160 / #1161 — closes the per-posting O(n) `byte_offset_to_position` regression Copilot flagged on #1157 but which never got backfilled across all touched handlers.

## Background

PRs #1156 / #1157 / #1159 switched several LSP handlers from line-arithmetic to per-posting `byte_offset_to_position` so they could use real `posting.span` data (issue #1142). That helper is O(n) per call, which made e.g. find-references on large files quadratic. Copilot flagged it in 7+ spots; PR #1160 introduced the `LineIndex` cache and #1161 backfilled the obvious offenders (references, inlay_hints, linked_editing, document_highlight, formatting, range_formatting). The remaining handlers — including the one Copilot specifically named (`call_hierarchy.rs`) — were missed.

## What changed

Converted every remaining production handler to build a `LineIndex` once at the entry point and thread it through helpers:

| Handler | Sites | Notes |
|---------|-------|-------|
| `call_hierarchy.rs` | 8 | The Copilot-flagged one. `find_account_definition` now takes `&LineIndex`. |
| `type_hierarchy.rs` | 2 | `find_account_location` now takes `&LineIndex`. |
| `code_actions.rs` | 5 | `is_account_in_range`, `check_unbalanced_transactions`, `find_open_directive_position` all threaded. Resolve path builds its own LineIndex. |
| `workspace_symbols.rs` | 1 | Hot per-directive loop. |
| `semantic_tokens.rs` | 1 | `apply_directive_modifiers` — runs on every semantic-tokens/delta/range request. |
| `document_links.rs` | 1 | `create_document_link` now reads line via `line_index.line_text` instead of `source.lines().nth`. |
| `execute_command.rs` | 2 | `sortTransactions` edit range computation. |

Also replaced `source.lines().nth(line)?` with `line_index.line_text(source, line)?` everywhere it was paired with a converted offset lookup — those `nth` calls were the same O(n) shape.

`byte_offset_to_position` stays in `utils.rs` for ad-hoc one-off conversions (the doc on it already warns to prefer `LineIndex` for multiple lookups). No production handler calls it anymore.

## Why

Each call is O(n) where n is the byte offset in the source. For a 10k-transaction file with 20-30k postings, per-posting calls were O(file_len × postings) = ~10⁹ ops per request — visible latency on rename, find-references, semantic-tokens refresh.

## Test plan

- [x] `cargo clippy -p rustledger-lsp --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test -p rustledger-lsp --all-features` — 146 tests pass
- [ ] CI full workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)