### PR TITLE
refactor(core): Link domain newtype (refs #1163 — AST complete)

### DIFF
--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -23,7 +23,7 @@ use std::fmt;
 
 use crate::intern::InternedStr;
 #[cfg(feature = "rkyv")]
-use crate::intern::{AsDecimal, AsInternedStr, AsNaiveDate, AsOptionInternedStr, AsVecInternedStr};
+use crate::intern::{AsDecimal, AsInternedStr, AsNaiveDate, AsOptionInternedStr};
 use crate::{Amount, CostSpec, IncompleteAmount};
 
 /// Metadata value types.
@@ -559,8 +559,7 @@ pub struct Transaction {
     /// Tags attached to this transaction
     pub tags: Vec<crate::Tag>,
     /// Links attached to this transaction
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsVecInternedStr))]
-    pub links: Vec<InternedStr>,
+    pub links: Vec<crate::Link>,
     /// Transaction metadata
     pub meta: Metadata,
     /// Postings (account entries), each wrapped with its source span and
@@ -615,7 +614,7 @@ impl Transaction {
 
     /// Add a link.
     #[must_use]
-    pub fn with_link(mut self, link: impl Into<InternedStr>) -> Self {
+    pub fn with_link(mut self, link: impl Into<crate::Link>) -> Self {
         self.links.push(link.into());
         self
     }
@@ -1200,8 +1199,7 @@ pub struct Document {
     /// Tags
     pub tags: Vec<crate::Tag>,
     /// Links
-    #[cfg_attr(feature = "rkyv", rkyv(with = AsVecInternedStr))]
-    pub links: Vec<InternedStr>,
+    pub links: Vec<crate::Link>,
     /// Metadata
     pub meta: Metadata,
 }
@@ -1233,7 +1231,7 @@ impl Document {
 
     /// Add a link.
     #[must_use]
-    pub fn with_link(mut self, link: impl Into<InternedStr>) -> Self {
+    pub fn with_link(mut self, link: impl Into<crate::Link>) -> Self {
         self.links.push(link.into());
         self
     }

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -41,20 +41,18 @@
 //!
 //! # When to use which
 //!
-//! [`Currency`], [`Account`], and [`Tag`] are fully plumbed through
-//! the AST; [`Link`] is defined but not yet wired up (final planned
-//! slice of #1163):
+//! All four newtypes — [`Currency`], [`Account`], [`Tag`], and
+//! [`Link`] — are fully plumbed through the AST:
 //!
-//! - [`Currency`] *(in use)*: `Commodity.currency`, `Open.currencies`
-//!   entries, `Amount.currency`, `CostSpec.currency`, `Price.currency`,
+//! - [`Currency`]: `Commodity.currency`, `Open.currencies` entries,
+//!   `Amount.currency`, `CostSpec.currency`, `Price.currency`,
 //!   `IncompleteAmount::CurrencyOnly`.
-//! - [`Account`] *(in use)*: `Open.account`, `Close.account`,
-//!   `Balance.account`, `Pad.account` / `source_account`,
-//!   `Note.account`, `Document.account`, `Posting.account`.
-//! - [`Tag`] *(in use)*: `Transaction.tags` entries,
-//!   `pushtag`/`poptag` stack, `Document.tags`.
-//! - [`Link`] *(planned)*: `Transaction.links` entries,
-//!   `Document.links`.
+//! - [`Account`]: `Open.account`, `Close.account`, `Balance.account`,
+//!   `Pad.account` / `source_account`, `Note.account`,
+//!   `Document.account`, `Posting.account`.
+//! - [`Tag`]: `Transaction.tags` entries, `pushtag`/`poptag` stack,
+//!   `Document.tags`.
+//! - [`Link`]: `Transaction.links` entries, `Document.links`.
 //!
 //! `MetaValue::{Account, Currency, Tag, Link}` are still `String`
 //! pending a separate decision on how meta values cross the typed

--- a/crates/rustledger-loader/src/dedup.rs
+++ b/crates/rustledger-loader/src/dedup.rs
@@ -71,21 +71,13 @@ fn do_intern(s: &mut InternedStr, interner: &mut StringInterner) -> bool {
     !was_new
 }
 
-/// Re-intern every entry of a `Vec<InternedStr>`, tallying the dedup
-/// hits into `dedup_count`. Hoisted to module scope rather than nested
-/// inside [`reintern_directive`] so clippy's `items_after_statements`
-/// lint stays happy.
-fn intern_vec(v: &mut [InternedStr], interner: &mut StringInterner, dedup_count: &mut usize) {
-    for s in v.iter_mut() {
-        if do_intern(s, interner) {
-            *dedup_count += 1;
-        }
-    }
-}
-
-/// Same as [`intern_vec`] but for slices of domain-typed identifiers
-/// (e.g., `Currency`, `Account`, `Tag`, `Link`). Calls
-/// `.as_interned_mut()` to reach the underlying `InternedStr`.
+/// Re-intern every entry of a slice of domain-typed identifiers
+/// (e.g., [`rustledger_core::Currency`], [`rustledger_core::Account`],
+/// [`rustledger_core::Tag`], [`rustledger_core::Link`]), tallying the
+/// dedup hits into `dedup_count`. Calls `get_inner` to reach the
+/// underlying `InternedStr`. Hoisted to module scope rather than
+/// nested inside [`reintern_directive`] so clippy's
+/// `items_after_statements` lint stays happy.
 fn intern_typed_vec<T>(
     v: &mut [T],
     interner: &mut StringInterner,
@@ -126,7 +118,12 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
                 &mut dedup_count,
                 rustledger_core::Tag::as_interned_mut,
             );
-            intern_vec(&mut txn.links, interner, &mut dedup_count);
+            intern_typed_vec(
+                &mut txn.links,
+                interner,
+                &mut dedup_count,
+                rustledger_core::Link::as_interned_mut,
+            );
 
             for posting in &mut txn.postings {
                 if do_intern(posting.account.as_interned_mut(), interner) {
@@ -235,7 +232,12 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
                 &mut dedup_count,
                 rustledger_core::Tag::as_interned_mut,
             );
-            intern_vec(&mut doc.links, interner, &mut dedup_count);
+            intern_typed_vec(
+                &mut doc.links,
+                interner,
+                &mut dedup_count,
+                rustledger_core::Link::as_interned_mut,
+            );
         }
         Directive::Price(price) => {
             if do_intern(price.currency.as_interned_mut(), interner) {

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -402,13 +402,13 @@ fn parse_tag(stream: &mut TokenStream<'_>) -> ParseRes<rustledger_core::Tag> {
     Err(())
 }
 
-fn parse_link(stream: &mut TokenStream<'_>) -> ParseRes<InternedStr> {
+fn parse_link(stream: &mut TokenStream<'_>) -> ParseRes<rustledger_core::Link> {
     if let Some(t) = stream.peek()
         && let Token::Link(s) = &t.token
     {
         let result = stream.interner.intern(&s[1..]); // Skip ^
         stream.advance();
-        return Ok(result);
+        return Ok(result.into());
     }
     Err(())
 }
@@ -1164,7 +1164,7 @@ fn parse_transaction_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedI
     // Tags and links — Vec::new() avoids an upfront heap allocation
     // when no tags/links are present (the common case).
     let mut tags: Vec<rustledger_core::Tag> = Vec::new();
-    let mut links: Vec<InternedStr> = Vec::new();
+    let mut links: Vec<rustledger_core::Link> = Vec::new();
 
     loop {
         if let Ok(tag) = parse_tag(stream) {
@@ -1557,7 +1557,7 @@ fn parse_document_directive(stream: &mut TokenStream<'_>) -> ParseRes<ParsedItem
 
     // Optional tags and links — Vec::new() avoids allocation when absent
     let mut tags: Vec<rustledger_core::Tag> = Vec::new();
-    let mut links: Vec<InternedStr> = Vec::new();
+    let mut links: Vec<rustledger_core::Link> = Vec::new();
     loop {
         if let Ok(tag) = parse_tag(stream) {
             tags.push(tag);


### PR DESCRIPTION
## Summary

Fourth and final newtype slice for [#1163](https://github.com/rustledger/rustledger/issues/1163). Wraps the \`links: Vec<InternedStr>\` fields on \`Transaction\` and \`Document\` behind the existing \`Link\` newtype.

**Issue #1163 AST coverage is now complete** (Currency in #1169, Account in #1171, Tag in #1172, Link here). The remaining \`MetaValue::{Account, Currency, Tag, Link}\` String variants are a separate design call and stay deferred.

## What changed

**AST fields**:
- \`Transaction.links: Vec<crate::Link>\` (was \`Vec<InternedStr>\`)
- \`Document.links: Vec<crate::Link>\`
- \`with_link\` constructors take \`impl Into<Link>\`

**Parser**:
- \`parse_link\` returns \`Link\` (was \`InternedStr\`)

**Loader dedup**:
- \`intern_typed_vec(&mut txn.links, ..., Link::as_interned_mut)\` for both Transaction and Document link slices
- **Dropped the now-unused \`intern_vec\` helper** — all four \`Vec<InternedStr>\` fields it served (tags, links on Transaction and Document) now go through the typed variant
- Renamed and re-documented the surviving \`intern_typed_vec\` helper to mention all four newtypes

**Cleanup**:
- Removed the unused \`AsVecInternedStr\` import from \`directive.rs\` (no remaining \`Vec<InternedStr>\` field needs the rkyv wrapper)

## Performance

- \`Link\` is \`#[repr(transparent)]\` over \`InternedStr\`; \`Hash\` / \`Eq\` delegate
- Loader dedup still hits the \`Arc::ptr_eq\` fast path via \`as_interned_mut()\`
- No new allocations

## #1163 status after this PR

| Newtype | Status |
|---------|--------|
| Currency | ✅ #1169 |
| Account | ✅ #1171 |
| Tag | ✅ #1172 |
| Link | ✅ this PR |
| \`MetaValue::*\` String variants | deferred — separate design |

The architectural goal of #1163 (compiler distinguishes the four identifier kinds at AST positions) is now met.

## Test plan

- [x] \`cargo check --workspace --all-features --all-targets\` — clean
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p rustledger-core -p rustledger-parser -p rustledger-loader -p rustledger-validate --all-features\` — pass
- [ ] CI full workspace + compat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)