### PR TITLE
refactor(plugin): split NativePlugin into SynthPlugin + RegularPlugin markers (#1166 Q3)

### DIFF
--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -21,7 +21,9 @@ jobs:
         uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
         with:
           path: rustledger
-          sparse-checkout: docs
+          sparse-checkout: |
+            docs
+            .nvmrc
       - name: Checkout website repo (for VitePress config)
         uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6
         with:
@@ -34,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v5
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'rustledger/.nvmrc'
       - name: Install dependencies
         working-directory: website
         run: npm ci

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -185,10 +185,13 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
     // Run plugins if requested
     let run_plugins: Vec<&str> = params.plugins.iter().map(String::as_str).collect();
     if !run_plugins.is_empty() && errors.is_empty() {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
 
         for plugin_name in run_plugins {
-            if let Some(plugin) = registry.find_any(plugin_name) {
+            // External API runs plugins on already-booked input — synth
+            // plugins are a loader-internal concern and would re-emit
+            // Opens for accounts the booking pass already opened.
+            if let Some(plugin) = registry.find_regular(plugin_name) {
                 let wrappers: Vec<_> = directives
                     .iter()
                     .enumerate()

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -188,7 +188,7 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
         let registry = NativePluginRegistry::new();
 
         for plugin_name in run_plugins {
-            if let Some(plugin) = registry.find(plugin_name) {
+            if let Some(plugin) = registry.find_any(plugin_name) {
                 let wrappers: Vec<_> = directives
                     .iter()
                     .enumerate()

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -51,8 +51,8 @@ pub use vfs::{DiskFileSystem, FileSystem, VirtualFileSystem};
 // Re-export processing API when features are enabled
 #[cfg(any(feature = "booking", feature = "plugins", feature = "validation"))]
 pub use process::{
-    ErrorLocation, ErrorSeverity, Ledger, LedgerError, LoadOptions, ProcessError, load, load_raw,
-    process,
+    ErrorLocation, ErrorSeverity, ExtraPlugin, Ledger, LedgerError, LoadOptions, ProcessError,
+    load, load_raw, process,
 };
 #[cfg(feature = "plugins")]
 pub use process::{PluginPass, run_plugins};

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -598,7 +598,7 @@ pub fn run_plugins(
     // Plugins not in the native synth registry (regular natives, WASM,
     // Python) default to non-synth — they run post-booking like
     // file-authored beancount plugins.
-    let is_synth = |name: &str| -> bool { registry.find_synth(name).is_some() };
+    let is_synth_plugin = |name: &str| -> bool { registry.find_synth(name).is_some() };
 
     // The API-level `options.auto_accounts` flag is a synth source.
     if options.auto_accounts && matches!(pass, PluginPass::PreBookingSynth | PluginPass::All) {
@@ -611,7 +611,7 @@ pub fn run_plugins(
     // callers (LSP / FFI / tests on already-booked input).
     if options.run_plugins {
         for plugin in file_plugins {
-            let synth = is_synth(&plugin.name);
+            let synth = is_synth_plugin(&plugin.name);
             let in_pass = match pass {
                 PluginPass::PreBookingSynth => synth,
                 PluginPass::PostBooking => !synth,
@@ -629,7 +629,7 @@ pub fn run_plugins(
 
     // CLI extras: same synth/regular split as file plugins.
     for (i, plugin_name) in options.extra_plugins.iter().enumerate() {
-        let synth = is_synth(plugin_name);
+        let synth = is_synth_plugin(plugin_name);
         let in_pass = match pass {
             PluginPass::PreBookingSynth => synth,
             PluginPass::PostBooking => !synth,

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -505,9 +505,10 @@ fn run_booking(
 /// `unrealized`, and `valuation` see filled-in per-unit values on the
 /// `CostNumber::PerUnitFromTotal` variant).
 ///
-/// Standalone callers (LSP, FFI, tests) that operate on already-booked
-/// input should pass [`PluginPass::All`] for the historical single-pass
-/// behavior.
+/// Standalone callers (LSP / FFI / tests on already-booked input) pass
+/// [`PluginPass::PostBooking`] — synth plugins are a loader-internal
+/// concern and would re-Open already-opened accounts if run a second
+/// time.
 #[cfg(feature = "plugins")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PluginPass {
@@ -521,10 +522,6 @@ pub enum PluginPass {
     /// Includes the 28 plugins that don't depend on synth state but
     /// may depend on booked cost specs.
     PostBooking,
-    /// Every plugin — historical single-pass behavior. Used by callers
-    /// (LSP, FFI, standalone tests) that don't run booking themselves
-    /// or that work on already-booked input.
-    All,
 }
 
 /// Run plugins on directives.
@@ -534,8 +531,7 @@ pub enum PluginPass {
 ///
 /// `pass` selects which subset of plugins to run — see [`PluginPass`].
 /// The loader pipeline calls this twice (synth pass before Early,
-/// regular pass after booking). LSP / FFI / standalone callers pass
-/// `PluginPass::All` for the historical behavior.
+/// regular pass after booking).
 #[cfg(feature = "plugins")]
 pub fn run_plugins(
     directives: &mut Vec<Spanned<Directive>>,
@@ -546,79 +542,75 @@ pub fn run_plugins(
     errors: &mut Vec<LedgerError>,
     pass: PluginPass,
 ) -> Result<(), ProcessError> {
-    use rustledger_plugin::{
-        DocumentDiscoveryPlugin, NativePlugin, NativePluginRegistry, PluginInput, PluginOptions,
-    };
+    use rustledger_plugin::{NativePlugin, NativePluginRegistry, PluginInput, PluginOptions};
 
-    // Resolve document directories relative to the main file's directory
-    // Document discovery only runs when run_plugins is true (respects raw mode)
+    // Resolve document directories relative to the main file's directory.
+    // Used to build doc_discovery's per-call config in the synth pass.
     let base_dir = source_map
         .files()
         .first()
         .and_then(|f| f.path.parent())
         .unwrap_or_else(|| std::path::Path::new("."));
 
-    // `document_discovery` is a synthesizer — runs in PreBookingSynth
-    // and All, skipped in PostBooking (it already injected directives
-    // during the synth pass).
-    let run_doc_discovery = matches!(pass, PluginPass::PreBookingSynth | PluginPass::All)
-        && options.run_plugins
-        && !file_options.documents.is_empty();
-    let has_document_dirs = run_doc_discovery;
-    let resolved_documents: Vec<String> = if has_document_dirs {
-        file_options
-            .documents
-            .iter()
-            .map(|d| {
-                let path = std::path::Path::new(d);
-                if path.is_absolute() {
-                    d.clone()
-                } else {
-                    base_dir.join(path).to_string_lossy().to_string()
-                }
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
+    // Access the process-wide registry singleton. The registry is
+    // immutable and stateless, so the same instance services every
+    // call.
+    let registry = NativePluginRegistry::global();
 
-    // Build the native plugin registry up front so we can classify each
-    // plugin by pass (synth vs regular) via typed lookups. Constructing
-    // the registry is O(n_plugins) and just instantiates the plugin
-    // structs; cheap to do before we know whether any plugins will run.
-    let registry = NativePluginRegistry::new();
+    // Build the unified list of plugins to invoke for this pass. Each
+    // entry carries `(name, config, force_python)`. The list includes:
+    //   1. Implicit synth plugins triggered by `LoadOptions` /
+    //      `file_options` (auto_accounts via `options.auto_accounts`;
+    //      document_discovery via non-empty `file_options.documents`).
+    //   2. File-declared plugins from `plugin "..."` directives.
+    //   3. CLI `--plugin` extras.
+    // Pass classification happens here — once — via `registry.find_synth`.
+    // A plugin enters the list iff its pass matches the requested `pass`.
+    let mut entries: Vec<(String, Option<String>, bool)> = Vec::new();
 
-    // Collect raw plugin names first (we'll resolve them with the registry later)
-    // Tuple: (name, config, force_python)
-    let mut raw_plugins: Vec<(String, Option<String>, bool)> = Vec::new();
-
-    // Classify a plugin by name using the typed registry. A plugin is
-    // synth iff `find_synth` returns Some — i.e. it implements the
-    // `SynthPlugin` marker trait (see `rustledger-plugin/src/native/mod.rs`).
-    // Plugins not in the native synth registry (regular natives, WASM,
-    // Python) default to non-synth — they run post-booking like
-    // file-authored beancount plugins.
-    let is_synth_plugin = |name: &str| -> bool { registry.find_synth(name).is_some() };
-
-    // The API-level `options.auto_accounts` flag is a synth source.
-    if options.auto_accounts && matches!(pass, PluginPass::PreBookingSynth | PluginPass::All) {
-        raw_plugins.push(("auto_accounts".to_string(), None, false));
+    if matches!(pass, PluginPass::PreBookingSynth) {
+        // Implicit synth: API-level auto_accounts flag.
+        if options.auto_accounts {
+            entries.push(("auto_accounts".to_string(), None, false));
+        }
+        // Implicit synth: document_discovery, driven by `option "documents"`.
+        // The plugin sits in the registry as a ZST; we hand it the
+        // resolved directories + base_dir via its config JSON.
+        if options.run_plugins && !file_options.documents.is_empty() {
+            let resolved: Vec<String> = file_options
+                .documents
+                .iter()
+                .map(|d| {
+                    let path = std::path::Path::new(d);
+                    if path.is_absolute() {
+                        d.clone()
+                    } else {
+                        base_dir.join(path).to_string_lossy().to_string()
+                    }
+                })
+                .collect();
+            let config = rustledger_plugin::document_discovery_config(base_dir, &resolved);
+            entries.push((
+                rustledger_plugin::DOCUMENT_DISCOVERY_NAME.to_string(),
+                Some(config),
+                false,
+            ));
+        }
     }
 
-    // File-declared plugins: synth plugins go in PreBookingSynth,
-    // everything else (including the 6 cost-spec-reading ones) goes in
-    // PostBooking. `PluginPass::All` runs everything for standalone
-    // callers (LSP / FFI / tests on already-booked input).
+    let pass_matches = |name: &str| -> bool {
+        let synth = registry.find_synth(name).is_some();
+        match pass {
+            PluginPass::PreBookingSynth => synth,
+            PluginPass::PostBooking => !synth,
+        }
+    };
+
+    // File-declared plugins.
     if options.run_plugins {
         for plugin in file_plugins {
-            let synth = is_synth_plugin(&plugin.name);
-            let in_pass = match pass {
-                PluginPass::PreBookingSynth => synth,
-                PluginPass::PostBooking => !synth,
-                PluginPass::All => true,
-            };
-            if in_pass {
-                raw_plugins.push((
+            if pass_matches(&plugin.name) {
+                entries.push((
                     plugin.name.clone(),
                     plugin.config.clone(),
                     plugin.force_python,
@@ -627,22 +619,15 @@ pub fn run_plugins(
         }
     }
 
-    // CLI extras: same synth/regular split as file plugins.
+    // CLI extra plugins.
     for (i, plugin_name) in options.extra_plugins.iter().enumerate() {
-        let synth = is_synth_plugin(plugin_name);
-        let in_pass = match pass {
-            PluginPass::PreBookingSynth => synth,
-            PluginPass::PostBooking => !synth,
-            PluginPass::All => true,
-        };
-        if in_pass {
+        if pass_matches(plugin_name) {
             let config = options.extra_plugin_configs.get(i).cloned().flatten();
-            raw_plugins.push((plugin_name.clone(), config, false));
+            entries.push((plugin_name.clone(), config, false));
         }
     }
 
-    // Check if we have any work to do - early return before creating registry
-    if raw_plugins.is_empty() && !has_document_dirs {
+    if entries.is_empty() {
         return Ok(());
     }
 
@@ -651,63 +636,36 @@ pub fn run_plugins(
         title: file_options.title.clone(),
     };
 
-    // Run document discovery plugin if documents directories are configured.
-    // Each plugin call builds wrappers freshly from the current `directives`,
-    // sends them to the plugin, receives `PluginOp`s, and applies the ops
-    // to update `directives` — spans on `Keep` / `Modify` ops are inherited
-    // from the original `directives` entry by index, so plugin-transformed
-    // directives retain byte-precise source locations.
-    if has_document_dirs {
-        let doc_plugin = DocumentDiscoveryPlugin::new(resolved_documents, base_dir.to_path_buf());
-        let wrappers = build_wrappers(directives, source_map);
-        let input = PluginInput {
-            directives: wrappers,
-            options: plugin_options.clone(),
-            config: None,
-        };
-        let output = doc_plugin.process(input);
-        record_plugin_errors(errors, output.errors, source_map);
-        apply_plugin_ops(directives, output.ops, errors, source_map)?;
-    }
-
-    // Run each plugin (registry was constructed earlier for the pass
-    // classification step).
-    if !raw_plugins.is_empty() {
-        for (raw_name, plugin_config, force_python) in &raw_plugins {
+    // Dispatch each entry. Native plugins resolve through the typed
+    // registry (`find_synth` / `find_regular`) keyed on the pass — the
+    // returned reference type reflects the pass. Anything that doesn't
+    // resolve falls through to the WASM/Python branches.
+    {
+        for (raw_name, plugin_config, force_python) in &entries {
             // Resolve the plugin name - try direct match first, then prefixed variants.
             // Skip native resolution when force_python is set (plugin "python:..." prefix).
-            // Existence checks use `find_any` (cross-pass) because at name-resolution
+            // Existence checks use `has` (cross-pass) because at name-resolution
             // time we only care "is this a known native plugin?"; the pass-correct
             // lookup happens at the invocation site below.
             let resolved_name = if *force_python {
                 None
-            } else if registry.find_any(raw_name).is_some() {
+            } else if registry.has(raw_name) {
                 Some(raw_name.as_str())
             } else if let Some(short_name) = raw_name.strip_prefix("beancount.plugins.") {
-                registry
-                    .find_any(short_name)
-                    .is_some()
-                    .then_some(short_name)
+                registry.has(short_name).then_some(short_name)
             } else if let Some(short_name) = raw_name.strip_prefix("beancount_reds_plugins.") {
-                registry
-                    .find_any(short_name)
-                    .is_some()
-                    .then_some(short_name)
+                registry.has(short_name).then_some(short_name)
             } else if let Some(short_name) = raw_name.strip_prefix("beancount_lazy_plugins.") {
-                registry
-                    .find_any(short_name)
-                    .is_some()
-                    .then_some(short_name)
+                registry.has(short_name).then_some(short_name)
             } else {
                 None
             };
 
-            // Dispatch via the typed registry: for the synth pass we look up
-            // through `find_synth` (a `RegularPlugin` won't be returned, even
-            // if it shares a name — the type system guarantees we only
-            // invoke the right kind for this pass). `All` falls back to
-            // `find_any` for standalone callers that don't care about the
-            // synth/regular split (LSP / FFI / tests on booked input).
+            // Dispatch via the typed registry: the lookup returns
+            // `Some` only if the plugin exists AND its marker trait
+            // matches the requested pass — a `RegularPlugin` won't
+            // be returned from `find_synth` (and vice versa), even
+            // on a name collision.
             let native_plugin: Option<&dyn NativePlugin> =
                 resolved_name.and_then(|name| match pass {
                     PluginPass::PreBookingSynth => {
@@ -716,7 +674,6 @@ pub fn run_plugins(
                     PluginPass::PostBooking => {
                         registry.find_regular(name).map(|p| p as &dyn NativePlugin)
                     }
-                    PluginPass::All => registry.find_any(name),
                 });
 
             if let Some(plugin) = native_plugin {

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -539,6 +539,17 @@ pub enum PluginPass {
 /// Executes native plugins (and document discovery) on the given directives,
 /// modifying them in-place. Plugin errors are appended to `errors`.
 ///
+/// A single plugin invocation in `run_plugins`'s unified dispatch
+/// list. `force_python` ("python:..." prefix) overrides native
+/// resolution; `config` is the plugin-specific string passed to
+/// `PluginInput.config`.
+#[cfg(feature = "plugins")]
+struct PluginInvocation {
+    name: String,
+    config: Option<String>,
+    force_python: bool,
+}
+
 /// `pass` selects which subset of plugins to run — see [`PluginPass`].
 /// The loader pipeline calls this twice (synth pass before Early,
 /// regular pass after booking).
@@ -567,8 +578,7 @@ pub fn run_plugins(
     // call.
     let registry = NativePluginRegistry::global();
 
-    // Build the unified list of plugins to invoke for this pass. Each
-    // entry carries `(name, config, force_python)`. The list includes:
+    // Build the unified list of plugins to invoke for this pass:
     //   1. Implicit synth plugins triggered by `LoadOptions` /
     //      `file_options` (auto_accounts via `options.auto_accounts`;
     //      document_discovery via non-empty `file_options.documents`).
@@ -576,16 +586,16 @@ pub fn run_plugins(
     //   3. CLI `--plugin` extras.
     // Pass classification happens here — once — via `registry.find_synth`.
     // A plugin enters the list iff its pass matches the requested `pass`.
-    let mut entries: Vec<(String, Option<String>, bool)> = Vec::new();
+    let mut entries: Vec<PluginInvocation> = Vec::new();
 
     if matches!(pass, PluginPass::PreBookingSynth) {
         // Implicit synth: API-level auto_accounts flag.
         if options.auto_accounts {
-            entries.push((
-                rustledger_plugin::AUTO_ACCOUNTS_NAME.to_string(),
-                None,
-                false,
-            ));
+            entries.push(PluginInvocation {
+                name: rustledger_plugin::AUTO_ACCOUNTS_NAME.to_string(),
+                config: None,
+                force_python: false,
+            });
         }
         // Implicit synth: document_discovery, driven by `option "documents"`.
         // The plugin sits in the registry as a ZST; we hand it the
@@ -603,12 +613,13 @@ pub fn run_plugins(
                     }
                 })
                 .collect();
-            let config = rustledger_plugin::document_discovery_config(base_dir, &resolved);
-            entries.push((
-                rustledger_plugin::DOCUMENT_DISCOVERY_NAME.to_string(),
-                Some(config),
-                false,
-            ));
+            entries.push(PluginInvocation {
+                name: rustledger_plugin::DOCUMENT_DISCOVERY_NAME.to_string(),
+                config: Some(rustledger_plugin::document_discovery_config(
+                    base_dir, &resolved,
+                )),
+                force_python: false,
+            });
         }
     }
 
@@ -622,11 +633,11 @@ pub fn run_plugins(
     if options.run_plugins {
         for plugin in file_plugins {
             if registry.find_synth(&plugin.name).is_some() == want_synth {
-                entries.push((
-                    plugin.name.clone(),
-                    plugin.config.clone(),
-                    plugin.force_python,
-                ));
+                entries.push(PluginInvocation {
+                    name: plugin.name.clone(),
+                    config: plugin.config.clone(),
+                    force_python: plugin.force_python,
+                });
             }
         }
     }
@@ -634,7 +645,11 @@ pub fn run_plugins(
     // CLI extra plugins.
     for extra in &options.extra_plugins {
         if registry.find_synth(&extra.name).is_some() == want_synth {
-            entries.push((extra.name.clone(), extra.config.clone(), false));
+            entries.push(PluginInvocation {
+                name: extra.name.clone(),
+                config: extra.config.clone(),
+                force_python: false,
+            });
         }
     }
 
@@ -651,26 +666,35 @@ pub fn run_plugins(
     // registry (`find_synth` / `find_regular`) keyed on the pass — the
     // returned reference type reflects the pass. Anything that doesn't
     // resolve falls through to the WASM/Python branches.
-    for (raw_name, plugin_config, force_python) in &entries {
-        // Resolve the plugin name. `has` / `find_synth` / `find_regular`
+    for invocation in &entries {
+        let PluginInvocation {
+            name: raw_name,
+            config: plugin_config,
+            force_python,
+        } = invocation;
+
+        // Dispatch via the typed registry. `find_synth`/`find_regular`
         // internally take the short name (last `.`-separated segment),
         // so prefixed names like `"beancount.plugins.implicit_prices"`
-        // and `"beancount_reds_plugins.zerosum.zerosum"` resolve through
-        // the same single call — no explicit prefix-stripping needed.
-        // `force_python` ("python:..." prefix) skips native resolution.
-        let resolved_name = (!*force_python && registry.has(raw_name)).then_some(raw_name.as_str());
-
-        // Dispatch via the typed registry: the lookup returns
-        // `Some` only if the plugin exists AND its marker trait
-        // matches the requested pass — a `RegularPlugin` won't
-        // be returned from `find_synth` (and vice versa), even
-        // on a name collision.
-        let native_plugin: Option<&dyn NativePlugin> = resolved_name.and_then(|name| match pass {
-            PluginPass::PreBookingSynth => {
-                registry.find_synth(name).map(|p| p as &dyn NativePlugin)
+        // resolve through the same call — no explicit prefix-stripping
+        // needed. Returns `Some` only if the plugin exists AND its
+        // marker trait matches the requested pass: a `RegularPlugin`
+        // won't be returned from `find_synth` (and vice versa), even
+        // on a name collision. Anything that returns `None` (WASM,
+        // Python, unknown names, wrong-pass natives) falls through
+        // to the WASM/Python branches below.
+        let native_plugin: Option<&dyn NativePlugin> = if *force_python {
+            None
+        } else {
+            match pass {
+                PluginPass::PreBookingSynth => registry
+                    .find_synth(raw_name)
+                    .map(|p| p as &dyn NativePlugin),
+                PluginPass::PostBooking => registry
+                    .find_regular(raw_name)
+                    .map(|p| p as &dyn NativePlugin),
             }
-            PluginPass::PostBooking => registry.find_regular(name).map(|p| p as &dyn NativePlugin),
-        });
+        };
 
         if let Some(plugin) = native_plugin {
             let wrappers = build_wrappers(directives, source_map);

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -9,6 +9,19 @@ use rustledger_parser::Spanned;
 use std::path::Path;
 use thiserror::Error;
 
+/// A CLI-supplied (or programmatic) extra plugin invocation.
+///
+/// Bundles the plugin name with its optional config string so the two
+/// can't drift apart — the previous parallel-Vec representation could
+/// silently misalign a config with the wrong plugin.
+#[derive(Debug, Clone)]
+pub struct ExtraPlugin {
+    /// Plugin name (short or fully-qualified module path).
+    pub name: String,
+    /// Plugin-specific config string, if any.
+    pub config: Option<String>,
+}
+
 /// Options for loading and processing a ledger.
 #[derive(Debug, Clone)]
 pub struct LoadOptions {
@@ -18,10 +31,9 @@ pub struct LoadOptions {
     pub run_plugins: bool,
     /// Run `auto_accounts` plugin (default: false).
     pub auto_accounts: bool,
-    /// Additional native plugins to run (by name).
-    pub extra_plugins: Vec<String>,
-    /// Plugin configurations for extra plugins.
-    pub extra_plugin_configs: Vec<Option<String>>,
+    /// Additional plugins to run (CLI `--plugin` or programmatic API),
+    /// each with an optional config string.
+    pub extra_plugins: Vec<ExtraPlugin>,
     /// Run validation after processing (default: true).
     pub validate: bool,
     /// Enable path security (prevent include traversal).
@@ -35,7 +47,6 @@ impl Default for LoadOptions {
             run_plugins: true,
             auto_accounts: false,
             extra_plugins: Vec::new(),
-            extra_plugin_configs: Vec::new(),
             validate: true,
             path_security: false,
         }
@@ -51,7 +62,6 @@ impl LoadOptions {
             run_plugins: false,
             auto_accounts: false,
             extra_plugins: Vec::new(),
-            extra_plugin_configs: Vec::new(),
             validate: false,
             path_security: false,
         }
@@ -622,10 +632,9 @@ pub fn run_plugins(
     }
 
     // CLI extra plugins.
-    for (i, plugin_name) in options.extra_plugins.iter().enumerate() {
-        if registry.find_synth(plugin_name).is_some() == want_synth {
-            let config = options.extra_plugin_configs.get(i).cloned().flatten();
-            entries.push((plugin_name.clone(), config, false));
+    for extra in &options.extra_plugins {
+        if registry.find_synth(&extra.name).is_some() == want_synth {
+            entries.push((extra.name.clone(), extra.config.clone(), false));
         }
     }
 
@@ -643,24 +652,13 @@ pub fn run_plugins(
     // returned reference type reflects the pass. Anything that doesn't
     // resolve falls through to the WASM/Python branches.
     for (raw_name, plugin_config, force_python) in &entries {
-        // Resolve the plugin name - try direct match first, then prefixed variants.
-        // Skip native resolution when force_python is set (plugin "python:..." prefix).
-        // Existence checks use `has` (cross-pass) because at name-resolution
-        // time we only care "is this a known native plugin?"; the pass-correct
-        // lookup happens at the invocation site below.
-        let resolved_name = if *force_python {
-            None
-        } else if registry.has(raw_name) {
-            Some(raw_name.as_str())
-        } else if let Some(short_name) = raw_name.strip_prefix("beancount.plugins.") {
-            registry.has(short_name).then_some(short_name)
-        } else if let Some(short_name) = raw_name.strip_prefix("beancount_reds_plugins.") {
-            registry.has(short_name).then_some(short_name)
-        } else if let Some(short_name) = raw_name.strip_prefix("beancount_lazy_plugins.") {
-            registry.has(short_name).then_some(short_name)
-        } else {
-            None
-        };
+        // Resolve the plugin name. `has` / `find_synth` / `find_regular`
+        // internally take the short name (last `.`-separated segment),
+        // so prefixed names like `"beancount.plugins.implicit_prices"`
+        // and `"beancount_reds_plugins.zerosum.zerosum"` resolve through
+        // the same single call — no explicit prefix-stripping needed.
+        // `force_python` ("python:..." prefix) skips native resolution.
+        let resolved_name = (!*force_python && registry.has(raw_name)).then_some(raw_name.as_str());
 
         // Dispatch via the typed registry: the lookup returns
         // `Some` only if the plugin exists AND its marker trait

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -571,7 +571,11 @@ pub fn run_plugins(
     if matches!(pass, PluginPass::PreBookingSynth) {
         // Implicit synth: API-level auto_accounts flag.
         if options.auto_accounts {
-            entries.push(("auto_accounts".to_string(), None, false));
+            entries.push((
+                rustledger_plugin::AUTO_ACCOUNTS_NAME.to_string(),
+                None,
+                false,
+            ));
         }
         // Implicit synth: document_discovery, driven by `option "documents"`.
         // The plugin sits in the registry as a ZST; we hand it the
@@ -598,18 +602,16 @@ pub fn run_plugins(
         }
     }
 
-    let pass_matches = |name: &str| -> bool {
-        let synth = registry.find_synth(name).is_some();
-        match pass {
-            PluginPass::PreBookingSynth => synth,
-            PluginPass::PostBooking => !synth,
-        }
-    };
+    // A plugin name belongs in the current pass iff its synth-marker
+    // membership matches `pass`. Non-native plugins (WASM/Python) are
+    // never in the synth registry and therefore always fall into the
+    // PostBooking pass.
+    let want_synth = matches!(pass, PluginPass::PreBookingSynth);
 
     // File-declared plugins.
     if options.run_plugins {
         for plugin in file_plugins {
-            if pass_matches(&plugin.name) {
+            if registry.find_synth(&plugin.name).is_some() == want_synth {
                 entries.push((
                     plugin.name.clone(),
                     plugin.config.clone(),
@@ -621,7 +623,7 @@ pub fn run_plugins(
 
     // CLI extra plugins.
     for (i, plugin_name) in options.extra_plugins.iter().enumerate() {
-        if pass_matches(plugin_name) {
+        if registry.find_synth(plugin_name).is_some() == want_synth {
             let config = options.extra_plugin_configs.get(i).cloned().flatten();
             entries.push((plugin_name.clone(), config, false));
         }
@@ -640,198 +642,191 @@ pub fn run_plugins(
     // registry (`find_synth` / `find_regular`) keyed on the pass — the
     // returned reference type reflects the pass. Anything that doesn't
     // resolve falls through to the WASM/Python branches.
-    {
-        for (raw_name, plugin_config, force_python) in &entries {
-            // Resolve the plugin name - try direct match first, then prefixed variants.
-            // Skip native resolution when force_python is set (plugin "python:..." prefix).
-            // Existence checks use `has` (cross-pass) because at name-resolution
-            // time we only care "is this a known native plugin?"; the pass-correct
-            // lookup happens at the invocation site below.
-            let resolved_name = if *force_python {
-                None
-            } else if registry.has(raw_name) {
-                Some(raw_name.as_str())
-            } else if let Some(short_name) = raw_name.strip_prefix("beancount.plugins.") {
-                registry.has(short_name).then_some(short_name)
-            } else if let Some(short_name) = raw_name.strip_prefix("beancount_reds_plugins.") {
-                registry.has(short_name).then_some(short_name)
-            } else if let Some(short_name) = raw_name.strip_prefix("beancount_lazy_plugins.") {
-                registry.has(short_name).then_some(short_name)
-            } else {
-                None
+    for (raw_name, plugin_config, force_python) in &entries {
+        // Resolve the plugin name - try direct match first, then prefixed variants.
+        // Skip native resolution when force_python is set (plugin "python:..." prefix).
+        // Existence checks use `has` (cross-pass) because at name-resolution
+        // time we only care "is this a known native plugin?"; the pass-correct
+        // lookup happens at the invocation site below.
+        let resolved_name = if *force_python {
+            None
+        } else if registry.has(raw_name) {
+            Some(raw_name.as_str())
+        } else if let Some(short_name) = raw_name.strip_prefix("beancount.plugins.") {
+            registry.has(short_name).then_some(short_name)
+        } else if let Some(short_name) = raw_name.strip_prefix("beancount_reds_plugins.") {
+            registry.has(short_name).then_some(short_name)
+        } else if let Some(short_name) = raw_name.strip_prefix("beancount_lazy_plugins.") {
+            registry.has(short_name).then_some(short_name)
+        } else {
+            None
+        };
+
+        // Dispatch via the typed registry: the lookup returns
+        // `Some` only if the plugin exists AND its marker trait
+        // matches the requested pass — a `RegularPlugin` won't
+        // be returned from `find_synth` (and vice versa), even
+        // on a name collision.
+        let native_plugin: Option<&dyn NativePlugin> = resolved_name.and_then(|name| match pass {
+            PluginPass::PreBookingSynth => {
+                registry.find_synth(name).map(|p| p as &dyn NativePlugin)
+            }
+            PluginPass::PostBooking => registry.find_regular(name).map(|p| p as &dyn NativePlugin),
+        });
+
+        if let Some(plugin) = native_plugin {
+            let wrappers = build_wrappers(directives, source_map);
+            let input = PluginInput {
+                directives: wrappers,
+                options: plugin_options.clone(),
+                config: plugin_config.clone(),
+            };
+            let output = plugin.process(input);
+            record_plugin_errors(errors, output.errors, source_map);
+            apply_plugin_ops(directives, output.ops, errors, source_map)?;
+        } else {
+            // Not a native plugin — categorize and handle
+            let plugin_path = std::path::Path::new(raw_name);
+            let ext = plugin_path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+
+            // The closure is only invoked from inside the wasm-plugins /
+            // python-plugins cfg blocks below. The whole function is
+            // already `#[cfg(feature = "plugins")]`, so this only matters
+            // when `plugins` is enabled but neither child feature is
+            // (e.g. `--features native-plugins`). Allow `unused_variables`
+            // for exactly that configuration. Underscore-prefixing the
+            // binding would have been the wrong fix because we DO call
+            // the closure in builds with one of the features enabled,
+            // which would trip `no_effect_underscore_binding` instead.
+            #[cfg_attr(
+                not(any(feature = "wasm-plugins", feature = "python-plugins")),
+                allow(unused_variables)
+            )]
+            let resolve_path = |name: &str| -> Result<std::path::PathBuf, String> {
+                let p = std::path::Path::new(name);
+                let resolved = if p.is_absolute() {
+                    p.to_path_buf()
+                } else {
+                    base_dir.join(name)
+                };
+
+                // Path security: prevent plugins from outside the ledger directory
+                if options.path_security
+                    && let (Ok(canon_base), Ok(canon_plugin)) =
+                        (base_dir.canonicalize(), resolved.canonicalize())
+                    && !canon_plugin.starts_with(&canon_base)
+                {
+                    return Err(format!(
+                        "plugin path '{name}' is outside the ledger directory"
+                    ));
+                }
+
+                Ok(resolved)
             };
 
-            // Dispatch via the typed registry: the lookup returns
-            // `Some` only if the plugin exists AND its marker trait
-            // matches the requested pass — a `RegularPlugin` won't
-            // be returned from `find_synth` (and vice versa), even
-            // on a name collision.
-            let native_plugin: Option<&dyn NativePlugin> =
-                resolved_name.and_then(|name| match pass {
-                    PluginPass::PreBookingSynth => {
-                        registry.find_synth(name).map(|p| p as &dyn NativePlugin)
-                    }
-                    PluginPass::PostBooking => {
-                        registry.find_regular(name).map(|p| p as &dyn NativePlugin)
-                    }
-                });
-
-            if let Some(plugin) = native_plugin {
-                let wrappers = build_wrappers(directives, source_map);
-                let input = PluginInput {
-                    directives: wrappers,
-                    options: plugin_options.clone(),
-                    config: plugin_config.clone(),
-                };
-                let output = plugin.process(input);
-                record_plugin_errors(errors, output.errors, source_map);
-                apply_plugin_ops(directives, output.ops, errors, source_map)?;
-            } else {
-                // Not a native plugin — categorize and handle
-                let plugin_path = std::path::Path::new(raw_name);
-                let ext = plugin_path
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-
-                // The closure is only invoked from inside the wasm-plugins /
-                // python-plugins cfg blocks below. The whole function is
-                // already `#[cfg(feature = "plugins")]`, so this only matters
-                // when `plugins` is enabled but neither child feature is
-                // (e.g. `--features native-plugins`). Allow `unused_variables`
-                // for exactly that configuration. Underscore-prefixing the
-                // binding would have been the wrong fix because we DO call
-                // the closure in builds with one of the features enabled,
-                // which would trip `no_effect_underscore_binding` instead.
-                #[cfg_attr(
-                    not(any(feature = "wasm-plugins", feature = "python-plugins")),
-                    allow(unused_variables)
-                )]
-                let resolve_path = |name: &str| -> Result<std::path::PathBuf, String> {
-                    let p = std::path::Path::new(name);
-                    let resolved = if p.is_absolute() {
-                        p.to_path_buf()
-                    } else {
-                        base_dir.join(name)
-                    };
-
-                    // Path security: prevent plugins from outside the ledger directory
-                    if options.path_security
-                        && let (Ok(canon_base), Ok(canon_plugin)) =
-                            (base_dir.canonicalize(), resolved.canonicalize())
-                        && !canon_plugin.starts_with(&canon_base)
-                    {
-                        return Err(format!(
-                            "plugin path '{name}' is outside the ledger directory"
-                        ));
-                    }
-
-                    Ok(resolved)
-                };
-
-                if ext == "wasm" {
-                    // WASM plugin
-                    #[cfg(feature = "wasm-plugins")]
-                    {
-                        let wasm_path = match resolve_path(raw_name) {
-                            Ok(p) => p,
-                            Err(e) => {
-                                errors.push(LedgerError::error("PLUGIN", e).with_phase("plugin"));
-                                continue;
-                            }
-                        };
-                        let wrappers = build_wrappers(directives, source_map);
-                        match run_wasm_plugin(&wasm_path, &wrappers, &plugin_options, plugin_config)
-                        {
-                            Ok((ops, plugin_errors)) => {
-                                for err in plugin_errors {
-                                    errors.push(err);
-                                }
-                                apply_plugin_ops(directives, ops, errors, source_map)?;
-                            }
-                            Err(e) => {
-                                errors.push(
-                                    LedgerError::error(
-                                        "PLUGIN",
-                                        format!("WASM plugin {} failed: {e}", wasm_path.display()),
-                                    )
-                                    .with_phase("plugin"),
-                                );
-                            }
-                        }
-                    }
-                    #[cfg(not(feature = "wasm-plugins"))]
-                    {
-                        errors.push(
-                            LedgerError::error(
-                                "PLUGIN",
-                                format!(
-                                    "WASM plugin '{raw_name}' requires the wasm-plugins feature",
-                                ),
-                            )
-                            .with_phase("plugin"),
-                        );
-                    }
-                } else if *force_python
-                    || ext == "py"
-                    || raw_name.contains(std::path::MAIN_SEPARATOR)
-                    || raw_name.contains('.')
+            if ext == "wasm" {
+                // WASM plugin
+                #[cfg(feature = "wasm-plugins")]
                 {
-                    // Python module or file-based plugin (or force_python via "python:" prefix)
-                    #[cfg(feature = "python-plugins")]
-                    {
-                        let resolved = match resolve_path(raw_name) {
-                            Ok(p) => p,
-                            Err(e) => {
-                                errors.push(LedgerError::error("PLUGIN", e).with_phase("plugin"));
-                                continue;
+                    let wasm_path = match resolve_path(raw_name) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            errors.push(LedgerError::error("PLUGIN", e).with_phase("plugin"));
+                            continue;
+                        }
+                    };
+                    let wrappers = build_wrappers(directives, source_map);
+                    match run_wasm_plugin(&wasm_path, &wrappers, &plugin_options, plugin_config) {
+                        Ok((ops, plugin_errors)) => {
+                            for err in plugin_errors {
+                                errors.push(err);
                             }
-                        };
-                        let wrappers = build_wrappers(directives, source_map);
-                        match run_python_plugin(
-                            raw_name,
-                            &resolved,
-                            base_dir,
-                            &wrappers,
-                            &plugin_options,
-                            plugin_config,
-                        ) {
-                            Ok((ops, plugin_errors)) => {
-                                for err in plugin_errors {
-                                    errors.push(err);
-                                }
-                                apply_plugin_ops(directives, ops, errors, source_map)?;
-                            }
-                            Err(e) => {
-                                errors.push(LedgerError::error("E8002", e).with_phase("plugin"));
-                            }
+                            apply_plugin_ops(directives, ops, errors, source_map)?;
+                        }
+                        Err(e) => {
+                            errors.push(
+                                LedgerError::error(
+                                    "PLUGIN",
+                                    format!("WASM plugin {} failed: {e}", wasm_path.display()),
+                                )
+                                .with_phase("plugin"),
+                            );
                         }
                     }
-                    #[cfg(not(feature = "python-plugins"))]
-                    {
-                        errors.push(
-                            LedgerError::error(
-                                "E8005",
-                                format!(
-                                    "Python plugin \"{raw_name}\" requires the python-plugins feature",
-                                ),
-                            )
-                            .with_phase("plugin"),
-                        );
+                }
+                #[cfg(not(feature = "wasm-plugins"))]
+                {
+                    errors.push(
+                        LedgerError::error(
+                            "PLUGIN",
+                            format!("WASM plugin '{raw_name}' requires the wasm-plugins feature",),
+                        )
+                        .with_phase("plugin"),
+                    );
+                }
+            } else if *force_python
+                || ext == "py"
+                || raw_name.contains(std::path::MAIN_SEPARATOR)
+                || raw_name.contains('.')
+            {
+                // Python module or file-based plugin (or force_python via "python:" prefix)
+                #[cfg(feature = "python-plugins")]
+                {
+                    let resolved = match resolve_path(raw_name) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            errors.push(LedgerError::error("PLUGIN", e).with_phase("plugin"));
+                            continue;
+                        }
+                    };
+                    let wrappers = build_wrappers(directives, source_map);
+                    match run_python_plugin(
+                        raw_name,
+                        &resolved,
+                        base_dir,
+                        &wrappers,
+                        &plugin_options,
+                        plugin_config,
+                    ) {
+                        Ok((ops, plugin_errors)) => {
+                            for err in plugin_errors {
+                                errors.push(err);
+                            }
+                            apply_plugin_ops(directives, ops, errors, source_map)?;
+                        }
+                        Err(e) => {
+                            errors.push(LedgerError::error("E8002", e).with_phase("plugin"));
+                        }
                     }
-                } else {
-                    // Completely unknown plugin name — try to suggest a module path
-                    #[cfg(feature = "python-plugins")]
-                    {
-                        use rustledger_plugin::python::{is_python_available, suggest_module_path};
-                        let suggestion = if is_python_available() {
-                            suggest_module_path(raw_name)
-                        } else {
-                            None
-                        };
-                        if let Some(module_path) = suggestion {
-                            errors.push(
+                }
+                #[cfg(not(feature = "python-plugins"))]
+                {
+                    errors.push(
+                        LedgerError::error(
+                            "E8005",
+                            format!(
+                                "Python plugin \"{raw_name}\" requires the python-plugins feature",
+                            ),
+                        )
+                        .with_phase("plugin"),
+                    );
+                }
+            } else {
+                // Completely unknown plugin name — try to suggest a module path
+                #[cfg(feature = "python-plugins")]
+                {
+                    use rustledger_plugin::python::{is_python_available, suggest_module_path};
+                    let suggestion = if is_python_available() {
+                        suggest_module_path(raw_name)
+                    } else {
+                        None
+                    };
+                    if let Some(module_path) = suggestion {
+                        errors.push(
                                 LedgerError::error(
                                     "E8004",
                                     format!(
@@ -840,18 +835,7 @@ pub fn run_plugins(
                                 )
                                 .with_phase("plugin"),
                             );
-                        } else {
-                            errors.push(
-                                LedgerError::error(
-                                    "E8001",
-                                    format!("Plugin not found: \"{raw_name}\""),
-                                )
-                                .with_phase("plugin"),
-                            );
-                        }
-                    }
-                    #[cfg(not(feature = "python-plugins"))]
-                    {
+                    } else {
                         errors.push(
                             LedgerError::error(
                                 "E8001",
@@ -861,10 +845,16 @@ pub fn run_plugins(
                         );
                     }
                 }
+                #[cfg(not(feature = "python-plugins"))]
+                {
+                    errors.push(
+                        LedgerError::error("E8001", format!("Plugin not found: \"{raw_name}\""))
+                            .with_phase("plugin"),
+                    );
+                }
             }
         }
     }
-
     // No final wrapper→directive conversion needed: `apply_plugin_ops`
     // updates `directives` in place after each plugin call, preserving
     // original spans on Keep/Modify ops. Plugin-synthesized directives

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -582,24 +582,23 @@ pub fn run_plugins(
         Vec::new()
     };
 
-    // Build the native plugin registry up front so we can ask each
-    // plugin whether it's a synthesizer (via `NativePlugin::is_synth`)
-    // during the classification step below. Constructing the registry
-    // is O(n_plugins) and just instantiates the plugin structs; it's
-    // cheap to do before we know whether any plugins will actually
-    // run.
+    // Build the native plugin registry up front so we can classify each
+    // plugin by pass (synth vs regular) via typed lookups. Constructing
+    // the registry is O(n_plugins) and just instantiates the plugin
+    // structs; cheap to do before we know whether any plugins will run.
     let registry = NativePluginRegistry::new();
 
     // Collect raw plugin names first (we'll resolve them with the registry later)
     // Tuple: (name, config, force_python)
     let mut raw_plugins: Vec<(String, Option<String>, bool)> = Vec::new();
 
-    // Classify a plugin by name. Self-classification lives on the
-    // `NativePlugin::is_synth` trait method (see
-    // `rustledger-plugin/src/native/mod.rs`). Plugins not in the
-    // native registry (WASM, Python) default to non-synth — they
-    // run post-booking like file-authored beancount plugins.
-    let is_synth = |name: &str| -> bool { registry.find(name).is_some_and(NativePlugin::is_synth) };
+    // Classify a plugin by name using the typed registry. A plugin is
+    // synth iff `find_synth` returns Some — i.e. it implements the
+    // `SynthPlugin` marker trait (see `rustledger-plugin/src/native/mod.rs`).
+    // Plugins not in the native synth registry (regular natives, WASM,
+    // Python) default to non-synth — they run post-booking like
+    // file-authored beancount plugins.
+    let is_synth = |name: &str| -> bool { registry.find_synth(name).is_some() };
 
     // The API-level `options.auto_accounts` flag is a synth source.
     if options.auto_accounts && matches!(pass, PluginPass::PreBookingSynth | PluginPass::All) {
@@ -671,29 +670,56 @@ pub fn run_plugins(
         apply_plugin_ops(directives, output.ops, errors, source_map)?;
     }
 
-    // Run each plugin (registry was constructed earlier for the
-    // synth classification step).
+    // Run each plugin (registry was constructed earlier for the pass
+    // classification step).
     if !raw_plugins.is_empty() {
         for (raw_name, plugin_config, force_python) in &raw_plugins {
             // Resolve the plugin name - try direct match first, then prefixed variants.
             // Skip native resolution when force_python is set (plugin "python:..." prefix).
+            // Existence checks use `find_any` (cross-pass) because at name-resolution
+            // time we only care "is this a known native plugin?"; the pass-correct
+            // lookup happens at the invocation site below.
             let resolved_name = if *force_python {
                 None
-            } else if registry.find(raw_name).is_some() {
+            } else if registry.find_any(raw_name).is_some() {
                 Some(raw_name.as_str())
             } else if let Some(short_name) = raw_name.strip_prefix("beancount.plugins.") {
-                registry.find(short_name).is_some().then_some(short_name)
+                registry
+                    .find_any(short_name)
+                    .is_some()
+                    .then_some(short_name)
             } else if let Some(short_name) = raw_name.strip_prefix("beancount_reds_plugins.") {
-                registry.find(short_name).is_some().then_some(short_name)
+                registry
+                    .find_any(short_name)
+                    .is_some()
+                    .then_some(short_name)
             } else if let Some(short_name) = raw_name.strip_prefix("beancount_lazy_plugins.") {
-                registry.find(short_name).is_some().then_some(short_name)
+                registry
+                    .find_any(short_name)
+                    .is_some()
+                    .then_some(short_name)
             } else {
                 None
             };
 
-            if let Some(name) = resolved_name
-                && let Some(plugin) = registry.find(name)
-            {
+            // Dispatch via the typed registry: for the synth pass we look up
+            // through `find_synth` (a `RegularPlugin` won't be returned, even
+            // if it shares a name — the type system guarantees we only
+            // invoke the right kind for this pass). `All` falls back to
+            // `find_any` for standalone callers that don't care about the
+            // synth/regular split (LSP / FFI / tests on booked input).
+            let native_plugin: Option<&dyn NativePlugin> =
+                resolved_name.and_then(|name| match pass {
+                    PluginPass::PreBookingSynth => {
+                        registry.find_synth(name).map(|p| p as &dyn NativePlugin)
+                    }
+                    PluginPass::PostBooking => {
+                        registry.find_regular(name).map(|p| p as &dyn NativePlugin)
+                    }
+                    PluginPass::All => registry.find_any(name),
+                });
+
+            if let Some(plugin) = native_plugin {
                 let wrappers = build_wrappers(directives, source_map);
                 let input = PluginInput {
                     directives: wrappers,

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -524,11 +524,14 @@ fn test_process_raw_mode() {
 
 #[test]
 fn test_process_with_extra_plugins() {
+    use rustledger_loader::ExtraPlugin;
     let path = fixtures_path("simple.beancount");
     let options = LoadOptions {
         run_plugins: false, // Don't run file plugins
-        extra_plugins: vec!["check_commodity".to_string()],
-        extra_plugin_configs: vec![None],
+        extra_plugins: vec![ExtraPlugin {
+            name: "check_commodity".to_string(),
+            config: None,
+        }],
         ..Default::default()
     };
 

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -229,23 +229,19 @@ pub fn validation_errors_to_diagnostics(
         // If booking fails, we leave the transaction as-is and let validation catch it
     }
 
-    // LSP simplification: run ALL plugins (synth + regular) post-booking,
-    // pre-validation. The loader's process::process() instead splits them —
-    // synth plugins run before Early validation, regular plugins run after
-    // booking, and Late validation runs last. The LSP path collapses these
-    // into a single pass for incremental-edit speed; see the rustdoc on
-    // validation_errors_to_diagnostics for the rationale and trade-offs.
-    // Running plugins here (rather than skipping them) still ensures
-    // plugin-transformed directives (e.g., effective_date splitting
-    // transactions across dates) are seen by validation (#793).
+    // LSP runs both plugin passes — synth then regular — on already-booked
+    // directives. The loader's process::process() splits these around its
+    // own Early/Late validation phases; the LSP collapses validation into
+    // a single step but still needs both plugin passes to fire so that
+    // synth-injected Opens (auto_accounts) suppress spurious E1001s and
+    // regular plugins (effective_date, etc.) transform directives before
+    // validation. See validation_errors_to_diagnostics for the LSP's
+    // pipeline rationale and trade-offs.
     if let Some(ctx) = plugin_ctx {
         // Emit info diagnostics for non-native plugins. The loader's run_plugins()
         // only executes native plugins — Python/WASM plugins are not run in the LSP.
         // Warn users so they understand why the LSP may disagree with `rledger check`.
-        //
-        // Create the registry once rather than calling is_builtin() per plugin
-        // (which internally allocates a new registry each time).
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
         for plugin in ctx.plugins {
             // Only show the diagnostic for plugins declared in the current file.
             if let Some(fid) = current_file_id
@@ -253,7 +249,7 @@ pub fn validation_errors_to_diagnostics(
             {
                 continue;
             }
-            let is_native = registry.find_any(&plugin.name).is_some();
+            let is_native = registry.has(&plugin.name);
             if !is_native {
                 let (start_line, start_col) = line_index.offset_to_position(plugin.span.start);
                 let (end_line, end_col) = line_index.offset_to_position(plugin.span.end);
@@ -284,15 +280,29 @@ pub fn validation_errors_to_diagnostics(
 
         let load_options = LoadOptions::default();
         let mut plugin_errors = Vec::new();
-        match rustledger_loader::run_plugins(
+        // Run synth pass first so auto_accounts can synthesize Opens
+        // for accounts referenced without explicit declaration; this
+        // suppresses spurious E1001 diagnostics in the LSP.
+        let synth_result = rustledger_loader::run_plugins(
             &mut booked_directives,
             ctx.plugins,
             ctx.file_options,
             &load_options,
             ctx.source_map,
             &mut plugin_errors,
-            rustledger_loader::PluginPass::All,
-        ) {
+            rustledger_loader::PluginPass::PreBookingSynth,
+        );
+        match synth_result.and_then(|()| {
+            rustledger_loader::run_plugins(
+                &mut booked_directives,
+                ctx.plugins,
+                ctx.file_options,
+                &load_options,
+                ctx.source_map,
+                &mut plugin_errors,
+                rustledger_loader::PluginPass::PostBooking,
+            )
+        }) {
             Ok(()) => {
                 // Convert plugin errors to diagnostics.
                 // Plugin errors don't carry file_id, so we only show them

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -253,7 +253,7 @@ pub fn validation_errors_to_diagnostics(
             {
                 continue;
             }
-            let is_native = registry.find(&plugin.name).is_some();
+            let is_native = registry.find_any(&plugin.name).is_some();
             if !is_native {
                 let (start_line, start_col) = line_index.offset_to_position(plugin.span.start);
                 let (end_line, end_col) = line_index.offset_to_position(plugin.span.end);

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -57,8 +57,8 @@ pub use convert::{
     directives_to_wrappers, wrapper_to_directive, wrappers_to_directives,
 };
 pub use native::{
-    AUTO_ACCOUNTS_NAME, DOCUMENT_DISCOVERY_NAME, DocumentDiscoveryPlugin, NativePlugin,
-    NativePluginRegistry, RegularPlugin, SynthPlugin, document_discovery_config,
+    AUTO_ACCOUNTS_NAME, DOCUMENT_DISCOVERY_NAME, NativePlugin, NativePluginRegistry, RegularPlugin,
+    SynthPlugin, document_discovery_config,
 };
 #[cfg(feature = "wasm-runtime")]
 pub use runtime::{

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -57,7 +57,8 @@ pub use convert::{
     directives_to_wrappers, wrapper_to_directive, wrappers_to_directives,
 };
 pub use native::{
-    DocumentDiscoveryPlugin, NativePlugin, NativePluginRegistry, RegularPlugin, SynthPlugin,
+    DOCUMENT_DISCOVERY_NAME, DocumentDiscoveryPlugin, NativePlugin, NativePluginRegistry,
+    RegularPlugin, SynthPlugin, document_discovery_config,
 };
 #[cfg(feature = "wasm-runtime")]
 pub use runtime::{

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -57,8 +57,8 @@ pub use convert::{
     directives_to_wrappers, wrapper_to_directive, wrappers_to_directives,
 };
 pub use native::{
-    DOCUMENT_DISCOVERY_NAME, DocumentDiscoveryPlugin, NativePlugin, NativePluginRegistry,
-    RegularPlugin, SynthPlugin, document_discovery_config,
+    AUTO_ACCOUNTS_NAME, DOCUMENT_DISCOVERY_NAME, DocumentDiscoveryPlugin, NativePlugin,
+    NativePluginRegistry, RegularPlugin, SynthPlugin, document_discovery_config,
 };
 #[cfg(feature = "wasm-runtime")]
 pub use runtime::{

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -56,7 +56,9 @@ pub use convert::{
     ConversionError, directive_to_wrapper, directive_to_wrapper_with_location,
     directives_to_wrappers, wrapper_to_directive, wrappers_to_directives,
 };
-pub use native::{DocumentDiscoveryPlugin, NativePlugin, NativePluginRegistry};
+pub use native::{
+    DocumentDiscoveryPlugin, NativePlugin, NativePluginRegistry, RegularPlugin, SynthPlugin,
+};
 #[cfg(feature = "wasm-runtime")]
 pub use runtime::{
     Plugin, PluginManager, RuntimeConfig, WasmPluginDirScanReport, WatchingPluginManager,

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -208,17 +208,15 @@ impl NativePluginRegistry {
             .map(std::convert::AsRef::as_ref)
     }
 
-    /// List all available plugins (both passes).
-    pub fn list(&self) -> Vec<&dyn NativePlugin> {
-        let mut out: Vec<&dyn NativePlugin> =
-            Vec::with_capacity(self.synth.len() + self.regular.len());
-        for p in &self.synth {
-            out.push(p.as_ref() as &dyn NativePlugin);
-        }
-        for p in &self.regular {
-            out.push(p.as_ref() as &dyn NativePlugin);
-        }
-        out
+    /// Iterate every plugin in the registry, synth then regular.
+    /// Returns trait references upcast to the base [`NativePlugin`] —
+    /// callers that need pass information should use
+    /// [`Self::find_synth`] / [`Self::find_regular`] instead.
+    pub fn iter(&self) -> impl Iterator<Item = &dyn NativePlugin> {
+        self.synth
+            .iter()
+            .map(|p| p.as_ref() as &dyn NativePlugin)
+            .chain(self.regular.iter().map(|p| p.as_ref() as &dyn NativePlugin))
     }
 
     /// Check if a name refers to any plugin in this registry, in
@@ -338,7 +336,7 @@ mod tests {
     fn test_registry_synth_and_regular_are_disjoint() {
         let registry = NativePluginRegistry::global();
 
-        for plugin in registry.list() {
+        for plugin in registry.iter() {
             let name = plugin.name();
             let in_synth = registry.find_synth(name).is_some();
             let in_regular = registry.find_regular(name).is_some();

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -20,18 +20,41 @@
 //! Each native plugin declares which pass it runs in by implementing
 //! either [`SynthPlugin`] or [`RegularPlugin`] (both extend the base
 //! [`NativePlugin`] trait). The registry holds two separately-typed
-//! `Vec`s, and the loader's runner consults the typed registry for
-//! the appropriate pass — a regular plugin can't accidentally be
-//! invoked in the synth pass because the registry lookup wouldn't
-//! find it there.
+//! Vecs (`Vec<Box<dyn SynthPlugin>>` and `Vec<Box<dyn RegularPlugin>>`),
+//! and the loader's runner consults the typed registry for the
+//! appropriate pass via [`NativePluginRegistry::find_synth`] /
+//! [`NativePluginRegistry::find_regular`]. The returned trait
+//! reference's type matches the pass: `find_synth` can never return
+//! a `RegularPlugin` and vice versa, so the dispatch site can't
+//! accidentally invoke a wrong-pass plugin even on a name collision.
+//!
+//! ## Where the discipline is enforced
+//!
+//! The marker traits are intentionally **not mutually exclusive** at
+//! the type level — `SynthPlugin` and `RegularPlugin` are empty
+//! sub-traits of `NativePlugin`, and nothing in the type system
+//! prevents a single type from implementing both. Exclusivity is
+//! enforced by:
+//!
+//! 1. **Registry construction convention**: each plugin is pushed
+//!    into exactly one of the two Vecs in `build_global_registry`.
+//! 2. **A pinned test** (`test_registry_synth_and_regular_are_disjoint`):
+//!    iterates `registry.iter()` and asserts every plugin lives in
+//!    exactly one Vec — CI catches a wrong-pass registration or a
+//!    type that implements both markers and ends up in both Vecs.
+//!
+//! The marker pair is therefore lighter than full type-level
+//! exclusivity (which would need negative trait bounds or a sealed
+//! pass-marker pattern that breaks object safety in our registry) —
+//! the cost is one assertion in CI instead of a compile error.
 //!
 //! ## Why a marker-trait pair rather than a single trait with a const
 //!
 //! `const PASS: PluginPass` on the base trait would be cleaner if
 //! consts were object-safe — but they aren't, and the registry uses
-//! trait objects (`Box<dyn NativePlugin>`) for heterogeneous
-//! storage. The marker-pair approach gets the same compile-time
-//! guarantee (a plugin can only fit one slot) at the cost of one
+//! trait objects (`Box<dyn SynthPlugin>` / `Box<dyn RegularPlugin>`)
+//! for heterogeneous storage. The marker-pair approach gives the
+//! dispatch-site type guarantee (described above) at the cost of one
 //! extra empty `impl` line per plugin.
 //!
 //! ## WASM and Python plugins
@@ -54,7 +77,13 @@ use crate::types::PluginOutput;
 /// Base capability for native plugins. Both [`SynthPlugin`] and
 /// [`RegularPlugin`] extend this — every native plugin has these
 /// three methods regardless of pass.
-pub trait NativePlugin: Send + Sync + 'static {
+///
+/// The bounds (`Send + Sync`) are the minimum to satisfy the
+/// global singleton registry; the registry's `Box<dyn ...>` storage
+/// implicitly requires `'static`, but the trait itself doesn't add
+/// that bound so external implementors can write borrowing impls
+/// for non-registry use (testing helpers, ad-hoc adapters).
+pub trait NativePlugin: Send + Sync {
     /// Plugin name (short form — `"implicit_prices"`, not the
     /// fully-qualified module path).
     fn name(&self) -> &'static str;
@@ -98,10 +127,18 @@ pub trait RegularPlugin: NativePlugin {}
 
 /// Registry of built-in native plugins, split by pass.
 ///
-/// Holding synth and regular plugins in separately-typed `Vec`s
-/// means the loader's pass-dispatch site can ask for the right kind
-/// directly — no runtime classification, no special cases, no
-/// hardcoded plugin-name lists.
+/// Holding synth and regular plugins in separately-typed `Vec`s lets
+/// the loader's pass-dispatch site ask for the right kind directly:
+/// the returned trait reference's type matches the pass, so a
+/// regular-pass plugin can't be returned from `find_synth` even on a
+/// name collision.
+///
+/// The loader still gates two **implicit** synth-pass invocations on
+/// `LoadOptions` / `Options` flags (`options.auto_accounts` and the
+/// `option "documents"` directive that drives `document_discovery`),
+/// but those flow through the same unified dispatch loop as
+/// file-declared and CLI plugins — there's no per-plugin special
+/// case at the dispatch site.
 pub struct NativePluginRegistry {
     synth: Vec<Box<dyn SynthPlugin>>,
     regular: Vec<Box<dyn RegularPlugin>>,

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -205,18 +205,9 @@ impl NativePluginRegistry {
     /// [`Self::find_regular`] instead.
     pub fn find_any(&self, name: &str) -> Option<&dyn NativePlugin> {
         let short_name = plugin_short_name(name);
-        if let Some(p) = self
-            .synth
-            .iter()
-            .find(|p| p.name() == short_name)
-            .map(std::convert::AsRef::as_ref)
-        {
-            return Some(p as &dyn NativePlugin);
-        }
-        self.regular
-            .iter()
-            .find(|p| p.name() == short_name)
-            .map(|p| std::convert::AsRef::as_ref(p) as &dyn NativePlugin)
+        let synth = self.synth.iter().map(|p| p.as_ref() as &dyn NativePlugin);
+        let regular = self.regular.iter().map(|p| p.as_ref() as &dyn NativePlugin);
+        synth.chain(regular).find(|p| p.name() == short_name)
     }
 
     /// List all available plugins (both passes).

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -2,6 +2,46 @@
 //!
 //! These plugins run as native Rust code for maximum performance.
 //! They implement the same interface as WASM plugins.
+//!
+//! ## Pass discrimination (issue #1166)
+//!
+//! Plugins run in one of two passes — see the loader's `PluginPass`
+//! enum:
+//!
+//! - **Pre-booking synth pass**: synthesizers like `auto_accounts`
+//!   and `document_discovery` that inject directives the Early
+//!   validator depends on (e.g. `Open` directives so account-
+//!   presence checks see them).
+//! - **Post-booking regular pass**: transformations on already-
+//!   booked directives — most plugins, including the cost-spec-
+//!   reading ones (`implicit_prices`, `unrealized`, etc.) that need
+//!   to see filled-in per-unit values from the booker.
+//!
+//! Each native plugin declares which pass it runs in by implementing
+//! either [`SynthPlugin`] or [`RegularPlugin`] (both extend the base
+//! [`NativePlugin`] trait). Pre-#1166 this was a single-trait runtime
+//! discriminator (`fn is_synth(&self) -> bool`); now the registry
+//! holds two separately-typed `Vec`s, and the loader's runner
+//! consults the typed registry for the appropriate pass — a regular
+//! plugin can't accidentally be invoked in the synth pass because
+//! the registry lookup wouldn't find it there.
+//!
+//! ## Why a marker-trait pair rather than a single trait with a const
+//!
+//! `const PASS: PluginPass` on the base trait would be cleaner if
+//! consts were object-safe — but they aren't, and the registry uses
+//! trait objects (`Box<dyn NativePlugin>`) for heterogeneous
+//! storage. The marker-pair approach gets the same compile-time
+//! guarantee (a plugin can only fit one slot) at the cost of one
+//! extra empty `impl` line per plugin.
+//!
+//! ## Plugins not in the native registry
+//!
+//! WASM and Python plugins are loaded at runtime by name and don't
+//! carry Rust-level type information. The loader's runner treats
+//! them as regular plugins by default; pass discrimination for
+//! those is left as future work (issue #1200's audit covers the
+//! cross-binding consistency story).
 
 mod plugins;
 
@@ -10,38 +50,60 @@ pub use plugins::*;
 use crate::types::PluginInput;
 use crate::types::PluginOutput;
 
-/// Trait for native plugins.
-pub trait NativePlugin: Send + Sync {
-    /// Plugin name.
+/// Base capability for native plugins. Both [`SynthPlugin`] and
+/// [`RegularPlugin`] extend this — every native plugin has these
+/// three methods regardless of pass.
+pub trait NativePlugin: Send + Sync + 'static {
+    /// Plugin name (short form — `"implicit_prices"`, not the
+    /// fully-qualified module path).
     fn name(&self) -> &'static str;
 
-    /// Plugin description.
+    /// Plugin description for `--help` and similar UI surfaces.
     fn description(&self) -> &'static str;
 
     /// Process directives and return modified directives + errors.
     fn process(&self, input: PluginInput) -> PluginOutput;
-
-    /// Whether this plugin synthesizes directives the loader's
-    /// `Phase::Early` validation depends on (e.g. injecting `Open`
-    /// directives so account-presence checks see them).
-    ///
-    /// Plugins returning `true` run in the loader's pre-booking pass;
-    /// plugins returning `false` (the default — transformations on
-    /// already-parsed directives) run post-booking so they see
-    /// filled-in `cost.number_per` values from the booker.
-    ///
-    /// This is the trait-level analogue of the loader's `PluginPass`
-    /// enum; the loader consults this method to classify each plugin
-    /// at scheduling time, avoiding a hardcoded list of synthesizer
-    /// names.
-    fn is_synth(&self) -> bool {
-        false
-    }
 }
 
-/// Registry of built-in native plugins.
+/// Marker trait: a plugin that runs in the **pre-booking synth pass**.
+///
+/// Synth plugins inject directives the Early validator depends on —
+/// e.g. `auto_accounts` injects `Open` directives so account-
+/// presence checks (E1001) see accounts that user code references
+/// without explicitly opening. They run BEFORE booking and BEFORE
+/// validation.
+///
+/// Implement this trait (in addition to [`NativePlugin`]) for any
+/// plugin that synthesizes directives. The registry's
+/// [`NativePluginRegistry::find_synth`] lookup only returns plugins
+/// implementing this marker; a regular plugin can't accidentally
+/// be invoked in the synth pass.
+pub trait SynthPlugin: NativePlugin {}
+
+/// Marker trait: a plugin that runs in the **post-booking regular pass**.
+///
+/// Regular plugins transform already-booked directives. The
+/// cost-spec-reading ones (`implicit_prices`,
+/// `capital_gains_classifier`, `check_average_cost`, `sell_gains`,
+/// `unrealized`, `valuation`) specifically need to see filled-in
+/// per-unit values on `CostNumber::PerUnitFromTotal` — which is
+/// what booking produces. Running them pre-booking would see the
+/// raw `Total` shape and produce wrong results.
+///
+/// Implement this trait (in addition to [`NativePlugin`]) for any
+/// plugin that transforms post-booking directives. Most plugins go
+/// here.
+pub trait RegularPlugin: NativePlugin {}
+
+/// Registry of built-in native plugins, split by pass.
+///
+/// Holding synth and regular plugins in separately-typed `Vec`s
+/// means the loader's pass-dispatch site can ask for the right kind
+/// directly — no runtime classification, no special cases, no
+/// hardcoded plugin-name lists.
 pub struct NativePluginRegistry {
-    plugins: Vec<Box<dyn NativePlugin>>,
+    synth: Vec<Box<dyn SynthPlugin>>,
+    regular: Vec<Box<dyn RegularPlugin>>,
 }
 
 /// Extract the short plugin name from a potentially qualified module path.
@@ -56,69 +118,128 @@ fn plugin_short_name(name: &str) -> &str {
 }
 
 impl NativePluginRegistry {
-    /// Create a new registry with all built-in plugins.
+    /// Create a new registry with all built-in plugins, partitioned
+    /// by pass.
+    ///
+    /// Each plugin's pass is determined by which marker trait
+    /// ([`SynthPlugin`] or [`RegularPlugin`]) it implements; the
+    /// compiler enforces the slot at registration time.
     pub fn new() -> Self {
-        Self {
-            plugins: vec![
-                Box::new(ImplicitPricesPlugin),
-                Box::new(CheckCommodityPlugin),
-                Box::new(AutoTagPlugin::new()),
-                Box::new(AutoAccountsPlugin),
-                Box::new(LeafOnlyPlugin),
-                Box::new(NoDuplicatesPlugin),
-                Box::new(OneCommodityPlugin),
-                Box::new(UniquePricesPlugin),
-                Box::new(CheckClosingPlugin),
-                Box::new(CloseTreePlugin),
-                Box::new(CoherentCostPlugin),
-                Box::new(ForecastPlugin),
-                Box::new(SellGainsPlugin),
-                Box::new(PedanticPlugin),
-                Box::new(RxTxnPlugin),
-                Box::new(SplitExpensesPlugin),
-                Box::new(UnrealizedPlugin::new()),
-                Box::new(NoUnusedPlugin),
-                Box::new(CheckDrainedPlugin),
-                Box::new(CommodityAttrPlugin::new()),
-                Box::new(CheckAverageCostPlugin::new()),
-                Box::new(CurrencyAccountsPlugin::new()),
-                Box::new(ZerosumPlugin),
-                Box::new(EffectiveDatePlugin),
-                Box::new(GenerateBaseCcyPricesPlugin),
-                Box::new(RenameAccountsPlugin),
-                Box::new(ValuationPlugin),
-                Box::new(CapitalGainsLongShortPlugin),
-                Box::new(CapitalGainsGainLossPlugin),
-                Box::new(BoxAccrualPlugin),
-            ],
-        }
+        let synth: Vec<Box<dyn SynthPlugin>> = vec![
+            Box::new(AutoAccountsPlugin),
+            // `document_discovery` is *also* a synth plugin per
+            // intent, but is instantiated per-call by the loader's
+            // runner (its constructor takes `base_dir` + resolved
+            // documents). The trait impl on `DocumentDiscoveryPlugin`
+            // still marks it correctly for any direct caller.
+        ];
+        let regular: Vec<Box<dyn RegularPlugin>> = vec![
+            Box::new(ImplicitPricesPlugin),
+            Box::new(CheckCommodityPlugin),
+            Box::new(AutoTagPlugin::new()),
+            Box::new(LeafOnlyPlugin),
+            Box::new(NoDuplicatesPlugin),
+            Box::new(OneCommodityPlugin),
+            Box::new(UniquePricesPlugin),
+            Box::new(CheckClosingPlugin),
+            Box::new(CloseTreePlugin),
+            Box::new(CoherentCostPlugin),
+            Box::new(ForecastPlugin),
+            Box::new(SellGainsPlugin),
+            Box::new(PedanticPlugin),
+            Box::new(RxTxnPlugin),
+            Box::new(SplitExpensesPlugin),
+            Box::new(UnrealizedPlugin::new()),
+            Box::new(NoUnusedPlugin),
+            Box::new(CheckDrainedPlugin),
+            Box::new(CommodityAttrPlugin::new()),
+            Box::new(CheckAverageCostPlugin::new()),
+            Box::new(CurrencyAccountsPlugin::new()),
+            Box::new(ZerosumPlugin),
+            Box::new(EffectiveDatePlugin),
+            Box::new(GenerateBaseCcyPricesPlugin),
+            Box::new(RenameAccountsPlugin),
+            Box::new(ValuationPlugin),
+            Box::new(CapitalGainsLongShortPlugin),
+            Box::new(CapitalGainsGainLossPlugin),
+            Box::new(BoxAccrualPlugin),
+        ];
+        Self { synth, regular }
     }
 
-    /// Find a plugin by name.
+    /// Find a **synth-pass** plugin by name.
     ///
-    /// Accepts both short names (`"implicit_prices"`) and fully qualified
-    /// module paths (`"beancount.plugins.implicit_prices"`).
-    pub fn find(&self, name: &str) -> Option<&dyn NativePlugin> {
+    /// Returns `None` if the plugin doesn't exist OR if it exists
+    /// but is a regular-pass plugin — the type system guarantees the
+    /// returned reference is `dyn SynthPlugin`.
+    ///
+    /// Accepts both short names (`"auto_accounts"`) and fully
+    /// qualified module paths (`"beancount.plugins.auto_accounts"`).
+    pub fn find_synth(&self, name: &str) -> Option<&dyn SynthPlugin> {
         let short_name = plugin_short_name(name);
-        self.plugins
+        self.synth
             .iter()
             .find(|p| p.name() == short_name)
             .map(std::convert::AsRef::as_ref)
     }
 
-    /// List all available plugins.
-    pub fn list(&self) -> Vec<&dyn NativePlugin> {
-        self.plugins.iter().map(AsRef::as_ref).collect()
+    /// Find a **regular-pass** plugin by name.
+    ///
+    /// Returns `None` if the plugin doesn't exist OR if it exists
+    /// but is a synth-pass plugin — the type system guarantees the
+    /// returned reference is `dyn RegularPlugin`.
+    pub fn find_regular(&self, name: &str) -> Option<&dyn RegularPlugin> {
+        let short_name = plugin_short_name(name);
+        self.regular
+            .iter()
+            .find(|p| p.name() == short_name)
+            .map(std::convert::AsRef::as_ref)
     }
 
-    /// Check if a name refers to a built-in plugin.
+    /// Find a plugin by name without caring about its pass.
+    ///
+    /// Used by `is_builtin` and other queries that only need to know
+    /// "does a plugin with this name exist." The returned reference
+    /// is upcast to [`NativePlugin`] (the base trait); callers that
+    /// need pass information should use [`Self::find_synth`] /
+    /// [`Self::find_regular`] instead.
+    pub fn find_any(&self, name: &str) -> Option<&dyn NativePlugin> {
+        let short_name = plugin_short_name(name);
+        if let Some(p) = self
+            .synth
+            .iter()
+            .find(|p| p.name() == short_name)
+            .map(std::convert::AsRef::as_ref)
+        {
+            return Some(p as &dyn NativePlugin);
+        }
+        self.regular
+            .iter()
+            .find(|p| p.name() == short_name)
+            .map(|p| std::convert::AsRef::as_ref(p) as &dyn NativePlugin)
+    }
+
+    /// List all available plugins (both passes).
+    pub fn list(&self) -> Vec<&dyn NativePlugin> {
+        let mut out: Vec<&dyn NativePlugin> =
+            Vec::with_capacity(self.synth.len() + self.regular.len());
+        for p in &self.synth {
+            out.push(p.as_ref() as &dyn NativePlugin);
+        }
+        for p in &self.regular {
+            out.push(p.as_ref() as &dyn NativePlugin);
+        }
+        out
+    }
+
+    /// Check if a name refers to a built-in plugin (either pass).
     ///
     /// Accepts both short names and fully qualified module paths.
     pub fn is_builtin(name: &str) -> bool {
         let short_name = plugin_short_name(name);
-        // Check against registered plugin names
         let registry = Self::new();
-        registry.plugins.iter().any(|p| p.name() == short_name)
+        registry.synth.iter().any(|p| p.name() == short_name)
+            || registry.regular.iter().any(|p| p.name() == short_name)
     }
 }
 
@@ -188,28 +309,73 @@ mod tests {
     }
 
     #[test]
-    fn test_registry_find_short_name() {
+    fn test_registry_find_regular_short_name() {
         let registry = NativePluginRegistry::new();
-        assert!(registry.find("implicit_prices").is_some());
-        assert!(registry.find("zerosum").is_some());
-        assert!(registry.find("nonexistent").is_none());
+        assert!(registry.find_regular("implicit_prices").is_some());
+        assert!(registry.find_regular("zerosum").is_some());
+        assert!(registry.find_regular("nonexistent").is_none());
     }
 
     #[test]
-    fn test_registry_find_qualified_name() {
+    fn test_registry_find_regular_qualified_name() {
         let registry = NativePluginRegistry::new();
-        assert!(registry.find("beancount.plugins.implicit_prices").is_some());
-        assert!(registry.find("beanahead.plugins.rx_txn_plugin").is_some());
         assert!(
             registry
-                .find("beancount_reds_plugins.zerosum.zerosum")
+                .find_regular("beancount.plugins.implicit_prices")
                 .is_some()
         );
         assert!(
             registry
-                .find("beancount_reds_plugins.capital_gains_classifier.gain_loss")
+                .find_regular("beanahead.plugins.rx_txn_plugin")
                 .is_some()
         );
+        assert!(
+            registry
+                .find_regular("beancount_reds_plugins.zerosum.zerosum")
+                .is_some()
+        );
+        assert!(
+            registry
+                .find_regular("beancount_reds_plugins.capital_gains_classifier.gain_loss")
+                .is_some()
+        );
+    }
+
+    /// Pin the trait-split contract (issue #1166): synth plugins live
+    /// in the synth registry, regular plugins in the regular. Looking
+    /// up a synth plugin via `find_regular` returns `None` (and vice
+    /// versa). This is what catches "regular plugin invoked in synth
+    /// pass" at the type level — the lookup wouldn't find it.
+    #[test]
+    fn test_registry_synth_and_regular_are_disjoint() {
+        let registry = NativePluginRegistry::new();
+
+        // auto_accounts is synth — visible from find_synth, absent
+        // from find_regular.
+        assert!(
+            registry.find_synth("auto_accounts").is_some(),
+            "auto_accounts must be in the synth registry",
+        );
+        assert!(
+            registry.find_regular("auto_accounts").is_none(),
+            "auto_accounts must NOT be in the regular registry — the trait split would be defeated",
+        );
+
+        // implicit_prices is regular — visible from find_regular,
+        // absent from find_synth.
+        assert!(
+            registry.find_regular("implicit_prices").is_some(),
+            "implicit_prices must be in the regular registry",
+        );
+        assert!(
+            registry.find_synth("implicit_prices").is_none(),
+            "implicit_prices must NOT be in the synth registry",
+        );
+
+        // `find_any` is the cross-pass lookup — finds either.
+        assert!(registry.find_any("auto_accounts").is_some());
+        assert!(registry.find_any("implicit_prices").is_some());
+        assert!(registry.find_any("nonexistent").is_none());
     }
 
     #[test]

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -118,10 +118,10 @@ fn plugin_short_name(name: &str) -> &str {
     name.rsplit('.').next().unwrap_or(name)
 }
 
-/// Process-wide singleton registry — the registry holds no per-load
-/// state, so allocating one per call is pure waste. Use
-/// [`NativePluginRegistry::global`] to access it.
-static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(|| {
+/// Build the singleton registry. Called once per process via the
+/// `LazyLock` below; broken out as a named function so the call stack
+/// reflects what's happening at first access.
+fn build_global_registry() -> NativePluginRegistry {
     let synth: Vec<Box<dyn SynthPlugin>> = vec![
         Box::new(AutoAccountsPlugin),
         Box::new(DocumentDiscoveryPlugin),
@@ -158,7 +158,12 @@ static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(|| {
         Box::new(BoxAccrualPlugin),
     ];
     NativePluginRegistry { synth, regular }
-});
+}
+
+/// Process-wide singleton registry — the registry holds no per-load
+/// state, so allocating one per call is pure waste. Use
+/// [`NativePluginRegistry::global`] to access it.
+static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(build_global_registry);
 
 impl NativePluginRegistry {
     /// Access the process-wide registry singleton.

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -19,12 +19,11 @@
 //!
 //! Each native plugin declares which pass it runs in by implementing
 //! either [`SynthPlugin`] or [`RegularPlugin`] (both extend the base
-//! [`NativePlugin`] trait). Pre-#1166 this was a single-trait runtime
-//! discriminator (`fn is_synth(&self) -> bool`); now the registry
-//! holds two separately-typed `Vec`s, and the loader's runner
-//! consults the typed registry for the appropriate pass — a regular
-//! plugin can't accidentally be invoked in the synth pass because
-//! the registry lookup wouldn't find it there.
+//! [`NativePlugin`] trait). The registry holds two separately-typed
+//! `Vec`s, and the loader's runner consults the typed registry for
+//! the appropriate pass — a regular plugin can't accidentally be
+//! invoked in the synth pass because the registry lookup wouldn't
+//! find it there.
 //!
 //! ## Why a marker-trait pair rather than a single trait with a const
 //!
@@ -46,6 +45,8 @@
 mod plugins;
 
 pub use plugins::*;
+
+use std::sync::LazyLock;
 
 use crate::types::PluginInput;
 use crate::types::PluginOutput;
@@ -117,21 +118,28 @@ fn plugin_short_name(name: &str) -> &str {
     name.rsplit('.').next().unwrap_or(name)
 }
 
+/// Process-wide singleton registry — the registry holds no per-load
+/// state, so allocating one per call is pure waste. Use
+/// [`NativePluginRegistry::global`] to access it.
+static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(NativePluginRegistry::new);
+
 impl NativePluginRegistry {
-    /// Create a new registry with all built-in plugins, partitioned
-    /// by pass.
+    /// Access the process-wide registry singleton.
     ///
-    /// Each plugin's pass is determined by which marker trait
-    /// ([`SynthPlugin`] or [`RegularPlugin`]) it implements; the
-    /// compiler enforces the slot at registration time.
-    pub fn new() -> Self {
+    /// The registry is immutable and stateless; reuse this reference
+    /// instead of constructing a fresh registry per call. The
+    /// underlying `LazyLock` initializes on first access.
+    #[must_use]
+    pub fn global() -> &'static Self {
+        &GLOBAL_REGISTRY
+    }
+
+    /// Construct a new registry. Crate-internal — production code
+    /// should use [`Self::global`]. Kept for `Default` and tests.
+    pub(crate) fn new() -> Self {
         let synth: Vec<Box<dyn SynthPlugin>> = vec![
             Box::new(AutoAccountsPlugin),
-            // `document_discovery` is *also* a synth plugin per
-            // intent, but is instantiated per-call by the loader's
-            // runner (its constructor takes `base_dir` + resolved
-            // documents). The trait impl on `DocumentDiscoveryPlugin`
-            // still marks it correctly for any direct caller.
+            Box::new(DocumentDiscoveryPlugin),
         ];
         let regular: Vec<Box<dyn RegularPlugin>> = vec![
             Box::new(ImplicitPricesPlugin),
@@ -188,26 +196,15 @@ impl NativePluginRegistry {
     /// Returns `None` if the plugin doesn't exist OR if it exists
     /// but is a synth-pass plugin — the type system guarantees the
     /// returned reference is `dyn RegularPlugin`.
+    ///
+    /// Accepts both short names (`"implicit_prices"`) and fully
+    /// qualified module paths (`"beancount.plugins.implicit_prices"`).
     pub fn find_regular(&self, name: &str) -> Option<&dyn RegularPlugin> {
         let short_name = plugin_short_name(name);
         self.regular
             .iter()
             .find(|p| p.name() == short_name)
             .map(std::convert::AsRef::as_ref)
-    }
-
-    /// Find a plugin by name without caring about its pass.
-    ///
-    /// Used by `is_builtin` and other queries that only need to know
-    /// "does a plugin with this name exist." The returned reference
-    /// is upcast to [`NativePlugin`] (the base trait); callers that
-    /// need pass information should use [`Self::find_synth`] /
-    /// [`Self::find_regular`] instead.
-    pub fn find_any(&self, name: &str) -> Option<&dyn NativePlugin> {
-        let short_name = plugin_short_name(name);
-        let synth = self.synth.iter().map(|p| p.as_ref() as &dyn NativePlugin);
-        let regular = self.regular.iter().map(|p| p.as_ref() as &dyn NativePlugin);
-        synth.chain(regular).find(|p| p.name() == short_name)
     }
 
     /// List all available plugins (both passes).
@@ -226,11 +223,21 @@ impl NativePluginRegistry {
     /// Check if a name refers to a built-in plugin (either pass).
     ///
     /// Accepts both short names and fully qualified module paths.
+    /// Consults the global singleton — no allocation per call.
+    #[must_use]
     pub fn is_builtin(name: &str) -> bool {
+        Self::global().has(name)
+    }
+
+    /// Check if a name refers to any plugin in this registry, in
+    /// either pass. Use this for existence queries; for invocation
+    /// use [`Self::find_synth`] / [`Self::find_regular`] so the
+    /// returned reference's type carries the pass.
+    #[must_use]
+    pub fn has(&self, name: &str) -> bool {
         let short_name = plugin_short_name(name);
-        let registry = Self::new();
-        registry.synth.iter().any(|p| p.name() == short_name)
-            || registry.regular.iter().any(|p| p.name() == short_name)
+        self.synth.iter().any(|p| p.name() == short_name)
+            || self.regular.iter().any(|p| p.name() == short_name)
     }
 }
 
@@ -332,41 +339,33 @@ mod tests {
         );
     }
 
-    /// Pin the trait-split contract (issue #1166): synth plugins live
-    /// in the synth registry, regular plugins in the regular. Looking
-    /// up a synth plugin via `find_regular` returns `None` (and vice
-    /// versa). This is what catches "regular plugin invoked in synth
-    /// pass" at the type level — the lookup wouldn't find it.
+    /// Pin the trait-split contract (issue #1166): EVERY plugin in the
+    /// registry lives in exactly one pass-typed Vec. This is what
+    /// catches "regular plugin invoked in synth pass" at the type
+    /// level — the lookup in the wrong Vec wouldn't find it.
+    ///
+    /// Exhaustive over `list()` so adding a new plugin without
+    /// declaring a pass marker can't slip past CI as a Vec-membership
+    /// mistake.
     #[test]
     fn test_registry_synth_and_regular_are_disjoint() {
         let registry = NativePluginRegistry::new();
 
-        // auto_accounts is synth — visible from find_synth, absent
-        // from find_regular.
-        assert!(
-            registry.find_synth("auto_accounts").is_some(),
-            "auto_accounts must be in the synth registry",
-        );
-        assert!(
-            registry.find_regular("auto_accounts").is_none(),
-            "auto_accounts must NOT be in the regular registry — the trait split would be defeated",
-        );
+        for plugin in registry.list() {
+            let name = plugin.name();
+            let in_synth = registry.find_synth(name).is_some();
+            let in_regular = registry.find_regular(name).is_some();
+            assert!(
+                in_synth ^ in_regular,
+                "plugin {name:?} must live in exactly one pass Vec (synth={in_synth}, regular={in_regular})",
+            );
+        }
 
-        // implicit_prices is regular — visible from find_regular,
-        // absent from find_synth.
-        assert!(
-            registry.find_regular("implicit_prices").is_some(),
-            "implicit_prices must be in the regular registry",
-        );
-        assert!(
-            registry.find_synth("implicit_prices").is_none(),
-            "implicit_prices must NOT be in the synth registry",
-        );
-
-        // `find_any` is the cross-pass lookup — finds either.
-        assert!(registry.find_any("auto_accounts").is_some());
-        assert!(registry.find_any("implicit_prices").is_some());
-        assert!(registry.find_any("nonexistent").is_none());
+        // Existence check finds plugins in either pass; a name not in
+        // either Vec returns false.
+        assert!(registry.has("auto_accounts"));
+        assert!(registry.has("implicit_prices"));
+        assert!(!registry.has("nonexistent"));
     }
 
     #[test]

--- a/crates/rustledger-plugin/src/native/mod.rs
+++ b/crates/rustledger-plugin/src/native/mod.rs
@@ -34,13 +34,13 @@
 //! guarantee (a plugin can only fit one slot) at the cost of one
 //! extra empty `impl` line per plugin.
 //!
-//! ## Plugins not in the native registry
+//! ## WASM and Python plugins
 //!
-//! WASM and Python plugins are loaded at runtime by name and don't
-//! carry Rust-level type information. The loader's runner treats
-//! them as regular plugins by default; pass discrimination for
-//! those is left as future work (issue #1200's audit covers the
-//! cross-binding consistency story).
+//! Non-native plugins don't implement `NativePlugin` and therefore
+//! aren't held in this registry. They're dispatched by the loader
+//! through path-based name resolution, run only in the post-booking
+//! regular pass, and never carry a synth/regular marker at the type
+//! level. Synth-pass semantics are a native-only concern.
 
 mod plugins;
 
@@ -121,7 +121,44 @@ fn plugin_short_name(name: &str) -> &str {
 /// Process-wide singleton registry — the registry holds no per-load
 /// state, so allocating one per call is pure waste. Use
 /// [`NativePluginRegistry::global`] to access it.
-static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(NativePluginRegistry::new);
+static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(|| {
+    let synth: Vec<Box<dyn SynthPlugin>> = vec![
+        Box::new(AutoAccountsPlugin),
+        Box::new(DocumentDiscoveryPlugin),
+    ];
+    let regular: Vec<Box<dyn RegularPlugin>> = vec![
+        Box::new(ImplicitPricesPlugin),
+        Box::new(CheckCommodityPlugin),
+        Box::new(AutoTagPlugin::new()),
+        Box::new(LeafOnlyPlugin),
+        Box::new(NoDuplicatesPlugin),
+        Box::new(OneCommodityPlugin),
+        Box::new(UniquePricesPlugin),
+        Box::new(CheckClosingPlugin),
+        Box::new(CloseTreePlugin),
+        Box::new(CoherentCostPlugin),
+        Box::new(ForecastPlugin),
+        Box::new(SellGainsPlugin),
+        Box::new(PedanticPlugin),
+        Box::new(RxTxnPlugin),
+        Box::new(SplitExpensesPlugin),
+        Box::new(UnrealizedPlugin::new()),
+        Box::new(NoUnusedPlugin),
+        Box::new(CheckDrainedPlugin),
+        Box::new(CommodityAttrPlugin::new()),
+        Box::new(CheckAverageCostPlugin::new()),
+        Box::new(CurrencyAccountsPlugin::new()),
+        Box::new(ZerosumPlugin),
+        Box::new(EffectiveDatePlugin),
+        Box::new(GenerateBaseCcyPricesPlugin),
+        Box::new(RenameAccountsPlugin),
+        Box::new(ValuationPlugin),
+        Box::new(CapitalGainsLongShortPlugin),
+        Box::new(CapitalGainsGainLossPlugin),
+        Box::new(BoxAccrualPlugin),
+    ];
+    NativePluginRegistry { synth, regular }
+});
 
 impl NativePluginRegistry {
     /// Access the process-wide registry singleton.
@@ -132,47 +169,6 @@ impl NativePluginRegistry {
     #[must_use]
     pub fn global() -> &'static Self {
         &GLOBAL_REGISTRY
-    }
-
-    /// Construct a new registry. Crate-internal — production code
-    /// should use [`Self::global`]. Kept for `Default` and tests.
-    pub(crate) fn new() -> Self {
-        let synth: Vec<Box<dyn SynthPlugin>> = vec![
-            Box::new(AutoAccountsPlugin),
-            Box::new(DocumentDiscoveryPlugin),
-        ];
-        let regular: Vec<Box<dyn RegularPlugin>> = vec![
-            Box::new(ImplicitPricesPlugin),
-            Box::new(CheckCommodityPlugin),
-            Box::new(AutoTagPlugin::new()),
-            Box::new(LeafOnlyPlugin),
-            Box::new(NoDuplicatesPlugin),
-            Box::new(OneCommodityPlugin),
-            Box::new(UniquePricesPlugin),
-            Box::new(CheckClosingPlugin),
-            Box::new(CloseTreePlugin),
-            Box::new(CoherentCostPlugin),
-            Box::new(ForecastPlugin),
-            Box::new(SellGainsPlugin),
-            Box::new(PedanticPlugin),
-            Box::new(RxTxnPlugin),
-            Box::new(SplitExpensesPlugin),
-            Box::new(UnrealizedPlugin::new()),
-            Box::new(NoUnusedPlugin),
-            Box::new(CheckDrainedPlugin),
-            Box::new(CommodityAttrPlugin::new()),
-            Box::new(CheckAverageCostPlugin::new()),
-            Box::new(CurrencyAccountsPlugin::new()),
-            Box::new(ZerosumPlugin),
-            Box::new(EffectiveDatePlugin),
-            Box::new(GenerateBaseCcyPricesPlugin),
-            Box::new(RenameAccountsPlugin),
-            Box::new(ValuationPlugin),
-            Box::new(CapitalGainsLongShortPlugin),
-            Box::new(CapitalGainsGainLossPlugin),
-            Box::new(BoxAccrualPlugin),
-        ];
-        Self { synth, regular }
     }
 
     /// Find a **synth-pass** plugin by name.
@@ -220,15 +216,6 @@ impl NativePluginRegistry {
         out
     }
 
-    /// Check if a name refers to a built-in plugin (either pass).
-    ///
-    /// Accepts both short names and fully qualified module paths.
-    /// Consults the global singleton — no allocation per call.
-    #[must_use]
-    pub fn is_builtin(name: &str) -> bool {
-        Self::global().has(name)
-    }
-
     /// Check if a name refers to any plugin in this registry, in
     /// either pass. Use this for existence queries; for invocation
     /// use [`Self::find_synth`] / [`Self::find_regular`] so the
@@ -238,12 +225,6 @@ impl NativePluginRegistry {
         let short_name = plugin_short_name(name);
         self.synth.iter().any(|p| p.name() == short_name)
             || self.regular.iter().any(|p| p.name() == short_name)
-    }
-}
-
-impl Default for NativePluginRegistry {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -308,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_registry_find_regular_short_name() {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
         assert!(registry.find_regular("implicit_prices").is_some());
         assert!(registry.find_regular("zerosum").is_some());
         assert!(registry.find_regular("nonexistent").is_none());
@@ -316,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_registry_find_regular_qualified_name() {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
         assert!(
             registry
                 .find_regular("beancount.plugins.implicit_prices")
@@ -346,10 +327,11 @@ mod tests {
     ///
     /// Exhaustive over `list()` so adding a new plugin without
     /// declaring a pass marker can't slip past CI as a Vec-membership
-    /// mistake.
+    /// mistake. Also covers `has` and prefix-stripping coverage that
+    /// the old separate `is_builtin_*` tests used to duplicate.
     #[test]
     fn test_registry_synth_and_regular_are_disjoint() {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
 
         for plugin in registry.list() {
             let name = plugin.name();
@@ -359,33 +341,21 @@ mod tests {
                 in_synth ^ in_regular,
                 "plugin {name:?} must live in exactly one pass Vec (synth={in_synth}, regular={in_regular})",
             );
+            assert!(
+                registry.has(name),
+                "list() yielded {name:?} but has() disagrees"
+            );
         }
 
-        // Existence check finds plugins in either pass; a name not in
-        // either Vec returns false.
-        assert!(registry.has("auto_accounts"));
-        assert!(registry.has("implicit_prices"));
+        // Non-existent names return false from every lookup.
         assert!(!registry.has("nonexistent"));
-    }
+        assert!(registry.find_synth("nonexistent").is_none());
+        assert!(registry.find_regular("nonexistent").is_none());
 
-    #[test]
-    fn test_is_builtin_short_name() {
-        assert!(NativePluginRegistry::is_builtin("implicit_prices"));
-        assert!(NativePluginRegistry::is_builtin("zerosum"));
-        assert!(!NativePluginRegistry::is_builtin("nonexistent"));
-    }
-
-    #[test]
-    fn test_is_builtin_qualified_name() {
-        assert!(NativePluginRegistry::is_builtin(
-            "beancount.plugins.implicit_prices"
-        ));
-        assert!(NativePluginRegistry::is_builtin(
-            "beanahead.plugins.rx_txn_plugin"
-        ));
-        assert!(NativePluginRegistry::is_builtin(
-            "beancount_reds_plugins.zerosum.zerosum"
-        ));
-        assert!(!NativePluginRegistry::is_builtin("some.random.nonexistent"));
+        // Prefix-stripping works for fully-qualified module paths.
+        assert!(registry.has("beancount.plugins.implicit_prices"));
+        assert!(registry.has("beanahead.plugins.rx_txn_plugin"));
+        assert!(registry.has("beancount_reds_plugins.zerosum.zerosum"));
+        assert!(!registry.has("some.random.nonexistent"));
     }
 }

--- a/crates/rustledger-plugin/src/native/plugins/auto_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/auto_accounts.rs
@@ -4,7 +4,7 @@ use crate::types::{
     DirectiveData, DirectiveWrapper, OpenData, PluginInput, PluginOp, PluginOutput,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, SynthPlugin};
 
 /// Plugin that auto-generates Open directives for accounts used without explicit open.
 pub struct AutoAccountsPlugin;
@@ -16,13 +16,6 @@ impl NativePlugin for AutoAccountsPlugin {
 
     fn description(&self) -> &'static str {
         "Auto-generate Open directives for used accounts"
-    }
-
-    /// Synthesizes `Open` directives the early validator needs to
-    /// see — must run pre-booking to suppress spurious E1001 errors
-    /// on accounts the plugin will auto-create.
-    fn is_synth(&self) -> bool {
-        true
     }
 
     fn process(&self, input: PluginInput) -> PluginOutput {
@@ -117,3 +110,8 @@ impl NativePlugin for AutoAccountsPlugin {
         }
     }
 }
+
+/// Synthesizes `Open` directives the early validator needs to see —
+/// must run pre-booking to suppress spurious E1001 errors on accounts
+/// the plugin will auto-create.
+impl SynthPlugin for AutoAccountsPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/auto_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/auto_accounts.rs
@@ -9,9 +9,14 @@ use super::super::{NativePlugin, SynthPlugin};
 /// Plugin that auto-generates Open directives for accounts used without explicit open.
 pub struct AutoAccountsPlugin;
 
+/// Name used by the registry, the loader (when emitting the implicit
+/// synth-pass entry for `options.auto_accounts`), and external callers.
+/// Kept as a constant so the three sites stay in sync.
+pub const AUTO_ACCOUNTS_NAME: &str = "auto_accounts";
+
 impl NativePlugin for AutoAccountsPlugin {
     fn name(&self) -> &'static str {
-        "auto_accounts"
+        AUTO_ACCOUNTS_NAME
     }
 
     fn description(&self) -> &'static str {

--- a/crates/rustledger-plugin/src/native/plugins/auto_tag.rs
+++ b/crates/rustledger-plugin/src/native/plugins/auto_tag.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that automatically adds tags based on account patterns.
 ///
@@ -88,6 +88,8 @@ impl NativePlugin for AutoTagPlugin {
         }
     }
 }
+
+impl RegularPlugin for AutoTagPlugin {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rustledger-plugin/src/native/plugins/box_accrual.rs
+++ b/crates/rustledger-plugin/src/native/plugins/box_accrual.rs
@@ -22,7 +22,7 @@ use crate::types::{
     PluginOutput, PostingData, TransactionData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin for splitting capital losses across multiple years.
 pub struct BoxAccrualPlugin;
@@ -206,6 +206,8 @@ impl NativePlugin for BoxAccrualPlugin {
         }
     }
 }
+
+impl RegularPlugin for BoxAccrualPlugin {}
 
 /// Format a decimal number with 2 decimal places.
 fn format_decimal(d: Decimal) -> String {

--- a/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
+++ b/crates/rustledger-plugin/src/native/plugins/capital_gains_classifier.rs
@@ -30,7 +30,7 @@ use crate::types::{
     PostingData, TransactionData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Regex for parsing capital gains config entries.
 /// Format: `'pattern': ['to_replace', 'repl1', 'repl2']`
@@ -72,6 +72,9 @@ impl NativePlugin for CapitalGainsGainLossPlugin {
         process_gain_loss(input)
     }
 }
+
+impl RegularPlugin for CapitalGainsLongShortPlugin {}
+impl RegularPlugin for CapitalGainsGainLossPlugin {}
 
 /// Configuration for `long_short` classification.
 struct LongShortConfig {

--- a/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_average_cost.rs
@@ -3,7 +3,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that validates reducing postings against the running average cost
 /// for accounts opened with the `NONE` booking method.
@@ -183,6 +183,8 @@ impl NativePlugin for CheckAverageCostPlugin {
         }
     }
 }
+
+impl RegularPlugin for CheckAverageCostPlugin {}
 
 #[cfg(test)]
 mod check_average_cost_tests {

--- a/crates/rustledger-plugin/src/native/plugins/check_closing.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_closing.rs
@@ -5,7 +5,7 @@ use crate::types::{
     PluginOutput,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 use super::utils::increment_date;
 
 /// Plugin that inserts zero balance assertion when posting has `closing: TRUE` metadata.
@@ -87,3 +87,5 @@ impl NativePlugin for CheckClosingPlugin {
         }
     }
 }
+
+impl RegularPlugin for CheckClosingPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/check_commodity.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_commodity.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that checks all used commodities are declared.
 pub struct CheckCommodityPlugin;
@@ -73,3 +73,5 @@ impl NativePlugin for CheckCommodityPlugin {
         }
     }
 }
+
+impl RegularPlugin for CheckCommodityPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/check_drained.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_drained.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, DirectiveWrapper, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 use super::utils::increment_date;
 
 /// Plugin that inserts zero balance assertions when balance sheet accounts are closed.
@@ -117,6 +117,8 @@ impl NativePlugin for CheckDrainedPlugin {
         }
     }
 }
+
+impl RegularPlugin for CheckDrainedPlugin {}
 
 #[cfg(test)]
 mod check_drained_tests {

--- a/crates/rustledger-plugin/src/native/plugins/close_tree.rs
+++ b/crates/rustledger-plugin/src/native/plugins/close_tree.rs
@@ -4,7 +4,7 @@ use crate::types::{
     CloseData, DirectiveData, DirectiveWrapper, PluginInput, PluginOp, PluginOutput,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that closes all descendant accounts when a parent account closes.
 ///
@@ -90,3 +90,5 @@ impl NativePlugin for CloseTreePlugin {
         }
     }
 }
+
+impl RegularPlugin for CloseTreePlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/coherent_cost.rs
+++ b/crates/rustledger-plugin/src/native/plugins/coherent_cost.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that ensures currencies are tracked consistently with cost or price-only.
 ///
@@ -73,3 +73,5 @@ impl NativePlugin for CoherentCostPlugin {
         }
     }
 }
+
+impl RegularPlugin for CoherentCostPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/commodity_attr.rs
+++ b/crates/rustledger-plugin/src/native/plugins/commodity_attr.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that validates Commodity directives have required metadata attributes.
 ///
@@ -173,6 +173,8 @@ impl NativePlugin for CommodityAttrPlugin {
         }
     }
 }
+
+impl RegularPlugin for CommodityAttrPlugin {}
 
 #[cfg(test)]
 mod commodity_attr_tests {

--- a/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/currency_accounts.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, DirectiveWrapper, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that auto-generates currency trading account postings.
 ///
@@ -314,6 +314,8 @@ impl NativePlugin for CurrencyAccountsPlugin {
         }
     }
 }
+
+impl RegularPlugin for CurrencyAccountsPlugin {}
 
 #[cfg(test)]
 mod currency_accounts_tests {

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -1,5 +1,7 @@
 //! Auto-discover documents from directories.
 
+use serde::Deserialize;
+
 use crate::types::{
     DirectiveData, DirectiveWrapper, DocumentData, PluginError, PluginInput, PluginOp, PluginOutput,
 };
@@ -17,45 +19,56 @@ const MAX_SCAN_DEPTH: usize = 32;
 /// For example: `documents/Assets/Bank/Checking/2024-01-15.statement.pdf`
 /// generates: `2024-01-15 document Assets:Bank:Checking "documents/Assets/Bank/Checking/2024-01-15.statement.pdf"`
 ///
-/// # Registry membership
+/// # Configuration
 ///
-/// `DocumentDiscoveryPlugin` implements [`crate::SynthPlugin`] for type-level
-/// correctness, but it is NOT held in [`crate::NativePluginRegistry::new`]'s
-/// `synth` Vec — its constructor requires per-load context (`base_dir` +
-/// resolved document directories), so the loader instantiates it ad-hoc in
-/// its document-discovery branch rather than looking it up by name. A user-
-/// authored `plugin "document_discovery"` declaration will therefore NOT
-/// resolve through the registry; document discovery is configured via
-/// `option "documents"` instead. The marker keeps the type signature
-/// consistent for any direct caller that constructs the plugin themselves.
+/// The plugin reads its per-load context (resolved document directories
+/// and the ledger's base directory for relative-path normalization) from
+/// [`PluginInput::config`] as a JSON object:
+///
+/// ```json
+/// {"base_dir": "/path/to/ledger", "directories": ["/abs/path/docs"]}
+/// ```
+///
+/// The loader constructs this config when populating the synth pass; if
+/// `config` is `None` or `directories` is empty, the plugin returns a
+/// no-op (every input directive is kept, nothing synthesized). This lets
+/// the plugin sit in the registry as a static instance and be dispatched
+/// through the normal synth-pass machinery.
 ///
 /// # Security
 ///
 /// - Symlinks are skipped to prevent infinite recursion from symlink cycles
 /// - Maximum recursion depth is enforced to prevent denial-of-service from deeply nested directories
-pub struct DocumentDiscoveryPlugin {
-    /// Directories to scan for documents (resolved to absolute paths).
-    pub directories: Vec<String>,
-    /// Base directory for resolving relative paths in existing document directives.
-    pub base_dir: std::path::PathBuf,
+pub struct DocumentDiscoveryPlugin;
+
+/// Name passed to file-declared / extra-plugin lookups and used by the
+/// loader when emitting the synth-pass config entry. Kept as a constant
+/// so the registry, the loader, and the rustdoc stay in sync.
+pub const DOCUMENT_DISCOVERY_NAME: &str = "document_discovery";
+
+/// JSON config schema parsed from [`PluginInput::config`].
+#[derive(Debug, Deserialize)]
+struct DocumentDiscoveryConfig {
+    base_dir: std::path::PathBuf,
+    directories: Vec<String>,
 }
 
-impl DocumentDiscoveryPlugin {
-    /// Create a new plugin with the given directories and base directory.
-    ///
-    /// The `base_dir` is used to resolve relative paths in existing document directives
-    /// for duplicate detection.
-    pub const fn new(directories: Vec<String>, base_dir: std::path::PathBuf) -> Self {
-        Self {
-            directories,
-            base_dir,
-        }
-    }
+/// Build the [`PluginInput::config`] JSON string for this plugin.
+///
+/// Centralized here so callers (the loader) don't need to know the
+/// schema — the plugin owns its own config shape.
+#[must_use]
+pub fn document_discovery_config(base_dir: &std::path::Path, directories: &[String]) -> String {
+    serde_json::json!({
+        "base_dir": base_dir,
+        "directories": directories,
+    })
+    .to_string()
 }
 
 impl NativePlugin for DocumentDiscoveryPlugin {
     fn name(&self) -> &'static str {
-        "document_discovery"
+        DOCUMENT_DISCOVERY_NAME
     }
 
     fn description(&self) -> &'static str {
@@ -64,6 +77,35 @@ impl NativePlugin for DocumentDiscoveryPlugin {
 
     fn process(&self, input: PluginInput) -> PluginOutput {
         use std::path::Path;
+
+        // No config → no-op pass-through. Lets the plugin sit in the
+        // registry unconditionally without doing work when the ledger
+        // hasn't declared `option "documents"`.
+        let Some(config_json) = input.config.as_deref() else {
+            return PluginOutput {
+                ops: (0..input.directives.len()).map(PluginOp::Keep).collect(),
+                errors: Vec::new(),
+            };
+        };
+
+        let config: DocumentDiscoveryConfig = match serde_json::from_str(config_json) {
+            Ok(c) => c,
+            Err(e) => {
+                return PluginOutput {
+                    ops: (0..input.directives.len()).map(PluginOp::Keep).collect(),
+                    errors: vec![PluginError::error(format!(
+                        "document_discovery: invalid config JSON: {e}"
+                    ))],
+                };
+            }
+        };
+
+        if config.directories.is_empty() {
+            return PluginOutput {
+                ops: (0..input.directives.len()).map(PluginOp::Keep).collect(),
+                errors: Vec::new(),
+            };
+        }
 
         let mut new_directives = Vec::new();
         let mut errors = Vec::new();
@@ -74,13 +116,11 @@ impl NativePlugin for DocumentDiscoveryPlugin {
         for wrapper in &input.directives {
             if let DirectiveData::Document(doc) = &wrapper.data {
                 let doc_path = Path::new(&doc.path);
-                // Resolve relative paths against base_dir
                 let resolved = if doc_path.is_absolute() {
                     doc_path.to_path_buf()
                 } else {
-                    self.base_dir.join(doc_path)
+                    config.base_dir.join(doc_path)
                 };
-                // Canonicalize for consistent path comparison
                 let normalized = resolved
                     .canonicalize()
                     .map_or_else(|_| doc.path.clone(), |p| p.to_string_lossy().to_string());
@@ -89,7 +129,7 @@ impl NativePlugin for DocumentDiscoveryPlugin {
         }
 
         // Scan each directory
-        for dir in &self.directories {
+        for dir in &config.directories {
             let dir_path = Path::new(dir);
             if !dir_path.exists() {
                 continue;

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -31,9 +31,12 @@ const MAX_SCAN_DEPTH: usize = 32;
 ///
 /// The loader constructs this config when populating the synth pass; if
 /// `config` is `None` or `directories` is empty, the plugin returns a
-/// no-op (every input directive is kept, nothing synthesized). This lets
-/// the plugin sit in the registry as a static instance and be dispatched
-/// through the normal synth-pass machinery.
+/// no-op (every input directive is kept, nothing synthesized). If `config`
+/// is present but malformed JSON, every input directive is still kept and
+/// a `PluginError::error` is added to the output errors — the plugin
+/// never silently drops directives on bad config. This lets the plugin
+/// sit in the registry as a static instance and be dispatched through
+/// the normal synth-pass machinery.
 ///
 /// # Security
 ///

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -17,6 +17,18 @@ const MAX_SCAN_DEPTH: usize = 32;
 /// For example: `documents/Assets/Bank/Checking/2024-01-15.statement.pdf`
 /// generates: `2024-01-15 document Assets:Bank:Checking "documents/Assets/Bank/Checking/2024-01-15.statement.pdf"`
 ///
+/// # Registry membership
+///
+/// `DocumentDiscoveryPlugin` implements [`crate::SynthPlugin`] for type-level
+/// correctness, but it is NOT held in [`crate::NativePluginRegistry::new`]'s
+/// `synth` Vec — its constructor requires per-load context (`base_dir` +
+/// resolved document directories), so the loader instantiates it ad-hoc in
+/// its document-discovery branch rather than looking it up by name. A user-
+/// authored `plugin "document_discovery"` declaration will therefore NOT
+/// resolve through the registry; document discovery is configured via
+/// `option "documents"` instead. The marker keeps the type signature
+/// consistent for any direct caller that constructs the plugin themselves.
+///
 /// # Security
 ///
 /// - Symlinks are skipped to prevent infinite recursion from symlink cycles

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -4,7 +4,7 @@ use crate::types::{
     DirectiveData, DirectiveWrapper, DocumentData, PluginError, PluginInput, PluginOp, PluginOutput,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, SynthPlugin};
 
 /// Maximum recursion depth for directory scanning to prevent denial-of-service from deeply nested structures.
 const MAX_SCAN_DEPTH: usize = 32;
@@ -108,6 +108,11 @@ impl NativePlugin for DocumentDiscoveryPlugin {
         PluginOutput { ops, errors }
     }
 }
+
+/// Synthesizes `Document` directives that downstream consumers expect
+/// alongside user-written ones — runs in the synth pass so the early
+/// validator sees them.
+impl SynthPlugin for DocumentDiscoveryPlugin {}
 
 /// Recursively scan a directory for document files.
 ///

--- a/crates/rustledger-plugin/src/native/plugins/effective_date.rs
+++ b/crates/rustledger-plugin/src/native/plugins/effective_date.rs
@@ -29,7 +29,7 @@ use crate::types::{
     PluginOutput, PostingData, TransactionData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin for handling effective dates on postings.
 pub struct EffectiveDatePlugin;
@@ -219,6 +219,8 @@ impl NativePlugin for EffectiveDatePlugin {
         }
     }
 }
+
+impl RegularPlugin for EffectiveDatePlugin {}
 
 /// Check if a transaction has any posting with `effective_date` metadata.
 fn has_effective_date_posting(txn: &TransactionData) -> bool {

--- a/crates/rustledger-plugin/src/native/plugins/forecast.rs
+++ b/crates/rustledger-plugin/src/native/plugins/forecast.rs
@@ -25,7 +25,7 @@ use std::sync::LazyLock;
 
 use crate::types::{DirectiveData, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Regex for parsing forecast patterns in narrations.
 /// Matches: `[MONTHLY]`, `[WEEKLY SKIP 2 TIMES]`, `[MONTHLY UNTIL 2025-12-31]`, etc.
@@ -147,6 +147,8 @@ impl NativePlugin for ForecastPlugin {
         }
     }
 }
+
+impl RegularPlugin for ForecastPlugin {}
 
 /// Generate dates according to the specified interval and constraints.
 fn generate_dates(

--- a/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/generate_base_ccy_prices.rs
@@ -21,7 +21,7 @@ use crate::types::{
     AmountData, DirectiveData, DirectiveWrapper, PluginInput, PluginOp, PluginOutput, PriceData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin for generating base currency prices.
 pub struct GenerateBaseCcyPricesPlugin;
@@ -113,6 +113,8 @@ impl NativePlugin for GenerateBaseCcyPricesPlugin {
         }
     }
 }
+
+impl RegularPlugin for GenerateBaseCcyPricesPlugin {}
 
 /// Build a price map from directives.
 /// Returns a map from (currency, `quote_currency`) to Vec<(date, rate)>

--- a/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/implicit_prices.rs
@@ -9,7 +9,7 @@ use rustledger_core::extract_per_unit_price;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Canonical key for tracking lots in the per-account inventory used
 /// by the cost-only "skip on REDUCED" check. Mirrors what Python
@@ -357,3 +357,5 @@ impl NativePlugin for ImplicitPricesPlugin {
         PluginOutput { ops, errors }
     }
 }
+
+impl RegularPlugin for ImplicitPricesPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/leaf_only.rs
+++ b/crates/rustledger-plugin/src/native/plugins/leaf_only.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that errors when posting to non-leaf (parent) accounts.
 pub struct LeafOnlyPlugin;
@@ -60,3 +60,5 @@ impl NativePlugin for LeafOnlyPlugin {
         }
     }
 }
+
+impl RegularPlugin for LeafOnlyPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/mod.rs
+++ b/crates/rustledger-plugin/src/native/plugins/mod.rs
@@ -45,7 +45,9 @@ pub use close_tree::CloseTreePlugin;
 pub use coherent_cost::CoherentCostPlugin;
 pub use commodity_attr::CommodityAttrPlugin;
 pub use currency_accounts::CurrencyAccountsPlugin;
-pub use document_discovery::DocumentDiscoveryPlugin;
+pub use document_discovery::{
+    DOCUMENT_DISCOVERY_NAME, DocumentDiscoveryPlugin, document_discovery_config,
+};
 pub use effective_date::EffectiveDatePlugin;
 pub use forecast::ForecastPlugin;
 pub use generate_base_ccy_prices::GenerateBaseCcyPricesPlugin;

--- a/crates/rustledger-plugin/src/native/plugins/mod.rs
+++ b/crates/rustledger-plugin/src/native/plugins/mod.rs
@@ -33,7 +33,7 @@ mod unrealized;
 mod valuation;
 mod zerosum;
 
-pub use auto_accounts::AutoAccountsPlugin;
+pub use auto_accounts::{AUTO_ACCOUNTS_NAME, AutoAccountsPlugin};
 pub use auto_tag::AutoTagPlugin;
 pub use box_accrual::BoxAccrualPlugin;
 pub use capital_gains_classifier::{CapitalGainsGainLossPlugin, CapitalGainsLongShortPlugin};

--- a/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_duplicates.rs
@@ -8,7 +8,7 @@
 
 use crate::types::{PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that detects duplicate transactions based on structural hash.
 pub struct NoDuplicatesPlugin;
@@ -35,3 +35,5 @@ impl NativePlugin for NoDuplicatesPlugin {
         }
     }
 }
+
+impl RegularPlugin for NoDuplicatesPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/no_unused.rs
+++ b/crates/rustledger-plugin/src/native/plugins/no_unused.rs
@@ -4,7 +4,7 @@ use crate::types::{
     DirectiveData, MetaValueData, PluginError, PluginInput, PluginOp, PluginOutput,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that identifies accounts that are opened but never used.
 ///
@@ -87,6 +87,8 @@ impl NativePlugin for NoUnusedPlugin {
         }
     }
 }
+
+impl RegularPlugin for NoUnusedPlugin {}
 
 #[cfg(test)]
 mod nounused_tests {

--- a/crates/rustledger-plugin/src/native/plugins/one_commodity.rs
+++ b/crates/rustledger-plugin/src/native/plugins/one_commodity.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that enforces single commodity per account.
 pub struct OneCommodityPlugin;
@@ -49,3 +49,5 @@ impl NativePlugin for OneCommodityPlugin {
         }
     }
 }
+
+impl RegularPlugin for OneCommodityPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/pedantic.rs
+++ b/crates/rustledger-plugin/src/native/plugins/pedantic.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 use super::check_commodity::CheckCommodityPlugin;
 use super::leaf_only::LeafOnlyPlugin;
 use super::no_duplicates::NoDuplicatesPlugin;
@@ -71,3 +71,5 @@ impl NativePlugin for PedanticPlugin {
         }
     }
 }
+
+impl RegularPlugin for PedanticPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/rename_accounts.rs
+++ b/crates/rustledger-plugin/src/native/plugins/rename_accounts.rs
@@ -19,7 +19,7 @@ use crate::types::{
     DirectiveData, DirectiveWrapper, PadData, PluginInput, PluginOp, PluginOutput, PostingData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Regex for parsing config key-value pairs.
 /// Format: `'pattern': 'replacement'`
@@ -80,6 +80,8 @@ impl NativePlugin for RenameAccountsPlugin {
         }
     }
 }
+
+impl RegularPlugin for RenameAccountsPlugin {}
 
 /// Cheap structural check — only compares the account name fields the
 /// rename plugin can touch. Avoids a full `PartialEq` requirement and

--- a/crates/rustledger-plugin/src/native/plugins/rx_txn.rs
+++ b/crates/rustledger-plugin/src/native/plugins/rx_txn.rs
@@ -5,7 +5,7 @@
 
 use crate::types::{DirectiveData, MetaValueData, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Tag used to identify Regular Expected Transactions.
 const TAG_RX: &str = "rx_txn";
@@ -66,6 +66,8 @@ impl NativePlugin for RxTxnPlugin {
         }
     }
 }
+
+impl RegularPlugin for RxTxnPlugin {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
+++ b/crates/rustledger-plugin/src/native/plugins/sell_gains.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that cross-checks declared gains against sale prices.
 ///
@@ -85,3 +85,5 @@ impl NativePlugin for SellGainsPlugin {
         }
     }
 }
+
+impl RegularPlugin for SellGainsPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/split_expenses.rs
+++ b/crates/rustledger-plugin/src/native/plugins/split_expenses.rs
@@ -32,7 +32,7 @@ use crate::types::{
     PluginOutput, PostingData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin for splitting expenses between multiple people.
 pub struct SplitExpensesPlugin;
@@ -193,6 +193,8 @@ impl NativePlugin for SplitExpensesPlugin {
         }
     }
 }
+
+impl RegularPlugin for SplitExpensesPlugin {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/rustledger-plugin/src/native/plugins/unique_prices.rs
+++ b/crates/rustledger-plugin/src/native/plugins/unique_prices.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that enforces unique prices (one per commodity pair per day).
 pub struct UniquePricesPlugin;
@@ -45,3 +45,5 @@ impl NativePlugin for UniquePricesPlugin {
         }
     }
 }
+
+impl RegularPlugin for UniquePricesPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/unrealized.rs
+++ b/crates/rustledger-plugin/src/native/plugins/unrealized.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{DirectiveData, PluginError, PluginInput, PluginOp, PluginOutput};
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Plugin that calculates unrealized gains on positions.
 ///
@@ -141,3 +141,5 @@ impl NativePlugin for UnrealizedPlugin {
         }
     }
 }
+
+impl RegularPlugin for UnrealizedPlugin {}

--- a/crates/rustledger-plugin/src/native/plugins/valuation.rs
+++ b/crates/rustledger-plugin/src/native/plugins/valuation.rs
@@ -33,7 +33,7 @@ use crate::types::{
     PriceAnnotationData, PriceData, TransactionData,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 const MAPPED_CURRENCY_PRECISION: u32 = 7;
 const TAG_TO_ADD: &str = "valuation-applied";
@@ -209,6 +209,8 @@ impl NativePlugin for ValuationPlugin {
         PluginOutput { ops, errors }
     }
 }
+
+impl RegularPlugin for ValuationPlugin {}
 
 /// Parse config metadata into `AccountConfig`.
 fn parse_config(metadata: &[(String, MetaValueData)]) -> Option<AccountConfig> {

--- a/crates/rustledger-plugin/src/native/plugins/zerosum.rs
+++ b/crates/rustledger-plugin/src/native/plugins/zerosum.rs
@@ -45,7 +45,7 @@ use crate::types::{
     PluginOp, PluginOutput,
 };
 
-use super::super::NativePlugin;
+use super::super::{NativePlugin, RegularPlugin};
 
 /// Default tolerance for matching amounts.
 const DEFAULT_TOLERANCE: &str = "0.0099";
@@ -333,6 +333,8 @@ impl NativePlugin for ZerosumPlugin {
         }
     }
 }
+
+impl RegularPlugin for ZerosumPlugin {}
 
 /// Parse the Python-style config dict.
 fn parse_config(

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -3055,7 +3055,10 @@ fn test_registry_finds_all_plugins() {
     ];
 
     for name in &plugin_names {
-        assert!(registry.find(name).is_some(), "should find plugin: {name}");
+        assert!(
+            registry.find_any(name).is_some(),
+            "should find plugin: {name}"
+        );
     }
 }
 
@@ -3063,8 +3066,12 @@ fn test_registry_finds_all_plugins() {
 fn test_registry_finds_with_beancount_prefix() {
     let registry = NativePluginRegistry::new();
 
-    assert!(registry.find("beancount.plugins.leafonly").is_some());
-    assert!(registry.find("beancount.plugins.noduplicates").is_some());
+    assert!(registry.find_any("beancount.plugins.leafonly").is_some());
+    assert!(
+        registry
+            .find_any("beancount.plugins.noduplicates")
+            .is_some()
+    );
 }
 
 #[test]
@@ -3085,7 +3092,7 @@ fn test_auto_accounts_generates_opens() {
     use rustledger_plugin::*;
 
     let registry = NativePluginRegistry::new();
-    let plugin: &dyn NativePlugin = registry.find("auto_accounts").unwrap();
+    let plugin: &dyn NativePlugin = registry.find_any("auto_accounts").unwrap();
 
     // Create test input with transaction using unopened accounts
     let input = PluginInput {
@@ -3185,7 +3192,7 @@ fn test_auto_accounts_same_date_ordering() {
     use rustledger_plugin::*;
 
     let registry = NativePluginRegistry::new();
-    let plugin: &dyn NativePlugin = registry.find("auto_accounts").unwrap();
+    let plugin: &dyn NativePlugin = registry.find_any("auto_accounts").unwrap();
 
     // Input: existing open + transaction that uses new account on same date as first use
     let input = PluginInput {

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -3068,15 +3068,15 @@ fn test_registry_finds_with_beancount_prefix() {
 }
 
 #[test]
-fn test_registry_list_all() {
+fn test_registry_iter_all() {
     let registry = NativePluginRegistry::global();
-    let plugins = registry.list();
+    let count = registry.iter().count();
 
     // Should have at least 13 plugins (14 minus auto_tag which might be different).
     // allow weak-count: registry-shape test — count grows as plugins are added,
     // pinning to a specific value would force every plugin addition to update
     // this test. See scripts/check-plugin-test-quality.sh.
-    assert!(plugins.len() >= 13, "should have at least 13 plugins");
+    assert!(count >= 13, "should have at least 13 plugins, got {count}");
 }
 
 #[test]

--- a/crates/rustledger-plugin/tests/native_plugins_test.rs
+++ b/crates/rustledger-plugin/tests/native_plugins_test.rs
@@ -3035,7 +3035,7 @@ proptest::proptest! {
 
 #[test]
 fn test_registry_finds_all_plugins() {
-    let registry = NativePluginRegistry::new();
+    let registry = NativePluginRegistry::global();
 
     // All 14 built-in plugins should be findable
     let plugin_names = [
@@ -3055,28 +3055,21 @@ fn test_registry_finds_all_plugins() {
     ];
 
     for name in &plugin_names {
-        assert!(
-            registry.find_any(name).is_some(),
-            "should find plugin: {name}"
-        );
+        assert!(registry.has(name), "should find plugin: {name}");
     }
 }
 
 #[test]
 fn test_registry_finds_with_beancount_prefix() {
-    let registry = NativePluginRegistry::new();
+    let registry = NativePluginRegistry::global();
 
-    assert!(registry.find_any("beancount.plugins.leafonly").is_some());
-    assert!(
-        registry
-            .find_any("beancount.plugins.noduplicates")
-            .is_some()
-    );
+    assert!(registry.has("beancount.plugins.leafonly"));
+    assert!(registry.has("beancount.plugins.noduplicates"));
 }
 
 #[test]
 fn test_registry_list_all() {
-    let registry = NativePluginRegistry::new();
+    let registry = NativePluginRegistry::global();
     let plugins = registry.list();
 
     // Should have at least 13 plugins (14 minus auto_tag which might be different).
@@ -3091,8 +3084,8 @@ fn test_auto_accounts_generates_opens() {
     use rustledger_plugin::types::*;
     use rustledger_plugin::*;
 
-    let registry = NativePluginRegistry::new();
-    let plugin: &dyn NativePlugin = registry.find_any("auto_accounts").unwrap();
+    let registry = NativePluginRegistry::global();
+    let plugin: &dyn NativePlugin = registry.find_synth("auto_accounts").unwrap();
 
     // Create test input with transaction using unopened accounts
     let input = PluginInput {
@@ -3191,8 +3184,8 @@ fn test_auto_accounts_same_date_ordering() {
     use rustledger_plugin::types::*;
     use rustledger_plugin::*;
 
-    let registry = NativePluginRegistry::new();
-    let plugin: &dyn NativePlugin = registry.find_any("auto_accounts").unwrap();
+    let registry = NativePluginRegistry::global();
+    let plugin: &dyn NativePlugin = registry.find_synth("auto_accounts").unwrap();
 
     // Input: existing open + transaction that uses new account on same date as first use
     let input = PluginInput {

--- a/crates/rustledger-plugin/tests/tla_proptest.rs
+++ b/crates/rustledger-plugin/tests/tla_proptest.rs
@@ -6,7 +6,7 @@
 //! Reference: spec/tla/PluginCorrect.tla
 
 use proptest::prelude::*;
-use rustledger_plugin::native::NativePluginRegistry;
+use rustledger_plugin::native::{NativePlugin, NativePluginRegistry};
 use rustledger_plugin::test_helpers::materialize_ops;
 use rustledger_plugin::types::*;
 
@@ -128,7 +128,7 @@ proptest! {
         date in date_strategy(),
         amount in amount_strategy(),
     ) {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
         let plugins = registry.list();
 
         // Track execution order
@@ -202,8 +202,8 @@ proptest! {
         }
 
         // Use a simple plugin that doesn't reorder
-        let registry = NativePluginRegistry::new();
-        if let Some(plugin) = registry.find_any("implicit_prices") {
+        let registry = NativePluginRegistry::global();
+        if let Some(plugin) = registry.find_regular("implicit_prices") {
             let input = make_input(directives);
             let input_dirs = input.directives.clone();
             let output = plugin.process(input);
@@ -244,15 +244,15 @@ proptest! {
             make_transaction(&date, "Test", &amount, "Expenses:Food"),
         ];
 
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
 
-        // First, run implicit_prices
-        let plugin1 = registry.find_any("implicit_prices").unwrap();
+        // First, run implicit_prices (regular pass)
+        let plugin1 = registry.find_regular("implicit_prices").unwrap();
         let input1 = make_input(directives.clone());
         let _output1 = plugin1.process(input1);
 
-        // Then run a different plugin on the SAME original input
-        let plugin2 = registry.find_any("auto_accounts").unwrap();
+        // Then run a synth-pass plugin on the SAME original input
+        let plugin2 = registry.find_synth("auto_accounts").unwrap();
         let input2 = make_input(directives);
         let _output2 = plugin2.process(input2);
 
@@ -270,7 +270,7 @@ proptest! {
         date in date_strategy(),
         amount in amount_strategy(),
     ) {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
 
         let directives = vec![
             make_open(&date, "Expenses:Food"),
@@ -278,9 +278,13 @@ proptest! {
             make_transaction(&date, "Test", &amount, "Expenses:Food"),
         ];
 
-        // Test a few specific plugins
+        // Test a few specific plugins — synth and regular need different lookups.
         for plugin_name in &["implicit_prices", "auto_accounts", "noduplicates"] {
-            if let Some(plugin) = registry.find_any(plugin_name) {
+            let plugin: Option<&dyn NativePlugin> = match *plugin_name {
+                "auto_accounts" => registry.find_synth(plugin_name).map(|p| p as &dyn NativePlugin),
+                _ => registry.find_regular(plugin_name).map(|p| p as &dyn NativePlugin),
+            };
+            if let Some(plugin) = plugin {
                 let input = make_input(directives.clone());
                 let input_dirs = input.directives.clone();
                 let output = plugin.process(input);
@@ -304,7 +308,7 @@ proptest! {
         date in date_strategy(),
         amount in amount_strategy(),
     ) {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
 
         let directives = vec![
             make_open(&date, "Expenses:Food"),
@@ -312,7 +316,7 @@ proptest! {
             make_transaction(&date, "Test", &amount, "Expenses:Food"),
         ];
 
-        if let Some(plugin) = registry.find_any("implicit_prices") {
+        if let Some(plugin) = registry.find_regular("implicit_prices") {
             let input = make_input(directives);
 
             let output1 = plugin.process(input.clone());
@@ -342,7 +346,8 @@ proptest! {
 
     /// Registry lookup is consistent.
     ///
-    /// Finding a plugin by name should always return the same plugin.
+    /// `has` is a pure function on the global singleton, so it must
+    /// return the same answer for repeated calls.
     #[test]
     fn prop_registry_lookup_consistent(
         plugin_name in prop::sample::select(vec![
@@ -353,26 +358,9 @@ proptest! {
             "noduplicates",
         ]),
     ) {
-        let registry = NativePluginRegistry::new();
-
-        let plugin1 = registry.find_any(plugin_name);
-        let plugin2 = registry.find_any(plugin_name);
-
-        match (plugin1, plugin2) {
-            (Some(p1), Some(p2)) => {
-                prop_assert_eq!(
-                    p1.name(),
-                    p2.name(),
-                    "Registry lookup should be consistent"
-                );
-            }
-            (None, None) => {
-                // Both not found is consistent
-            }
-            _ => {
-                prop_assert!(false, "Inconsistent registry lookup");
-            }
-        }
+        let registry = NativePluginRegistry::global();
+        prop_assert_eq!(registry.has(plugin_name), registry.has(plugin_name));
+        prop_assert!(registry.has(plugin_name), "every sampled name is a known plugin");
     }
 
     /// Registry accepts beancount.plugins.* prefix.
@@ -384,33 +372,18 @@ proptest! {
             "auto_accounts",
         ]),
     ) {
-        let registry = NativePluginRegistry::new();
-
-        // With prefix
+        let registry = NativePluginRegistry::global();
         let prefixed = format!("beancount.plugins.{plugin_name}");
-        let with_prefix = registry.find_any(&prefixed);
-
-        // Without prefix
-        let without_prefix = registry.find_any(plugin_name);
-
-        match (with_prefix, without_prefix) {
-            (Some(p1), Some(p2)) => {
-                prop_assert_eq!(
-                    p1.name(),
-                    p2.name(),
-                    "Prefix should be stripped correctly"
-                );
-            }
-            _ => {
-                prop_assert!(false, "Both lookups should succeed");
-            }
-        }
+        prop_assert!(
+            registry.has(&prefixed) && registry.has(plugin_name),
+            "prefix should be stripped — both lookups should succeed",
+        );
     }
 
     /// Registry listing returns all plugins.
     #[test]
     fn prop_registry_list_complete(_dummy in 0..1i32) {
-        let registry = NativePluginRegistry::new();
+        let registry = NativePluginRegistry::global();
         let plugins = registry.list();
 
         // Should have at least 14 plugins

--- a/crates/rustledger-plugin/tests/tla_proptest.rs
+++ b/crates/rustledger-plugin/tests/tla_proptest.rs
@@ -6,9 +6,9 @@
 //! Reference: spec/tla/PluginCorrect.tla
 
 use proptest::prelude::*;
+use rustledger_plugin::NativePluginRegistry;
 use rustledger_plugin::test_helpers::materialize_ops;
 use rustledger_plugin::types::*;
-use rustledger_plugin::{NativePlugin, NativePluginRegistry};
 
 // ============================================================================
 // Test Strategies
@@ -278,25 +278,21 @@ proptest! {
             make_transaction(&date, "Test", &amount, "Expenses:Food"),
         ];
 
-        // Test a few specific plugins — synth and regular need different lookups.
-        for plugin_name in &["implicit_prices", "auto_accounts", "noduplicates"] {
-            let plugin: Option<&dyn NativePlugin> = match *plugin_name {
-                "auto_accounts" => registry.find_synth(plugin_name).map(|p| p as &dyn NativePlugin),
-                _ => registry.find_regular(plugin_name).map(|p| p as &dyn NativePlugin),
-            };
-            if let Some(plugin) = plugin {
-                let input = make_input(directives.clone());
-                let input_dirs = input.directives.clone();
-                let output = plugin.process(input);
-                let materialized = materialize_ops(&input_dirs, &output);
+        // Iterate every plugin in the registry — `list()` yields both
+        // synth and regular plugins uniformly as `&dyn NativePlugin`,
+        // so no per-name pass classification is needed at this layer.
+        for plugin in registry.list() {
+            let input = make_input(directives.clone());
+            let input_dirs = input.directives.clone();
+            let output = plugin.process(input);
+            let materialized = materialize_ops(&input_dirs, &output);
 
-                // Output should be valid (no panic, has directives)
-                prop_assert!(
-                    !materialized.is_empty(),
-                    "Plugin {} should produce valid output",
-                    plugin_name
-                );
-            }
+            // Output should be valid (no panic, has directives)
+            prop_assert!(
+                !materialized.is_empty(),
+                "Plugin {} should produce valid output",
+                plugin.name()
+            );
         }
     }
 

--- a/crates/rustledger-plugin/tests/tla_proptest.rs
+++ b/crates/rustledger-plugin/tests/tla_proptest.rs
@@ -6,9 +6,9 @@
 //! Reference: spec/tla/PluginCorrect.tla
 
 use proptest::prelude::*;
-use rustledger_plugin::native::{NativePlugin, NativePluginRegistry};
 use rustledger_plugin::test_helpers::materialize_ops;
 use rustledger_plugin::types::*;
+use rustledger_plugin::{NativePlugin, NativePluginRegistry};
 
 // ============================================================================
 // Test Strategies

--- a/crates/rustledger-plugin/tests/tla_proptest.rs
+++ b/crates/rustledger-plugin/tests/tla_proptest.rs
@@ -6,9 +6,9 @@
 //! Reference: spec/tla/PluginCorrect.tla
 
 use proptest::prelude::*;
-use rustledger_plugin::NativePluginRegistry;
 use rustledger_plugin::test_helpers::materialize_ops;
 use rustledger_plugin::types::*;
+use rustledger_plugin::{NativePlugin, NativePluginRegistry};
 
 // ============================================================================
 // Test Strategies
@@ -129,7 +129,7 @@ proptest! {
         amount in amount_strategy(),
     ) {
         let registry = NativePluginRegistry::global();
-        let plugins = registry.list();
+        let plugins: Vec<_> = registry.iter().collect();
 
         // Track execution order
         let execution_order: Vec<String> = plugins.iter().map(|p| p.name().to_string()).collect();
@@ -278,10 +278,10 @@ proptest! {
             make_transaction(&date, "Test", &amount, "Expenses:Food"),
         ];
 
-        // Iterate every plugin in the registry — `list()` yields both
+        // Iterate every plugin in the registry — `iter()` yields both
         // synth and regular plugins uniformly as `&dyn NativePlugin`,
         // so no per-name pass classification is needed at this layer.
-        for plugin in registry.list() {
+        for plugin in registry.iter() {
             let input = make_input(directives.clone());
             let input_dirs = input.directives.clone();
             let output = plugin.process(input);
@@ -380,17 +380,16 @@ proptest! {
     #[test]
     fn prop_registry_list_complete(_dummy in 0..1i32) {
         let registry = NativePluginRegistry::global();
-        let plugins = registry.list();
+        let count = registry.iter().count();
 
         // Should have at least 14 plugins
         prop_assert!(
-            plugins.len() >= 14,
-            "Registry should have at least 14 plugins, got {}",
-            plugins.len()
+            count >= 14,
+            "Registry should have at least 14 plugins, got {count}",
         );
 
         // All plugins should have unique names
-        let names: Vec<&str> = plugins.iter().map(|p| p.name()).collect();
+        let names: Vec<&str> = registry.iter().map(NativePlugin::name).collect();
         let mut sorted_names = names.clone();
         sorted_names.sort_unstable();
         sorted_names.dedup();

--- a/crates/rustledger-plugin/tests/tla_proptest.rs
+++ b/crates/rustledger-plugin/tests/tla_proptest.rs
@@ -203,7 +203,7 @@ proptest! {
 
         // Use a simple plugin that doesn't reorder
         let registry = NativePluginRegistry::new();
-        if let Some(plugin) = registry.find("implicit_prices") {
+        if let Some(plugin) = registry.find_any("implicit_prices") {
             let input = make_input(directives);
             let input_dirs = input.directives.clone();
             let output = plugin.process(input);
@@ -247,12 +247,12 @@ proptest! {
         let registry = NativePluginRegistry::new();
 
         // First, run implicit_prices
-        let plugin1 = registry.find("implicit_prices").unwrap();
+        let plugin1 = registry.find_any("implicit_prices").unwrap();
         let input1 = make_input(directives.clone());
         let _output1 = plugin1.process(input1);
 
         // Then run a different plugin on the SAME original input
-        let plugin2 = registry.find("auto_accounts").unwrap();
+        let plugin2 = registry.find_any("auto_accounts").unwrap();
         let input2 = make_input(directives);
         let _output2 = plugin2.process(input2);
 
@@ -280,7 +280,7 @@ proptest! {
 
         // Test a few specific plugins
         for plugin_name in &["implicit_prices", "auto_accounts", "noduplicates"] {
-            if let Some(plugin) = registry.find(plugin_name) {
+            if let Some(plugin) = registry.find_any(plugin_name) {
                 let input = make_input(directives.clone());
                 let input_dirs = input.directives.clone();
                 let output = plugin.process(input);
@@ -312,7 +312,7 @@ proptest! {
             make_transaction(&date, "Test", &amount, "Expenses:Food"),
         ];
 
-        if let Some(plugin) = registry.find("implicit_prices") {
+        if let Some(plugin) = registry.find_any("implicit_prices") {
             let input = make_input(directives);
 
             let output1 = plugin.process(input.clone());
@@ -355,8 +355,8 @@ proptest! {
     ) {
         let registry = NativePluginRegistry::new();
 
-        let plugin1 = registry.find(plugin_name);
-        let plugin2 = registry.find(plugin_name);
+        let plugin1 = registry.find_any(plugin_name);
+        let plugin2 = registry.find_any(plugin_name);
 
         match (plugin1, plugin2) {
             (Some(p1), Some(p2)) => {
@@ -388,10 +388,10 @@ proptest! {
 
         // With prefix
         let prefixed = format!("beancount.plugins.{plugin_name}");
-        let with_prefix = registry.find(&prefixed);
+        let with_prefix = registry.find_any(&prefixed);
 
         // Without prefix
-        let without_prefix = registry.find(plugin_name);
+        let without_prefix = registry.find_any(plugin_name);
 
         match (with_prefix, without_prefix) {
             (Some(p1), Some(p2)) => {

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -307,8 +307,11 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
     }
 
     // Find and run the plugin
-    let registry = NativePluginRegistry::new();
-    let Some(plugin) = registry.find_any(plugin_name) else {
+    let registry = NativePluginRegistry::global();
+    // External API runs plugins on already-booked input — synth
+    // plugins are a loader-internal concern and would re-emit Opens
+    // for accounts the booking pass already opened.
+    let Some(plugin) = registry.find_regular(plugin_name) else {
         let result = PluginResult {
             directives: Vec::new(),
             errors: vec![Error::new(format!("Unknown plugin: {plugin_name}"))],
@@ -364,7 +367,7 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
 pub fn list_plugins() -> Result<JsValue, JsError> {
     use rustledger_plugin::NativePluginRegistry;
 
-    let registry = NativePluginRegistry::new();
+    let registry = NativePluginRegistry::global();
     let plugins: Vec<PluginInfo> = registry
         .list()
         .iter()

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -369,7 +369,6 @@ pub fn list_plugins() -> Result<JsValue, JsError> {
 
     let registry = NativePluginRegistry::global();
     let plugins: Vec<PluginInfo> = registry
-        .list()
         .iter()
         .map(|p| PluginInfo {
             name: p.name().to_string(),

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -308,7 +308,7 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
 
     // Find and run the plugin
     let registry = NativePluginRegistry::new();
-    let Some(plugin) = registry.find(plugin_name) else {
+    let Some(plugin) = registry.find_any(plugin_name) else {
         let result = PluginResult {
             directives: Vec::new(),
             errors: vec![Error::new(format!("Unknown plugin: {plugin_name}"))],

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -98,8 +98,11 @@ fn execute_plugin(directives: &[Directive], plugin_name: &str) -> Result<JsValue
         wrappers_to_directives,
     };
 
-    let registry = NativePluginRegistry::new();
-    let Some(plugin) = registry.find_any(plugin_name) else {
+    let registry = NativePluginRegistry::global();
+    // External API runs plugins on already-booked input — synth
+    // plugins are a loader-internal concern and would re-emit Opens
+    // for accounts the booking pass already opened.
+    let Some(plugin) = registry.find_regular(plugin_name) else {
         let result = PluginResult {
             directives: Vec::new(),
             errors: vec![Error::new(format!("Unknown plugin: {plugin_name}"))],

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -99,7 +99,7 @@ fn execute_plugin(directives: &[Directive], plugin_name: &str) -> Result<JsValue
     };
 
     let registry = NativePluginRegistry::new();
-    let Some(plugin) = registry.find(plugin_name) else {
+    let Some(plugin) = registry.find_any(plugin_name) else {
         let result = PluginResult {
             directives: Vec::new(),
             errors: vec![Error::new(format!("Unknown plugin: {plugin_name}"))],

--- a/crates/rustledger/benches/v016_baseline.rs
+++ b/crates/rustledger/benches/v016_baseline.rs
@@ -120,8 +120,13 @@ fn write_tempfile(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
 fn run_process(path: &std::path::Path, plugin_names: &[&str]) {
     let raw = load_raw(path).expect("load_raw");
     let opts = LoadOptions {
-        extra_plugins: plugin_names.iter().map(|s| (*s).to_string()).collect(),
-        extra_plugin_configs: vec![None; plugin_names.len()],
+        extra_plugins: plugin_names
+            .iter()
+            .map(|s| rustledger_loader::ExtraPlugin {
+                name: (*s).to_string(),
+                config: None,
+            })
+            .collect(),
         ..LoadOptions::default()
     };
     let ledger = process(raw, &opts).expect("process");

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -559,8 +559,14 @@ pub fn run(args: &Args) -> Result<ExitCode> {
     let load_options = rustledger_loader::LoadOptions {
         run_plugins: true,
         auto_accounts: args.auto,
-        extra_plugins: args.native_plugins.clone(),
-        extra_plugin_configs: vec![None; args.native_plugins.len()],
+        extra_plugins: args
+            .native_plugins
+            .iter()
+            .map(|name| rustledger_loader::ExtraPlugin {
+                name: name.clone(),
+                config: None,
+            })
+            .collect(),
         validate: true,
         ..Default::default()
     };

--- a/docs/development/contributing-plugins.md
+++ b/docs/development/contributing-plugins.md
@@ -110,36 +110,34 @@ pub use my_plugin::MyPlugin;
 ```
 
 Then register it in `crates/rustledger-plugin/src/native/mod.rs`. The registry
-holds two separately-typed `Vec`s, one per pass — add your plugin to the
+is a `LazyLock<NativePluginRegistry>` singleton initialized from two
+separately-typed `Vec`s, one per pass — add your plugin to the
 `regular` Vec (or `synth`, if it implements `SynthPlugin`):
 
 ```rust
-impl NativePluginRegistry {
-    pub fn new() -> Self {
-        let synth: Vec<Box<dyn SynthPlugin>> = vec![
-            Box::new(AutoAccountsPlugin),
-            // ... other synth plugins ...
-        ];
-        let regular: Vec<Box<dyn RegularPlugin>> = vec![
-            // ... existing regular plugins ...
-            Box::new(ImplicitPricesPlugin),
-            Box::new(CheckCommodityPlugin),
-            // Add your plugin to the appropriate list
-            Box::new(MyPlugin),
-        ];
-        Self { synth, regular }
-    }
-}
+static GLOBAL_REGISTRY: LazyLock<NativePluginRegistry> = LazyLock::new(|| {
+    let synth: Vec<Box<dyn SynthPlugin>> = vec![
+        Box::new(AutoAccountsPlugin),
+        // ... other synth plugins ...
+    ];
+    let regular: Vec<Box<dyn RegularPlugin>> = vec![
+        // ... existing regular plugins ...
+        Box::new(ImplicitPricesPlugin),
+        Box::new(CheckCommodityPlugin),
+        // Add your plugin to the appropriate list
+        Box::new(MyPlugin),
+    ];
+    NativePluginRegistry { synth, regular }
+});
 ```
 
-### 3. Add Aliases (Optional)
+### 3. Prefix Aliases (Automatic)
 
-For Python beancount compatibility, add aliases in `registry.rs`:
-
-```rust
-// Allow both "my_plugin" and "beancount.plugins.my_plugin"
-registry.add_alias("beancount.plugins.my_plugin", "my_plugin");
-```
+Plugin name lookups automatically strip well-known prefixes — short
+names (`"my_plugin"`) and fully-qualified module paths
+(`"beancount.plugins.my_plugin"`, `"beancount_reds_plugins.my_plugin.my_plugin"`)
+both resolve through the same `find_synth` / `find_regular` calls.
+No explicit alias registration is needed.
 
 ### 4. Write Tests
 
@@ -224,8 +222,8 @@ Add integration tests in `crates/rustledger-plugin/tests/`:
 ```rust
 // crates/rustledger-plugin/tests/my_plugin_test.rs
 
-use rustledger_plugin::native::{NativePlugin, NativePluginRegistry};
 use rustledger_plugin::types::*;
+use rustledger_plugin::{NativePlugin, NativePluginRegistry};
 
 // Helper to create test input
 fn make_input(directives: Vec<DirectiveWrapper>) -> PluginInput {
@@ -259,8 +257,14 @@ fn make_transaction(date: &str, narration: &str) -> DirectiveWrapper {
 
 #[test]
 fn test_my_plugin_integration() {
-    let registry = NativePluginRegistry::new();
-    let plugin = registry.find("my_plugin").expect("plugin should exist");
+    // Process-wide singleton — no allocation per call.
+    let registry = NativePluginRegistry::global();
+    // `find_regular` returns `Option<&dyn RegularPlugin>` — the type
+    // system guarantees we won't accidentally invoke a synth-pass
+    // plugin in a regular-pass test (and vice versa for `find_synth`).
+    let plugin = registry
+        .find_regular("my_plugin")
+        .expect("plugin should exist");
 
     let input = make_input(vec![
         make_transaction("2024-01-15", "Test transaction"),

--- a/docs/development/contributing-plugins.md
+++ b/docs/development/contributing-plugins.md
@@ -47,7 +47,7 @@ Create a new file in `crates/rustledger-plugin/src/native/plugins/`:
 ````rust
 // crates/rustledger-plugin/src/native/plugins/my_plugin.rs
 
-use crate::native::NativePlugin;
+use crate::native::{NativePlugin, RegularPlugin};
 use crate::types::{PluginError, PluginErrorSeverity, PluginInput, PluginOp, PluginOutput};
 
 /// My Plugin - brief description.
@@ -88,11 +88,13 @@ impl NativePlugin for MyPlugin {
         let ops = (0..input.directives.len()).map(PluginOp::Keep).collect();
         PluginOutput { ops, errors }
     }
-
-    // Override `is_synth() -> true` if this plugin synthesizes directives
-    // (e.g. injected `Open`s) that the loader's pre-booking Early validation
-    // depends on. Defaults to false (post-booking pass).
 }
+
+// Mark the plugin's pass — runs post-booking, like most plugins.
+// If your plugin synthesizes directives (e.g. injected `Open`s) that the
+// loader's pre-booking Early validation depends on, implement `SynthPlugin`
+// instead.
+impl RegularPlugin for MyPlugin {}
 ````
 
 ### 2. Register the Plugin
@@ -107,20 +109,25 @@ mod my_plugin;
 pub use my_plugin::MyPlugin;
 ```
 
-Then register it in `crates/rustledger-plugin/src/native/mod.rs`:
+Then register it in `crates/rustledger-plugin/src/native/mod.rs`. The registry
+holds two separately-typed `Vec`s, one per pass — add your plugin to the
+`regular` Vec (or `synth`, if it implements `SynthPlugin`):
 
 ```rust
 impl NativePluginRegistry {
     pub fn new() -> Self {
-        Self {
-            plugins: vec![
-                // ... existing plugins ...
-                Box::new(ImplicitPricesPlugin),
-                Box::new(CheckCommodityPlugin),
-                // Add your plugin to the list
-                Box::new(MyPlugin),
-            ],
-        }
+        let synth: Vec<Box<dyn SynthPlugin>> = vec![
+            Box::new(AutoAccountsPlugin),
+            // ... other synth plugins ...
+        ];
+        let regular: Vec<Box<dyn RegularPlugin>> = vec![
+            // ... existing regular plugins ...
+            Box::new(ImplicitPricesPlugin),
+            Box::new(CheckCommodityPlugin),
+            // Add your plugin to the appropriate list
+            Box::new(MyPlugin),
+        ];
+        Self { synth, regular }
     }
 }
 ```
@@ -345,8 +352,15 @@ Keep every input index and append `PluginOp::Insert(wrapper)` for each
 synthesized directive. Inserted directives get `SYNTHESIZED_FILE_ID`
 and a zero span. If your plugin synthesizes `Open` or `Document`
 directives that the loader's pre-booking Early validation depends on,
-also override `is_synth(&self) -> bool { true }` so the loader runs it
-in the synth pass.
+implement `SynthPlugin` (instead of `RegularPlugin`) so the loader runs it
+in the synth pass:
+
+```rust
+impl SynthPlugin for MyPlugin {}
+```
+
+Implement exactly one of `SynthPlugin` or `RegularPlugin` — the registry's
+typed `Vec`s reject anything else at compile time.
 
 ```rust
 fn process(&self, input: PluginInput) -> PluginOutput {

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -136,9 +136,10 @@ Input File
 │      run BEFORE Early validation    │
 │    - e.g. auto_accounts,            │
 │      document_discovery             │
-│    - Selected via                   │
-│      NativePlugin::is_synth()       │
-│      → PluginPass::Synth            │
+│    - Plugins declare their pass via │
+│      the SynthPlugin marker trait;  │
+│      the registry's typed Vec       │
+│      → PluginPass::PreBookingSynth  │
 └─────────────────────────────────────┘
     │
     ▼
@@ -263,11 +264,11 @@ Plugins are executed by `run_plugins()` in `rustledger-loader`, the single sourc
 - **WASM plugins**: Any language compiled to WASM, sandboxed via wasmtime
 - **Python plugins**: CPython compiled to WASI, runs existing beancount plugins
 
-Plugin execution is **split across two passes** of the pipeline (see the seven-step diagram above). Plugins declare which pass they belong to via `NativePlugin::is_synth()`, which selects between the two `PluginPass` variants:
+Plugin execution is **split across two passes** of the pipeline (see the seven-step diagram above). Native plugins declare which pass they belong to via marker subtraits — `SynthPlugin` or `RegularPlugin` — each of which extends the base `NativePlugin` capability. The registry stores them in two separately-typed `Vec`s, and the loader looks up the pass-appropriate kind directly through `find_synth` / `find_regular`. This selects between the two `PluginPass` variants:
 
-- **Synth plugins** (`PluginPass::Synth`) run **before Early validation**. These are account- or directive-injecting plugins like `auto_accounts` and `document_discovery`. Running them first means the Early validator's account-presence checks (Open-before-use) see the directives synth plugins inject — preventing false positives that would otherwise occur when a plugin is responsible for opening an account that subsequent transactions reference.
+- **Synth plugins** (`PluginPass::PreBookingSynth`) run **before Early validation**. These are account- or directive-injecting plugins like `auto_accounts` and `document_discovery`. Running them first means the Early validator's account-presence checks (Open-before-use) see the directives synth plugins inject — preventing false positives that would otherwise occur when a plugin is responsible for opening an account that subsequent transactions reference.
 
-- **Regular plugins** (`PluginPass::Regular`) — every plugin where `is_synth()` returns `false` — run **after booking**. This is the right phase for plugins that consume booked output, particularly cost-spec readers that need `cost.number_per` filled in from a total cost spec (the booking engine computes this). Validators that need post-interpolation amounts also belong here.
+- **Regular plugins** (`PluginPass::PostBooking`) — every plugin implementing `RegularPlugin` — run **after booking**. This is the right phase for plugins that consume booked output, particularly cost-spec readers that need `cost.number_per` filled in from a total cost spec (the booking engine computes this). Validators that need post-interpolation amounts also belong here.
 
 After the regular pass, **Late validation** runs (balance assertions, commodity checks, post-booking invariants), then the loader finalizes the ledger by re-merging plugin-emitted directives into the sorted stream.
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -86,12 +86,15 @@ sort → synth-plugins → Early validation → booking
      → regular-plugins → Late validation → finalize
 ```
 
-Native plugins opt into the synth pass by overriding `is_synth(&self) -> bool`
-on the `NativePlugin` trait (default: `false`). The loader uses the
-`PluginPass` enum (`PreBookingSynth`, `PostBooking`, `All`) to select
-which subset of plugins to run on each pass. Standalone callers (LSP,
-FFI, tests) that operate on already-booked input pass `PluginPass::All`
-for the historical single-pass behavior.
+Native plugins declare their pass by implementing exactly one of two
+marker subtraits — `SynthPlugin` or `RegularPlugin` — both of which
+extend the base `NativePlugin` capability. The registry stores them in
+two separately-typed `Vec`s, and the loader looks up the right kind via
+`find_synth` / `find_regular`. The loader uses the `PluginPass` enum
+(`PreBookingSynth`, `PostBooking`, `All`) to select which subset of
+plugins to run on each pass. Standalone callers (LSP, FFI, tests) that
+operate on already-booked input pass `PluginPass::All` for the
+historical single-pass behavior.
 
 Within each pass, plugins still execute in the order they appear in
 your file. This matters because:

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -91,10 +91,10 @@ marker subtraits — `SynthPlugin` or `RegularPlugin` — both of which
 extend the base `NativePlugin` capability. The registry stores them in
 two separately-typed `Vec`s, and the loader looks up the right kind via
 `find_synth` / `find_regular`. The loader uses the `PluginPass` enum
-(`PreBookingSynth`, `PostBooking`, `All`) to select which subset of
-plugins to run on each pass. Standalone callers (LSP, FFI, tests) that
-operate on already-booked input pass `PluginPass::All` for the
-historical single-pass behavior.
+(`PreBookingSynth`, `PostBooking`) to select which subset of plugins to
+run on each pass. Callers that operate on already-booked input (LSP /
+FFI / standalone tests) invoke `run_plugins` twice — once per pass —
+matching the loader's own pipeline.
 
 Within each pass, plugins still execute in the order they appear in
 your file. This matters because:


### PR DESCRIPTION
## Summary

Completes the loader/plugin refactor outlined in issue #1166. The runtime `fn is_synth(&self) -> bool` discriminator on `NativePlugin` is gone; plugin pass classification is now a compile-time property of registry membership. The loader's `run_plugins` lost ~70 lines of legacy indirection. The registry is a process-wide singleton; `DocumentDiscoveryPlugin` is a unit struct held statically; `PluginPass::All`, `find_any`, `is_builtin`, `Default for NativePluginRegistry`, parallel `extra_plugins`/`extra_plugin_configs` Vecs, and a dead prefix-stripping ladder are all gone.

Five commits on this branch:

1. `767a2317` — original trait split (`SynthPlugin` / `RegularPlugin` marker subtraits, typed registry Vecs, all 30 plugins migrated)
2. `80640d99` — review v1 polish (docs, re-exports, terser `find_any`, rustdoc consistency)
3. `eb06d602` — phases 1-6 (singleton registry, drop `PluginPass::All`, doc_discovery in registry, kill `raw_plugins`)
4. `fb89116e` — review v3 polish (drop `is_builtin`/`Default`, `AUTO_ACCOUNTS_NAME`, doc fixes)
5. `8902279f` — review v4 polish (dead prefix-stripping, `ExtraPlugin` struct, asymmetric re-export, `build_global_registry`)

All changes are intentionally breaking; no compatibility shims. Closes #1166.

## The trait split

```rust
pub trait NativePlugin: Send + Sync + 'static {
    fn name(&self) -> &'static str;
    fn description(&self) -> &'static str;
    fn process(&self, input: PluginInput) -> PluginOutput;
}

pub trait SynthPlugin: NativePlugin {}    // runs pre-booking
pub trait RegularPlugin: NativePlugin {}  // runs post-booking

pub struct NativePluginRegistry {
    synth: Vec<Box<dyn SynthPlugin>>,
    regular: Vec<Box<dyn RegularPlugin>>,
}
```

`auto_accounts` and `document_discovery` implement `SynthPlugin`; the other 28 implement `RegularPlugin`. Adding a new plugin without a marker is a compile error — `Box::new(NewPlugin)` can't satisfy either `dyn SynthPlugin` or `dyn RegularPlugin`. An exhaustive test (`test_registry_synth_and_regular_are_disjoint`) iterates `registry.list()` and pins that every plugin lives in exactly one pass Vec.

## Where the compile-time guarantees live

- **Registry construction**: a plugin that doesn't implement `SynthPlugin` or `RegularPlugin` can't be `Box::new(...)`ed into the typed Vec — adding a new plugin without a pass declaration is a compile error.
- **Invocation site**: `find_synth` returns `&dyn SynthPlugin`, `find_regular` returns `&dyn RegularPlugin`. A `RegularPlugin` cannot be returned by `find_synth` even on a name collision, so the dispatch reference type always matches the pass.
- **External API surface**: FFI/WASM `run_plugin_by_name` entry points only accept `find_regular` lookups — synth plugins are not invokable from outside the loader.

## Loader simplification

`run_plugins` now reads as:

```rust
let registry = NativePluginRegistry::global();
let mut entries: Vec<(String, Option<String>, bool)> = Vec::new();

if matches!(pass, PluginPass::PreBookingSynth) {
    if options.auto_accounts {
        entries.push((AUTO_ACCOUNTS_NAME.into(), None, false));
    }
    if options.run_plugins && !file_options.documents.is_empty() {
        let resolved = resolve_documents(&file_options.documents, base_dir);
        let config = rustledger_plugin::document_discovery_config(base_dir, &resolved);
        entries.push((DOCUMENT_DISCOVERY_NAME.into(), Some(config), false));
    }
}

let want_synth = matches!(pass, PluginPass::PreBookingSynth);

for plugin in file_plugins {
    if registry.find_synth(&plugin.name).is_some() == want_synth {
        entries.push((plugin.name.clone(), plugin.config.clone(), plugin.force_python));
    }
}
for extra in &options.extra_plugins {
    if registry.find_synth(&extra.name).is_some() == want_synth {
        entries.push((extra.name.clone(), extra.config.clone(), false));
    }
}

for (raw_name, config, force_python) in &entries {
    let resolved = (!*force_python && registry.has(raw_name)).then_some(raw_name.as_str());
    let native = resolved.and_then(|n| match pass {
        PluginPass::PreBookingSynth => registry.find_synth(n).map(|p| p as &dyn NativePlugin),
        PluginPass::PostBooking    => registry.find_regular(n).map(|p| p as &dyn NativePlugin),
    });
    // invoke or fall through to WASM/Python
}
```

One Vec, one dispatch loop, no special cases. No closures, no classification functions, no intermediate "raw plugins" Vec, no prefix-stripping ladder (the registry's `has`/`find_*` already strip via `plugin_short_name` internally), no hardcoded `has_document_dirs` branch.

## LSP

`validation_errors_to_diagnostics` previously passed `PluginPass::All` to bypass the synth/regular split. Now it calls `run_plugins` twice — once with `PreBookingSynth`, once with `PostBooking` — matching the loader's main pipeline. Same end-to-end behavior (`auto_accounts` still synthesizes Opens that suppress spurious E1001 diagnostics, verified by `test_native_plugin_runs_in_lsp_diagnostics`).

## Breaking changes

Single CHANGELOG entry worth:

- `NativePlugin::is_synth(&self)` removed — plugins declare their pass via `impl SynthPlugin` or `impl RegularPlugin`.
- `NativePluginRegistry::find_any` removed — use `has(name) -> bool` for existence checks, `find_synth`/`find_regular` for invocation.
- `NativePluginRegistry::find` (legacy combined lookup) removed.
- `NativePluginRegistry::is_builtin` removed — call `NativePluginRegistry::global().has(name)`.
- `NativePluginRegistry::new()` removed — use `NativePluginRegistry::global()` for the process-wide singleton.
- `Default for NativePluginRegistry` removed — every caller goes through `global()`.
- `PluginPass::All` removed — callers run both passes explicitly via two `run_plugins` invocations.
- `DocumentDiscoveryPlugin::new(directories, base_dir)` and the struct's fields removed — plugin is a unit ZST reading config from `PluginInput.config` as JSON.
- `DocumentDiscoveryPlugin` no longer re-exported at the crate root — available at `rustledger_plugin::native::DocumentDiscoveryPlugin` for the rare direct caller.
- `LoadOptions::extra_plugins: Vec<String>` + `LoadOptions::extra_plugin_configs: Vec<Option<String>>` replaced with `LoadOptions::extra_plugins: Vec<ExtraPlugin>` (struct with `name` + `config` fields). Eliminates index-misalignment footgun.
- FFI/WASM `run_plugin_by_name` APIs only resolve regular plugins; passing a synth plugin name returns "unknown plugin".

## New public API

- `NativePluginRegistry::global() -> &'static Self` — `LazyLock` singleton accessor
- `NativePluginRegistry::has(&self, name) -> bool` — existence check that doesn't return a trait reference
- `SynthPlugin`, `RegularPlugin` traits — marker subtraits of `NativePlugin`
- `AUTO_ACCOUNTS_NAME`, `DOCUMENT_DISCOVERY_NAME` constants
- `document_discovery_config(base_dir, directories) -> String` — helper for callers building the doc_discovery config
- `ExtraPlugin { name, config }` struct in `rustledger-loader`

## Test plan

- [x] `cargo check --all-features --all-targets`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` — all green, 0 failures
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features`
- [x] `cargo fmt --all -- --check`
- [x] Exhaustive disjointness test over `registry.list()` — every plugin lives in exactly one pass Vec, every plugin's name resolves via `has` (covers prefix-stripping)
- [x] LSP integration tests (`test_native_plugin_runs_in_lsp_diagnostics`, etc.) verify two-pass invocation produces the same diagnostics as the old single-pass shortcut
- [x] `prop_plugin_output_valid` proptest iterates the entire registry instead of a hardcoded plugin list

🤖 Generated with [Claude Code](https://claude.com/claude-code)