### PR TITLE
fix(query): row_group_keys invariant in parallel non-DISTINCT path (closes #1175)

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -164,7 +164,17 @@ impl Executor<'_> {
                         }
                     }
                 } else {
+                    // Bulk-assign for performance, but keep the
+                    // `row_group_keys` sidecar in lockstep with `rows`
+                    // (issue #1175). The sidecar is a load-bearing
+                    // invariant — `QueryResult::sort_by` `assert_eq!`s
+                    // the lengths because a desynced sidecar would
+                    // silently apply the wrong currency hint to a row.
+                    // Non-aggregate rows get `None` per row, matching
+                    // what `add_row` would set.
+                    let n = rows.len();
                     result.rows = rows;
+                    result.row_group_keys.resize(n, None);
                 }
             } else {
                 // Sequential evaluation for small datasets or window queries

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -9339,8 +9339,9 @@ fn test_convert_with_null_second_arg_has_helpful_error_message() {
 /// load-bearing `assert_eq!` in `QueryResult::sort_by` and panic.
 ///
 /// The bug only triggered above `PARALLEL_THRESHOLD = 1000` postings,
-/// so this test materializes 1100 transactions before running the
-/// user's reproducer query shape (SELECT … WHERE … ORDER BY date DESC).
+/// so this test materializes 1100 postings (550 transactions × 2
+/// postings each) before running the user's reproducer query shape
+/// (SELECT … WHERE … ORDER BY date DESC).
 #[test]
 fn test_query_with_order_by_above_parallel_threshold() {
     // 1100 postings = 550 transactions × 2 postings each. Crosses

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -9331,3 +9331,73 @@ fn test_convert_with_null_second_arg_has_helpful_error_message() {
         "error should explicitly mention NULL + what was expected, got: {msg}"
     );
 }
+
+/// Regression test for #1175: the parallel non-DISTINCT execution
+/// path bulk-assigned `result.rows = rows` without keeping the
+/// `row_group_keys` sidecar in lockstep. Any subsequent `ORDER BY`
+/// (or the implicit GROUP BY default sort) would then hit the
+/// load-bearing `assert_eq!` in `QueryResult::sort_by` and panic.
+///
+/// The bug only triggered above `PARALLEL_THRESHOLD = 1000` postings,
+/// so this test materializes 1100 transactions before running the
+/// user's reproducer query shape (SELECT … WHERE … ORDER BY date DESC).
+#[test]
+fn test_query_with_order_by_above_parallel_threshold() {
+    // 1100 postings = 550 transactions × 2 postings each. Crosses
+    // PARALLEL_THRESHOLD (1000) so the parallel evaluation branch fires.
+    let mut directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+    ];
+    for i in 0..550 {
+        let day = u32::try_from((i % 28) + 1).unwrap();
+        let month = u32::try_from((i % 12) + 1).unwrap();
+        directives.push(Directive::Transaction(
+            Transaction::new(date(2024, month, day), "grocery shopping")
+                .with_payee("Grocery Store")
+                .with_synthesized_posting(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(10), "USD"),
+                ))
+                .with_synthesized_posting(Posting::new(
+                    "Assets:Bank",
+                    Amount::new(dec!(-10), "USD"),
+                )),
+        ));
+    }
+
+    // The exact shape from the bug report — ORDER BY DESC + regex
+    // filter, no DISTINCT, no GROUP BY. Pre-fix this panicked at
+    // `executor/types.rs:336` with the sidecar invariant assertion.
+    let result = execute_query(
+        r#"SELECT date, payee, narration, account, number, currency
+           WHERE (payee ~ "gro" OR narration ~ "gro" OR account ~ "gro")
+           ORDER BY date DESC"#,
+        &directives,
+    );
+
+    // Every selected posting matches "gro" via narration or payee, so
+    // we expect 1100 rows back. Reaching this assertion at all is the
+    // regression — pre-fix the path panicked inside `sort_by` before
+    // returning. The sidecar invariant itself is guarded by a
+    // production-code `assert_eq!` in `QueryResult::sort_by` (crate
+    // internal; not visible from this integration test), so a future
+    // regression would surface here as a panic rather than a
+    // misordered result.
+    assert_eq!(result.rows.len(), 1100, "expected 1100 matching rows");
+
+    // Spot-check that ORDER BY DESC ran correctly — first row's date
+    // must be >= last row's date.
+    let first_date = match &result.rows[0][0] {
+        Value::Date(d) => *d,
+        v => panic!("first row[0] not a Date: {v:?}"),
+    };
+    let last_date = match &result.rows[result.rows.len() - 1][0] {
+        Value::Date(d) => *d,
+        v => panic!("last row[0] not a Date: {v:?}"),
+    };
+    assert!(
+        first_date >= last_date,
+        "ORDER BY date DESC: first={first_date}, last={last_date}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes [#1175](https://github.com/rustledger/rustledger/issues/1175) — `SELECT … WHERE … ORDER BY` panicked on any ledger with ≥1000 postings.

## Root cause

The parallel evaluation fast path in `executor/execution.rs:167` bulk-assigned rows without keeping the `row_group_keys` sidecar in lockstep:

\`\`\`rust
if query.distinct {
    // ...uses add_row() — correct, updates both vectors
} else {
    result.rows = rows;   // ← BUG: skips the sidecar
}
\`\`\`

`QueryResult` has a `row_group_keys: Vec<Option<Vec<Value>>>` sidecar that must stay in lockstep with `rows`. The `add_row()` / `add_aggregate_row()` constructors both maintain the invariant; this fast path bypassed them.

Then `ORDER BY` (or the implicit GROUP BY default sort) triggered `QueryResult::sort_by`, which has a load-bearing `assert_eq!` on the lengths — boom.

## Why it hit users but slipped through tests

Three conditions are needed:
1. ≥ `PARALLEL_THRESHOLD` (1000) postings → triggers the parallel branch
2. Non-DISTINCT → skips `add_row()`
3. Subsequent sort → triggers the assertion

No existing test exercises all three. Real ledgers do (the reporter had 1360 matching rows).

## Fix

Two lines: resize the sidecar to `None` per row after the bulk assignment, matching what `add_row()` would do for non-aggregate rows.

## Test plan

- [x] Added `test_query_with_order_by_above_parallel_threshold` that materializes 1100 postings and runs the reporter's exact query shape
- [x] Verified the test **fails pre-fix** with the same panic from the bug report (`rows.len() != row_group_keys.len(), left: 1100, right: 0`)
- [x] Verified the test **passes post-fix**
- [x] `cargo clippy -p rustledger-query --all-features --all-targets -- -D warnings` clean
- [ ] CI full workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)