### PR TITLE
feat(query): accept string amount in CONVERT() (closes #1179)

### DIFF
--- a/crates/rustledger-core/src/amount.rs
+++ b/crates/rustledger-core/src/amount.rs
@@ -188,8 +188,9 @@ impl fmt::Display for Amount {
     }
 }
 
-/// Error produced by [`Amount::from_str`] when the input doesn't match
-/// the `<number> <currency>` shape that [`fmt::Display`] emits.
+/// Error produced by the [`FromStr`](std::str::FromStr) impl on
+/// [`Amount`] when the input doesn't match the `<number> <currency>`
+/// shape that [`fmt::Display`] emits.
 ///
 /// Carries the offending input so callers can surface an actionable
 /// message ("you wrote X, expected Y") rather than a generic parse
@@ -203,7 +204,8 @@ pub struct AmountParseError {
     pub reason: AmountParseErrorReason,
 }
 
-/// Distinguishes the failure modes of [`Amount::from_str`].
+/// Distinguishes the failure modes of [`Amount`]'s
+/// [`FromStr`](std::str::FromStr) impl.
 ///
 /// Separate from [`AmountParseError`] so callers can match on the
 /// category (e.g. for distinct error codes) without parsing the

--- a/crates/rustledger-core/src/amount.rs
+++ b/crates/rustledger-core/src/amount.rs
@@ -188,6 +188,142 @@ impl fmt::Display for Amount {
     }
 }
 
+/// Error produced by [`Amount::from_str`] when the input doesn't match
+/// the `<number> <currency>` shape that [`fmt::Display`] emits.
+///
+/// Carries the offending input so callers can surface an actionable
+/// message ("you wrote X, expected Y") rather than a generic parse
+/// failure. The wire format is strict on purpose: see the `FromStr`
+/// docstring for the supported shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmountParseError {
+    /// The original input string the caller passed.
+    pub input: String,
+    /// Why the parse failed (caller-displayable, no internal jargon).
+    pub reason: AmountParseErrorReason,
+}
+
+/// Distinguishes the failure modes of [`Amount::from_str`].
+///
+/// Separate from [`AmountParseError`] so callers can match on the
+/// category (e.g. for distinct error codes) without parsing the
+/// message string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AmountParseErrorReason {
+    /// Input had fewer or more than 2 whitespace-separated tokens.
+    NotTwoTokens,
+    /// The number token didn't parse as a [`Decimal`] (carries the
+    /// offending token, not the full input).
+    InvalidNumber(String),
+    /// The currency token isn't a valid beancount commodity (must be
+    /// uppercase ASCII letters, digits, `'`, `.`, `_`, `-`, starting
+    /// with an uppercase letter; max 24 chars).
+    InvalidCurrency(String),
+}
+
+impl fmt::Display for AmountParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.reason {
+            AmountParseErrorReason::NotTwoTokens => write!(
+                f,
+                "invalid amount literal {:?}: expected `<number> <currency>` (e.g. \"100 USD\")",
+                self.input,
+            ),
+            AmountParseErrorReason::InvalidNumber(tok) => write!(
+                f,
+                "invalid amount literal {:?}: {:?} doesn't parse as a decimal number",
+                self.input, tok,
+            ),
+            AmountParseErrorReason::InvalidCurrency(tok) => write!(
+                f,
+                "invalid amount literal {:?}: {:?} isn't a valid commodity \
+                 (uppercase ASCII, may contain digits/'./_/-, max 24 chars)",
+                self.input, tok,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AmountParseError {}
+
+impl std::str::FromStr for Amount {
+    type Err = AmountParseError;
+
+    /// Parse `<number> <currency>` — the exact shape produced by
+    /// [`fmt::Display`]. Round-trip is lossless:
+    /// `Amount::from_str(&amt.to_string()) == Ok(amt)`.
+    ///
+    /// Strict by design — there is intentionally no Python beancount
+    /// equivalent of this parser, so we set the wire contract. Accepts:
+    /// - Any whitespace (one or more spaces/tabs) between the number
+    ///   and currency.
+    /// - Leading or trailing whitespace around the whole string.
+    /// - Negative numbers (`-100 USD`).
+    /// - Fractional decimals (`100.50 USD`).
+    ///
+    /// Rejects (typed error rather than silent fallback):
+    /// - Currency-first form (`"USD 100"`).
+    /// - Number-only (`"100"`) or currency-only (`"USD"`).
+    /// - Scientific notation (`"1e2 USD"`).
+    /// - Thousands separators (`"1,000 USD"`).
+    /// - Lowercase commodity (`"100 usd"`).
+    /// - Empty / whitespace-only strings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmountParseError`] describing which axis of the
+    /// expected shape was violated; see [`AmountParseErrorReason`].
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.split_whitespace();
+        let (Some(num_tok), Some(cur_tok), None) = (iter.next(), iter.next(), iter.next()) else {
+            return Err(AmountParseError {
+                input: s.to_string(),
+                reason: AmountParseErrorReason::NotTwoTokens,
+            });
+        };
+
+        // `from_str_exact` rejects scientific notation, thousands
+        // separators, embedded whitespace — exactly what we want for
+        // strict parsing.
+        let number = Decimal::from_str_exact(num_tok).map_err(|_| AmountParseError {
+            input: s.to_string(),
+            reason: AmountParseErrorReason::InvalidNumber(num_tok.to_string()),
+        })?;
+
+        if !is_valid_commodity(cur_tok) {
+            return Err(AmountParseError {
+                input: s.to_string(),
+                reason: AmountParseErrorReason::InvalidCurrency(cur_tok.to_string()),
+            });
+        }
+
+        Ok(Self::new(number, cur_tok))
+    }
+}
+
+/// Beancount commodity validation: uppercase letter first, then
+/// uppercase letters, digits, `'`, `.`, `_`, or `-`. 1–24 chars.
+///
+/// Matches the parser's commodity-token rule (see
+/// `rustledger-parser::lexer`). Kept inline here rather than reaching
+/// into the parser to avoid a `rustledger-core → rustledger-parser`
+/// dep cycle (parser already depends on core).
+fn is_valid_commodity(s: &str) -> bool {
+    if s.is_empty() || s.len() > 24 {
+        return false;
+    }
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_uppercase() {
+        return false;
+    }
+    chars.all(|c| {
+        c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '\'' | '.' | '_' | '-')
+    })
+}
+
 // Arithmetic operations on references
 
 impl Add for &Amount {
@@ -541,5 +677,138 @@ mod tests {
         // Different currencies
         let f = Amount::new(dec!(100.00), "EUR");
         assert!(!a.eq_auto_tolerance(&f));
+    }
+
+    // ===== FromStr tests (#1179) =====
+
+    use std::str::FromStr;
+
+    #[test]
+    fn amount_from_str_round_trips_display() {
+        // Load-bearing invariant: `from_str(&amt.to_string()) == Ok(amt)`.
+        // If `Display` or `FromStr` ever drifts apart, this catches it
+        // before silent breakage. Cover positive, negative, fractional,
+        // zero, and large magnitudes.
+        for amt in [
+            Amount::new(dec!(100), "USD"),
+            Amount::new(dec!(-50.25), "EUR"),
+            Amount::new(dec!(0), "GBP"),
+            Amount::new(dec!(1234567.89), "JPY"),
+            Amount::new(dec!(0.0001), "USD"),
+        ] {
+            let displayed = amt.to_string();
+            assert_eq!(
+                Amount::from_str(&displayed),
+                Ok(amt.clone()),
+                "round-trip lost data: Display produced {displayed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn amount_from_str_accepts_canonical_forms() {
+        assert_eq!(
+            Amount::from_str("100 USD"),
+            Ok(Amount::new(dec!(100), "USD"))
+        );
+        assert_eq!(
+            Amount::from_str("-50.25 EUR"),
+            Ok(Amount::new(dec!(-50.25), "EUR"))
+        );
+        // Extra whitespace around tokens is fine — we use
+        // split_whitespace, which collapses runs of spaces/tabs.
+        assert_eq!(
+            Amount::from_str("  100   USD  "),
+            Ok(Amount::new(dec!(100), "USD"))
+        );
+        // Single character commodity is legal.
+        assert_eq!(Amount::from_str("1 X"), Ok(Amount::new(dec!(1), "X")));
+        // Commodity with allowed special chars (`'`, `.`, `_`, `-`,
+        // digits after the first character).
+        assert_eq!(
+            Amount::from_str("100 RY-2024"),
+            Ok(Amount::new(dec!(100), "RY-2024"))
+        );
+    }
+
+    #[test]
+    fn amount_from_str_rejects_currency_first() {
+        // `"USD 100"` looks like a unit-only form to humans but isn't
+        // what Display emits. Reject so users don't get silent wrong
+        // results — `USD` would parse as the number token and fail at
+        // `Decimal::from_str_exact`.
+        let err = Amount::from_str("USD 100").expect_err("currency-first must reject");
+        assert!(matches!(
+            err.reason,
+            AmountParseErrorReason::InvalidNumber(_)
+        ));
+    }
+
+    #[test]
+    fn amount_from_str_rejects_single_token() {
+        for s in ["", "  ", "100", "USD"] {
+            let err = Amount::from_str(s).expect_err("single token must reject");
+            assert!(
+                matches!(err.reason, AmountParseErrorReason::NotTwoTokens),
+                "expected NotTwoTokens for {s:?}, got {:?}",
+                err.reason
+            );
+        }
+    }
+
+    #[test]
+    fn amount_from_str_rejects_extra_tokens() {
+        let err = Amount::from_str("100 USD extra").expect_err("trailing token must reject");
+        assert!(matches!(err.reason, AmountParseErrorReason::NotTwoTokens));
+    }
+
+    #[test]
+    fn amount_from_str_rejects_scientific_notation() {
+        // `Decimal::from_str_exact` rejects `1e2` — we want that strict
+        // behavior here so `CONVERT('1e2 USD', 'EUR')` fails loudly
+        // rather than parsing incorrectly or coercing.
+        let err = Amount::from_str("1e2 USD").expect_err("scientific must reject");
+        assert!(matches!(
+            err.reason,
+            AmountParseErrorReason::InvalidNumber(_)
+        ));
+    }
+
+    #[test]
+    fn amount_from_str_rejects_thousands_separator() {
+        let err = Amount::from_str("1,000 USD").expect_err("thousands sep must reject");
+        assert!(matches!(
+            err.reason,
+            AmountParseErrorReason::InvalidNumber(_)
+        ));
+    }
+
+    #[test]
+    fn amount_from_str_rejects_lowercase_currency() {
+        let err = Amount::from_str("100 usd").expect_err("lowercase commodity must reject");
+        assert!(matches!(
+            err.reason,
+            AmountParseErrorReason::InvalidCurrency(_)
+        ));
+    }
+
+    #[test]
+    fn amount_from_str_rejects_currency_starting_with_digit() {
+        // Beancount commodities must start with an uppercase letter.
+        let err = Amount::from_str("100 1USD").expect_err("digit-first commodity must reject");
+        assert!(matches!(
+            err.reason,
+            AmountParseErrorReason::InvalidCurrency(_)
+        ));
+    }
+
+    #[test]
+    fn amount_from_str_error_message_names_input() {
+        // Plugin/BQL callers surface this Display to users; it must
+        // name what they wrote so they can fix it without guessing.
+        let err = Amount::from_str("oopsie daisy").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("oopsie daisy"), "error must echo input: {msg}");
+        assert!(msg.contains("doesn't parse"), "error must explain: {msg}");
     }
 }

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -60,7 +60,7 @@ pub mod visit;
 #[cfg(kani)]
 mod kani_proofs;
 
-pub use amount::{Amount, IncompleteAmount};
+pub use amount::{Amount, AmountParseError, AmountParseErrorReason, IncompleteAmount};
 pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec};
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -187,8 +187,38 @@ impl Executor<'_> {
                 }
             }
             Value::Number(n) => {
-                // Just wrap the number as an amount with the target currency
+                // Just wrap the number as an amount with the target
+                // currency. Note the asymmetry with the `Value::String`
+                // arm below: `CONVERT(100, 'EUR')` returns `100 EUR`
+                // (no conversion — the bare number has no source
+                // currency), but `CONVERT('100 USD', 'EUR')` does an
+                // actual conversion.
                 Ok(Value::Amount(Amount::new(n, &target_currency)))
+            }
+            Value::String(s) => {
+                // String input is a rustledger extension (issue #1179),
+                // not present in Python beancount. Lets users write
+                // ad-hoc currency conversions like
+                // `SELECT CONVERT('100 USD', 'EUR')` without anchoring
+                // them to a posting. Strict parser (see
+                // `Amount::from_str`): malformed input surfaces as a
+                // typed `QueryError` rather than a silent zero or a
+                // panic.
+                let amt: Amount = s.parse().map_err(|e| {
+                    QueryError::Type(format!("CONVERT: first argument {e} (e.g. \"100 USD\")"))
+                })?;
+                if amt.currency == target_currency {
+                    Ok(Value::Amount(amt))
+                } else if let Some(converted) = convert_amount(&amt) {
+                    Ok(Value::Amount(converted))
+                } else {
+                    // Match the `Value::Amount` arm: no price available
+                    // → return original unchanged. Switching to an
+                    // error here would diverge from
+                    // `CONVERT(<amount>, ...)` for the same
+                    // "no rate found" case.
+                    Ok(Value::Amount(amt))
+                }
             }
             Value::Null => {
                 // For null values (e.g., empty sum), return zero in target currency
@@ -196,7 +226,8 @@ impl Executor<'_> {
                 Ok(Value::Amount(Amount::new(Decimal::ZERO, &target_currency)))
             }
             _ => Err(QueryError::Type(
-                "CONVERT expects a position, amount, inventory, or number".to_string(),
+                "CONVERT expects a position, amount, inventory, number, or amount-string"
+                    .to_string(),
             )),
         }
     }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -100,6 +100,21 @@ fn execute_query(query_str: &str, directives: &[Directive]) -> QueryResult {
     executor.execute(&query).expect("query should execute")
 }
 
+/// Run a query expected to fail at execution time and return the error.
+///
+/// Distinct from `execute_query` so call sites stay readable when the
+/// test is asserting the *error* shape (typed `QueryError`) rather
+/// than the result rows. Parse failures still panic — those are a
+/// different category and a different test would catch them.
+#[allow(dead_code)] // Used by the #1179 string-input tests; future test files may grow more uses.
+fn execute_query_err(query_str: &str, directives: &[Directive]) -> rustledger_query::QueryError {
+    let query = parse(query_str).expect("query should parse");
+    let mut executor = Executor::new(directives);
+    executor
+        .execute(&query)
+        .expect_err("query should fail at execution")
+}
+
 // ============================================================================
 // Query Parsing Tests
 // ============================================================================
@@ -9413,4 +9428,199 @@ fn test_query_with_order_by_above_parallel_threshold() {
         first_date >= last_date,
         "ORDER BY date DESC: first={first_date}, last={last_date}"
     );
+}
+
+// ============================================================================
+// CONVERT('<amount-string>', '<currency>') — issue #1179
+// ============================================================================
+//
+// Rustledger extension (not in Python beancount): a string literal as
+// the first argument is parsed as `<number> <currency>` and converted
+// using the price database. Mirrors the existing `convert(<amount>,
+// '<currency>')` behavior — same `convert_amount` helper, same
+// "fall back to original on missing rate" semantics.
+
+/// Build a minimal one-posting ledger so the default SELECT iterates
+/// over a single row. The reporter's actual workflow today involves
+/// "a fake book with prices and a fictional account" for the same
+/// reason — BQL's default postings table needs at least one row to
+/// project the constant CONVERT result onto. Adding postings-table
+/// independence (`SELECT … FROM #constants` or scalar queries) is a
+/// separate feature.
+fn make_convert_string_test_directives() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Income:Other")),
+        Directive::Price(Price::new(
+            date(2024, 1, 10),
+            "USD",
+            Amount::new(dec!(0.85), "EUR"),
+        )),
+        // One transaction → one posting iteration target.
+        Directive::Transaction(
+            Transaction::new(date(2024, 2, 1), "Trigger")
+                .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(1), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Income:Other",
+                    Amount::new(dec!(-1), "USD"),
+                )),
+        ),
+    ]
+}
+
+#[test]
+fn test_convert_string_input_1179_reporter_example() {
+    // Reporter's example shape from the issue:
+    //   SELECT CONVERT('100 USD', 'EUR') as conversion
+    // Filtered to one row so the constant projection is unambiguous.
+    let directives = make_convert_string_test_directives();
+    let result = execute_query(
+        "SELECT CONVERT('100 USD', 'EUR') as conversion \
+         WHERE account = 'Assets:Bank'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][0] {
+        Value::Amount(amt) => {
+            assert_eq!(amt.currency.as_ref(), "EUR");
+            assert_eq!(amt.number, dec!(85.00)); // 100 × 0.85
+        }
+        other => panic!("Expected Amount, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_convert_string_input_same_currency_no_op() {
+    // When source and target currencies match, the parsed amount is
+    // returned unchanged — same shortcut as the `Value::Amount` arm.
+    // No price lookup happens.
+    let directives = make_convert_string_test_directives();
+    let result = execute_query(
+        "SELECT CONVERT('250.50 USD', 'USD') WHERE account = 'Assets:Bank'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][0] {
+        Value::Amount(amt) => {
+            assert_eq!(amt.currency.as_ref(), "USD");
+            assert_eq!(amt.number, dec!(250.50));
+        }
+        other => panic!("Expected Amount, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_convert_string_input_no_rate_returns_original() {
+    // Match the `Value::Amount` arm: when no price is available the
+    // original is returned unchanged rather than errored. Diverging
+    // here would surprise users mixing string and amount inputs.
+    // (No USD→GBP price in the fixture.)
+    let directives = make_convert_string_test_directives();
+    let result = execute_query(
+        "SELECT CONVERT('100 USD', 'GBP') WHERE account = 'Assets:Bank'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][0] {
+        Value::Amount(amt) => {
+            // No rate → original amount, original currency.
+            assert_eq!(amt.currency.as_ref(), "USD");
+            assert_eq!(amt.number, dec!(100));
+        }
+        other => panic!("Expected Amount with original currency, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_convert_string_input_negative_amount() {
+    // Negative amounts are accepted by `Amount::from_str` and
+    // round-trip through the price multiply correctly. Pin so a future
+    // strictening of the parser doesn't accidentally reject signs.
+    let directives = make_convert_string_test_directives();
+    let result = execute_query(
+        "SELECT CONVERT('-100 USD', 'EUR') WHERE account = 'Assets:Bank'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][0] {
+        Value::Amount(amt) => {
+            assert_eq!(amt.currency.as_ref(), "EUR");
+            assert_eq!(amt.number, dec!(-85.00));
+        }
+        other => panic!("Expected Amount, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_convert_string_input_with_explicit_date() {
+    // The 3-arg form `CONVERT(value, currency, date)` works the same
+    // way for string input — picks the rate at the given date.
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Income:Other")),
+        Directive::Price(Price::new(
+            date(2024, 1, 1),
+            "USD",
+            Amount::new(dec!(0.80), "EUR"),
+        )),
+        Directive::Price(Price::new(
+            date(2024, 6, 1),
+            "USD",
+            Amount::new(dec!(0.95), "EUR"),
+        )),
+        Directive::Transaction(
+            Transaction::new(date(2024, 3, 15), "Trigger")
+                .with_synthesized_posting(Posting::new("Assets:Bank", Amount::new(dec!(1), "USD")))
+                .with_synthesized_posting(Posting::new(
+                    "Income:Other",
+                    Amount::new(dec!(-1), "USD"),
+                )),
+        ),
+    ];
+    let result = execute_query(
+        "SELECT CONVERT('100 USD', 'EUR', 2024-03-15) WHERE account = 'Assets:Bank'",
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    match &result.rows[0][0] {
+        Value::Amount(amt) => {
+            assert_eq!(amt.currency.as_ref(), "EUR");
+            // Latest price ≤ 2024-03-15 is the Jan 1 price (0.80).
+            assert_eq!(amt.number, dec!(80.00));
+        }
+        other => panic!("Expected Amount, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_convert_string_input_rejects_garbage() {
+    // Strict parser: malformed input becomes a typed BQL error, not
+    // a silent zero. The error message should name the offending
+    // string so users can fix it without guessing.
+    let directives = make_convert_string_test_directives();
+
+    for bad in [
+        "garbage",   // single token
+        "USD 100",   // currency-first
+        "1,000 USD", // thousands separator
+        "1e2 USD",   // scientific notation
+        "100 usd",   // lowercase commodity
+    ] {
+        let query = format!("SELECT CONVERT('{bad}', 'EUR') WHERE account = 'Assets:Bank'");
+        let err = execute_query_err(&query, &directives);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CONVERT"),
+            "input {bad:?} must surface a CONVERT-prefixed error, got: {msg}"
+        );
+        assert!(
+            msg.contains(bad),
+            "input {bad:?} must be echoed in the error, got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`CONVERT('100 USD', 'EUR')` now works as a rustledger extension to the BQL CONVERT function. Lets users write ad-hoc currency conversions on top of an existing price database without anchoring the conversion to a posting's value. Python beancount has no equivalent — the issue's compat checkbox confirms this is new ground.

Reporter's example shape:
\`\`\`sql
SELECT CONVERT('100 USD', 'EUR') WHERE account = 'Assets:Bank'
\`\`\`

## Implementation

- **`impl FromStr for Amount`** in rustledger-core. Strict parser: exactly `<number> <currency>` with whitespace between tokens. Rejects currency-first, thousands separators, scientific notation, lowercase commodities, leading-digit commodities, empty/single tokens. Lossless round-trip with `Display`.
- **`AmountParseError` / `AmountParseErrorReason`** carrying the offending input and failure category, so callers can produce actionable error messages.
- **New `Value::String` arm in `eval_convert`** that parses via `Amount::from_str`, then funnels through the existing `convert_amount` helper. Same semantics as the `Value::Amount` arm: same-currency shortcut, no-rate-found returns original unchanged.

The 3-arg form `CONVERT('100 USD', 'EUR', 2024-01-15)` works the same way — picks the rate at the specified date.

## Test plan

- [x] 10 unit tests in `rustledger-core::amount` pinning `Amount::from_str` strictness (round-trip, canonical forms, currency-first rejection, single-token rejection, extra-token rejection, scientific rejection, thousands-sep rejection, lowercase rejection, digit-first commodity rejection, error message includes input).
- [x] 6 BQL integration tests covering the reporter's example, same-currency shortcut, no-rate path, negative amounts, explicit-date form, and typed error messages for every malformed input shape.
- [x] `cargo test -p rustledger-core -p rustledger-query --all-features` — all pass.
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean.

Closes #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)