### PR TITLE
refactor(core): CostSpec invalid states unrepresentable (closes #1164)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# `getrandom` 0.3+ requires both a Cargo feature (`wasm_js`) AND a
+# RUSTFLAGS cfg (`--cfg getrandom_backend="wasm_js"`) before it will
+# compile on `wasm32-unknown-unknown`. The transitive chain via
+# `imbl` (#1195) → `rand_xoshiro` → `rand_core 0.9` → `getrandom 0.3`
+# pulls it into every wasm build, so the cfg has to be set at the
+# workspace level rather than per-crate. Without this, any change
+# touching `crates/rustledger-{wasm,parser,core}/**` trips the WASM CI
+# workflow's `wasm-pack test --node` step.
+#
+# See https://docs.rs/getrandom/0.3/#webassembly-support for the
+# backend cfg story.
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,7 +7,17 @@
 # touching `crates/rustledger-{wasm,parser,core}/**` trips the WASM CI
 # workflow's `wasm-pack test --node` step.
 #
+# **Env-var trap**: if the `RUSTFLAGS` environment variable is set
+# during a wasm32 build (e.g. a CI step exports
+# `RUSTFLAGS=-Dwarnings`), it takes complete precedence over these
+# rustflags — Cargo does NOT merge env and config, env wins outright.
+# The build will then break with the exact "getrandom backend not
+# configured" error this file exists to suppress. If you must set
+# `RUSTFLAGS` from CI while building wasm, append
+# `--cfg getrandom_backend="wasm_js"` to the env value.
+#
 # See https://docs.rs/getrandom/0.3/#webassembly-support for the
-# backend cfg story.
+# backend cfg story and the Cargo reference for env-vs-config
+# precedence rules.
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,9 +1788,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4015,6 +4017,7 @@ version = "0.15.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "jiff",
  "js-sys",
  "rkyv 0.8.16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,6 +3453,7 @@ dependencies = [
  "rustledger-validate",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "sha2 0.11.0",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/crates/rustledger-booking/fuzz/Cargo.toml
+++ b/crates/rustledger-booking/fuzz/Cargo.toml
@@ -18,6 +18,12 @@ path = ".."
 
 [dependencies.rustledger-core]
 path = "../../rustledger-core"
+# Opt into the fuzz feature so the harness can construct
+# intentionally inconsistent `BookedCost` values via
+# `from_fuzz_unchecked` (review A-4.4). The constructor is
+# `#[cfg(any(feature = "fuzz", test))]` gated, so normal builds
+# can't reach it; fuzz targets must declare the dep this way.
+features = ["fuzz"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
+++ b/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
@@ -10,7 +10,8 @@ use libfuzzer_sys::fuzz_target;
 use rust_decimal::Decimal;
 use rustledger_booking::BookingEngine;
 use rustledger_core::{
-    Amount, BookingMethod, CostSpec, IncompleteAmount, NaiveDate, Posting, Transaction,
+    Amount, BookedCost, BookingMethod, CostNumber, CostSpec, IncompleteAmount, NaiveDate, Posting,
+    Transaction,
 };
 
 /// Fuzzer-friendly booking method selector.
@@ -39,13 +40,31 @@ impl From<FuzzBookingMethod> for BookingMethod {
     }
 }
 
+/// Fuzzer-friendly cost-number variant. Single tagged enum mirroring
+/// the host `CostNumber`, so the fuzzer can only produce inputs the
+/// type system allows (no silent both-set state from parallel
+/// `Option<i32>` axes).
+#[derive(Debug, Arbitrary)]
+enum FuzzCostNumber {
+    /// `{value USD}` per-unit shape.
+    PerUnit { value_cents: i32 },
+    /// `{{value USD}}` total shape.
+    Total { value_cents: i32 },
+    /// Post-booking shape with both halves. The fuzzer can supply
+    /// inconsistent pairs (per_unit * |units| ≠ total) to stress the
+    /// trust-boundary code in `from_wrapper` / FFI input that must
+    /// reject or coerce them rather than silently inject garbage.
+    PerUnitFromTotal {
+        per_unit_cents: i32,
+        total_cents: i32,
+    },
+}
+
 /// Fuzzer-friendly cost spec configuration.
 #[derive(Debug, Arbitrary)]
 struct FuzzCostSpec {
-    /// Per-unit cost (cents, to avoid huge decimals)
-    number_per: Option<i32>,
-    /// Total cost
-    number_total: Option<i32>,
+    /// Cost number variant (none → bare `{}` cost spec).
+    number: Option<FuzzCostNumber>,
     /// Whether to use a cost currency
     has_currency: bool,
     /// Whether to merge lots (average cost)
@@ -136,8 +155,11 @@ fuzz_target!(|input: FuzzTransaction| {
         let units = Decimal::new(buy.units as i64, 0);
         let cost = make_decimal(buy.cost_cents as i32);
 
-        let posting = Posting::new("Assets:Stock", Amount::new(units, "CORP"))
-            .with_cost(CostSpec::empty().with_per_unit(cost).with_currency("USD"));
+        let posting = Posting::new("Assets:Stock", Amount::new(units, "CORP")).with_cost(
+            CostSpec::empty()
+                .with_number(CostNumber::PerUnit { value: cost })
+                .with_currency("USD"),
+        );
         let counter = Posting::new("Assets:Cash", Amount::new(-units * cost, "USD"));
 
         let txn = Transaction::new(buy_date, format!("Buy {i}"))
@@ -168,11 +190,32 @@ fuzz_target!(|input: FuzzTransaction| {
 
             if let Some(ref cost) = fuzz_posting.cost {
                 let mut spec = CostSpec::empty();
-                if let Some(per) = cost.number_per {
-                    spec = spec.with_per_unit(make_decimal(per));
-                }
-                if let Some(total) = cost.number_total {
-                    spec = spec.with_total(make_decimal(total));
+                if let Some(n) = &cost.number {
+                    // Construct via the typed enum directly — the
+                    // fuzzer's `Arbitrary` impl picks exactly one
+                    // variant, so the both-set state simply can't
+                    // appear here. PerUnitFromTotal can carry an
+                    // inconsistent pair (per_unit * |units| ≠ total);
+                    // that's intentional, to stress trust-boundary
+                    // code in other crates that consume CostSpec.
+                    let cn = match n {
+                        FuzzCostNumber::PerUnit { value_cents } => CostNumber::PerUnit {
+                            value: make_decimal(*value_cents),
+                        },
+                        FuzzCostNumber::Total { value_cents } => CostNumber::Total {
+                            value: make_decimal(*value_cents),
+                        },
+                        FuzzCostNumber::PerUnitFromTotal {
+                            per_unit_cents,
+                            total_cents,
+                        } => CostNumber::PerUnitFromTotal(
+                            BookedCost::from_parts_unchecked_trusted(
+                                make_decimal(*per_unit_cents),
+                                make_decimal(*total_cents),
+                            ),
+                        ),
+                    };
+                    spec = spec.with_number(cn);
                 }
                 if cost.has_currency {
                     spec = spec.with_currency("USD");

--- a/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
+++ b/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
@@ -137,7 +137,7 @@ fuzz_target!(|input: FuzzTransaction| {
         let cost = make_decimal(buy.cost_cents as i32);
 
         let posting = Posting::new("Assets:Stock", Amount::new(units, "CORP"))
-            .with_cost(CostSpec::empty().with_number_per(cost).with_currency("USD"));
+            .with_cost(CostSpec::empty().with_per_unit(cost).with_currency("USD"));
         let counter = Posting::new("Assets:Cash", Amount::new(-units * cost, "USD"));
 
         let txn = Transaction::new(buy_date, format!("Buy {i}"))
@@ -169,10 +169,10 @@ fuzz_target!(|input: FuzzTransaction| {
             if let Some(ref cost) = fuzz_posting.cost {
                 let mut spec = CostSpec::empty();
                 if let Some(per) = cost.number_per {
-                    spec = spec.with_number_per(make_decimal(per));
+                    spec = spec.with_per_unit(make_decimal(per));
                 }
                 if let Some(total) = cost.number_total {
-                    spec = spec.with_number_total(make_decimal(total));
+                    spec = spec.with_total(make_decimal(total));
                 }
                 if cost.has_currency {
                     spec = spec.with_currency("USD");

--- a/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
+++ b/crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs
@@ -209,7 +209,18 @@ fuzz_target!(|input: FuzzTransaction| {
                             per_unit_cents,
                             total_cents,
                         } => CostNumber::PerUnitFromTotal(
-                            BookedCost::from_parts_unchecked_trusted(
+                            // `from_fuzz_unchecked` exists specifically
+                            // for this case — the fuzzer deliberately
+                            // generates inconsistent (per_unit, total)
+                            // pairs to stress downstream consumers
+                            // (residual math, format rendering,
+                            // fingerprint hashing) that read
+                            // `b.per_unit` and `b.total` without
+                            // re-validating. Distinct from
+                            // `from_archive_bytes_trusted` so grep
+                            // tells trusted archive readers apart
+                            // from fuzz pathological-input generators.
+                            BookedCost::from_fuzz_unchecked(
                                 make_decimal(*per_unit_cents),
                                 make_decimal(*total_cents),
                             ),

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -251,8 +251,9 @@ impl BookingEngine {
                                     // Set cost from the matched lot
                                     if let Some(cost) = &matched_pos.cost {
                                         new_posting.cost = Some(CostSpec {
-                                            number_per: Some(cost.number),
-                                            number_total: None,
+                                            number: Some(rustledger_core::CostNumber::PerUnit(
+                                                cost.number,
+                                            )),
                                             currency: Some(cost.currency.clone()),
                                             date: cost.date,
                                             label: cost.label.clone(),
@@ -279,8 +280,9 @@ impl BookingEngine {
 
                                 // Update posting with filled cost
                                 result.postings[idx].cost = Some(CostSpec {
-                                    number_per: Some(matched_cost.number),
-                                    number_total: None,
+                                    number: Some(rustledger_core::CostNumber::PerUnit(
+                                        matched_cost.number,
+                                    )),
                                     currency: Some(matched_cost.currency.clone()),
                                     date: matched_cost.date,
                                     label: None,
@@ -318,19 +320,23 @@ impl BookingEngine {
                     // If not a reduction: fall through to augmentation code below
                 }
 
-                if cost_spec.number_total.is_some() && cost_spec.number_per.is_none() {
-                    // This is an augmentation with total cost - convert to per-unit
-                    // e.g., `1.763 VIIIX {{300.00 USD}}` -> `1.763 VIIIX {170.165... USD}`
-                    // Preserve full precision to avoid cost basis errors when selling.
-                    if let (Some(total), Some(currency)) =
-                        (&cost_spec.number_total, &cost_spec.currency)
+                if let Some(rustledger_core::CostNumber::Total(total)) = cost_spec.number {
+                    // Augmentation with total cost — convert to the
+                    // post-booking `PerUnitFromTotal` shape:
+                    //   `1.763 VIIIX {{300.00 USD}}` → derived per-unit
+                    //   170.165… with total 300.00 preserved.
+                    // The preserved total is load-bearing for
+                    // precision-preserving residual math (#1026) —
+                    // division-then-multiplication at the
+                    // `rust_decimal` 28-digit ceiling loses precision.
+                    if let Some(currency) = &cost_spec.currency
                         && !units.number.is_zero()
                     {
-                        // Calculate per-unit cost - preserve full precision
-                        let per_unit = *total / units.number.abs();
+                        let per_unit = total / units.number.abs();
                         result.postings[idx].cost = Some(CostSpec {
-                            number_per: Some(per_unit),
-                            number_total: cost_spec.number_total, // Preserve for precise residual calculation
+                            number: Some(rustledger_core::CostNumber::PerUnitFromTotal(
+                                rustledger_core::BookedCost { per_unit, total },
+                            )),
                             currency: Some(currency.clone()),
                             // Fill in transaction date if no date specified
                             date: cost_spec.date.or(Some(txn.date)),
@@ -342,9 +348,7 @@ impl BookingEngine {
                 }
 
                 // Fill in dates and currencies for augmentations (not already booked)
-                if !booked_indices.contains(&idx)
-                    && (cost_spec.number_per.is_some() || cost_spec.number_total.is_some())
-                {
+                if !booked_indices.contains(&idx) && cost_spec.number.is_some() {
                     // Cost spec has a number but may be missing date or currency
                     // Fill in missing parts from price annotation, other postings, and transaction date
                     let inferred_currency = cost_spec.currency.clone().or_else(|| {
@@ -377,8 +381,7 @@ impl BookingEngine {
                     // Only update if we actually inferred something
                     if inferred_currency.is_some() || inferred_date.is_some() {
                         result.postings[idx].cost = Some(CostSpec {
-                            number_per: cost_spec.number_per,
-                            number_total: cost_spec.number_total,
+                            number: cost_spec.number,
                             currency: inferred_currency.or_else(|| cost_spec.currency.clone()),
                             date: inferred_date.or(cost_spec.date),
                             label: cost_spec.label.clone(),
@@ -449,19 +452,20 @@ impl BookingEngine {
                 } else {
                     // Add to inventory
                     let position = if let Some(cost_spec) = &posting.cost {
-                        // Try per-unit cost first, then total cost
-                        let per_unit_cost = if let Some(per_unit) = &cost_spec.number_per {
-                            Some(*per_unit)
-                        } else if let Some(total) = &cost_spec.number_total {
-                            // Convert total cost to per-unit cost - preserve full precision
-                            // to avoid cost basis errors when selling
-                            if units.number.is_zero() {
-                                None
-                            } else {
-                                Some(*total / units.number.abs())
+                        // Resolve per-unit cost: PerUnit/PerUnitFromTotal
+                        // carry it directly; Total needs the
+                        // total/|units| division.
+                        let per_unit_cost = match cost_spec.number {
+                            Some(rustledger_core::CostNumber::PerUnit(per)) => Some(per),
+                            Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
+                                Some(b.per_unit)
                             }
-                        } else {
-                            None
+                            Some(rustledger_core::CostNumber::Total(total))
+                                if !units.number.is_zero() =>
+                            {
+                                Some(total / units.number.abs())
+                            }
+                            Some(rustledger_core::CostNumber::Total(_)) | None => None,
                         };
 
                         // Infer cost currency from price annotation or other postings.
@@ -699,9 +703,14 @@ mod tests {
         let buy_posting = &booked_buy.transaction.postings[0];
         assert!(buy_posting.cost.is_some());
         let cost_spec = buy_posting.cost.as_ref().unwrap();
-        // Both total and per-unit should be set (total preserved for precise residual calc)
-        assert!(cost_spec.number_total.is_some());
-        assert!(cost_spec.number_per.is_some());
+        // Booking should have converted the user-written Total into
+        // the post-booking PerUnitFromTotal shape — the per-unit value
+        // is computed for lot tracking and the total is preserved for
+        // exact residual math.
+        assert!(matches!(
+            cost_spec.number,
+            Some(rustledger_core::CostNumber::PerUnitFromTotal(_))
+        ));
 
         // Sell all shares at $191 per unit
         let sell = Transaction::new(date(2016, 6, 15), "Sell stock")

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -335,7 +335,7 @@ impl BookingEngine {
                         let per_unit = total / units.number.abs();
                         result.postings[idx].cost = Some(CostSpec {
                             number: Some(rustledger_core::CostNumber::PerUnitFromTotal(
-                                rustledger_core::BookedCost { per_unit, total },
+                                rustledger_core::BookedCost::new(per_unit, total, units.number),
                             )),
                             currency: Some(currency.clone()),
                             // Fill in transaction date if no date specified
@@ -572,7 +572,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -597,7 +597,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -653,7 +653,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(1.763), "VIIIX")).with_cost(
                     CostSpec::empty()
-                        .with_number_total(dec!(300.00))
+                        .with_total(dec!(300.00))
                         .with_currency("USD"),
                 ),
             )
@@ -686,7 +686,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(1.763), "VIIIX")).with_cost(
                     CostSpec::empty()
-                        .with_number_total(dec!(300.00))
+                        .with_total(dec!(300.00))
                         .with_currency("USD"),
                 ),
             )
@@ -745,7 +745,7 @@ mod tests {
         let sell = Transaction::new(date(2022, 6, 17), "SELLOPT")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-1), "AAPL"))
-                    .with_cost(CostSpec::empty().with_number_per(dec!(40.0)))
+                    .with_cost(CostSpec::empty().with_per_unit(dec!(40.0)))
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(0.4), "USD"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Stock", Amount::new(dec!(40.0), "USD")));
@@ -792,7 +792,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -833,7 +833,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -872,7 +872,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -935,7 +935,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -979,7 +979,7 @@ mod tests {
         let open = Transaction::new(date(2026, 1, 1), "Opening balance")
             .with_synthesized_posting(
                 Posting::new("Assets:Abc", Amount::new(dec!(1), "ABC"))
-                    .with_cost(CostSpec::empty().with_number_per(dec!(1))), // No currency!
+                    .with_cost(CostSpec::empty().with_per_unit(dec!(1))), // No currency!
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -1014,7 +1014,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Abc", Amount::new(dec!(-1), "ABC")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(1))
+                        .with_per_unit(dec!(1))
                         .with_currency("USD"),
                 ),
             )
@@ -1045,7 +1045,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "ADA")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(0.50))
+                        .with_per_unit(dec!(0.50))
                         .with_currency("USD")
                         .with_date(date(2021, 1, 1)),
                 ),
@@ -1058,7 +1058,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "ADA")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(0.52))
+                        .with_per_unit(dec!(0.52))
                         .with_currency("USD")
                         .with_date(date(2022, 5, 19)),
                 ),
@@ -1185,7 +1185,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(100), "HOOG")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(1.50))
+                        .with_per_unit(dec!(1.50))
                         .with_currency("EUR"),
                 ),
             )
@@ -1208,7 +1208,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(50), "HOOG")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(1.70))
+                        .with_per_unit(dec!(1.70))
                         .with_currency("EUR"),
                 ),
             )

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -251,9 +251,9 @@ impl BookingEngine {
                                     // Set cost from the matched lot
                                     if let Some(cost) = &matched_pos.cost {
                                         new_posting.cost = Some(CostSpec {
-                                            number: Some(rustledger_core::CostNumber::PerUnit(
-                                                cost.number,
-                                            )),
+                                            number: Some(rustledger_core::CostNumber::PerUnit {
+                                                value: cost.number,
+                                            }),
                                             currency: Some(cost.currency.clone()),
                                             date: cost.date,
                                             label: cost.label.clone(),
@@ -280,9 +280,9 @@ impl BookingEngine {
 
                                 // Update posting with filled cost
                                 result.postings[idx].cost = Some(CostSpec {
-                                    number: Some(rustledger_core::CostNumber::PerUnit(
-                                        matched_cost.number,
-                                    )),
+                                    number: Some(rustledger_core::CostNumber::PerUnit {
+                                        value: matched_cost.number,
+                                    }),
                                     currency: Some(matched_cost.currency.clone()),
                                     date: matched_cost.date,
                                     label: None,
@@ -320,7 +320,8 @@ impl BookingEngine {
                     // If not a reduction: fall through to augmentation code below
                 }
 
-                if let Some(rustledger_core::CostNumber::Total(total)) = cost_spec.number {
+                if let Some(rustledger_core::CostNumber::Total { value: total }) = cost_spec.number
+                {
                     // Augmentation with total cost — convert to the
                     // post-booking `PerUnitFromTotal` shape:
                     //   `1.763 VIIIX {{300.00 USD}}` → derived per-unit
@@ -456,16 +457,16 @@ impl BookingEngine {
                         // carry it directly; Total needs the
                         // total/|units| division.
                         let per_unit_cost = match cost_spec.number {
-                            Some(rustledger_core::CostNumber::PerUnit(per)) => Some(per),
+                            Some(rustledger_core::CostNumber::PerUnit { value: per }) => Some(per),
                             Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
                                 Some(b.per_unit)
                             }
-                            Some(rustledger_core::CostNumber::Total(total))
+                            Some(rustledger_core::CostNumber::Total { value: total })
                                 if !units.number.is_zero() =>
                             {
                                 Some(total / units.number.abs())
                             }
-                            Some(rustledger_core::CostNumber::Total(_)) | None => None,
+                            Some(rustledger_core::CostNumber::Total { value: _ }) | None => None,
                         };
 
                         // Infer cost currency from price annotation or other postings.
@@ -572,7 +573,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -597,7 +600,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -653,7 +658,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(1.763), "VIIIX")).with_cost(
                     CostSpec::empty()
-                        .with_total(dec!(300.00))
+                        .with_number(rustledger_core::CostNumber::Total {
+                            value: dec!(300.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -686,7 +693,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(1.763), "VIIIX")).with_cost(
                     CostSpec::empty()
-                        .with_total(dec!(300.00))
+                        .with_number(rustledger_core::CostNumber::Total {
+                            value: dec!(300.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -745,7 +754,11 @@ mod tests {
         let sell = Transaction::new(date(2022, 6, 17), "SELLOPT")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-1), "AAPL"))
-                    .with_cost(CostSpec::empty().with_per_unit(dec!(40.0)))
+                    .with_cost(
+                        CostSpec::empty().with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(40.0),
+                        }),
+                    )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(0.4), "USD"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Stock", Amount::new(dec!(40.0), "USD")));
@@ -792,7 +805,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -833,7 +848,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -872,7 +889,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -935,7 +954,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -978,8 +999,10 @@ mod tests {
         //   Equity:Opening-Balances -1 USD
         let open = Transaction::new(date(2026, 1, 1), "Opening balance")
             .with_synthesized_posting(
-                Posting::new("Assets:Abc", Amount::new(dec!(1), "ABC"))
-                    .with_cost(CostSpec::empty().with_per_unit(dec!(1))), // No currency!
+                Posting::new("Assets:Abc", Amount::new(dec!(1), "ABC")).with_cost(
+                    CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1) }),
+                ), // No currency!
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -1014,7 +1037,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Abc", Amount::new(dec!(-1), "ABC")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(1))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1) })
                         .with_currency("USD"),
                 ),
             )
@@ -1045,7 +1068,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "ADA")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(0.50))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(0.50) })
                         .with_currency("USD")
                         .with_date(date(2021, 1, 1)),
                 ),
@@ -1058,7 +1081,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "ADA")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(0.52))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(0.52) })
                         .with_currency("USD")
                         .with_date(date(2022, 5, 19)),
                 ),
@@ -1185,7 +1208,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(100), "HOOG")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(1.50))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.50) })
                         .with_currency("EUR"),
                 ),
             )
@@ -1208,7 +1231,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(50), "HOOG")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(1.70))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.70) })
                         .with_currency("EUR"),
                 ),
             )

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -722,7 +722,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(100.00))
+                        .with_per_unit(dec!(100.00))
                         .with_currency("USD"),
                 ),
             )
@@ -774,7 +774,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_total(dec!(1000.00))
+                        .with_total(dec!(1000.00))
                         .with_currency("USD"),
                 ),
             )
@@ -801,7 +801,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(8), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(701.20))
+                        .with_per_unit(dec!(701.20))
                         .with_currency("USD"),
                 ),
             )
@@ -837,7 +837,7 @@ mod tests {
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_number_per(dec!(100.00))
+                            .with_per_unit(dec!(100.00))
                             .with_currency("USD"),
                     )
                     .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
@@ -870,7 +870,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(100.00))
+                        .with_per_unit(dec!(100.00))
                         .with_currency("USD"),
                 ),
             )
@@ -905,7 +905,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-5), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(100.00))
+                        .with_per_unit(dec!(100.00))
                         .with_currency("USD"),
                 ),
             )
@@ -1023,7 +1023,7 @@ mod tests {
                     "Assets:Vanguard:IRA:Trad:VFIFX",
                     Amount::new(dec!(10), "VFIFX"),
                 )
-                .with_cost(rustledger_core::CostSpec::empty().with_number_per(dec!(100))),
+                .with_cost(rustledger_core::CostSpec::empty().with_per_unit(dec!(100))),
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -1059,7 +1059,7 @@ mod tests {
                     "Assets:Vanguard:IRA:Trad:VFIFX",
                     Amount::new(dec!(10), "VFIFX"),
                 )
-                .with_cost(rustledger_core::CostSpec::empty().with_number_per(dec!(100))),
+                .with_cost(rustledger_core::CostSpec::empty().with_per_unit(dec!(100))),
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -1108,7 +1108,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Abc", Amount::new(dec!(12.3340), "ABC")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(140.02))
+                        .with_per_unit(dec!(140.02))
                         .with_currency("USD"),
                 ),
             )
@@ -1193,7 +1193,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(1), "CSU")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(2800.01))
+                        .with_per_unit(dec!(2800.01))
                         .with_currency("CAD"),
                 ),
             )
@@ -1259,7 +1259,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "USDC")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(1.0))
+                        .with_per_unit(dec!(1.0))
                         .with_currency("USD"),
                 ),
             )
@@ -1300,7 +1300,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_per(dec!(0))
+                        .with_per_unit(dec!(0))
                         .with_currency("USD"),
                 ),
             )
@@ -1328,7 +1328,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_number_total(dec!(0))
+                        .with_total(dec!(0))
                         .with_currency("USD"),
                 ),
             )

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -215,11 +215,11 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
 
                     let cost_curr = inferred_currency.as_ref()?;
                     match cost_spec.number {
-                        Some(rustledger_core::CostNumber::PerUnit(per_unit)) => {
+                        Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => {
                             let cost_amount = amount.number * per_unit;
                             Some((cost_curr.clone(), cost_amount))
                         }
-                        Some(rustledger_core::CostNumber::Total(total)) => {
+                        Some(rustledger_core::CostNumber::Total { value: total }) => {
                             // Sign depends on units sign — the spec
                             // names the total magnitude, not the
                             // direction.
@@ -722,7 +722,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(100.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(100.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -774,7 +776,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_total(dec!(1000.00))
+                        .with_number(rustledger_core::CostNumber::Total {
+                            value: dec!(1000.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -801,7 +805,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(8), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(701.20))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(701.20),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -837,7 +843,9 @@ mod tests {
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "HOOL"))
                     .with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_per_unit(dec!(100.00))
+                            .with_number(rustledger_core::CostNumber::PerUnit {
+                                value: dec!(100.00),
+                            })
                             .with_currency("USD"),
                     )
                     .with_price(rustledger_core::PriceAnnotation::unit(Amount::new(
@@ -870,7 +878,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(100.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(100.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -905,7 +915,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-5), "HOOL")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(100.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(100.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -1023,7 +1035,10 @@ mod tests {
                     "Assets:Vanguard:IRA:Trad:VFIFX",
                     Amount::new(dec!(10), "VFIFX"),
                 )
-                .with_cost(rustledger_core::CostSpec::empty().with_per_unit(dec!(100))),
+                .with_cost(
+                    rustledger_core::CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) }),
+                ),
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -1059,7 +1074,10 @@ mod tests {
                     "Assets:Vanguard:IRA:Trad:VFIFX",
                     Amount::new(dec!(10), "VFIFX"),
                 )
-                .with_cost(rustledger_core::CostSpec::empty().with_per_unit(dec!(100))),
+                .with_cost(
+                    rustledger_core::CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) }),
+                ),
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -1108,7 +1126,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Abc", Amount::new(dec!(12.3340), "ABC")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(140.02))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(140.02),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -1193,7 +1213,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(1), "CSU")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(2800.01))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(2800.01),
+                        })
                         .with_currency("CAD"),
                 ),
             )
@@ -1259,7 +1281,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "USDC")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(1.0))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.0) })
                         .with_currency("USD"),
                 ),
             )
@@ -1300,7 +1322,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_per_unit(dec!(0))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(0) })
                         .with_currency("USD"),
                 ),
             )
@@ -1328,7 +1350,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     rustledger_core::CostSpec::empty()
-                        .with_total(dec!(0))
+                        .with_number(rustledger_core::CostNumber::Total { value: dec!(0) })
                         .with_currency("USD"),
                 ),
             )
@@ -1507,7 +1529,9 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec {
-            number: Some(rustledger_core::CostNumber::PerUnit(dec!(170.16734))),
+            number: Some(rustledger_core::CostNumber::PerUnit {
+                value: dec!(170.16734),
+            }),
             currency: Some(Currency::from("USD")),
             date: None,
             label: None,
@@ -1575,7 +1599,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Brokerage", Amount::new(dec!(1.763), "STOCK")).with_cost(
                     CostSpec {
-                        number: Some(rustledger_core::CostNumber::Total(dec!(300.00))),
+                        number: Some(rustledger_core::CostNumber::Total {
+                            value: dec!(300.00),
+                        }),
                         currency: Some(Currency::from("USD")),
                         date: None,
                         label: None,

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -213,18 +213,25 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         .or_else(|| crate::price_currency_of(posting))
                         .or_else(|| get_inferred_currency(&mut inferred_cost_currency));
 
-                    if let (Some(per_unit), Some(cost_curr)) =
-                        (&cost_spec.number_per, &inferred_currency)
-                    {
-                        let cost_amount = amount.number * per_unit;
-                        Some((cost_curr.clone(), cost_amount))
-                    } else if let (Some(total), Some(cost_curr)) =
-                        (&cost_spec.number_total, &inferred_currency)
-                    {
-                        // For total cost, sign depends on units sign
-                        Some((cost_curr.clone(), *total * amount.number.signum()))
-                    } else {
-                        None // Cost spec without determinable amount (e.g., empty `{}`)
+                    let cost_curr = inferred_currency.as_ref()?;
+                    match cost_spec.number {
+                        Some(rustledger_core::CostNumber::PerUnit(per_unit)) => {
+                            let cost_amount = amount.number * per_unit;
+                            Some((cost_curr.clone(), cost_amount))
+                        }
+                        Some(rustledger_core::CostNumber::Total(total)) => {
+                            // Sign depends on units sign — the spec
+                            // names the total magnitude, not the
+                            // direction.
+                            Some((cost_curr.clone(), total * amount.number.signum()))
+                        }
+                        Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
+                            // Use the preserved total for precision
+                            // (same rationale as the residual block
+                            // above).
+                            Some((cost_curr.clone(), b.total * amount.number.signum()))
+                        }
+                        None => None, // empty `{}`
                     }
                 });
 
@@ -1500,8 +1507,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec {
-            number_per: Some(dec!(170.16734)),
-            number_total: None,
+            number: Some(rustledger_core::CostNumber::PerUnit(dec!(170.16734))),
             currency: Some(Currency::from("USD")),
             date: None,
             label: None,
@@ -1569,8 +1575,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Brokerage", Amount::new(dec!(1.763), "STOCK")).with_cost(
                     CostSpec {
-                        number_per: None,
-                        number_total: Some(dec!(300.00)),
+                        number: Some(rustledger_core::CostNumber::Total(dec!(300.00))),
                         currency: Some(Currency::from("USD")),
                         date: None,
                         label: None,

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -523,7 +523,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -549,7 +549,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_total(dec!(1500.00))
+                        .with_total(dec!(1500.00))
                         .with_currency("USD"),
                 ),
             )
@@ -571,7 +571,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_total(dec!(1500.00))
+                        .with_total(dec!(1500.00))
                         .with_currency("USD"),
                 ),
             )
@@ -840,7 +840,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
@@ -866,7 +866,7 @@ mod tests {
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "AAPL"))
                     .with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150.00))
+                            .with_per_unit(dec!(150.00))
                             .with_currency("USD"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(175.00), "USD"))),
@@ -895,14 +895,14 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock:US", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(150.00))
+                        .with_per_unit(dec!(150.00))
                         .with_currency("USD"),
                 ),
             )
             .with_synthesized_posting(
                 Posting::new("Assets:Stock:EU", Amount::new(dec!(5), "SAP")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(100.00))
+                        .with_per_unit(dec!(100.00))
                         .with_currency("EUR"),
                 ),
             )
@@ -954,7 +954,7 @@ mod tests {
                     "Assets:Vanguard:IRA:Trad:VFIFX",
                     Amount::new(dec!(10), "VFIFX"),
                 )
-                .with_cost(CostSpec::empty().with_number_per(dec!(100))),
+                .with_cost(CostSpec::empty().with_per_unit(dec!(100))),
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -981,7 +981,7 @@ mod tests {
         let txn = Transaction::new(date(2026, 1, 1), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "VFIFX"))
-                    .with_cost(CostSpec::empty().with_number_total(dec!(1000))),
+                    .with_cost(CostSpec::empty().with_total(dec!(1000))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
 
@@ -997,7 +997,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(100))
+                        .with_per_unit(dec!(100))
                         .with_currency("EUR"), // Explicit EUR
                 ),
             )
@@ -1019,7 +1019,7 @@ mod tests {
         let txn = Transaction::new(date(2026, 1, 1), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))
-                    .with_cost(CostSpec::empty().with_number_per(dec!(100)))
+                    .with_cost(CostSpec::empty().with_per_unit(dec!(100)))
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(105), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
@@ -1042,7 +1042,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(0))
+                        .with_per_unit(dec!(0))
                         .with_currency("USD"),
                 ),
             )
@@ -1060,7 +1060,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(10))
+                        .with_per_unit(dec!(10))
                         .with_currency("EUR"),
                 ),
             )
@@ -1079,7 +1079,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(1000), "SHIB")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(0))
+                        .with_per_unit(dec!(0))
                         .with_currency("JPY"),
                 ),
             )

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -197,20 +197,26 @@ pub fn calculate_residual(transaction: &Transaction) -> HashMap<Currency, Decima
                     .or_else(|| price_currency_of(posting))
                     .or_else(|| get_inferred_currency(&mut inferred_cost_currency));
 
-                // Check number_total first: when both per-unit and total are present
-                // (booking preserves total), use the total directly for exact residual
-                // calculation. Division-then-multiplication loses precision.
-                if let (Some(total), Some(cost_curr)) =
-                    (&cost_spec.number_total, &inferred_currency)
-                {
-                    Some((cost_curr.clone(), *total * units.number.signum()))
-                } else if let (Some(per_unit), Some(cost_curr)) =
-                    (&cost_spec.number_per, &inferred_currency)
-                {
-                    let cost_amount = units.number * per_unit;
-                    Some((cost_curr.clone(), cost_amount))
-                } else {
-                    None // Cost spec without determinable amount (e.g., empty `{}`)
+                // `PerUnitFromTotal` and `Total` both carry a total
+                // that booking preserves for exact residual math —
+                // using the total avoids the
+                // division-then-multiplication precision loss that
+                // would happen if we recomputed from `per_unit`.
+                // `PerUnit` (user-written per-unit) goes through the
+                // multiplication path.
+                let cost_curr = inferred_currency.as_ref()?;
+                match cost_spec.number {
+                    Some(rustledger_core::CostNumber::Total(total)) => {
+                        Some((cost_curr.clone(), total * units.number.signum()))
+                    }
+                    Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
+                        Some((cost_curr.clone(), b.total * units.number.signum()))
+                    }
+                    Some(rustledger_core::CostNumber::PerUnit(per_unit)) => {
+                        let cost_amount = units.number * per_unit;
+                        Some((cost_curr.clone(), cost_amount))
+                    }
+                    None => None, // empty `{}`
                 }
             });
 
@@ -286,23 +292,24 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Currency
                     .or_else(|| price_currency_of(posting))
                     .or_else(|| get_inferred_currency(&mut inferred_cost_currency));
 
-                // Check number_total first: when both per-unit and total are present
-                // (booking preserves total), use the total directly for exact residual
-                // calculation. Division-then-multiplication loses precision.
-                if let (Some(total), Some(cost_curr)) =
-                    (&cost_spec.number_total, &inferred_currency)
-                {
-                    Some((
+                // BigDecimal version of the same matcher as above.
+                // `PerUnitFromTotal` joins `Total` in the precision-
+                // preserving branch.
+                let cost_curr = inferred_currency.as_ref()?;
+                match cost_spec.number {
+                    Some(rustledger_core::CostNumber::Total(total)) => Some((
                         cost_curr.clone(),
-                        to_big(*total) * to_big(units.number.signum()),
-                    ))
-                } else if let (Some(per_unit), Some(cost_curr)) =
-                    (&cost_spec.number_per, &inferred_currency)
-                {
-                    let cost_amount = &units_number * to_big(*per_unit);
-                    Some((cost_curr.clone(), cost_amount))
-                } else {
-                    None
+                        to_big(total) * to_big(units.number.signum()),
+                    )),
+                    Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => Some((
+                        cost_curr.clone(),
+                        to_big(b.total) * to_big(units.number.signum()),
+                    )),
+                    Some(rustledger_core::CostNumber::PerUnit(per_unit)) => {
+                        let cost_amount = &units_number * to_big(per_unit);
+                        Some((cost_curr.clone(), cost_amount))
+                    }
+                    None => None,
                 }
             });
 

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -206,13 +206,13 @@ pub fn calculate_residual(transaction: &Transaction) -> HashMap<Currency, Decima
                 // multiplication path.
                 let cost_curr = inferred_currency.as_ref()?;
                 match cost_spec.number {
-                    Some(rustledger_core::CostNumber::Total(total)) => {
+                    Some(rustledger_core::CostNumber::Total { value: total }) => {
                         Some((cost_curr.clone(), total * units.number.signum()))
                     }
                     Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
                         Some((cost_curr.clone(), b.total * units.number.signum()))
                     }
-                    Some(rustledger_core::CostNumber::PerUnit(per_unit)) => {
+                    Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => {
                         let cost_amount = units.number * per_unit;
                         Some((cost_curr.clone(), cost_amount))
                     }
@@ -297,7 +297,7 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Currency
                 // preserving branch.
                 let cost_curr = inferred_currency.as_ref()?;
                 match cost_spec.number {
-                    Some(rustledger_core::CostNumber::Total(total)) => Some((
+                    Some(rustledger_core::CostNumber::Total { value: total }) => Some((
                         cost_curr.clone(),
                         to_big(total) * to_big(units.number.signum()),
                     )),
@@ -305,7 +305,7 @@ pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Currency
                         cost_curr.clone(),
                         to_big(b.total) * to_big(units.number.signum()),
                     )),
-                    Some(rustledger_core::CostNumber::PerUnit(per_unit)) => {
+                    Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => {
                         let cost_amount = &units_number * to_big(per_unit);
                         Some((cost_curr.clone(), cost_amount))
                     }
@@ -523,7 +523,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -549,7 +551,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_total(dec!(1500.00))
+                        .with_number(rustledger_core::CostNumber::Total {
+                            value: dec!(1500.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -571,7 +575,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_total(dec!(1500.00))
+                        .with_number(rustledger_core::CostNumber::Total {
+                            value: dec!(1500.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -840,7 +846,9 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
@@ -866,7 +874,9 @@ mod tests {
                 Posting::new("Assets:Stock", Amount::new(dec!(-10), "AAPL"))
                     .with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150.00))
+                            .with_number(rustledger_core::CostNumber::PerUnit {
+                                value: dec!(150.00),
+                            })
                             .with_currency("USD"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(175.00), "USD"))),
@@ -895,14 +905,18 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock:US", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(150.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(150.00),
+                        })
                         .with_currency("USD"),
                 ),
             )
             .with_synthesized_posting(
                 Posting::new("Assets:Stock:EU", Amount::new(dec!(5), "SAP")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(100.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit {
+                            value: dec!(100.00),
+                        })
                         .with_currency("EUR"),
                 ),
             )
@@ -954,7 +968,10 @@ mod tests {
                     "Assets:Vanguard:IRA:Trad:VFIFX",
                     Amount::new(dec!(10), "VFIFX"),
                 )
-                .with_cost(CostSpec::empty().with_per_unit(dec!(100))),
+                .with_cost(
+                    CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) }),
+                ),
             )
             .with_synthesized_posting(Posting::new(
                 "Equity:Opening-Balances",
@@ -980,8 +997,10 @@ mod tests {
         // 10 VFIFX {{1000}} with -1000 USD posting
         let txn = Transaction::new(date(2026, 1, 1), "Test")
             .with_synthesized_posting(
-                Posting::new("Assets:Stock", Amount::new(dec!(10), "VFIFX"))
-                    .with_cost(CostSpec::empty().with_total(dec!(1000))),
+                Posting::new("Assets:Stock", Amount::new(dec!(10), "VFIFX")).with_cost(
+                    CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::Total { value: dec!(1000) }),
+                ),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
 
@@ -997,7 +1016,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(100))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
                         .with_currency("EUR"), // Explicit EUR
                 ),
             )
@@ -1019,7 +1038,10 @@ mod tests {
         let txn = Transaction::new(date(2026, 1, 1), "Test")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))
-                    .with_cost(CostSpec::empty().with_per_unit(dec!(100)))
+                    .with_cost(
+                        CostSpec::empty()
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) }),
+                    )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(105), "EUR"))),
             )
             .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1000), "USD")));
@@ -1042,7 +1064,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(0))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(0) })
                         .with_currency("USD"),
                 ),
             )
@@ -1060,7 +1082,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(100), "TOKEN")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(10))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(10) })
                         .with_currency("EUR"),
                 ),
             )
@@ -1079,7 +1101,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Crypto", Amount::new(dec!(1000), "SHIB")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(0))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(0) })
                         .with_currency("JPY"),
                 ),
             )

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -19,6 +19,12 @@ bench = false
 default = ["rkyv"]
 # Enable rkyv serialization for binary cache
 rkyv = ["dep:rkyv"]
+# Enable fuzz-harness-only constructors that bypass invariants.
+# Off by default so normal builds can't call them — only fuzz targets
+# and integration tests that explicitly want to stress trust-boundary
+# code in convert bridges should opt in. The constructors are also
+# `#[doc(hidden)]` so they don't appear in rustdoc either way.
+fuzz = []
 
 [dependencies]
 rust_decimal = { workspace = true, features = ["serde", "maths"] }

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -261,6 +261,44 @@ pub struct BookedCost {
     pub total: Decimal,
 }
 
+impl BookedCost {
+    /// Construct from booking with a precision invariant check.
+    ///
+    /// In debug builds, asserts that `per_unit * |units| ≈ total` to
+    /// the limits of `rust_decimal` precision. Callers are the booker
+    /// (which derives `per_unit = total / |units|`) and the FFI input
+    /// bridge (which must not construct inconsistent pairs).
+    ///
+    /// # Panics
+    ///
+    /// In debug builds: if `per_unit * |units|` differs from `total` by
+    /// more than 1e-20 (a generous tolerance well inside the
+    /// `rust_decimal` 28-digit precision floor). Release builds skip
+    /// the check.
+    #[must_use]
+    pub fn new(per_unit: Decimal, total: Decimal, units: Decimal) -> Self {
+        let units_abs = units.abs();
+        debug_assert!(
+            // Zero-units booking is degenerate; the booker doesn't
+            // construct `PerUnitFromTotal` in that case (see book.rs).
+            // External constructors that pass zero get a free pass.
+            units_abs.is_zero() || (per_unit * units_abs - total).abs() < Decimal::new(1, 20),
+            "BookedCost invariant violated: per_unit ({per_unit}) * |units| ({units_abs}) != total ({total})",
+        );
+        Self { per_unit, total }
+    }
+
+    /// Construct without invariant check, for callers that have
+    /// already validated consistency (e.g. rkyv deserialization,
+    /// trusted-byte loaders).
+    ///
+    /// Prefer [`Self::new`] when the units are at hand.
+    #[must_use]
+    pub const fn from_parts_unchecked(per_unit: Decimal, total: Decimal) -> Self {
+        Self { per_unit, total }
+    }
+}
+
 impl CostNumber {
     /// Return the per-unit value if this number carries one.
     ///
@@ -335,23 +373,31 @@ impl CostSpec {
         Self::default()
     }
 
-    /// Set the per-unit cost.
+    /// Set the cost number to a per-unit value.
     ///
-    /// Overwrites any previously-set number (per-unit or total) — the
-    /// shapes are mutually exclusive by construction.
+    /// Convenience for `with_number(CostNumber::PerUnit(n))`. Use
+    /// [`Self::with_number`] when you already have a [`CostNumber`].
     #[must_use]
-    pub const fn with_number_per(mut self, number: Decimal) -> Self {
-        self.number = Some(CostNumber::PerUnit(number));
-        self
+    pub const fn with_per_unit(self, number: Decimal) -> Self {
+        self.with_number(CostNumber::PerUnit(number))
     }
 
-    /// Set the total cost.
+    /// Set the cost number to a total value.
     ///
-    /// Overwrites any previously-set number (per-unit or total) — the
-    /// shapes are mutually exclusive by construction.
+    /// Convenience for `with_number(CostNumber::Total(n))`. Use
+    /// [`Self::with_number`] when you already have a [`CostNumber`].
     #[must_use]
-    pub const fn with_number_total(mut self, number: Decimal) -> Self {
-        self.number = Some(CostNumber::Total(number));
+    pub const fn with_total(self, number: Decimal) -> Self {
+        self.with_number(CostNumber::Total(number))
+    }
+
+    /// Set the cost number directly.
+    ///
+    /// The mutual exclusion between per-unit and total is enforced by
+    /// the [`CostNumber`] enum — there is no way to set both.
+    #[must_use]
+    pub const fn with_number(mut self, number: CostNumber) -> Self {
+        self.number = Some(number);
         self
     }
 
@@ -436,7 +482,9 @@ impl CostSpec {
     /// calculated as `total / |units|`. Full precision is preserved to
     /// avoid cost basis errors when the position is later sold.
     /// `PerUnitFromTotal` already carries the derived per-unit value
-    /// from a prior booking pass — use it directly.
+    /// from a prior booking pass — using `b.per_unit` directly is
+    /// equivalent to recomputing `b.total / |units|` because
+    /// [`BookedCost::new`] enforces that invariant at construction.
     ///
     /// Returns `None` if required fields (currency, number) are missing.
     #[must_use]
@@ -447,7 +495,9 @@ impl CostSpec {
             CostNumber::PerUnit(per) => per,
             // Calculated from total — preserve full precision.
             CostNumber::Total(total) => total / units.abs(),
-            // Already booked from a total.
+            // Already booked: `b.per_unit == b.total / |units|` by
+            // `BookedCost::new`'s invariant, so this is identical to
+            // the `Total` arm above but without the redivision.
             CostNumber::PerUnitFromTotal(b) => b.per_unit,
         };
 
@@ -594,11 +644,11 @@ mod tests {
         assert!(CostSpec::empty().matches(&cost));
 
         // Match by number
-        let spec = CostSpec::empty().with_number_per(dec!(150.00));
+        let spec = CostSpec::empty().with_per_unit(dec!(150.00));
         assert!(spec.matches(&cost));
 
         // Wrong number
-        let spec = CostSpec::empty().with_number_per(dec!(160.00));
+        let spec = CostSpec::empty().with_per_unit(dec!(160.00));
         assert!(!spec.matches(&cost));
 
         // Match by currency
@@ -615,7 +665,7 @@ mod tests {
 
         // Match by all
         let spec = CostSpec::empty()
-            .with_number_per(dec!(150.00))
+            .with_per_unit(dec!(150.00))
             .with_currency("USD")
             .with_date(date(2024, 1, 15))
             .with_label("lot1");
@@ -625,7 +675,7 @@ mod tests {
     #[test]
     fn test_cost_spec_resolve() {
         let spec = CostSpec::empty()
-            .with_number_per(dec!(150.00))
+            .with_per_unit(dec!(150.00))
             .with_currency("USD");
 
         let cost = spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
@@ -637,11 +687,130 @@ mod tests {
     #[test]
     fn test_cost_spec_resolve_total() {
         let spec = CostSpec::empty()
-            .with_number_total(dec!(1500.00))
+            .with_total(dec!(1500.00))
             .with_currency("USD");
 
         let cost = spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
         assert_eq!(cost.number, dec!(150.00)); // 1500 / 10
         assert_eq!(cost.currency, "USD");
+    }
+
+    // ===== BookedCost / PerUnitFromTotal tests (#1164) =====
+
+    #[test]
+    fn booked_cost_new_accepts_consistent_pair() {
+        // 10 units of "300 total" → 30 per-unit. Constructor must
+        // accept; debug_assert sees per_unit * |units| == total.
+        let b = BookedCost::new(dec!(30), dec!(300), dec!(10));
+        assert_eq!(b.per_unit, dec!(30));
+        assert_eq!(b.total, dec!(300));
+    }
+
+    #[test]
+    fn booked_cost_new_accepts_negative_units() {
+        // Sales (negative units) still produce consistent
+        // PerUnitFromTotal: per_unit * |units| == total uses .abs().
+        let b = BookedCost::new(dec!(30), dec!(300), dec!(-10));
+        assert_eq!(b.per_unit, dec!(30));
+    }
+
+    #[test]
+    #[should_panic(expected = "BookedCost invariant violated")]
+    fn booked_cost_new_rejects_inconsistent_pair_in_debug() {
+        // per_unit (50) * |units| (10) = 500, NOT 300. Invariant must
+        // fire. Release builds would skip the check by design — this
+        // test verifies the debug-build safety net.
+        let _ = BookedCost::new(dec!(50), dec!(300), dec!(10));
+    }
+
+    #[test]
+    fn booked_cost_new_allows_zero_units() {
+        // Zero units is degenerate — the booker doesn't construct
+        // PerUnitFromTotal there, but external callers (FFI input)
+        // might. Constructor gives them a pass.
+        let b = BookedCost::new(dec!(7), dec!(99), dec!(0));
+        assert_eq!(b.per_unit, dec!(7));
+        assert_eq!(b.total, dec!(99));
+    }
+
+    #[test]
+    fn booked_cost_from_parts_unchecked_skips_invariant() {
+        // rkyv deserialization and plugin round-trip use this when
+        // units aren't at hand. Constructs the inconsistent pair
+        // without panicking — verifying it's truly unchecked.
+        let b = BookedCost::from_parts_unchecked(dec!(50), dec!(300));
+        assert_eq!(b.per_unit, dec!(50));
+        assert_eq!(b.total, dec!(300));
+    }
+
+    #[test]
+    fn cost_number_per_unit_accessor() {
+        assert_eq!(CostNumber::PerUnit(dec!(150)).per_unit(), Some(dec!(150)));
+        assert_eq!(CostNumber::Total(dec!(1500)).per_unit(), None);
+        let b = BookedCost::new(dec!(30), dec!(300), dec!(10));
+        assert_eq!(CostNumber::PerUnitFromTotal(b).per_unit(), Some(dec!(30)));
+    }
+
+    #[test]
+    fn cost_number_total_accessor() {
+        assert_eq!(CostNumber::PerUnit(dec!(150)).total(), None);
+        assert_eq!(CostNumber::Total(dec!(1500)).total(), Some(dec!(1500)));
+        let b = BookedCost::new(dec!(30), dec!(300), dec!(10));
+        assert_eq!(CostNumber::PerUnitFromTotal(b).total(), Some(dec!(300)));
+    }
+
+    #[test]
+    fn cost_spec_resolve_per_unit_from_total_uses_per_unit_directly() {
+        // Verifies the documented optimization: by `BookedCost::new`'s
+        // invariant, b.per_unit == b.total / |units|, so resolve()
+        // returns b.per_unit without redivision. The result must equal
+        // what the `Total` arm would have computed.
+        let b = BookedCost::new(dec!(30), dec!(300), dec!(10));
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::PerUnitFromTotal(b))
+            .with_currency("USD");
+
+        let cost = spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
+        assert_eq!(cost.number, dec!(30));
+        assert_eq!(cost.currency, "USD");
+
+        // Same shape via raw Total → same number after division.
+        let total_spec = CostSpec::empty().with_total(dec!(300)).with_currency("USD");
+        let total_cost = total_spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
+        assert_eq!(cost.number, total_cost.number);
+    }
+
+    #[test]
+    fn cost_spec_matches_per_unit_from_total() {
+        // PerUnitFromTotal must match against a Cost by its per-unit
+        // value (the lot's canonical number) — this is what lot
+        // reduction code path needs.
+        let cost = Cost::new(dec!(150.00), "USD")
+            .with_date(date(2024, 1, 15))
+            .with_label("lot1");
+
+        let b = BookedCost::new(dec!(150), dec!(300), dec!(2));
+        let spec = CostSpec::empty().with_number(CostNumber::PerUnitFromTotal(b));
+        assert!(spec.matches(&cost));
+
+        // Wrong per-unit: must not match.
+        let wrong = BookedCost::new(dec!(160), dec!(320), dec!(2));
+        let wrong_spec = CostSpec::empty().with_number(CostNumber::PerUnitFromTotal(wrong));
+        assert!(!wrong_spec.matches(&cost));
+    }
+
+    #[test]
+    fn cost_spec_display_renders_per_unit_from_total_as_per_unit() {
+        // Python-beancount compat: post-booking display uses per-unit
+        // form even though source was `{{...}}`. This pins the
+        // documented format-amount.rs behavior.
+        let b = BookedCost::new(dec!(150), dec!(300), dec!(2));
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::PerUnitFromTotal(b))
+            .with_currency("USD");
+        let s = format!("{spec}");
+        // Per-unit form: just the per_unit value, not `# total`.
+        assert!(s.contains("150"), "expected per-unit 150 in {s}");
+        assert!(!s.contains("# 300"), "must NOT render as `# total` ({s})");
     }
 }

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -290,19 +290,26 @@ pub struct BookedCost {
 
 /// Diagnostic for a failed [`BookedCost`] consistency check.
 ///
-/// Returned by [`BookedCost::try_new`] when the supplied
-/// `per_unit * |units|` does not agree with `total` to within the
-/// `rust_decimal` rounding floor (or when `units == 0`, which makes
-/// the pair structurally untrustworthy — every `per_unit` "works" by
-/// zero-multiplication, so the invariant carries no information).
+/// Returned by [`BookedCost::try_new`] in three cases:
+/// - **Mismatch**: `per_unit * |units|` doesn't agree with `total` to
+///   within the `rust_decimal` rounding floor.
+/// - **Zero units**: every `per_unit` "works" by zero-multiplication
+///   so the invariant carries no information; the post-booking shape
+///   is structurally meaningless without units.
+/// - **Overflow**: `per_unit * |units|` would exceed `Decimal::MAX`
+///   (~7.92e28). Both operands fit in `Decimal` individually but their
+///   product doesn't. A wire client can reach this with extreme
+///   inputs; surfacing it as a typed error keeps the host from
+///   panicking on multiplication.
 ///
-/// Carries the inputs and the computed residual so trust-boundary
-/// callers can surface a meaningful error to the originating plugin
-/// or wire client ("you sent `per_unit=50, total=999` with `units=10`;
-/// derived total would be 500, off by 499 — far outside tolerance
-/// 1e-20"). Mapping this to a `ConversionError` variant gives plugin
-/// authors a typed category for the failure instead of conflating
-/// with `InvalidNumber` (parse failure).
+/// Carries the inputs and (for the mismatch case) the computed
+/// residual so trust-boundary callers can surface a meaningful error
+/// to the originating plugin or wire client ("you sent
+/// `per_unit=50, total=999` with `units=10`; derived total would be
+/// 500, off by 499 — far outside tolerance 1e-20"). Mapping this to a
+/// `ConversionError` variant gives plugin authors a typed category
+/// for the failure instead of conflating with `InvalidNumber` (parse
+/// failure).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BookedCostInvariantError {
     /// The per-unit value the caller supplied.
@@ -313,18 +320,32 @@ pub struct BookedCostInvariantError {
     /// so error messages can show what came in).
     pub units: Decimal,
     /// `per_unit * |units|`, the value we'd expect `total` to equal.
+    /// `Decimal::ZERO` when the multiplication couldn't be performed
+    /// (zero units, or overflow — see [`Self::overflow`]).
     pub derived_total: Decimal,
     /// `|derived_total - total|`, the magnitude of the violation.
+    /// `Decimal::ZERO` for the zero-units and overflow cases.
     pub abs_diff: Decimal,
     /// The tolerance threshold we tested against. `None` when units
-    /// was zero (the invariant doesn't apply; we reject anyway because
-    /// the pair is structurally meaningless for the post-booking
-    /// shape).
+    /// was zero or the multiplication overflowed — see
+    /// [`Self::overflow`] to distinguish the two.
     pub tolerance: Option<Decimal>,
+    /// `true` when `per_unit * |units|` overflowed `Decimal::MAX`
+    /// (~7.92e28). Distinguishes the overflow case from the zero-units
+    /// case, since both leave `tolerance: None`.
+    pub overflow: bool,
 }
 
 impl fmt::Display for BookedCostInvariantError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.overflow {
+            return write!(
+                f,
+                "BookedCost invariant check overflowed Decimal precision: per_unit ({}) * |units| ({}) exceeds Decimal::MAX (~7.92e28)",
+                self.per_unit,
+                self.units.abs(),
+            );
+        }
         match self.tolerance {
             Some(tol) => write!(
                 f,
@@ -379,10 +400,32 @@ impl BookedCost {
                 derived_total: Decimal::ZERO,
                 abs_diff: Decimal::ZERO,
                 tolerance: None,
+                overflow: false,
             });
         }
-        let derived_total = per_unit * units_abs;
+        // `per_unit` and `units_abs` each fit in `Decimal` individually
+        // (they came through `from_str_exact` or were constructed by
+        // the booker from values that did), but their product can
+        // exceed `Decimal::MAX` (~7.92e28). `Decimal::mul` panics on
+        // overflow — at a trust boundary that would crash the host
+        // from wire input, defeating `try_new`'s typed-error contract.
+        // Surface overflow as a typed error instead.
+        let Some(derived_total) = per_unit.checked_mul(units_abs) else {
+            return Err(BookedCostInvariantError {
+                per_unit,
+                total,
+                units,
+                derived_total: Decimal::ZERO,
+                abs_diff: Decimal::ZERO,
+                tolerance: None,
+                overflow: true,
+            });
+        };
         let abs_diff = (derived_total - total).abs();
+        // `total.abs() * 1e-24` cannot overflow: `Decimal::MAX` is
+        // ~7.92e28, so the product is bounded by ~7.92e4. The relative
+        // tolerance scales with the magnitude of `total`; the absolute
+        // floor (`1e-20`) keeps the window sane for near-zero totals.
         let relative = total.abs() * Decimal::new(1, 24);
         let tolerance = if relative > Decimal::new(1, 20) {
             relative
@@ -399,6 +442,7 @@ impl BookedCost {
                 derived_total,
                 abs_diff,
                 tolerance: Some(tolerance),
+                overflow: false,
             })
         }
     }
@@ -406,11 +450,13 @@ impl BookedCost {
     /// Construct from booking with a precision invariant check.
     ///
     /// In debug builds, asserts that `per_unit * |units| ≈ total` to
-    /// the limits of `rust_decimal` precision (see
-    /// [`Self::check_invariant`] for the tolerance). Callers are the
-    /// booker (which derives `per_unit = total / |units|`) and the
-    /// plugin / FFI ingress bridges (which must validate consistency
-    /// before constructing).
+    /// the limits of `rust_decimal` precision (tolerance:
+    /// `max(1e-20, |total| * 1e-24)`, derived from the booker's
+    /// `total / |units|` divisor truncating at 28 significant digits;
+    /// see the private `check_invariant` helper for the exact
+    /// computation). Callers are the booker (which derives
+    /// `per_unit = total / |units|`) and the plugin / FFI ingress
+    /// bridges (which must validate consistency before constructing).
     ///
     /// # Panics
     ///
@@ -961,6 +1007,7 @@ mod tests {
         assert_eq!(err.derived_total, dec!(500));
         assert_eq!(err.abs_diff, dec!(499));
         assert!(err.tolerance.is_some(), "tolerance must be reported");
+        assert!(!err.overflow, "this case is mismatch, not overflow");
 
         // Display includes both supplied and derived values for
         // plugin-author diagnostics.
@@ -980,6 +1027,7 @@ mod tests {
         let err = BookedCost::try_new(dec!(999999), dec!(0.01), dec!(0))
             .expect_err("zero units must be rejected, not silently accepted");
         assert!(err.tolerance.is_none(), "zero-units error has no tolerance");
+        assert!(!err.overflow, "this is zero-units, not overflow");
         assert!(format!("{err}").contains("non-zero units"));
     }
 
@@ -987,6 +1035,35 @@ mod tests {
     fn booked_cost_try_new_accepts_consistent_pair() {
         let result = BookedCost::try_new(dec!(50), dec!(500), dec!(10));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn booked_cost_try_new_surfaces_overflow_instead_of_panicking() {
+        // Trust-boundary regression guard: a wire client can submit
+        // per_unit and units that each fit in Decimal but whose product
+        // exceeds Decimal::MAX (~7.92e28). Pre-fix `check_invariant`
+        // used bare `*` and panicked the host on multiplication;
+        // `try_new` now surfaces it as a typed error so FFI / plugin
+        // bridges can map it to ConversionError and propagate to the
+        // caller. Inputs: 5e15 × 5e15 = 2.5e31, well over Decimal::MAX.
+        let per_unit = Decimal::from_str_exact("5000000000000000").unwrap();
+        let units = Decimal::from_str_exact("5000000000000000").unwrap();
+        let total = Decimal::from_str_exact("0.01").unwrap();
+        let err = BookedCost::try_new(per_unit, total, units)
+            .expect_err("overflow must surface as Err, not panic");
+        assert!(err.overflow, "overflow flag must be set");
+        assert!(
+            err.tolerance.is_none(),
+            "no tolerance comparison performed for overflow",
+        );
+        assert_eq!(err.derived_total, Decimal::ZERO);
+        assert_eq!(err.abs_diff, Decimal::ZERO);
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("overflow") || msg.contains("Decimal::MAX"),
+            "error message must name the overflow condition, got: {msg}"
+        );
     }
 
     #[test]
@@ -1164,6 +1241,70 @@ mod tests {
             booked_bytes.as_ref(),
             pu_only_bytes.as_ref(),
             "PerUnitFromTotal and PerUnit must serialize distinctly (preserved total is load-bearing)"
+        );
+    }
+
+    /// Frozen byte fixtures for the v8 archived layout.
+    ///
+    /// The intra-build distinctness test above only catches drift
+    /// where variants collide with each other. It would NOT catch a
+    /// uniform encoding shift (e.g. a future rkyv minor bump that
+    /// changes how `Archived<Decimal>` packs, or an accidental
+    /// attribute change). When that happens, every variant moves
+    /// together so distinctness still holds, but user caches on disk
+    /// silently fail to deserialize as garbage in the new layout.
+    ///
+    /// Capturing the exact bytes here pins the on-disk contract:
+    /// any drift trips this test, forcing the developer to either
+    /// (a) revert the encoding change, or (b) bump `CACHE_VERSION` in
+    /// `rustledger-loader/src/cache.rs` so old cache files are
+    /// short-circuited at the header check.
+    ///
+    /// **If this test fails** and you intend the new encoding to be
+    /// the contract going forward: regenerate the fixtures by
+    /// printing `rkyv::to_bytes(&cn)` for each variant and bump
+    /// `CACHE_VERSION` in the same commit.
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn cost_number_archived_bytes_match_v8_fixtures() {
+        let cases: &[(&str, CostNumber, &[u8])] = &[
+            (
+                "PerUnit { value: 150 }",
+                CostNumber::PerUnit { value: dec!(150) },
+                &[
+                    0, 0, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0,
+                ],
+            ),
+            (
+                "Total { value: 1500 }",
+                CostNumber::Total { value: dec!(1500) },
+                &[
+                    1, 0, 0, 0, 0, 220, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0,
+                ],
+            ),
+            (
+                "PerUnitFromTotal { per_unit: 150, total: 300 }",
+                CostNumber::PerUnitFromTotal(BookedCost::new(dec!(150), dec!(300), dec!(2))),
+                &[
+                    2, 0, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 1, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                ],
+            ),
+        ];
+        let mut mismatches = Vec::new();
+        for (name, cn, expected) in cases {
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(cn).unwrap();
+            if bytes.as_ref() != *expected {
+                mismatches.push(format!("  `{name}` → {:?}", bytes.as_ref()));
+            }
+        }
+        assert!(
+            mismatches.is_empty(),
+            "rkyv layout drifted from v8 fixtures — bump CACHE_VERSION and \
+             update the fixtures in this test if intentional. Actual bytes:\n{}",
+            mismatches.join("\n"),
         );
     }
 

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -473,10 +473,12 @@ impl BookedCost {
     ///
     /// Separate from [`Self::from_archive_bytes_trusted`] so the
     /// "trusted" name doesn't lie at fuzz call sites — the fuzzer
-    /// explicitly generates pathological inputs. Both have the same
-    /// implementation but different intent in the codebase. Future
-    /// review can grep for `from_fuzz_unchecked` to find every fuzz-
-    /// path bypass without flagging the legitimate archive readers.
+    /// explicitly generates pathological inputs. Gated behind the
+    /// `fuzz` Cargo feature so normal builds can't reach it (review
+    /// A-4.4); fuzz targets and integration tests that want to
+    /// stress trust-boundary code in convert bridges must opt in via
+    /// `features = ["fuzz"]` on their `rustledger-core` dep.
+    #[cfg(any(feature = "fuzz", test))]
     #[doc(hidden)]
     #[must_use]
     pub const fn from_fuzz_unchecked(per_unit: Decimal, total: Decimal) -> Self {
@@ -1100,6 +1102,69 @@ mod tests {
             let back: CostNumber = serde_json::from_str(&json).unwrap();
             assert_eq!(cn, back, "round trip lost data for {cn:?}");
         }
+    }
+
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn cost_number_rkyv_round_trip_preserves_all_variants() {
+        // Cache v8 docstring claims tuple→struct variant migration is
+        // byte-compatible (review A-4.1). Verify by round-tripping
+        // each variant through rkyv archive bytes — if the
+        // serialize/deserialize pair loses info or panics, the cache
+        // claim is wrong and v8 must bump to v9.
+        for cn in [
+            CostNumber::PerUnit { value: dec!(150) },
+            CostNumber::Total { value: dec!(1500) },
+            CostNumber::PerUnitFromTotal(BookedCost::new(dec!(30), dec!(300), dec!(10))),
+        ] {
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&cn).unwrap();
+            let back: CostNumber =
+                rkyv::from_bytes::<CostNumber, rkyv::rancor::Error>(&bytes).unwrap();
+            assert_eq!(cn, back, "rkyv round-trip lost data for variant {cn:?}");
+        }
+    }
+
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn cost_number_archived_bytes_snapshot() {
+        // Layout snapshot: if rkyv's encoding ever changes (version
+        // upgrade, attribute change, or accidental shape drift), this
+        // test fires and CACHE_VERSION must bump (review A-4.1).
+        // Each archived byte sequence is a fixed contract — any change
+        // means existing cache files on user disks become invalid.
+        let per_unit = CostNumber::PerUnit { value: dec!(150) };
+        let per_unit_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&per_unit).unwrap();
+        assert!(
+            !per_unit_bytes.is_empty(),
+            "PerUnit must serialize to non-empty bytes"
+        );
+
+        let total = CostNumber::Total { value: dec!(1500) };
+        let total_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&total).unwrap();
+        assert!(!total_bytes.is_empty());
+
+        // Critical pin: PerUnit and Total of the same numeric value
+        // serialize to different bytes (the discriminator must be
+        // distinct). If they collide, the cache cannot distinguish
+        // `{150 USD}` from `{{150 USD}}`.
+        let pu_same = CostNumber::PerUnit { value: dec!(1500) };
+        let pu_same_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&pu_same).unwrap();
+        assert_ne!(
+            total_bytes.as_ref(),
+            pu_same_bytes.as_ref(),
+            "PerUnit and Total of the same value must serialize distinctly"
+        );
+
+        // PerUnitFromTotal must also be distinct from PerUnit-only.
+        let booked = CostNumber::PerUnitFromTotal(BookedCost::new(dec!(150), dec!(300), dec!(2)));
+        let booked_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&booked).unwrap();
+        let pu_only = CostNumber::PerUnit { value: dec!(150) };
+        let pu_only_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&pu_only).unwrap();
+        assert_ne!(
+            booked_bytes.as_ref(),
+            pu_only_bytes.as_ref(),
+            "PerUnitFromTotal and PerUnit must serialize distinctly (preserved total is load-bearing)"
+        );
     }
 
     #[test]

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -6,6 +6,14 @@
 //! A [`CostSpec`] is used for matching against existing costs or specifying
 //! new costs when all fields may not be known.
 
+// rkyv 0.8's `derive(Archive)` synthesizes per-variant `Archived*`
+// structs for struct-style enum variants. The generated `pub value:
+// Archived<Decimal>` field on those structs does not inherit the
+// source variant's field docs, which would fire `missing_docs` under
+// `-D warnings`. Limited to this module so hand-written items still
+// get the lint, but the macro-generated ones don't trip it.
+#![cfg_attr(feature = "rkyv", allow(missing_docs))]
+
 use crate::NaiveDate;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -218,21 +226,34 @@ impl fmt::Display for Cost {
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+// Serde uses the `kind`-tagged internal representation so this enum
+// matches the wire shape used by FFI-WASI, WASM, Python compat, and
+// plugin-types. Pre-tag, serde defaulted to the external-tag form
+// (`{"PerUnit": "100"}`) which diverged from those boundaries —
+// downstream clients had to know which surface they were talking to.
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CostNumber {
     /// Per-unit cost as written: `{150.00 USD}`. Booking leaves this
     /// shape unchanged.
-    PerUnit(#[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))] Decimal),
+    PerUnit {
+        /// Per-unit value.
+        #[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))]
+        value: Decimal,
+    },
     /// Total cost as written: `{{ 1500.00 USD }}`. Booking rewrites
     /// this to [`Self::PerUnitFromTotal`] once units are known.
-    Total(#[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))] Decimal),
+    Total {
+        /// Total value.
+        #[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))]
+        value: Decimal,
+    },
     /// Post-booking state: a per-unit value derived from a
     /// `{{ total USD }}` spec at booking time, with the source total
     /// preserved for exact residual math. Pre-#1164 this was modeled
     /// implicitly by setting both `number_per` and `number_total` on
     /// `CostSpec`. The payload is a separate [`BookedCost`] struct
-    /// rather than an inline struct variant so rkyv's per-variant
-    /// archived struct keeps `missing_docs` quiet — the wrapped
-    /// struct's fields carry the docs.
+    /// so the booking-time invariant lives on a named type with
+    /// constructor methods that enforce it.
     PerUnitFromTotal(BookedCost),
 }
 
@@ -262,39 +283,81 @@ pub struct BookedCost {
 }
 
 impl BookedCost {
+    /// Check that `per_unit * |units|` agrees with `total` to within
+    /// `rust_decimal`'s rounding floor.
+    ///
+    /// The booker derives `per_unit = total / |units|` at 28 significant
+    /// digits; back-multiplying truncates similarly. The residual can
+    /// reach a few ULP, which scales with `|total|`. Tolerance is
+    /// `max(1e-20, |total| * 1e-24)` — `1e-24` is ~10000x larger than
+    /// one ULP for typical magnitudes, while the absolute floor
+    /// guarantees a sane window for near-zero totals.
+    fn invariant_holds(per_unit: Decimal, total: Decimal, units_abs: Decimal) -> bool {
+        if units_abs.is_zero() {
+            // Zero-units booking is degenerate; the booker doesn't
+            // construct `PerUnitFromTotal` in that case (see book.rs).
+            // External constructors that pass zero get a free pass.
+            return true;
+        }
+        let derived = per_unit * units_abs;
+        let abs_diff = (derived - total).abs();
+        let relative = total.abs() * Decimal::new(1, 24);
+        let tolerance = if relative > Decimal::new(1, 20) {
+            relative
+        } else {
+            Decimal::new(1, 20)
+        };
+        abs_diff <= tolerance
+    }
+
     /// Construct from booking with a precision invariant check.
     ///
     /// In debug builds, asserts that `per_unit * |units| ≈ total` to
-    /// the limits of `rust_decimal` precision. Callers are the booker
-    /// (which derives `per_unit = total / |units|`) and the FFI input
-    /// bridge (which must not construct inconsistent pairs).
+    /// the limits of `rust_decimal` precision (see
+    /// [`Self::invariant_holds`] for the tolerance). Callers are the
+    /// booker (which derives `per_unit = total / |units|`) and the
+    /// plugin / FFI ingress bridges (which must validate consistency
+    /// before constructing).
     ///
     /// # Panics
     ///
-    /// In debug builds: if `per_unit * |units|` differs from `total` by
-    /// more than 1e-20 (a generous tolerance well inside the
-    /// `rust_decimal` 28-digit precision floor). Release builds skip
+    /// In debug builds: if the invariant fails. Release builds skip
     /// the check.
     #[must_use]
     pub fn new(per_unit: Decimal, total: Decimal, units: Decimal) -> Self {
         let units_abs = units.abs();
         debug_assert!(
-            // Zero-units booking is degenerate; the booker doesn't
-            // construct `PerUnitFromTotal` in that case (see book.rs).
-            // External constructors that pass zero get a free pass.
-            units_abs.is_zero() || (per_unit * units_abs - total).abs() < Decimal::new(1, 20),
+            Self::invariant_holds(per_unit, total, units_abs),
             "BookedCost invariant violated: per_unit ({per_unit}) * |units| ({units_abs}) != total ({total})",
         );
         Self { per_unit, total }
     }
 
-    /// Construct without invariant check, for callers that have
-    /// already validated consistency (e.g. rkyv deserialization,
-    /// trusted-byte loaders).
-    ///
-    /// Prefer [`Self::new`] when the units are at hand.
+    /// Try to construct, returning `None` if the consistency invariant
+    /// fails. Use this at trust boundaries (FFI input, plugin egress)
+    /// where the caller may have supplied inconsistent values and you
+    /// want to reject rather than panic in debug or accept silently in
+    /// release.
     #[must_use]
-    pub const fn from_parts_unchecked(per_unit: Decimal, total: Decimal) -> Self {
+    pub fn try_new(per_unit: Decimal, total: Decimal, units: Decimal) -> Option<Self> {
+        if Self::invariant_holds(per_unit, total, units.abs()) {
+            Some(Self { per_unit, total })
+        } else {
+            None
+        }
+    }
+
+    /// Construct without invariant check.
+    ///
+    /// Reserved for rkyv deserialization of trusted archive bytes the
+    /// host itself wrote. **Do not call from boundary code** — every
+    /// FFI / plugin / parser ingress must go through [`Self::try_new`]
+    /// or [`Self::new`] so inconsistent pairs cannot enter the host.
+    /// The bypass exists only because rkyv archives carry no units at
+    /// the deserialization site.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn from_parts_unchecked_trusted(per_unit: Decimal, total: Decimal) -> Self {
         Self { per_unit, total }
     }
 }
@@ -308,9 +371,9 @@ impl CostNumber {
     #[must_use]
     pub const fn per_unit(&self) -> Option<Decimal> {
         match self {
-            Self::PerUnit(n) => Some(*n),
+            Self::PerUnit { value } => Some(*value),
             Self::PerUnitFromTotal(b) => Some(b.per_unit),
-            Self::Total(_) => None,
+            Self::Total { .. } => None,
         }
     }
 
@@ -322,9 +385,9 @@ impl CostNumber {
     #[must_use]
     pub const fn total(&self) -> Option<Decimal> {
         match self {
-            Self::Total(n) => Some(*n),
+            Self::Total { value } => Some(*value),
             Self::PerUnitFromTotal(b) => Some(b.total),
-            Self::PerUnit(_) => None,
+            Self::PerUnit { .. } => None,
         }
     }
 }
@@ -373,28 +436,23 @@ impl CostSpec {
         Self::default()
     }
 
-    /// Set the cost number to a per-unit value.
-    ///
-    /// Convenience for `with_number(CostNumber::PerUnit(n))`. Use
-    /// [`Self::with_number`] when you already have a [`CostNumber`].
-    #[must_use]
-    pub const fn with_per_unit(self, number: Decimal) -> Self {
-        self.with_number(CostNumber::PerUnit(number))
-    }
-
-    /// Set the cost number to a total value.
-    ///
-    /// Convenience for `with_number(CostNumber::Total(n))`. Use
-    /// [`Self::with_number`] when you already have a [`CostNumber`].
-    #[must_use]
-    pub const fn with_total(self, number: Decimal) -> Self {
-        self.with_number(CostNumber::Total(number))
-    }
-
     /// Set the cost number directly.
     ///
     /// The mutual exclusion between per-unit and total is enforced by
-    /// the [`CostNumber`] enum — there is no way to set both.
+    /// the [`CostNumber`] enum — there is no way to set both. Callers
+    /// construct the variant explicitly:
+    ///
+    /// ```ignore
+    /// CostSpec::empty().with_number(CostNumber::PerUnit { value: dec!(150) });
+    /// CostSpec::empty().with_number(CostNumber::Total { value: dec!(1500) });
+    /// ```
+    ///
+    /// Pre-#1164 this slot was a pair of `Option<Decimal>` fields;
+    /// pre-this-PR there were `with_per_unit` / `with_total`
+    /// convenience shims that perpetuated the two-axis mental model
+    /// in caller code and silently overwrote each other if both were
+    /// called. Both are gone — there's exactly one way to set a cost
+    /// number now.
     #[must_use]
     pub const fn with_number(mut self, number: CostNumber) -> Self {
         self.number = Some(number);
@@ -492,9 +550,9 @@ impl CostSpec {
         let currency = self.currency.clone()?;
         let number = match self.number? {
             // User-specified per-unit cost.
-            CostNumber::PerUnit(per) => per,
+            CostNumber::PerUnit { value: per } => per,
             // Calculated from total — preserve full precision.
-            CostNumber::Total(total) => total / units.abs(),
+            CostNumber::Total { value: total } => total / units.abs(),
             // Already booked: `b.per_unit == b.total / |units|` by
             // `BookedCost::new`'s invariant, so this is identical to
             // the `Total` arm above but without the redivision.
@@ -517,9 +575,9 @@ impl fmt::Display for CostSpec {
         let mut parts = Vec::with_capacity(5);
 
         match self.number {
-            Some(CostNumber::PerUnit(n)) => parts.push(format!("{n}")),
+            Some(CostNumber::PerUnit { value: n }) => parts.push(format!("{n}")),
             Some(CostNumber::PerUnitFromTotal(b)) => parts.push(format!("{}", b.per_unit)),
-            Some(CostNumber::Total(n)) => parts.push(format!("# {n}")),
+            Some(CostNumber::Total { value: n }) => parts.push(format!("# {n}")),
             None => {}
         }
         if let Some(c) = &self.currency {
@@ -644,11 +702,15 @@ mod tests {
         assert!(CostSpec::empty().matches(&cost));
 
         // Match by number
-        let spec = CostSpec::empty().with_per_unit(dec!(150.00));
+        let spec = CostSpec::empty().with_number(crate::CostNumber::PerUnit {
+            value: dec!(150.00),
+        });
         assert!(spec.matches(&cost));
 
         // Wrong number
-        let spec = CostSpec::empty().with_per_unit(dec!(160.00));
+        let spec = CostSpec::empty().with_number(crate::CostNumber::PerUnit {
+            value: dec!(160.00),
+        });
         assert!(!spec.matches(&cost));
 
         // Match by currency
@@ -665,7 +727,9 @@ mod tests {
 
         // Match by all
         let spec = CostSpec::empty()
-            .with_per_unit(dec!(150.00))
+            .with_number(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            })
             .with_currency("USD")
             .with_date(date(2024, 1, 15))
             .with_label("lot1");
@@ -675,7 +739,9 @@ mod tests {
     #[test]
     fn test_cost_spec_resolve() {
         let spec = CostSpec::empty()
-            .with_per_unit(dec!(150.00))
+            .with_number(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            })
             .with_currency("USD");
 
         let cost = spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
@@ -687,7 +753,9 @@ mod tests {
     #[test]
     fn test_cost_spec_resolve_total() {
         let spec = CostSpec::empty()
-            .with_total(dec!(1500.00))
+            .with_number(crate::CostNumber::Total {
+                value: dec!(1500.00),
+            })
             .with_currency("USD");
 
         let cost = spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
@@ -734,27 +802,63 @@ mod tests {
     }
 
     #[test]
-    fn booked_cost_from_parts_unchecked_skips_invariant() {
-        // rkyv deserialization and plugin round-trip use this when
-        // units aren't at hand. Constructs the inconsistent pair
-        // without panicking — verifying it's truly unchecked.
-        let b = BookedCost::from_parts_unchecked(dec!(50), dec!(300));
+    fn booked_cost_from_parts_unchecked_trusted_skips_invariant() {
+        // rkyv deserialization uses this when units aren't at hand.
+        // Constructs the inconsistent pair without panicking —
+        // verifying it's truly unchecked. Plugin / FFI ingress code
+        // must NOT use this path; they get `try_new`.
+        let b = BookedCost::from_parts_unchecked_trusted(dec!(50), dec!(300));
         assert_eq!(b.per_unit, dec!(50));
         assert_eq!(b.total, dec!(300));
     }
 
     #[test]
+    fn booked_cost_try_new_rejects_inconsistent_pair() {
+        // Trust-boundary constructor must return None for inconsistent
+        // pairs instead of either panicking (new) or accepting
+        // silently (unchecked). 10 units × 50/u = 500, not 999.
+        let result = BookedCost::try_new(dec!(50), dec!(999), dec!(10));
+        assert!(result.is_none(), "expected None for inconsistent input");
+    }
+
+    #[test]
+    fn booked_cost_try_new_accepts_consistent_pair() {
+        let result = BookedCost::try_new(dec!(50), dec!(500), dec!(10));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn booked_cost_invariant_tolerates_rust_decimal_rounding() {
+        // The booker computes per_unit = total / |units| at 28-digit
+        // precision; back-multiplying truncates the same way. The
+        // tolerance must accommodate the ULP-scale residual that real
+        // ledgers exercise — the original tight 1e-20 floor fired
+        // spuriously on cases like 300 / 1.763.
+        let total = dec!(300);
+        let units = dec!(1.763);
+        let per_unit = total / units;
+        // This must NOT panic.
+        let _ = BookedCost::new(per_unit, total, units);
+    }
+
+    #[test]
     fn cost_number_per_unit_accessor() {
-        assert_eq!(CostNumber::PerUnit(dec!(150)).per_unit(), Some(dec!(150)));
-        assert_eq!(CostNumber::Total(dec!(1500)).per_unit(), None);
+        assert_eq!(
+            CostNumber::PerUnit { value: dec!(150) }.per_unit(),
+            Some(dec!(150))
+        );
+        assert_eq!(CostNumber::Total { value: dec!(1500) }.per_unit(), None);
         let b = BookedCost::new(dec!(30), dec!(300), dec!(10));
         assert_eq!(CostNumber::PerUnitFromTotal(b).per_unit(), Some(dec!(30)));
     }
 
     #[test]
     fn cost_number_total_accessor() {
-        assert_eq!(CostNumber::PerUnit(dec!(150)).total(), None);
-        assert_eq!(CostNumber::Total(dec!(1500)).total(), Some(dec!(1500)));
+        assert_eq!(CostNumber::PerUnit { value: dec!(150) }.total(), None);
+        assert_eq!(
+            CostNumber::Total { value: dec!(1500) }.total(),
+            Some(dec!(1500))
+        );
         let b = BookedCost::new(dec!(30), dec!(300), dec!(10));
         assert_eq!(CostNumber::PerUnitFromTotal(b).total(), Some(dec!(300)));
     }
@@ -775,7 +879,9 @@ mod tests {
         assert_eq!(cost.currency, "USD");
 
         // Same shape via raw Total → same number after division.
-        let total_spec = CostSpec::empty().with_total(dec!(300)).with_currency("USD");
+        let total_spec = CostSpec::empty()
+            .with_number(crate::CostNumber::Total { value: dec!(300) })
+            .with_currency("USD");
         let total_cost = total_spec.resolve(dec!(10), date(2024, 1, 15)).unwrap();
         assert_eq!(cost.number, total_cost.number);
     }
@@ -797,6 +903,43 @@ mod tests {
         let wrong = BookedCost::new(dec!(160), dec!(320), dec!(2));
         let wrong_spec = CostSpec::empty().with_number(CostNumber::PerUnitFromTotal(wrong));
         assert!(!wrong_spec.matches(&cost));
+    }
+
+    #[test]
+    fn cost_number_serde_emits_kind_tagged_shape() {
+        // The unified wire shape across plugin-types, FFI-WASI, WASM,
+        // and Python compat is `{"kind": "per_unit", "value": "100"}`
+        // etc. This test pins that crate::CostNumber serde
+        // matches — silent drift here breaks every downstream client.
+        let pu = CostNumber::PerUnit { value: dec!(100) };
+        let json = serde_json::to_value(pu).unwrap();
+        assert_eq!(json["kind"], "per_unit", "PerUnit must use kind tag");
+
+        let t = CostNumber::Total { value: dec!(1500) };
+        let json = serde_json::to_value(t).unwrap();
+        assert_eq!(json["kind"], "total");
+
+        let b = BookedCost::new(dec!(150), dec!(300), dec!(2));
+        let puft = CostNumber::PerUnitFromTotal(b);
+        let json = serde_json::to_value(puft).unwrap();
+        assert_eq!(json["kind"], "per_unit_from_total");
+        assert_eq!(json["per_unit"], "150");
+        assert_eq!(json["total"], "300");
+    }
+
+    #[test]
+    fn cost_number_serde_round_trip() {
+        // The cross-language wire contract is only honored if Rust
+        // can also deserialize what it serialized. Pin the round-trip.
+        for cn in [
+            CostNumber::PerUnit { value: dec!(42) },
+            CostNumber::Total { value: dec!(420) },
+            CostNumber::PerUnitFromTotal(BookedCost::new(dec!(150), dec!(300), dec!(2))),
+        ] {
+            let json = serde_json::to_string(&cn).unwrap();
+            let back: CostNumber = serde_json::from_str(&json).unwrap();
+            assert_eq!(cn, back, "round trip lost data for {cn:?}");
+        }
     }
 
     #[test]

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -6,12 +6,15 @@
 //! A [`CostSpec`] is used for matching against existing costs or specifying
 //! new costs when all fields may not be known.
 
-// rkyv 0.8's `derive(Archive)` synthesizes per-variant `Archived*`
-// structs for struct-style enum variants. The generated `pub value:
-// Archived<Decimal>` field on those structs does not inherit the
-// source variant's field docs, which would fire `missing_docs` under
-// `-D warnings`. Limited to this module so hand-written items still
-// get the lint, but the macro-generated ones don't trip it.
+// rkyv's enum derive (used on `CostNumber` below) synthesizes a
+// per-variant `Archived*` struct whose generated `pub value` field
+// doesn't inherit the source variant's field doc. Item-level
+// `#[allow(missing_docs)]` doesn't propagate into the macro-emitted
+// sibling items, so the suppression must live at module scope.
+// Limited to the `rkyv` feature so hand-written items still get the
+// lint under non-rkyv builds; reviewers should check that any new
+// rkyv-archived type added to this file has docs on its source fields
+// (review A-3.2).
 #![cfg_attr(feature = "rkyv", allow(missing_docs))]
 
 use crate::NaiveDate;
@@ -231,6 +234,9 @@ impl fmt::Display for Cost {
 // plugin-types. Pre-tag, serde defaulted to the external-tag form
 // (`{"PerUnit": "100"}`) which diverged from those boundaries —
 // downstream clients had to know which surface they were talking to.
+// (Module-level `allow(missing_docs)` at the top of this file
+// silences the rkyv-generated archived-struct field doc warnings —
+// see the file header comment.)
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CostNumber {
     /// Per-unit cost as written: `{150.00 USD}`. Booking leaves this
@@ -282,9 +288,68 @@ pub struct BookedCost {
     pub total: Decimal,
 }
 
+/// Diagnostic for a failed [`BookedCost`] consistency check.
+///
+/// Returned by [`BookedCost::try_new`] when the supplied
+/// `per_unit * |units|` does not agree with `total` to within the
+/// `rust_decimal` rounding floor (or when `units == 0`, which makes
+/// the pair structurally untrustworthy — every `per_unit` "works" by
+/// zero-multiplication, so the invariant carries no information).
+///
+/// Carries the inputs and the computed residual so trust-boundary
+/// callers can surface a meaningful error to the originating plugin
+/// or wire client ("you sent `per_unit=50, total=999` with `units=10`;
+/// derived total would be 500, off by 499 — far outside tolerance
+/// 1e-20"). Mapping this to a `ConversionError` variant gives plugin
+/// authors a typed category for the failure instead of conflating
+/// with `InvalidNumber` (parse failure).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BookedCostInvariantError {
+    /// The per-unit value the caller supplied.
+    pub per_unit: Decimal,
+    /// The total value the caller supplied.
+    pub total: Decimal,
+    /// The units value the caller supplied (caller-side sign retained
+    /// so error messages can show what came in).
+    pub units: Decimal,
+    /// `per_unit * |units|`, the value we'd expect `total` to equal.
+    pub derived_total: Decimal,
+    /// `|derived_total - total|`, the magnitude of the violation.
+    pub abs_diff: Decimal,
+    /// The tolerance threshold we tested against. `None` when units
+    /// was zero (the invariant doesn't apply; we reject anyway because
+    /// the pair is structurally meaningless for the post-booking
+    /// shape).
+    pub tolerance: Option<Decimal>,
+}
+
+impl fmt::Display for BookedCostInvariantError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.tolerance {
+            Some(tol) => write!(
+                f,
+                "BookedCost invariant violated: per_unit ({}) * |units| ({}) = {} ≠ total ({}); abs_diff {} exceeds tolerance {}",
+                self.per_unit,
+                self.units.abs(),
+                self.derived_total,
+                self.total,
+                self.abs_diff,
+                tol,
+            ),
+            None => write!(
+                f,
+                "BookedCost requires non-zero units; got per_unit ({}), total ({}), units (0)",
+                self.per_unit, self.total,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BookedCostInvariantError {}
+
 impl BookedCost {
-    /// Check that `per_unit * |units|` agrees with `total` to within
-    /// `rust_decimal`'s rounding floor.
+    /// Check `per_unit * |units| ≈ total` to within `rust_decimal`
+    /// rounding tolerance, returning the diagnostic on failure.
     ///
     /// The booker derives `per_unit = total / |units|` at 28 significant
     /// digits; back-multiplying truncates similarly. The residual can
@@ -292,29 +357,57 @@ impl BookedCost {
     /// `max(1e-20, |total| * 1e-24)` — `1e-24` is ~10000x larger than
     /// one ULP for typical magnitudes, while the absolute floor
     /// guarantees a sane window for near-zero totals.
-    fn invariant_holds(per_unit: Decimal, total: Decimal, units_abs: Decimal) -> bool {
+    ///
+    /// **`units == 0` is rejected**: the post-booking shape implies the
+    /// booker derived `per_unit` from `total / |units|`, which is
+    /// undefined for zero units. A zero-units `PerUnitFromTotal` is
+    /// structurally meaningless and the caller should use the raw
+    /// `PerUnit` / `Total` variants. Pre-fix the zero-units case
+    /// short-circuited to `true`, which defeated the trust-boundary
+    /// guard at every input bridge (review B-3.1).
+    fn check_invariant(
+        per_unit: Decimal,
+        total: Decimal,
+        units: Decimal,
+    ) -> Result<(), BookedCostInvariantError> {
+        let units_abs = units.abs();
         if units_abs.is_zero() {
-            // Zero-units booking is degenerate; the booker doesn't
-            // construct `PerUnitFromTotal` in that case (see book.rs).
-            // External constructors that pass zero get a free pass.
-            return true;
+            return Err(BookedCostInvariantError {
+                per_unit,
+                total,
+                units,
+                derived_total: Decimal::ZERO,
+                abs_diff: Decimal::ZERO,
+                tolerance: None,
+            });
         }
-        let derived = per_unit * units_abs;
-        let abs_diff = (derived - total).abs();
+        let derived_total = per_unit * units_abs;
+        let abs_diff = (derived_total - total).abs();
         let relative = total.abs() * Decimal::new(1, 24);
         let tolerance = if relative > Decimal::new(1, 20) {
             relative
         } else {
             Decimal::new(1, 20)
         };
-        abs_diff <= tolerance
+        if abs_diff <= tolerance {
+            Ok(())
+        } else {
+            Err(BookedCostInvariantError {
+                per_unit,
+                total,
+                units,
+                derived_total,
+                abs_diff,
+                tolerance: Some(tolerance),
+            })
+        }
     }
 
     /// Construct from booking with a precision invariant check.
     ///
     /// In debug builds, asserts that `per_unit * |units| ≈ total` to
     /// the limits of `rust_decimal` precision (see
-    /// [`Self::invariant_holds`] for the tolerance). Callers are the
+    /// [`Self::check_invariant`] for the tolerance). Callers are the
     /// booker (which derives `per_unit = total / |units|`) and the
     /// plugin / FFI ingress bridges (which must validate consistency
     /// before constructing).
@@ -322,42 +415,71 @@ impl BookedCost {
     /// # Panics
     ///
     /// In debug builds: if the invariant fails. Release builds skip
-    /// the check.
+    /// the check (but trust-boundary callers should use
+    /// [`Self::try_new`] for runtime validation in release too).
     #[must_use]
     pub fn new(per_unit: Decimal, total: Decimal, units: Decimal) -> Self {
-        let units_abs = units.abs();
         debug_assert!(
-            Self::invariant_holds(per_unit, total, units_abs),
-            "BookedCost invariant violated: per_unit ({per_unit}) * |units| ({units_abs}) != total ({total})",
+            Self::check_invariant(per_unit, total, units).is_ok(),
+            "{}",
+            Self::check_invariant(per_unit, total, units).unwrap_err(),
         );
         Self { per_unit, total }
     }
 
-    /// Try to construct, returning `None` if the consistency invariant
-    /// fails. Use this at trust boundaries (FFI input, plugin egress)
-    /// where the caller may have supplied inconsistent values and you
-    /// want to reject rather than panic in debug or accept silently in
-    /// release.
-    #[must_use]
-    pub fn try_new(per_unit: Decimal, total: Decimal, units: Decimal) -> Option<Self> {
-        if Self::invariant_holds(per_unit, total, units.abs()) {
-            Some(Self { per_unit, total })
-        } else {
-            None
-        }
+    /// Try to construct, returning a typed error if the consistency
+    /// invariant fails. Use this at trust boundaries (FFI input,
+    /// plugin egress) where the caller may have supplied inconsistent
+    /// values and you want to reject rather than panic in debug or
+    /// accept silently in release.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BookedCostInvariantError`] when:
+    /// - `units == 0` (the post-booking shape is structurally
+    ///   undefined for zero units; callers should send `PerUnit` or
+    ///   `Total` instead).
+    /// - `per_unit * |units|` differs from `total` by more than
+    ///   `max(1e-20, |total| * 1e-24)`.
+    pub fn try_new(
+        per_unit: Decimal,
+        total: Decimal,
+        units: Decimal,
+    ) -> Result<Self, BookedCostInvariantError> {
+        Self::check_invariant(per_unit, total, units)?;
+        Ok(Self { per_unit, total })
     }
 
-    /// Construct without invariant check.
+    /// Construct from rkyv archive bytes the host itself wrote.
     ///
-    /// Reserved for rkyv deserialization of trusted archive bytes the
-    /// host itself wrote. **Do not call from boundary code** — every
-    /// FFI / plugin / parser ingress must go through [`Self::try_new`]
-    /// or [`Self::new`] so inconsistent pairs cannot enter the host.
-    /// The bypass exists only because rkyv archives carry no units at
-    /// the deserialization site.
+    /// Bypasses the consistency invariant because rkyv archives carry
+    /// no units at the deserialization site, and the host invariant
+    /// was already enforced when the bytes were written. **Do not
+    /// call from boundary code** — every FFI / plugin / parser
+    /// ingress must go through [`Self::try_new`] (which surfaces a
+    /// typed error) so inconsistent pairs cannot enter the host.
+    ///
+    /// The name reflects the trust assumption: the caller has
+    /// verified (via cache-version checks, archive integrity, etc.)
+    /// that the bytes were produced by this host's own booker.
     #[doc(hidden)]
     #[must_use]
-    pub const fn from_parts_unchecked_trusted(per_unit: Decimal, total: Decimal) -> Self {
+    pub const fn from_archive_bytes_trusted(per_unit: Decimal, total: Decimal) -> Self {
+        Self { per_unit, total }
+    }
+
+    /// Construct an *intentionally inconsistent* `BookedCost` for
+    /// fuzzing trust-boundary code that must reject such inputs.
+    ///
+    /// Separate from [`Self::from_archive_bytes_trusted`] so the
+    /// "trusted" name doesn't lie at fuzz call sites — the fuzzer
+    /// explicitly generates pathological inputs. Both have the same
+    /// implementation but different intent in the codebase. Future
+    /// review can grep for `from_fuzz_unchecked` to find every fuzz-
+    /// path bypass without flagging the legitimate archive readers.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn from_fuzz_unchecked(per_unit: Decimal, total: Decimal) -> Self {
         Self { per_unit, total }
     }
 }
@@ -792,39 +914,77 @@ mod tests {
     }
 
     #[test]
-    fn booked_cost_new_allows_zero_units() {
-        // Zero units is degenerate — the booker doesn't construct
-        // PerUnitFromTotal there, but external callers (FFI input)
-        // might. Constructor gives them a pass.
-        let b = BookedCost::new(dec!(7), dec!(99), dec!(0));
-        assert_eq!(b.per_unit, dec!(7));
-        assert_eq!(b.total, dec!(99));
+    #[should_panic(expected = "requires non-zero units")]
+    fn booked_cost_new_rejects_zero_units_in_debug() {
+        // Post-A-3.5/B-3.1: zero units is structurally meaningless
+        // for the post-booking shape (every per_unit "works" by
+        // zero-multiplication). `new` debug-asserts and panics;
+        // `try_new` returns a typed error. The booker never
+        // constructs PerUnitFromTotal with zero units (see book.rs),
+        // so this only fires when boundary code forgets to validate.
+        let _ = BookedCost::new(dec!(7), dec!(99), dec!(0));
     }
 
     #[test]
-    fn booked_cost_from_parts_unchecked_trusted_skips_invariant() {
+    fn booked_cost_from_archive_bytes_trusted_skips_invariant() {
         // rkyv deserialization uses this when units aren't at hand.
         // Constructs the inconsistent pair without panicking —
         // verifying it's truly unchecked. Plugin / FFI ingress code
         // must NOT use this path; they get `try_new`.
-        let b = BookedCost::from_parts_unchecked_trusted(dec!(50), dec!(300));
+        let b = BookedCost::from_archive_bytes_trusted(dec!(50), dec!(300));
         assert_eq!(b.per_unit, dec!(50));
         assert_eq!(b.total, dec!(300));
     }
 
     #[test]
-    fn booked_cost_try_new_rejects_inconsistent_pair() {
-        // Trust-boundary constructor must return None for inconsistent
-        // pairs instead of either panicking (new) or accepting
-        // silently (unchecked). 10 units × 50/u = 500, not 999.
-        let result = BookedCost::try_new(dec!(50), dec!(999), dec!(10));
-        assert!(result.is_none(), "expected None for inconsistent input");
+    fn booked_cost_from_fuzz_unchecked_skips_invariant() {
+        // Fuzz harness uses this to generate pathological inputs that
+        // stress trust-boundary code in convert bridges. Distinct
+        // from the archive constructor at the source level so grep
+        // can identify each kind of bypass.
+        let b = BookedCost::from_fuzz_unchecked(dec!(999999), dec!(0.01));
+        assert_eq!(b.per_unit, dec!(999999));
+        assert_eq!(b.total, dec!(0.01));
+    }
+
+    #[test]
+    fn booked_cost_try_new_rejects_inconsistent_pair_with_diagnostic() {
+        // Trust-boundary constructor must return a typed error for
+        // inconsistent pairs. 10 units × 50/u = 500, not 999.
+        let err = BookedCost::try_new(dec!(50), dec!(999), dec!(10))
+            .expect_err("expected invariant error for inconsistent input");
+        assert_eq!(err.per_unit, dec!(50));
+        assert_eq!(err.total, dec!(999));
+        assert_eq!(err.units, dec!(10));
+        assert_eq!(err.derived_total, dec!(500));
+        assert_eq!(err.abs_diff, dec!(499));
+        assert!(err.tolerance.is_some(), "tolerance must be reported");
+
+        // Display includes both supplied and derived values for
+        // plugin-author diagnostics.
+        let msg = format!("{err}");
+        assert!(msg.contains("50") && msg.contains("999") && msg.contains("500"));
+    }
+
+    #[test]
+    fn booked_cost_try_new_rejects_zero_units() {
+        // Pre-fix the zero-units case short-circuited to "valid",
+        // defeating the trust-boundary guard at every input bridge
+        // (review B-3.1). PerUnitFromTotal is structurally
+        // meaningless for zero units — every per_unit "works" by
+        // zero-multiplication. Reject explicitly with `tolerance:
+        // None` so callers can distinguish this from a numeric
+        // mismatch.
+        let err = BookedCost::try_new(dec!(999999), dec!(0.01), dec!(0))
+            .expect_err("zero units must be rejected, not silently accepted");
+        assert!(err.tolerance.is_none(), "zero-units error has no tolerance");
+        assert!(format!("{err}").contains("non-zero units"));
     }
 
     #[test]
     fn booked_cost_try_new_accepts_consistent_pair() {
         let result = BookedCost::try_new(dec!(50), dec!(500), dec!(10));
-        assert!(result.is_some());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -187,18 +187,136 @@ impl fmt::Display for Cost {
 /// let spec2 = CostSpec::default().with_date(rustledger_core::naive_date(2024, 1, 16).unwrap());
 /// assert!(!spec2.matches(&cost));
 /// ```
+/// The numeric component of a [`CostSpec`].
+///
+/// Beancount cost specs name a number in one of two source-level
+/// shapes:
+///
+/// - `{150.00 USD}` — per-unit cost ([`Self::PerUnit`])
+/// - `{{ 1500.00 USD }}` — total cost for the posting's units
+///   ([`Self::Total`])
+///
+/// During booking the engine converts `Total(t)` into a third state,
+/// [`Self::PerUnitFromTotal`], carrying both the derived per-unit
+/// value (for display, lot tracking) and the original total (for
+/// precision-preserving residual math — division-then-multiplication
+/// loses precision at the `rust_decimal` 28-digit ceiling).
+///
+/// A cost spec without a number at all (e.g. `{}` for a booking-
+/// deferred lot match) is represented by `CostSpec.number: None`.
+///
+/// Pre-#1164 the per-unit and total numbers were two independent
+/// `Option<Decimal>` fields on `CostSpec`. The invalid both-set state
+/// was prevented only by parser discipline and downstream defensive
+/// branches; the "booked from total" state was modeled accidentally
+/// by setting both fields, with the meaning encoded only in code
+/// comments. Folding the axes into one enum makes both the
+/// pre-booking invalid state unrepresentable AND the post-booking
+/// derived state explicit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub enum CostNumber {
+    /// Per-unit cost as written: `{150.00 USD}`. Booking leaves this
+    /// shape unchanged.
+    PerUnit(#[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))] Decimal),
+    /// Total cost as written: `{{ 1500.00 USD }}`. Booking rewrites
+    /// this to [`Self::PerUnitFromTotal`] once units are known.
+    Total(#[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))] Decimal),
+    /// Post-booking state: a per-unit value derived from a
+    /// `{{ total USD }}` spec at booking time, with the source total
+    /// preserved for exact residual math. Pre-#1164 this was modeled
+    /// implicitly by setting both `number_per` and `number_total` on
+    /// `CostSpec`. The payload is a separate [`BookedCost`] struct
+    /// rather than an inline struct variant so rkyv's per-variant
+    /// archived struct keeps `missing_docs` quiet — the wrapped
+    /// struct's fields carry the docs.
+    PerUnitFromTotal(BookedCost),
+}
+
+/// Payload of [`CostNumber::PerUnitFromTotal`].
+///
+/// Carries both the per-unit value derived at booking time and the
+/// original `{{ total }}` cost so residual math can use the exact
+/// total (avoiding the division-then-multiplication precision loss
+/// that hits the `rust_decimal` 28-digit ceiling on long ledgers).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub struct BookedCost {
+    /// Per-unit cost, derived as `total / |units|` during booking.
+    /// Used by lot tracking, display (Python-compat post-booking
+    /// per-unit form), and validation reads that want a per-unit
+    /// value.
+    #[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))]
+    pub per_unit: Decimal,
+    /// Original total as written. Used by residual calculation to
+    /// avoid the division-then-multiplication precision loss that
+    /// would otherwise leak into balance checks.
+    #[cfg_attr(feature = "rkyv", rkyv(with = AsDecimal))]
+    pub total: Decimal,
+}
+
+impl CostNumber {
+    /// Return the per-unit value if this number carries one.
+    ///
+    /// - [`Self::PerUnit`] → `Some(its Decimal)`
+    /// - [`Self::PerUnitFromTotal`] → `Some(per_unit)`
+    /// - [`Self::Total`] → `None` (booking hasn't computed per-unit yet)
+    #[must_use]
+    pub const fn per_unit(&self) -> Option<Decimal> {
+        match self {
+            Self::PerUnit(n) => Some(*n),
+            Self::PerUnitFromTotal(b) => Some(b.per_unit),
+            Self::Total(_) => None,
+        }
+    }
+
+    /// Return the total value if this number carries one.
+    ///
+    /// - [`Self::Total`] → `Some(its Decimal)`
+    /// - [`Self::PerUnitFromTotal`] → `Some(total)`
+    /// - [`Self::PerUnit`] → `None`
+    #[must_use]
+    pub const fn total(&self) -> Option<Decimal> {
+        match self {
+            Self::Total(n) => Some(*n),
+            Self::PerUnitFromTotal(b) => Some(b.total),
+            Self::PerUnit(_) => None,
+        }
+    }
+}
+
+/// A cost specification on a posting (`{...}` or `{{...}}`).
+///
+/// Carries the parsed cost-spec axes: the numeric component (per-unit
+/// vs total, modeled as the mutually-exclusive [`CostNumber`] enum),
+/// currency, lot date, label, and merge flag. Any subset may be
+/// missing — `{}` corresponds to all-fields-`None` plus `merge: false`,
+/// which lets the booker do lot matching deferred to inventory.
+///
+/// Pre-#1164 this struct had two independent `Option<Decimal>` fields
+/// (`number_per`, `number_total`). The mutual-exclusion invariant was
+/// enforced only by parser discipline; the post-booking "derived per-
+/// unit from total" state was modeled accidentally by setting both
+/// fields at once. The new shape (`number: Option<CostNumber>`) makes
+/// the invalid state unrepresentable and the derived state explicit.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
 pub struct CostSpec {
-    /// Cost per unit (if specified)
-    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsDecimal>))]
-    pub number_per: Option<Decimal>,
-    /// Total cost (if specified) - alternative to `number_per`
-    #[cfg_attr(feature = "rkyv", rkyv(with = rkyv::with::Map<AsDecimal>))]
-    pub number_total: Option<Decimal>,
+    /// The numeric component: per-unit, total, or absent.
+    ///
+    /// Replaces the pre-#1164 `number_per` / `number_total` pair, which
+    /// allowed the invalid both-set state at the type level. See
+    /// [`CostNumber`] for the per-unit vs total distinction.
+    pub number: Option<CostNumber>,
     /// Currency of the cost (if specified)
     pub currency: Option<crate::Currency>,
     /// Acquisition date (if specified)
@@ -218,16 +336,22 @@ impl CostSpec {
     }
 
     /// Set the per-unit cost.
+    ///
+    /// Overwrites any previously-set number (per-unit or total) — the
+    /// shapes are mutually exclusive by construction.
     #[must_use]
     pub const fn with_number_per(mut self, number: Decimal) -> Self {
-        self.number_per = Some(number);
+        self.number = Some(CostNumber::PerUnit(number));
         self
     }
 
     /// Set the total cost.
+    ///
+    /// Overwrites any previously-set number (per-unit or total) — the
+    /// shapes are mutually exclusive by construction.
     #[must_use]
     pub const fn with_number_total(mut self, number: Decimal) -> Self {
-        self.number_total = Some(number);
+        self.number = Some(CostNumber::Total(number));
         self
     }
 
@@ -262,8 +386,7 @@ impl CostSpec {
     /// Check if this is an empty cost spec (all fields None).
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.number_per.is_none()
-            && self.number_total.is_none()
+        self.number.is_none()
             && self.currency.is_none()
             && self.date.is_none()
             && self.label.is_none()
@@ -273,11 +396,16 @@ impl CostSpec {
     /// Check if this cost spec matches a cost.
     ///
     /// All specified fields must match the corresponding cost fields.
+    /// Per-unit matching uses `CostNumber::per_unit()` — a `Total`-only
+    /// spec doesn't constrain the per-unit lot value (booking hasn't
+    /// resolved it yet), but a `PerUnitFromTotal` post-booking spec
+    /// does.
     #[must_use]
     pub fn matches(&self, cost: &Cost) -> bool {
-        // Check per-unit cost
-        if let Some(n) = &self.number_per
-            && n != &cost.number
+        // Check per-unit cost — constrains the lot whenever the spec
+        // carries a per-unit value (PerUnit or PerUnitFromTotal).
+        if let Some(n) = self.number.and_then(|cn| cn.per_unit())
+            && n != cost.number
         {
             return false;
         }
@@ -304,23 +432,23 @@ impl CostSpec {
 
     /// Resolve this cost spec to a concrete cost, given the number of units.
     ///
-    /// If `number_total` is specified, the per-unit cost is calculated as
-    /// `number_total / units`. Full precision is preserved to avoid cost basis
-    /// errors when the position is later sold.
+    /// If the number is `CostNumber::Total`, the per-unit cost is
+    /// calculated as `total / |units|`. Full precision is preserved to
+    /// avoid cost basis errors when the position is later sold.
+    /// `PerUnitFromTotal` already carries the derived per-unit value
+    /// from a prior booking pass — use it directly.
     ///
-    /// Returns `None` if required fields (currency) are missing.
+    /// Returns `None` if required fields (currency, number) are missing.
     #[must_use]
     pub fn resolve(&self, units: Decimal, date: NaiveDate) -> Option<Cost> {
         let currency = self.currency.clone()?;
-
-        let number = if let Some(per) = self.number_per {
-            // User-specified per-unit cost
-            per
-        } else if let Some(total) = self.number_total {
-            // Calculated from total - preserve full precision
-            total / units.abs()
-        } else {
-            return None;
+        let number = match self.number? {
+            // User-specified per-unit cost.
+            CostNumber::PerUnit(per) => per,
+            // Calculated from total — preserve full precision.
+            CostNumber::Total(total) => total / units.abs(),
+            // Already booked from a total.
+            CostNumber::PerUnitFromTotal(b) => b.per_unit,
         };
 
         Some(Cost {
@@ -335,14 +463,14 @@ impl CostSpec {
 impl fmt::Display for CostSpec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
-        // Max 6 elements: number_per, number_total, currency, date, label, merge
-        let mut parts = Vec::with_capacity(6);
+        // Max 5 elements: number, currency, date, label, merge
+        let mut parts = Vec::with_capacity(5);
 
-        if let Some(n) = self.number_per {
-            parts.push(format!("{n}"));
-        }
-        if let Some(n) = self.number_total {
-            parts.push(format!("# {n}"));
+        match self.number {
+            Some(CostNumber::PerUnit(n)) => parts.push(format!("{n}")),
+            Some(CostNumber::PerUnitFromTotal(b)) => parts.push(format!("{}", b.per_unit)),
+            Some(CostNumber::Total(n)) => parts.push(format!("# {n}")),
+            None => {}
         }
         if let Some(c) = &self.currency {
             parts.push(c.to_string());

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -1038,6 +1038,23 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "overflow")]
+    fn booked_cost_new_panics_in_debug_on_overflow() {
+        // `BookedCost::new` debug-asserts the invariant. Overflow
+        // should reach the assertion via `check_invariant`'s Err, then
+        // panic with a message that names the failure mode — same
+        // contract as the existing zero-units / mismatch debug
+        // asserts. Without this test, a future refactor of
+        // `check_invariant`'s error path could swallow the overflow
+        // case at the `new` call site (e.g. by short-circuiting to
+        // Ok or by using a different Display) and the `new`-side
+        // contract would degrade silently. Inputs: 5e15 × 5e15 →
+        // 2.5e31, which exceeds Decimal::MAX (~7.92e28).
+        let huge = Decimal::from_str_exact("5000000000000000").unwrap();
+        let _ = BookedCost::new(huge, Decimal::from_str_exact("0.01").unwrap(), huge);
+    }
+
+    #[test]
     fn booked_cost_try_new_surfaces_overflow_instead_of_panicking() {
         // Trust-boundary regression guard: a wire client can submit
         // per_unit and units that each fit in Decimal but whose product
@@ -1244,69 +1261,10 @@ mod tests {
         );
     }
 
-    /// Frozen byte fixtures for the v8 archived layout.
-    ///
-    /// The intra-build distinctness test above only catches drift
-    /// where variants collide with each other. It would NOT catch a
-    /// uniform encoding shift (e.g. a future rkyv minor bump that
-    /// changes how `Archived<Decimal>` packs, or an accidental
-    /// attribute change). When that happens, every variant moves
-    /// together so distinctness still holds, but user caches on disk
-    /// silently fail to deserialize as garbage in the new layout.
-    ///
-    /// Capturing the exact bytes here pins the on-disk contract:
-    /// any drift trips this test, forcing the developer to either
-    /// (a) revert the encoding change, or (b) bump `CACHE_VERSION` in
-    /// `rustledger-loader/src/cache.rs` so old cache files are
-    /// short-circuited at the header check.
-    ///
-    /// **If this test fails** and you intend the new encoding to be
-    /// the contract going forward: regenerate the fixtures by
-    /// printing `rkyv::to_bytes(&cn)` for each variant and bump
-    /// `CACHE_VERSION` in the same commit.
-    #[cfg(feature = "rkyv")]
-    #[test]
-    fn cost_number_archived_bytes_match_v8_fixtures() {
-        let cases: &[(&str, CostNumber, &[u8])] = &[
-            (
-                "PerUnit { value: 150 }",
-                CostNumber::PerUnit { value: dec!(150) },
-                &[
-                    0, 0, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0,
-                ],
-            ),
-            (
-                "Total { value: 1500 }",
-                CostNumber::Total { value: dec!(1500) },
-                &[
-                    1, 0, 0, 0, 0, 220, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0,
-                ],
-            ),
-            (
-                "PerUnitFromTotal { per_unit: 150, total: 300 }",
-                CostNumber::PerUnitFromTotal(BookedCost::new(dec!(150), dec!(300), dec!(2))),
-                &[
-                    2, 0, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 1, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0,
-                ],
-            ),
-        ];
-        let mut mismatches = Vec::new();
-        for (name, cn, expected) in cases {
-            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(cn).unwrap();
-            if bytes.as_ref() != *expected {
-                mismatches.push(format!("  `{name}` → {:?}", bytes.as_ref()));
-            }
-        }
-        assert!(
-            mismatches.is_empty(),
-            "rkyv layout drifted from v8 fixtures — bump CACHE_VERSION and \
-             update the fixtures in this test if intentional. Actual bytes:\n{}",
-            mismatches.join("\n"),
-        );
-    }
+    // Frozen byte fixtures for the v8 cache layout live alongside
+    // CACHE_VERSION in `rustledger-loader::cache::tests` so the
+    // version constant and the on-disk byte layout sit in one place
+    // — see `cost_number_archived_bytes_match_v8_fixtures` there.
 
     #[test]
     fn cost_spec_display_renders_per_unit_from_total_as_per_unit() {

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -219,9 +219,9 @@ impl Posting {
     /// location, use [`crate::Spanned::map`]:
     ///
     /// ```no_run
-    /// # use rustledger_core::{Posting, Amount, CostSpec, Spanned};
+    /// # use rustledger_core::{Posting, Amount, CostSpec, CostNumber, Spanned};
     /// # use rust_decimal_macros::dec;
-    /// # let cost = CostSpec { number_per: Some(dec!(150)), number_total: None,
+    /// # let cost = CostSpec { number: Some(CostNumber::PerUnit(dec!(150))),
     /// #     currency: Some("USD".into()), date: None, label: None, merge: false };
     /// let spanned: Spanned<Posting> = Spanned::synthesized(
     ///     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -221,7 +221,7 @@ impl Posting {
     /// ```no_run
     /// # use rustledger_core::{Posting, Amount, CostSpec, CostNumber, Spanned};
     /// # use rust_decimal_macros::dec;
-    /// # let cost = CostSpec { number: Some(CostNumber::PerUnit(dec!(150))),
+    /// # let cost = CostSpec { number: Some(CostNumber::PerUnit { value: dec!(150) }),
     /// #     currency: Some("USD".into()), date: None, label: None, merge: false };
     /// let spanned: Spanned<Posting> = Spanned::synthesized(
     ///     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))
@@ -1606,14 +1606,14 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:AccountB", Amount::new(dec!(11.11), "USD")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(0.90))
+                            .with_number(crate::CostNumber::PerUnit { value: dec!(0.90) })
                             .with_currency("EUR"),
                     ),
                 )
                 .with_synthesized_posting(
                     Posting::new("Assets:Transit", Amount::new(dec!(-11.11), "USD")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(0.90))
+                            .with_number(crate::CostNumber::PerUnit { value: dec!(0.90) })
                             .with_currency("EUR"),
                     ),
                 ),
@@ -1628,7 +1628,7 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:Transit", Amount::new(dec!(11.11), "USD")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(0.90))
+                            .with_number(crate::CostNumber::PerUnit { value: dec!(0.90) })
                             .with_currency("EUR"),
                     ),
                 ),
@@ -1657,7 +1657,7 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(-10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(crate::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -1674,7 +1674,7 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(crate::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -1606,14 +1606,14 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:AccountB", Amount::new(dec!(11.11), "USD")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(0.90))
+                            .with_per_unit(dec!(0.90))
                             .with_currency("EUR"),
                     ),
                 )
                 .with_synthesized_posting(
                     Posting::new("Assets:Transit", Amount::new(dec!(-11.11), "USD")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(0.90))
+                            .with_per_unit(dec!(0.90))
                             .with_currency("EUR"),
                     ),
                 ),
@@ -1628,7 +1628,7 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:Transit", Amount::new(dec!(11.11), "USD")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(0.90))
+                            .with_per_unit(dec!(0.90))
                             .with_currency("EUR"),
                     ),
                 ),
@@ -1657,7 +1657,7 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(-10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -1674,7 +1674,7 @@ mod tests {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )

--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -298,8 +298,7 @@ mod tests {
                     account: "Assets:Stock".into(),
                     units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "AAPL"))),
                     cost: Some(CostSpec {
-                        number_per: Some(dec!(150)),
-                        number_total: None,
+                        number: Some(crate::CostNumber::PerUnit(dec!(150))),
                         currency: Some("JPY".into()),
                         date: None,
                         label: None,

--- a/crates/rustledger-core/src/extract.rs
+++ b/crates/rustledger-core/src/extract.rs
@@ -298,7 +298,7 @@ mod tests {
                     account: "Assets:Stock".into(),
                     units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "AAPL"))),
                     cost: Some(CostSpec {
-                        number: Some(crate::CostNumber::PerUnit(dec!(150))),
+                        number: Some(crate::CostNumber::PerUnit { value: dec!(150) }),
                         currency: Some("JPY".into()),
                         date: None,
                         label: None,

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -128,19 +128,33 @@ mod tests {
     fn cost_spec_total_preserves_date_label_merge() {
         // Pre-A-3.9 the Total arm short-circuited after writing the
         // amount, dropping date/label/merge. A round-trip through the
-        // parser would silently lose those fields.
+        // parser would silently lose those fields. Exact-match
+        // assertion (review A-4.2) — pins delimiter, order, and
+        // whitespace, not just field presence.
         let spec = CostSpec::empty()
             .with_number(CostNumber::Total { value: dec!(1500) })
             .with_currency("USD")
             .with_date(crate::naive_date(2024, 1, 15).unwrap())
             .with_label("lot1")
             .with_merge();
-        let rendered = format_cost_spec(&spec);
-        assert!(rendered.starts_with("{{"));
-        assert!(rendered.ends_with("}}"));
-        assert!(rendered.contains("1500 USD"));
-        assert!(rendered.contains("2024-01-15"));
-        assert!(rendered.contains("\"lot1\""));
-        assert!(rendered.contains('*'));
+        assert_eq!(
+            format_cost_spec(&spec),
+            "{{1500 USD, 2024-01-15, \"lot1\", *}}"
+        );
+    }
+
+    #[test]
+    fn cost_spec_per_unit_preserves_date_label_merge() {
+        // Symmetric coverage for the per-unit shape (single braces).
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::PerUnit { value: dec!(150) })
+            .with_currency("USD")
+            .with_date(crate::naive_date(2024, 1, 15).unwrap())
+            .with_label("lot1")
+            .with_merge();
+        assert_eq!(
+            format_cost_spec(&spec),
+            "{150 USD, 2024-01-15, \"lot1\", *}"
+        );
     }
 }

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -20,13 +20,13 @@ pub fn format_cost_spec(spec: &CostSpec) -> String {
     // to match Python beancount's post-booking output.
     if let Some(curr) = &spec.currency {
         match spec.number {
-            Some(crate::CostNumber::PerUnit(num)) => {
+            Some(crate::CostNumber::PerUnit { value: num }) => {
                 parts.push(format!("{num} {curr}"));
             }
             Some(crate::CostNumber::PerUnitFromTotal(b)) => {
                 parts.push(format!("{} {curr}", b.per_unit));
             }
-            Some(crate::CostNumber::Total(num)) => {
+            Some(crate::CostNumber::Total { value: num }) => {
                 // Total cost uses double braces.
                 return format!("{{{{{num} {curr}}}}}");
             }
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn cost_spec_per_unit_renders_single_braces() {
         let spec = CostSpec::empty()
-            .with_per_unit(dec!(150))
+            .with_number(crate::CostNumber::PerUnit { value: dec!(150) })
             .with_currency("USD");
         assert_eq!(format_cost_spec(&spec), "{150 USD}");
     }
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn cost_spec_total_renders_double_braces() {
         let spec = CostSpec::empty()
-            .with_total(dec!(1500))
+            .with_number(crate::CostNumber::Total { value: dec!(1500) })
             .with_currency("USD");
         assert_eq!(format_cost_spec(&spec), "{{1500 USD}}");
     }

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -63,3 +63,57 @@ pub fn format_price_annotation(price: &PriceAnnotation) -> String {
         None => sigil,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BookedCost, CostNumber, CostSpec};
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn cost_spec_per_unit_renders_single_braces() {
+        let spec = CostSpec::empty()
+            .with_per_unit(dec!(150))
+            .with_currency("USD");
+        assert_eq!(format_cost_spec(&spec), "{150 USD}");
+    }
+
+    #[test]
+    fn cost_spec_total_renders_double_braces() {
+        let spec = CostSpec::empty()
+            .with_total(dec!(1500))
+            .with_currency("USD");
+        assert_eq!(format_cost_spec(&spec), "{{1500 USD}}");
+    }
+
+    #[test]
+    fn cost_spec_per_unit_from_total_renders_as_per_unit() {
+        // Python-compat post-booking rendering: the source `{{...}}`
+        // becomes per-unit braces after booking derives a per_unit.
+        // This is the load-bearing assertion for matching upstream
+        // beancount's `Position.__str__` after booking — the original
+        // `{{...}}` form is gone post-booking even in upstream.
+        let b = BookedCost::new(dec!(150), dec!(300), dec!(2));
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::PerUnitFromTotal(b))
+            .with_currency("USD");
+        assert_eq!(format_cost_spec(&spec), "{150 USD}");
+    }
+
+    #[test]
+    fn cost_spec_empty_renders_braces() {
+        let spec = CostSpec::empty();
+        assert_eq!(format_cost_spec(&spec), "{}");
+    }
+
+    #[test]
+    fn cost_spec_currency_only_renders_bare() {
+        // Pin the existing behavior: `format_cost_spec` only emits
+        // currency when a number is present. A currency-only spec
+        // renders as `{}` (currency is dropped). This matches Python
+        // beancount's `Position.__str__` for currency-only lot
+        // matches.
+        let spec = CostSpec::empty().with_currency("USD");
+        assert_eq!(format_cost_spec(&spec), "{}");
+    }
+}

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -9,6 +9,16 @@ pub fn format_amount(amount: &Amount) -> String {
 }
 
 /// Format a cost specification.
+///
+/// **Precondition: pre-booking input.** The parser only ever emits
+/// `CostNumber::PerUnit` or `CostNumber::Total`, so source-level
+/// formatters (`rledger format`) round-trip exactly. The
+/// `PerUnitFromTotal` arm is reached only if a caller hands in a
+/// post-booking spec — in that case we emit the derived per-unit in
+/// single braces (matching Python beancount's post-booking
+/// `Position.__str__` output). That collapses the user-written
+/// `{{ total }}` source form, so do NOT call this on booked
+/// directives if you need the original `{{...}}` to survive.
 pub fn format_cost_spec(spec: &CostSpec) -> String {
     // Max 4 elements: amount, date, label, merge.
     let mut parts = Vec::with_capacity(4);

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -17,7 +17,11 @@ pub fn format_cost_spec(spec: &CostSpec) -> String {
     // shape; the per-unit / total distinction comes from the typed
     // `CostNumber` (post-#1164 the invalid both-set state is
     // unrepresentable). `PerUnitFromTotal` renders in per-unit form
-    // to match Python beancount's post-booking output.
+    // to match Python beancount's post-booking output. `Total` uses
+    // double braces — pre-fix this short-circuit-returned without
+    // emitting date/label/merge, causing `{{1500 USD, 2024-01-15,
+    // "lot1"}}` to round-trip as `{{1500 USD}}` (review A-3.9).
+    let uses_double_braces = matches!(spec.number, Some(crate::CostNumber::Total { .. }));
     if let Some(curr) = &spec.currency {
         match spec.number {
             Some(crate::CostNumber::PerUnit { value: num }) => {
@@ -27,8 +31,7 @@ pub fn format_cost_spec(spec: &CostSpec) -> String {
                 parts.push(format!("{} {curr}", b.per_unit));
             }
             Some(crate::CostNumber::Total { value: num }) => {
-                // Total cost uses double braces.
-                return format!("{{{{{num} {curr}}}}}");
+                parts.push(format!("{num} {curr}"));
             }
             None => {}
         }
@@ -49,7 +52,11 @@ pub fn format_cost_spec(spec: &CostSpec) -> String {
         parts.push("*".to_string());
     }
 
-    format!("{{{}}}", parts.join(", "))
+    if uses_double_braces {
+        format!("{{{{{}}}}}", parts.join(", "))
+    } else {
+        format!("{{{}}}", parts.join(", "))
+    }
 }
 
 /// Format a price annotation.
@@ -115,5 +122,25 @@ mod tests {
         // matches.
         let spec = CostSpec::empty().with_currency("USD");
         assert_eq!(format_cost_spec(&spec), "{}");
+    }
+
+    #[test]
+    fn cost_spec_total_preserves_date_label_merge() {
+        // Pre-A-3.9 the Total arm short-circuited after writing the
+        // amount, dropping date/label/merge. A round-trip through the
+        // parser would silently lose those fields.
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::Total { value: dec!(1500) })
+            .with_currency("USD")
+            .with_date(crate::naive_date(2024, 1, 15).unwrap())
+            .with_label("lot1")
+            .with_merge();
+        let rendered = format_cost_spec(&spec);
+        assert!(rendered.starts_with("{{"));
+        assert!(rendered.ends_with("}}"));
+        assert!(rendered.contains("1500 USD"));
+        assert!(rendered.contains("2024-01-15"));
+        assert!(rendered.contains("\"lot1\""));
+        assert!(rendered.contains('*'));
     }
 }

--- a/crates/rustledger-core/src/format/amount.rs
+++ b/crates/rustledger-core/src/format/amount.rs
@@ -13,12 +13,25 @@ pub fn format_cost_spec(spec: &CostSpec) -> String {
     // Max 4 elements: amount, date, label, merge.
     let mut parts = Vec::with_capacity(4);
 
-    // Amount (per-unit or total)
-    if let (Some(num), Some(curr)) = (&spec.number_per, &spec.currency) {
-        parts.push(format!("{num} {curr}"));
-    } else if let (Some(num), Some(curr)) = (&spec.number_total, &spec.currency) {
-        // Total cost uses double braces
-        return format!("{{{{{num} {curr}}}}}");
+    // Amount (per-unit or total). Currency is required for either
+    // shape; the per-unit / total distinction comes from the typed
+    // `CostNumber` (post-#1164 the invalid both-set state is
+    // unrepresentable). `PerUnitFromTotal` renders in per-unit form
+    // to match Python beancount's post-booking output.
+    if let Some(curr) = &spec.currency {
+        match spec.number {
+            Some(crate::CostNumber::PerUnit(num)) => {
+                parts.push(format!("{num} {curr}"));
+            }
+            Some(crate::CostNumber::PerUnitFromTotal(b)) => {
+                parts.push(format!("{} {curr}", b.per_unit));
+            }
+            Some(crate::CostNumber::Total(num)) => {
+                // Total cost uses double braces.
+                return format!("{{{{{num} {curr}}}}}");
+            }
+            None => {}
+        }
     }
 
     // Date

--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -260,7 +260,9 @@ mod tests {
     #[test]
     fn test_format_cost_spec_per_unit() {
         let spec = CostSpec {
-            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
+            number: Some(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            }),
             currency: Some("USD".into()),
             date: None,
             label: None,
@@ -272,7 +274,9 @@ mod tests {
     #[test]
     fn test_format_cost_spec_total() {
         let spec = CostSpec {
-            number: Some(crate::CostNumber::Total(dec!(1500.00))),
+            number: Some(crate::CostNumber::Total {
+                value: dec!(1500.00),
+            }),
             currency: Some("USD".into()),
             date: None,
             label: None,
@@ -284,7 +288,9 @@ mod tests {
     #[test]
     fn test_format_cost_spec_with_date() {
         let spec = CostSpec {
-            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
+            number: Some(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            }),
             currency: Some("USD".into()),
             date: Some(date(2024, 1, 15)),
             label: None,
@@ -296,7 +302,9 @@ mod tests {
     #[test]
     fn test_format_cost_spec_with_label() {
         let spec = CostSpec {
-            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
+            number: Some(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            }),
             currency: Some("USD".into()),
             date: None,
             label: Some("lot-a".to_string()),
@@ -308,7 +316,9 @@ mod tests {
     #[test]
     fn test_format_cost_spec_with_merge() {
         let spec = CostSpec {
-            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
+            number: Some(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            }),
             currency: Some("USD".into()),
             date: None,
             label: None,
@@ -320,7 +330,9 @@ mod tests {
     #[test]
     fn test_format_cost_spec_all_fields() {
         let spec = CostSpec {
-            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
+            number: Some(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            }),
             currency: Some("USD".into()),
             date: Some(date(2024, 1, 15)),
             label: Some("lot-a".to_string()),
@@ -772,7 +784,9 @@ mod tests {
             account: "Assets:Brokerage".into(),
             units: Some(IncompleteAmount::Complete(Amount::new(dec!(10), "AAPL"))),
             cost: Some(CostSpec {
-                number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
+                number: Some(crate::CostNumber::PerUnit {
+                    value: dec!(150.00),
+                }),
                 currency: Some("USD".into()),
                 date: Some(date(2024, 1, 15)),
                 label: None,

--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -260,8 +260,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_per_unit() {
         let spec = CostSpec {
-            number_per: Some(dec!(150.00)),
-            number_total: None,
+            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
             currency: Some("USD".into()),
             date: None,
             label: None,
@@ -273,8 +272,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_total() {
         let spec = CostSpec {
-            number_per: None,
-            number_total: Some(dec!(1500.00)),
+            number: Some(crate::CostNumber::Total(dec!(1500.00))),
             currency: Some("USD".into()),
             date: None,
             label: None,
@@ -286,8 +284,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_with_date() {
         let spec = CostSpec {
-            number_per: Some(dec!(150.00)),
-            number_total: None,
+            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
             currency: Some("USD".into()),
             date: Some(date(2024, 1, 15)),
             label: None,
@@ -299,8 +296,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_with_label() {
         let spec = CostSpec {
-            number_per: Some(dec!(150.00)),
-            number_total: None,
+            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
             currency: Some("USD".into()),
             date: None,
             label: Some("lot-a".to_string()),
@@ -312,8 +308,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_with_merge() {
         let spec = CostSpec {
-            number_per: Some(dec!(150.00)),
-            number_total: None,
+            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
             currency: Some("USD".into()),
             date: None,
             label: None,
@@ -325,8 +320,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_all_fields() {
         let spec = CostSpec {
-            number_per: Some(dec!(150.00)),
-            number_total: None,
+            number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
             currency: Some("USD".into()),
             date: Some(date(2024, 1, 15)),
             label: Some("lot-a".to_string()),
@@ -341,8 +335,7 @@ mod tests {
     #[test]
     fn test_format_cost_spec_empty() {
         let spec = CostSpec {
-            number_per: None,
-            number_total: None,
+            number: None,
             currency: None,
             date: None,
             label: None,
@@ -779,8 +772,7 @@ mod tests {
             account: "Assets:Brokerage".into(),
             units: Some(IncompleteAmount::Complete(Amount::new(dec!(10), "AAPL"))),
             cost: Some(CostSpec {
-                number_per: Some(dec!(150.00)),
-                number_total: None,
+                number: Some(crate::CostNumber::PerUnit(dec!(150.00))),
                 currency: Some("USD".into()),
                 date: Some(date(2024, 1, 15)),
                 label: None,

--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -93,16 +93,16 @@ pub fn extract_per_unit_price<T>(
     // divides by `|units|` here.
     if let Some((number, currency)) = cost {
         match number {
-            Some(crate::CostNumber::PerUnit(per)) => {
+            Some(crate::CostNumber::PerUnit { value: per }) => {
                 return Some((per, currency));
             }
             Some(crate::CostNumber::PerUnitFromTotal(b)) => {
                 return Some((b.per_unit, currency));
             }
-            Some(crate::CostNumber::Total(total)) if !units_number.is_zero() => {
+            Some(crate::CostNumber::Total { value: total }) if !units_number.is_zero() => {
                 return Some((total / units_number.abs(), currency));
             }
-            Some(crate::CostNumber::Total(_)) | None => {}
+            Some(crate::CostNumber::Total { value: _ }) | None => {}
         }
     }
 
@@ -154,7 +154,7 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(0),
             Some((true, dec!(100), "EUR")),
-            Some((Some(crate::CostNumber::PerUnit(dec!(50))), "USD")),
+            Some((Some(crate::CostNumber::PerUnit { value: dec!(50) }), "USD")),
         );
         assert_eq!(p, Some((dec!(50), "USD")));
     }
@@ -173,7 +173,10 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(10),
             None,
-            Some((Some(crate::CostNumber::PerUnit(dec!(50.00))), "USD")),
+            Some((
+                Some(crate::CostNumber::PerUnit { value: dec!(50.00) }),
+                "USD",
+            )),
         );
         assert_eq!(p, Some((dec!(50.00), "USD")));
     }
@@ -184,7 +187,7 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(10),
             None,
-            Some((Some(crate::CostNumber::Total(dec!(500))), "USD")),
+            Some((Some(crate::CostNumber::Total { value: dec!(500) }), "USD")),
         );
         assert_eq!(p, Some((dec!(50), "USD")));
     }
@@ -194,7 +197,7 @@ mod tests {
         let p = extract_per_unit_price::<&str>(
             dec!(0),
             None,
-            Some((Some(crate::CostNumber::Total(dec!(500))), "USD")),
+            Some((Some(crate::CostNumber::Total { value: dec!(500) }), "USD")),
         );
         assert_eq!(p, None);
     }
@@ -212,7 +215,10 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(5),
             Some((false, dec!(1.40), "EUR")),
-            Some((Some(crate::CostNumber::PerUnit(dec!(1.25))), "EUR")),
+            Some((
+                Some(crate::CostNumber::PerUnit { value: dec!(1.25) }),
+                "EUR",
+            )),
         );
         assert_eq!(p, Some((dec!(1.40), "EUR")));
     }
@@ -223,7 +229,10 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(-10),
             Some((true, dec!(14), "EUR")),
-            Some((Some(crate::CostNumber::PerUnit(dec!(1.25))), "EUR")),
+            Some((
+                Some(crate::CostNumber::PerUnit { value: dec!(1.25) }),
+                "EUR",
+            )),
         );
         assert_eq!(p, Some((dec!(1.4), "EUR")));
     }
@@ -249,7 +258,7 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(10),
             None,
-            Some((Some(crate::CostNumber::PerUnit(dec!(7))), "USD")),
+            Some((Some(crate::CostNumber::PerUnit { value: dec!(7) }), "USD")),
         );
         assert_eq!(p, Some((dec!(7), "USD")));
     }

--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -59,15 +59,19 @@ use rust_decimal::Decimal;
 ///   has a usable `@`/`@@` annotation. Callers should pass `None` for
 ///   incomplete annotations (e.g. `@ EUR` without a number) so the
 ///   helper falls through cleanly.
-/// - `cost`: `Some((number_per, number_total, currency))` if the
-///   posting has a `{...}` cost spec with at least one of `per`/`total`
-///   parsed. Both inner numbers are `Option<Decimal>` because the cost
-///   spec may have only one or the other.
+/// - `cost`: `Some((number, currency))` if the posting has a `{...}`
+///   cost spec. The number is the typed `Option<CostNumber>` from the
+///   spec — `None` means the spec carried no number at all (`{}`),
+///   `Some(CostNumber::PerUnit)` and `Some(CostNumber::Total)` carry
+///   their respective shapes. The mutual-exclusion invariant is
+///   enforced by the type — pre-#1164 this was a `(Option<Decimal>,
+///   Option<Decimal>)` pair that the helper had to defensively
+///   tie-break.
 #[must_use]
 pub fn extract_per_unit_price<T>(
     units_number: Decimal,
     annotation: Option<(bool, Decimal, T)>,
-    cost: Option<(Option<Decimal>, Option<Decimal>, T)>,
+    cost: Option<(Option<crate::CostNumber>, T)>,
 ) -> Option<(Decimal, T)> {
     // Priority 1: price annotation.
     if let Some((is_total, amount, currency)) = annotation {
@@ -83,16 +87,22 @@ pub fn extract_per_unit_price<T>(
         }
     }
 
-    // Priority 2: cost spec. number_per wins over number_total when
-    // both are set.
-    if let Some((per, total, currency)) = cost {
-        if let Some(per) = per {
-            return Some((per, currency));
-        }
-        if let Some(total) = total
-            && !units_number.is_zero()
-        {
-            return Some((total / units_number.abs(), currency));
+    // Priority 2: cost spec. The pre-#1164 per-vs-total tie-break
+    // becomes a single match: PerUnit and PerUnitFromTotal already
+    // carry the per-unit value; Total carries a magnitude that
+    // divides by `|units|` here.
+    if let Some((number, currency)) = cost {
+        match number {
+            Some(crate::CostNumber::PerUnit(per)) => {
+                return Some((per, currency));
+            }
+            Some(crate::CostNumber::PerUnitFromTotal(b)) => {
+                return Some((b.per_unit, currency));
+            }
+            Some(crate::CostNumber::Total(total)) if !units_number.is_zero() => {
+                return Some((total / units_number.abs(), currency));
+            }
+            Some(crate::CostNumber::Total(_)) | None => {}
         }
     }
 
@@ -144,7 +154,7 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(0),
             Some((true, dec!(100), "EUR")),
-            Some((Some(dec!(50)), None, "USD")),
+            Some((Some(crate::CostNumber::PerUnit(dec!(50))), "USD")),
         );
         assert_eq!(p, Some((dec!(50), "USD")));
     }
@@ -160,20 +170,32 @@ mod tests {
     #[test]
     fn cost_per_unit_used_when_no_annotation() {
         // 10 ABC {50.00 USD} → 50.00.
-        let p = extract_per_unit_price(dec!(10), None, Some((Some(dec!(50.00)), None, "USD")));
+        let p = extract_per_unit_price(
+            dec!(10),
+            None,
+            Some((Some(crate::CostNumber::PerUnit(dec!(50.00))), "USD")),
+        );
         assert_eq!(p, Some((dec!(50.00), "USD")));
     }
 
     #[test]
     fn cost_total_divides_by_unit_count() {
         // 10 ABC {{500 USD}} → 500 / 10 = 50.
-        let p = extract_per_unit_price(dec!(10), None, Some((None, Some(dec!(500)), "USD")));
+        let p = extract_per_unit_price(
+            dec!(10),
+            None,
+            Some((Some(crate::CostNumber::Total(dec!(500))), "USD")),
+        );
         assert_eq!(p, Some((dec!(50), "USD")));
     }
 
     #[test]
     fn cost_total_with_zero_units_returns_none() {
-        let p = extract_per_unit_price::<&str>(dec!(0), None, Some((None, Some(dec!(500)), "USD")));
+        let p = extract_per_unit_price::<&str>(
+            dec!(0),
+            None,
+            Some((Some(crate::CostNumber::Total(dec!(500))), "USD")),
+        );
         assert_eq!(p, None);
     }
 
@@ -190,7 +212,7 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(5),
             Some((false, dec!(1.40), "EUR")),
-            Some((Some(dec!(1.25)), None, "EUR")),
+            Some((Some(crate::CostNumber::PerUnit(dec!(1.25))), "EUR")),
         );
         assert_eq!(p, Some((dec!(1.40), "EUR")));
     }
@@ -201,22 +223,14 @@ mod tests {
         let p = extract_per_unit_price(
             dec!(-10),
             Some((true, dec!(14), "EUR")),
-            Some((Some(dec!(1.25)), None, "EUR")),
+            Some((Some(crate::CostNumber::PerUnit(dec!(1.25))), "EUR")),
         );
         assert_eq!(p, Some((dec!(1.4), "EUR")));
     }
 
-    #[test]
-    fn cost_per_wins_over_cost_total_when_both_present() {
-        // {50 USD, 500 USD-total} — number_per takes precedence,
-        // matching Python beancount's tie-break.
-        let p = extract_per_unit_price(
-            dec!(10),
-            None,
-            Some((Some(dec!(50)), Some(dec!(999)), "USD")),
-        );
-        assert_eq!(p, Some((dec!(50), "USD")));
-    }
+    // Note: the pre-#1164 "cost_per wins over cost_total when both are set"
+    // tie-break test is gone — the type system now forbids the both-set
+    // state at construction time, so there's nothing to tie-break.
 
     // ===== Empty cases =====
 
@@ -232,7 +246,11 @@ mod tests {
         // passes `None` for annotation → fall through. Cost present →
         // use it. The returned currency is the cost's, not anything
         // remembered from the dropped annotation.
-        let p = extract_per_unit_price(dec!(10), None, Some((Some(dec!(7)), None, "USD")));
+        let p = extract_per_unit_price(
+            dec!(10),
+            None,
+            Some((Some(crate::CostNumber::PerUnit(dec!(7))), "USD")),
+        );
         assert_eq!(p, Some((dec!(7), "USD")));
     }
 }

--- a/crates/rustledger-core/src/implicit_prices.rs
+++ b/crates/rustledger-core/src/implicit_prices.rs
@@ -37,19 +37,21 @@ use rust_decimal::Decimal;
 ///    `units_number.abs()`. For `@` (`is_total = false`), returns the
 ///    number directly.
 /// 2. **Cost spec** — only as a fallback when no usable price
-///    annotation. Within the cost spec, `number_per` takes precedence
-///    over `number_total` when both are set (matching Python
-///    beancount's per-vs-total tie-break). `number_total` is divided
-///    by `units_number.abs()`.
+///    annotation. `CostNumber::PerUnit` and `PerUnitFromTotal` carry
+///    a per-unit value directly. `CostNumber::Total` is divided by
+///    `units_number.abs()`. (Pre-#1164 the cost spec could carry a
+///    `number_per` *and* a `number_total` simultaneously; the typed
+///    enum makes that state unrepresentable.)
 /// 3. **No price** — returns `None`.
 ///
 /// Edge cases:
 /// - Zero units with a total-form input (annotation `@@` or
-///   `cost.number_total`): can't compute per-unit, falls through to
+///   `CostNumber::Total`): can't compute per-unit, falls through to
 ///   the next priority. If nothing else is available, returns `None`.
-/// - Zero units with a per-unit-form input (annotation `@` or
-///   `cost.number_per`): the per-unit amount is returned as-is —
-///   "1 share = $X regardless of how many shares you transacted."
+/// - Zero units with a per-unit-form input (annotation `@`,
+///   `CostNumber::PerUnit`, or `PerUnitFromTotal`): the per-unit
+///   amount is returned as-is — "1 share = $X regardless of how many
+///   shares you transacted."
 ///
 /// # Parameters
 ///

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1921,7 +1921,9 @@ mod tests {
         inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
 
         // With cost spec filtering to the 200 USD lot, should find unique match
-        let spec = CostSpec::empty().with_per_unit(dec!(200.00));
+        let spec = CostSpec::empty().with_number(crate::CostNumber::PerUnit {
+            value: dec!(200.00),
+        });
         let result = inv
             .reduce(
                 &Amount::new(dec!(-5), "AAPL"),

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -1921,7 +1921,7 @@ mod tests {
         inv.add(Position::with_cost(Amount::new(dec!(10), "AAPL"), cost2));
 
         // With cost spec filtering to the 200 USD lot, should find unique match
-        let spec = CostSpec::empty().with_number_per(dec!(200.00));
+        let spec = CostSpec::empty().with_per_unit(dec!(200.00));
         let result = inv
             .reduce(
                 &Amount::new(dec!(-5), "AAPL"),

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod visit;
 mod kani_proofs;
 
 pub use amount::{Amount, IncompleteAmount};
-pub use cost::{Cost, CostSpec};
+pub use cost::{BookedCost, Cost, CostNumber, CostSpec};
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod visit;
 mod kani_proofs;
 
 pub use amount::{Amount, IncompleteAmount};
-pub use cost::{BookedCost, Cost, CostNumber, CostSpec};
+pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec};
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -283,12 +283,12 @@ mod tests {
 
         // Matching spec
         let spec = CostSpec::empty()
-            .with_number_per(dec!(150.00))
+            .with_per_unit(dec!(150.00))
             .with_currency("USD");
         assert!(pos.matches_cost_spec(&spec));
 
         // Non-matching spec
-        let spec = CostSpec::empty().with_number_per(dec!(160.00));
+        let spec = CostSpec::empty().with_per_unit(dec!(160.00));
         assert!(!pos.matches_cost_spec(&spec));
     }
 

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -283,12 +283,16 @@ mod tests {
 
         // Matching spec
         let spec = CostSpec::empty()
-            .with_per_unit(dec!(150.00))
+            .with_number(crate::CostNumber::PerUnit {
+                value: dec!(150.00),
+            })
             .with_currency("USD");
         assert!(pos.matches_cost_spec(&spec));
 
         // Non-matching spec
-        let spec = CostSpec::empty().with_per_unit(dec!(160.00));
+        let spec = CostSpec::empty().with_number(crate::CostNumber::PerUnit {
+            value: dec!(160.00),
+        });
         assert!(!pos.matches_cost_spec(&spec));
     }
 

--- a/crates/rustledger-core/src/visit.rs
+++ b/crates/rustledger-core/src/visit.rs
@@ -332,7 +332,7 @@ mod tests {
                     account: "Assets:Stock".into(),
                     units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "USD"))),
                     cost: Some(CostSpec {
-                        number: Some(crate::CostNumber::PerUnit(dec!(1))),
+                        number: Some(crate::CostNumber::PerUnit { value: dec!(1) }),
                         currency: Some("USD".into()),
                         date: None,
                         label: None,

--- a/crates/rustledger-core/src/visit.rs
+++ b/crates/rustledger-core/src/visit.rs
@@ -332,8 +332,7 @@ mod tests {
                     account: "Assets:Stock".into(),
                     units: Some(crate::IncompleteAmount::from(Amount::new(dec!(10), "USD"))),
                     cost: Some(CostSpec {
-                        number_per: Some(dec!(1)),
-                        number_total: None,
+                        number: Some(crate::CostNumber::PerUnit(dec!(1))),
                         currency: Some("USD".into()),
                         date: None,
                         label: None,

--- a/crates/rustledger-core/tests/property_tests.rs
+++ b/crates/rustledger-core/tests/property_tests.rs
@@ -275,7 +275,7 @@ proptest! {
     #[test]
     fn prop_cost_spec_matches_self(cost in arb_cost()) {
         let spec = CostSpec::empty()
-            .with_per_unit(cost.number)
+            .with_number(rustledger_core::CostNumber::PerUnit { value: cost.number })
             .with_currency(&cost.currency);
 
         prop_assert!(spec.matches(&cost));

--- a/crates/rustledger-core/tests/property_tests.rs
+++ b/crates/rustledger-core/tests/property_tests.rs
@@ -275,7 +275,7 @@ proptest! {
     #[test]
     fn prop_cost_spec_matches_self(cost in arb_cost()) {
         let spec = CostSpec::empty()
-            .with_number_per(cost.number)
+            .with_per_unit(cost.number)
             .with_currency(&cost.currency);
 
         prop_assert!(spec.matches(&cost));

--- a/crates/rustledger-core/tests/tla_proptest.rs
+++ b/crates/rustledger-core/tests/tla_proptest.rs
@@ -370,7 +370,7 @@ proptest! {
         // STRICT should succeed with exactly one matching lot
         // and specific cost provided
         let cost_spec = CostSpec::default()
-            .with_per_unit(cost_dec)
+            .with_number(rustledger_core::CostNumber::PerUnit { value: cost_dec })
             .with_currency("USD")
             .with_date(date);
         let result = inv.reduce(

--- a/crates/rustledger-core/tests/tla_proptest.rs
+++ b/crates/rustledger-core/tests/tla_proptest.rs
@@ -370,7 +370,7 @@ proptest! {
         // STRICT should succeed with exactly one matching lot
         // and specific cost provided
         let cost_spec = CostSpec::default()
-            .with_number_per(cost_dec)
+            .with_per_unit(cost_dec)
             .with_currency("USD")
             .with_date(date);
         let result = inv.reduce(

--- a/crates/rustledger-ffi-wasi/src/commands/clamp.rs
+++ b/crates/rustledger-ffi-wasi/src/commands/clamp.rs
@@ -341,12 +341,51 @@ fn parse_cost_and_create_position(
     amount: rustledger_core::Amount,
     cost: &serde_json::Value,
 ) -> Position {
-    // Get cost number - if missing or invalid, fall back to simple position
-    let Some(cost_number_str) = cost.get("number").and_then(|n| n.as_str()) else {
+    // The cost.number field is the `kind`-tagged enum produced by
+    // FFI-WASI output (mirroring `rustledger_core::CostNumber`).
+    // Parse the variant: `per_unit` and `per_unit_from_total` carry a
+    // per-unit value directly; `total` needs the back-division via
+    // amount.number. Pre-PR this read `cost.get("number").as_str()`
+    // and silently dropped every cost because the new shape is an
+    // object, not a string.
+    let Some(cost_number_obj) = cost.get("number") else {
         return Position::simple(amount);
     };
-    let Ok(cost_number) = rustledger_core::Decimal::from_str_exact(cost_number_str) else {
-        return Position::simple(amount);
+    let kind = cost_number_obj.get("kind").and_then(|k| k.as_str());
+    let cost_number = match kind {
+        Some(kind_str @ ("per_unit" | "per_unit_from_total")) => {
+            let field = if kind_str == "per_unit" {
+                "value"
+            } else {
+                "per_unit"
+            };
+            let value = cost_number_obj.get(field).and_then(|v| v.as_str());
+            let Some(s) = value else {
+                return Position::simple(amount);
+            };
+            let Ok(d) = rustledger_core::Decimal::from_str_exact(s) else {
+                return Position::simple(amount);
+            };
+            d
+        }
+        Some("total") => {
+            // Pre-booking total spec — derive per-unit from total /
+            // |units|. This branch shouldn't fire on post-booking
+            // inventory snapshots (the booker should have rewritten
+            // Total → PerUnitFromTotal) but handles the case for
+            // robustness.
+            let Some(s) = cost_number_obj.get("value").and_then(|v| v.as_str()) else {
+                return Position::simple(amount);
+            };
+            let Ok(total) = rustledger_core::Decimal::from_str_exact(s) else {
+                return Position::simple(amount);
+            };
+            if amount.number.is_zero() {
+                return Position::simple(amount);
+            }
+            total / amount.number.abs()
+        }
+        _ => return Position::simple(amount),
     };
 
     // Get cost currency - if missing or empty, fall back to simple position
@@ -708,5 +747,100 @@ mod tests {
         assert!(!is_income_statement_account("Assets:Bank"));
         assert!(!is_income_statement_account("Liabilities:CreditCard"));
         assert!(!is_income_statement_account("Equity:Opening-Balances"));
+    }
+
+    // ==========================================================================
+    // parse_cost_and_create_position — regression guard for the
+    // wire-shape silent-drop bug fixed alongside the typed-CostNumber
+    // unification. Pre-fix this function read `cost.number.as_str()`,
+    // which silently returned None for the new tagged-enum shape, so
+    // every cost-bearing position downgraded to Position::simple.
+    // ==========================================================================
+
+    #[test]
+    fn parse_cost_with_per_unit_tagged_shape_preserves_cost() {
+        let amount = rustledger_core::Amount::new(
+            rustledger_core::Decimal::from_str_exact("10").unwrap(),
+            "STK",
+        );
+        let cost = serde_json::json!({
+            "number": {"kind": "per_unit", "value": "100"},
+            "currency": "USD",
+        });
+        let pos = parse_cost_and_create_position(amount, &cost);
+        let cost = pos.cost.expect("cost must be preserved");
+        assert_eq!(
+            cost.number,
+            rustledger_core::Decimal::from_str_exact("100").unwrap()
+        );
+        assert_eq!(cost.currency.as_ref(), "USD");
+    }
+
+    #[test]
+    fn parse_cost_with_per_unit_from_total_uses_per_unit() {
+        let amount = rustledger_core::Amount::new(
+            rustledger_core::Decimal::from_str_exact("10").unwrap(),
+            "STK",
+        );
+        let cost = serde_json::json!({
+            "number": {"kind": "per_unit_from_total", "per_unit": "30", "total": "300"},
+            "currency": "USD",
+        });
+        let pos = parse_cost_and_create_position(amount, &cost);
+        let cost = pos.cost.expect("cost must be preserved");
+        assert_eq!(
+            cost.number,
+            rustledger_core::Decimal::from_str_exact("30").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_cost_with_total_tagged_shape_derives_per_unit() {
+        let amount = rustledger_core::Amount::new(
+            rustledger_core::Decimal::from_str_exact("10").unwrap(),
+            "STK",
+        );
+        let cost = serde_json::json!({
+            "number": {"kind": "total", "value": "1500"},
+            "currency": "USD",
+        });
+        let pos = parse_cost_and_create_position(amount, &cost);
+        let cost = pos.cost.expect("cost must be preserved");
+        assert_eq!(
+            cost.number,
+            rustledger_core::Decimal::from_str_exact("150").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_cost_falls_back_when_number_missing() {
+        let amount = rustledger_core::Amount::new(
+            rustledger_core::Decimal::from_str_exact("10").unwrap(),
+            "STK",
+        );
+        let cost = serde_json::json!({"currency": "USD"});
+        let pos = parse_cost_and_create_position(amount, &cost);
+        assert!(
+            pos.cost.is_none(),
+            "bare-currency cost must fall back to simple"
+        );
+    }
+
+    #[test]
+    fn parse_cost_with_legacy_string_number_falls_back() {
+        // Pre-PR shape sent number as a string. After the typed-enum
+        // migration the bridge correctly rejects this — verifying we
+        // don't silently misparse a stringly-typed value as a per-
+        // unit number.
+        let amount = rustledger_core::Amount::new(
+            rustledger_core::Decimal::from_str_exact("10").unwrap(),
+            "STK",
+        );
+        let cost = serde_json::json!({"number": "100", "currency": "USD"});
+        let pos = parse_cost_and_create_position(amount, &cost);
+        assert!(
+            pos.cost.is_none(),
+            "legacy string-number shape must fall back, not silently accept"
+        );
     }
 }

--- a/crates/rustledger-ffi-wasi/src/commands/clamp.rs
+++ b/crates/rustledger-ffi-wasi/src/commands/clamp.rs
@@ -389,8 +389,9 @@ fn create_summary_transaction(
         };
 
         let cost = position.cost.as_ref().map(|c| PostingCost {
-            number: Some(c.number.to_string()),
-            number_total: None,
+            number: Some(crate::types::CostNumber::PerUnit {
+                value: c.number.to_string(),
+            }),
             currency: Some(c.currency.to_string()),
             date: c.date.map(|d| d.to_string()),
             label: c.label.clone(),

--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -165,10 +165,12 @@ pub fn directive_to_json(directive: &Directive, line: u32, filename: &str) -> Di
                         let cost = p.cost.as_ref().map(|c| {
                             use crate::types::output::CostNumber as WireCN;
                             let number = c.number.map(|n| match n {
-                                rustledger_core::CostNumber::PerUnit(d) => WireCN::PerUnit {
-                                    value: d.to_string(),
-                                },
-                                rustledger_core::CostNumber::Total(d) => WireCN::Total {
+                                rustledger_core::CostNumber::PerUnit { value: d } => {
+                                    WireCN::PerUnit {
+                                        value: d.to_string(),
+                                    }
+                                }
+                                rustledger_core::CostNumber::Total { value: d } => WireCN::Total {
                                     value: d.to_string(),
                                 },
                                 rustledger_core::CostNumber::PerUnitFromTotal(b) => {

--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -157,16 +157,32 @@ pub fn directive_to_json(directive: &Directive, line: u32, filename: &str) -> Di
                             })
                         });
 
-                        // Extract cost
-                        let cost = p.cost.as_ref().map(|c| PostingCost {
-                            number: c.number_per.as_ref().map(std::string::ToString::to_string),
-                            number_total: c
-                                .number_total
-                                .as_ref()
-                                .map(std::string::ToString::to_string),
-                            currency: c.currency.as_ref().map(std::string::ToString::to_string),
-                            date: c.date.map(|d| d.to_string()),
-                            label: c.label.clone(),
+                        // Extract cost. The wire shape predates the
+                        // #1164 `CostNumber` enum and keeps the two
+                        // flat fields; the bridge below maps each
+                        // variant onto them. `PerUnitFromTotal` (post-
+                        // booking) emits both so downstream consumers
+                        // can read either form without re-deriving.
+                        let cost = p.cost.as_ref().map(|c| {
+                            let (number, number_total) = match c.number {
+                                Some(rustledger_core::CostNumber::PerUnit(d)) => {
+                                    (Some(d.to_string()), None)
+                                }
+                                Some(rustledger_core::CostNumber::Total(d)) => {
+                                    (None, Some(d.to_string()))
+                                }
+                                Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
+                                    (Some(b.per_unit.to_string()), Some(b.total.to_string()))
+                                }
+                                None => (None, None),
+                            };
+                            PostingCost {
+                                number,
+                                number_total,
+                                currency: c.currency.as_ref().map(std::string::ToString::to_string),
+                                date: c.date.map(|d| d.to_string()),
+                                label: c.label.clone(),
+                            }
                         });
 
                         // Extract price from PriceAnnotation

--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -157,28 +157,29 @@ pub fn directive_to_json(directive: &Directive, line: u32, filename: &str) -> Di
                             })
                         });
 
-                        // Extract cost. The wire shape predates the
-                        // #1164 `CostNumber` enum and keeps the two
-                        // flat fields; the bridge below maps each
-                        // variant onto them. `PerUnitFromTotal` (post-
-                        // booking) emits both so downstream consumers
-                        // can read either form without re-deriving.
+                        // Extract cost. The wire `CostNumber` is a
+                        // tagged enum that mirrors the host shape — JSON
+                        // consumers branch on `kind` exactly like Rust
+                        // pattern matching, with no risk of constructing
+                        // the both-set invalid state.
                         let cost = p.cost.as_ref().map(|c| {
-                            let (number, number_total) = match c.number {
-                                Some(rustledger_core::CostNumber::PerUnit(d)) => {
-                                    (Some(d.to_string()), None)
+                            use crate::types::output::CostNumber as WireCN;
+                            let number = c.number.map(|n| match n {
+                                rustledger_core::CostNumber::PerUnit(d) => WireCN::PerUnit {
+                                    value: d.to_string(),
+                                },
+                                rustledger_core::CostNumber::Total(d) => WireCN::Total {
+                                    value: d.to_string(),
+                                },
+                                rustledger_core::CostNumber::PerUnitFromTotal(b) => {
+                                    WireCN::PerUnitFromTotal {
+                                        per_unit: b.per_unit.to_string(),
+                                        total: b.total.to_string(),
+                                    }
                                 }
-                                Some(rustledger_core::CostNumber::Total(d)) => {
-                                    (None, Some(d.to_string()))
-                                }
-                                Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
-                                    (Some(b.per_unit.to_string()), Some(b.total.to_string()))
-                                }
-                                None => (None, None),
-                            };
+                            });
                             PostingCost {
                                 number,
-                                number_total,
                                 currency: c.currency.as_ref().map(std::string::ToString::to_string),
                                 date: c.date.map(|d| d.to_string()),
                                 label: c.label.clone(),

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -12,17 +12,49 @@ pub struct InputAmount {
     pub currency: String,
 }
 
+/// Input cost-number for entry creation.
+///
+/// Mirrors the host `CostNumber` enum on the wire. Consumers supply
+/// `{"kind": "per_unit", "value": "..."}` or `{"kind": "total", "value":
+/// "..."}` for unbooked specs. `per_unit_from_total` is reserved for
+/// already-booked posting input and is rejected if the per-unit and
+/// total are inconsistent with the supplied units.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InputCostNumber {
+    /// `{value USD}` — per-unit cost.
+    PerUnit {
+        /// Per-unit value.
+        value: String,
+    },
+    /// `{{value USD}}` — total cost.
+    Total {
+        /// Total value.
+        value: String,
+    },
+    /// Post-booking: derived per-unit and preserved source total.
+    PerUnitFromTotal {
+        /// Derived per-unit.
+        per_unit: String,
+        /// Source total.
+        total: String,
+    },
+}
+
 /// Input cost for entry creation.
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct InputCost {
+    /// Cost number (per-unit, total, or post-booking pair).
+    /// `None` corresponds to a bare `{}` cost spec.
     #[serde(default)]
-    pub number: Option<String>,
-    #[serde(default)]
-    pub number_total: Option<String>,
+    pub number: Option<InputCostNumber>,
+    /// Cost currency.
     #[serde(default)]
     pub currency: Option<String>,
+    /// Acquisition date.
     #[serde(default)]
     pub date: Option<String>,
+    /// Lot label.
     #[serde(default)]
     pub label: Option<String>,
 }
@@ -224,34 +256,35 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                     });
 
                     let cost = p.cost.as_ref().map(|c| {
-                        // The wire shape keeps `number` (per-unit) and
-                        // `number_total` as independent optional fields
-                        // for back-compat; the new `CostNumber` enum
-                        // requires picking one. Per-unit wins when both
-                        // are sent (matches the pre-#1164 booker's
-                        // tie-break and the upstream beancount
-                        // behavior).
-                        let number_per = c
-                            .number
-                            .as_ref()
-                            .and_then(|n| rustledger_core::Decimal::from_str_exact(n).ok());
-                        let number_total = c
-                            .number_total
-                            .as_ref()
-                            .and_then(|n| rustledger_core::Decimal::from_str_exact(n).ok());
-                        let number = match (number_per, number_total) {
-                            (Some(per), Some(total)) => {
-                                Some(rustledger_core::CostNumber::PerUnitFromTotal(
-                                    rustledger_core::BookedCost {
-                                        per_unit: per,
-                                        total,
-                                    },
-                                ))
+                        // The wire `InputCostNumber` is a tagged enum
+                        // that mirrors the host `CostNumber`. Callers
+                        // pick exactly one variant; the type system
+                        // prevents constructing the both-set state.
+                        let number = c.number.as_ref().map(|n| match n {
+                            crate::types::input::InputCostNumber::PerUnit { value } => {
+                                rustledger_core::CostNumber::PerUnit(
+                                    rustledger_core::Decimal::from_str_exact(value)
+                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
+                                )
                             }
-                            (Some(per), None) => Some(rustledger_core::CostNumber::PerUnit(per)),
-                            (None, Some(total)) => Some(rustledger_core::CostNumber::Total(total)),
-                            (None, None) => None,
-                        };
+                            crate::types::input::InputCostNumber::Total { value } => {
+                                rustledger_core::CostNumber::Total(
+                                    rustledger_core::Decimal::from_str_exact(value)
+                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
+                                )
+                            }
+                            crate::types::input::InputCostNumber::PerUnitFromTotal {
+                                per_unit,
+                                total,
+                            } => rustledger_core::CostNumber::PerUnitFromTotal(
+                                rustledger_core::BookedCost::from_parts_unchecked(
+                                    rustledger_core::Decimal::from_str_exact(per_unit)
+                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
+                                    rustledger_core::Decimal::from_str_exact(total)
+                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
+                                ),
+                            ),
+                        });
                         rustledger_core::CostSpec {
                             number,
                             currency: c.currency.clone().map(Into::into),
@@ -479,5 +512,94 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 meta: json_map_to_metadata(meta),
             }))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== Input cost-number wire-format tests (#1164) =====
+    //
+    // The wire `InputCostNumber` enum is the boundary that makes the
+    // both-set invalid state structurally unrepresentable. These tests
+    // pin that property — neither serde nor the bridge can construct
+    // a CostSpec with both per-unit AND total set unless they come in
+    // via the explicit `per_unit_from_total` variant (which carries
+    // the post-booking invariant).
+
+    #[test]
+    fn input_cost_number_per_unit_parses() {
+        let json = r#"{"kind": "per_unit", "value": "100"}"#;
+        let cn: InputCostNumber = serde_json::from_str(json).unwrap();
+        match cn {
+            InputCostNumber::PerUnit { value } => assert_eq!(value, "100"),
+            _ => panic!("expected PerUnit"),
+        }
+    }
+
+    #[test]
+    fn input_cost_number_total_parses() {
+        let json = r#"{"kind": "total", "value": "1500"}"#;
+        let cn: InputCostNumber = serde_json::from_str(json).unwrap();
+        match cn {
+            InputCostNumber::Total { value } => assert_eq!(value, "1500"),
+            _ => panic!("expected Total"),
+        }
+    }
+
+    #[test]
+    fn input_cost_number_per_unit_from_total_parses() {
+        let json = r#"{"kind": "per_unit_from_total", "per_unit": "150", "total": "300"}"#;
+        let cn: InputCostNumber = serde_json::from_str(json).unwrap();
+        match cn {
+            InputCostNumber::PerUnitFromTotal { per_unit, total } => {
+                assert_eq!(per_unit, "150");
+                assert_eq!(total, "300");
+            }
+            _ => panic!("expected PerUnitFromTotal"),
+        }
+    }
+
+    #[test]
+    fn input_cost_number_rejects_unknown_kind() {
+        // Wire shape strict: unknown discriminator is an error, not a
+        // silent fallback. Important so future variants don't get
+        // confused with mistyped input.
+        let json = r#"{"kind": "per_unit_with_total", "value": "100"}"#;
+        let result: Result<InputCostNumber, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "expected error for unknown kind, got Ok");
+    }
+
+    #[test]
+    fn input_cost_number_rejects_missing_kind() {
+        // No `kind` discriminator → serde can't pick a variant.
+        let json = r#"{"value": "100"}"#;
+        let result: Result<InputCostNumber, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "expected error without kind tag, got Ok");
+    }
+
+    #[test]
+    fn input_cost_number_rejects_legacy_flat_shape() {
+        // The pre-#1164 wire shape `{"number_per": "...", "number_total": null}`
+        // is gone. Sending it gets a parse error, which is the right
+        // behavior — silent coercion to `PerUnit` would mask client
+        // bugs and re-introduce the invalid both-set state through
+        // the bridge.
+        let json = r#"{"number_per": "100", "number_total": null}"#;
+        let result: Result<InputCostNumber, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "expected error for legacy flat shape, got Ok"
+        );
+    }
+
+    #[test]
+    fn input_cost_with_no_number_parses_as_bare_brace() {
+        // `{}` lot match: the `number` field is absent or null.
+        let json = r#"{"currency": "USD"}"#;
+        let cost: InputCost = serde_json::from_str(json).unwrap();
+        assert!(cost.number.is_none());
+        assert_eq!(cost.currency.as_deref(), Some("USD"));
     }
 }

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -257,33 +257,55 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
 
                     let cost = p.cost.as_ref().map(|c| {
                         // The wire `InputCostNumber` is a tagged enum
-                        // that mirrors the host `CostNumber`. Callers
-                        // pick exactly one variant; the type system
-                        // prevents constructing the both-set state.
+                        // mirroring the host `CostNumber`. The type
+                        // system prevents the both-set state; here we
+                        // additionally enforce the
+                        // `per_unit * |units| == total` invariant for
+                        // PerUnitFromTotal so external clients cannot
+                        // smuggle in inconsistent post-booking pairs.
+                        let parse = |s: &str| {
+                            rustledger_core::Decimal::from_str_exact(s)
+                                .unwrap_or_else(|_| rustledger_core::Decimal::from(0))
+                        };
+                        let posting_units = units
+                            .as_ref()
+                            .and_then(|u: &rustledger_core::IncompleteAmount| u.as_amount());
                         let number = c.number.as_ref().map(|n| match n {
                             crate::types::input::InputCostNumber::PerUnit { value } => {
-                                rustledger_core::CostNumber::PerUnit(
-                                    rustledger_core::Decimal::from_str_exact(value)
-                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                                )
+                                rustledger_core::CostNumber::PerUnit {
+                                    value: parse(value),
+                                }
                             }
                             crate::types::input::InputCostNumber::Total { value } => {
-                                rustledger_core::CostNumber::Total(
-                                    rustledger_core::Decimal::from_str_exact(value)
-                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                                )
+                                rustledger_core::CostNumber::Total {
+                                    value: parse(value),
+                                }
                             }
                             crate::types::input::InputCostNumber::PerUnitFromTotal {
                                 per_unit,
                                 total,
-                            } => rustledger_core::CostNumber::PerUnitFromTotal(
-                                rustledger_core::BookedCost::from_parts_unchecked(
-                                    rustledger_core::Decimal::from_str_exact(per_unit)
-                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                                    rustledger_core::Decimal::from_str_exact(total)
-                                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                                ),
-                            ),
+                            } => {
+                                let per_unit_d = parse(per_unit);
+                                let total_d = parse(total);
+                                // `try_new` returns None if the pair is
+                                // inconsistent with the posting's
+                                // units; we fall back to interpreting
+                                // as raw PerUnit so the directive still
+                                // parses but loses the bogus total
+                                // (loud truncation > silent corruption).
+                                let units_n = posting_units.as_ref().map_or_else(
+                                    || rustledger_core::Decimal::from(0),
+                                    |a| a.number,
+                                );
+                                match rustledger_core::BookedCost::try_new(
+                                    per_unit_d, total_d, units_n,
+                                ) {
+                                    Some(b) => rustledger_core::CostNumber::PerUnitFromTotal(b),
+                                    None => {
+                                        rustledger_core::CostNumber::PerUnit { value: per_unit_d }
+                                    }
+                                }
+                            }
                         });
                         rustledger_core::CostSpec {
                             number,

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -42,10 +42,18 @@ pub enum InputCostNumber {
 }
 
 /// Input cost for entry creation.
-#[derive(Debug, Deserialize, Clone, Default)]
+///
+/// `Option` fields follow serde's standard convention: an omitted JSON
+/// field is treated as `None` (this can't be tightened without a
+/// custom `Deserialize` impl — serde's `Option` deserializer is
+/// inherently lenient). `#[serde(deny_unknown_fields)]` catches the
+/// other half of the client-bug risk: a misspelled field name will
+/// fail to parse instead of silently being dropped (review A-3.8).
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct InputCost {
     /// Cost number (per-unit, total, or post-booking pair).
-    /// `None` corresponds to a bare `{}` cost spec.
+    /// `None` / absent corresponds to a bare `{}` cost spec.
     #[serde(default)]
     pub number: Option<InputCostNumber>,
     /// Cost currency.
@@ -255,66 +263,69 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                         })
                     });
 
-                    let cost = p.cost.as_ref().map(|c| {
-                        // The wire `InputCostNumber` is a tagged enum
-                        // mirroring the host `CostNumber`. The type
-                        // system prevents the both-set state; here we
-                        // additionally enforce the
-                        // `per_unit * |units| == total` invariant for
-                        // PerUnitFromTotal so external clients cannot
-                        // smuggle in inconsistent post-booking pairs.
-                        let parse = |s: &str| {
-                            rustledger_core::Decimal::from_str_exact(s)
-                                .unwrap_or_else(|_| rustledger_core::Decimal::from(0))
-                        };
-                        let posting_units = units
-                            .as_ref()
-                            .and_then(|u: &rustledger_core::IncompleteAmount| u.as_amount());
-                        let number = c.number.as_ref().map(|n| match n {
-                            crate::types::input::InputCostNumber::PerUnit { value } => {
-                                rustledger_core::CostNumber::PerUnit {
-                                    value: parse(value),
+                    let cost = p
+                        .cost
+                        .as_ref()
+                        .map(|c| {
+                            // The wire `InputCostNumber` is a tagged enum
+                            // mirroring the host `CostNumber`. The type
+                            // system prevents the both-set state; we
+                            // additionally enforce the
+                            // `per_unit * |units| == total` invariant for
+                            // PerUnitFromTotal so external clients cannot
+                            // smuggle in inconsistent post-booking pairs.
+                            // Inconsistent pairs become a parse error
+                            // (review B-3.1) — silently falling back to
+                            // PerUnit and dropping the supplied total
+                            // would itself be a corruption pattern.
+                            let parse = |s: &str| {
+                                rustledger_core::Decimal::from_str_exact(s).map_err(|e| {
+                                    format!("invalid cost number {s:?}: {e}")
+                                })
+                            };
+                            let posting_units = units
+                                .as_ref()
+                                .and_then(|u: &rustledger_core::IncompleteAmount| u.as_amount());
+                            let number = match c.number.as_ref() {
+                                None => None,
+                                Some(crate::types::input::InputCostNumber::PerUnit { value }) => {
+                                    Some(rustledger_core::CostNumber::PerUnit { value: parse(value)? })
                                 }
-                            }
-                            crate::types::input::InputCostNumber::Total { value } => {
-                                rustledger_core::CostNumber::Total {
-                                    value: parse(value),
+                                Some(crate::types::input::InputCostNumber::Total { value }) => {
+                                    Some(rustledger_core::CostNumber::Total { value: parse(value)? })
                                 }
-                            }
-                            crate::types::input::InputCostNumber::PerUnitFromTotal {
-                                per_unit,
-                                total,
-                            } => {
-                                let per_unit_d = parse(per_unit);
-                                let total_d = parse(total);
-                                // `try_new` returns None if the pair is
-                                // inconsistent with the posting's
-                                // units; we fall back to interpreting
-                                // as raw PerUnit so the directive still
-                                // parses but loses the bogus total
-                                // (loud truncation > silent corruption).
-                                let units_n = posting_units.as_ref().map_or_else(
-                                    || rustledger_core::Decimal::from(0),
-                                    |a| a.number,
-                                );
-                                match rustledger_core::BookedCost::try_new(
-                                    per_unit_d, total_d, units_n,
-                                ) {
-                                    Some(b) => rustledger_core::CostNumber::PerUnitFromTotal(b),
-                                    None => {
-                                        rustledger_core::CostNumber::PerUnit { value: per_unit_d }
-                                    }
+                                Some(crate::types::input::InputCostNumber::PerUnitFromTotal {
+                                    per_unit,
+                                    total,
+                                }) => {
+                                    let per_unit_d = parse(per_unit)?;
+                                    let total_d = parse(total)?;
+                                    // PerUnitFromTotal is the post-booking
+                                    // shape — the wire client MUST supply
+                                    // units. Missing units → reject (not
+                                    // "fall back to PerUnit", which would
+                                    // silently drop the supplied total).
+                                    let units_n = posting_units.as_ref().map(|a| a.number).ok_or_else(|| {
+                                        "PerUnitFromTotal cost requires units on the posting — \
+                                         this is the post-booking shape and is meaningless without units. \
+                                         Send `{kind:\"per_unit\", value:...}` or `{kind:\"total\", value:...}` for unbooked specs.".to_string()
+                                    })?;
+                                    let booked = rustledger_core::BookedCost::try_new(
+                                        per_unit_d, total_d, units_n,
+                                    )
+                                    .map_err(|e| format!("{e}"))?;
+                                    Some(rustledger_core::CostNumber::PerUnitFromTotal(booked))
                                 }
-                            }
-                        });
-                        rustledger_core::CostSpec {
-                            number,
-                            currency: c.currency.clone().map(Into::into),
-                            date: c.date.as_ref().and_then(|d| d.parse::<NaiveDate>().ok()),
-                            label: c.label.clone(),
-                            merge: false,
-                        }
-                    });
+                            };
+                            Ok::<_, String>(rustledger_core::CostSpec {
+                                number,
+                                currency: c.currency.clone().map(Into::into),
+                                date: c.date.as_ref().and_then(|d| d.parse::<NaiveDate>().ok()),
+                                label: c.label.clone(),
+                                merge: false,
+                            })
+                        })
+                        .transpose()?;
 
                     let price = p.price.as_ref().map(|pr| {
                         rustledger_core::PriceAnnotation::unit(rustledger_core::Amount {
@@ -324,7 +335,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                         })
                     });
 
-                    rustledger_core::Spanned::synthesized(rustledger_core::Posting {
+                    Ok::<_, String>(rustledger_core::Spanned::synthesized(rustledger_core::Posting {
                         account: p.account.clone().into(),
                         units,
                         cost,
@@ -333,9 +344,9 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                         meta: json_map_to_metadata(&p.meta),
                         comments: Vec::new(),
                         trailing_comments: Vec::new(),
-                    })
+                    }))
                 })
-                .collect();
+                .collect::<Result<_, String>>()?;
 
             Ok(Directive::Transaction(rustledger_core::Transaction {
                 date,
@@ -618,10 +629,112 @@ mod tests {
 
     #[test]
     fn input_cost_with_no_number_parses_as_bare_brace() {
-        // `{}` lot match: the `number` field is absent or null.
+        // `{}` lot match: number absent → bare cost spec. Serde's
+        // Option deserializer treats missing fields as `None` by
+        // convention; we lean on `deny_unknown_fields` for the other
+        // client-bug case (misspelled field).
         let json = r#"{"currency": "USD"}"#;
         let cost: InputCost = serde_json::from_str(json).unwrap();
         assert!(cost.number.is_none());
         assert_eq!(cost.currency.as_deref(), Some("USD"));
+    }
+
+    #[test]
+    fn input_cost_rejects_unknown_field() {
+        // `deny_unknown_fields` catches misspelled fields that would
+        // otherwise be silently dropped (review A-3.8). A client
+        // sending an unrecognized key (e.g. `cost_number` instead of
+        // `number`) gets a parse error instead of an unexpectedly
+        // bare cost spec on the directive.
+        let json = r#"{"cost_number": {"kind": "per_unit", "value": "100"}, "currency": "USD"}"#;
+        let result: Result<InputCost, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "expected parse error for unknown field, got Ok"
+        );
+    }
+
+    #[test]
+    fn input_cost_per_unit_from_total_rejected_when_inconsistent() {
+        // Bridge-level test through the actual conversion path:
+        // PerUnitFromTotal with mismatched per_unit/total/units must
+        // produce a typed error string, not silently coerce to
+        // PerUnit. Pre-fix this fell back to `PerUnit { value:
+        // per_unit_d }`, dropping the supplied total.
+        let entry_json = r#"{
+            "type": "transaction",
+            "date": "2024-01-15",
+            "flag": "*",
+            "payee": null,
+            "narration": "Buy stock",
+            "tags": [],
+            "links": [],
+            "meta": {},
+            "postings": [
+                {
+                    "account": "Assets:Stock",
+                    "units": {"number": "10", "currency": "STK"},
+                    "cost": {
+                        "number": {"kind": "per_unit_from_total", "per_unit": "999999", "total": "0.01"},
+                        "currency": "USD",
+                        "date": null,
+                        "label": null
+                    },
+                    "price": null,
+                    "meta": {}
+                }
+            ]
+        }"#;
+        let entry: InputEntry = serde_json::from_str(entry_json).unwrap();
+        let result = input_entry_to_directive(&entry);
+        assert!(
+            result.is_err(),
+            "inconsistent PerUnitFromTotal must reject at the bridge"
+        );
+        let err = result.unwrap_err();
+        // Diagnostic mentions the invariant so plugin authors can fix
+        // their wire client.
+        assert!(
+            err.contains("invariant") || err.contains("per_unit") || err.contains("total"),
+            "error message must describe the invariant violation, got: {err}"
+        );
+    }
+
+    #[test]
+    fn input_cost_per_unit_from_total_rejected_when_units_missing() {
+        // PerUnitFromTotal is post-booking; a plugin sending it
+        // without units is malformed (review B-3.1). The bridge must
+        // reject rather than default units to 0 (which the
+        // pre-fix `invariant_holds` short-circuit accepted).
+        let entry_json = r#"{
+            "type": "transaction",
+            "date": "2024-01-15",
+            "flag": "*",
+            "payee": null,
+            "narration": "Buy stock",
+            "tags": [],
+            "links": [],
+            "meta": {},
+            "postings": [
+                {
+                    "account": "Assets:Stock",
+                    "units": null,
+                    "cost": {
+                        "number": {"kind": "per_unit_from_total", "per_unit": "999999", "total": "0.01"},
+                        "currency": "USD",
+                        "date": null,
+                        "label": null
+                    },
+                    "price": null,
+                    "meta": {}
+                }
+            ]
+        }"#;
+        let entry: InputEntry = serde_json::from_str(entry_json).unwrap();
+        let result = input_entry_to_directive(&entry);
+        assert!(
+            result.is_err(),
+            "PerUnitFromTotal without units must reject (post-booking shape requires units)"
+        );
     }
 }

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -223,19 +223,42 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                         })
                     });
 
-                    let cost = p.cost.as_ref().map(|c| rustledger_core::CostSpec {
-                        number_per: c
+                    let cost = p.cost.as_ref().map(|c| {
+                        // The wire shape keeps `number` (per-unit) and
+                        // `number_total` as independent optional fields
+                        // for back-compat; the new `CostNumber` enum
+                        // requires picking one. Per-unit wins when both
+                        // are sent (matches the pre-#1164 booker's
+                        // tie-break and the upstream beancount
+                        // behavior).
+                        let number_per = c
                             .number
                             .as_ref()
-                            .and_then(|n| rustledger_core::Decimal::from_str_exact(n).ok()),
-                        number_total: c
+                            .and_then(|n| rustledger_core::Decimal::from_str_exact(n).ok());
+                        let number_total = c
                             .number_total
                             .as_ref()
-                            .and_then(|n| rustledger_core::Decimal::from_str_exact(n).ok()),
-                        currency: c.currency.clone().map(Into::into),
-                        date: c.date.as_ref().and_then(|d| d.parse::<NaiveDate>().ok()),
-                        label: c.label.clone(),
-                        merge: false,
+                            .and_then(|n| rustledger_core::Decimal::from_str_exact(n).ok());
+                        let number = match (number_per, number_total) {
+                            (Some(per), Some(total)) => {
+                                Some(rustledger_core::CostNumber::PerUnitFromTotal(
+                                    rustledger_core::BookedCost {
+                                        per_unit: per,
+                                        total,
+                                    },
+                                ))
+                            }
+                            (Some(per), None) => Some(rustledger_core::CostNumber::PerUnit(per)),
+                            (None, Some(total)) => Some(rustledger_core::CostNumber::Total(total)),
+                            (None, None) => None,
+                        };
+                        rustledger_core::CostSpec {
+                            number,
+                            currency: c.currency.clone().map(Into::into),
+                            date: c.date.as_ref().and_then(|d| d.parse::<NaiveDate>().ok()),
+                            label: c.label.clone(),
+                            merge: false,
+                        }
                     });
 
                     let price = p.price.as_ref().map(|pr| {

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -5,6 +5,27 @@ use std::collections::HashMap;
 use rustledger_core::{Directive, MetaValue, Metadata, NaiveDate};
 use serde::Deserialize;
 
+/// Parse an `InputAmount` to a host `Amount`, propagating decimal parse
+/// errors instead of silently coercing them to zero.
+///
+/// Pre-fix every amount-bearing field on the wire used
+/// `unwrap_or_else(|_| Decimal::from(0))`, which meant a balance
+/// assertion like `{"amount": {"number": "garbage", "currency":
+/// "USD"}}` was accepted as `0 USD` — silently defeating balance
+/// checks (review B-4.1). All callers now propagate the parse error
+/// to the wire client.
+fn parse_input_amount(
+    field: &str,
+    amount: &InputAmount,
+) -> Result<rustledger_core::Amount, String> {
+    let number = rustledger_core::Decimal::from_str_exact(&amount.number)
+        .map_err(|e| format!("invalid {field} number {:?}: {e}", amount.number))?;
+    Ok(rustledger_core::Amount {
+        number,
+        currency: amount.currency.clone().into(),
+    })
+}
+
 /// Input amount for entry creation.
 #[derive(Debug, Deserialize, Clone)]
 pub struct InputAmount {
@@ -65,6 +86,13 @@ pub struct InputCost {
     /// Lot label.
     #[serde(default)]
     pub label: Option<String>,
+    /// Merge-into-existing-lot flag (the `*` marker on a cost spec —
+    /// triggers average-cost booking for the position). Pre-A-4.6 the
+    /// FFI bridge hard-coded `false`, which silently diverged from the
+    /// plugin egress (`from_wrapper.rs`) that does accept the field.
+    /// Both ingress surfaces now consume `merge` uniformly.
+    #[serde(default)]
+    pub merge: bool,
 }
 
 /// Input posting for entry creation.
@@ -188,6 +216,13 @@ fn default_flag() -> String {
 }
 
 /// Convert JSON metadata value to core `MetaValue`.
+///
+/// Unparsable numeric values become `MetaValue::None` (review B-4.1)
+/// rather than silently coercing to zero. Metadata is informational
+/// so a typed `MetaValue::None` is the right "I saw something but
+/// couldn't interpret it as a number" signal — preferable to either
+/// silently substituting zero (loses the original value) or panicking
+/// (heavyweight for a metadata field).
 pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
     match value {
         serde_json::Value::String(s) => MetaValue::String(s.clone()),
@@ -196,10 +231,10 @@ pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
             if let Some(i) = n.as_i64() {
                 MetaValue::Number(rustledger_core::Decimal::from(i))
             } else if let Some(f) = n.as_f64() {
-                MetaValue::Number(
-                    rustledger_core::Decimal::from_str_exact(&f.to_string())
-                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                )
+                match rustledger_core::Decimal::from_str_exact(&f.to_string()) {
+                    Ok(d) => MetaValue::Number(d),
+                    Err(_) => MetaValue::None,
+                }
             } else {
                 MetaValue::None
             }
@@ -210,11 +245,13 @@ pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
             if let (Some(number), Some(currency)) = (obj.get("number"), obj.get("currency"))
                 && let (Some(n), Some(c)) = (number.as_str(), currency.as_str())
             {
-                return MetaValue::Amount(rustledger_core::Amount {
-                    number: rustledger_core::Decimal::from_str_exact(n)
-                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                    currency: c.into(),
-                });
+                return match rustledger_core::Decimal::from_str_exact(n) {
+                    Ok(number) => MetaValue::Amount(rustledger_core::Amount {
+                        number,
+                        currency: c.into(),
+                    }),
+                    Err(_) => MetaValue::None,
+                };
             }
             MetaValue::None
         }
@@ -255,13 +292,12 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
             let postings: Vec<rustledger_core::Spanned<rustledger_core::Posting>> = postings
                 .iter()
                 .map(|p| {
-                    let units = p.units.as_ref().map(|u| {
-                        rustledger_core::IncompleteAmount::Complete(rustledger_core::Amount {
-                            number: rustledger_core::Decimal::from_str_exact(&u.number)
-                                .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                            currency: u.currency.clone().into(),
-                        })
-                    });
+                    let units = p
+                        .units
+                        .as_ref()
+                        .map(|u| parse_input_amount("posting units", u))
+                        .transpose()?
+                        .map(rustledger_core::IncompleteAmount::Complete);
 
                     let cost = p
                         .cost
@@ -322,18 +358,17 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                                 currency: c.currency.clone().map(Into::into),
                                 date: c.date.as_ref().and_then(|d| d.parse::<NaiveDate>().ok()),
                                 label: c.label.clone(),
-                                merge: false,
+                                merge: c.merge,
                             })
                         })
                         .transpose()?;
 
-                    let price = p.price.as_ref().map(|pr| {
-                        rustledger_core::PriceAnnotation::unit(rustledger_core::Amount {
-                            number: rustledger_core::Decimal::from_str_exact(&pr.number)
-                                .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                            currency: pr.currency.clone().into(),
-                        })
-                    });
+                    let price = p
+                        .price
+                        .as_ref()
+                        .map(|pr| parse_input_amount("posting price", pr))
+                        .transpose()?
+                        .map(rustledger_core::PriceAnnotation::unit);
 
                     Ok::<_, String>(rustledger_core::Spanned::synthesized(rustledger_core::Posting {
                         account: p.account.clone().into(),
@@ -404,11 +439,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
             Ok(Directive::Balance(rustledger_core::Balance {
                 date,
                 account: account.clone().into(),
-                amount: rustledger_core::Amount {
-                    number: rustledger_core::Decimal::from_str_exact(&amount.number)
-                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                    currency: amount.currency.clone().into(),
-                },
+                amount: parse_input_amount("balance amount", amount)?,
                 tolerance: None,
                 meta: json_map_to_metadata(meta),
             }))
@@ -455,11 +486,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
             Ok(Directive::Price(rustledger_core::Price {
                 date,
                 currency: currency.clone().into(),
-                amount: rustledger_core::Amount {
-                    number: rustledger_core::Decimal::from_str_exact(&amount.number)
-                        .unwrap_or_else(|_| rustledger_core::Decimal::from(0)),
-                    currency: amount.currency.clone().into(),
-                },
+                amount: parse_input_amount("price amount", amount)?,
                 meta: json_map_to_metadata(meta),
             }))
         }
@@ -698,6 +725,80 @@ mod tests {
             err.contains("invariant") || err.contains("per_unit") || err.contains("total"),
             "error message must describe the invariant violation, got: {err}"
         );
+    }
+
+    #[test]
+    fn balance_with_malformed_amount_is_rejected() {
+        // The load-bearing B-4.1 regression guard: a balance
+        // assertion with a non-numeric amount field used to be
+        // silently accepted as `0 USD`, defeating balance checks.
+        // The wire bridge now propagates the parse error so the
+        // client knows their payload was malformed.
+        let entry_json = r#"{
+            "type": "balance",
+            "date": "2024-01-15",
+            "account": "Assets:Bank",
+            "amount": {"number": "garbage", "currency": "USD"},
+            "meta": {}
+        }"#;
+        let entry: InputEntry = serde_json::from_str(entry_json).unwrap();
+        let result = input_entry_to_directive(&entry);
+        assert!(
+            result.is_err(),
+            "malformed balance amount must surface a parse error, not silently coerce to 0"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("balance amount") && err.contains("garbage"),
+            "error must name both the field and the offending value, got: {err}"
+        );
+    }
+
+    #[test]
+    fn price_with_malformed_amount_is_rejected() {
+        let entry_json = r#"{
+            "type": "price",
+            "date": "2024-01-15",
+            "currency": "AAPL",
+            "amount": {"number": "abc", "currency": "USD"},
+            "meta": {}
+        }"#;
+        let entry: InputEntry = serde_json::from_str(entry_json).unwrap();
+        let result = input_entry_to_directive(&entry);
+        assert!(
+            result.is_err(),
+            "malformed price amount must surface a parse error"
+        );
+        assert!(result.unwrap_err().contains("price amount"));
+    }
+
+    #[test]
+    fn posting_with_malformed_units_is_rejected() {
+        let entry_json = r#"{
+            "type": "transaction",
+            "date": "2024-01-15",
+            "flag": "*",
+            "payee": null,
+            "narration": "Buy",
+            "tags": [], "links": [],
+            "meta": {},
+            "postings": [
+                {
+                    "account": "Assets:Stock",
+                    "units": {"number": "not-a-number", "currency": "STK"},
+                    "cost": null,
+                    "price": null,
+                    "meta": {}
+                }
+            ]
+        }"#;
+        let entry: InputEntry = serde_json::from_str(entry_json).unwrap();
+        let result = input_entry_to_directive(&entry);
+        assert!(
+            result.is_err(),
+            "malformed posting units must surface a parse error"
+        );
+        assert!(result.unwrap_err().contains("posting units"));
     }
 
     #[test]

--- a/crates/rustledger-ffi-wasi/src/types/mod.rs
+++ b/crates/rustledger-ffi-wasi/src/types/mod.rs
@@ -5,7 +5,7 @@ pub mod output;
 
 pub use input::{InputEntry, input_entry_to_directive};
 pub use output::{
-    Amount, BatchOutput, ColumnInfo, DirectiveJson, Error, Include, LedgerOptions, LoadOutput,
-    Meta, Plugin, Posting, PostingCost, QueryOutput, TypedValue, ValidateOutput,
+    Amount, BatchOutput, ColumnInfo, CostNumber, DirectiveJson, Error, Include, LedgerOptions,
+    LoadOutput, Meta, Plugin, Posting, PostingCost, QueryOutput, TypedValue, ValidateOutput,
     meta_value_to_json,
 };

--- a/crates/rustledger-ffi-wasi/src/types/output.rs
+++ b/crates/rustledger-ffi-wasi/src/types/output.rs
@@ -103,14 +103,39 @@ pub struct Amount {
     pub currency: String,
 }
 
+/// Wire-format of the numeric component of a [`PostingCost`].
+///
+/// Mirrors the host's `rustledger_core::CostNumber` enum so JSON
+/// consumers see the same mutual exclusion the host enforces. The
+/// `kind` tag is the discriminator; consumers should switch on it
+/// rather than probing for present-but-null fields.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CostNumber {
+    /// Per-unit cost (e.g., `{100 USD}`).
+    PerUnit {
+        /// Per-unit value.
+        value: String,
+    },
+    /// Total cost as written (e.g., `{{1000 USD}}`), pre-booking.
+    Total {
+        /// Total value.
+        value: String,
+    },
+    /// Post-booking: derived per-unit plus preserved source total.
+    PerUnitFromTotal {
+        /// Derived per-unit.
+        per_unit: String,
+        /// Original total.
+        total: String,
+    },
+}
+
 #[derive(Serialize)]
 pub struct PostingCost {
-    /// Per-unit cost (e.g., {100 USD})
+    /// Cost number (per-unit, total, or post-booking pair).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub number: Option<String>,
-    /// Total cost (e.g., {{1000 USD}})
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub number_total: Option<String>,
+    pub number: Option<CostNumber>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -416,6 +441,67 @@ pub struct BatchOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ===== Cost-number wire-format tests (#1164) =====
+    //
+    // These pin the JSON shape FFI consumers depend on. Mirrors host
+    // `CostNumber` exactly — any silent shape change is a wire break.
+
+    #[test]
+    fn cost_number_per_unit_serializes_with_kind_tag() {
+        let cn = CostNumber::PerUnit {
+            value: "100".into(),
+        };
+        let json = serde_json::to_value(&cn).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"kind": "per_unit", "value": "100"})
+        );
+    }
+
+    #[test]
+    fn cost_number_total_serializes_with_kind_tag() {
+        let cn = CostNumber::Total {
+            value: "1500".into(),
+        };
+        let json = serde_json::to_value(&cn).unwrap();
+        assert_eq!(json, serde_json::json!({"kind": "total", "value": "1500"}));
+    }
+
+    #[test]
+    fn cost_number_per_unit_from_total_carries_both_values() {
+        let cn = CostNumber::PerUnitFromTotal {
+            per_unit: "150".into(),
+            total: "300".into(),
+        };
+        let json = serde_json::to_value(&cn).unwrap();
+        // Load-bearing: the preserved total survives serialization so
+        // downstream consumers don't have to redivide. This is what
+        // the pre-PR shape silently lost.
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "per_unit_from_total",
+                "per_unit": "150",
+                "total": "300",
+            })
+        );
+    }
+
+    #[test]
+    fn posting_cost_omits_number_when_none() {
+        let pc = PostingCost {
+            number: None,
+            currency: Some("USD".into()),
+            date: None,
+            label: None,
+        };
+        let json = serde_json::to_string(&pc).unwrap();
+        // `skip_serializing_if = "Option::is_none"` keeps the JSON
+        // shape lean — a bare `{USD}` lot match has no `number` key.
+        assert!(!json.contains("number"));
+        assert!(json.contains("currency"));
+    }
 
     #[test]
     fn test_error_default_phase_is_parse() {

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -886,6 +886,100 @@ mod tests {
         let _ = fs::remove_dir(&temp_dir);
     }
 
+    /// Frozen byte fixtures for the v8 cache layout of
+    /// [`rustledger_core::CostNumber`].
+    ///
+    /// The intra-build distinctness test in `rustledger-core::cost`
+    /// (`cost_number_archived_bytes_snapshot`) only catches drift
+    /// where variants collide with each other. It would NOT catch a
+    /// uniform encoding shift (e.g. a future rkyv minor bump that
+    /// changes how `Archived<Decimal>` packs, or an accidental
+    /// attribute change). When that happens every variant moves
+    /// together so distinctness still holds, but user caches on disk
+    /// silently fail to deserialize as garbage in the new layout.
+    ///
+    /// Capturing the exact bytes here pins the on-disk contract:
+    /// any drift trips this test, forcing the developer to either
+    /// (a) revert the encoding change, or (b) bump
+    /// [`CACHE_VERSION`] so old cache files are short-circuited at
+    /// the header check. The companion `cache_version_matches_v8`
+    /// assertion below fires if a developer regenerates the fixtures
+    /// without bumping the version constant in the same commit.
+    ///
+    /// **If this test fails** and you intend the new encoding to be
+    /// the contract going forward: regenerate the fixtures by
+    /// printing `rkyv::to_bytes(&cn)` for each variant, bump
+    /// `CACHE_VERSION` to `9`, and update both the fixtures and the
+    /// `cache_version_matches_v8` constant below in the same commit.
+    ///
+    /// Gated to little-endian targets — `rkyv::to_bytes` uses native
+    /// endianness, so the hardcoded bytes are valid for `x86_64` /
+    /// `aarch64` but would spuriously fail on big-endian platforms
+    /// (`s390x`, `ppc64be`). `CACHE_VERSION`'s purpose is same-machine
+    /// read guarding, so non-portable bytes aren't a real defect,
+    /// just a test-portability footnote.
+    #[cfg(target_endian = "little")]
+    #[test]
+    fn cost_number_archived_bytes_match_v8_fixtures() {
+        use rust_decimal_macros::dec;
+        use rustledger_core::{BookedCost, CostNumber};
+
+        // Tripwire: regenerating the byte fixtures below without
+        // bumping CACHE_VERSION leaves users with rotten caches. The
+        // assertion fires when CACHE_VERSION advances past 8, forcing
+        // the developer to also update the fixtures (or remove this
+        // tripwire if v9's contract is identical to v8 for CostNumber
+        // — which is unusual but possible).
+        const FIXTURE_VERSION: u32 = 8;
+        assert_eq!(
+            CACHE_VERSION, FIXTURE_VERSION,
+            "CACHE_VERSION advanced past the fixture version; regenerate \
+             the byte fixtures in this test and update FIXTURE_VERSION, \
+             or remove the tripwire if v{CACHE_VERSION}'s CostNumber \
+             encoding is byte-identical to v8.",
+        );
+
+        let cases: &[(&str, CostNumber, &[u8])] = &[
+            (
+                "PerUnit { value: 150 }",
+                CostNumber::PerUnit { value: dec!(150) },
+                &[
+                    0, 0, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0,
+                ],
+            ),
+            (
+                "Total { value: 1500 }",
+                CostNumber::Total { value: dec!(1500) },
+                &[
+                    1, 0, 0, 0, 0, 220, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0,
+                ],
+            ),
+            (
+                "PerUnitFromTotal { per_unit: 150, total: 300 }",
+                CostNumber::PerUnitFromTotal(BookedCost::new(dec!(150), dec!(300), dec!(2))),
+                &[
+                    2, 0, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 1, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0,
+                ],
+            ),
+        ];
+        let mut mismatches = Vec::new();
+        for (name, cn, expected) in cases {
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(cn).unwrap();
+            if bytes.as_ref() != *expected {
+                mismatches.push(format!("  `{name}` → {:?}", bytes.as_ref()));
+            }
+        }
+        assert!(
+            mismatches.is_empty(),
+            "rkyv layout drifted from v8 fixtures — bump CACHE_VERSION and \
+             update the fixtures in this test if intentional. Actual bytes:\n{}",
+            mismatches.join("\n"),
+        );
+    }
+
     #[test]
     fn test_reintern_directives_deduplication() {
         let date = rustledger_core::naive_date(2024, 1, 15).unwrap();

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -218,7 +218,14 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     `{ kind: PriceKind, amount: Option<IncompleteAmount> }`
 ///     (#1167). Old cache bytes for the enum's discriminant would
 ///     deserialize as nonsense in the new struct layout.
-const CACHE_VERSION: u32 = 7;
+/// v8: `CostSpec.{number_per,number_total}: Option<Decimal>` collapsed
+///     into `CostSpec.number: Option<CostNumber>` where `CostNumber` is
+///     a 3-variant enum (`PerUnit`, `Total`, `PerUnitFromTotal`)
+///     (#1164). The archived layout is structurally different
+///     (Option<Decimal> + Option<Decimal> → Option<discriminant +
+///     payload>); reading v7 bytes into the v8 layout would produce
+///     garbage cost numbers. Bumping forces regeneration.
+const CACHE_VERSION: u32 = 8;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -225,6 +225,16 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     (Option<Decimal> + Option<Decimal> → Option<discriminant +
 ///     payload>); reading v7 bytes into the v8 layout would produce
 ///     garbage cost numbers. Bumping forces regeneration.
+///     Subsequent #1164 follow-up commits converted `CostNumber`'s
+///     variants from tuple form (`PerUnit(Decimal)`) to struct form
+///     (`PerUnit { value: Decimal }`) so serde could apply
+///     `tag = "kind"` for cross-boundary wire unification. The rkyv-
+///     archived layout for a single-field struct variant is byte-
+///     identical to the tuple variant (both pack `Archived<Decimal>`
+///     positionally) — verified against rkyv 0.8.16 — so this change
+///     does NOT require a separate version bump. If a future rkyv
+///     version changes that encoding, OR if `CostNumber` gains
+///     additional fields, bump to v9.
 const CACHE_VERSION: u32 = 8;
 
 /// Cache header stored at the start of cache files.

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -694,10 +694,16 @@ fn build_display_context(directives: &[Spanned<Directive>], options: &Options) -
                     {
                         ctx.update(number, currency);
                     }
-                    // Cost (CostSpec)
+                    // Cost (CostSpec) — feed either per-unit or total
+                    // to the display-context inference, since both are
+                    // user-written amounts whose precision the context
+                    // should respect.
                     if let Some(ref cost) = posting.cost
-                        && let (Some(number), Some(currency)) =
-                            (cost.number_per.or(cost.number_total), &cost.currency)
+                        && let (Some(number), Some(currency)) = (
+                            cost.number
+                                .map(|cn| cn.per_unit().or_else(|| cn.total()).unwrap_or_default()),
+                            &cost.currency,
+                        )
                     {
                         ctx.update(number, currency.as_str());
                     }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -694,14 +694,17 @@ fn build_display_context(directives: &[Spanned<Directive>], options: &Options) -
                     {
                         ctx.update(number, currency);
                     }
-                    // Cost (CostSpec) — feed either per-unit or total
-                    // to the display-context inference, since both are
-                    // user-written amounts whose precision the context
-                    // should respect.
+                    // Cost (CostSpec) — feed the user-written amount to
+                    // the display-context inference. Prefer `total()`
+                    // over `per_unit()` so that for `PerUnitFromTotal`
+                    // we sample the user's literal `{{ total }}` rather
+                    // than the booker-derived per-unit (which has been
+                    // divided by |units| and typically carries far more
+                    // trailing precision than the source spec).
                     if let Some(ref cost) = posting.cost
                         && let (Some(number), Some(currency)) = (
                             cost.number
-                                .map(|cn| cn.per_unit().or_else(|| cn.total()).unwrap_or_default()),
+                                .map(|cn| cn.total().or_else(|| cn.per_unit()).unwrap_or_default()),
                             &cost.currency,
                         )
                     {

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -257,9 +257,9 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     // Opens / Documents that Early checks depend on (E1001 account
     // presence, E5001 missing-document file). Only this narrow synth
     // subset runs here; everything else waits until after booking
-    // (step 5) so cost-spec-reading plugins see filled-in
-    // `cost.number_per` values. See `PluginPass` rustdoc for the
-    // detailed split rationale.
+    // (step 5) so cost-spec-reading plugins see filled-in per-unit
+    // values on the `CostNumber::PerUnitFromTotal` variant. See
+    // `PluginPass` rustdoc for the detailed split rationale.
     #[cfg(feature = "plugins")]
     if options.run_plugins || options.auto_accounts {
         run_plugins(
@@ -356,7 +356,8 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     // Runs AFTER booking so cost-spec-reading plugins
     // (`implicit_prices`, `capital_gains_classifier`,
     // `check_average_cost`, `sell_gains`, `unrealized`, `valuation`)
-    // see filled-in `cost.number_per` values. This matches Python
+    // see filled-in per-unit values on the
+    // `CostNumber::PerUnitFromTotal` variant. This matches Python
     // beancount's plugins-after-booking ordering and closes
     // rustledger#1117. Failed transactions were partitioned out
     // above; plugins only see successfully-booked input.
@@ -491,8 +492,8 @@ fn run_booking(
 /// depend on), and once with [`PluginPass::PostBooking`] after booking
 /// (so cost-spec-reading plugins like `implicit_prices`,
 /// `capital_gains_classifier`, `check_average_cost`, `sell_gains`,
-/// `unrealized`, and `valuation` see filled-in `cost.number_per`
-/// values).
+/// `unrealized`, and `valuation` see filled-in per-unit values on the
+/// `CostNumber::PerUnitFromTotal` variant).
 ///
 /// Standalone callers (LSP, FFI, tests) that operate on already-booked
 /// input should pass [`PluginPass::All`] for the historical single-pass

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -21,13 +21,16 @@ rust_decimal.workspace = true
 jiff.workspace = true
 blake3.workspace = true
 regex.workspace = true
-# Replaced linfa-bayes 0.8 (pinned to ndarray 0.16) with ferrolearn-bayes
-# 0.4 (already on ndarray 0.17, MIT/Apache, MSRV 1.85). Same MultinomialNB
-# classifier, plus a real `predict_proba` so the ML categorizer's
-# confidence scores can be honest instead of the previous 0.8/0.0 fakery.
-# Unblocks the ndarray 0.16 -> 0.17 bump in this PR and the downstream
-# getrandom 0.2 -> 0.4 follow-up. `ferrolearn-core` is required for the
-# `Fit` trait that brings `MultinomialNB::fit` into scope.
+
+# ML stack — host-only. `ferrolearn-bayes` pulls `faer` → `spindle` →
+# `atomic-wait`, which doesn't compile on `wasm32-unknown-unknown`
+# (no `platform::wake_*` impl for the wasm target). The ML
+# categorizer doesn't run in browsers/WASI today — gate the deps off
+# wasm targets and gate the `ml` module body the same way. Same
+# MultinomialNB classifier as the linfa-bayes predecessor it replaced
+# (#1194), with a real `predict_proba`. `ferrolearn-core` brings the
+# `Fit` trait into scope for `MultinomialNB::fit`.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ferrolearn-bayes = "0.4"
 ferrolearn-core = "0.4"
 ndarray = "0.17"

--- a/crates/rustledger-ops/src/fingerprint.rs
+++ b/crates/rustledger-ops/src/fingerprint.rs
@@ -151,6 +151,16 @@ fn hash_cost<H: Hasher>(cost: &CostData, hasher: &mut H) {
             2u8.hash(hasher);
             s.hash(hasher);
         }
+        Some(CostNumberData::PerUnitFromTotal { per_unit, total }) => {
+            // Post-booking state must hash distinctly from raw PerUnit
+            // — two transactions with the same per_unit can have
+            // different source totals (e.g. {{150}} vs {150}*units
+            // when units rounds to the same per_unit), and the
+            // fingerprint must not collapse them.
+            3u8.hash(hasher);
+            per_unit.hash(hasher);
+            total.hash(hasher);
+        }
     }
     currency.hash(hasher);
     date.hash(hasher);

--- a/crates/rustledger-ops/src/fingerprint.rs
+++ b/crates/rustledger-ops/src/fingerprint.rs
@@ -129,16 +129,29 @@ fn hash_amount<H: Hasher>(amount: &AmountData, hasher: &mut H) {
 
 /// Hash a cost's structural fields.
 fn hash_cost<H: Hasher>(cost: &CostData, hasher: &mut H) {
+    use rustledger_plugin_types::CostNumberData;
     let CostData {
-        number_per,
-        number_total,
+        number,
         currency,
         date,
         label,
         merge,
     } = cost;
-    number_per.hash(hasher);
-    number_total.hash(hasher);
+    // Hash the typed number variant + payload. Pre-#1164 we hashed
+    // two parallel Option<String> fields; the new shape forbids the
+    // both-set state but the hash must still distinguish PerUnit from
+    // Total (same number, different meaning) so we tag the variant.
+    match number {
+        None => 0u8.hash(hasher),
+        Some(CostNumberData::PerUnit(s)) => {
+            1u8.hash(hasher);
+            s.hash(hasher);
+        }
+        Some(CostNumberData::Total(s)) => {
+            2u8.hash(hasher);
+            s.hash(hasher);
+        }
+    }
     currency.hash(hasher);
     date.hash(hasher);
     label.hash(hasher);
@@ -462,10 +475,10 @@ mod tests {
 
     #[test]
     fn distinct_costs_produce_different_hashes() {
+        use rustledger_plugin_types::CostNumberData;
         let mut txn1 = make_txn(Some("Store"), "Buy shares", "100.00");
         txn1.postings[0].cost = Some(CostData {
-            number_per: Some("10.00".to_string()),
-            number_total: None,
+            number: Some(CostNumberData::PerUnit("10.00".to_string())),
             currency: Some("USD".to_string()),
             date: None,
             label: None,
@@ -473,8 +486,7 @@ mod tests {
         });
         let mut txn2 = make_txn(Some("Store"), "Buy shares", "100.00");
         txn2.postings[0].cost = Some(CostData {
-            number_per: Some("11.00".to_string()),
-            number_total: None,
+            number: Some(CostNumberData::PerUnit("11.00".to_string())),
             currency: Some("USD".to_string()),
             date: None,
             label: None,

--- a/crates/rustledger-ops/src/fingerprint.rs
+++ b/crates/rustledger-ops/src/fingerprint.rs
@@ -143,11 +143,11 @@ fn hash_cost<H: Hasher>(cost: &CostData, hasher: &mut H) {
     // Total (same number, different meaning) so we tag the variant.
     match number {
         None => 0u8.hash(hasher),
-        Some(CostNumberData::PerUnit(s)) => {
+        Some(CostNumberData::PerUnit { value: s }) => {
             1u8.hash(hasher);
             s.hash(hasher);
         }
-        Some(CostNumberData::Total(s)) => {
+        Some(CostNumberData::Total { value: s }) => {
             2u8.hash(hasher);
             s.hash(hasher);
         }
@@ -488,7 +488,9 @@ mod tests {
         use rustledger_plugin_types::CostNumberData;
         let mut txn1 = make_txn(Some("Store"), "Buy shares", "100.00");
         txn1.postings[0].cost = Some(CostData {
-            number: Some(CostNumberData::PerUnit("10.00".to_string())),
+            number: Some(CostNumberData::PerUnit {
+                value: "10.00".to_string(),
+            }),
             currency: Some("USD".to_string()),
             date: None,
             label: None,
@@ -496,7 +498,9 @@ mod tests {
         });
         let mut txn2 = make_txn(Some("Store"), "Buy shares", "100.00");
         txn2.postings[0].cost = Some(CostData {
-            number: Some(CostNumberData::PerUnit("11.00".to_string())),
+            number: Some(CostNumberData::PerUnit {
+                value: "11.00".to_string(),
+            }),
             currency: Some("USD".to_string()),
             date: None,
             label: None,

--- a/crates/rustledger-ops/src/lib.rs
+++ b/crates/rustledger-ops/src/lib.rs
@@ -14,7 +14,10 @@
 //! - [`merchants`] — built-in merchant dictionary of common patterns
 //! - [`enrichment`] — shared types for operation results (confidence, method, alternatives)
 //! - [`reconcile`] — balance reconciliation against statement ending balances
-//! - [`ml`] — ML-based categorization (TF-IDF + Naive Bayes via ferrolearn-bayes)
+//! - `ml` — ML-based categorization (TF-IDF + Naive Bayes via
+//!   ferrolearn-bayes). Host-only: `ferrolearn-bayes` pulls
+//!   `atomic-wait`, which does not compile on
+//!   `wasm32-unknown-unknown`. The module is absent on wasm targets.
 //! - [`transfer`] — inter-account transfer detection and linking
 
 #![forbid(unsafe_code)]
@@ -25,6 +28,7 @@ pub mod dedup;
 pub mod enrichment;
 pub mod fingerprint;
 pub mod merchants;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod ml;
 pub mod reconcile;
 pub mod transfer;

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -744,7 +744,7 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
                 stream.advance();
                 // The number after # is the total
                 if let Ok(total) = parse_expr(stream) {
-                    spec.number_total = Some(total);
+                    spec.number = Some(rustledger_core::CostNumber::Total(total));
                     if let Ok(c) = parse_currency(stream) {
                         spec.currency = Some(c);
                     }
@@ -752,11 +752,11 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
                 }
             }
 
-            if is_total {
-                spec.number_total = Some(number);
+            spec.number = Some(if is_total {
+                rustledger_core::CostNumber::Total(number)
             } else {
-                spec.number_per = Some(number);
-            }
+                rustledger_core::CostNumber::PerUnit(number)
+            });
 
             // Optional currency
             if let Ok(c) = parse_currency(stream) {

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -744,7 +744,7 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
                 stream.advance();
                 // The number after # is the total
                 if let Ok(total) = parse_expr(stream) {
-                    spec.number = Some(rustledger_core::CostNumber::Total(total));
+                    spec.number = Some(rustledger_core::CostNumber::Total { value: total });
                     if let Ok(c) = parse_currency(stream) {
                         spec.currency = Some(c);
                     }
@@ -753,9 +753,9 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
             }
 
             spec.number = Some(if is_total {
-                rustledger_core::CostNumber::Total(number)
+                rustledger_core::CostNumber::Total { value: number }
             } else {
-                rustledger_core::CostNumber::PerUnit(number)
+                rustledger_core::CostNumber::PerUnit { value: number }
             });
 
             // Optional currency

--- a/crates/rustledger-parser/src/parser.rs
+++ b/crates/rustledger-parser/src/parser.rs
@@ -742,7 +742,20 @@ fn parse_cost_spec(stream: &mut TokenStream<'_>) -> ParseRes<CostSpec> {
                 && matches!(t.token, Token::Hash)
             {
                 stream.advance();
-                // The number after # is the total
+                // `{ N # T USD }` source carries both a per-unit (`N`)
+                // and a total (`T`). The booker derives per-unit as
+                // `T / |units|`, so the user-written `N` is
+                // informationally redundant — Python beancount treats
+                // this form as semantically equivalent to
+                // `{{ T USD }}` and we follow suit by keeping only the
+                // total. If the user-written N ever disagrees with
+                // T / |units|, the validator's NegativeCost / balance
+                // checks operate on the booker-derived value, which is
+                // the canonical one. The pre-#1164 shape stored both
+                // numbers and required downstream code to know which
+                // one was authoritative; the new shape makes the
+                // total-wins precedence explicit at the parser site.
+                let _ = number; // Drop the user-written per-unit per the rationale above.
                 if let Ok(total) = parse_expr(stream) {
                     spec.number = Some(rustledger_core::CostNumber::Total { value: total });
                     if let Ok(c) = parse_currency(stream) {

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -979,6 +979,55 @@ fn test_reject_incomplete_final_directive_at_eof() {
     );
 }
 
+/// Regression: `{ N # T USD }` source carries both a per-unit and a
+/// total. The booker derives per-unit as `T / |units|`, so the
+/// user-written `N` is informationally redundant — Python beancount
+/// treats this form as semantically equivalent to `{{ T USD }}` and
+/// we follow suit. Pin the precedence so a future refactor can't
+/// silently flip it (e.g. by keeping `N` instead and dropping `T`,
+/// which would invert the post-booking value of every cost-basis
+/// read of this spec form).
+#[test]
+fn test_cost_spec_n_hash_t_uses_total() {
+    use rust_decimal_macros::dec;
+    use rustledger_core::CostNumber;
+
+    let source = "
+2024-01-01 open Assets:Stock
+2024-01-01 open Assets:Cash USD
+
+2024-01-15 *
+  Assets:Stock  10 STK {50 # 1500 USD}
+  Assets:Cash  -1500.00 USD
+";
+    let result = parse_ok(source);
+    let txn = result
+        .directives
+        .iter()
+        .find_map(|d| match &d.value {
+            Directive::Transaction(t) => Some(t),
+            _ => None,
+        })
+        .expect("transaction present");
+    let cost = txn.postings[0]
+        .value
+        .cost
+        .as_ref()
+        .expect("cost spec present");
+    assert_eq!(
+        cost.number,
+        Some(CostNumber::Total { value: dec!(1500) }),
+        "the `#` form must store the post-`#` total, not the pre-`#` per-unit"
+    );
+    assert_eq!(
+        cost.currency
+            .as_ref()
+            .map(rustledger_core::Currency::as_str),
+        Some("USD"),
+        "currency must still be captured after the `# T` clause"
+    );
+}
+
 /// Regression: an unclosed cost brace followed by EOF (no trailing newline)
 /// should also produce a parse error, not silently drop the cost.
 #[test]

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -323,7 +323,10 @@ fn test_parse_transaction_with_cost() {
         let posting = &txn.postings[0];
         assert!(posting.cost.is_some());
         let cost = posting.cost.as_ref().unwrap();
-        assert_eq!(cost.number_per.unwrap().to_string(), "185.50");
+        assert_eq!(
+            cost.number.unwrap().per_unit().unwrap().to_string(),
+            "185.50"
+        );
         assert_eq!(cost.currency.as_deref(), Some("USD"));
     } else {
         panic!("expected transaction");

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -507,12 +507,25 @@ pub struct AmountData {
 /// plugins that care about precision (e.g. `currency_accounts`, which
 /// matches Python's `beancount.core.convert.get_cost`) can use the
 /// original total rather than redividing.
+///
+/// Serializes as `{"kind": "per_unit", "value": "100"}` /
+/// `{"kind": "total", "value": "1500"}` / `{"kind":
+/// "per_unit_from_total", "per_unit": "150", "total": "300"}` — the
+/// `kind`-tagged shape is shared with FFI-WASI, WASM, and Python so
+/// every client language sees one wire contract.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CostNumberData {
     /// Per-unit cost: `{150.00 USD}`.
-    PerUnit(String),
+    PerUnit {
+        /// Per-unit value.
+        value: String,
+    },
     /// Total cost for the posting's units: `{{ 1500.00 USD }}`.
-    Total(String),
+    Total {
+        /// Total value.
+        value: String,
+    },
     /// Post-booking derived per-unit with the original total preserved.
     /// `per_unit == total / |units|` by host construction; preferring
     /// `total` for cost-basis-style reads avoids the
@@ -532,8 +545,11 @@ impl CostNumberData {
     #[must_use]
     pub fn per_unit(&self) -> Option<&str> {
         match self {
-            Self::PerUnit(s) | Self::PerUnitFromTotal { per_unit: s, .. } => Some(s),
-            Self::Total(_) => None,
+            Self::PerUnit { value }
+            | Self::PerUnitFromTotal {
+                per_unit: value, ..
+            } => Some(value),
+            Self::Total { .. } => None,
         }
     }
 
@@ -542,8 +558,8 @@ impl CostNumberData {
     #[must_use]
     pub fn total(&self) -> Option<&str> {
         match self {
-            Self::Total(s) | Self::PerUnitFromTotal { total: s, .. } => Some(s),
-            Self::PerUnit(_) => None,
+            Self::Total { value } | Self::PerUnitFromTotal { total: value, .. } => Some(value),
+            Self::PerUnit { .. } => None,
         }
     }
 }

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -500,12 +500,52 @@ pub struct AmountData {
 /// invalid both-set state on the wire and forced every plugin to write
 /// "what if both?" defensive branches. Numbers are stringly-typed for
 /// arbitrary precision across the WASM boundary.
+///
+/// `PerUnitFromTotal` is the post-booking shape that plugins see after
+/// the booker has derived a per-unit value from a `{{ total }}` spec.
+/// It carries BOTH the derived per-unit AND the original total so
+/// plugins that care about precision (e.g. `currency_accounts`, which
+/// matches Python's `beancount.core.convert.get_cost`) can use the
+/// original total rather than redividing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CostNumberData {
     /// Per-unit cost: `{150.00 USD}`.
     PerUnit(String),
     /// Total cost for the posting's units: `{{ 1500.00 USD }}`.
     Total(String),
+    /// Post-booking derived per-unit with the original total preserved.
+    /// `per_unit == total / |units|` by host construction; preferring
+    /// `total` for cost-basis-style reads avoids the
+    /// division-then-multiplication precision loss that hits the
+    /// `rust_decimal` 28-digit ceiling on long ledgers.
+    PerUnitFromTotal {
+        /// Derived per-unit value.
+        per_unit: String,
+        /// Original `{{ total }}` as written.
+        total: String,
+    },
+}
+
+impl CostNumberData {
+    /// Per-unit value if the variant carries one ([`Self::PerUnit`] or
+    /// [`Self::PerUnitFromTotal`]); `None` for raw [`Self::Total`].
+    #[must_use]
+    pub fn per_unit(&self) -> Option<&str> {
+        match self {
+            Self::PerUnit(s) | Self::PerUnitFromTotal { per_unit: s, .. } => Some(s),
+            Self::Total(_) => None,
+        }
+    }
+
+    /// Total value if the variant carries one ([`Self::Total`] or
+    /// [`Self::PerUnitFromTotal`]); `None` for raw [`Self::PerUnit`].
+    #[must_use]
+    pub fn total(&self) -> Option<&str> {
+        match self {
+            Self::Total(s) | Self::PerUnitFromTotal { total: s, .. } => Some(s),
+            Self::PerUnit(_) => None,
+        }
+    }
 }
 
 /// Cost data for serialization.

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -491,15 +491,34 @@ pub struct AmountData {
     pub currency: String,
 }
 
+/// The numeric component of a [`CostData`].
+///
+/// Mirrors the host's `rustledger_core::CostNumber` on the wire. The
+/// per-unit vs total axes are mutually exclusive by construction —
+/// pre-#1164 they were split into independent `number_per` /
+/// `number_total` Option fields on `CostData`, which allowed the
+/// invalid both-set state on the wire and forced every plugin to write
+/// "what if both?" defensive branches. Numbers are stringly-typed for
+/// arbitrary precision across the WASM boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CostNumberData {
+    /// Per-unit cost: `{150.00 USD}`.
+    PerUnit(String),
+    /// Total cost for the posting's units: `{{ 1500.00 USD }}`.
+    Total(String),
+}
+
 /// Cost data for serialization.
 ///
 /// Represents cost specifications like `{100 USD}` or `{100 USD, 2024-01-01, "lot1"}`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CostData {
-    /// Per-unit cost number.
-    pub number_per: Option<String>,
-    /// Total cost number.
-    pub number_total: Option<String>,
+    /// The numeric component: per-unit, total, or absent (e.g. `{}`).
+    ///
+    /// Pre-#1164 this was a pair of `Option<String>` fields
+    /// (`number_per` and `number_total`); see [`CostNumberData`] for
+    /// the rationale behind the consolidation.
+    pub number: Option<CostNumberData>,
     /// Cost currency.
     pub currency: Option<String>,
     /// Acquisition date.

--- a/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
+++ b/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
@@ -1,0 +1,86 @@
+//! Wire-format round-trip tests for `CostNumberData` (#1164).
+//!
+//! These tests pin the JSON shape that plugins and the Python compat
+//! shim depend on. Any change in serde representation here is a wire-
+//! format break for every plugin language binding.
+
+use rustledger_plugin_types::CostNumberData;
+
+#[test]
+fn per_unit_serializes_with_tag() {
+    let cn = CostNumberData::PerUnit("100".to_string());
+    let json = serde_json::to_string(&cn).unwrap();
+    assert_eq!(json, r#"{"PerUnit":"100"}"#);
+}
+
+#[test]
+fn total_serializes_with_tag() {
+    let cn = CostNumberData::Total("1500".to_string());
+    let json = serde_json::to_string(&cn).unwrap();
+    assert_eq!(json, r#"{"Total":"1500"}"#);
+}
+
+#[test]
+fn per_unit_from_total_serializes_with_nested_fields() {
+    let cn = CostNumberData::PerUnitFromTotal {
+        per_unit: "150".to_string(),
+        total: "300".to_string(),
+    };
+    let json = serde_json::to_string(&cn).unwrap();
+    assert_eq!(
+        json,
+        r#"{"PerUnitFromTotal":{"per_unit":"150","total":"300"}}"#
+    );
+}
+
+#[test]
+fn per_unit_round_trip() {
+    let cn = CostNumberData::PerUnit("100".to_string());
+    let json = serde_json::to_string(&cn).unwrap();
+    let back: CostNumberData = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.per_unit(), Some("100"));
+    assert_eq!(back.total(), None);
+}
+
+#[test]
+fn total_round_trip() {
+    let cn = CostNumberData::Total("1500".to_string());
+    let json = serde_json::to_string(&cn).unwrap();
+    let back: CostNumberData = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.per_unit(), None);
+    assert_eq!(back.total(), Some("1500"));
+}
+
+#[test]
+fn per_unit_from_total_round_trip() {
+    let cn = CostNumberData::PerUnitFromTotal {
+        per_unit: "150".to_string(),
+        total: "300".to_string(),
+    };
+    let json = serde_json::to_string(&cn).unwrap();
+    let back: CostNumberData = serde_json::from_str(&json).unwrap();
+    // Both accessors must return Some — this is the load-bearing
+    // assertion that plugins like currency_accounts can access the
+    // preserved total without losing it on the wire.
+    assert_eq!(back.per_unit(), Some("150"));
+    assert_eq!(back.total(), Some("300"));
+}
+
+#[test]
+fn accessors_exhaustively_cover_variants() {
+    // Regression guard: if a future variant is added without updating
+    // the accessors, this test stays green only by accident. The
+    // exhaustive match in the impl is what guarantees coverage; this
+    // test is a behavioral spot-check.
+    for cn in [
+        CostNumberData::PerUnit("1".into()),
+        CostNumberData::Total("2".into()),
+        CostNumberData::PerUnitFromTotal {
+            per_unit: "3".into(),
+            total: "30".into(),
+        },
+    ] {
+        // At least one accessor returns Some for every variant.
+        assert!(cn.per_unit().is_some() || cn.total().is_some());
+    }
+}

--- a/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
+++ b/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
@@ -101,14 +101,22 @@ fn per_unit_from_total_round_trip() {
     assert_eq!(back.total(), Some("300"));
 }
 
-// ===== MessagePack wire-format tests (review A-3.11) =====
+// ===== MessagePack wire-format tests (review A-3.11 / A-4.3) =====
 //
 // The *actual* WASM plugin wire transport is MessagePack, not JSON
-// (see `rustledger-plugin/src/wasm/runtime.rs` rmp_serde calls). The
-// JSON tests above pin the human-readable shape; these pin the
-// binary wire so a future change to msgpack serializer settings
-// (e.g. forcing positional struct encoding) doesn't silently break
-// cross-language plugin compat.
+// (see `rmp_serde::to_vec` / `from_slice` at
+// `rustledger-plugin/src/runtime.rs:230` and `:273`). The JSON
+// tests above pin the human-readable shape; these pin the binary
+// wire so a future change to msgpack serializer settings (e.g.
+// switching to `to_vec_named` for self-describing maps, or
+// `Serializer::new(buf).with_struct_map(false)` for compact
+// positional encoding) doesn't silently break cross-language plugin
+// compat.
+//
+// IMPORTANT: these tests use `rmp_serde::to_vec` and `from_slice`
+// because that's what production uses. If runtime.rs ever changes
+// to a different serializer call, update these tests to match —
+// otherwise wire-shape drift passes here while real plugins break.
 
 #[test]
 fn per_unit_msgpack_round_trip() {

--- a/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
+++ b/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
@@ -7,35 +7,68 @@
 use rustledger_plugin_types::CostNumberData;
 
 #[test]
-fn per_unit_serializes_with_tag() {
-    let cn = CostNumberData::PerUnit("100".to_string());
-    let json = serde_json::to_string(&cn).unwrap();
-    assert_eq!(json, r#"{"PerUnit":"100"}"#);
+fn per_unit_serializes_with_kind_tag() {
+    let cn = CostNumberData::PerUnit {
+        value: "100".to_string(),
+    };
+    let json = serde_json::to_value(&cn).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({"kind": "per_unit", "value": "100"})
+    );
 }
 
 #[test]
-fn total_serializes_with_tag() {
-    let cn = CostNumberData::Total("1500".to_string());
-    let json = serde_json::to_string(&cn).unwrap();
-    assert_eq!(json, r#"{"Total":"1500"}"#);
+fn total_serializes_with_kind_tag() {
+    let cn = CostNumberData::Total {
+        value: "1500".to_string(),
+    };
+    let json = serde_json::to_value(&cn).unwrap();
+    assert_eq!(json, serde_json::json!({"kind": "total", "value": "1500"}));
 }
 
 #[test]
-fn per_unit_from_total_serializes_with_nested_fields() {
+fn per_unit_from_total_serializes_with_kind_tag_and_both_fields() {
     let cn = CostNumberData::PerUnitFromTotal {
         per_unit: "150".to_string(),
         total: "300".to_string(),
     };
-    let json = serde_json::to_string(&cn).unwrap();
+    let json = serde_json::to_value(&cn).unwrap();
     assert_eq!(
         json,
-        r#"{"PerUnitFromTotal":{"per_unit":"150","total":"300"}}"#
+        serde_json::json!({
+            "kind": "per_unit_from_total",
+            "per_unit": "150",
+            "total": "300",
+        })
+    );
+}
+
+#[test]
+fn unified_wire_shape_matches_ffi_wasi_and_wasm() {
+    // Load-bearing regression guard: plugin-types, FFI-WASI, WASM,
+    // and Python compat all emit the same `kind`-tagged shape. If
+    // serde defaults ever drift here, downstream clients written
+    // against the unified shape silently break — this assertion
+    // catches it. The `kind` value uses snake_case to match the
+    // FFI-WASI/WASM convention.
+    let cn = CostNumberData::PerUnit {
+        value: "1".to_string(),
+    };
+    let json = serde_json::to_value(&cn).unwrap();
+    assert_eq!(json["kind"], "per_unit", "kind must be snake_case");
+    assert!(json.get("value").is_some(), "value field must be present");
+    assert!(
+        json.get("PerUnit").is_none(),
+        "must NOT use external-tag (pre-PR shape)"
     );
 }
 
 #[test]
 fn per_unit_round_trip() {
-    let cn = CostNumberData::PerUnit("100".to_string());
+    let cn = CostNumberData::PerUnit {
+        value: "100".to_string(),
+    };
     let json = serde_json::to_string(&cn).unwrap();
     let back: CostNumberData = serde_json::from_str(&json).unwrap();
     assert_eq!(back.per_unit(), Some("100"));
@@ -44,7 +77,9 @@ fn per_unit_round_trip() {
 
 #[test]
 fn total_round_trip() {
-    let cn = CostNumberData::Total("1500".to_string());
+    let cn = CostNumberData::Total {
+        value: "1500".to_string(),
+    };
     let json = serde_json::to_string(&cn).unwrap();
     let back: CostNumberData = serde_json::from_str(&json).unwrap();
     assert_eq!(back.per_unit(), None);
@@ -73,8 +108,8 @@ fn accessors_exhaustively_cover_variants() {
     // exhaustive match in the impl is what guarantees coverage; this
     // test is a behavioral spot-check.
     for cn in [
-        CostNumberData::PerUnit("1".into()),
-        CostNumberData::Total("2".into()),
+        CostNumberData::PerUnit { value: "1".into() },
+        CostNumberData::Total { value: "2".into() },
         CostNumberData::PerUnitFromTotal {
             per_unit: "3".into(),
             total: "30".into(),

--- a/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
+++ b/crates/rustledger-plugin-types/tests/cost_number_wire_format.rs
@@ -101,6 +101,91 @@ fn per_unit_from_total_round_trip() {
     assert_eq!(back.total(), Some("300"));
 }
 
+// ===== MessagePack wire-format tests (review A-3.11) =====
+//
+// The *actual* WASM plugin wire transport is MessagePack, not JSON
+// (see `rustledger-plugin/src/wasm/runtime.rs` rmp_serde calls). The
+// JSON tests above pin the human-readable shape; these pin the
+// binary wire so a future change to msgpack serializer settings
+// (e.g. forcing positional struct encoding) doesn't silently break
+// cross-language plugin compat.
+
+#[test]
+fn per_unit_msgpack_round_trip() {
+    let cn = CostNumberData::PerUnit {
+        value: "100".to_string(),
+    };
+    let bytes = rmp_serde::to_vec(&cn).unwrap();
+    let back: CostNumberData = rmp_serde::from_slice(&bytes).unwrap();
+    assert_eq!(back.per_unit(), Some("100"));
+    assert_eq!(back.total(), None);
+}
+
+#[test]
+fn total_msgpack_round_trip() {
+    let cn = CostNumberData::Total {
+        value: "1500".to_string(),
+    };
+    let bytes = rmp_serde::to_vec(&cn).unwrap();
+    let back: CostNumberData = rmp_serde::from_slice(&bytes).unwrap();
+    assert_eq!(back.per_unit(), None);
+    assert_eq!(back.total(), Some("1500"));
+}
+
+#[test]
+fn per_unit_from_total_msgpack_round_trip() {
+    // Load-bearing: post-booking PerUnitFromTotal must survive the
+    // msgpack round-trip with both halves intact. If serializer
+    // settings drop the discriminator, the variant degrades silently
+    // to one half — exactly the silent-degradation pattern this PR
+    // was designed to prevent.
+    let cn = CostNumberData::PerUnitFromTotal {
+        per_unit: "150".to_string(),
+        total: "300".to_string(),
+    };
+    let bytes = rmp_serde::to_vec(&cn).unwrap();
+    let back: CostNumberData = rmp_serde::from_slice(&bytes).unwrap();
+    assert_eq!(back.per_unit(), Some("150"));
+    assert_eq!(back.total(), Some("300"));
+}
+
+#[test]
+fn cost_data_msgpack_round_trip_preserves_all_variants() {
+    use rustledger_plugin_types::CostData;
+
+    for number in [
+        Some(CostNumberData::PerUnit { value: "1".into() }),
+        Some(CostNumberData::Total { value: "10".into() }),
+        Some(CostNumberData::PerUnitFromTotal {
+            per_unit: "1".into(),
+            total: "10".into(),
+        }),
+        None,
+    ] {
+        let cost = CostData {
+            number,
+            currency: Some("USD".into()),
+            date: Some("2024-01-15".into()),
+            label: Some("lot1".into()),
+            merge: false,
+        };
+        let bytes = rmp_serde::to_vec(&cost).unwrap();
+        let back: CostData = rmp_serde::from_slice(&bytes).unwrap();
+        match (&cost.number, &back.number) {
+            (None, None) => {}
+            (Some(a), Some(b)) => {
+                assert_eq!(a.per_unit(), b.per_unit());
+                assert_eq!(a.total(), b.total());
+            }
+            _ => panic!("msgpack round trip mutated cost.number presence"),
+        }
+        assert_eq!(cost.currency, back.currency);
+        assert_eq!(cost.date, back.date);
+        assert_eq!(cost.label, back.label);
+        assert_eq!(cost.merge, back.merge);
+    }
+}
+
 #[test]
 fn accessors_exhaustively_cover_variants() {
     // Regression guard: if a future variant is added without updating

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -170,25 +170,26 @@ pub(super) fn data_to_cost(
         Some(CostNumberData::PerUnitFromTotal { per_unit, total }) => {
             let per_unit_d = parse(per_unit)?;
             let total_d = parse(total)?;
-            // Validate the post-booking invariant
-            // `per_unit * |units| == total` if units are known.
-            // Plugins that mutate one half without the other land in
-            // inventory with bogus state otherwise. When units are
-            // unknown (e.g. interpolation-pending posting) we trust
-            // the wire — the booker re-validates later.
-            match units_number {
-                Some(u) => match rustledger_core::BookedCost::try_new(per_unit_d, total_d, u) {
-                    Some(b) => Some(rustledger_core::CostNumber::PerUnitFromTotal(b)),
-                    None => {
-                        return Err(ConversionError::InvalidNumber(format!(
-                            "PerUnitFromTotal invariant violated: per_unit ({per_unit_d}) * |{u}| != total ({total_d})"
-                        )));
-                    }
-                },
-                None => Some(rustledger_core::CostNumber::PerUnitFromTotal(
-                    rustledger_core::BookedCost::from_parts_unchecked_trusted(per_unit_d, total_d),
-                )),
-            }
+            // `PerUnitFromTotal` is the post-booking shape by
+            // definition — a posting with it must already have units
+            // (the booker put them there). A plugin that emits this
+            // variant without units is malformed; reject rather than
+            // trust silently. The booker does NOT re-validate plugin-
+            // supplied `PerUnitFromTotal` later — pattern matches read
+            // `b.per_unit` / `b.total` without checking consistency
+            // (review B-3.2).
+            let units = units_number.ok_or_else(|| {
+                // Synthesize a units=0 error so the diagnostic
+                // explains why we rejected. `try_new` returns
+                // `tolerance: None` for zero units, which the Display
+                // impl renders as "requires non-zero units".
+                ConversionError::BookedCostInvariantViolated(
+                    rustledger_core::BookedCost::try_new(per_unit_d, total_d, Decimal::ZERO)
+                        .expect_err("zero-units invariant always fails"),
+                )
+            })?;
+            let booked = rustledger_core::BookedCost::try_new(per_unit_d, total_d, units)?;
+            Some(rustledger_core::CostNumber::PerUnitFromTotal(booked))
         }
         None => None,
     };

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -62,7 +62,16 @@ pub(super) fn data_to_posting(data: &PostingData) -> Result<Posting, ConversionE
         .as_ref()
         .map(data_to_incomplete_amount)
         .transpose()?;
-    let cost = data.cost.as_ref().map(data_to_cost).transpose()?;
+    // Thread the parsed units into the cost bridge so PerUnitFromTotal
+    // can validate the per_unit/total/units consistency invariant. A
+    // plugin that mutates one half without the other gets caught at
+    // the boundary instead of silently corrupting inventory state.
+    let units_number = units.as_ref().and_then(IncompleteAmount::number);
+    let cost = data
+        .cost
+        .as_ref()
+        .map(|c| data_to_cost(c, units_number))
+        .transpose()?;
     let price = data
         .price
         .as_ref()
@@ -143,23 +152,43 @@ pub(super) fn data_to_amount(data: &AmountData) -> Result<Amount, ConversionErro
     Ok(Amount::new(number, &data.currency))
 }
 
-pub(super) fn data_to_cost(data: &CostData) -> Result<CostSpec, ConversionError> {
+pub(super) fn data_to_cost(
+    data: &CostData,
+    units_number: Option<Decimal>,
+) -> Result<CostSpec, ConversionError> {
     use crate::types::CostNumberData;
     let parse = |s: &String| {
         Decimal::from_str_exact(s).map_err(|_| ConversionError::InvalidNumber(s.clone()))
     };
     let number = match &data.number {
-        Some(CostNumberData::PerUnit(s)) => Some(rustledger_core::CostNumber::PerUnit(parse(s)?)),
-        Some(CostNumberData::Total(s)) => Some(rustledger_core::CostNumber::Total(parse(s)?)),
+        Some(CostNumberData::PerUnit { value: s }) => {
+            Some(rustledger_core::CostNumber::PerUnit { value: parse(s)? })
+        }
+        Some(CostNumberData::Total { value: s }) => {
+            Some(rustledger_core::CostNumber::Total { value: parse(s)? })
+        }
         Some(CostNumberData::PerUnitFromTotal { per_unit, total }) => {
-            // Plugins that mutate post-booking costs round-trip the
-            // variant intact; we use the unchecked constructor because
-            // the bridge has no access to the original units (plugins
-            // see the wire form). The booker's own construction goes
-            // through `BookedCost::new` with the invariant assertion.
-            Some(rustledger_core::CostNumber::PerUnitFromTotal(
-                rustledger_core::BookedCost::from_parts_unchecked(parse(per_unit)?, parse(total)?),
-            ))
+            let per_unit_d = parse(per_unit)?;
+            let total_d = parse(total)?;
+            // Validate the post-booking invariant
+            // `per_unit * |units| == total` if units are known.
+            // Plugins that mutate one half without the other land in
+            // inventory with bogus state otherwise. When units are
+            // unknown (e.g. interpolation-pending posting) we trust
+            // the wire — the booker re-validates later.
+            match units_number {
+                Some(u) => match rustledger_core::BookedCost::try_new(per_unit_d, total_d, u) {
+                    Some(b) => Some(rustledger_core::CostNumber::PerUnitFromTotal(b)),
+                    None => {
+                        return Err(ConversionError::InvalidNumber(format!(
+                            "PerUnitFromTotal invariant violated: per_unit ({per_unit_d}) * |{u}| != total ({total_d})"
+                        )));
+                    }
+                },
+                None => Some(rustledger_core::CostNumber::PerUnitFromTotal(
+                    rustledger_core::BookedCost::from_parts_unchecked_trusted(per_unit_d, total_d),
+                )),
+            }
         }
         None => None,
     };

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -144,21 +144,16 @@ pub(super) fn data_to_amount(data: &AmountData) -> Result<Amount, ConversionErro
 }
 
 pub(super) fn data_to_cost(data: &CostData) -> Result<CostSpec, ConversionError> {
-    let number_per = data
-        .number_per
-        .as_ref()
-        .map(|s| Decimal::from_str_exact(s))
-        .transpose()
-        .map_err(|_| ConversionError::InvalidNumber(data.number_per.clone().unwrap_or_default()))?;
-
-    let number_total = data
-        .number_total
-        .as_ref()
-        .map(|s| Decimal::from_str_exact(s))
-        .transpose()
-        .map_err(|_| {
-            ConversionError::InvalidNumber(data.number_total.clone().unwrap_or_default())
-        })?;
+    use crate::types::CostNumberData;
+    let number = match &data.number {
+        Some(CostNumberData::PerUnit(s)) => Some(rustledger_core::CostNumber::PerUnit(
+            Decimal::from_str_exact(s).map_err(|_| ConversionError::InvalidNumber(s.clone()))?,
+        )),
+        Some(CostNumberData::Total(s)) => Some(rustledger_core::CostNumber::Total(
+            Decimal::from_str_exact(s).map_err(|_| ConversionError::InvalidNumber(s.clone()))?,
+        )),
+        None => None,
+    };
 
     let date = data
         .date
@@ -168,8 +163,7 @@ pub(super) fn data_to_cost(data: &CostData) -> Result<CostSpec, ConversionError>
         .map_err(|_| ConversionError::InvalidDate(data.date.clone().unwrap_or_default()))?;
 
     Ok(CostSpec {
-        number_per,
-        number_total,
+        number,
         currency: data.currency.as_ref().map(|c| c.clone().into()),
         date,
         label: data.label.clone(),

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -173,20 +173,16 @@ pub(super) fn data_to_cost(
             // `PerUnitFromTotal` is the post-booking shape by
             // definition — a posting with it must already have units
             // (the booker put them there). A plugin that emits this
-            // variant without units is malformed; reject rather than
-            // trust silently. The booker does NOT re-validate plugin-
-            // supplied `PerUnitFromTotal` later — pattern matches read
+            // variant without units is malformed; reject with a typed
+            // error that distinguishes "missing" from "inconsistent"
+            // so plugin authors get an actionable diagnostic. The
+            // booker does NOT re-validate plugin-supplied
+            // `PerUnitFromTotal` later — pattern matches read
             // `b.per_unit` / `b.total` without checking consistency
-            // (review B-3.2).
-            let units = units_number.ok_or_else(|| {
-                // Synthesize a units=0 error so the diagnostic
-                // explains why we rejected. `try_new` returns
-                // `tolerance: None` for zero units, which the Display
-                // impl renders as "requires non-zero units".
-                ConversionError::BookedCostInvariantViolated(
-                    rustledger_core::BookedCost::try_new(per_unit_d, total_d, Decimal::ZERO)
-                        .expect_err("zero-units invariant always fails"),
-                )
+            // (review B-3.2 / B-4.2).
+            let units = units_number.ok_or(ConversionError::PerUnitFromTotalMissingUnits {
+                per_unit: per_unit_d,
+                total: total_d,
             })?;
             let booked = rustledger_core::BookedCost::try_new(per_unit_d, total_d, units)?;
             Some(rustledger_core::CostNumber::PerUnitFromTotal(booked))

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -145,13 +145,22 @@ pub(super) fn data_to_amount(data: &AmountData) -> Result<Amount, ConversionErro
 
 pub(super) fn data_to_cost(data: &CostData) -> Result<CostSpec, ConversionError> {
     use crate::types::CostNumberData;
+    let parse = |s: &String| {
+        Decimal::from_str_exact(s).map_err(|_| ConversionError::InvalidNumber(s.clone()))
+    };
     let number = match &data.number {
-        Some(CostNumberData::PerUnit(s)) => Some(rustledger_core::CostNumber::PerUnit(
-            Decimal::from_str_exact(s).map_err(|_| ConversionError::InvalidNumber(s.clone()))?,
-        )),
-        Some(CostNumberData::Total(s)) => Some(rustledger_core::CostNumber::Total(
-            Decimal::from_str_exact(s).map_err(|_| ConversionError::InvalidNumber(s.clone()))?,
-        )),
+        Some(CostNumberData::PerUnit(s)) => Some(rustledger_core::CostNumber::PerUnit(parse(s)?)),
+        Some(CostNumberData::Total(s)) => Some(rustledger_core::CostNumber::Total(parse(s)?)),
+        Some(CostNumberData::PerUnitFromTotal { per_unit, total }) => {
+            // Plugins that mutate post-booking costs round-trip the
+            // variant intact; we use the unchecked constructor because
+            // the bridge has no access to the original units (plugins
+            // see the wire form). The booker's own construction goes
+            // through `BookedCost::new` with the invariant assertion.
+            Some(rustledger_core::CostNumber::PerUnitFromTotal(
+                rustledger_core::BookedCost::from_parts_unchecked(parse(per_unit)?, parse(total)?),
+            ))
+        }
         None => None,
     };
 

--- a/crates/rustledger-plugin/src/convert/mod.rs
+++ b/crates/rustledger-plugin/src/convert/mod.rs
@@ -25,12 +25,24 @@ pub enum ConversionError {
     /// Invalid date format.
     #[error("invalid date format: {0}")]
     InvalidDate(String),
-    /// Invalid number format.
+    /// Invalid number format. Use for parse failures only — for a pair
+    /// of valid numbers that fail a cross-field invariant, see
+    /// [`Self::BookedCostInvariantViolated`].
     #[error("invalid number format: {0}")]
     InvalidNumber(String),
     /// Invalid flag format.
     #[error("invalid flag: {0}")]
     InvalidFlag(String),
+    /// A `PerUnitFromTotal` cost spec carries a (`per_unit`, `total`)
+    /// pair that doesn't agree with the posting's units. Returned by
+    /// the plugin egress and FFI input bridges when a plugin author
+    /// or JSON client supplies the post-booking shape with
+    /// inconsistent values — e.g. mutates `per_unit` without updating
+    /// `total`. The inner [`BookedCostInvariantError`] carries the
+    /// supplied values, the derived total, and the tolerance for
+    /// plugin-author diagnostics.
+    #[error("cost spec invariant violated: {0}")]
+    BookedCostInvariantViolated(#[from] rustledger_core::BookedCostInvariantError),
     /// A `SourceSpan` byte offset from the plugin wire format does not
     /// fit in `usize` on the host. This is effectively impossible in
     /// practice — `SourceSpan` is `u64` and the host is 64-bit on every

--- a/crates/rustledger-plugin/src/convert/mod.rs
+++ b/crates/rustledger-plugin/src/convert/mod.rs
@@ -43,6 +43,24 @@ pub enum ConversionError {
     /// plugin-author diagnostics.
     #[error("cost spec invariant violated: {0}")]
     BookedCostInvariantViolated(#[from] rustledger_core::BookedCostInvariantError),
+    /// A plugin emitted a `PerUnitFromTotal` cost spec without
+    /// supplying the posting's units. The post-booking shape is
+    /// undefined without units (`per_unit = total / |units|` requires
+    /// them) — a plugin emitting it untouched should keep the units
+    /// the host gave it; a plugin emitting a fresh post-booking spec
+    /// must include matching units. Distinct from
+    /// [`Self::BookedCostInvariantViolated`] because "missing" is a
+    /// different category from "inconsistent" — plugin authors fix
+    /// each with different actions (forgot vs miscalculated).
+    #[error(
+        "PerUnitFromTotal cost spec requires units on the posting (got per_unit {per_unit}, total {total}, no units)"
+    )]
+    PerUnitFromTotalMissingUnits {
+        /// The per-unit value the plugin supplied.
+        per_unit: rustledger_core::Decimal,
+        /// The total value the plugin supplied.
+        total: rustledger_core::Decimal,
+    },
     /// A `SourceSpan` byte offset from the plugin wire format does not
     /// fit in `usize` on the host. This is effectively impossible in
     /// practice — `SourceSpan` is `u64` and the host is 64-bit on every

--- a/crates/rustledger-plugin/src/convert/mod.rs
+++ b/crates/rustledger-plugin/src/convert/mod.rs
@@ -38,9 +38,9 @@ pub enum ConversionError {
     /// the plugin egress and FFI input bridges when a plugin author
     /// or JSON client supplies the post-booking shape with
     /// inconsistent values — e.g. mutates `per_unit` without updating
-    /// `total`. The inner [`BookedCostInvariantError`] carries the
-    /// supplied values, the derived total, and the tolerance for
-    /// plugin-author diagnostics.
+    /// `total`. The inner [`rustledger_core::BookedCostInvariantError`]
+    /// carries the supplied values, the derived total, and the
+    /// tolerance for plugin-author diagnostics.
     #[error("cost spec invariant violated: {0}")]
     BookedCostInvariantViolated(#[from] rustledger_core::BookedCostInvariantError),
     /// A plugin emitted a `PerUnitFromTotal` cost spec without

--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -86,16 +86,17 @@ pub(super) fn amount_to_data(amount: &Amount) -> AmountData {
 pub(super) fn cost_to_data(cost: &CostSpec) -> CostData {
     use crate::types::CostNumberData;
     CostData {
-        // PerUnitFromTotal is the post-booking shape — surface its
-        // per-unit value to plugins (it's what they typically want;
-        // the source total only matters for residual precision inside
-        // the booker/validator and shouldn't leak through the wire
-        // unless we add a discriminator for it later).
+        // PerUnitFromTotal preserves both the derived per-unit AND the
+        // original `{{ total }}` on the wire. Plugins that want a
+        // per-unit value use `CostNumberData::per_unit()`; those that
+        // want the precise total (e.g. cost-basis reads matching
+        // Python's `beancount.core.convert.get_cost`) use `total()`.
         number: cost.number.map(|n| match n {
             rustledger_core::CostNumber::PerUnit(d) => CostNumberData::PerUnit(d.to_string()),
-            rustledger_core::CostNumber::PerUnitFromTotal(b) => {
-                CostNumberData::PerUnit(b.per_unit.to_string())
-            }
+            rustledger_core::CostNumber::PerUnitFromTotal(b) => CostNumberData::PerUnitFromTotal {
+                per_unit: b.per_unit.to_string(),
+                total: b.total.to_string(),
+            },
             rustledger_core::CostNumber::Total(d) => CostNumberData::Total(d.to_string()),
         }),
         currency: cost.currency.as_ref().map(ToString::to_string),

--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -92,12 +92,16 @@ pub(super) fn cost_to_data(cost: &CostSpec) -> CostData {
         // want the precise total (e.g. cost-basis reads matching
         // Python's `beancount.core.convert.get_cost`) use `total()`.
         number: cost.number.map(|n| match n {
-            rustledger_core::CostNumber::PerUnit(d) => CostNumberData::PerUnit(d.to_string()),
+            rustledger_core::CostNumber::PerUnit { value: d } => CostNumberData::PerUnit {
+                value: d.to_string(),
+            },
             rustledger_core::CostNumber::PerUnitFromTotal(b) => CostNumberData::PerUnitFromTotal {
                 per_unit: b.per_unit.to_string(),
                 total: b.total.to_string(),
             },
-            rustledger_core::CostNumber::Total(d) => CostNumberData::Total(d.to_string()),
+            rustledger_core::CostNumber::Total { value: d } => CostNumberData::Total {
+                value: d.to_string(),
+            },
         }),
         currency: cost.currency.as_ref().map(ToString::to_string),
         date: cost.date.map(|d| d.to_string()),

--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -84,9 +84,20 @@ pub(super) fn amount_to_data(amount: &Amount) -> AmountData {
 }
 
 pub(super) fn cost_to_data(cost: &CostSpec) -> CostData {
+    use crate::types::CostNumberData;
     CostData {
-        number_per: cost.number_per.map(|n| n.to_string()),
-        number_total: cost.number_total.map(|n| n.to_string()),
+        // PerUnitFromTotal is the post-booking shape — surface its
+        // per-unit value to plugins (it's what they typically want;
+        // the source total only matters for residual precision inside
+        // the booker/validator and shouldn't leak through the wire
+        // unless we add a discriminator for it later).
+        number: cost.number.map(|n| match n {
+            rustledger_core::CostNumber::PerUnit(d) => CostNumberData::PerUnit(d.to_string()),
+            rustledger_core::CostNumber::PerUnitFromTotal(b) => {
+                CostNumberData::PerUnit(b.per_unit.to_string())
+            }
+            rustledger_core::CostNumber::Total(d) => CostNumberData::Total(d.to_string()),
+        }),
         currency: cost.currency.as_ref().map(ToString::to_string),
         date: cost.date.map(|d| d.to_string()),
         label: cost.label.clone(),

--- a/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
+++ b/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
@@ -204,16 +204,15 @@ fn process_long_short(input: PluginInput) -> PluginOutput {
                         // Calculate gain
                         // Capital-gains classification operates on
                         // post-booking transactions where the cost
-                        // carries a per-unit value (booking fills it
-                        // in for PerUnitFromTotal too).
-                        let cost_number = match &cost.number {
-                            Some(rustledger_plugin_types::CostNumberData::PerUnit(n)) => {
-                                Decimal::from_str(n).ok().unwrap_or(Decimal::ZERO)
-                            }
-                            Some(rustledger_plugin_types::CostNumberData::Total(_)) | None => {
-                                Decimal::ZERO
-                            }
-                        };
+                        // carries a per-unit value (both PerUnit and
+                        // PerUnitFromTotal expose per_unit()).
+                        let cost_number = cost
+                            .number
+                            .as_ref()
+                            .and_then(|cn| cn.per_unit())
+                            .map_or(Decimal::ZERO, |s| {
+                                Decimal::from_str(s).unwrap_or(Decimal::ZERO)
+                            });
                         let price_number = price
                             .amount
                             .as_ref()

--- a/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
+++ b/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
@@ -202,11 +202,18 @@ fn process_long_short(input: PluginInput) -> PluginOutput {
 
                     if let Some(cost_date) = cost_date {
                         // Calculate gain
-                        let cost_number = cost
-                            .number_per
-                            .as_ref()
-                            .and_then(|n| Decimal::from_str(n).ok())
-                            .unwrap_or(Decimal::ZERO);
+                        // Capital-gains classification operates on
+                        // post-booking transactions where the cost
+                        // carries a per-unit value (booking fills it
+                        // in for PerUnitFromTotal too).
+                        let cost_number = match &cost.number {
+                            Some(rustledger_plugin_types::CostNumberData::PerUnit(n)) => {
+                                Decimal::from_str(n).ok().unwrap_or(Decimal::ZERO)
+                            }
+                            Some(rustledger_plugin_types::CostNumberData::Total(_)) | None => {
+                                Decimal::ZERO
+                            }
+                        };
                         let price_number = price
                             .amount
                             .as_ref()

--- a/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
@@ -110,11 +110,16 @@ impl NativePlugin for CheckAverageCostPlugin {
 
                     if units_num > Decimal::ZERO {
                         // Acquisition: add to inventory
-                        let cost_per = cost
-                            .number_per
-                            .as_ref()
-                            .and_then(|s| Decimal::from_str(s).ok())
-                            .unwrap_or_default();
+                        // Wire-format reads only see per-unit costs
+                        // for the average-cost gate — total-only specs
+                        // are pre-booking and don't yet carry a
+                        // per-unit value.
+                        let cost_per = match &cost.number {
+                            Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
+                                Decimal::from_str(s).ok().unwrap_or_default()
+                            }
+                            _ => Decimal::ZERO,
+                        };
 
                         let entry = inventory
                             .entry(key)
@@ -130,12 +135,14 @@ impl NativePlugin for CheckAverageCostPlugin {
                         {
                             let avg_cost = *total_cost / *total_units;
 
-                            // Get the cost used in this posting
-                            let used_cost = cost
-                                .number_per
-                                .as_ref()
-                                .and_then(|s| Decimal::from_str(s).ok())
-                                .unwrap_or_default();
+                            // Get the cost used in this posting.
+                            // Same per-unit-only read as above.
+                            let used_cost = match &cost.number {
+                                Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
+                                    Decimal::from_str(s).ok().unwrap_or_default()
+                                }
+                                _ => Decimal::ZERO,
+                            };
 
                             // Calculate relative difference
                             let diff = (used_cost - avg_cost).abs();
@@ -224,8 +231,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("100.00".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "100.00".to_string(),
+                                )),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -257,8 +265,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("100.00".to_string()), // Matches average
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "100.00".to_string(),
+                                )), // Matches average
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -309,8 +318,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("100.00".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "100.00".to_string(),
+                                )),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -342,8 +352,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("90.00".to_string()), // 10% different from avg
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "90.00".to_string(),
+                                )), // 10% different from avg
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -396,8 +407,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("100.00".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "100.00".to_string(),
+                                )),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -429,8 +441,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("120.00".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "120.00".to_string(),
+                                )),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -462,8 +475,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("110.00".to_string()), // Matches average
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "110.00".to_string(),
+                                )), // Matches average
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -535,8 +549,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number_per: Some("100.00".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "100.00".to_string(),
+                                )),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -570,8 +585,9 @@ mod check_average_cost_tests {
                             cost: Some(CostData {
                                 // 50% off the average — would fire for NONE,
                                 // but must be silent for STRICT/default.
-                                number_per: Some("50.00".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                    "50.00".to_string(),
+                                )),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,

--- a/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
@@ -109,17 +109,16 @@ impl NativePlugin for CheckAverageCostPlugin {
                     let key = (posting.account.clone(), units.currency.clone());
 
                     if units_num > Decimal::ZERO {
-                        // Acquisition: add to inventory
-                        // Wire-format reads only see per-unit costs
-                        // for the average-cost gate — total-only specs
-                        // are pre-booking and don't yet carry a
-                        // per-unit value.
-                        let cost_per = match &cost.number {
-                            Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
-                                Decimal::from_str(s).ok().unwrap_or_default()
-                            }
-                            _ => Decimal::ZERO,
-                        };
+                        // Acquisition: add to inventory. `per_unit()`
+                        // covers both PerUnit and PerUnitFromTotal;
+                        // raw Total (pre-booking) has no per-unit yet
+                        // and yields zero (gate is permissive there).
+                        let cost_per = cost
+                            .number
+                            .as_ref()
+                            .and_then(|cn| cn.per_unit())
+                            .map(|s| Decimal::from_str(s).unwrap_or_default())
+                            .unwrap_or_default();
 
                         let entry = inventory
                             .entry(key)
@@ -137,12 +136,12 @@ impl NativePlugin for CheckAverageCostPlugin {
 
                             // Get the cost used in this posting.
                             // Same per-unit-only read as above.
-                            let used_cost = match &cost.number {
-                                Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
-                                    Decimal::from_str(s).ok().unwrap_or_default()
-                                }
-                                _ => Decimal::ZERO,
-                            };
+                            let used_cost = cost
+                                .number
+                                .as_ref()
+                                .and_then(|cn| cn.per_unit())
+                                .map(|s| Decimal::from_str(s).unwrap_or_default())
+                                .unwrap_or_default();
 
                             // Calculate relative difference
                             let diff = (used_cost - avg_cost).abs();

--- a/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
@@ -230,9 +230,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "100.00".to_string(),
-                                )),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "100.00".to_string(),
+                                }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -264,9 +264,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "100.00".to_string(),
-                                )), // Matches average
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "100.00".to_string(),
+                                }), // Matches average
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -317,9 +317,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "100.00".to_string(),
-                                )),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "100.00".to_string(),
+                                }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -351,9 +351,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "90.00".to_string(),
-                                )), // 10% different from avg
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "90.00".to_string(),
+                                }), // 10% different from avg
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -406,9 +406,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "100.00".to_string(),
-                                )),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "100.00".to_string(),
+                                }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -440,9 +440,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "120.00".to_string(),
-                                )),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "120.00".to_string(),
+                                }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -474,9 +474,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "110.00".to_string(),
-                                )), // Matches average
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "110.00".to_string(),
+                                }), // Matches average
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -548,9 +548,9 @@ mod check_average_cost_tests {
                                 currency: "AAPL".to_string(),
                             }),
                             cost: Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "100.00".to_string(),
-                                )),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "100.00".to_string(),
+                                }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -584,9 +584,9 @@ mod check_average_cost_tests {
                             cost: Some(CostData {
                                 // 50% off the average — would fire for NONE,
                                 // but must be silent for STRICT/default.
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                    "50.00".to_string(),
-                                )),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                    value: "50.00".to_string(),
+                                }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -155,20 +155,22 @@ impl NativePlugin for CurrencyAccountsPlugin {
                         .currency
                         .clone()
                         .unwrap_or_else(|| units.currency.clone());
-                    let amount = if let Some(per) = &cost.number_per {
-                        let per = Decimal::from_str(per).unwrap_or_default();
-                        units_num * per
-                    } else if let Some(total) = &cost.number_total {
-                        let total = Decimal::from_str(total).unwrap_or_default();
-                        // Total cost magnitude with sign following units
-                        // (matches beancount.core.convert.get_cost).
-                        if units_num.is_sign_negative() {
-                            -total.abs()
-                        } else {
-                            total.abs()
+                    let amount = match &cost.number {
+                        Some(rustledger_plugin_types::CostNumberData::PerUnit(per)) => {
+                            let per = Decimal::from_str(per).unwrap_or_default();
+                            units_num * per
                         }
-                    } else {
-                        units_num
+                        Some(rustledger_plugin_types::CostNumberData::Total(total)) => {
+                            let total = Decimal::from_str(total).unwrap_or_default();
+                            // Total cost magnitude with sign following
+                            // units (matches `beancount.core.convert.get_cost`).
+                            if units_num.is_sign_negative() {
+                                -total.abs()
+                            } else {
+                                total.abs()
+                            }
+                        }
+                        None => units_num,
                     };
                     Some((amount, currency))
                 } else if let Some(price) = &posting.price {
@@ -442,8 +444,9 @@ mod currency_accounts_tests {
 
         let mut p1 = posting("Assets:Shares:RING", "9", "RING");
         p1.cost = Some(CostData {
-            number_per: Some("68.55".to_string()),
-            number_total: None,
+            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                "68.55".to_string(),
+            )),
             currency: Some("USD".to_string()),
             date: None,
             label: None,

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -142,8 +142,9 @@ impl NativePlugin for CurrencyAccountsPlugin {
             }
 
             // `weight(posting)` returns (amount, currency):
-            //   - Cost: (units * number_per, cost.currency), or total cost
-            //     with sign following units.
+            //   - Cost (PerUnit): (units * per_unit, cost.currency).
+            //   - Cost (Total / PerUnitFromTotal): preserved total
+            //     magnitude with sign following units.
             //   - Price: (units * price, price.currency). For @@ (is_total),
             //     weight magnitude is the total price, sign follows units.
             //   - Else: (units.amount, units.currency)

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -155,30 +155,39 @@ impl NativePlugin for CurrencyAccountsPlugin {
                         .currency
                         .clone()
                         .unwrap_or_else(|| units.currency.clone());
-                    // Prefer the preserved total when the cost carries
-                    // one (matches Python's `beancount.core.convert.get_cost`,
-                    // which uses the source total exactly and avoids the
-                    // division-then-multiplication precision loss).
+                    // Exhaustive variant match. The Total and
+                    // PerUnitFromTotal arms use the preserved total
+                    // (matching Python's `beancount.core.convert.get_cost`,
+                    // which uses the source total exactly and avoids
+                    // the division-then-multiplication precision
+                    // loss). PerUnit multiplies. Future variant
+                    // additions to `CostNumberData` will compile-fail
+                    // here, which is what we want.
                     let amount = match &cost.number {
-                        Some(cn) if cn.total().is_some() => {
-                            let total =
-                                Decimal::from_str(cn.total().unwrap_or("0")).unwrap_or_default();
-                            // Total cost magnitude with sign following units.
+                        Some(rustledger_plugin_types::CostNumberData::PerUnit { value }) => {
+                            let per = Decimal::from_str(value).unwrap_or_default();
+                            units_num * per
+                        }
+                        Some(rustledger_plugin_types::CostNumberData::Total { value }) => {
+                            let total = Decimal::from_str(value).unwrap_or_default();
                             if units_num.is_sign_negative() {
                                 -total.abs()
                             } else {
                                 total.abs()
                             }
                         }
-                        Some(rustledger_plugin_types::CostNumberData::PerUnit(per)) => {
-                            let per = Decimal::from_str(per).unwrap_or_default();
-                            units_num * per
+                        Some(rustledger_plugin_types::CostNumberData::PerUnitFromTotal {
+                            total,
+                            ..
+                        }) => {
+                            let total = Decimal::from_str(total).unwrap_or_default();
+                            if units_num.is_sign_negative() {
+                                -total.abs()
+                            } else {
+                                total.abs()
+                            }
                         }
-                        // `PerUnitFromTotal` is caught by the first arm
-                        // (its `total()` is Some); the remaining
-                        // matchable case here is unreachable but kept
-                        // exhaustive for safety against future variants.
-                        Some(_) | None => units_num,
+                        None => units_num,
                     };
                     Some((amount, currency))
                 } else if let Some(price) = &posting.price {
@@ -452,9 +461,9 @@ mod currency_accounts_tests {
 
         let mut p1 = posting("Assets:Shares:RING", "9", "RING");
         p1.cost = Some(CostData {
-            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                "68.55".to_string(),
-            )),
+            number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                value: "68.55".to_string(),
+            }),
             currency: Some("USD".to_string()),
             date: None,
             label: None,

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -155,22 +155,30 @@ impl NativePlugin for CurrencyAccountsPlugin {
                         .currency
                         .clone()
                         .unwrap_or_else(|| units.currency.clone());
+                    // Prefer the preserved total when the cost carries
+                    // one (matches Python's `beancount.core.convert.get_cost`,
+                    // which uses the source total exactly and avoids the
+                    // division-then-multiplication precision loss).
                     let amount = match &cost.number {
-                        Some(rustledger_plugin_types::CostNumberData::PerUnit(per)) => {
-                            let per = Decimal::from_str(per).unwrap_or_default();
-                            units_num * per
-                        }
-                        Some(rustledger_plugin_types::CostNumberData::Total(total)) => {
-                            let total = Decimal::from_str(total).unwrap_or_default();
-                            // Total cost magnitude with sign following
-                            // units (matches `beancount.core.convert.get_cost`).
+                        Some(cn) if cn.total().is_some() => {
+                            let total =
+                                Decimal::from_str(cn.total().unwrap_or("0")).unwrap_or_default();
+                            // Total cost magnitude with sign following units.
                             if units_num.is_sign_negative() {
                                 -total.abs()
                             } else {
                                 total.abs()
                             }
                         }
-                        None => units_num,
+                        Some(rustledger_plugin_types::CostNumberData::PerUnit(per)) => {
+                            let per = Decimal::from_str(per).unwrap_or_default();
+                            units_num * per
+                        }
+                        // `PerUnitFromTotal` is caught by the first arm
+                        // (its `total()` is Some); the remaining
+                        // matchable case here is unreachable but kept
+                        // exhaustive for safety against future variants.
+                        Some(_) | None => units_num,
                     };
                     Some((amount, currency))
                 } else if let Some(price) = &posting.price {

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -184,22 +184,41 @@ impl NativePlugin for ImplicitPricesPlugin {
                 // CostNumber for the shared helper.
                 let cost = posting.cost.as_ref().and_then(|c| {
                     let currency = c.currency.clone()?;
+                    // Plugin-side units (already-booked) are available
+                    // via the posting; use them so PerUnitFromTotal
+                    // goes through `try_new` and inconsistent pairs
+                    // collapse to PerUnit (loud truncation > silent
+                    // corruption).
+                    let units_n = posting
+                        .units
+                        .as_ref()
+                        .and_then(|u| Decimal::from_str(&u.number).ok())
+                        .unwrap_or_default();
                     let number = match &c.number {
-                        Some(rustledger_plugin_types::CostNumberData::PerUnit(n)) => Some(
-                            rustledger_core::CostNumber::PerUnit(Decimal::from_str(n).ok()?),
-                        ),
-                        Some(rustledger_plugin_types::CostNumberData::Total(n)) => Some(
-                            rustledger_core::CostNumber::Total(Decimal::from_str(n).ok()?),
-                        ),
+                        Some(rustledger_plugin_types::CostNumberData::PerUnit { value: n }) => {
+                            Some(rustledger_core::CostNumber::PerUnit {
+                                value: Decimal::from_str(n).ok()?,
+                            })
+                        }
+                        Some(rustledger_plugin_types::CostNumberData::Total { value: n }) => {
+                            Some(rustledger_core::CostNumber::Total {
+                                value: Decimal::from_str(n).ok()?,
+                            })
+                        }
                         Some(rustledger_plugin_types::CostNumberData::PerUnitFromTotal {
                             per_unit,
                             total,
-                        }) => Some(rustledger_core::CostNumber::PerUnitFromTotal(
-                            rustledger_core::BookedCost::from_parts_unchecked(
-                                Decimal::from_str(per_unit).ok()?,
-                                Decimal::from_str(total).ok()?,
-                            ),
-                        )),
+                        }) => {
+                            let per_unit_d = Decimal::from_str(per_unit).ok()?;
+                            let total_d = Decimal::from_str(total).ok()?;
+                            match rustledger_core::BookedCost::try_new(per_unit_d, total_d, units_n)
+                            {
+                                Some(b) => Some(rustledger_core::CostNumber::PerUnitFromTotal(b)),
+                                None => {
+                                    Some(rustledger_core::CostNumber::PerUnit { value: per_unit_d })
+                                }
+                            }
+                        }
                         None => return None,
                     };
                     Some((number, currency))

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -1,8 +1,8 @@
 //! Plugin that generates price entries from transaction costs and prices.
 
 use crate::types::{
-    AmountData, CostData, DirectiveData, DirectiveWrapper, PluginInput, PluginOp, PluginOutput,
-    PriceAnnotationData, PriceAnnotationView, PriceData,
+    AmountData, CostData, DirectiveData, DirectiveWrapper, PluginError, PluginInput, PluginOp,
+    PluginOutput, PriceAnnotationData, PriceAnnotationView, PriceData,
 };
 use rust_decimal::Decimal;
 use rustledger_core::extract_per_unit_price;
@@ -119,6 +119,7 @@ impl NativePlugin for ImplicitPricesPlugin {
 
     fn process(&self, input: PluginInput) -> PluginOutput {
         let mut generated_prices = Vec::new();
+        let mut errors: Vec<PluginError> = Vec::new();
 
         // Per-account lot quantities, keyed identically to Python's
         // `Inventory.add_amount`. Used solely to detect REDUCED for
@@ -181,48 +182,93 @@ impl NativePlugin for ImplicitPricesPlugin {
                 // Same shape for cost: only build the descriptor when
                 // a currency is present AND the cost number parses.
                 // Translate from wire format (CostNumberData) to core
-                // CostNumber for the shared helper.
-                let cost = posting.cost.as_ref().and_then(|c| {
+                // CostNumber for the shared helper. Conversion failures
+                // (e.g. a plugin upstream emitted inconsistent
+                // `PerUnitFromTotal`) surface as plugin warnings rather
+                // than silent drops — a plugin author whose buggy
+                // emission produces zero implicit prices now gets a
+                // signal (review A-4.5). `units_number` is already
+                // parsed above (line 150); reuse it instead of
+                // re-parsing.
+                let cost_result = posting.cost.as_ref().and_then(|c| {
                     let currency = c.currency.clone()?;
-                    // Plugin-side units (already-booked) are available
-                    // via the posting; use them so PerUnitFromTotal
-                    // goes through `try_new` with a real units value.
-                    // Inconsistent pairs or missing units → drop the
-                    // descriptor entirely (this is the implicit-price
-                    // emission path, not the host's wire-ingress path
-                    // — dropping a bad descriptor here just means we
-                    // don't emit an implicit price for that posting,
-                    // which is the right conservative behavior).
-                    let units_n = posting
-                        .units
-                        .as_ref()
-                        .and_then(|u| Decimal::from_str(&u.number).ok())?;
                     let number = match &c.number {
                         Some(rustledger_plugin_types::CostNumberData::PerUnit { value: n }) => {
-                            Some(rustledger_core::CostNumber::PerUnit {
-                                value: Decimal::from_str(n).ok()?,
-                            })
+                            match Decimal::from_str(n) {
+                                Ok(d) => Some(rustledger_core::CostNumber::PerUnit { value: d }),
+                                Err(_) => {
+                                    return Some(Err(format!(
+                                        "implicit_prices: posting on account {:?} has cost \
+                                         per_unit {n:?} that doesn't parse as a decimal",
+                                        posting.account
+                                    )));
+                                }
+                            }
                         }
                         Some(rustledger_plugin_types::CostNumberData::Total { value: n }) => {
-                            Some(rustledger_core::CostNumber::Total {
-                                value: Decimal::from_str(n).ok()?,
-                            })
+                            match Decimal::from_str(n) {
+                                Ok(d) => Some(rustledger_core::CostNumber::Total { value: d }),
+                                Err(_) => {
+                                    return Some(Err(format!(
+                                        "implicit_prices: posting on account {:?} has cost \
+                                         total {n:?} that doesn't parse as a decimal",
+                                        posting.account
+                                    )));
+                                }
+                            }
                         }
                         Some(rustledger_plugin_types::CostNumberData::PerUnitFromTotal {
                             per_unit,
                             total,
                         }) => {
-                            let per_unit_d = Decimal::from_str(per_unit).ok()?;
-                            let total_d = Decimal::from_str(total).ok()?;
-                            let booked =
-                                rustledger_core::BookedCost::try_new(per_unit_d, total_d, units_n)
-                                    .ok()?;
-                            Some(rustledger_core::CostNumber::PerUnitFromTotal(booked))
+                            let per_unit_d = match Decimal::from_str(per_unit) {
+                                Ok(d) => d,
+                                Err(_) => {
+                                    return Some(Err(format!(
+                                        "implicit_prices: posting on account {:?} has \
+                                         PerUnitFromTotal per_unit {per_unit:?} that doesn't \
+                                         parse as a decimal",
+                                        posting.account
+                                    )));
+                                }
+                            };
+                            let total_d = match Decimal::from_str(total) {
+                                Ok(d) => d,
+                                Err(_) => {
+                                    return Some(Err(format!(
+                                        "implicit_prices: posting on account {:?} has \
+                                         PerUnitFromTotal total {total:?} that doesn't parse \
+                                         as a decimal",
+                                        posting.account
+                                    )));
+                                }
+                            };
+                            match rustledger_core::BookedCost::try_new(
+                                per_unit_d,
+                                total_d,
+                                units_number,
+                            ) {
+                                Ok(b) => Some(rustledger_core::CostNumber::PerUnitFromTotal(b)),
+                                Err(e) => {
+                                    return Some(Err(format!(
+                                        "implicit_prices: posting on account {:?}: {e}",
+                                        posting.account
+                                    )));
+                                }
+                            }
                         }
                         None => return None,
                     };
-                    Some((number, currency))
+                    Some(Ok((number, currency)))
                 });
+                let cost = match cost_result {
+                    Some(Ok(c)) => Some(c),
+                    Some(Err(msg)) => {
+                        errors.push(PluginError::warning(msg));
+                        None
+                    }
+                    None => None,
+                };
 
                 // Update the per-account lot tracker BEFORE deciding
                 // whether to emit. The pre-update quantity is what
@@ -308,9 +354,6 @@ impl NativePlugin for ImplicitPricesPlugin {
             ops.push(PluginOp::Insert(w));
         }
 
-        PluginOutput {
-            ops,
-            errors: Vec::new(),
-        }
+        PluginOutput { ops, errors }
     }
 }

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -39,16 +39,18 @@ type LotKey = (String, String, Option<String>);
 /// anyway, but we don't assume that.
 fn cost_fingerprint(cost: &CostData, units_number: Decimal) -> Option<String> {
     let currency = cost.currency.as_deref()?;
-    let per_unit_decimal: Decimal = if let Some(per_str) = &cost.number_per {
-        Decimal::from_str(per_str).ok()?
-    } else if let Some(total_str) = &cost.number_total {
-        let total = Decimal::from_str(total_str).ok()?;
-        if units_number.is_zero() {
-            return None;
+    let per_unit_decimal: Decimal = match &cost.number {
+        Some(rustledger_plugin_types::CostNumberData::PerUnit(per_str)) => {
+            Decimal::from_str(per_str).ok()?
         }
-        total / units_number.abs()
-    } else {
-        return None;
+        Some(rustledger_plugin_types::CostNumberData::Total(total_str)) => {
+            let total = Decimal::from_str(total_str).ok()?;
+            if units_number.is_zero() {
+                return None;
+            }
+            total / units_number.abs()
+        }
+        None => return None,
     };
     let per_unit = per_unit_decimal.normalize().to_string();
     let date = cost.date.as_deref().unwrap_or("");
@@ -176,22 +178,21 @@ impl NativePlugin for ImplicitPricesPlugin {
                     });
 
                 // Same shape for cost: only build the descriptor when
-                // a currency is present AND at least one of per/total
-                // parses.
+                // a currency is present AND the cost number parses.
+                // Translate from wire format (CostNumberData) to core
+                // CostNumber for the shared helper.
                 let cost = posting.cost.as_ref().and_then(|c| {
                     let currency = c.currency.clone()?;
-                    let per = c
-                        .number_per
-                        .as_ref()
-                        .and_then(|n| Decimal::from_str(n).ok());
-                    let total = c
-                        .number_total
-                        .as_ref()
-                        .and_then(|n| Decimal::from_str(n).ok());
-                    if per.is_none() && total.is_none() {
-                        return None;
-                    }
-                    Some((per, total, currency))
+                    let number = match &c.number {
+                        Some(rustledger_plugin_types::CostNumberData::PerUnit(n)) => Some(
+                            rustledger_core::CostNumber::PerUnit(Decimal::from_str(n).ok()?),
+                        ),
+                        Some(rustledger_plugin_types::CostNumberData::Total(n)) => Some(
+                            rustledger_core::CostNumber::Total(Decimal::from_str(n).ok()?),
+                        ),
+                        None => return None,
+                    };
+                    Some((number, currency))
                 });
 
                 // Update the per-account lot tracker BEFORE deciding
@@ -218,8 +219,11 @@ impl NativePlugin for ImplicitPricesPlugin {
                 // cost path when the posting is augmenting (or a
                 // first-time CREATED). Calling the helper twice is
                 // cheap and avoids duplicating its priority logic.
-                let from_annotation =
-                    extract_per_unit_price(units_number, annotation, None::<(_, _, String)>);
+                let from_annotation = extract_per_unit_price(
+                    units_number,
+                    annotation,
+                    None::<(Option<rustledger_core::CostNumber>, String)>,
+                );
                 let chosen = match (from_annotation, reduced) {
                     (Some(p), _) => Some(p),
                     (None, false) => extract_per_unit_price(units_number, None, cost),

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -32,11 +32,11 @@ type LotKey = (String, String, Option<String>);
 /// phantom price emit this gate exists to prevent would slip back in.
 /// Caught by Copilot review on PR #1061.
 ///
-/// We canonicalize `number_per` from `number_total` (dividing by
-/// `|units|`) when only the total is set — keeps the key consistent
+/// We canonicalize per-unit from total (dividing by `|units|`) when
+/// only the raw `Total` form is set — keeps the key consistent
 /// regardless of which form the cost was originally written in. After
-/// booking has run the `number_per` field is normally populated
-/// anyway, but we don't assume that.
+/// booking has run, the post-booking `PerUnitFromTotal` variant
+/// carries per-unit already, but we don't assume that.
 fn cost_fingerprint(cost: &CostData, units_number: Decimal) -> Option<String> {
     let currency = cost.currency.as_deref()?;
     // `per_unit()` covers both PerUnit and PerUnitFromTotal (both
@@ -99,8 +99,8 @@ fn cost_fingerprint(cost: &CostData, units_number: Decimal) -> Option<String> {
 /// earlier in the pipeline, the gate would over-suppress on
 /// pre-split crossing postings.
 ///
-/// Lots with a cost spec that carries neither `number_per` nor
-/// `number_total` (e.g. bare `{2024-01-01}`) aren't tracked in the
+/// Lots with a cost spec that carries no `number` at all (e.g. bare
+/// `{2024-01-01}` — `CostNumber` is `None`) aren't tracked in the
 /// inventory — `cost_fingerprint` returns `None` and the posting
 /// passes through the cost-emit branch directly. Python's
 /// `Inventory.add_amount` would still track these, but since the
@@ -186,14 +186,17 @@ impl NativePlugin for ImplicitPricesPlugin {
                     let currency = c.currency.clone()?;
                     // Plugin-side units (already-booked) are available
                     // via the posting; use them so PerUnitFromTotal
-                    // goes through `try_new` and inconsistent pairs
-                    // collapse to PerUnit (loud truncation > silent
-                    // corruption).
+                    // goes through `try_new` with a real units value.
+                    // Inconsistent pairs or missing units → drop the
+                    // descriptor entirely (this is the implicit-price
+                    // emission path, not the host's wire-ingress path
+                    // — dropping a bad descriptor here just means we
+                    // don't emit an implicit price for that posting,
+                    // which is the right conservative behavior).
                     let units_n = posting
                         .units
                         .as_ref()
-                        .and_then(|u| Decimal::from_str(&u.number).ok())
-                        .unwrap_or_default();
+                        .and_then(|u| Decimal::from_str(&u.number).ok())?;
                     let number = match &c.number {
                         Some(rustledger_plugin_types::CostNumberData::PerUnit { value: n }) => {
                             Some(rustledger_core::CostNumber::PerUnit {
@@ -211,13 +214,10 @@ impl NativePlugin for ImplicitPricesPlugin {
                         }) => {
                             let per_unit_d = Decimal::from_str(per_unit).ok()?;
                             let total_d = Decimal::from_str(total).ok()?;
-                            match rustledger_core::BookedCost::try_new(per_unit_d, total_d, units_n)
-                            {
-                                Some(b) => Some(rustledger_core::CostNumber::PerUnitFromTotal(b)),
-                                None => {
-                                    Some(rustledger_core::CostNumber::PerUnit { value: per_unit_d })
-                                }
-                            }
+                            let booked =
+                                rustledger_core::BookedCost::try_new(per_unit_d, total_d, units_n)
+                                    .ok()?;
+                            Some(rustledger_core::CostNumber::PerUnitFromTotal(booked))
                         }
                         None => return None,
                     };

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -39,18 +39,19 @@ type LotKey = (String, String, Option<String>);
 /// anyway, but we don't assume that.
 fn cost_fingerprint(cost: &CostData, units_number: Decimal) -> Option<String> {
     let currency = cost.currency.as_deref()?;
-    let per_unit_decimal: Decimal = match &cost.number {
-        Some(rustledger_plugin_types::CostNumberData::PerUnit(per_str)) => {
-            Decimal::from_str(per_str).ok()?
+    // `per_unit()` covers both PerUnit and PerUnitFromTotal (both
+    // carry per-unit by host construction). Raw Total needs division
+    // here; bare-`{}` returns None.
+    let cn = cost.number.as_ref()?;
+    let per_unit_decimal: Decimal = if let Some(per_str) = cn.per_unit() {
+        Decimal::from_str(per_str).ok()?
+    } else {
+        let total_str = cn.total()?;
+        let total = Decimal::from_str(total_str).ok()?;
+        if units_number.is_zero() {
+            return None;
         }
-        Some(rustledger_plugin_types::CostNumberData::Total(total_str)) => {
-            let total = Decimal::from_str(total_str).ok()?;
-            if units_number.is_zero() {
-                return None;
-            }
-            total / units_number.abs()
-        }
-        None => return None,
+        total / units_number.abs()
     };
     let per_unit = per_unit_decimal.normalize().to_string();
     let date = cost.date.as_deref().unwrap_or("");
@@ -190,6 +191,15 @@ impl NativePlugin for ImplicitPricesPlugin {
                         Some(rustledger_plugin_types::CostNumberData::Total(n)) => Some(
                             rustledger_core::CostNumber::Total(Decimal::from_str(n).ok()?),
                         ),
+                        Some(rustledger_plugin_types::CostNumberData::PerUnitFromTotal {
+                            per_unit,
+                            total,
+                        }) => Some(rustledger_core::CostNumber::PerUnitFromTotal(
+                            rustledger_core::BookedCost::from_parts_unchecked(
+                                Decimal::from_str(per_unit).ok()?,
+                                Decimal::from_str(total).ok()?,
+                            ),
+                        )),
                         None => return None,
                     };
                     Some((number, currency))

--- a/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
+++ b/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
@@ -38,12 +38,17 @@ impl NativePlugin for SellGainsPlugin {
                             continue;
                         }
 
-                        // Get cost basis
-                        let cost_per = cost
-                            .number_per
-                            .as_ref()
-                            .and_then(|s| Decimal::from_str(s).ok())
-                            .unwrap_or_default();
+                        // Get cost basis — sell_gains operates on
+                        // post-booking transactions where the cost
+                        // carries a per-unit value.
+                        let cost_per = match &cost.number {
+                            Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
+                                Decimal::from_str(s).ok().unwrap_or_default()
+                            }
+                            Some(rustledger_plugin_types::CostNumberData::Total(_)) | None => {
+                                Decimal::ZERO
+                            }
+                        };
 
                         // Get sale price
                         let sale_price = price

--- a/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
+++ b/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
@@ -40,15 +40,14 @@ impl NativePlugin for SellGainsPlugin {
 
                         // Get cost basis — sell_gains operates on
                         // post-booking transactions where the cost
-                        // carries a per-unit value.
-                        let cost_per = match &cost.number {
-                            Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
-                                Decimal::from_str(s).ok().unwrap_or_default()
-                            }
-                            Some(rustledger_plugin_types::CostNumberData::Total(_)) | None => {
-                                Decimal::ZERO
-                            }
-                        };
+                        // carries a per-unit value (PerUnit or
+                        // PerUnitFromTotal, both expose per_unit()).
+                        let cost_per = cost
+                            .number
+                            .as_ref()
+                            .and_then(|cn| cn.per_unit())
+                            .map(|s| Decimal::from_str(s).unwrap_or_default())
+                            .unwrap_or_default();
 
                         // Get sale price
                         let sale_price = price

--- a/crates/rustledger-plugin/src/native/plugins/unrealized.rs
+++ b/crates/rustledger-plugin/src/native/plugins/unrealized.rs
@@ -79,14 +79,17 @@ impl NativePlugin for UnrealizedPlugin {
                     if let Some(units) = &posting.units {
                         let units_num = Decimal::from_str(&units.number).unwrap_or_default();
 
-                        let cost_basis = if let Some(cost) = &posting.cost {
-                            cost.number_per
-                                .as_ref()
-                                .and_then(|s| Decimal::from_str(s).ok())
-                                .unwrap_or_default()
-                                * units_num.abs()
-                        } else {
-                            Decimal::ZERO
+                        // Unrealized-gains operates on post-booking
+                        // transactions where the cost carries a per-
+                        // unit value.
+                        let cost_basis = match posting.cost.as_ref().and_then(|c| c.number.as_ref())
+                        {
+                            Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
+                                Decimal::from_str(s).ok().unwrap_or_default() * units_num.abs()
+                            }
+                            Some(rustledger_plugin_types::CostNumberData::Total(_)) | None => {
+                                Decimal::ZERO
+                            }
                         };
 
                         let account_positions =

--- a/crates/rustledger-plugin/src/native/plugins/unrealized.rs
+++ b/crates/rustledger-plugin/src/native/plugins/unrealized.rs
@@ -80,17 +80,23 @@ impl NativePlugin for UnrealizedPlugin {
                         let units_num = Decimal::from_str(&units.number).unwrap_or_default();
 
                         // Unrealized-gains operates on post-booking
-                        // transactions where the cost carries a per-
-                        // unit value.
-                        let cost_basis = match posting.cost.as_ref().and_then(|c| c.number.as_ref())
-                        {
-                            Some(rustledger_plugin_types::CostNumberData::PerUnit(s)) => {
-                                Decimal::from_str(s).ok().unwrap_or_default() * units_num.abs()
-                            }
-                            Some(rustledger_plugin_types::CostNumberData::Total(_)) | None => {
-                                Decimal::ZERO
-                            }
-                        };
+                        // transactions. Prefer the preserved total
+                        // when available (PerUnitFromTotal) for exact
+                        // cost basis; fall back to per_unit * |units|
+                        // for source `{...}` per-unit costs.
+                        let cost_basis = posting
+                            .cost
+                            .as_ref()
+                            .and_then(|c| c.number.as_ref())
+                            .map_or(Decimal::ZERO, |cn| match cn.total() {
+                                Some(s) => Decimal::from_str(s).unwrap_or_default(),
+                                None => cn
+                                    .per_unit()
+                                    .map(|s| {
+                                        Decimal::from_str(s).unwrap_or_default() * units_num.abs()
+                                    })
+                                    .unwrap_or_default(),
+                            });
 
                         let account_positions =
                             positions.entry(posting.account.clone()).or_default();

--- a/crates/rustledger-plugin/src/native/plugins/valuation.rs
+++ b/crates/rustledger-plugin/src/native/plugins/valuation.rs
@@ -320,9 +320,9 @@ fn transform_transaction(
                         currency: state.config.currency.clone(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            format_decimal(state.last_price),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: format_decimal(state.last_price),
+                        }),
                         currency: Some(units.currency.clone()),
                         date: Some(directive.date.clone()),
                         label: None,
@@ -474,9 +474,9 @@ fn handle_total_price_posting(
             currency: state.config.currency.clone(),
         }),
         cost: Some(CostData {
-            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                format_decimal(state.last_price),
-            )),
+            number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                value: format_decimal(state.last_price),
+            }),
             currency: Some(units_currency.to_string()),
             date: Some(date.to_string()),
             label: None,
@@ -525,9 +525,9 @@ fn process_fifo_sell(
                     currency: state.config.currency.clone(),
                 }),
                 cost: Some(CostData {
-                    number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                        format_decimal(lot.cost_per_unit),
-                    )),
+                    number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                        value: format_decimal(lot.cost_per_unit),
+                    }),
                     currency: Some(currency.to_string()),
                     date: Some(lot.date.clone()),
                     label: None,
@@ -569,9 +569,9 @@ fn process_fifo_sell(
                     currency: state.config.currency.clone(),
                 }),
                 cost: Some(CostData {
-                    number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                        format_decimal(lot.cost_per_unit),
-                    )),
+                    number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                        value: format_decimal(lot.cost_per_unit),
+                    }),
                     currency: Some(currency.to_string()),
                     date: Some(lot.date.clone()),
                     label: None,

--- a/crates/rustledger-plugin/src/native/plugins/valuation.rs
+++ b/crates/rustledger-plugin/src/native/plugins/valuation.rs
@@ -320,8 +320,9 @@ fn transform_transaction(
                         currency: state.config.currency.clone(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some(format_decimal(state.last_price)),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            format_decimal(state.last_price),
+                        )),
                         currency: Some(units.currency.clone()),
                         date: Some(directive.date.clone()),
                         label: None,
@@ -473,8 +474,9 @@ fn handle_total_price_posting(
             currency: state.config.currency.clone(),
         }),
         cost: Some(CostData {
-            number_per: Some(format_decimal(state.last_price)),
-            number_total: None,
+            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                format_decimal(state.last_price),
+            )),
             currency: Some(units_currency.to_string()),
             date: Some(date.to_string()),
             label: None,
@@ -523,8 +525,9 @@ fn process_fifo_sell(
                     currency: state.config.currency.clone(),
                 }),
                 cost: Some(CostData {
-                    number_per: Some(format_decimal(lot.cost_per_unit)),
-                    number_total: None,
+                    number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                        format_decimal(lot.cost_per_unit),
+                    )),
                     currency: Some(currency.to_string()),
                     date: Some(lot.date.clone()),
                     label: None,
@@ -566,8 +569,9 @@ fn process_fifo_sell(
                     currency: state.config.currency.clone(),
                 }),
                 cost: Some(CostData {
-                    number_per: Some(format_decimal(lot.cost_per_unit)),
-                    number_total: None,
+                    number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                        format_decimal(lot.cost_per_unit),
+                    )),
                     currency: Some(currency.to_string()),
                     date: Some(lot.date.clone()),
                     label: None,

--- a/crates/rustledger-plugin/src/python/compat.rs
+++ b/crates/rustledger-plugin/src/python/compat.rs
@@ -75,6 +75,19 @@ Custom = namedtuple('Custom', ['meta', 'date', 'type', 'values'])
 
 Cost = namedtuple('Cost', ['number', 'currency', 'date', 'label'])
 
+# `CostSpec` shape matches upstream `beancount.core.data.CostSpec`
+# verbatim — `number_per` / `number_total` are the two flat fields
+# Python plugins read directly. The host's typed `CostNumber` enum
+# (rustledger_core::CostNumber) is flattened to these two fields by
+# `_parse_cost_spec` below.
+#
+# This is an INTENTIONAL legacy-shape match (Python compat policy
+# bucket 2: "not fixable locally" — see project CLAUDE.md). Upstream
+# beancount's Python API is what every existing Python plugin codes
+# against; presenting a different shape here would break every
+# Python plugin in the ecosystem. The host's stricter `CostNumber`
+# shape is the right model internally, but the Python compat surface
+# matches upstream's API by design.
 CostSpec = namedtuple('CostSpec', [
     'number_per', 'number_total', 'currency', 'date', 'label', 'merge'
 ])

--- a/crates/rustledger-plugin/src/python/compat.rs
+++ b/crates/rustledger-plugin/src/python/compat.rs
@@ -154,12 +154,36 @@ def _parse_cost(d):
 
 
 def _parse_cost_spec(d):
-    """Parse a cost spec dict to CostSpec namedtuple."""
+    """Parse a cost spec dict to CostSpec namedtuple.
+
+    Reads the post-#1164 typed `number` shape from Rust:
+        - {"PerUnit": "100"}                           → number_per=100, number_total=None
+        - {"Total": "1500"}                            → number_per=None, number_total=1500
+        - {"PerUnitFromTotal": {"per_unit":..., "total":...}}
+                                                       → both fields populated
+        - null                                         → both None (bare `{}`)
+
+    The Python-side `CostSpec` namedtuple still presents two flat
+    fields for upstream beancount API compatibility; the bridge
+    flattens the typed enum into those fields here.
+    """
     if d is None:
         return None
+    number_per = None
+    number_total = None
+    n = d.get('number')
+    if isinstance(n, dict):
+        if 'PerUnit' in n:
+            number_per = _parse_decimal(n['PerUnit'])
+        elif 'Total' in n:
+            number_total = _parse_decimal(n['Total'])
+        elif 'PerUnitFromTotal' in n:
+            inner = n['PerUnitFromTotal']
+            number_per = _parse_decimal(inner.get('per_unit'))
+            number_total = _parse_decimal(inner.get('total'))
     return CostSpec(
-        number_per=_parse_decimal(d.get('number_per')),
-        number_total=_parse_decimal(d.get('number_total')),
+        number_per=number_per,
+        number_total=number_total,
         currency=d.get('currency', ''),
         date=_parse_date(d.get('date')),
         label=d.get('label'),
@@ -334,30 +358,49 @@ def _serialize_cost(c):
 
 
 def _serialize_cost_spec(c):
-    """Serialize a CostSpec to dict (matches Rust CostData format)."""
+    """Serialize a CostSpec to dict (matches Rust CostData format).
+
+    Emits the post-#1164 typed `number` shape:
+        - per_unit only       → {"PerUnit": "100"}
+        - total only          → {"Total": "1500"}
+        - both (post-booking) → {"PerUnitFromTotal": {"per_unit":..., "total":...}}
+        - neither             → number is None (bare `{}`)
+
+    Inputs accepted: CostSpec namedtuple (has number_per/number_total)
+    or Cost namedtuple (has number). The latter is mapped to PerUnit.
+    """
     if c is None:
         return None
-    # Handle both Cost and CostSpec namedtuples
     if hasattr(c, 'number_per'):
-        # CostSpec
+        number_per = c.number_per
+        number_total = c.number_total if hasattr(c, 'number_total') else None
+        if number_per is not None and number_total is not None:
+            number = {'PerUnitFromTotal': {
+                'per_unit': _serialize_decimal(number_per),
+                'total': _serialize_decimal(number_total),
+            }}
+        elif number_per is not None:
+            number = {'PerUnit': _serialize_decimal(number_per)}
+        elif number_total is not None:
+            number = {'Total': _serialize_decimal(number_total)}
+        else:
+            number = None
         return {
-            'number_per': _serialize_decimal(c.number_per),
-            'number_total': _serialize_decimal(c.number_total) if hasattr(c, 'number_total') else None,
+            'number': number,
             'currency': c.currency if c.currency else None,
             'date': _serialize_date(c.date),
             'label': c.label,
             'merge': c.merge if hasattr(c, 'merge') else False
         }
-    else:
-        # Cost (convert to CostSpec format)
-        return {
-            'number_per': _serialize_decimal(c.number),
-            'number_total': None,
-            'currency': c.currency if c.currency else None,
-            'date': _serialize_date(c.date),
-            'label': c.label,
-            'merge': False
-        }
+    # Cost namedtuple: a single `number` field, treated as per-unit.
+    number = {'PerUnit': _serialize_decimal(c.number)} if c.number is not None else None
+    return {
+        'number': number,
+        'currency': c.currency if c.currency else None,
+        'date': _serialize_date(c.date),
+        'label': c.label,
+        'merge': False
+    }
 
 
 def _serialize_posting(p):

--- a/crates/rustledger-plugin/src/python/compat.rs
+++ b/crates/rustledger-plugin/src/python/compat.rs
@@ -156,12 +156,13 @@ def _parse_cost(d):
 def _parse_cost_spec(d):
     """Parse a cost spec dict to CostSpec namedtuple.
 
-    Reads the post-#1164 typed `number` shape from Rust:
-        - {"PerUnit": "100"}                           → number_per=100, number_total=None
-        - {"Total": "1500"}                            → number_per=None, number_total=1500
-        - {"PerUnitFromTotal": {"per_unit":..., "total":...}}
-                                                       → both fields populated
-        - null                                         → both None (bare `{}`)
+    Reads the unified `kind`-tagged shape shared with FFI-WASI, WASM,
+    and plugin-types:
+        - {"kind": "per_unit", "value": "100"}            → number_per=100, number_total=None
+        - {"kind": "total", "value": "1500"}              → number_per=None, number_total=1500
+        - {"kind": "per_unit_from_total",
+           "per_unit": "150", "total": "300"}             → both populated
+        - null                                            → both None (bare `{}`)
 
     The Python-side `CostSpec` namedtuple still presents two flat
     fields for upstream beancount API compatibility; the bridge
@@ -173,14 +174,14 @@ def _parse_cost_spec(d):
     number_total = None
     n = d.get('number')
     if isinstance(n, dict):
-        if 'PerUnit' in n:
-            number_per = _parse_decimal(n['PerUnit'])
-        elif 'Total' in n:
-            number_total = _parse_decimal(n['Total'])
-        elif 'PerUnitFromTotal' in n:
-            inner = n['PerUnitFromTotal']
-            number_per = _parse_decimal(inner.get('per_unit'))
-            number_total = _parse_decimal(inner.get('total'))
+        kind = n.get('kind')
+        if kind == 'per_unit':
+            number_per = _parse_decimal(n.get('value'))
+        elif kind == 'total':
+            number_total = _parse_decimal(n.get('value'))
+        elif kind == 'per_unit_from_total':
+            number_per = _parse_decimal(n.get('per_unit'))
+            number_total = _parse_decimal(n.get('total'))
     return CostSpec(
         number_per=number_per,
         number_total=number_total,
@@ -360,14 +361,16 @@ def _serialize_cost(c):
 def _serialize_cost_spec(c):
     """Serialize a CostSpec to dict (matches Rust CostData format).
 
-    Emits the post-#1164 typed `number` shape:
-        - per_unit only       → {"PerUnit": "100"}
-        - total only          → {"Total": "1500"}
-        - both (post-booking) → {"PerUnitFromTotal": {"per_unit":..., "total":...}}
+    Emits the unified `kind`-tagged number shape shared with FFI-WASI,
+    WASM, and plugin-types:
+        - per_unit only       → {"kind": "per_unit", "value": "100"}
+        - total only          → {"kind": "total", "value": "1500"}
+        - both (post-booking) → {"kind": "per_unit_from_total",
+                                 "per_unit": ..., "total": ...}
         - neither             → number is None (bare `{}`)
 
     Inputs accepted: CostSpec namedtuple (has number_per/number_total)
-    or Cost namedtuple (has number). The latter is mapped to PerUnit.
+    or Cost namedtuple (has number). The latter is mapped to per_unit.
     """
     if c is None:
         return None
@@ -375,14 +378,15 @@ def _serialize_cost_spec(c):
         number_per = c.number_per
         number_total = c.number_total if hasattr(c, 'number_total') else None
         if number_per is not None and number_total is not None:
-            number = {'PerUnitFromTotal': {
+            number = {
+                'kind': 'per_unit_from_total',
                 'per_unit': _serialize_decimal(number_per),
                 'total': _serialize_decimal(number_total),
-            }}
+            }
         elif number_per is not None:
-            number = {'PerUnit': _serialize_decimal(number_per)}
+            number = {'kind': 'per_unit', 'value': _serialize_decimal(number_per)}
         elif number_total is not None:
-            number = {'Total': _serialize_decimal(number_total)}
+            number = {'kind': 'total', 'value': _serialize_decimal(number_total)}
         else:
             number = None
         return {
@@ -393,7 +397,10 @@ def _serialize_cost_spec(c):
             'merge': c.merge if hasattr(c, 'merge') else False
         }
     # Cost namedtuple: a single `number` field, treated as per-unit.
-    number = {'PerUnit': _serialize_decimal(c.number)} if c.number is not None else None
+    if c.number is not None:
+        number = {'kind': 'per_unit', 'value': _serialize_decimal(c.number)}
+    else:
+        number = None
     return {
         'number': number,
         'currency': c.currency if c.currency else None,

--- a/crates/rustledger-plugin/src/python/mod.rs
+++ b/crates/rustledger-plugin/src/python/mod.rs
@@ -34,6 +34,7 @@ mod compat;
 mod download;
 mod runtime;
 
+pub use compat::BEANCOUNT_COMPAT_PY;
 pub use runtime::{PythonRuntime, is_python_available, suggest_module_path};
 
 /// Python plugin error types.

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -226,7 +226,13 @@ impl Plugin {
         // Instantiate the module
         let instance = linker.instantiate(&mut store, &self.module)?;
 
-        // Serialize input
+        // Serialize input. The serializer choice (default-mode
+        // `to_vec`, not `to_vec_named`) is pinned by the
+        // cross-boundary wire-format tests in
+        // `rustledger-plugin-types/tests/cost_number_wire_format.rs`.
+        // If you change this call to a different rmp_serde entry
+        // point, update those tests to match — otherwise plugins
+        // built against the old wire shape silently break.
         let input_bytes = rmp_serde::to_vec(input)?;
 
         // `validate_loaded_module` proved `memory` presence at load

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -130,9 +130,9 @@ fn make_transaction_with_cost(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            cost.0.to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: cost.0.to_string(),
+                        }),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -206,9 +206,9 @@ fn make_transaction_with_cost_and_price_total(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            cost.0.to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: cost.0.to_string(),
+                        }),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -271,9 +271,9 @@ fn make_transaction_with_cost_and_price(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            cost.0.to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: cost.0.to_string(),
+                        }),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -1325,9 +1325,9 @@ fn test_noduplicates_total_vs_per_unit_cost_differ() {
         && let Some(cost) = &mut t.postings[0].cost
     {
         // Swap to total cost form
-        cost.number = Some(rustledger_plugin_types::CostNumberData::Total(
-            "1500.00".to_string(),
-        ));
+        cost.number = Some(rustledger_plugin_types::CostNumberData::Total {
+            value: "1500.00".to_string(),
+        });
     }
     let input = make_input(vec![
         make_open("2024-01-01", "Assets:Stock"),
@@ -2087,9 +2087,9 @@ fn test_check_commodity_undeclared_cost_currency() {
                             currency: "HOOL".to_string(),
                         }),
                         cost: Some(CostData {
-                            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                "100.00".to_string(),
-                            )),
+                            number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                value: "100.00".to_string(),
+                            }),
                             currency: Some("USD".to_string()),
                             date: None,
                             label: None,
@@ -2150,9 +2150,9 @@ fn test_check_commodity_cost_with_none_currency_skipped() {
                         // Cost present but with currency = None — must NOT
                         // be added to the used-commodities set.
                         cost: Some(CostData {
-                            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                                "100.00".to_string(),
-                            )),
+                            number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                                value: "100.00".to_string(),
+                            }),
                             currency: None,
                             date: None,
                             label: None,
@@ -2498,9 +2498,9 @@ fn test_implicit_prices_from_cost_total() {
                             currency: "ABC".to_string(),
                         }),
                         cost: Some(CostData {
-                            number: Some(rustledger_plugin_types::CostNumberData::Total(
-                                "500".to_string(),
-                            )),
+                            number: Some(rustledger_plugin_types::CostNumberData::Total {
+                                value: "500".to_string(),
+                            }),
                             currency: Some("USD".to_string()),
                             date: None,
                             label: None,
@@ -4461,7 +4461,7 @@ proptest::proptest! {
                         }),
                         cost: if has_cost {
                             Some(CostData {
-                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit("100".to_string())),
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit { value: "100".to_string() }),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -4964,9 +4964,9 @@ fn make_sale_with_gain_posting(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            cost.0.to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: cost.0.to_string(),
+                        }),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -5208,9 +5208,9 @@ fn test_sell_gains_two_sales_share_one_income_posting() {
                         currency: "AAPL".to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            "100".to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: "100".to_string(),
+                        }),
                         currency: Some("USD".to_string()),
                         date: None,
                         label: None,
@@ -5237,9 +5237,9 @@ fn test_sell_gains_two_sales_share_one_income_posting() {
                         currency: "AAPL".to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            "200".to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: "200".to_string(),
+                        }),
                         currency: Some("USD".to_string()),
                         date: None,
                         label: None,
@@ -5332,7 +5332,7 @@ proptest::proptest! {
                 currency: "AAPL".to_string(),
             }),
             cost: Some(CostData {
-                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(cost_d.to_string())),
+                number: Some(rustledger_plugin_types::CostNumberData::PerUnit { value: cost_d.to_string() }),
                 currency: Some("USD".to_string()),
                 date: None,
                 label: None,
@@ -7955,9 +7955,9 @@ fn make_long_short_sale(
                         currency: asset.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            cost.0.to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: cost.0.to_string(),
+                        }),
                         currency: Some(cost.1.to_string()),
                         date: Some(cost_date.to_string()),
                         label: None,
@@ -8250,9 +8250,9 @@ fn test_capital_gains_long_short_no_cost_date_passes_through_unchanged() {
                         currency: "AAPL".to_string(),
                     }),
                     cost: Some(CostData {
-                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
-                            "100".to_string(),
-                        )),
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit {
+                            value: "100".to_string(),
+                        }),
                         currency: Some("USD".to_string()),
                         date: None, // ← the branch under test
                         label: None,

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -130,8 +130,9 @@ fn make_transaction_with_cost(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some(cost.0.to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            cost.0.to_string(),
+                        )),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -205,8 +206,9 @@ fn make_transaction_with_cost_and_price_total(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some(cost.0.to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            cost.0.to_string(),
+                        )),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -269,8 +271,9 @@ fn make_transaction_with_cost_and_price(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some(cost.0.to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            cost.0.to_string(),
+                        )),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -1322,8 +1325,9 @@ fn test_noduplicates_total_vs_per_unit_cost_differ() {
         && let Some(cost) = &mut t.postings[0].cost
     {
         // Swap to total cost form
-        cost.number_per = None;
-        cost.number_total = Some("1500.00".to_string());
+        cost.number = Some(rustledger_plugin_types::CostNumberData::Total(
+            "1500.00".to_string(),
+        ));
     }
     let input = make_input(vec![
         make_open("2024-01-01", "Assets:Stock"),
@@ -2083,8 +2087,9 @@ fn test_check_commodity_undeclared_cost_currency() {
                             currency: "HOOL".to_string(),
                         }),
                         cost: Some(CostData {
-                            number_per: Some("100.00".to_string()),
-                            number_total: None,
+                            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                "100.00".to_string(),
+                            )),
                             currency: Some("USD".to_string()),
                             date: None,
                             label: None,
@@ -2145,8 +2150,9 @@ fn test_check_commodity_cost_with_none_currency_skipped() {
                         // Cost present but with currency = None — must NOT
                         // be added to the used-commodities set.
                         cost: Some(CostData {
-                            number_per: Some("100.00".to_string()),
-                            number_total: None,
+                            number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                                "100.00".to_string(),
+                            )),
                             currency: None,
                             date: None,
                             label: None,
@@ -2492,8 +2498,9 @@ fn test_implicit_prices_from_cost_total() {
                             currency: "ABC".to_string(),
                         }),
                         cost: Some(CostData {
-                            number_per: None,
-                            number_total: Some("500".to_string()),
+                            number: Some(rustledger_plugin_types::CostNumberData::Total(
+                                "500".to_string(),
+                            )),
                             currency: Some("USD".to_string()),
                             date: None,
                             label: None,
@@ -4454,8 +4461,7 @@ proptest::proptest! {
                         }),
                         cost: if has_cost {
                             Some(CostData {
-                                number_per: Some("100".to_string()),
-                                number_total: None,
+                                number: Some(rustledger_plugin_types::CostNumberData::PerUnit("100".to_string())),
                                 currency: Some("USD".to_string()),
                                 date: None,
                                 label: None,
@@ -4958,8 +4964,9 @@ fn make_sale_with_gain_posting(
                         currency: units.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some(cost.0.to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            cost.0.to_string(),
+                        )),
                         currency: Some(cost.1.to_string()),
                         date: None,
                         label: None,
@@ -5201,8 +5208,9 @@ fn test_sell_gains_two_sales_share_one_income_posting() {
                         currency: "AAPL".to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some("100".to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            "100".to_string(),
+                        )),
                         currency: Some("USD".to_string()),
                         date: None,
                         label: None,
@@ -5229,8 +5237,9 @@ fn test_sell_gains_two_sales_share_one_income_posting() {
                         currency: "AAPL".to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some("200".to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            "200".to_string(),
+                        )),
                         currency: Some("USD".to_string()),
                         date: None,
                         label: None,
@@ -5323,8 +5332,7 @@ proptest::proptest! {
                 currency: "AAPL".to_string(),
             }),
             cost: Some(CostData {
-                number_per: Some(cost_d.to_string()),
-                number_total: None,
+                number: Some(rustledger_plugin_types::CostNumberData::PerUnit(cost_d.to_string())),
                 currency: Some("USD".to_string()),
                 date: None,
                 label: None,
@@ -7947,8 +7955,9 @@ fn make_long_short_sale(
                         currency: asset.1.to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some(cost.0.to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            cost.0.to_string(),
+                        )),
                         currency: Some(cost.1.to_string()),
                         date: Some(cost_date.to_string()),
                         label: None,
@@ -8241,8 +8250,9 @@ fn test_capital_gains_long_short_no_cost_date_passes_through_unchanged() {
                         currency: "AAPL".to_string(),
                     }),
                     cost: Some(CostData {
-                        number_per: Some("100".to_string()),
-                        number_total: None,
+                        number: Some(rustledger_plugin_types::CostNumberData::PerUnit(
+                            "100".to_string(),
+                        )),
                         currency: Some("USD".to_string()),
                         date: None, // ← the branch under test
                         label: None,

--- a/crates/rustledger-plugin/tests/python_compat_cost_round_trip.rs
+++ b/crates/rustledger-plugin/tests/python_compat_cost_round_trip.rs
@@ -1,0 +1,232 @@
+//! Round-trip tests for the Python compat shim's `CostSpec`
+//! parse/serialize functions (#1164 regression guard).
+//!
+//! These tests exec the host `python3` against the embedded
+//! `BEANCOUNT_COMPAT_PY` source and verify that Rust's typed
+//! `CostData` JSON shape survives the Python parse → re-serialize
+//! → Python parse round-trip with values intact.
+//!
+//! Without this test the silent value-loss the agent reviewer flagged
+//! (Rust serializes as `{"PerUnit": "100"}`, Python tries to read
+//! `number_per` and gets `None`) returns the first time the wire
+//! shape drifts again. The test is skipped when host `python3` isn't
+//! available so it doesn't break developers on minimal systems. Gated
+//! behind the `python-plugins` feature so it only runs when the
+//! relevant code is compiled in.
+
+#![cfg(feature = "python-plugins")]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use rustledger_plugin::python::BEANCOUNT_COMPAT_PY;
+
+fn host_python_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Execute a Python script that loads the compat shim and runs the
+/// caller's test body, returning stdout. Panics with stderr on
+/// failure so test output points at the actual Python error.
+fn run_python(test_body: &str) -> String {
+    let mut child = Command::new("python3")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn python3");
+
+    let script = format!("{BEANCOUNT_COMPAT_PY}\n\n# ---- test body ----\n{test_body}");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(script.as_bytes())
+        .expect("write script");
+
+    let out = child.wait_with_output().expect("wait_with_output");
+    assert!(
+        out.status.success(),
+        "python3 failed:\n--- stderr ---\n{}\n--- stdout ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+    String::from_utf8(out.stdout).expect("utf8 stdout")
+}
+
+#[test]
+fn per_unit_round_trip_through_python() {
+    if !host_python_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    // Rust serializes `CostNumber::PerUnit(100)` as {"PerUnit": "100"}
+    // via serde's default enum encoding. The Python `_parse_cost_spec`
+    // must read that shape and populate `number_per`.
+    let out = run_python(
+        r"
+import json
+input_dict = {
+    'number': {'PerUnit': '100.00'},
+    'currency': 'USD',
+    'date': '2024-01-15',
+    'label': None,
+    'merge': False,
+}
+spec = _parse_cost_spec(input_dict)
+assert spec.number_per is not None, f'number_per is None — silent value loss! spec={spec!r}'
+assert str(spec.number_per) == '100.00', f'expected 100.00, got {spec.number_per!r}'
+assert spec.number_total is None, f'number_total should be None, got {spec.number_total!r}'
+assert spec.currency == 'USD'
+
+# Now re-serialize and check the wire shape Rust will read back
+out_dict = _serialize_cost_spec(spec)
+print(json.dumps(out_dict, sort_keys=True))
+",
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
+    assert_eq!(
+        parsed["number"],
+        serde_json::json!({"PerUnit": "100.00"}),
+        "Python re-serialization lost the variant tag"
+    );
+}
+
+#[test]
+fn total_round_trip_through_python() {
+    if !host_python_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    let out = run_python(
+        r"
+import json
+spec = _parse_cost_spec({
+    'number': {'Total': '1500.00'},
+    'currency': 'USD',
+    'date': None,
+    'label': None,
+    'merge': False,
+})
+assert spec.number_per is None
+assert str(spec.number_total) == '1500.00', f'expected 1500.00, got {spec.number_total!r}'
+print(json.dumps(_serialize_cost_spec(spec), sort_keys=True))
+",
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
+    assert_eq!(parsed["number"], serde_json::json!({"Total": "1500.00"}));
+}
+
+#[test]
+fn per_unit_from_total_round_trip_through_python() {
+    if !host_python_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    // The post-booking variant: Python flattens to two fields
+    // (number_per + number_total) for upstream beancount API
+    // compatibility, but the re-serialize must reconstruct the
+    // PerUnitFromTotal variant so the preserved total survives the
+    // round trip.
+    let out = run_python(
+        r"
+import json
+spec = _parse_cost_spec({
+    'number': {'PerUnitFromTotal': {'per_unit': '150.00', 'total': '300.00'}},
+    'currency': 'USD',
+    'date': None,
+    'label': None,
+    'merge': False,
+})
+# Both fields populated on the Python side
+assert spec.number_per is not None and str(spec.number_per) == '150.00'
+assert spec.number_total is not None and str(spec.number_total) == '300.00'
+# Re-serialize preserves the variant
+print(json.dumps(_serialize_cost_spec(spec), sort_keys=True))
+",
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
+    assert_eq!(
+        parsed["number"],
+        serde_json::json!({"PerUnitFromTotal": {"per_unit": "150.00", "total": "300.00"}}),
+        "round-trip lost the preserved total — currency_accounts and friends would silently regress"
+    );
+}
+
+#[test]
+fn bare_brace_round_trip_through_python() {
+    if !host_python_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    // Bare `{}` cost: number is None on the Python side and stays
+    // None on re-serialize. Distinct from a currency-only spec.
+    let out = run_python(
+        r"
+import json
+spec = _parse_cost_spec({
+    'number': None,
+    'currency': 'USD',
+    'date': None,
+    'label': None,
+    'merge': False,
+})
+assert spec.number_per is None and spec.number_total is None
+print(json.dumps(_serialize_cost_spec(spec), sort_keys=True))
+",
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
+    assert!(
+        parsed["number"].is_null(),
+        "bare-brace re-serialize must emit null number, got {parsed:?}"
+    );
+}
+
+#[test]
+fn legacy_flat_shape_no_longer_silently_works() {
+    if !host_python_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+
+    // The pre-#1164 wire shape had `number_per` / `number_total` at
+    // the top level. Sending it should NOT silently populate the
+    // Python CostSpec (which is what was happening — and how the
+    // silent value-loss regression hid). Both fields stay None.
+    let out = run_python(
+        r"
+import json
+spec = _parse_cost_spec({
+    'number_per': '100',
+    'number_total': None,
+    'currency': 'USD',
+    'date': None,
+    'label': None,
+    'merge': False,
+})
+# The new parser only reads from `number`. Legacy keys are ignored.
+result = {
+    'per_was_read': spec.number_per is not None,
+    'total_was_read': spec.number_total is not None,
+}
+print(json.dumps(result))
+",
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
+    assert_eq!(
+        parsed["per_was_read"], false,
+        "Python compat must NOT silently accept legacy `number_per`; it's the regression vector"
+    );
+}

--- a/crates/rustledger-plugin/tests/python_compat_cost_round_trip.rs
+++ b/crates/rustledger-plugin/tests/python_compat_cost_round_trip.rs
@@ -64,14 +64,15 @@ fn per_unit_round_trip_through_python() {
         return;
     }
 
-    // Rust serializes `CostNumber::PerUnit(100)` as {"PerUnit": "100"}
-    // via serde's default enum encoding. The Python `_parse_cost_spec`
-    // must read that shape and populate `number_per`.
+    // Rust serializes `CostNumber::PerUnit(100)` as
+    // {"kind":"per_unit","value":"100.00"} via the unified `kind`-tag
+    // shape. The Python `_parse_cost_spec` must read that shape and
+    // populate `number_per`.
     let out = run_python(
         r"
 import json
 input_dict = {
-    'number': {'PerUnit': '100.00'},
+    'number': {'kind': 'per_unit', 'value': '100.00'},
     'currency': 'USD',
     'date': '2024-01-15',
     'label': None,
@@ -92,8 +93,8 @@ print(json.dumps(out_dict, sort_keys=True))
     let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
     assert_eq!(
         parsed["number"],
-        serde_json::json!({"PerUnit": "100.00"}),
-        "Python re-serialization lost the variant tag"
+        serde_json::json!({"kind": "per_unit", "value": "100.00"}),
+        "Python re-serialization lost the unified `kind`-tag shape"
     );
 }
 
@@ -108,7 +109,7 @@ fn total_round_trip_through_python() {
         r"
 import json
 spec = _parse_cost_spec({
-    'number': {'Total': '1500.00'},
+    'number': {'kind': 'total', 'value': '1500.00'},
     'currency': 'USD',
     'date': None,
     'label': None,
@@ -121,7 +122,10 @@ print(json.dumps(_serialize_cost_spec(spec), sort_keys=True))
     );
 
     let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
-    assert_eq!(parsed["number"], serde_json::json!({"Total": "1500.00"}));
+    assert_eq!(
+        parsed["number"],
+        serde_json::json!({"kind": "total", "value": "1500.00"})
+    );
 }
 
 #[test]
@@ -140,7 +144,11 @@ fn per_unit_from_total_round_trip_through_python() {
         r"
 import json
 spec = _parse_cost_spec({
-    'number': {'PerUnitFromTotal': {'per_unit': '150.00', 'total': '300.00'}},
+    'number': {
+        'kind': 'per_unit_from_total',
+        'per_unit': '150.00',
+        'total': '300.00',
+    },
     'currency': 'USD',
     'date': None,
     'label': None,
@@ -157,7 +165,11 @@ print(json.dumps(_serialize_cost_spec(spec), sort_keys=True))
     let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
     assert_eq!(
         parsed["number"],
-        serde_json::json!({"PerUnitFromTotal": {"per_unit": "150.00", "total": "300.00"}}),
+        serde_json::json!({
+            "kind": "per_unit_from_total",
+            "per_unit": "150.00",
+            "total": "300.00",
+        }),
         "round-trip lost the preserved total — currency_accounts and friends would silently regress"
     );
 }
@@ -190,6 +202,37 @@ print(json.dumps(_serialize_cost_spec(spec), sort_keys=True))
     assert!(
         parsed["number"].is_null(),
         "bare-brace re-serialize must emit null number, got {parsed:?}"
+    );
+}
+
+#[test]
+fn python_emits_kind_tagged_shape_matching_ffi_wasi_and_wasm() {
+    // Pins the unification invariant: Python compat emits exactly the
+    // same shape as FFI-WASI / WASM / plugin-types. If serde defaults
+    // ever drift on the Rust side, this test catches the cross-
+    // boundary mismatch from the Python side directly.
+    if !host_python_available() {
+        eprintln!("skipping: python3 not available");
+        return;
+    }
+    let out = run_python(
+        r"
+import json
+# Construct a CostSpec namedtuple via parse, then re-serialize and
+# verify the wire shape matches what every other binding emits.
+spec = _parse_cost_spec({
+    'number': {'kind': 'per_unit', 'value': '42'},
+    'currency': 'USD', 'date': None, 'label': None, 'merge': False,
+})
+print(json.dumps(_serialize_cost_spec(spec)['number'], sort_keys=True))
+",
+    );
+    let parsed: serde_json::Value = serde_json::from_str(out.trim()).expect("json");
+    assert_eq!(parsed["kind"], "per_unit");
+    assert_eq!(parsed["value"], "42");
+    assert!(
+        parsed.get("PerUnit").is_none(),
+        "Python must NOT emit the pre-unification external-tag shape"
     );
 }
 

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use rustledger_core::{Amount, Position, Transaction};
+use rustledger_core::{Amount, CostNumber, Position, Transaction};
 
 use crate::ast::{Expr, Literal, Target};
 use crate::error::QueryError;
@@ -256,13 +256,17 @@ impl Executor<'_> {
                 .amount()
                 .map_or(Value::Null, |u| Value::Amount(u.clone()))),
             "cost" => {
-                // Get the cost of the posting
+                // Get the cost of the posting. Both `PerUnit` and the
+                // post-booking `PerUnitFromTotal` carry a per-unit
+                // value; `Total` is divided to derive one. The pre-
+                // booking `Total` case is unlikely here (this column
+                // sees post-booking data) but is handled for safety.
                 if let Some(units) = posting.amount()
                     && let Some(cost) = &posting.cost
-                    && let Some(number_per) = &cost.number_per
+                    && let Some(cost_num) = cost.number.as_ref().and_then(CostNumber::per_unit)
                     && let Some(currency) = &cost.currency
                 {
-                    let total = units.number.abs() * number_per;
+                    let total = units.number.abs() * cost_num;
                     return Ok(Value::Amount(Amount::new(total, currency.clone())));
                 }
                 Ok(Value::Null)
@@ -313,11 +317,16 @@ impl Executor<'_> {
                 };
                 Ok(Value::String(desc))
             }
-            // Cost number (per-unit cost)
+            // Cost number (per-unit cost). After booking, both
+            // `PerUnit` and `PerUnitFromTotal` expose a per-unit
+            // value via `per_unit()`. Pre-booking `Total` returns
+            // None — callers wanting a per-unit must compute it from
+            // units, which the booker has already done by the time
+            // this column is queried.
             "cost_number" => Ok(posting
                 .cost
                 .as_ref()
-                .and_then(|c| c.number_per)
+                .and_then(|c| c.number.as_ref().and_then(CostNumber::per_unit))
                 .map_or(Value::Null, Value::Number)),
             // Cost currency
             "cost_currency" => Ok(posting

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -788,7 +788,7 @@ mod tests {
                 Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                     .with_cost(
                         CostSpec::default()
-                            .with_per_unit(dec!(1.25))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.25) })
                             .with_currency("EUR"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -811,7 +811,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(10), "XYZ")).with_cost(
                     CostSpec::default()
-                        .with_per_unit(dec!(50.00))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(50.00) })
                         .with_currency("USD"),
                 ),
             )
@@ -855,7 +855,7 @@ mod tests {
                 Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                     .with_cost(
                         CostSpec::default()
-                            .with_per_unit(dec!(1.25))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.25) })
                             .with_currency("EUR"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -879,7 +879,7 @@ mod tests {
             Posting::new("Assets:Stocks", Amount::new(dec!(0), "ABC"))
                 .with_cost(
                     CostSpec::default()
-                        .with_per_unit(dec!(50))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(50) })
                         .with_currency("USD"),
                 )
                 .with_price(PriceAnnotation::total(Amount::new(dec!(100), "EUR"))),
@@ -912,7 +912,7 @@ mod tests {
                 Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                     .with_cost(
                         CostSpec::default()
-                            .with_per_unit(dec!(1.25))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.25) })
                             .with_currency("EUR"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -957,7 +957,9 @@ mod tests {
                         Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                             .with_cost(
                                 CostSpec::default()
-                                    .with_per_unit(dec!(1.25))
+                                    .with_number(rustledger_core::CostNumber::PerUnit {
+                                        value: dec!(1.25),
+                                    })
                                     .with_currency("EUR"),
                             )
                             .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -995,7 +997,9 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-10), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_per_unit(dec!(0.5113))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(0.5113),
+                                })
                                 .with_currency("EUR"),
                         ),
                     )
@@ -1009,7 +1013,9 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-20), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_per_unit(dec!(0.5113))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(0.5113),
+                                })
                                 .with_currency("EUR"),
                         ),
                     )
@@ -1068,7 +1074,9 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-10), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_per_unit(dec!(0.5113))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(0.5113),
+                                })
                                 .with_currency("EUR"),
                         ),
                     )
@@ -1082,7 +1090,9 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-20), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_per_unit(dec!(0.5113))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(0.5113),
+                                })
                                 .with_currency("EUR"),
                         ),
                     )

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -217,10 +217,7 @@ impl PriceDatabase {
             });
             let cost = posting.cost.as_ref().and_then(|c| {
                 let currency = c.currency.clone()?;
-                if c.number_per.is_none() && c.number_total.is_none() {
-                    return None;
-                }
-                Some((c.number_per, c.number_total, currency))
+                Some((c.number, currency))
             });
 
             let Some((per_unit, quote)) =

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -788,7 +788,7 @@ mod tests {
                 Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                     .with_cost(
                         CostSpec::default()
-                            .with_number_per(dec!(1.25))
+                            .with_per_unit(dec!(1.25))
                             .with_currency("EUR"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -811,7 +811,7 @@ mod tests {
             .with_synthesized_posting(
                 Posting::new("Assets:Stocks", Amount::new(dec!(10), "XYZ")).with_cost(
                     CostSpec::default()
-                        .with_number_per(dec!(50.00))
+                        .with_per_unit(dec!(50.00))
                         .with_currency("USD"),
                 ),
             )
@@ -855,7 +855,7 @@ mod tests {
                 Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                     .with_cost(
                         CostSpec::default()
-                            .with_number_per(dec!(1.25))
+                            .with_per_unit(dec!(1.25))
                             .with_currency("EUR"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -879,7 +879,7 @@ mod tests {
             Posting::new("Assets:Stocks", Amount::new(dec!(0), "ABC"))
                 .with_cost(
                     CostSpec::default()
-                        .with_number_per(dec!(50))
+                        .with_per_unit(dec!(50))
                         .with_currency("USD"),
                 )
                 .with_price(PriceAnnotation::total(Amount::new(dec!(100), "EUR"))),
@@ -912,7 +912,7 @@ mod tests {
                 Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                     .with_cost(
                         CostSpec::default()
-                            .with_number_per(dec!(1.25))
+                            .with_per_unit(dec!(1.25))
                             .with_currency("EUR"),
                     )
                     .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -957,7 +957,7 @@ mod tests {
                         Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                             .with_cost(
                                 CostSpec::default()
-                                    .with_number_per(dec!(1.25))
+                                    .with_per_unit(dec!(1.25))
                                     .with_currency("EUR"),
                             )
                             .with_price(PriceAnnotation::unit(Amount::new(dec!(1.40), "EUR"))),
@@ -995,7 +995,7 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-10), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_number_per(dec!(0.5113))
+                                .with_per_unit(dec!(0.5113))
                                 .with_currency("EUR"),
                         ),
                     )
@@ -1009,7 +1009,7 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-20), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_number_per(dec!(0.5113))
+                                .with_per_unit(dec!(0.5113))
                                 .with_currency("EUR"),
                         ),
                     )
@@ -1068,7 +1068,7 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-10), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_number_per(dec!(0.5113))
+                                .with_per_unit(dec!(0.5113))
                                 .with_currency("EUR"),
                         ),
                     )
@@ -1082,7 +1082,7 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-20), "BAM")).with_cost(
                             CostSpec::default()
-                                .with_number_per(dec!(0.5113))
+                                .with_per_unit(dec!(0.5113))
                                 .with_currency("EUR"),
                         ),
                     )

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -652,7 +652,7 @@ fn test_journal_position_column_preserves_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -755,7 +755,7 @@ fn test_journal_at_cost_position_is_amount_not_position() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -791,7 +791,7 @@ fn test_journal_at_units_position_is_amount_not_position() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -831,7 +831,7 @@ fn test_journal_at_cost_collapses_balance_to_cost_currency() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -880,7 +880,7 @@ fn test_journal_at_cost_with_from_clause_filters_then_collapses() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -895,7 +895,7 @@ fn test_journal_at_cost_with_from_clause_filters_then_collapses() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(20), "MSFT")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(300))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(300) })
                             .with_currency("USD"),
                     ),
                 )
@@ -938,7 +938,7 @@ fn test_journal_at_units_strips_cost_from_balance() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -1017,7 +1017,7 @@ fn test_journal_at_cost_balance_keeps_mixed_cost_currencies() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -1033,7 +1033,7 @@ fn test_journal_at_cost_balance_keeps_mixed_cost_currencies() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(5), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(130))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(130) })
                             .with_currency("EUR"),
                     ),
                 )
@@ -4012,7 +4012,7 @@ fn make_holdings_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(100))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
                             .with_currency("USD")
                             .with_date(date(2024, 1, 15)),
                     ),
@@ -4028,7 +4028,7 @@ fn make_holdings_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(5), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(120))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(120) })
                             .with_currency("USD")
                             .with_date(date(2024, 3, 20)),
                     ),
@@ -4305,7 +4305,7 @@ fn test_cost_mixed_inventory_with_and_without_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(100))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
                             .with_currency("USD"),
                     ),
                 )
@@ -4379,7 +4379,7 @@ fn make_multi_currency_holdings() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(100))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
                             .with_currency("USD")
                             .with_date(date(2024, 1, 15)),
                     ),
@@ -4395,7 +4395,7 @@ fn make_multi_currency_holdings() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(5), "GOOG")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD")
                             .with_date(date(2024, 2, 10)),
                     ),
@@ -5240,7 +5240,7 @@ fn make_chained_price_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stocks", Amount::new(dec!(5), "GOOG")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(80))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(80) })
                             .with_currency("EUR")
                             .with_date(date(2024, 2, 15)),
                     ),
@@ -5400,7 +5400,7 @@ fn make_issue_892_directives() -> Vec<Directive> {
             Transaction::new(date(2020, 1, 1), "Buy stock").with_synthesized_posting(
                 Posting::new("Assets:Brokerage", Amount::new(dec!(4), "SP")).with_cost(
                     CostSpec::empty()
-                        .with_per_unit(dec!(250))
+                        .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(250) })
                         .with_currency("USD")
                         .with_date(date(2020, 1, 1)),
                 ),
@@ -5614,7 +5614,7 @@ fn test_prices_table_excludes_transaction_derived_implicit_prices() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(520))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(520) })
                             .with_currency("USD"),
                     ),
                 )
@@ -5651,7 +5651,7 @@ fn test_value_works_without_explicit_price_directive() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(520))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(520) })
                             .with_currency("USD"),
                     ),
                 )
@@ -6971,7 +6971,7 @@ fn test_postings_table_cost_columns() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD")
                             .with_date(date(2024, 1, 15))
                             .with_label("lot1"),
@@ -7203,7 +7203,7 @@ fn test_aggregate_context_weight_on_values() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -7273,7 +7273,7 @@ fn test_postings_table_position_column_with_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -7449,7 +7449,7 @@ fn test_postings_table_weight_column() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -8060,7 +8060,7 @@ fn test_issue_567_value_uses_implicit_price_from_annotation() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stocks", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(1.25))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.25) })
                             .with_currency("EUR")
                             .with_date(date(2024, 1, 10)),
                     ),
@@ -8077,7 +8077,9 @@ fn test_issue_567_value_uses_implicit_price_from_annotation() {
                     Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(1.25))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(1.25),
+                                })
                                 .with_currency("EUR")
                                 .with_date(date(2024, 1, 10)),
                         )
@@ -8139,7 +8141,7 @@ fn test_issue_567_value_sum_position_with_implicit_price() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stocks", Amount::new(dec!(10), "XYZ")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(50))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(50) })
                             .with_currency("USD"),
                     ),
                 )
@@ -8155,7 +8157,9 @@ fn test_issue_567_value_sum_position_with_implicit_price() {
                     Posting::new("Assets:Stocks", Amount::new(dec!(-5), "XYZ"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(50))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(50),
+                                })
                                 .with_currency("USD"),
                         )
                         .with_price(PriceAnnotation::unit(Amount::new(dec!(60), "USD"))),
@@ -8329,7 +8333,7 @@ fn make_issue_575_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Investment", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(100))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(100) })
                             .with_currency("EUR"),
                     ),
                 )
@@ -8531,7 +8535,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(1.25))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.25) })
                             .with_currency("EUR"),
                     ),
                 )
@@ -8546,7 +8550,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(7), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(1.30))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.30) })
                             .with_currency("EUR"),
                     ),
                 )
@@ -8562,7 +8566,9 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-5), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(1.25))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(1.25),
+                                })
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 1)),
                         )
@@ -8580,7 +8586,9 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-3), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(1.30))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(1.30),
+                                })
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 2)),
                         )
@@ -8701,7 +8709,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(1.25))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.25) })
                             .with_currency("EUR"),
                     ),
                 )
@@ -8716,7 +8724,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(7), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_per_unit(dec!(1.30))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(1.30) })
                             .with_currency("EUR"),
                     ),
                 )
@@ -8732,7 +8740,9 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-5), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(1.25))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(1.25),
+                                })
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 1)),
                         )
@@ -8750,7 +8760,9 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-3), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(1.30))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(1.30),
+                                })
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 2)),
                         )

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -652,7 +652,7 @@ fn test_journal_position_column_preserves_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -755,7 +755,7 @@ fn test_journal_at_cost_position_is_amount_not_position() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -791,7 +791,7 @@ fn test_journal_at_units_position_is_amount_not_position() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -831,7 +831,7 @@ fn test_journal_at_cost_collapses_balance_to_cost_currency() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -880,7 +880,7 @@ fn test_journal_at_cost_with_from_clause_filters_then_collapses() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -895,7 +895,7 @@ fn test_journal_at_cost_with_from_clause_filters_then_collapses() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(20), "MSFT")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(300))
+                            .with_per_unit(dec!(300))
                             .with_currency("USD"),
                     ),
                 )
@@ -938,7 +938,7 @@ fn test_journal_at_units_strips_cost_from_balance() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -1017,7 +1017,7 @@ fn test_journal_at_cost_balance_keeps_mixed_cost_currencies() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -1033,7 +1033,7 @@ fn test_journal_at_cost_balance_keeps_mixed_cost_currencies() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(5), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(130))
+                            .with_per_unit(dec!(130))
                             .with_currency("EUR"),
                     ),
                 )
@@ -4012,7 +4012,7 @@ fn make_holdings_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(100))
+                            .with_per_unit(dec!(100))
                             .with_currency("USD")
                             .with_date(date(2024, 1, 15)),
                     ),
@@ -4028,7 +4028,7 @@ fn make_holdings_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(5), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(120))
+                            .with_per_unit(dec!(120))
                             .with_currency("USD")
                             .with_date(date(2024, 3, 20)),
                     ),
@@ -4305,7 +4305,7 @@ fn test_cost_mixed_inventory_with_and_without_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(100))
+                            .with_per_unit(dec!(100))
                             .with_currency("USD"),
                     ),
                 )
@@ -4379,7 +4379,7 @@ fn make_multi_currency_holdings() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(100))
+                            .with_per_unit(dec!(100))
                             .with_currency("USD")
                             .with_date(date(2024, 1, 15)),
                     ),
@@ -4395,7 +4395,7 @@ fn make_multi_currency_holdings() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(5), "GOOG")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD")
                             .with_date(date(2024, 2, 10)),
                     ),
@@ -5240,7 +5240,7 @@ fn make_chained_price_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stocks", Amount::new(dec!(5), "GOOG")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(80))
+                            .with_per_unit(dec!(80))
                             .with_currency("EUR")
                             .with_date(date(2024, 2, 15)),
                     ),
@@ -5400,7 +5400,7 @@ fn make_issue_892_directives() -> Vec<Directive> {
             Transaction::new(date(2020, 1, 1), "Buy stock").with_synthesized_posting(
                 Posting::new("Assets:Brokerage", Amount::new(dec!(4), "SP")).with_cost(
                     CostSpec::empty()
-                        .with_number_per(dec!(250))
+                        .with_per_unit(dec!(250))
                         .with_currency("USD")
                         .with_date(date(2020, 1, 1)),
                 ),
@@ -5614,7 +5614,7 @@ fn test_prices_table_excludes_transaction_derived_implicit_prices() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(520))
+                            .with_per_unit(dec!(520))
                             .with_currency("USD"),
                     ),
                 )
@@ -5651,7 +5651,7 @@ fn test_value_works_without_explicit_price_directive() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(520))
+                            .with_per_unit(dec!(520))
                             .with_currency("USD"),
                     ),
                 )
@@ -6971,7 +6971,7 @@ fn test_postings_table_cost_columns() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD")
                             .with_date(date(2024, 1, 15))
                             .with_label("lot1"),
@@ -7203,7 +7203,7 @@ fn test_aggregate_context_weight_on_values() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -7273,7 +7273,7 @@ fn test_postings_table_position_column_with_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -7449,7 +7449,7 @@ fn test_postings_table_weight_column() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Brokerage", Amount::new(dec!(10), "AAPL")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )
@@ -8060,7 +8060,7 @@ fn test_issue_567_value_uses_implicit_price_from_annotation() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stocks", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(1.25))
+                            .with_per_unit(dec!(1.25))
                             .with_currency("EUR")
                             .with_date(date(2024, 1, 10)),
                     ),
@@ -8077,7 +8077,7 @@ fn test_issue_567_value_uses_implicit_price_from_annotation() {
                     Posting::new("Assets:Stocks", Amount::new(dec!(-5), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(1.25))
+                                .with_per_unit(dec!(1.25))
                                 .with_currency("EUR")
                                 .with_date(date(2024, 1, 10)),
                         )
@@ -8139,7 +8139,7 @@ fn test_issue_567_value_sum_position_with_implicit_price() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stocks", Amount::new(dec!(10), "XYZ")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(50))
+                            .with_per_unit(dec!(50))
                             .with_currency("USD"),
                     ),
                 )
@@ -8155,7 +8155,7 @@ fn test_issue_567_value_sum_position_with_implicit_price() {
                     Posting::new("Assets:Stocks", Amount::new(dec!(-5), "XYZ"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(50))
+                                .with_per_unit(dec!(50))
                                 .with_currency("USD"),
                         )
                         .with_price(PriceAnnotation::unit(Amount::new(dec!(60), "USD"))),
@@ -8329,7 +8329,7 @@ fn make_issue_575_directives() -> Vec<Directive> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Investment", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(100))
+                            .with_per_unit(dec!(100))
                             .with_currency("EUR"),
                     ),
                 )
@@ -8531,7 +8531,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(1.25))
+                            .with_per_unit(dec!(1.25))
                             .with_currency("EUR"),
                     ),
                 )
@@ -8546,7 +8546,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(7), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(1.30))
+                            .with_per_unit(dec!(1.30))
                             .with_currency("EUR"),
                     ),
                 )
@@ -8562,7 +8562,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-5), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(1.25))
+                                .with_per_unit(dec!(1.25))
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 1)),
                         )
@@ -8580,7 +8580,7 @@ fn test_issue_593_cost_preserves_sign_for_sells() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-3), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(1.30))
+                                .with_per_unit(dec!(1.30))
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 2)),
                         )
@@ -8701,7 +8701,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(5), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(1.25))
+                            .with_per_unit(dec!(1.25))
                             .with_currency("EUR"),
                     ),
                 )
@@ -8716,7 +8716,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                 .with_synthesized_posting(
                     Posting::new("Equity:Stocks", Amount::new(dec!(7), "ABC")).with_cost(
                         CostSpec::empty()
-                            .with_number_per(dec!(1.30))
+                            .with_per_unit(dec!(1.30))
                             .with_currency("EUR"),
                     ),
                 )
@@ -8732,7 +8732,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-5), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(1.25))
+                                .with_per_unit(dec!(1.25))
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 1)),
                         )
@@ -8750,7 +8750,7 @@ fn test_issue_593_value_uses_latest_implicit_price() {
                     Posting::new("Equity:Stocks", Amount::new(dec!(-3), "ABC"))
                         .with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(1.30))
+                                .with_per_unit(dec!(1.30))
                                 .with_currency("EUR")
                                 .with_date(date(2025, 4, 2)),
                         )

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -62,7 +62,7 @@ pub use error::{ErrorCode, Severity, ValidationError};
 /// residuals, inventory updates, balance assertions) run as
 /// [`Phase::Late`] AFTER booking AND after the regular plugin pass
 /// (so cost-spec-reading plugins like `implicit_prices` see filled
-/// `cost.number_per` values).
+/// per-unit values on the `CostNumber::PerUnitFromTotal` variant).
 ///
 /// The pipeline is therefore:
 ///     sort → synth-plugins → Early → book → regular-plugins → Late → finalize

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -1546,7 +1546,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec::empty()
-            .with_number_per(dec!(150))
+            .with_per_unit(dec!(150))
             .with_currency("USD");
 
         let directives = vec![
@@ -1604,7 +1604,7 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(150))
+                                .with_per_unit(dec!(150))
                                 .with_currency("USD"),
                         ),
                     )
@@ -1619,7 +1619,7 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL")).with_cost(
                             CostSpec::empty()
-                                .with_number_per(dec!(160))
+                                .with_per_unit(dec!(160))
                                 .with_currency("USD"),
                         ),
                     )
@@ -1644,7 +1644,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec::empty()
-            .with_number_per(dec!(150))
+            .with_per_unit(dec!(150))
             .with_currency("USD");
 
         let directives = vec![
@@ -1714,7 +1714,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec::empty()
-            .with_number_per(dec!(150))
+            .with_per_unit(dec!(150))
             .with_currency("USD");
 
         let directives = vec![
@@ -1858,7 +1858,7 @@ mod tests {
                 Transaction::new(date(2024, 1, 15), "Grant").with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(100), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_number_per(dec!(0))
+                            .with_per_unit(dec!(0))
                             .with_currency("USD"),
                     ),
                 ),
@@ -1881,7 +1881,7 @@ mod tests {
                 Transaction::new(date(2024, 1, 15), "Buy").with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(100), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 ),

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -1546,7 +1546,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec::empty()
-            .with_per_unit(dec!(150))
+            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
             .with_currency("USD");
 
         let directives = vec![
@@ -1604,7 +1604,9 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(150))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(150),
+                                })
                                 .with_currency("USD"),
                         ),
                     )
@@ -1619,7 +1621,9 @@ mod tests {
                     .with_synthesized_posting(
                         Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL")).with_cost(
                             CostSpec::empty()
-                                .with_per_unit(dec!(160))
+                                .with_number(rustledger_core::CostNumber::PerUnit {
+                                    value: dec!(160),
+                                })
                                 .with_currency("USD"),
                         ),
                     )
@@ -1644,7 +1648,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec::empty()
-            .with_per_unit(dec!(150))
+            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
             .with_currency("USD");
 
         let directives = vec![
@@ -1714,7 +1718,7 @@ mod tests {
         use rustledger_core::CostSpec;
 
         let cost_spec = CostSpec::empty()
-            .with_per_unit(dec!(150))
+            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
             .with_currency("USD");
 
         let directives = vec![
@@ -1858,7 +1862,7 @@ mod tests {
                 Transaction::new(date(2024, 1, 15), "Grant").with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(100), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_per_unit(dec!(0))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(0) })
                             .with_currency("USD"),
                     ),
                 ),
@@ -1881,7 +1885,7 @@ mod tests {
                 Transaction::new(date(2024, 1, 15), "Buy").with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(100), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 ),

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -155,6 +155,12 @@ pub fn validate_transaction_structure(
         if let Some(cost) = &posting.cost
             && let Some(cn) = cost.number
         {
+            // Read-only destructure: the `BookedCost { total: value, .. }`
+            // pattern pulls the user-written `total` out for the negative
+            // check, but does NOT construct a new `BookedCost`. Do not
+            // copy this pattern to *build* a `BookedCost` — that would
+            // bypass the consistency invariant enforced by
+            // `BookedCost::new` / `try_new`.
             let (label, value) = match cn {
                 rustledger_core::CostNumber::PerUnit { value } => ("per-unit", value),
                 rustledger_core::CostNumber::Total { value }

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -98,7 +98,11 @@ pub fn validate_transaction_structure(
     // matching Python beancount behavior.
     let is_zero_cost_single = txn.postings.len() == 1
         && txn.postings[0].cost.as_ref().is_some_and(|c| {
-            c.number_per.is_some_and(|n| n.is_zero()) || c.number_total.is_some_and(|n| n.is_zero())
+            // Either per-unit or total carrying zero counts.
+            c.number.is_some_and(|cn| {
+                cn.per_unit().is_some_and(|n| n.is_zero())
+                    || cn.total().is_some_and(|n| n.is_zero())
+            })
         });
     if txn.postings.len() == 1 && !is_zero_cost_single {
         errors.push(ValidationError::new(
@@ -147,7 +151,11 @@ pub fn validate_transaction_structure(
                 |a| format!("{} {}", a.number, a.currency),
             );
             let cost_currency = cost.currency.as_ref().map_or("?", |c| c.as_str());
-            if let Some(per) = cost.number_per
+            // Check per-unit and total components independently —
+            // PerUnitFromTotal carries both, so a single spec can
+            // trigger both negative-cost errors if both values went
+            // negative.
+            if let Some(per) = cost.number.and_then(|cn| cn.per_unit())
                 && per < Decimal::ZERO
             {
                 errors.push(ValidationError::new(
@@ -159,7 +167,7 @@ pub fn validate_transaction_structure(
                     txn.date,
                 ));
             }
-            if let Some(total) = cost.number_total
+            if let Some(total) = cost.number.and_then(|cn| cn.total())
                 && total < Decimal::ZERO
             {
                 errors.push(ValidationError::new(
@@ -260,7 +268,7 @@ pub fn validate_transaction_balance(
     // This matches Python beancount behavior where booking runs before balance checking.
     let has_empty_cost_spec = txn.postings.iter().any(|p| {
         if let Some(cost) = &p.cost {
-            cost.number_per.is_none() && cost.number_total.is_none()
+            cost.number.is_none()
         } else {
             false
         }
@@ -371,9 +379,11 @@ pub fn calculate_tolerances(
                 let units_quantum = decimal_quantum(units.number);
                 let tolerance = units_quantum * options.tolerance_multiplier;
 
-                // Cost contribution
+                // Cost contribution — only per-unit cost feeds into
+                // tolerance inference. `PerUnitFromTotal` and `PerUnit`
+                // both expose a per-unit value via `per_unit()`.
                 if let Some(cost_spec) = &posting.cost
-                    && let Some(cost_per_unit) = cost_spec.number_per
+                    && let Some(cost_per_unit) = cost_spec.number.and_then(|cn| cn.per_unit())
                     && let Some(cost_currency) = &cost_spec.currency
                 {
                     let cost_tolerance = tolerance * cost_per_unit;
@@ -498,13 +508,13 @@ pub fn process_inventory_reduction(
     // `{"lot1"}`). These are unbooked postings where either:
     //   - Booking wasn't run (standalone validation), or
     //   - Booking failed and already reported the error (normal pipeline).
-    // If booking succeeded, it would have filled in number_per from the matched
-    // lot. Re-running lot matching here would double-report or diverge from the
-    // booking engine's decisions. This mirrors `validate_transaction_balance`,
-    // which also skips balance checking when a posting has an unresolved cost.
+    // If booking succeeded, it would have filled in a per-unit cost
+    // from the matched lot. Re-running lot matching here would
+    // double-report or diverge from the booking engine's decisions.
+    // This mirrors `validate_transaction_balance`, which also skips
+    // balance checking when a posting has an unresolved cost.
     if let Some(cost) = &posting.cost
-        && cost.number_per.is_none()
-        && cost.number_total.is_none()
+        && cost.number.is_none()
     {
         return;
     }

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -143,37 +143,36 @@ pub fn validate_transaction_structure(
         }
     }
 
-    // Check for negative cost amounts
+    // Check for negative cost amounts. One error per posting, even
+    // when the spec is `PerUnitFromTotal` and carries both halves: by
+    // `BookedCost`'s invariant `per_unit * |units| = total`, the two
+    // values share sign, so reporting both would be two errors for
+    // one underlying problem. Prefer the user-written value
+    // (`total` for `PerUnitFromTotal`, since that's the literal
+    // `{{ total }}` the user typed and what they can fix). Fall back
+    // to per-unit for raw `PerUnit` specs.
     for posting in &txn.postings {
-        if let Some(cost) = &posting.cost {
-            let units_str = posting.amount().map_or_else(
-                || "?".to_string(),
-                |a| format!("{} {}", a.number, a.currency),
-            );
-            let cost_currency = cost.currency.as_ref().map_or("?", |c| c.as_str());
-            // Check per-unit and total components independently —
-            // PerUnitFromTotal carries both, so a single spec can
-            // trigger both negative-cost errors if both values went
-            // negative.
-            if let Some(per) = cost.number.and_then(|cn| cn.per_unit())
-                && per < Decimal::ZERO
-            {
+        if let Some(cost) = &posting.cost
+            && let Some(cn) = cost.number
+        {
+            let (label, value) = match cn {
+                rustledger_core::CostNumber::PerUnit { value } => ("per-unit", value),
+                rustledger_core::CostNumber::Total { value }
+                | rustledger_core::CostNumber::PerUnitFromTotal(rustledger_core::BookedCost {
+                    total: value,
+                    ..
+                }) => ("total", value),
+            };
+            if value < Decimal::ZERO {
+                let units_str = posting.amount().map_or_else(
+                    || "?".to_string(),
+                    |a| format!("{} {}", a.number, a.currency),
+                );
+                let cost_currency = cost.currency.as_ref().map_or("?", |c| c.as_str());
                 errors.push(ValidationError::new(
                     ErrorCode::NegativeCost,
                     format!(
-                        "Cost is negative: per-unit cost ({per} {cost_currency}) for {units_str} in posting to {}",
-                        posting.account
-                    ),
-                    txn.date,
-                ));
-            }
-            if let Some(total) = cost.number.and_then(|cn| cn.total())
-                && total < Decimal::ZERO
-            {
-                errors.push(ValidationError::new(
-                    ErrorCode::NegativeCost,
-                    format!(
-                        "Cost is negative: total cost ({total} {cost_currency}) for {units_str} in posting to {}",
+                        "Cost is negative: {label} cost ({value} {cost_currency}) for {units_str} in posting to {}",
                         posting.account
                     ),
                     txn.date,

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -291,7 +291,7 @@ fn test_e4005_negative_cost_per_unit() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_per_unit(dec!(-150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(-150) })
                             .with_currency("USD"),
                     ),
                 )
@@ -316,7 +316,7 @@ fn test_e4005_negative_total_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_total(dec!(-1500))
+                            .with_number(rustledger_core::CostNumber::Total { value: dec!(-1500) })
                             .with_currency("USD"),
                     ),
                 )
@@ -341,7 +341,7 @@ fn test_e4005_positive_cost_ok() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_per_unit(dec!(150))
+                            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(150) })
                             .with_currency("USD"),
                     ),
                 )

--- a/crates/rustledger-validate/tests/validation_integration_test.rs
+++ b/crates/rustledger-validate/tests/validation_integration_test.rs
@@ -291,7 +291,7 @@ fn test_e4005_negative_cost_per_unit() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_number_per(dec!(-150))
+                            .with_per_unit(dec!(-150))
                             .with_currency("USD"),
                     ),
                 )
@@ -316,7 +316,7 @@ fn test_e4005_negative_total_cost() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_number_total(dec!(-1500))
+                            .with_total(dec!(-1500))
                             .with_currency("USD"),
                     ),
                 )
@@ -341,7 +341,7 @@ fn test_e4005_positive_cost_ok() {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
                         rustledger_core::CostSpec::empty()
-                            .with_number_per(dec!(150))
+                            .with_per_unit(dec!(150))
                             .with_currency("USD"),
                     ),
                 )

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -44,6 +44,7 @@ console_error_panic_hook = "0.1"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 js-sys = "0.3"
+serde_json.workspace = true
 
 [package.metadata.wasm-pack.profile.release]
 # Optimize for speed (aligned with profile.wasm-release opt-level = 3)

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -44,7 +44,22 @@ console_error_panic_hook = "0.1"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 js-sys = "0.3"
+
+# Host-only dev-dep: the wire-format tests that need it are
+# `#[cfg(not(target_arch = "wasm32"))]` since they only validate
+# target-independent JSON shape — keep `serde_json` off the wasm32
+# test compile to avoid pulling extra dep chains.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 serde_json.workspace = true
+
+# `getrandom` 0.3 (pulled in transitively via `imbl` → `rand_xoshiro`
+# since #1195) requires both the `wasm_js` Cargo feature AND a
+# RUSTFLAGS cfg (`--cfg getrandom_backend="wasm_js"`, set in
+# `.cargo/config.toml` at the workspace root) before it will compile
+# on `wasm32-unknown-unknown`. A direct dep here forces Cargo to union
+# the feature into the transitive getrandom 0.3 instance.
+[target.wasm32-unknown-unknown.dependencies]
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 
 [package.metadata.wasm-pack.profile.release]
 # Optimize for speed (aligned with profile.wasm-release opt-level = 3)

--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -110,11 +110,20 @@ export interface Amount {
 }
 
 /**
+ * Cost-number tagged enum mirroring `rustledger_core::CostNumber`.
+ * Discriminate via the `kind` field; never probe for present-but-null fields.
+ */
+export type CostNumber =
+  | { kind: 'per_unit'; value: string }
+  | { kind: 'total'; value: string }
+  | { kind: 'per_unit_from_total'; per_unit: string; total: string };
+
+/**
  * Cost specification for a posting.
  */
 export interface CostSpec {
-  /** Per-unit cost number. */
-  number_per: string | null;
+  /** Cost number (per-unit, total, or post-booking pair). */
+  number: CostNumber | null;
   /** Cost currency. */
   currency: string | null;
   /** Acquisition date. */

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -151,13 +151,20 @@ export interface Amount {
 }
 
 /**
+ * Cost-number tagged enum mirroring `rustledger_core::CostNumber`.
+ * Discriminate via the `kind` field.
+ */
+export type CostNumber =
+    | { kind: 'per_unit'; value: string }
+    | { kind: 'total'; value: string }
+    | { kind: 'per_unit_from_total'; per_unit: string; total: string };
+
+/**
  * A cost specification.
  */
 export interface CostSpec {
-    /** Per-unit cost */
-    number_per?: string;
-    /** Total cost */
-    number_total?: string;
+    /** Cost number (per-unit, total, or post-booking pair) */
+    number?: CostNumber;
     /** Cost currency */
     currency?: string;
     /** Acquisition date */

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -40,7 +40,18 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
                         currency: u.currency().map(ToString::to_string).unwrap_or_default(),
                     }),
                     cost: p.cost.as_ref().map(|c| PostingCostJson {
-                        number_per: c.number_per.map(|n| n.to_string()),
+                        // The WASM wire shape only exposes per-unit;
+                        // `Total` (pre-booking) has no per-unit yet so
+                        // serializes as None. After booking, `Total`
+                        // becomes `PerUnitFromTotal` and surfaces the
+                        // derived per-unit. Callers wanting the
+                        // original total form should consume the
+                        // FFI-WASI wire shape, which keeps both.
+                        number_per: c
+                            .number
+                            .as_ref()
+                            .and_then(rustledger_core::CostNumber::per_unit)
+                            .map(|n| n.to_string()),
                         currency: c.currency.as_ref().map(ToString::to_string),
                         date: c.date.map(|d| d.to_string()),
                         label: c.label.clone(),

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -3,7 +3,8 @@
 use rustledger_core::Directive;
 
 use crate::types::{
-    AmountValue, CellValue, CostValue, DirectiveJson, PositionValue, PostingCostJson, PostingJson,
+    AmountValue, CellValue, CostNumberJson, CostValue, DirectiveJson, PositionValue,
+    PostingCostJson, PostingJson,
 };
 
 /// Convert a Directive to its JSON representation.
@@ -40,18 +41,22 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
                         currency: u.currency().map(ToString::to_string).unwrap_or_default(),
                     }),
                     cost: p.cost.as_ref().map(|c| PostingCostJson {
-                        // The WASM wire shape only exposes per-unit;
-                        // `Total` (pre-booking) has no per-unit yet so
-                        // serializes as None. After booking, `Total`
-                        // becomes `PerUnitFromTotal` and surfaces the
-                        // derived per-unit. Callers wanting the
-                        // original total form should consume the
-                        // FFI-WASI wire shape, which keeps both.
-                        number_per: c
-                            .number
-                            .as_ref()
-                            .and_then(rustledger_core::CostNumber::per_unit)
-                            .map(|n| n.to_string()),
+                        // The wire `CostNumberJson` is a tagged enum
+                        // mirroring `CostNumber`; JS branches on `kind`.
+                        number: c.number.map(|n| match n {
+                            rustledger_core::CostNumber::PerUnit(d) => CostNumberJson::PerUnit {
+                                value: d.to_string(),
+                            },
+                            rustledger_core::CostNumber::Total(d) => CostNumberJson::Total {
+                                value: d.to_string(),
+                            },
+                            rustledger_core::CostNumber::PerUnitFromTotal(b) => {
+                                CostNumberJson::PerUnitFromTotal {
+                                    per_unit: b.per_unit.to_string(),
+                                    total: b.total.to_string(),
+                                }
+                            }
+                        }),
                         currency: c.currency.as_ref().map(ToString::to_string),
                         date: c.date.map(|d| d.to_string()),
                         label: c.label.clone(),

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -44,12 +44,16 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
                         // The wire `CostNumberJson` is a tagged enum
                         // mirroring `CostNumber`; JS branches on `kind`.
                         number: c.number.map(|n| match n {
-                            rustledger_core::CostNumber::PerUnit(d) => CostNumberJson::PerUnit {
-                                value: d.to_string(),
-                            },
-                            rustledger_core::CostNumber::Total(d) => CostNumberJson::Total {
-                                value: d.to_string(),
-                            },
+                            rustledger_core::CostNumber::PerUnit { value: d } => {
+                                CostNumberJson::PerUnit {
+                                    value: d.to_string(),
+                                }
+                            }
+                            rustledger_core::CostNumber::Total { value: d } => {
+                                CostNumberJson::Total {
+                                    value: d.to_string(),
+                                }
+                            }
                             rustledger_core::CostNumber::PerUnitFromTotal(b) => {
                                 CostNumberJson::PerUnitFromTotal {
                                     per_unit: b.per_unit.to_string(),

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -800,7 +800,8 @@ include "accounts.beancount"
         let load = load_and_book(source);
         assert!(load.errors.is_empty(), "errors: {:?}", load.errors);
 
-        // Find the transaction and check that cost has number_per set
+        // Find the transaction and check that the booked cost carries
+        // a per-unit value derived from the source `{{...}}` total.
         let txn = load
             .directives
             .iter()
@@ -822,8 +823,10 @@ include "accounts.beancount"
 
         let cost = prop_posting.cost.as_ref().expect("should have cost");
         let per_unit = cost
-            .number_per
-            .expect("total cost {{}} should be converted to per-unit cost, but number_per is None");
+            .number
+            .as_ref()
+            .and_then(rustledger_core::CostNumber::per_unit)
+            .expect("total cost {{}} should be booked into a CostNumber that exposes per_unit()");
 
         // 150.00 / 273.2200 ≈ 0.5490
         let expected = rustledger_core::Decimal::from_str("0.5490").unwrap();
@@ -917,10 +920,13 @@ include "accounts.beancount"
             directives
                 .iter()
                 .find_map(|d| match d {
-                    rustledger_core::Directive::Transaction(t) => t
-                        .postings
-                        .iter()
-                        .find_map(|p| p.cost.as_ref().and_then(|c| c.number_per)),
+                    rustledger_core::Directive::Transaction(t) => t.postings.iter().find_map(|p| {
+                        p.cost.as_ref().and_then(|c| {
+                            c.number
+                                .as_ref()
+                                .and_then(rustledger_core::CostNumber::per_unit)
+                        })
+                    }),
                     _ => None,
                 })
                 .expect("should have a cost")

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -89,9 +89,18 @@ export interface Amount {
     currency: string;
 }
 
+/**
+ * Posting cost number. Tagged enum mirroring `rustledger_core::CostNumber`.
+ * Discriminate via the `kind` field; never probe for present-but-null fields.
+ */
+export type CostNumber =
+    | { kind: 'per_unit'; value: string }
+    | { kind: 'total'; value: string }
+    | { kind: 'per_unit_from_total'; per_unit: string; total: string };
+
 /** Posting cost specification. */
 export interface PostingCost {
-    number_per?: string;
+    number?: CostNumber;
     currency?: string;
     date?: string;
     label?: string;

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -578,7 +578,13 @@ pub struct EditorReferencesResult {
     pub references: Vec<EditorReference>,
 }
 
-#[cfg(test)]
+// Wire-format pins live in a host-only test module: they test
+// `serde_json` round-trips which are target-independent, and pulling
+// `serde_json` into the wasm32 test target activates a `getrandom`
+// transitive that fails to compile on `wasm32-unknown-unknown`
+// without the `wasm_js` backend flag. The shape we're pinning is the
+// same on every target, so running these on the host is sufficient.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod cost_number_wire_tests {
     //! Wire-format pins for #1164. Catches silent shape drift that
     //! would break TypeScript clients.

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -138,12 +138,39 @@ pub struct PostingJson {
     pub price: Option<AmountValue>,
 }
 
+/// Wire-format of the numeric component of a [`PostingCostJson`].
+///
+/// Mirrors `rustledger_core::CostNumber` on the wire so JS consumers
+/// see the same mutual exclusion the host enforces. Use the `kind`
+/// field as the discriminator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CostNumberJson {
+    /// Per-unit cost (e.g., `{100 USD}`).
+    PerUnit {
+        /// Per-unit value.
+        value: String,
+    },
+    /// Total cost as written (e.g., `{{1000 USD}}`), pre-booking.
+    Total {
+        /// Total value.
+        value: String,
+    },
+    /// Post-booking derived per-unit with preserved source total.
+    PerUnitFromTotal {
+        /// Derived per-unit.
+        per_unit: String,
+        /// Source total.
+        total: String,
+    },
+}
+
 /// A posting cost in JSON-serializable form.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostingCostJson {
-    /// Cost per unit.
+    /// Cost number (per-unit, total, or post-booking pair).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub number_per: Option<String>,
+    pub number: Option<CostNumberJson>,
     /// Cost currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<String>,
@@ -549,4 +576,96 @@ pub struct EditorReferencesResult {
     pub kind: ReferenceKind,
     /// All references found.
     pub references: Vec<EditorReference>,
+}
+
+#[cfg(test)]
+mod cost_number_wire_tests {
+    //! Wire-format pins for #1164. Catches silent shape drift that
+    //! would break TypeScript clients.
+
+    use super::*;
+
+    #[test]
+    fn per_unit_serializes_with_kind_tag() {
+        let cn = CostNumberJson::PerUnit {
+            value: "100".into(),
+        };
+        let json = serde_json::to_value(&cn).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"kind": "per_unit", "value": "100"})
+        );
+    }
+
+    #[test]
+    fn total_serializes_with_kind_tag() {
+        let cn = CostNumberJson::Total {
+            value: "1500".into(),
+        };
+        let json = serde_json::to_value(&cn).unwrap();
+        assert_eq!(json, serde_json::json!({"kind": "total", "value": "1500"}));
+    }
+
+    #[test]
+    fn per_unit_from_total_carries_both_values() {
+        let cn = CostNumberJson::PerUnitFromTotal {
+            per_unit: "150".into(),
+            total: "300".into(),
+        };
+        let json = serde_json::to_value(&cn).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "per_unit_from_total",
+                "per_unit": "150",
+                "total": "300",
+            })
+        );
+    }
+
+    #[test]
+    fn round_trip_all_variants() {
+        for cn in [
+            CostNumberJson::PerUnit { value: "1".into() },
+            CostNumberJson::Total { value: "10".into() },
+            CostNumberJson::PerUnitFromTotal {
+                per_unit: "1".into(),
+                total: "10".into(),
+            },
+        ] {
+            let json = serde_json::to_string(&cn).unwrap();
+            let back: CostNumberJson = serde_json::from_str(&json).unwrap();
+            // Same JSON on round-trip means the wire shape is stable.
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        }
+    }
+
+    #[test]
+    fn posting_cost_with_total_pre_booking_distinguishes_from_bare_brace() {
+        // Pre-PR, a `Total` cost serialized as `{number: null,
+        // currency: ...}` — indistinguishable from a deliberate
+        // `{USD}` lot match. The new shape preserves the variant.
+        let with_total = PostingCostJson {
+            number: Some(CostNumberJson::Total {
+                value: "1500".into(),
+            }),
+            currency: Some("USD".into()),
+            date: None,
+            label: None,
+        };
+        let bare = PostingCostJson {
+            number: None,
+            currency: Some("USD".into()),
+            date: None,
+            label: None,
+        };
+        let with_total_json = serde_json::to_value(&with_total).unwrap();
+        let bare_json = serde_json::to_value(&bare).unwrap();
+        assert_ne!(
+            with_total_json, bare_json,
+            "pre-booking Total and bare {{}} must serialize distinctly"
+        );
+        assert!(with_total_json["number"].is_object());
+        assert!(bare_json.get("number").is_none());
+    }
 }

--- a/crates/rustledger/src/cmd/doctor/region.rs
+++ b/crates/rustledger/src/cmd/doctor/region.rs
@@ -83,15 +83,28 @@ pub(super) fn cmd_region<W: Write>(
                     Some(Conversion::Cost) => {
                         // Use cost if available, otherwise fall back to units
                         if let Some(ref cost) = posting.cost {
-                            // Calculate total cost from cost spec
-                            let total_cost = if let Some(total) = cost.number_total {
-                                // Total cost was specified directly
+                            // Calculate total cost from cost spec. The
+                            // post-#1164 `CostNumber` enum keeps the
+                            // original total when booking derives a
+                            // per-unit (`PerUnitFromTotal`), so the
+                            // `total()` accessor is preferred here for
+                            // precision; the `PerUnit` fallback
+                            // multiplies by units, matching the pre-
+                            // #1164 branch order (total → per-unit →
+                            // none).
+                            let total_cost = if let Some(total) = cost
+                                .number
+                                .as_ref()
+                                .and_then(rustledger_core::CostNumber::total)
+                            {
                                 total
-                            } else if let Some(per_unit) = cost.number_per {
-                                // Calculate total from per-unit cost
+                            } else if let Some(per_unit) = cost
+                                .number
+                                .as_ref()
+                                .and_then(rustledger_core::CostNumber::per_unit)
+                            {
                                 amount.number * per_unit
                             } else {
-                                // No cost info, fall back to units
                                 amount.number
                             };
                             let currency = cost

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -880,10 +880,6 @@ criteria = "safe-to-deploy"
 version = "1.20.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.unicode-segmentation]]
-version = "1.13.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.untrusted]]
 version = "0.9.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -701,6 +701,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.unicode-segmentation]]
+version = "1.13.2"
+when = "2026-03-26"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
 [[publisher.unicode-width]]
 version = "0.1.14"
 when = "2024-09-19"
@@ -2851,6 +2858,15 @@ end = "2025-10-23"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.wildcard-audits.unicode-segmentation]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-05-15"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.wildcard-audits.unicode-width]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2865,7 +2881,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
## Summary

Collapses the pre-#1164 `CostSpec.{number_per, number_total}: Option<Decimal>` pair — which allowed the both-set invalid state at the type level — into a single `number: Option<CostNumber>` where `CostNumber` is a three-variant enum that makes both the pre-booking invalid state unrepresentable AND the post-booking derived state explicit.

### `CostNumber` shape

```rust
pub enum CostNumber {
    PerUnit { value: Decimal },       // user wrote `{150 USD}`
    Total   { value: Decimal },       // user wrote `{{1500 USD}}`
    PerUnitFromTotal(BookedCost),     // post-booking — derived per-unit + preserved total
}

pub struct BookedCost {
    pub per_unit: Decimal, // total / |units| during booking
    pub total: Decimal,    // original total preserved for exact residual math
}
```

The `PerUnitFromTotal` variant fills the role the old code modeled accidentally by setting both `number_per` AND `number_total` on the same spec — that state is real (the booker needs the original total for precision-preserving residual math at the `rust_decimal` 28-digit ceiling, see #1026) but the old shape encoded it only in code comments.

`BookedCost` exposes three constructors with explicit trust levels:
- `new` (debug-only invariant assert; production callers in the booker)
- `try_new` (typed `Result` for trust boundaries — FFI ingress, plugin egress)
- `from_archive_bytes_trusted` (`#[doc(hidden)]`, rkyv only)
- `from_fuzz_unchecked` (`cfg(feature = "fuzz")`, fuzz harness only)

`try_new` returns `BookedCostInvariantError` for three cases: tolerance mismatch, zero units, and `Decimal::MAX` overflow during the cross-check multiplication (a wire client can send `per_unit` and `units` that each fit in `Decimal` but whose product doesn't — that path now surfaces as a typed error instead of panicking the host).

### Unified wire format

The host enum's `kind`-tagged serde representation is used end-to-end across `rustledger_core::CostNumber`, `plugin-types::CostNumberData`, `ffi-wasi::Input/OutputCostNumber`, `wasm::CostNumberJson`, and Python compat. Wire clients discriminate on `kind` — `{"kind":"per_unit","value":"..."}` / `{"kind":"total","value":"..."}` / `{"kind":"per_unit_from_total","per_unit":"...","total":"..."}`. Pre-PR each surface had its own shape; the round-trip regression tests in `plugin-types/tests/cost_number_wire_format.rs`, `python_compat_cost_round_trip.rs`, and the rkyv-archive snapshot pin the wire contract.

### Loader cache

Bumped from v7 → v8 — old archived bytes for `Option<Decimal> + Option<Decimal>` would deserialize as garbage in the new `Option<discriminant + payload>` layout, so the header check forces regeneration. A new `cost_number_archived_bytes_match_v8_fixtures` test pins the exact bytes for each variant so any future rkyv encoding drift trips the test (forcing either a revert or a v9 bump in the same commit).

### Note on the WASM workflow

The PR's diff touches `crates/rustledger-{wasm,parser,core}/**`, which triggers the `WASM` CI workflow's `wasm-pack test --node` step — and exposed pre-existing wasm32 regressions from main (`imbl` 7's transitive `getrandom 0.3`, and `ferrolearn-bayes`'s `atomic-wait` transitive). Fixed in this PR rather than splitting:
- `.cargo/config.toml` sets `--cfg getrandom_backend="wasm_js"` for `wasm32-unknown-unknown`.
- `rustledger-wasm` declares `getrandom 0.3` with the `wasm_js` feature so Cargo unions it into the transitive instance.
- `rustledger-ops::ml` and its `ferrolearn-*`/`ndarray` deps are gated `cfg(not(target_arch = "wasm32"))` — the ML categorizer is host-only by design.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets` clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-features` all pass
- [x] `cargo build --target=wasm32-unknown-unknown --tests -p rustledger-wasm` clean
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features` clean

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
