### PR TITLE
fix(booking): respect NONE booking method during reduction (closes #1182)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -216,7 +216,21 @@ impl BookingEngine {
                     // Check if these units reduce existing cost-bearing inventory lots.
                     // Only positions with a cost basis are considered; simple (no-cost)
                     // positions are ignored to avoid misclassifying augmentations.
-                    let is_reduction = inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
+                    //
+                    // Under `option "booking_method" "NONE"` (issue #1182),
+                    // reduction matching is skipped entirely: NONE means
+                    // "accumulate positions without booking against
+                    // existing lots." Otherwise the booker would replace
+                    // the user-written `{{ total }}` cost spec with a
+                    // FIFO-matched per-unit (line ~282 below), and the
+                    // residual calculation downstream would weigh the
+                    // posting by the matched lots' costs instead of the
+                    // user's stated total — producing a phantom
+                    // E3001 imbalance for ledgers that round-trip
+                    // cleanly through Python beancount.
+                    let method = self.method_for(&posting.account);
+                    let is_reduction = method != BookingMethod::None
+                        && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
                     if is_reduction {
                         // Use reduce (not try_reduce) to actually update the working inventory.
@@ -228,7 +242,7 @@ impl BookingEngine {
                         // pipeline path in `rustledger check` filters failed transactions
                         // out of the validator's input to avoid double-reporting against
                         // the validator's independent lot-matching pass.
-                        let method = self.method_for(&posting.account);
+                        // (`method` is resolved above next to the NONE-method gate.)
                         let booking_result = inv
                             .reduce(units, Some(cost_spec), method)
                             .map_err(|e| convert_core_booking_error(e, &posting.account))?;
@@ -444,7 +458,13 @@ impl BookingEngine {
                 // signs differ for the same currency. Only cost-bearing positions
                 // are considered, so simple (no-cost) positions don't trigger
                 // false reduction detection.
-                let is_reduction = posting.cost.is_some()
+                //
+                // NONE booking (issue #1182) treats every posting as an
+                // augmentation. Mixed-sign positions accumulate in the
+                // inventory — Python beancount's semantic for the NONE
+                // method, which the parallel guard in `book()` mirrors.
+                let is_reduction = method != BookingMethod::None
+                    && posting.cost.is_some()
                     && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
                 if is_reduction {

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -285,10 +285,30 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     // commodities, pending pads, accumulated tolerances) into the late
     // phase at step 5 so balance assertions and inventory updates see
     // everything the early phase recorded.
+    //
+    // Resolve the effective booking method once, here, so both the
+    // validator (early/late phases — needs it to seed each opened
+    // account's per-account booking method, see issue #1182) and the
+    // booking engine at step 4 see the same value. File-level
+    // `option "booking_method"` wins when explicitly set; otherwise
+    // the API-level `LoadOptions.booking_method` is used.
+    #[cfg(any(feature = "validation", feature = "booking"))]
+    let effective_booking_method = {
+        let file_set = raw.options.set_options.contains("booking_method");
+        if file_set {
+            raw.options
+                .booking_method
+                .parse()
+                .unwrap_or(options.booking_method)
+        } else {
+            options.booking_method
+        }
+    };
+
     #[cfg(feature = "validation")]
     let mut validation_session = if options.validate {
         Some(rustledger_validate::ValidationSession::new(
-            build_validation_options(&raw.options, &raw.source_map),
+            build_validation_options(&raw.options, &raw.source_map, effective_booking_method),
         ))
     } else {
         None
@@ -336,18 +356,8 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     // re-merged for the final `Ledger.directives` so the user still
     // sees their original input.
     #[cfg(feature = "booking")]
-    let (mut booked, failed): (Vec<Spanned<Directive>>, Vec<Spanned<Directive>>) = {
-        let file_set_booking = raw.options.set_options.contains("booking_method");
-        let effective_method = if file_set_booking {
-            raw.options
-                .booking_method
-                .parse()
-                .unwrap_or(options.booking_method)
-        } else {
-            options.booking_method
-        };
-        run_booking(directives, effective_method, &mut errors)
-    };
+    let (mut booked, failed): (Vec<Spanned<Directive>>, Vec<Spanned<Directive>>) =
+        run_booking(directives, effective_booking_method, &mut errors);
     #[cfg(not(feature = "booking"))]
     let (mut booked, failed): (Vec<Spanned<Directive>>, Vec<Spanned<Directive>>) =
         (directives, Vec::new());
@@ -1146,6 +1156,7 @@ fn sanitize_inner_posting_spans(directive: &mut Directive, source_map: &SourceMa
 fn build_validation_options(
     file_options: &Options,
     source_map: &SourceMap,
+    default_booking_method: BookingMethod,
 ) -> rustledger_validate::ValidationOptions {
     use rustledger_validate::ValidationOptions;
 
@@ -1184,6 +1195,7 @@ fn build_validation_options(
         .with_infer_tolerance_from_cost(file_options.infer_tolerance_from_cost)
         .with_tolerance_multiplier(file_options.inferred_tolerance_multiplier)
         .with_inferred_tolerance_default(file_options.inferred_tolerance_default.clone())
+        .with_default_booking_method(default_booking_method)
 }
 
 /// Convert a batch of [`rustledger_validate::ValidationError`]s into

--- a/crates/rustledger-loader/tests/fixtures/booking_none_total_cost_1182.beancount
+++ b/crates/rustledger-loader/tests/fixtures/booking_none_total_cost_1182.beancount
@@ -1,0 +1,27 @@
+; Regression fixture for issue #1182.
+;
+; Under `option "booking_method" "NONE"`, a sell with a `{{ total }}` cost
+; spec against existing positive-quantity inventory should NOT trigger
+; lot-matching. Pre-fix, the booker treated it as a reduction and
+; replaced the user-written total with a FIFO-derived per-unit cost,
+; producing a phantom E3001 (residual 50 GBP). The validator's parallel
+; lot-match pass independently raised E4001/E4003.
+;
+; This is the reporter's exact fixture from the GitHub issue.
+
+option "booking_method" "NONE"
+
+2000-01-01 open Assets:Cash
+2000-01-01 open Assets:Broker
+
+2024-11-01 * "Broker" "Buy"
+  Assets:Broker  10 X {{ 100 GBP }}
+  Assets:Cash  -100 GBP
+
+2024-11-01 * "Broker" "Buy"
+  Assets:Broker  10 X {{ 120 GBP }}
+  Assets:Cash  -120 GBP
+
+2024-11-01 * "Broker" "Sell"
+  Assets:Broker  -15 X {{ 210 GBP }}
+  Assets:Cash  210 GBP

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -738,6 +738,42 @@ fn test_booking_method_none() {
     );
 }
 
+/// Regression for #1182. The reporter's fixture (two `{{ total }}`
+/// buys followed by a `{{ total }}` sell against the accumulated
+/// inventory) failed end-to-end under `option "booking_method" "NONE"`:
+///
+/// 1. The booker treated the sell as a reduction (signs differ),
+///    matched FIFO across both buy lots, and rewrote the cost spec
+///    from `{{ 210 GBP }}` to `PerUnit { 10 GBP }` (first lot's
+///    per-unit). The residual calc then weighed the posting at
+///    `-10*10 + -5*12 = -160 GBP` against `Assets:Cash +210 GBP`,
+///    producing a phantom E3001 imbalance of 50 GBP.
+/// 2. After gating the booker on `BookingMethod::None`, the validator's
+///    parallel lot-match pass still ran (because `AccountState.booking`
+///    defaulted to STRICT — the file-level option wasn't plumbed
+///    through), re-raising E4001/E4003.
+///
+/// The fix gates both paths on `method != BookingMethod::None` AND
+/// plumbs the file-level default into `ValidationOptions` so opens
+/// without an explicit method inherit it.
+///
+/// Asserts no error of any kind, including E3001/E4001/E4003 — they all
+/// regress the same root cause from different angles.
+#[test]
+fn test_booking_none_total_cost_no_lot_matching_1182() {
+    let path = fixtures_path("booking_none_total_cost_1182.beancount");
+    let options = LoadOptions::default();
+
+    let ledger = load(&path, &options).expect("should load and process");
+
+    assert!(
+        ledger.errors.is_empty(),
+        "issue #1182: NONE booking with {{{{ total }}}} reductions must \
+         not raise any errors — got: {:?}",
+        ledger.errors,
+    );
+}
+
 #[test]
 fn test_booking_method_strict_with_size() {
     let path = fixtures_path("booking_strict_with_size.beancount");

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -150,6 +150,16 @@ pub struct ValidationOptions {
     /// Per-currency default tolerances (matches Python beancount's `inferred_tolerance_default`).
     /// e.g., `{"GBP": 0.004}` means GBP transactions tolerate up to 0.004 residual.
     pub inferred_tolerance_default: FxHashMap<String, Decimal>,
+    /// Default booking method for accounts without an explicit method on
+    /// their `open` directive. Sourced from the file-level
+    /// `option "booking_method"` (or the API-level `LoadOptions`
+    /// default). Mirrors the resolved `effective_method` the booking
+    /// engine sees — without this, the validator's per-account
+    /// lot-matching pass falls back to `BookingMethod::default()`
+    /// (i.e., STRICT) regardless of the file's stated method,
+    /// re-raising the very `NoMatchingLot`/`AmbiguousMatch` errors
+    /// the booker just decided to skip under `NONE` (issue #1182).
+    pub default_booking_method: BookingMethod,
 }
 
 impl Default for ValidationOptions {
@@ -171,6 +181,7 @@ impl Default for ValidationOptions {
             infer_tolerance_from_cost: false,
             tolerance_multiplier: Decimal::new(5, 1), // 0.5
             inferred_tolerance_default: FxHashMap::default(),
+            default_booking_method: BookingMethod::default(),
         }
     }
 }
@@ -229,6 +240,16 @@ impl ValidationOptions {
     #[must_use]
     pub fn with_inferred_tolerance_default(mut self, defaults: FxHashMap<String, Decimal>) -> Self {
         self.inferred_tolerance_default = defaults;
+        self
+    }
+
+    /// Set the default booking method (file-level
+    /// `option "booking_method"`). Accounts without an explicit method
+    /// on their `open` directive inherit this rather than falling
+    /// through to `BookingMethod::default()`.
+    #[must_use]
+    pub const fn with_default_booking_method(mut self, method: BookingMethod) -> Self {
+        self.default_booking_method = method;
         self
     }
 }

--- a/crates/rustledger-validate/src/validators/account.rs
+++ b/crates/rustledger-validate/src/validators/account.rs
@@ -35,11 +35,17 @@ pub fn validate_open(state: &mut LedgerState, open: &Open, errors: &mut Vec<Vali
         return;
     }
 
+    // Fall back to the file-level default booking method (set from
+    // `option "booking_method"`) rather than `BookingMethod::default()`
+    // (STRICT). Without this, opening `2000-01-01 open Assets:Foo` under
+    // `option "booking_method" "NONE"` would still validate against
+    // STRICT semantics and re-raise the lot-matching errors the booker
+    // just skipped — see issue #1182.
     let booking = open
         .booking
         .as_ref()
         .and_then(|b| b.parse::<BookingMethod>().ok())
-        .unwrap_or_default();
+        .unwrap_or(state.options.default_booking_method);
 
     state.accounts.insert(
         open.account.clone(),

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -481,8 +481,17 @@ pub fn update_inventories(
         // the opposite sign for the same currency. Simple (no-cost) positions
         // are ignored. This correctly handles sell-to-open (selling into empty
         // inventory) as an augmentation, not a reduction.
-        let is_reduction =
-            posting.cost.is_some() && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
+        //
+        // Under `option "booking_method" "NONE"` (issue #1182), every
+        // posting is an augmentation — NONE accumulates positions
+        // without lot matching. Mirrors the parallel guards in
+        // `rustledger-booking::book::book` and `BookingEngine::apply`.
+        // Without this gate, the validator's independent lot-matching
+        // pass would re-raise the ambiguous/no-matching-lot errors
+        // the booker just decided to skip.
+        let is_reduction = booking_method != BookingMethod::None
+            && posting.cost.is_some()
+            && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
         if is_reduction {
             process_inventory_reduction(inv, posting, units, booking_method, txn, errors);


### PR DESCRIPTION
## Summary

`option "booking_method" "NONE"` was ignored on the reduction path. Every sign-flipping cost-bearing posting was treated as a reduction, FIFO/LIFO/etc. lot-matching ran against existing lots, and the user-written `{{ total }}` was rewritten to the matched lot's per-unit. Downstream the residual calc weighed the posting by that derived per-unit instead of the user's stated total, producing a phantom E3001 imbalance. The reporter's fixture errored with `residual 50 GBP`; bean-check accepts it cleanly.

## Fix

Two parts — the bug surfaced in both the booking engine and the validator's parallel lot-match pass:

1. **Booker** — gate `is_reduction` on `method != BookingMethod::None` in `book::book`, `BookingEngine::apply`, and the validator's `update_inventories`. NONE means every posting is an augmentation; mixed-sign positions accumulate without lot matching. Mirrors Python beancount.
2. **Plumbing** — `validate_open` was falling back to `BookingMethod::default()` (STRICT) for accounts without an explicit method on their `open`, regardless of the file-level `option "booking_method"`. Plumb the resolved `effective_method` (hoisted once in `loader::process`) into a new `ValidationOptions::default_booking_method` so both the validator session and the booking engine see the same value.

## Test plan

- [x] New regression fixture `booking_none_total_cost_1182.beancount` reproduces the reporter's exact 3-transaction sequence; integration test `test_booking_none_total_cost_no_lot_matching_1182` asserts no errors of any kind.
- [x] `bean-check` accepts the fixture (Python-compat sanity check).
- [x] Existing `test_booking_method_none` (which used `@`-priced postings, not `{{ total }}` costs) still passes — no behavioral change for the previously-covered shape.
- [x] `cargo test -p rustledger-booking -p rustledger-validate -p rustledger-loader --all-features` — all pass.
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean.

Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)