### PR TITLE
refactor(core): factor PriceAnnotation orthogonal axes (closes #1167)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -292,13 +292,14 @@ impl BookingEngine {
                             // Calculate capital gain if there's a price
                             if let Some(cost_basis) = &booking_result.cost_basis
                                 && let Some(price) = &posting.price
+                                && let Some(amt) =
+                                    price.amount.as_ref().and_then(IncompleteAmount::as_amount)
                             {
-                                let sale_price = match price {
-                                    rustledger_core::PriceAnnotation::Unit(a) => {
-                                        a.number * units.number.abs()
+                                let sale_price = match price.kind {
+                                    rustledger_core::PriceKind::Unit => {
+                                        amt.number * units.number.abs()
                                     }
-                                    rustledger_core::PriceAnnotation::Total(a) => a.number,
-                                    _ => continue,
+                                    rustledger_core::PriceKind::Total => amt.number,
                                 };
 
                                 let gain_amount = sale_price - cost_basis.number;
@@ -347,21 +348,15 @@ impl BookingEngine {
                     // Cost spec has a number but may be missing date or currency
                     // Fill in missing parts from price annotation, other postings, and transaction date
                     let inferred_currency = cost_spec.currency.clone().or_else(|| {
-                        // First try price annotation on this posting
+                        // First try price annotation on this posting.
+                        // `kind` (Unit vs Total) doesn't change the currency,
+                        // so it's irrelevant here — we just want whatever
+                        // currency the price names, complete or incomplete.
                         posting
                                 .price
                                 .as_ref()
-                                .and_then(|p| match p {
-                                    rustledger_core::PriceAnnotation::Unit(a)
-                                    | rustledger_core::PriceAnnotation::Total(a) => {
-                                        Some(a.currency.clone())
-                                    }
-                                    rustledger_core::PriceAnnotation::UnitIncomplete(inc)
-                                    | rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                                        inc.currency().map(Into::into)
-                                    }
-                                    _ => None,
-                                })
+                                .and_then(|p| p.amount.as_ref())
+                                .and_then(|inc| inc.currency().map(Into::into))
                                 // Then try inferring from other postings in the transaction
                                 .or_else(|| crate::infer_cost_currency_from_postings(txn))
                     });
@@ -469,24 +464,15 @@ impl BookingEngine {
                             None
                         };
 
-                        // Infer cost currency from price annotation or other postings
+                        // Infer cost currency from price annotation or other postings.
+                        // `kind` doesn't affect the currency — see the parallel
+                        // block above for the same pattern.
                         let cost_currency = cost_spec.currency.clone().or_else(|| {
-                            // First try price annotation on this posting
                             posting
                                 .price
                                 .as_ref()
-                                .and_then(|p| match p {
-                                    rustledger_core::PriceAnnotation::Unit(a)
-                                    | rustledger_core::PriceAnnotation::Total(a) => {
-                                        Some(a.currency.clone())
-                                    }
-                                    rustledger_core::PriceAnnotation::UnitIncomplete(inc)
-                                    | rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                                        inc.currency().map(Into::into)
-                                    }
-                                    _ => None,
-                                })
-                                // Then try inferring from other postings in the transaction
+                                .and_then(|p| p.amount.as_ref())
+                                .and_then(|inc| inc.currency().map(Into::into))
                                 .or_else(|| crate::infer_cost_currency_from_postings(txn))
                         });
 
@@ -623,7 +609,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL"))
                     .with_cost(CostSpec::empty()) // Empty - needs lot matching
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(175.00), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(175.00), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:Cash",
@@ -722,7 +708,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-1.763), "VIIIX"))
                     .with_cost(CostSpec::empty())
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(191.00), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(191.00), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:Cash",
@@ -751,7 +737,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-1), "AAPL"))
                     .with_cost(CostSpec::empty().with_number_per(dec!(40.0)))
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(0.4), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(0.4), "USD"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Stock", Amount::new(dec!(40.0), "USD")));
 
@@ -814,7 +800,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(PriceAnnotation::Total(Amount::new(dec!(875.00), "USD"))),
+                    .with_price(PriceAnnotation::total(Amount::new(dec!(875.00), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:Cash",
@@ -852,7 +838,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(175.00), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(175.00), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:Cash",
@@ -956,7 +942,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(150.00), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(150.00), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:Cash",
@@ -1202,7 +1188,7 @@ mod tests {
         let sell = Transaction::new(date(2024, 1, 15), "Sell 25 HOOG without cost spec")
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(-25), "HOOG"))
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.60), "EUR"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(1.60), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(40), "EUR")));
 

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -257,45 +257,21 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         *cost_unknowns_by_currency.entry(curr).or_default() += 1;
                     }
                 } else if let Some(price) = &posting.price {
-                    // Price annotation: converts units to price currency
-                    // Note: We do NOT track scale from per-unit prices (they're multipliers).
-                    // We DO track scale from total prices (they're explicit amounts).
-                    match price {
-                        rustledger_core::PriceAnnotation::Unit(price_amt) => {
-                            let converted = amount.number.abs() * price_amt.number;
-                            *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                converted * amount.number.signum();
-                        }
-                        rustledger_core::PriceAnnotation::Total(price_amt) => {
-                            // Total price is an explicit amount — track its
-                            // scale only when non-integer, matching the
-                            // posting.units rule above. An integer `@@ 1 USD`
-                            // shouldn't quantize an elided same-currency
-                            // residual to whole units.
-                            let scale = price_amt.number.scale();
-                            if scale > 0 {
-                                max_scale_by_currency
-                                    .entry(price_amt.currency.clone())
-                                    .and_modify(|s| *s = (*s).max(scale))
-                                    .or_insert(scale);
-                            }
-                            *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                price_amt.number * amount.number.signum();
-                        }
-                        rustledger_core::PriceAnnotation::UnitIncomplete(inc) => {
-                            if let Some(price_amt) = inc.as_amount() {
-                                let converted = amount.number.abs() * price_amt.number;
-                                *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                    converted * amount.number.signum();
-                            } else {
-                                // Can't calculate, fall back to units
-                                *residuals.entry(amount.currency.clone()).or_default() +=
-                                    amount.number;
-                            }
-                        }
-                        rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                            if let Some(price_amt) = inc.as_amount() {
-                                // Same filter as the Total branch above.
+                    // Price annotation: converts units to price currency.
+                    // Scale tracking: per-unit prices are multipliers, so we
+                    // do NOT track their scale. Total prices are explicit
+                    // amounts, so we DO track theirs (non-integer scale
+                    // only — an integer `@@ 1 USD` shouldn't quantize an
+                    // elided same-currency residual to whole units).
+                    if let Some(price_amt) =
+                        price.amount.as_ref().and_then(IncompleteAmount::as_amount)
+                    {
+                        let (curr, signed) = match price.kind {
+                            rustledger_core::PriceKind::Unit => (
+                                price_amt.currency.clone(),
+                                amount.number.abs() * price_amt.number * amount.number.signum(),
+                            ),
+                            rustledger_core::PriceKind::Total => {
                                 let scale = price_amt.number.scale();
                                 if scale > 0 {
                                     max_scale_by_currency
@@ -303,19 +279,16 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                                         .and_modify(|s| *s = (*s).max(scale))
                                         .or_insert(scale);
                                 }
-                                *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                    price_amt.number * amount.number.signum();
-                            } else {
-                                // Can't calculate, fall back to units
-                                *residuals.entry(amount.currency.clone()).or_default() +=
-                                    amount.number;
+                                (
+                                    price_amt.currency.clone(),
+                                    price_amt.number * amount.number.signum(),
+                                )
                             }
-                        }
-                        // Empty price annotations - fall back to units
-                        rustledger_core::PriceAnnotation::UnitEmpty
-                        | rustledger_core::PriceAnnotation::TotalEmpty => {
-                            *residuals.entry(amount.currency.clone()).or_default() += amount.number;
-                        }
+                        };
+                        *residuals.entry(curr).or_default() += signed;
+                    } else {
+                        // Incomplete/empty price annotation — fall back to units
+                        *residuals.entry(amount.currency.clone()).or_default() += amount.number;
                     }
                 } else {
                     // Simple posting: weight is just the units
@@ -337,16 +310,15 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                     .as_ref()
                     .and_then(|c| c.currency.clone())
                     .or_else(|| {
-                        posting.price.as_ref().and_then(|p| match p {
-                            rustledger_core::PriceAnnotation::Unit(a) => Some(a.currency.clone()),
-                            rustledger_core::PriceAnnotation::Total(a) => Some(a.currency.clone()),
-                            rustledger_core::PriceAnnotation::UnitIncomplete(inc)
-                            | rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                                inc.as_amount().map(|a| a.currency.clone())
-                            }
-                            rustledger_core::PriceAnnotation::UnitEmpty
-                            | rustledger_core::PriceAnnotation::TotalEmpty => None,
-                        })
+                        // Pull currency from the price's complete amount,
+                        // regardless of kind. Incomplete/empty prices
+                        // contribute nothing here.
+                        posting
+                            .price
+                            .as_ref()
+                            .and_then(|p| p.amount.as_ref())
+                            .and_then(IncompleteAmount::as_amount)
+                            .map(|a| a.currency.clone())
                     });
 
                 if let Some(curr) = currency {
@@ -861,7 +833,7 @@ mod tests {
                             .with_number_per(dec!(100.00))
                             .with_currency("USD"),
                     )
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(120.00),
                         "USD",
                     ))),
@@ -1389,7 +1361,7 @@ mod tests {
                     Amount::new(dec!(-13000.00), "SH513050"),
                 )
                 .with_cost(CostSpec::empty()) // empty `{}` — unknown cost
-                .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                     dec!(1.300),
                     "CNY",
                 ))),
@@ -1433,7 +1405,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(150),
                         "USD",
                     ))),
@@ -1457,7 +1429,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:StockA", Amount::new(dec!(-10), "AAPL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(150),
                         "USD",
                     ))),
@@ -1465,7 +1437,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:StockB", Amount::new(dec!(-5), "GOOG"))
                     .with_cost(CostSpec::empty())
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(2000),
                         "USD",
                     ))),
@@ -1491,7 +1463,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(CostSpec::empty()) // cost-unknown in USD
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(150),
                         "USD",
                     ))),
@@ -1544,7 +1516,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Brokerage", Amount::new(dec!(-1.763), "STOCK"))
                     .with_cost(cost_spec)
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(191.00),
                         "USD",
                     ))),
@@ -1622,7 +1594,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Brokerage", Amount::new(dec!(-1.763), "STOCK"))
                     .with_cost(CostSpec::empty())
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(191.00), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(191.00), "USD"))),
             )
             .with_synthesized_posting(Posting::auto("Income:Capital-Gains"));
 
@@ -1669,7 +1641,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(150),
                         "USD",
                     ))),

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -57,24 +57,45 @@ pub fn calculate_tolerance(amounts: &[&Amount]) -> HashMap<Currency, Decimal> {
 
 /// Extract the currency named in a posting's price annotation, if any.
 ///
-/// Walks all `PriceAnnotation` shapes — `Unit`, `Total`, the `Incomplete`
-/// variants when they carry a complete amount, and the empty variants
-/// (which return `None`). Used by the booking residual computations and
-/// interpolation to look up a posting's price-side currency without
-/// duplicating the match in three places.
+/// Returns the currency on `IncompleteAmount::Complete`. `CurrencyOnly`,
+/// `NumberOnly`, and the bare-sigil form (`amount: None`) all return
+/// `None` — they're shapes where the currency is either missing or
+/// supplied later by interpolation. `kind` (Unit vs Total) is irrelevant
+/// at this layer.
 #[must_use]
 pub(crate) fn price_currency_of(posting: &rustledger_core::Posting) -> Option<Currency> {
-    posting.price.as_ref().and_then(|p| match p {
-        rustledger_core::PriceAnnotation::Unit(a) | rustledger_core::PriceAnnotation::Total(a) => {
-            Some(a.currency.clone())
-        }
-        rustledger_core::PriceAnnotation::UnitIncomplete(inc)
-        | rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-            inc.as_amount().map(|a| a.currency.clone())
-        }
-        rustledger_core::PriceAnnotation::UnitEmpty
-        | rustledger_core::PriceAnnotation::TotalEmpty => None,
-    })
+    posting
+        .price
+        .as_ref()
+        .and_then(|p| p.amount.as_ref())
+        .and_then(IncompleteAmount::as_amount)
+        .map(|a| a.currency.clone())
+}
+
+/// Compute the (currency, signed contribution) a price annotation
+/// adds to a transaction's residual for the given units.
+///
+/// `kind = Unit` ⇒ contribution is `|units| * price * sign(units)`;
+/// `kind = Total` ⇒ contribution is `price * sign(units)`.
+///
+/// Returns `None` for incomplete/empty price annotations where the
+/// currency or number is missing — the caller falls back to weighing
+/// the posting in its units currency. Used by both `calculate_residual`
+/// and `calculate_residual_precise` so the Unit-vs-Total semantics
+/// live in one place.
+fn price_residual_contribution(
+    price: &rustledger_core::PriceAnnotation,
+    units: &rustledger_core::Amount,
+) -> Option<(Currency, Decimal)> {
+    let amt = price
+        .amount
+        .as_ref()
+        .and_then(IncompleteAmount::as_amount)?;
+    let signed = match price.kind {
+        rustledger_core::PriceKind::Unit => units.number.abs() * amt.number * units.number.signum(),
+        rustledger_core::PriceKind::Total => amt.number * units.number.signum(),
+    };
+    Some((amt.currency.clone(), signed))
 }
 
 /// Infer the cost currency from other postings in the transaction.
@@ -102,20 +123,8 @@ pub(crate) fn infer_cost_currency_from_postings(transaction: &Transaction) -> Op
                 IncompleteAmount::Complete(amount) => {
                     // If this posting has a price annotation, the "real" currency
                     // is the price currency, not the units currency
-                    if let Some(price) = &posting.price {
-                        match price {
-                            rustledger_core::PriceAnnotation::Unit(a)
-                            | rustledger_core::PriceAnnotation::Total(a) => {
-                                return Some(a.currency.clone());
-                            }
-                            rustledger_core::PriceAnnotation::UnitIncomplete(inc)
-                            | rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                                if let Some(a) = inc.as_amount() {
-                                    return Some(a.currency.clone());
-                                }
-                            }
-                            _ => {}
-                        }
+                    if let Some(c) = price_currency_of(posting) {
+                        return Some(c);
                     }
                     // Simple posting - use its currency
                     return Some(amount.currency.clone());
@@ -221,41 +230,12 @@ pub fn calculate_residual(transaction: &Transaction) -> HashMap<Currency, Decima
             } else if let Some(price) = &posting.price {
                 // Price annotation: converts units to price currency for balance purposes.
                 // The weight is in the price currency, not the units currency.
-                match price {
-                    rustledger_core::PriceAnnotation::Unit(price_amt) => {
-                        let converted = units.number.abs() * price_amt.number;
-                        *residuals.entry(price_amt.currency.clone()).or_default() +=
-                            converted * units.number.signum();
-                    }
-                    rustledger_core::PriceAnnotation::Total(price_amt) => {
-                        *residuals.entry(price_amt.currency.clone()).or_default() +=
-                            price_amt.number * units.number.signum();
-                    }
-                    // Incomplete price annotations - extract what we can
-                    rustledger_core::PriceAnnotation::UnitIncomplete(inc) => {
-                        if let Some(price_amt) = inc.as_amount() {
-                            let converted = units.number.abs() * price_amt.number;
-                            *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                converted * units.number.signum();
-                        } else {
-                            // Can't calculate price conversion, fall back to units
-                            *residuals.entry(units.currency.clone()).or_default() += units.number;
-                        }
-                    }
-                    rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                        if let Some(price_amt) = inc.as_amount() {
-                            *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                price_amt.number * units.number.signum();
-                        } else {
-                            // Can't calculate price conversion, fall back to units
-                            *residuals.entry(units.currency.clone()).or_default() += units.number;
-                        }
-                    }
-                    // Empty price annotations - fall back to units
-                    rustledger_core::PriceAnnotation::UnitEmpty
-                    | rustledger_core::PriceAnnotation::TotalEmpty => {
-                        *residuals.entry(units.currency.clone()).or_default() += units.number;
-                    }
+                if let Some((curr, contribution)) = price_residual_contribution(price, units) {
+                    *residuals.entry(curr).or_default() += contribution;
+                } else {
+                    // Incomplete or bare-sigil price annotation — can't
+                    // calculate a price-currency conversion, fall back to units.
+                    *residuals.entry(units.currency.clone()).or_default() += units.number;
                 }
             } else {
                 // Simple posting: weight is just the units
@@ -335,40 +315,23 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Currency
                 // to the price branch produces a wrong-weight balanced
                 // residual (issue #1026).
             } else if let Some(price) = &posting.price {
-                match price {
-                    rustledger_core::PriceAnnotation::Unit(price_amt) => {
-                        let converted = units_number.abs() * to_big(price_amt.number);
-                        *residuals.entry(price_amt.currency.clone()).or_default() +=
-                            converted * to_big(units.number.signum());
-                    }
-                    rustledger_core::PriceAnnotation::Total(price_amt) => {
-                        *residuals.entry(price_amt.currency.clone()).or_default() +=
-                            to_big(price_amt.number) * to_big(units.number.signum());
-                    }
-                    rustledger_core::PriceAnnotation::UnitIncomplete(inc) => {
-                        if let Some(price_amt) = inc.as_amount() {
-                            let converted = units_number.abs() * to_big(price_amt.number);
-                            *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                converted * to_big(units.number.signum());
-                        } else {
-                            *residuals.entry(units.currency.clone()).or_default() +=
-                                units_number.clone();
+                // Same Unit/Total semantics as `calculate_residual`, but
+                // running through BigDecimal to avoid 28-digit precision
+                // loss. Inline because the `BigDecimal` math doesn't fit
+                // the shared `price_residual_contribution` (which returns
+                // `Decimal`).
+                if let Some(amt) = price.amount.as_ref().and_then(IncompleteAmount::as_amount) {
+                    let signed = match price.kind {
+                        rustledger_core::PriceKind::Unit => {
+                            units_number.abs() * to_big(amt.number) * to_big(units.number.signum())
                         }
-                    }
-                    rustledger_core::PriceAnnotation::TotalIncomplete(inc) => {
-                        if let Some(price_amt) = inc.as_amount() {
-                            *residuals.entry(price_amt.currency.clone()).or_default() +=
-                                to_big(price_amt.number) * to_big(units.number.signum());
-                        } else {
-                            *residuals.entry(units.currency.clone()).or_default() +=
-                                units_number.clone();
+                        rustledger_core::PriceKind::Total => {
+                            to_big(amt.number) * to_big(units.number.signum())
                         }
-                    }
-                    rustledger_core::PriceAnnotation::UnitEmpty
-                    | rustledger_core::PriceAnnotation::TotalEmpty => {
-                        *residuals.entry(units.currency.clone()).or_default() +=
-                            units_number.clone();
-                    }
+                    };
+                    *residuals.entry(amt.currency.clone()).or_default() += signed;
+                } else {
+                    *residuals.entry(units.currency.clone()).or_default() += units_number.clone();
                 }
             } else {
                 *residuals.entry(units.currency.clone()).or_default() += units_number;
@@ -404,33 +367,32 @@ pub fn is_balanced(transaction: &Transaction, tolerances: &HashMap<Currency, Dec
 ///
 /// Matches Python beancount behavior where `@@` is converted to `@`.
 pub fn normalize_prices(txn: &mut Transaction) {
-    use rustledger_core::PriceAnnotation;
+    use rustledger_core::{PriceAnnotation, PriceKind};
 
     for posting in &mut txn.postings {
         if let (Some(IncompleteAmount::Complete(units)), Some(price)) =
             (&posting.units, &posting.price)
+            && price.kind == PriceKind::Total
         {
-            let normalized = match price {
-                PriceAnnotation::Total(total_amount) if !units.number.is_zero() => {
+            let normalized = match price.amount.as_ref().and_then(IncompleteAmount::as_amount) {
+                Some(total_amount) if !units.number.is_zero() => {
                     let per_unit = total_amount.number / units.number.abs();
-                    Some(PriceAnnotation::Unit(Amount::new(
+                    Some(PriceAnnotation::unit(Amount::new(
                         per_unit,
                         &total_amount.currency,
                     )))
                 }
-                PriceAnnotation::TotalIncomplete(inc) if !units.number.is_zero() => {
-                    if let Some(total_amount) = inc.as_amount() {
-                        let per_unit = total_amount.number / units.number.abs();
-                        Some(PriceAnnotation::Unit(Amount::new(
-                            per_unit,
-                            &total_amount.currency,
-                        )))
+                Some(_) => None, // units.number is zero — leave alone
+                None => {
+                    // Empty (`@@` with no amount) — Total → Unit sigil swap.
+                    // `total_incomplete` with no complete amount cannot be
+                    // normalized because we don't have a number to divide.
+                    if price.amount.is_none() {
+                        Some(PriceAnnotation::unit_empty())
                     } else {
                         None
                     }
                 }
-                PriceAnnotation::TotalEmpty => Some(PriceAnnotation::UnitEmpty),
-                _ => None,
             };
             if let Some(normalized_price) = normalized {
                 posting.price = Some(normalized_price);
@@ -652,7 +614,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(150),
                         "USD",
                     ))),
@@ -679,7 +641,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(CostSpec::empty())
-                    .with_price(rustledger_core::PriceAnnotation::Unit(Amount::new(
+                    .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
                         dec!(150),
                         "USD",
                     ))),
@@ -704,7 +666,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Currency exchange")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(-100.00), "USD"))
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(0.85), "EUR"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(0.85), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR")));
 
@@ -723,7 +685,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Currency exchange")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(-100.00), "USD"))
-                    .with_price(PriceAnnotation::Total(Amount::new(dec!(85.00), "EUR"))),
+                    .with_price(PriceAnnotation::total(Amount::new(dec!(85.00), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR")));
 
@@ -739,7 +701,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Buy EUR")
             .with_synthesized_posting(
                 Posting::new("Assets:EUR", Amount::new(dec!(85.00), "EUR"))
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.18), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(1.18), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:USD",
@@ -758,7 +720,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Exchange")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(-100.00), "USD")).with_price(
-                    PriceAnnotation::UnitIncomplete(IncompleteAmount::Complete(Amount::new(
+                    PriceAnnotation::unit_incomplete(IncompleteAmount::Complete(Amount::new(
                         dec!(0.85),
                         "EUR",
                     ))),
@@ -776,7 +738,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Exchange")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(-100.00), "USD")).with_price(
-                    PriceAnnotation::TotalIncomplete(IncompleteAmount::Complete(Amount::new(
+                    PriceAnnotation::total_incomplete(IncompleteAmount::Complete(Amount::new(
                         dec!(85.00),
                         "EUR",
                     ))),
@@ -794,7 +756,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(100.00), "USD")).with_price(
-                    PriceAnnotation::UnitIncomplete(IncompleteAmount::NumberOnly(dec!(0.85))),
+                    PriceAnnotation::unit_incomplete(IncompleteAmount::NumberOnly(dec!(0.85))),
                 ),
             )
             .with_synthesized_posting(Posting::new(
@@ -813,7 +775,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(100.00), "USD")).with_price(
-                    PriceAnnotation::TotalIncomplete(IncompleteAmount::NumberOnly(dec!(85.00))),
+                    PriceAnnotation::total_incomplete(IncompleteAmount::NumberOnly(dec!(85.00))),
                 ),
             )
             .with_synthesized_posting(Posting::new(
@@ -831,7 +793,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(100.00), "USD"))
-                    .with_price(PriceAnnotation::UnitEmpty),
+                    .with_price(PriceAnnotation::unit_empty()),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:USD",
@@ -849,7 +811,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:USD", Amount::new(dec!(100.00), "USD"))
-                    .with_price(PriceAnnotation::TotalEmpty),
+                    .with_price(PriceAnnotation::total_empty()),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:USD",
@@ -900,7 +862,7 @@ mod tests {
                             .with_number_per(dec!(150.00))
                             .with_currency("USD"),
                     )
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(175.00), "USD"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(175.00), "USD"))),
             )
             .with_synthesized_posting(Posting::new(
                 "Assets:Cash",
@@ -1051,7 +1013,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))
                     .with_cost(CostSpec::empty().with_number_per(dec!(100)))
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(105), "EUR"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(105), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
 

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -283,60 +283,128 @@ impl fmt::Display for Posting {
     }
 }
 
-/// Price annotation for a posting (@ or @@).
+/// Whether a price annotation is per-unit (`@`) or total (`@@`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub enum PriceKind {
+    /// Per-unit price (`@`).
+    Unit,
+    /// Total price for the posting (`@@`).
+    Total,
+}
+
+impl fmt::Display for PriceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Unit => "@",
+            Self::Total => "@@",
+        })
+    }
+}
+
+/// Price annotation for a posting (`@` or `@@`).
 ///
-/// Price annotations can be incomplete (missing number or currency)
-/// before interpolation fills in the missing values.
+/// Factored along its two orthogonal axes (#1167):
+/// - `kind`: per-unit (`@`) vs total (`@@`)
+/// - `amount`: present (possibly with missing number or currency that
+///   interpolation will fill) vs absent (the bare `@`/`@@` sigil
+///   without any amount)
+///
+/// Pre-#1167 these axes were flattened into a 6-variant enum
+/// (`Unit/Total/UnitIncomplete/TotalIncomplete/UnitEmpty/TotalEmpty`),
+/// which forced every consumer to write six match arms even when only
+/// one axis mattered.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-pub enum PriceAnnotation {
-    /// Per-unit price (@) with complete amount
-    Unit(Amount),
-    /// Total price (@@) with complete amount
-    Total(Amount),
-    /// Per-unit price (@) with incomplete amount
-    UnitIncomplete(IncompleteAmount),
-    /// Total price (@@) with incomplete amount
-    TotalIncomplete(IncompleteAmount),
-    /// Empty per-unit price (@ with no amount)
-    UnitEmpty,
-    /// Empty total price (@@ with no amount)
-    TotalEmpty,
+pub struct PriceAnnotation {
+    /// Per-unit (`@`) or total (`@@`).
+    pub kind: PriceKind,
+    /// The price amount, or `None` for the bare-sigil form.
+    /// `IncompleteAmount::Complete` indicates the parser saw a full
+    /// number+currency; the other variants indicate one of those
+    /// pieces was elided and will be filled by interpolation.
+    pub amount: Option<IncompleteAmount>,
 }
 
 impl PriceAnnotation {
-    /// Get the complete amount if available.
+    /// Per-unit (`@`) price with a complete amount.
     #[must_use]
-    pub const fn amount(&self) -> Option<&Amount> {
-        match self {
-            Self::Unit(a) | Self::Total(a) => Some(a),
-            Self::UnitIncomplete(ia) | Self::TotalIncomplete(ia) => ia.as_amount(),
-            Self::UnitEmpty | Self::TotalEmpty => None,
+    pub const fn unit(amount: Amount) -> Self {
+        Self {
+            kind: PriceKind::Unit,
+            amount: Some(IncompleteAmount::Complete(amount)),
         }
     }
 
-    /// Check if this is a per-unit price (@ vs @@).
+    /// Total (`@@`) price with a complete amount.
+    #[must_use]
+    pub const fn total(amount: Amount) -> Self {
+        Self {
+            kind: PriceKind::Total,
+            amount: Some(IncompleteAmount::Complete(amount)),
+        }
+    }
+
+    /// Per-unit (`@`) price with an incomplete amount.
+    #[must_use]
+    pub const fn unit_incomplete(amount: IncompleteAmount) -> Self {
+        Self {
+            kind: PriceKind::Unit,
+            amount: Some(amount),
+        }
+    }
+
+    /// Total (`@@`) price with an incomplete amount.
+    #[must_use]
+    pub const fn total_incomplete(amount: IncompleteAmount) -> Self {
+        Self {
+            kind: PriceKind::Total,
+            amount: Some(amount),
+        }
+    }
+
+    /// Bare per-unit sigil (`@`) with no amount.
+    #[must_use]
+    pub const fn unit_empty() -> Self {
+        Self {
+            kind: PriceKind::Unit,
+            amount: None,
+        }
+    }
+
+    /// Bare total sigil (`@@`) with no amount.
+    #[must_use]
+    pub const fn total_empty() -> Self {
+        Self {
+            kind: PriceKind::Total,
+            amount: None,
+        }
+    }
+
+    /// Get the complete amount if available.
+    #[must_use]
+    pub fn amount(&self) -> Option<&Amount> {
+        self.amount.as_ref().and_then(IncompleteAmount::as_amount)
+    }
+
+    /// Check if this is a per-unit price (`@` vs `@@`).
     #[must_use]
     pub const fn is_unit(&self) -> bool {
-        matches!(
-            self,
-            Self::Unit(_) | Self::UnitIncomplete(_) | Self::UnitEmpty
-        )
+        matches!(self.kind, PriceKind::Unit)
     }
 }
 
 impl fmt::Display for PriceAnnotation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Unit(a) => write!(f, "@ {a}"),
-            Self::Total(a) => write!(f, "@@ {a}"),
-            Self::UnitIncomplete(ia) => write!(f, "@ {ia}"),
-            Self::TotalIncomplete(ia) => write!(f, "@@ {ia}"),
-            Self::UnitEmpty => write!(f, "@"),
-            Self::TotalEmpty => write!(f, "@@"),
+        match &self.amount {
+            Some(amt) => write!(f, "{} {amt}", self.kind),
+            None => write!(f, "{}", self.kind),
         }
     }
 }

--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -305,7 +305,7 @@ mod tests {
                         label: None,
                         merge: false,
                     }),
-                    price: Some(PriceAnnotation::Unit(Amount::new(dec!(1.1), "CHF"))),
+                    price: Some(PriceAnnotation::unit(Amount::new(dec!(1.1), "CHF"))),
                     flag: None,
                     meta: posting_meta,
                     comments: vec![],

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -41,12 +41,12 @@ pub fn format_cost_spec(spec: &CostSpec) -> String {
 
 /// Format a price annotation.
 pub fn format_price_annotation(price: &PriceAnnotation) -> String {
-    match price {
-        PriceAnnotation::Unit(amount) => format!("@ {}", format_amount(amount)),
-        PriceAnnotation::Total(amount) => format!("@@ {}", format_amount(amount)),
-        PriceAnnotation::UnitIncomplete(inc) => format!("@ {}", format_incomplete_amount(inc)),
-        PriceAnnotation::TotalIncomplete(inc) => format!("@@ {}", format_incomplete_amount(inc)),
-        PriceAnnotation::UnitEmpty => "@".to_string(),
-        PriceAnnotation::TotalEmpty => "@@".to_string(),
+    let sigil = price.kind.to_string();
+    match &price.amount {
+        Some(crate::IncompleteAmount::Complete(amt)) => {
+            format!("{sigil} {}", format_amount(amt))
+        }
+        Some(inc) => format!("{sigil} {}", format_incomplete_amount(inc)),
+        None => sigil,
     }
 }

--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -353,37 +353,37 @@ mod tests {
 
     #[test]
     fn test_format_price_annotation_unit() {
-        let price = PriceAnnotation::Unit(Amount::new(dec!(150.00), "USD"));
+        let price = PriceAnnotation::unit(Amount::new(dec!(150.00), "USD"));
         assert_eq!(format_price_annotation(&price), "@ 150.00 USD");
     }
 
     #[test]
     fn test_format_price_annotation_total() {
-        let price = PriceAnnotation::Total(Amount::new(dec!(1500.00), "USD"));
+        let price = PriceAnnotation::total(Amount::new(dec!(1500.00), "USD"));
         assert_eq!(format_price_annotation(&price), "@@ 1500.00 USD");
     }
 
     #[test]
     fn test_format_price_annotation_unit_incomplete() {
-        let price = PriceAnnotation::UnitIncomplete(IncompleteAmount::NumberOnly(dec!(150.00)));
+        let price = PriceAnnotation::unit_incomplete(IncompleteAmount::NumberOnly(dec!(150.00)));
         assert_eq!(format_price_annotation(&price), "@ 150.00");
     }
 
     #[test]
     fn test_format_price_annotation_total_incomplete() {
-        let price = PriceAnnotation::TotalIncomplete(IncompleteAmount::CurrencyOnly("USD".into()));
+        let price = PriceAnnotation::total_incomplete(IncompleteAmount::CurrencyOnly("USD".into()));
         assert_eq!(format_price_annotation(&price), "@@ USD");
     }
 
     #[test]
     fn test_format_price_annotation_unit_empty() {
-        let price = PriceAnnotation::UnitEmpty;
+        let price = PriceAnnotation::unit_empty();
         assert_eq!(format_price_annotation(&price), "@");
     }
 
     #[test]
     fn test_format_price_annotation_total_empty() {
-        let price = PriceAnnotation::TotalEmpty;
+        let price = PriceAnnotation::total_empty();
         assert_eq!(format_price_annotation(&price), "@@");
     }
 
@@ -786,7 +786,7 @@ mod tests {
                 label: None,
                 merge: false,
             }),
-            price: Some(PriceAnnotation::Unit(Amount::new(dec!(155.00), "USD"))),
+            price: Some(PriceAnnotation::unit(Amount::new(dec!(155.00), "USD"))),
             meta: Default::default(),
             comments: Vec::new(),
             trailing_comments: Vec::new(),

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -64,7 +64,7 @@ pub use amount::{Amount, IncompleteAmount};
 pub use cost::{Cost, CostSpec};
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
-    Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, Query, Transaction,
+    Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,
     parse_precision_meta, sort_directives,
 };
 pub use display_context::{DEFAULT_CURRENCY, DisplayContext, Precision};

--- a/crates/rustledger-core/src/visit.rs
+++ b/crates/rustledger-core/src/visit.rs
@@ -37,7 +37,7 @@
 //! the parser's index. Separating the concerns keeps the AST
 //! value types pure.
 
-use crate::{Directive, MetaValue, Metadata, PriceAnnotation};
+use crate::{Directive, IncompleteAmount, MetaValue, Metadata, PriceAnnotation};
 
 /// Walk every position a currency name can appear in this directive,
 /// invoking `visit` once per occurrence.
@@ -49,7 +49,7 @@ use crate::{Directive, MetaValue, Metadata, PriceAnnotation};
 /// - `Price` directive (base `currency` and `amount.currency`)
 /// - `Posting.units.currency()` (units side, including `CurrencyOnly`)
 /// - `Posting.cost.currency` (cost spec)
-/// - `Posting.price` (all 6 `PriceAnnotation` variants)
+/// - `Posting.price` (any `PriceAnnotation`, regardless of `kind`)
 /// - `MetaValue::Currency` / `MetaValue::Amount` in any directive's
 ///   or posting's metadata block
 /// - `Custom.values` entries that are `MetaValue::Currency` or
@@ -230,14 +230,18 @@ fn visit_meta_value_account<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a str
 }
 
 fn visit_price_currency<'a>(price: &'a PriceAnnotation, visit: &mut impl FnMut(&'a str)) {
-    match price {
-        PriceAnnotation::Unit(a) | PriceAnnotation::Total(a) => visit(a.currency.as_str()),
-        PriceAnnotation::UnitIncomplete(ia) | PriceAnnotation::TotalIncomplete(ia) => {
-            if let Some(c) = ia.currency() {
+    // Post-#1167: PriceAnnotation factors into orthogonal kind+amount
+    // axes, so the six pre-#1167 arms collapse to one inspection of
+    // `amount`. The `kind` (Unit vs Total) is irrelevant for currency
+    // extraction.
+    match &price.amount {
+        Some(IncompleteAmount::Complete(amt)) => visit(amt.currency.as_str()),
+        Some(inc) => {
+            if let Some(c) = inc.currency() {
                 visit(c);
             }
         }
-        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => {}
+        None => {}
     }
 }
 
@@ -335,7 +339,7 @@ mod tests {
                         label: None,
                         merge: false,
                     }),
-                    price: Some(PriceAnnotation::Unit(Amount::new(dec!(1), "USD"))),
+                    price: Some(PriceAnnotation::unit(Amount::new(dec!(1), "USD"))),
                     flag: None,
                     meta: Default::default(),
                     comments: vec![],
@@ -493,23 +497,23 @@ mod tests {
         };
 
         // Unit + Total: each surface one currency.
-        let unit = Directive::Transaction(txn(PriceAnnotation::Unit(Amount::new(dec!(1), "USD"))));
+        let unit = Directive::Transaction(txn(PriceAnnotation::unit(Amount::new(dec!(1), "USD"))));
         let total =
-            Directive::Transaction(txn(PriceAnnotation::Total(Amount::new(dec!(1), "EUR"))));
+            Directive::Transaction(txn(PriceAnnotation::total(Amount::new(dec!(1), "EUR"))));
         // Incomplete-Complete + Incomplete-CurrencyOnly both have a
         // currency; Incomplete-NumberOnly does not.
-        let inc_complete = Directive::Transaction(txn(PriceAnnotation::UnitIncomplete(
+        let inc_complete = Directive::Transaction(txn(PriceAnnotation::unit_incomplete(
             crate::IncompleteAmount::Complete(Amount::new(dec!(1), "GBP")),
         )));
-        let inc_curr = Directive::Transaction(txn(PriceAnnotation::TotalIncomplete(
+        let inc_curr = Directive::Transaction(txn(PriceAnnotation::total_incomplete(
             crate::IncompleteAmount::CurrencyOnly("JPY".into()),
         )));
-        let inc_num = Directive::Transaction(txn(PriceAnnotation::UnitIncomplete(
+        let inc_num = Directive::Transaction(txn(PriceAnnotation::unit_incomplete(
             crate::IncompleteAmount::NumberOnly(dec!(1)),
         )));
         // Empty variants surface nothing.
-        let unit_empty = Directive::Transaction(txn(PriceAnnotation::UnitEmpty));
-        let total_empty = Directive::Transaction(txn(PriceAnnotation::TotalEmpty));
+        let unit_empty = Directive::Transaction(txn(PriceAnnotation::unit_empty()));
+        let total_empty = Directive::Transaction(txn(PriceAnnotation::total_empty()));
 
         let directives = vec![
             unit,

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -239,7 +239,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                     });
 
                     let price = p.price.as_ref().map(|pr| {
-                        rustledger_core::PriceAnnotation::Unit(rustledger_core::Amount {
+                        rustledger_core::PriceAnnotation::unit(rustledger_core::Amount {
                             number: rustledger_core::Decimal::from_str_exact(&pr.number)
                                 .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
                             currency: pr.currency.clone().into(),

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -214,7 +214,11 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     fields) changed their archive wrappers. Bumping the version
 ///     forces regeneration so we don't risk rkyv reading old bytes
 ///     into a structurally-different `ArchivedMetaValue`.
-const CACHE_VERSION: u32 = 6;
+/// v7: `PriceAnnotation` refactored from 6-variant enum to
+///     `{ kind: PriceKind, amount: Option<IncompleteAmount> }`
+///     (#1167). Old cache bytes for the enum's discriminant would
+///     deserialize as nonsense in the new struct layout.
+const CACHE_VERSION: u32 = 7;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]

--- a/crates/rustledger-loader/src/dedup.rs
+++ b/crates/rustledger-loader/src/dedup.rs
@@ -25,9 +25,8 @@
 //! cache-hit path in `rustledger`'s `check` command and the WASM
 //! parsed-ledger constructor call it explicitly.
 
-use rustledger_core::Directive;
 use rustledger_core::intern::{InternedStr, StringInterner};
-use rustledger_core::{IncompleteAmount, MetaValue, Metadata, PriceAnnotation};
+use rustledger_core::{Directive, IncompleteAmount, MetaValue, Metadata};
 use rustledger_parser::Spanned;
 
 /// Re-intern all strings in directives to deduplicate memory.
@@ -199,29 +198,22 @@ fn reintern_directive(directive: &mut Directive, interner: &mut StringInterner) 
                 {
                     dedup_count += 1;
                 }
-                // Price annotation
-                if let Some(ref mut price) = posting.price {
-                    match price {
-                        PriceAnnotation::Unit(amt) | PriceAnnotation::Total(amt) => {
+                // Price annotation: walk whichever amount shape it
+                // carries; `kind` (Unit vs Total) doesn't carry an
+                // interned string.
+                if let Some(price) = &mut posting.price {
+                    match &mut price.amount {
+                        Some(IncompleteAmount::Complete(amt)) => {
                             if do_intern(amt.currency.as_interned_mut(), interner) {
                                 dedup_count += 1;
                             }
                         }
-                        PriceAnnotation::UnitIncomplete(inc)
-                        | PriceAnnotation::TotalIncomplete(inc) => match inc {
-                            IncompleteAmount::Complete(amt) => {
-                                if do_intern(amt.currency.as_interned_mut(), interner) {
-                                    dedup_count += 1;
-                                }
+                        Some(IncompleteAmount::CurrencyOnly(cur)) => {
+                            if do_intern(cur.as_interned_mut(), interner) {
+                                dedup_count += 1;
                             }
-                            IncompleteAmount::CurrencyOnly(cur) => {
-                                if do_intern(cur.as_interned_mut(), interner) {
-                                    dedup_count += 1;
-                                }
-                            }
-                            IncompleteAmount::NumberOnly(_) => {}
-                        },
-                        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => {}
+                        }
+                        Some(IncompleteAmount::NumberOnly(_)) | None => {}
                     }
                 }
             }

--- a/crates/rustledger-lsp/src/ledger_state.rs
+++ b/crates/rustledger-lsp/src/ledger_state.rs
@@ -42,17 +42,15 @@ pub fn discover_journal_file(workspace_root: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Extract currency from a price annotation if available.
+/// Extract currency from a price annotation if available. `kind`
+/// (Unit vs Total) doesn't change the currency; we just walk the
+/// underlying amount.
 fn extract_price_currency(price: &PriceAnnotation) -> Option<String> {
-    match price {
-        PriceAnnotation::Unit(amount) | PriceAnnotation::Total(amount) => {
-            Some(amount.currency.to_string())
-        }
-        PriceAnnotation::UnitIncomplete(inc) | PriceAnnotation::TotalIncomplete(inc) => {
-            inc.currency().map(|c| c.to_string())
-        }
-        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => None,
-    }
+    price
+        .amount
+        .as_ref()
+        .and_then(|inc| inc.currency())
+        .map(str::to_string)
 }
 
 /// Configuration for the LSP server, parsed from initialization options.

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -796,9 +796,9 @@ fn parse_price_annotation(stream: &mut TokenStream<'_>) -> ParseRes<PriceAnnotat
     let save_pos = stream.pos;
     if let Ok(amount) = parse_amount(stream) {
         return Ok(if is_total {
-            PriceAnnotation::Total(amount)
+            PriceAnnotation::total(amount)
         } else {
-            PriceAnnotation::Unit(amount)
+            PriceAnnotation::unit(amount)
         });
     }
     stream.pos = save_pos;
@@ -807,9 +807,9 @@ fn parse_price_annotation(stream: &mut TokenStream<'_>) -> ParseRes<PriceAnnotat
     if let Ok(currency) = parse_currency(stream) {
         let incomplete = IncompleteAmount::CurrencyOnly(currency);
         return Ok(if is_total {
-            PriceAnnotation::TotalIncomplete(incomplete)
+            PriceAnnotation::total_incomplete(incomplete)
         } else {
-            PriceAnnotation::UnitIncomplete(incomplete)
+            PriceAnnotation::unit_incomplete(incomplete)
         });
     }
     stream.pos = save_pos;
@@ -818,9 +818,9 @@ fn parse_price_annotation(stream: &mut TokenStream<'_>) -> ParseRes<PriceAnnotat
     if let Ok(number) = parse_expr(stream) {
         let incomplete = IncompleteAmount::NumberOnly(number);
         return Ok(if is_total {
-            PriceAnnotation::TotalIncomplete(incomplete)
+            PriceAnnotation::total_incomplete(incomplete)
         } else {
-            PriceAnnotation::UnitIncomplete(incomplete)
+            PriceAnnotation::unit_incomplete(incomplete)
         });
     }
     stream.pos = save_pos;

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -183,9 +183,9 @@ pub(super) fn data_to_price_annotation(
     if let Some(amount_data) = &data.amount {
         let amount = data_to_amount(amount_data)?;
         if data.is_total {
-            Ok(PriceAnnotation::Total(amount))
+            Ok(PriceAnnotation::total(amount))
         } else {
-            Ok(PriceAnnotation::Unit(amount))
+            Ok(PriceAnnotation::unit(amount))
         }
     } else if data.number.is_some() || data.currency.is_some() {
         // Incomplete price
@@ -203,16 +203,16 @@ pub(super) fn data_to_price_annotation(
             unreachable!()
         };
         if data.is_total {
-            Ok(PriceAnnotation::TotalIncomplete(incomplete))
+            Ok(PriceAnnotation::total_incomplete(incomplete))
         } else {
-            Ok(PriceAnnotation::UnitIncomplete(incomplete))
+            Ok(PriceAnnotation::unit_incomplete(incomplete))
         }
     } else {
         // Empty price
         if data.is_total {
-            Ok(PriceAnnotation::TotalEmpty)
+            Ok(PriceAnnotation::total_empty())
         } else {
-            Ok(PriceAnnotation::UnitEmpty)
+            Ok(PriceAnnotation::unit_empty())
         }
     }
 }

--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -95,39 +95,22 @@ pub(super) fn cost_to_data(cost: &CostSpec) -> CostData {
 }
 
 pub(super) fn price_annotation_to_data(price: &PriceAnnotation) -> PriceAnnotationData {
-    match price {
-        PriceAnnotation::Unit(amount) => PriceAnnotationData {
-            is_total: false,
+    let is_total = matches!(price.kind, rustledger_core::PriceKind::Total);
+    match &price.amount {
+        Some(rustledger_core::IncompleteAmount::Complete(amount)) => PriceAnnotationData {
+            is_total,
             amount: Some(amount_to_data(amount)),
             number: None,
             currency: None,
         },
-        PriceAnnotation::Total(amount) => PriceAnnotationData {
-            is_total: true,
-            amount: Some(amount_to_data(amount)),
-            number: None,
-            currency: None,
-        },
-        PriceAnnotation::UnitIncomplete(inc) => PriceAnnotationData {
-            is_total: false,
+        Some(inc) => PriceAnnotationData {
+            is_total,
             amount: inc.as_amount().map(amount_to_data),
             number: inc.number().map(|n| n.to_string()),
             currency: inc.currency().map(String::from),
         },
-        PriceAnnotation::TotalIncomplete(inc) => PriceAnnotationData {
-            is_total: true,
-            amount: inc.as_amount().map(amount_to_data),
-            number: inc.number().map(|n| n.to_string()),
-            currency: inc.currency().map(String::from),
-        },
-        PriceAnnotation::UnitEmpty => PriceAnnotationData {
-            is_total: false,
-            amount: None,
-            number: None,
-            currency: None,
-        },
-        PriceAnnotation::TotalEmpty => PriceAnnotationData {
-            is_total: true,
+        None => PriceAnnotationData {
+            is_total,
             amount: None,
             number: None,
             currency: None,

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -337,28 +337,18 @@ impl Executor<'_> {
                 .as_ref()
                 .and_then(|c| c.label.as_ref())
                 .map_or(Value::Null, |l| Value::String(l.clone()))),
-            // Price annotation
+            // Price annotation: return the complete amount (`kind`
+            // doesn't matter for the BQL `price` accessor — Python
+            // bean-query yields the same Amount for `@` and `@@`).
+            // Incomplete amounts or bare-sigil prices return Null.
             "price" => {
-                use rustledger_core::PriceAnnotation;
-                if let Some(price) = &posting.price {
-                    match price {
-                        PriceAnnotation::Unit(amount) | PriceAnnotation::Total(amount) => {
-                            Ok(Value::Amount(amount.clone()))
-                        }
-                        PriceAnnotation::UnitIncomplete(inc)
-                        | PriceAnnotation::TotalIncomplete(inc) => {
-                            // Try to get complete amount from incomplete
-                            if let Some(amount) = inc.as_amount().cloned() {
-                                Ok(Value::Amount(amount))
-                            } else {
-                                Ok(Value::Null)
-                            }
-                        }
-                        PriceAnnotation::UnitEmpty | PriceAnnotation::TotalEmpty => Ok(Value::Null),
-                    }
-                } else {
-                    Ok(Value::Null)
-                }
+                use rustledger_core::IncompleteAmount;
+                Ok(posting
+                    .price
+                    .as_ref()
+                    .and_then(|p| p.amount.as_ref())
+                    .and_then(IncompleteAmount::as_amount)
+                    .map_or(Value::Null, |a| Value::Amount(a.clone())))
             }
             // All accounts in the transaction
             "accounts" => Ok(Value::StringSet(

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -794,7 +794,7 @@ mod tests {
                             .with_number_per(dec!(1.25))
                             .with_currency("EUR"),
                     )
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(7.00), "EUR")));
 
@@ -836,7 +836,7 @@ mod tests {
         let txn = Transaction::new(date(2024, 1, 15), "Sell")
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(-10), "ABC"))
-                    .with_price(PriceAnnotation::Total(Amount::new(dec!(1500), "USD"))),
+                    .with_price(PriceAnnotation::total(Amount::new(dec!(1500), "USD"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(1500), "USD")));
 
@@ -861,7 +861,7 @@ mod tests {
                             .with_number_per(dec!(1.25))
                             .with_currency("EUR"),
                     )
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(7.00), "EUR")));
 
@@ -885,7 +885,7 @@ mod tests {
                         .with_number_per(dec!(50))
                         .with_currency("USD"),
                 )
-                .with_price(PriceAnnotation::Total(Amount::new(dec!(100), "EUR"))),
+                .with_price(PriceAnnotation::total(Amount::new(dec!(100), "EUR"))),
         );
 
         let db = PriceDatabase::from_directives(&[Directive::Transaction(txn)]);
@@ -918,7 +918,7 @@ mod tests {
                             .with_number_per(dec!(1.25))
                             .with_currency("EUR"),
                     )
-                    .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                    .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(7.00), "EUR")));
 
@@ -963,7 +963,7 @@ mod tests {
                                     .with_number_per(dec!(1.25))
                                     .with_currency("EUR"),
                             )
-                            .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                            .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
                     )
                     .with_synthesized_posting(Posting::new(
                         "Assets:Cash",

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7052,7 +7052,7 @@ fn test_postings_table_price_column() {
             Transaction::new(date(2024, 1, 15), "Buy at price")
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL"))
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(150), "USD"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(150), "USD"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Cash",
@@ -7494,7 +7494,7 @@ fn test_postings_table_weight_per_unit_price() {
             Transaction::new(date(2024, 1, 15), "Buy euros")
                 .with_synthesized_posting(
                     Posting::new("Assets:Foreign", Amount::new(dec!(100), "EUR"))
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.10), "USD"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(1.10), "USD"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank",
@@ -7523,7 +7523,7 @@ fn test_postings_table_weight_total_price() {
             Transaction::new(date(2024, 1, 15), "Buy euros")
                 .with_synthesized_posting(
                     Posting::new("Assets:Foreign", Amount::new(dec!(100), "EUR"))
-                        .with_price(PriceAnnotation::Total(Amount::new(dec!(110), "USD"))),
+                        .with_price(PriceAnnotation::total(Amount::new(dec!(110), "USD"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank",
@@ -7553,7 +7553,7 @@ fn test_weight_column_total_price_default_from() {
             Transaction::new(date(2024, 1, 15), "Buy euros")
                 .with_synthesized_posting(
                     Posting::new("Assets:Foreign", Amount::new(dec!(100), "EUR"))
-                        .with_price(PriceAnnotation::Total(Amount::new(dec!(110), "USD"))),
+                        .with_price(PriceAnnotation::total(Amount::new(dec!(110), "USD"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank",
@@ -7587,7 +7587,7 @@ fn test_weight_total_price_credit_side_flips_sign() {
             Transaction::new(date(2025, 1, 23), "insurance matured")
                 .with_synthesized_posting(
                     Posting::new("Assets:Insurance", Amount::new(dec!(-27204.53), "BAM"))
-                        .with_price(PriceAnnotation::Total(Amount::new(dec!(15152.07), "EUR"))),
+                        .with_price(PriceAnnotation::total(Amount::new(dec!(15152.07), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Cash",
@@ -8081,7 +8081,7 @@ fn test_issue_567_value_uses_implicit_price_from_annotation() {
                                 .with_currency("EUR")
                                 .with_date(date(2024, 1, 10)),
                         )
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Cash",
@@ -8158,7 +8158,7 @@ fn test_issue_567_value_sum_position_with_implicit_price() {
                                 .with_number_per(dec!(50))
                                 .with_currency("USD"),
                         )
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(60), "USD"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(60), "USD"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Cash",
@@ -8566,7 +8566,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 1)),
                         )
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.35), "EUR"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(1.35), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank:Checking",
@@ -8584,7 +8584,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 2)),
                         )
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank:Checking",
@@ -8736,7 +8736,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 1)),
                         )
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.35), "EUR"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(1.35), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank:Checking",
@@ -8754,7 +8754,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 2)),
                         )
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(1.40), "EUR"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:Bank:Checking",

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -380,23 +380,21 @@ pub fn calculate_tolerances(
                     *cost_tolerances.entry(cost_currency.clone()).or_default() += cost_tolerance;
                 }
 
-                // Price contribution
-                if let Some(price) = &posting.price {
-                    match price {
-                        rustledger_core::PriceAnnotation::Unit(price_amt) => {
-                            let price_tolerance = tolerance * price_amt.number;
-                            *cost_tolerances
-                                .entry(price_amt.currency.clone())
-                                .or_default() += price_tolerance;
-                        }
-                        rustledger_core::PriceAnnotation::Total(price_amt) => {
-                            let price_tolerance = tolerance * price_amt.number;
-                            *cost_tolerances
-                                .entry(price_amt.currency.clone())
-                                .or_default() += price_tolerance;
-                        }
-                        _ => {}
-                    }
+                // Price contribution: only complete amounts contribute
+                // (incomplete/empty price annotations are filled in by
+                // interpolation later). `kind` (Unit vs Total) doesn't
+                // change the tolerance math here — both use `tolerance *
+                // price_amt.number`.
+                if let Some(price) = &posting.price
+                    && let Some(price_amt) = price
+                        .amount
+                        .as_ref()
+                        .and_then(rustledger_core::IncompleteAmount::as_amount)
+                {
+                    let price_tolerance = tolerance * price_amt.number;
+                    *cost_tolerances
+                        .entry(price_amt.currency.clone())
+                        .or_default() += price_tolerance;
                 }
             }
         }

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -425,7 +425,7 @@ fn test_valid_multi_currency_with_price() {
             Transaction::new(date(2024, 1, 15), "Currency exchange")
                 .with_synthesized_posting(
                     Posting::new("Assets:USD", Amount::new(dec!(100), "USD"))
-                        .with_price(PriceAnnotation::Unit(Amount::new(dec!(0.85), "EUR"))),
+                        .with_price(PriceAnnotation::unit(Amount::new(dec!(0.85), "EUR"))),
                 )
                 .with_synthesized_posting(Posting::new(
                     "Assets:EUR",

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -11,13 +11,15 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
     use rustledger_core::PriceAnnotation;
 
     fn price_annotation_to_amount(pr: &PriceAnnotation) -> Option<AmountValue> {
-        match pr {
-            PriceAnnotation::Unit(a) | PriceAnnotation::Total(a) => Some(AmountValue {
+        // JSON only emits the amount when it's complete; `kind` is
+        // encoded separately by callers that care.
+        pr.amount
+            .as_ref()
+            .and_then(rustledger_core::IncompleteAmount::as_amount)
+            .map(|a| AmountValue {
                 number: a.number.to_string(),
                 currency: a.currency.to_string(),
-            }),
-            _ => None,
-        }
+            })
     }
 
     match directive {


### PR DESCRIPTION
## Summary

Closes [#1167](https://github.com/rustledger/rustledger/issues/1167). `PriceAnnotation` was a 6-variant enum flattening two orthogonal axes:

- **kind**: per-unit (`@`) vs total (`@@`)
- **completeness**: Complete amount / IncompleteAmount / no amount

This made every consumer write 6 match arms even when only one axis mattered.

## New shape

```rust
pub enum PriceKind { Unit, Total }

pub struct PriceAnnotation {
    pub kind: PriceKind,
    pub amount: Option<IncompleteAmount>,
}
```

The five non-empty old variants collapse to `(kind, Some(amount))`; the two empty variants collapse to `(kind, None)`.

## Construction sites preserved

New constructors keep the variant-style readability:

| Old | New |
|-----|-----|
| `PriceAnnotation::Unit(amt)` | `PriceAnnotation::unit(amt)` |
| `PriceAnnotation::Total(amt)` | `PriceAnnotation::total(amt)` |
| `PriceAnnotation::UnitIncomplete(inc)` | `PriceAnnotation::unit_incomplete(inc)` |
| `PriceAnnotation::TotalIncomplete(inc)` | `PriceAnnotation::total_incomplete(inc)` |
| `PriceAnnotation::UnitEmpty` | `PriceAnnotation::unit_empty()` |
| `PriceAnnotation::TotalEmpty` | `PriceAnnotation::total_empty()` |

Only match arms had to change shape.

## Wins

- **20+ consumers shed 6-arm boilerplate**. The two big residual blocks in `rustledger-booking` (the `Decimal` and `BigDecimal` calculators) lose ~30 lines each.
- **Shared helper**: `price_residual_contribution(price, units)` lives in `rustledger-booking` and factors the Unit-vs-Total signed-amount math so it lives in one place instead of being duplicated across the precise and non-precise residual calculators.
- **`is_unit()` and `amount()` helpers** become trivial: `matches!(self.kind, PriceKind::Unit)` and `self.amount.as_ref().and_then(IncompleteAmount::as_amount)`.

## Breaking changes

**The serde JSON shape changes** (caught in Copilot review).

- Old (enum-tagged):
  ```json
  {"Unit": {"number": "150", "currency": "USD"}}
  {"UnitEmpty": null}
  ```
- New (struct):
  ```json
  {"kind": "Unit", "amount": {"Complete": {"number": "150", "currency": "USD"}}}
  {"kind": "Unit", "amount": null}
  ```

This is intentional. No in-tree consumer reads `PriceAnnotation` via derived serde — the ffi-wasi crate, the plugin convert layer, and the wasm crate all use their own DTOs. The plugin wire format (`PriceAnnotationData` in `rustledger-plugin-types`) is unaffected.

External consumers of the derived serde on the core AST would need to update. Given the project's stance on correctness over wire compat (see the #1163 / #1174 cadence), this is the right tradeoff.

**The rkyv archive shape also changes**, handled by the `CACHE_VERSION` bump 5 → 6. Same precedent as #1151 (`Spanned<Posting>`) and #1174 (newtype payloads). Note: PR #1174 also bumps to 6 — whichever lands first will need the second to rebase to 7.

## What didn't change

- Parser input syntax (unchanged — beancount source format).
- `Display` (unchanged — `@ 150 USD` / `@@`).
- Plugin wire (`MetaValueData` / `PriceAnnotationData`) — independent of `PriceAnnotation`.
- BQL semantics: `Value::Amount` at the SQL boundary for `price` accessor — matches `bean-query`.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets` — clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test` across 9 affected crates (core, parser, booking, validate, query, loader, plugin, lsp, cli) — all pass
- [ ] CI full workspace + compat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)