### PR TITLE
refactor(core): Account domain newtype (refs #1163)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -8,8 +8,8 @@
 
 use rustc_hash::FxHashMap;
 use rustledger_core::{
-    AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, IncompleteAmount, InternedStr,
-    Inventory, Position, Posting, ReductionScope, Transaction,
+    AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, IncompleteAmount, Inventory,
+    Position, Posting, ReductionScope, Transaction,
 };
 use thiserror::Error;
 
@@ -61,7 +61,7 @@ pub struct BookedTransaction {
 #[derive(Debug, Clone)]
 pub struct CapitalGain {
     /// The account holding the asset.
-    pub account: InternedStr,
+    pub account: rustledger_core::Account,
     /// The currency of the asset.
     pub currency: rustledger_core::Currency,
     /// The gain amount (positive) or loss (negative).
@@ -76,13 +76,13 @@ pub struct CapitalGain {
 #[derive(Debug, Default)]
 pub struct BookingEngine {
     /// Inventory per account.
-    inventories: FxHashMap<InternedStr, Inventory>,
+    inventories: FxHashMap<rustledger_core::Account, Inventory>,
     /// Default booking method, used for accounts without an explicit
     /// booking method on their `open` directive.
     booking_method: BookingMethod,
     /// Per-account booking method overrides (from `open` directives).
     /// Looked up first, falling back to `booking_method` if absent.
-    account_methods: FxHashMap<InternedStr, BookingMethod>,
+    account_methods: FxHashMap<rustledger_core::Account, BookingMethod>,
 }
 
 impl BookingEngine {
@@ -112,7 +112,7 @@ impl BookingEngine {
     /// that account, so the engine uses the per-account method (e.g. FIFO,
     /// LIFO, NONE) rather than the engine-wide default. Subsequent calls
     /// overwrite the previous method for the account.
-    pub fn set_account_method(&mut self, account: InternedStr, method: BookingMethod) {
+    pub fn set_account_method(&mut self, account: rustledger_core::Account, method: BookingMethod) {
         self.account_methods.insert(account, method);
     }
 
@@ -142,7 +142,7 @@ impl BookingEngine {
 
     /// Resolve the booking method for an account, falling back to the
     /// engine-wide default if not registered.
-    fn method_for(&self, account: &InternedStr) -> BookingMethod {
+    fn method_for(&self, account: &rustledger_core::Account) -> BookingMethod {
         self.account_methods
             .get(account)
             .copied()
@@ -151,7 +151,7 @@ impl BookingEngine {
 
     /// Get the inventory for an account.
     #[must_use]
-    pub fn inventory(&self, account: &InternedStr) -> Option<&Inventory> {
+    pub fn inventory(&self, account: &rustledger_core::Account) -> Option<&Inventory> {
         self.inventories.get(account)
     }
 
@@ -192,7 +192,7 @@ impl BookingEngine {
         // inventory every time it appears. Without deduping, the optimization
         // would be silently undone by transactions that list the same
         // account more than once.
-        let mut working_inventories: FxHashMap<InternedStr, Inventory> =
+        let mut working_inventories: FxHashMap<rustledger_core::Account, Inventory> =
             FxHashMap::with_capacity_and_hasher(txn.postings.len(), Default::default());
         for posting in &txn.postings {
             if let Some(inv) = self.inventories.get(&posting.account) {
@@ -535,7 +535,7 @@ impl BookingEngine {
 /// the booking layer and the validator (#748 / #750).
 fn convert_core_booking_error(
     err: rustledger_core::BookingError,
-    account: &InternedStr,
+    account: &rustledger_core::Account,
 ) -> BookingError {
     BookingError::Inventory(err.with_account(account.clone()))
 }

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -4,7 +4,7 @@
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
-use rustledger_core::{Amount, Currency, IncompleteAmount, InternedStr, Transaction};
+use rustledger_core::{Amount, Currency, IncompleteAmount, Transaction};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -36,9 +36,8 @@ pub enum InterpolationError {
     /// Cannot infer currency for a posting.
     #[error("cannot infer currency for posting to account {account}")]
     CannotInferCurrency {
-        /// The account of the posting. Account migration is a
-        /// follow-up — see issue #1163.
-        account: InternedStr,
+        /// The account of the posting.
+        account: rustledger_core::Account,
     },
 
     /// Transaction does not balance after interpolation.

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -24,8 +24,7 @@
 
 use rust_decimal::Decimal;
 use rustledger_core::{
-    Amount, Currency, Directive, InternedStr, Inventory, NaiveDate, Pad, Position, Posting,
-    Transaction,
+    Amount, Currency, Directive, Inventory, NaiveDate, Pad, Position, Posting, Transaction,
 };
 use std::collections::HashMap;
 use std::ops::Neg;
@@ -49,7 +48,7 @@ pub struct PadError {
     /// Error message.
     pub message: String,
     /// Account involved.
-    pub account: Option<InternedStr>,
+    pub account: Option<rustledger_core::Account>,
 }
 
 impl PadError {
@@ -63,7 +62,7 @@ impl PadError {
     }
 
     /// Add account context.
-    pub fn with_account(mut self, account: impl Into<InternedStr>) -> Self {
+    pub fn with_account(mut self, account: impl Into<rustledger_core::Account>) -> Self {
         self.account = Some(account.into());
         self
     }
@@ -101,9 +100,9 @@ struct PendingPad {
 /// - Any errors encountered
 pub fn process_pads(directives: &[Directive]) -> PadResult {
     let num_directives = directives.len();
-    let mut inventories: HashMap<InternedStr, Inventory> =
+    let mut inventories: HashMap<rustledger_core::Account, Inventory> =
         HashMap::with_capacity(num_directives.min(16));
-    let mut pending_pads: HashMap<InternedStr, PendingPad> = HashMap::with_capacity(4);
+    let mut pending_pads: HashMap<rustledger_core::Account, PendingPad> = HashMap::with_capacity(4);
     let mut padding_transactions = Vec::with_capacity(num_directives.min(16));
     let mut errors = Vec::with_capacity(4);
 

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -141,8 +141,7 @@ const fn meta_value_kind(v: &MetaValue) -> &'static str {
 )]
 pub struct Posting {
     /// The account for this posting
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// The units (may be incomplete or None for auto-calculated postings)
     pub units: Option<IncompleteAmount>,
     /// Cost specification for the position
@@ -164,7 +163,7 @@ pub struct Posting {
 impl Posting {
     /// Create a new posting with the given account and complete units.
     #[must_use]
-    pub fn new(account: impl Into<InternedStr>, units: Amount) -> Self {
+    pub fn new(account: impl Into<crate::Account>, units: Amount) -> Self {
         Self {
             account: account.into(),
             units: Some(IncompleteAmount::Complete(units)),
@@ -179,7 +178,7 @@ impl Posting {
 
     /// Create a new posting with an incomplete amount.
     #[must_use]
-    pub fn with_incomplete(account: impl Into<InternedStr>, units: IncompleteAmount) -> Self {
+    pub fn with_incomplete(account: impl Into<crate::Account>, units: IncompleteAmount) -> Self {
         Self {
             account: account.into(),
             units: Some(units),
@@ -194,7 +193,7 @@ impl Posting {
 
     /// Create a posting without any amount (to be fully interpolated).
     #[must_use]
-    pub fn auto(account: impl Into<InternedStr>) -> Self {
+    pub fn auto(account: impl Into<crate::Account>) -> Self {
         Self {
             account: account.into(),
             units: None,
@@ -765,8 +764,7 @@ pub struct Balance {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Account to check
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// Expected amount
     pub amount: Amount,
     /// Tolerance (if explicitly specified)
@@ -779,7 +777,7 @@ pub struct Balance {
 impl Balance {
     /// Create a new balance assertion.
     #[must_use]
-    pub fn new(date: NaiveDate, account: impl Into<InternedStr>, amount: Amount) -> Self {
+    pub fn new(date: NaiveDate, account: impl Into<crate::Account>, amount: Amount) -> Self {
         Self {
             date,
             account: account.into(),
@@ -827,8 +825,7 @@ pub struct Open {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Account name (e.g., "Assets:Bank:Checking")
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// Allowed currencies (empty = any currency allowed)
     pub currencies: Vec<crate::Currency>,
     /// Booking method for this account
@@ -840,7 +837,7 @@ pub struct Open {
 impl Open {
     /// Create a new open directive.
     #[must_use]
-    pub fn new(date: NaiveDate, account: impl Into<InternedStr>) -> Self {
+    pub fn new(date: NaiveDate, account: impl Into<crate::Account>) -> Self {
         Self {
             date,
             account: account.into(),
@@ -903,8 +900,7 @@ pub struct Close {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Account name
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// Metadata
     pub meta: Metadata,
 }
@@ -912,7 +908,7 @@ pub struct Close {
 impl Close {
     /// Create a new close directive.
     #[must_use]
-    pub fn new(date: NaiveDate, account: impl Into<InternedStr>) -> Self {
+    pub fn new(date: NaiveDate, account: impl Into<crate::Account>) -> Self {
         Self {
             date,
             account: account.into(),
@@ -991,11 +987,9 @@ pub struct Pad {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Account to pad
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// Source account for padding (e.g., Equity:Opening-Balances)
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub source_account: InternedStr,
+    pub source_account: crate::Account,
     /// Metadata
     pub meta: Metadata,
 }
@@ -1005,8 +999,8 @@ impl Pad {
     #[must_use]
     pub fn new(
         date: NaiveDate,
-        account: impl Into<InternedStr>,
-        source_account: impl Into<InternedStr>,
+        account: impl Into<crate::Account>,
+        source_account: impl Into<crate::Account>,
     ) -> Self {
         Self {
             date,
@@ -1147,8 +1141,7 @@ pub struct Note {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Account
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// Note text
     pub comment: String,
     /// Metadata
@@ -1160,7 +1153,7 @@ impl Note {
     #[must_use]
     pub fn new(
         date: NaiveDate,
-        account: impl Into<InternedStr>,
+        account: impl Into<crate::Account>,
         comment: impl Into<String>,
     ) -> Self {
         Self {
@@ -1202,8 +1195,7 @@ pub struct Document {
     #[cfg_attr(feature = "rkyv", rkyv(with = AsNaiveDate))]
     pub date: NaiveDate,
     /// Account
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsInternedStr))]
-    pub account: InternedStr,
+    pub account: crate::Account,
     /// File path to the document
     pub path: String,
     /// Tags
@@ -1219,7 +1211,11 @@ pub struct Document {
 impl Document {
     /// Create a new document directive.
     #[must_use]
-    pub fn new(date: NaiveDate, account: impl Into<InternedStr>, path: impl Into<String>) -> Self {
+    pub fn new(
+        date: NaiveDate,
+        account: impl Into<crate::Account>,
+        path: impl Into<String>,
+    ) -> Self {
         Self {
             date,
             account: account.into(),

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -41,13 +41,14 @@
 //!
 //! # When to use which
 //!
-//! [`Currency`] is fully plumbed through the AST; the other three
-//! are defined but not yet wired up (planned slices of #1163):
+//! [`Currency`] and [`Account`] are fully plumbed through the AST;
+//! [`Tag`] and [`Link`] are defined but not yet wired up (planned
+//! slices of #1163):
 //!
 //! - [`Currency`] *(in use)*: `Commodity.currency`, `Open.currencies`
 //!   entries, `Amount.currency`, `CostSpec.currency`, `Price.currency`,
 //!   `IncompleteAmount::CurrencyOnly`.
-//! - [`Account`] *(planned)*: `Open.account`, `Close.account`,
+//! - [`Account`] *(in use)*: `Open.account`, `Close.account`,
 //!   `Balance.account`, `Pad.account` / `source_account`,
 //!   `Note.account`, `Document.account`, `Posting.account`.
 //! - [`Tag`] *(planned)*: `Transaction.tags` entries,

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -12,7 +12,6 @@ use smallvec::SmallVec;
 use std::fmt;
 use std::str::FromStr;
 
-use crate::intern::InternedStr;
 use crate::{Amount, CostSpec, Position};
 
 /// Inline storage for `BookingResult::matched`.
@@ -210,7 +209,7 @@ impl BookingError {
     /// wording cannot drift between them — the failure mode that produced
     /// #748.
     #[must_use]
-    pub const fn with_account(self, account: InternedStr) -> AccountedBookingError {
+    pub const fn with_account(self, account: crate::Account) -> AccountedBookingError {
         AccountedBookingError {
             error: self,
             account,
@@ -232,7 +231,7 @@ pub struct AccountedBookingError {
     /// The underlying inventory-level error.
     pub error: BookingError,
     /// The account whose inventory produced the error.
-    pub account: InternedStr,
+    pub account: crate::Account,
 }
 
 impl fmt::Display for AccountedBookingError {

--- a/crates/rustledger-loader/src/dedup.rs
+++ b/crates/rustledger-loader/src/dedup.rs
@@ -124,7 +124,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             intern_vec(&mut txn.links, interner, &mut dedup_count);
 
             for posting in &mut txn.postings {
-                if do_intern(&mut posting.account, interner) {
+                if do_intern(posting.account.as_interned_mut(), interner) {
                     dedup_count += 1;
                 }
                 // Units
@@ -178,7 +178,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             }
         }
         Directive::Balance(bal) => {
-            if do_intern(&mut bal.account, interner) {
+            if do_intern(bal.account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
             if do_intern(bal.amount.currency.as_interned_mut(), interner) {
@@ -186,7 +186,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             }
         }
         Directive::Open(open) => {
-            if do_intern(&mut open.account, interner) {
+            if do_intern(open.account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
             intern_typed_vec(
@@ -197,7 +197,7 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             );
         }
         Directive::Close(close) => {
-            if do_intern(&mut close.account, interner) {
+            if do_intern(close.account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
         }
@@ -207,20 +207,20 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
             }
         }
         Directive::Pad(pad) => {
-            if do_intern(&mut pad.account, interner) {
+            if do_intern(pad.account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
-            if do_intern(&mut pad.source_account, interner) {
+            if do_intern(pad.source_account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
         }
         Directive::Note(note) => {
-            if do_intern(&mut note.account, interner) {
+            if do_intern(note.account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
         }
         Directive::Document(doc) => {
-            if do_intern(&mut doc.account, interner) {
+            if do_intern(doc.account.as_interned_mut(), interner) {
                 dedup_count += 1;
             }
             // Pre-Copilot this skipped tags/links. They're now covered.

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -1143,10 +1143,10 @@ include "transactions.beancount"
             .load(Path::new("main.beancount"))
             .unwrap();
 
-        // Collect every `Assets:Bank` `InternedStr` (one from `open`,
-        // one from the posting). They originate in different files, so
+        // Collect every `Assets:Bank` `Account` (one from `open`, one
+        // from the posting). They originate in different files, so
         // pre-fix they had distinct `Arc<str>` allocations.
-        let bank_accounts: Vec<&rustledger_core::InternedStr> = result
+        let bank_accounts: Vec<&rustledger_core::Account> = result
             .directives
             .iter()
             .filter_map(|s| match &s.value {
@@ -1168,7 +1168,9 @@ include "transactions.beancount"
             "expected one Open and one posting for Assets:Bank"
         );
         assert!(
-            bank_accounts[0].ptr_eq(bank_accounts[1]),
+            bank_accounts[0]
+                .as_interned()
+                .ptr_eq(bank_accounts[1].as_interned()),
             "Assets:Bank from cross-file open/posting must share the same Arc<str> \
              after Loader::load runs reintern_directives"
         );

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -361,13 +361,13 @@ fn process_string_escapes(s: &str) -> String {
     result
 }
 
-fn parse_account(stream: &mut TokenStream<'_>) -> ParseRes<InternedStr> {
+fn parse_account(stream: &mut TokenStream<'_>) -> ParseRes<rustledger_core::Account> {
     if let Some(t) = stream.peek()
         && let Token::Account(s) = &t.token
     {
         let result = stream.interner.intern(s);
         stream.advance();
-        return Ok(result);
+        return Ok(result.into());
     }
     Err(())
 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHashMap;
 
 use regex::{Regex, RegexBuilder};
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, Directive, InternedStr, Inventory, Metadata, NaiveDate, Position};
+use rustledger_core::{Amount, Directive, Inventory, Metadata, NaiveDate, Position};
 #[cfg(test)]
 use rustledger_core::{MetaValue, Transaction};
 use rustledger_loader::SourceMap;
@@ -332,8 +332,8 @@ impl<'a> Executor<'a> {
     fn build_balances_with_filter(
         &self,
         from: Option<&FromClause>,
-    ) -> Result<FxHashMap<InternedStr, Inventory>, QueryError> {
-        let mut balances: FxHashMap<InternedStr, Inventory> = FxHashMap::default();
+    ) -> Result<FxHashMap<rustledger_core::Account, Inventory>, QueryError> {
+        let mut balances: FxHashMap<rustledger_core::Account, Inventory> = FxHashMap::default();
 
         // Iterate over whichever directive source is populated. When the
         // Executor is built via `new_with_sources`, `self.directives` is empty
@@ -417,7 +417,8 @@ impl<'a> Executor<'a> {
         // Per-account running balance — accumulates every posting regardless of
         // FROM/WHERE filters, so `account_balance` always reflects the account's
         // true ledger balance at the point of the posting.
-        let mut account_balances: FxHashMap<InternedStr, Inventory> = FxHashMap::default();
+        let mut account_balances: FxHashMap<rustledger_core::Account, Inventory> =
+            FxHashMap::default();
         // Single cumulative running balance across WHERE-filtered postings in
         // iteration order. This is the bean-query `balance` semantic: a snapshot
         // of "everything selected so far" rather than a per-account view.
@@ -2512,7 +2513,8 @@ impl<'a> Executor<'a> {
         let mut table = Table::new(columns);
 
         // Per-account running balance — exposed as `account_balance`.
-        let mut account_balances: FxHashMap<InternedStr, Inventory> = FxHashMap::default();
+        let mut account_balances: FxHashMap<rustledger_core::Account, Inventory> =
+            FxHashMap::default();
         // Cumulative running balance across all postings — exposed as `balance`,
         // matching bean-query's "running sum of all postings rendered so far".
         // The #postings table has no WHERE filter at this layer, so cumulative

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -105,7 +105,7 @@ const PARALLEL_SORT_THRESHOLD: usize = 5000;
 const PARALLEL_DOC_EXISTS_THRESHOLD: usize = 64;
 use rust_decimal::Decimal;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustledger_core::{BookingMethod, Commodity, Directive, InternedStr, Inventory};
+use rustledger_core::{BookingMethod, Commodity, Directive, Inventory};
 use rustledger_parser::{SYNTHESIZED_FILE_ID, Spanned};
 
 /// Account state for tracking lifecycle.
@@ -237,7 +237,7 @@ impl ValidationOptions {
 #[derive(Debug, Clone)]
 struct PendingPad {
     /// Source account for padding.
-    source_account: InternedStr,
+    source_account: rustledger_core::Account,
     /// Date of the pad directive.
     date: NaiveDate,
     /// Currencies for which this pad has already inserted padding.
@@ -253,13 +253,13 @@ struct PendingPad {
 #[derive(Debug, Default)]
 pub struct LedgerState {
     /// Account states.
-    accounts: FxHashMap<InternedStr, AccountState>,
+    accounts: FxHashMap<rustledger_core::Account, AccountState>,
     /// Account inventories.
-    inventories: FxHashMap<InternedStr, Inventory>,
+    inventories: FxHashMap<rustledger_core::Account, Inventory>,
     /// Declared commodities.
     commodities: FxHashSet<rustledger_core::Currency>,
     /// Pending pad directives (account -> list of pads).
-    pending_pads: FxHashMap<InternedStr, Vec<PendingPad>>,
+    pending_pads: FxHashMap<rustledger_core::Account, Vec<PendingPad>>,
     /// Validation options.
     options: ValidationOptions,
     /// Track previous directive date for out-of-order detection.
@@ -274,7 +274,7 @@ pub struct LedgerState {
     /// Keyed by `(account, date)` rather than account alone so that if
     /// reopen-after-close is ever supported, a legitimate later close on
     /// the same account still runs the inventory check.
-    pub(crate) late_close_processed: FxHashSet<(InternedStr, NaiveDate)>,
+    pub(crate) late_close_processed: FxHashSet<(rustledger_core::Account, NaiveDate)>,
 }
 
 impl LedgerState {
@@ -321,7 +321,7 @@ impl LedgerState {
 
     /// Get all account names.
     pub fn accounts(&self) -> impl Iterator<Item = &str> {
-        self.accounts.keys().map(InternedStr::as_str)
+        self.accounts.keys().map(rustledger_core::Account::as_str)
     }
 
     /// Import option warnings from the loader and convert them to validation errors.

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -7,7 +7,7 @@ use crate::error::{ErrorCode, ValidationError};
 use crate::{LedgerState, PendingPad};
 
 use rustc_hash::FxHashMap;
-use rustledger_core::{InternedStr, Inventory};
+use rustledger_core::Inventory;
 
 /// Multiplier for balance assertion tolerance (matches Python beancount).
 /// Balance assertions use 2x the `tolerance_multiplier` option.
@@ -19,8 +19,8 @@ const BALANCE_TOLERANCE_MULTIPLIER: Decimal = Decimal::TWO;
 /// `Assets:Bank:Savings`, etc. This function checks for exact match or
 /// sub-account prefix (account followed by `:`) without allocating.
 fn sum_account_and_subaccounts(
-    inventories: &FxHashMap<InternedStr, Inventory>,
-    account: &InternedStr,
+    inventories: &FxHashMap<rustledger_core::Account, Inventory>,
+    account: &rustledger_core::Account,
     currency: &rustledger_core::Currency,
 ) -> Decimal {
     let account_str = account.as_str();

--- a/crates/rustledger/src/cmd/doctor/directories.rs
+++ b/crates/rustledger/src/cmd/doctor/directories.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rustledger_core::{Directive, InternedStr};
+use rustledger_core::{Account, Directive};
 use rustledger_loader::Loader;
 use std::collections::BTreeSet;
 use std::fs;
@@ -17,7 +17,7 @@ pub(super) fn cmd_directories<W: Write>(
         .with_context(|| format!("failed to load {}", file.display()))?;
 
     // Collect all account names
-    let mut accounts: BTreeSet<InternedStr> = BTreeSet::new();
+    let mut accounts: BTreeSet<Account> = BTreeSet::new();
     for spanned in &load_result.directives {
         match &spanned.value {
             Directive::Open(open) => {

--- a/crates/rustledger/src/cmd/doctor/missing_open.rs
+++ b/crates/rustledger/src/cmd/doctor/missing_open.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rustledger_core::{Directive, InternedStr, NaiveDate};
+use rustledger_core::{Account, Directive, NaiveDate};
 use rustledger_loader::Loader;
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
@@ -12,10 +12,10 @@ pub(super) fn cmd_missing_open<W: Write>(file: &PathBuf, writer: &mut W) -> Resu
         .with_context(|| format!("failed to load {}", file.display()))?;
 
     // Collect all accounts that are opened
-    let mut opened_accounts: HashSet<InternedStr> = HashSet::new();
+    let mut opened_accounts: HashSet<Account> = HashSet::new();
 
     // Collect all accounts that are used and their first use date
-    let mut used_accounts: BTreeMap<InternedStr, NaiveDate> = BTreeMap::new();
+    let mut used_accounts: BTreeMap<Account, NaiveDate> = BTreeMap::new();
 
     for spanned in &load_result.directives {
         match &spanned.value {

--- a/crates/rustledger/src/cmd/extract_cmd/suggest.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/suggest.rs
@@ -93,7 +93,7 @@ pub(super) fn apply_ml_suggestions(
             // confidence; if the predicted account differs from the
             // fallback, rewrite it.
             if predicted != contra.account.as_str() {
-                txn.postings[1].account = InternedStr::from(predicted);
+                txn.postings[1].account = rustledger_core::Account::from(predicted);
                 stats.modified += 1;
             }
         }

--- a/crates/rustledger/src/cmd/report_cmd/balances.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balances.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, InternedStr, Inventory};
+use rustledger_core::{Directive, Inventory};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -14,7 +14,7 @@ pub(super) fn report_balances<W: Write>(
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
-    let mut balances: BTreeMap<InternedStr, Inventory> = BTreeMap::new();
+    let mut balances: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
 
     for directive in directives {
         match directive {

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -48,7 +48,8 @@ pub(super) fn report_balsheet<W: Write>(
         }
     }
 
-    // Helper to sum inventory by currency (uses InternedStr to avoid allocations)
+    // Helper to sum inventory by currency, keyed by the Currency newtype
+    // so the BTreeMap insert path doesn't allocate.
     fn sum_by_currency(
         balances: &BTreeMap<rustledger_core::Account, Inventory>,
     ) -> BTreeMap<rustledger_core::Currency, Decimal> {

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, InternedStr, Inventory};
+use rustledger_core::{Directive, Inventory};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -13,9 +13,9 @@ pub(super) fn report_balsheet<W: Write>(
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
-    let mut assets: BTreeMap<InternedStr, Inventory> = BTreeMap::new();
-    let mut liabilities: BTreeMap<InternedStr, Inventory> = BTreeMap::new();
-    let mut equity: BTreeMap<InternedStr, Inventory> = BTreeMap::new();
+    let mut assets: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
+    let mut liabilities: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
+    let mut equity: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
 
     for directive in directives {
         if let Directive::Transaction(txn) = directive {
@@ -50,7 +50,7 @@ pub(super) fn report_balsheet<W: Write>(
 
     // Helper to sum inventory by currency (uses InternedStr to avoid allocations)
     fn sum_by_currency(
-        balances: &BTreeMap<InternedStr, Inventory>,
+        balances: &BTreeMap<rustledger_core::Account, Inventory>,
     ) -> BTreeMap<rustledger_core::Currency, Decimal> {
         let mut totals: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
         for inv in balances.values() {
@@ -64,7 +64,7 @@ pub(super) fn report_balsheet<W: Write>(
     // Collect rows: (section, account, amount, currency)
     fn collect_rows(
         section: &str,
-        balances: &BTreeMap<InternedStr, Inventory>,
+        balances: &BTreeMap<rustledger_core::Account, Inventory>,
     ) -> Vec<(String, String, Decimal, String)> {
         let mut rows = Vec::new();
         for (account, inventory) in balances {
@@ -143,7 +143,7 @@ pub(super) fn report_balsheet<W: Write>(
             fn write_section<W: Write>(
                 writer: &mut W,
                 title: &str,
-                balances: &BTreeMap<InternedStr, Inventory>,
+                balances: &BTreeMap<rustledger_core::Account, Inventory>,
             ) -> Result<BTreeMap<rustledger_core::Currency, Decimal>> {
                 writeln!(writer, "{title}")?;
                 writeln!(writer, "{}", "-".repeat(60))?;

--- a/crates/rustledger/src/cmd/report_cmd/holdings.rs
+++ b/crates/rustledger/src/cmd/report_cmd/holdings.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, InternedStr};
+use rustledger_core::Directive;
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -15,8 +15,10 @@ pub(super) fn report_holdings<W: Write>(
     writer: &mut W,
 ) -> Result<()> {
     // Track holdings: account -> currency -> (units, cost_basis, cost_currency)
-    let mut holdings: BTreeMap<InternedStr, BTreeMap<String, (Decimal, Decimal, String)>> =
-        BTreeMap::new();
+    let mut holdings: BTreeMap<
+        rustledger_core::Account,
+        BTreeMap<String, (Decimal, Decimal, String)>,
+    > = BTreeMap::new();
 
     for directive in directives {
         if let Directive::Transaction(txn) = directive {

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, InternedStr, Inventory};
+use rustledger_core::{Directive, Inventory};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -13,8 +13,8 @@ pub(super) fn report_income<W: Write>(
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
-    let mut income: BTreeMap<InternedStr, Inventory> = BTreeMap::new();
-    let mut expenses: BTreeMap<InternedStr, Inventory> = BTreeMap::new();
+    let mut income: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
+    let mut expenses: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
 
     for directive in directives {
         if let Directive::Transaction(txn) = directive {
@@ -38,7 +38,7 @@ pub(super) fn report_income<W: Write>(
     }
 
     fn sum_by_currency(
-        balances: &BTreeMap<InternedStr, Inventory>,
+        balances: &BTreeMap<rustledger_core::Account, Inventory>,
     ) -> BTreeMap<rustledger_core::Currency, Decimal> {
         let mut totals: BTreeMap<rustledger_core::Currency, Decimal> = BTreeMap::new();
         for inv in balances.values() {
@@ -51,7 +51,7 @@ pub(super) fn report_income<W: Write>(
 
     fn collect_rows(
         section: &str,
-        balances: &BTreeMap<InternedStr, Inventory>,
+        balances: &BTreeMap<rustledger_core::Account, Inventory>,
     ) -> Vec<(String, String, Decimal, String)> {
         let mut rows = Vec::new();
         for (account, inventory) in balances {
@@ -131,7 +131,7 @@ pub(super) fn report_income<W: Write>(
             fn write_section<W: Write>(
                 writer: &mut W,
                 title: &str,
-                balances: &BTreeMap<InternedStr, Inventory>,
+                balances: &BTreeMap<rustledger_core::Account, Inventory>,
             ) -> Result<BTreeMap<rustledger_core::Currency, Decimal>> {
                 writeln!(writer, "{title}")?;
                 writeln!(writer, "{}", "-".repeat(60))?;


### PR DESCRIPTION
## Summary

Second slice of [#1163](https://github.com/rustledger/rustledger/issues/1163). After [#1169](https://github.com/rustledger/rustledger/pull/1169) plumbed \`Currency\`, this PR does the same for \`Account\` — the 8 \`account: InternedStr\` fields on Open / Close / Balance / Pad / Note / Document / Posting now use the typed newtype.

## What changed

**AST field types** (rustledger-core/src/directive.rs):
- \`Posting.account\`
- \`Open.account\`, \`Close.account\`
- \`Balance.account\`
- \`Pad.account\`, \`Pad.source_account\`
- \`Note.account\`
- \`Document.account\`

All now \`crate::Account\` instead of \`InternedStr\`. Constructors take \`impl Into<Account>\` so bare-string call sites continue to compile.

**Hot maps migrated in tandem** to avoid per-lookup conversions:
- \`BookingEngine.inventories: FxHashMap<Account, Inventory>\`
- \`BookingEngine.account_methods: FxHashMap<Account, BookingMethod>\`
- \`LedgerState.accounts / inventories / pending_pads / late_close_processed\`
- \`Executor\`'s per-from balance maps (\`FxHashMap<Account, Inventory>\`)
- Report-cmd \`BTreeMap<Account, Inventory>\` totals (balsheet, income, balances, holdings)
- \`pad::process_pads\` internal HashMaps

**Error types** that previously carried bare \`InternedStr\`:
- \`AccountedBookingError.account\` → \`Account\`
- \`InterpolationError::CannotInferCurrency.account\` → \`Account\`
- \`CapitalGain.account\` → \`Account\`
- \`PadError.account\` → \`Option<Account>\`

**Parser** (one-line change): \`parse_account\` returns \`Account\` instead of \`InternedStr\`. Everything downstream just compiles.

**Loader dedup pass** uses \`account.as_interned_mut()\` to feed the workspace-wide interner without unwrapping the newtype. No allocation, same dedup behaviour.

## Why

The compiler can now distinguish accounts from currencies, tags, and arbitrary interned strings at the type level — passing a \`Currency\` where an \`Account\` is expected (or vice versa) is now a type error, not a runtime bug.

## Performance

- \`Account\` is \`#[repr(transparent)]\` over \`InternedStr\`
- \`Hash\` / \`Eq\` delegate to \`InternedStr\` (\`Arc::ptr_eq\` fast path preserved end-to-end)
- HashMap keys migrated in tandem — zero conversion sites in hot loops
- \`Borrow<str>\` impl preserved for ergonomic \`map.get(\"Assets:Bank\")\` lookups

## What's deferred

- Tag migration (\`Transaction.tags\`, \`Document.tags\`, pushtag/poptag)
- Link migration (\`Transaction.links\`, \`Document.links\`)
- \`MetaValue::{Account, Currency, Tag, Link}\` — still \`String\`, design decision deferred

## Test plan

- [x] \`cargo check --workspace --all-features --all-targets\` — clean
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p rustledger-core -p rustledger-parser -p rustledger-booking -p rustledger-validate -p rustledger-query -p rustledger-loader -p rustledger -p rustledger-lsp --all-features\` — 1800+ pass
- [ ] CI full workspace test + compat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)