### PR TITLE
feat(test): cross-binding wire-format equivalence harness (#1200 item 1)

### DIFF
--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -59,11 +59,18 @@ jobs:
           gh api "repos/$REPO/contents/Cargo.lock?ref=$PR_SHA" \
             --jq '.content' | base64 -d > Cargo.lock
 
-          # Get list of changed files and fetch any Cargo.toml files
+          # Get list of changed files and fetch what `cargo metadata` needs:
+          # Cargo.toml files for the new dep graph, PLUS the default target
+          # file (src/lib.rs or src/main.rs) for any new workspace member.
+          # Without the target file, cargo metadata refuses to load the new
+          # crate's manifest ("no targets specified" or "rename file to
+          # src/lib.rs"). Fetching the source file is safe: cargo metadata
+          # parses Cargo.toml and resolves the dep graph but does NOT
+          # compile or execute the source.
           # Using --paginate to handle PRs with many files, and while read to handle spaces in paths
           gh api --paginate "repos/$REPO/pulls/${{ github.event.pull_request.number }}/files" \
             --jq '.[].filename' | while IFS= read -r file; do
-            if [[ "$file" == *"Cargo.toml" ]]; then
+            if [[ "$file" == *"Cargo.toml" || "$file" == */src/lib.rs || "$file" == */src/main.rs ]]; then
               echo "Fetching $file from PR"
               # Ensure parent directory exists (might be new in the PR)
               mkdir -p "$(dirname "$file")"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,6 +4037,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustledger-wire-format-tests"
+version = "0.15.0"
+dependencies = [
+ "jiff",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "rustledger-core",
+ "rustledger-ffi-wasi",
+ "rustledger-wasm",
+ "serde_json",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wire-format-tests"
-version = "0.15.0"
+version = "0.0.0"
 dependencies = [
  "rust_decimal",
  "rust_decimal_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4040,7 +4040,6 @@ dependencies = [
 name = "rustledger-wire-format-tests"
 version = "0.15.0"
 dependencies = [
- "jiff",
  "rust_decimal",
  "rust_decimal_macros",
  "rustledger-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/rustledger-wasm",
   "crates/rustledger-ffi-wasi",
   "crates/rustledger-lsp",
+  "crates/rustledger-wire-format-tests",
 ]
 # Exclude wasm from default builds (requires wasm32 target)
 default-members = [
@@ -30,6 +31,7 @@ default-members = [
   "crates/rustledger-ops",
   "crates/rustledger",
   "crates/rustledger-lsp",
+  "crates/rustledger-wire-format-tests",
 ]
 
 [workspace.package]
@@ -162,6 +164,8 @@ rustledger-plugin = { version = "0.15.0", path = "crates/rustledger-plugin", def
 rustledger-plugin-types = { version = "0.15.0", path = "crates/rustledger-plugin-types" }
 rustledger-importer = { version = "0.15.0", path = "crates/rustledger-importer" }
 rustledger-ops = { version = "0.15.0", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.15.0", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.15.0", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-ffi-wasi/src/lib.rs
+++ b/crates/rustledger-ffi-wasi/src/lib.rs
@@ -1,0 +1,46 @@
+// The exposed DTO types (DirectiveJson, Posting, Amount, etc.) carry
+// many fields whose meaning is the JSON-RPC API. Per-field rustdoc
+// would duplicate the JSON-RPC reference and drift from it. The lib
+// is internal-for-testing scope, not a stable public API — until
+// item 2 of issue #1200 (ts-rs generation) lands, treat the
+// rust-side type docs as authoritative for shape only.
+#![allow(missing_docs)]
+
+//! Library surface for the rustledger FFI-WASI binding.
+//!
+//! Most consumers run this crate as a WASI module (see `main.rs` and
+//! the JSON-RPC API doc on the binary). But the `Directive → JSON`
+//! conversion functions and DTO types are also useful as a library
+//! — primarily for cross-binding equivalence tests (issue #1200) that
+//! need to compare this binding's wire format against
+//! `rustledger-wasm`'s.
+//!
+//! The binary in `main.rs` consumes these modules through this lib
+//! rather than re-`mod`-ing them, so there's a single source of truth.
+//!
+//! ## Visibility
+//!
+//! Two `pub` modules: [`convert`] (for `directive_to_json` and the
+//! related conversion functions used by cross-binding equivalence
+//! tests) and [`jsonrpc`] (for the binary shim). DTO types are
+//! re-exported at the crate root when they're part of the conversion
+//! surface; the rest of the internal `types`, `commands`, and
+//! `helpers` modules are `pub(crate)`.
+
+pub mod convert;
+pub mod jsonrpc;
+
+pub(crate) mod commands;
+pub(crate) mod helpers;
+pub(crate) mod types;
+
+// Re-export the wire-format DTOs that cross-binding tests inspect.
+// Keeping the surface narrow avoids documenting every RPC-response
+// type that lives in `types::*` but isn't part of the
+// `Directive → JSON` conversion contract.
+pub use types::{Amount, CostNumber, DirectiveJson, Meta, Posting, PostingCost, TypedValue};
+
+/// API version for compatibility detection.
+/// Increment minor version for backwards-compatible changes.
+/// Increment major version for breaking changes.
+pub const API_VERSION: &str = "1.0";

--- a/crates/rustledger-ffi-wasi/src/main.rs
+++ b/crates/rustledger-ffi-wasi/src/main.rs
@@ -26,16 +26,7 @@
 //! - `entry.create`, `entry.createBatch`, `entry.filter`, `entry.clamp`
 //! - `util.version`, `util.types`, `util.isEncrypted`, `util.getAccountType`
 
-mod commands;
-mod convert;
-mod helpers;
-mod jsonrpc;
-mod types;
-
-/// API version for compatibility detection.
-/// Increment minor version for backwards-compatible changes.
-/// Increment major version for breaking changes.
-pub(crate) const API_VERSION: &str = "1.0";
+use rustledger_ffi_wasi::jsonrpc;
 
 fn main() {
     let exit_code = jsonrpc::process_stdin();

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -976,7 +976,7 @@ pub fn run_plugins(
                     errors.push(
                         LedgerError::error(
                             "PLUGIN",
-                            format!("WASM plugin '{raw_name}' requires the wasm-plugins feature",),
+                            format!("WASM plugin '{raw_name}' requires the wasm-plugins feature"),
                         )
                         .with_phase("plugin"),
                     );

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -39,7 +39,11 @@
 
 // Internal modules
 mod cache;
-mod convert;
+// `convert` is `pub` so the cross-binding equivalence test crate
+// (`rustledger-wire-format-tests`, issue #1200) can call
+// `directive_to_json` directly. JS consumers use the bindings in
+// `api`/`parsed_ledger` instead.
+pub mod convert;
 mod editor;
 mod helpers;
 mod utils;

--- a/crates/rustledger-wire-format-tests/Cargo.toml
+++ b/crates/rustledger-wire-format-tests/Cargo.toml
@@ -12,22 +12,22 @@ categories.workspace = true
 authors.workspace = true
 publish = false
 
+# The lib is empty — this crate exists only to host the integration
+# tests under `tests/` that depend on multiple wire-format bindings
+# (FFI-WASI + WASM). Cargo picks up `tests/` automatically given a
+# default `src/lib.rs`.
 [lib]
-# Empty lib — the test harness lives in `tests/`. A bare lib target is
-# required for integration tests to be picked up.
-path = "src/lib.rs"
-
-[dependencies]
-# (No runtime dependencies — the lib is empty.)
 
 [dev-dependencies]
 rustledger-core.workspace = true
 rustledger-ffi-wasi.workspace = true
 rustledger-wasm.workspace = true
 serde_json.workspace = true
+# `rust_decimal` is required by the `dec!` macro expansion — the
+# macro emits code that names `rust_decimal::Decimal` directly,
+# so a transitive dep through `rustledger-core` isn't enough.
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
-jiff.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rustledger-wire-format-tests/Cargo.toml
+++ b/crates/rustledger-wire-format-tests/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "rustledger-wire-format-tests"
+description = "Cross-binding wire-format equivalence tests — pins FFI-WASI and WASM JSON shapes against shared fixtures (issue #1200)"
+version = "0.15.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+authors.workspace = true
+publish = false
+
+[lib]
+# Empty lib — the test harness lives in `tests/`. A bare lib target is
+# required for integration tests to be picked up.
+path = "src/lib.rs"
+
+[dependencies]
+# (No runtime dependencies — the lib is empty.)
+
+[dev-dependencies]
+rustledger-core.workspace = true
+rustledger-ffi-wasi.workspace = true
+rustledger-wasm.workspace = true
+serde_json.workspace = true
+rust_decimal.workspace = true
+rust_decimal_macros.workspace = true
+jiff.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rustledger-wire-format-tests/Cargo.toml
+++ b/crates/rustledger-wire-format-tests/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rustledger-wire-format-tests"
-description = "Cross-binding wire-format equivalence tests — pins FFI-WASI and WASM JSON shapes against shared fixtures (issue #1200)"
-version = "0.15.0"
+description = "Cross-binding wire-format equivalence tests -- pins FFI-WASI and WASM JSON shapes against shared fixtures (issue #1200)"
+# Never published — kept at 0.0.0 to make the unpublished intent explicit.
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wire-format-tests/Cargo.toml
+++ b/crates/rustledger-wire-format-tests/Cargo.toml
@@ -13,11 +13,13 @@ categories.workspace = true
 authors.workspace = true
 publish = false
 
-# The lib is empty — this crate exists only to host the integration
-# tests under `tests/` that depend on multiple wire-format bindings
-# (FFI-WASI + WASM). Cargo picks up `tests/` automatically given a
-# default `src/lib.rs`.
-[lib]
+# No `[lib]` / `[[bin]]` declared on purpose: this crate exists only
+# to host the integration tests under `tests/`, and cargo auto-detects
+# the empty `src/lib.rs` (which has to exist so `tests/` can `use` the
+# dev-dependencies). Declaring `[lib]` explicitly would force cargo to
+# require `src/lib.rs` even when only `Cargo.toml` is present — which
+# breaks the `Update Exemptions` workflow, since it fetches Cargo.toml
+# files from PRs without their `src/`.
 
 [dev-dependencies]
 rustledger-core.workspace = true

--- a/crates/rustledger-wire-format-tests/src/lib.rs
+++ b/crates/rustledger-wire-format-tests/src/lib.rs
@@ -1,0 +1,11 @@
+//! Cross-binding wire-format equivalence tests.
+//!
+//! This crate has no runtime API. It exists to host integration tests
+//! in `tests/` that depend on multiple wire-format bindings
+//! (`rustledger-ffi-wasi` and `rustledger-wasm`) and assert their
+//! `Directive → JSON` outputs agree on shared fixtures.
+//!
+//! See issue #1200 for the motivation and audit candidates. Each
+//! audit finding lands as an additional fixture row in
+//! `tests/equivalence.rs` — so any drift between bindings is caught
+//! by CI rather than waiting for a user-filed issue.

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -15,6 +15,18 @@
 //! it because each test only knew about its own DTO. See issue #1200
 //! for the broader audit/scaffold plan.
 //!
+//! ## What this catches — and what it doesn't
+//!
+//! The harness catches **drift between bindings**: if one binding
+//! starts emitting a different shape than the other, the
+//! corresponding fixture fails. It does **not** catch
+//! **wrong-in-lockstep** bugs — if both bindings emit the same buggy
+//! shape, the test passes. Treat equivalence as a necessary but not
+//! sufficient condition for correctness. For audit fixtures that care
+//! about a specific field being present (not just symmetric across
+//! bindings), use [`assert_field_present`] to additionally pin the
+//! presence in the wire output.
+//!
 //! ## Known divergences (normalized away in this test)
 //!
 //! Each divergence below should be converged in a follow-up PR (it's
@@ -98,6 +110,39 @@ fn strip_top_level_empty_meta_and_nulls(json: &mut serde_json::Value) {
     }
 }
 
+/// Assert that a field appears in **both** bindings' JSON output.
+/// Used by audit fixtures that need to verify a specific field is
+/// actually present in the wire shape — equivalence alone wouldn't
+/// catch a both-binding drop. Walks the JSON object via dot-separated
+/// `path` (e.g. `"tags"`, `"postings.0.account"`).
+#[track_caller]
+fn assert_field_present(label: &str, directive: &Directive, path: &str) {
+    let ffi_wasi = serde_json::to_value(rustledger_ffi_wasi::convert::directive_to_json(
+        directive,
+        1,
+        "test.bean",
+    ))
+    .expect("FFI-WASI DirectiveJson is always JSON-serializable");
+    let wasm = serde_json::to_value(rustledger_wasm::convert::directive_to_json(directive))
+        .expect("WASM DirectiveJson is always JSON-serializable");
+
+    for (binding, value) in [("ffi-wasi", &ffi_wasi), ("wasm", &wasm)] {
+        let mut cursor = value;
+        for segment in path.split('.') {
+            cursor = if let Ok(idx) = segment.parse::<usize>() {
+                cursor.get(idx)
+            } else {
+                cursor.get(segment)
+            }
+            .unwrap_or_else(|| {
+                panic!(
+                    "fixture {label:?}: {binding} output missing field {path:?} (at segment {segment:?})\nfull output: {value:#}",
+                )
+            });
+        }
+    }
+}
+
 /// Run a `Directive` through both bindings' `directive_to_json` and
 /// assert the JSON outputs agree after normalization.
 ///
@@ -172,22 +217,54 @@ fn fixture_metadata_all_variants() -> Metadata {
 // Tests
 // =============================================================================
 
-/// Metadata equivalence — every `MetaValue` flavor produces the
-/// same JSON shape in both bindings. This is the original #1168
-/// motivation: WASM dropped the whole `meta` field for the crate's
-/// lifetime before #1199. The exhaustive-variants fixture means
-/// any future drop of a single variant is caught.
+/// Metadata equivalence on a Transaction — every `MetaValue`
+/// flavor produces the same JSON shape in both bindings. This is
+/// the original #1168 motivation: WASM dropped the whole `meta`
+/// field for the crate's lifetime before #1199. The exhaustive-
+/// variants fixture means any future drop of a single variant is
+/// caught.
 #[test]
-fn metadata_equivalence_across_all_meta_value_variants() {
-    let txn = Transaction::new(naive_date(2024, 1, 15).unwrap(), "test")
+fn metadata_equivalence_on_transaction_directive() {
+    let mut txn = Transaction::new(naive_date(2024, 1, 15).unwrap(), "test")
         .with_posting(fixture_posting("Assets:Cash", "100.00", "USD"))
         .with_posting(fixture_posting("Expenses:Food", "-100.00", "USD"))
         .with_tag(Tag::new("trip"));
-    let mut txn = txn;
     txn.meta = fixture_metadata_all_variants();
 
     let directive = Directive::Transaction(txn);
+    assert_field_present("transaction_with_all_meta_variants", &directive, "meta");
     assert_wire_equivalent("transaction_with_all_meta_variants", &directive);
+}
+
+/// Metadata equivalence on an Open — same exhaustive `MetaValue`
+/// fixture, different directive variant. Catches a binding that
+/// handles metadata correctly on Transaction but drops it on
+/// other directive variants.
+#[test]
+fn metadata_equivalence_on_open_directive() {
+    let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
+        .with_currencies(vec![Currency::new("USD")])
+        .with_meta(fixture_metadata_all_variants());
+    let directive = Directive::Open(open);
+    assert_field_present("open_with_all_meta_variants", &directive, "meta");
+    assert_wire_equivalent("open_with_all_meta_variants", &directive);
+}
+
+/// Metadata equivalence on a Document — also covers the audit
+/// candidate fields (`tags`/`links`) when carrying metadata.
+#[test]
+fn metadata_equivalence_on_document_directive() {
+    let document = Document {
+        date: naive_date(2024, 1, 15).unwrap(),
+        account: Account::new("Assets:Bank"),
+        path: "statements/2024-01.pdf".to_string(),
+        tags: vec![Tag::new("statement")],
+        links: vec![],
+        meta: fixture_metadata_all_variants(),
+    };
+    let directive = Directive::Document(document);
+    assert_field_present("document_with_all_meta_variants", &directive, "meta");
+    assert_wire_equivalent("document_with_all_meta_variants", &directive);
 }
 
 /// Smoke test that a minimal Open directive (no metadata, no
@@ -205,7 +282,12 @@ fn open_with_booking_method_equivalence() {
     let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
         .with_currencies(vec![Currency::new("USD")])
         .with_booking("STRICT");
-    assert_wire_equivalent("open_with_booking", &Directive::Open(open));
+    let directive = Directive::Open(open);
+    // Pin `booking` is present in both wire shapes — pre-#1199 WASM
+    // emitted it as a Debug-formatted quoted string; the audit
+    // confirmed the format is now standardized.
+    assert_field_present("open_with_booking", &directive, "booking");
+    assert_wire_equivalent("open_with_booking", &directive);
 }
 
 #[test]
@@ -218,12 +300,11 @@ fn close_directive_equivalence() {
 }
 
 /// Audit finding from issue #1200 item 3: WASM drops `Balance.tolerance`
-/// entirely from its wire shape; FFI-WASI emits it. Until WASM's
-/// `DirectiveJson::Balance` variant gains a `tolerance` field, this
-/// test stays `#[ignore]`d but documents the expected convergence
-/// target. Remove the `#[ignore]` once WASM is fixed.
+/// entirely from its wire shape; FFI-WASI emits it. Tracked in #1206
+/// with a concrete fix plan. Remove the `#[ignore]` once WASM emits
+/// the field — the test then pins the convergence going forward.
 #[test]
-#[ignore = "WASM drops Balance.tolerance — fix in a follow-up PR; tracked in #1200"]
+#[ignore = "WASM drops Balance.tolerance — tracked in #1206"]
 fn balance_directive_with_tolerance_equivalence() {
     let mut balance = Balance::new(
         naive_date(2024, 6, 1).unwrap(),
@@ -276,14 +357,14 @@ fn note_directive_equivalence() {
     assert_wire_equivalent("note_basic", &Directive::Note(note));
 }
 
-/// Audit candidate from issue #1200 item 3: `Document.tags` /
-/// `Document.links` exist on the core type but were never plumbed
-/// through `plugin-types::DocumentData`. The plugin-types DTO is a
-/// separate wire shape — this test exercises the FFI-WASI/WASM
-/// JSON-RPC + JS API shapes specifically (both have `Document`
-/// variants in their `DirectiveJson` enums). If either binding
-/// drops `tags`/`links`, this fixture surfaces it.
+/// Audit finding from issue #1200 item 3 — caught by the
+/// `assert_field_present` helper, not by equivalence:
+/// **both bindings** drop `Document.tags` and `Document.links` from
+/// their wire shape (lockstep-wrong, so equivalence alone would
+/// have passed silently). Tracked in #1208 with a concrete fix
+/// plan for both bindings.
 #[test]
+#[ignore = "Both bindings drop Document.tags and Document.links — tracked in #1208"]
 fn document_directive_with_tags_and_links_equivalence() {
     let document = Document {
         date: naive_date(2024, 1, 15).unwrap(),
@@ -293,10 +374,10 @@ fn document_directive_with_tags_and_links_equivalence() {
         links: vec![Link::new("inv-2024-01")],
         meta: Metadata::default(),
     };
-    assert_wire_equivalent(
-        "document_with_tags_and_links",
-        &Directive::Document(document),
-    );
+    let directive = Directive::Document(document);
+    assert_field_present("document_with_tags_and_links", &directive, "tags");
+    assert_field_present("document_with_tags_and_links", &directive, "links");
+    assert_wire_equivalent("document_with_tags_and_links", &directive);
 }
 
 #[test]
@@ -314,10 +395,10 @@ fn query_directive_equivalence() {
 /// emits each value as a tagged union `{type: "...", value: ...}`,
 /// which is type-safe — a JS consumer can distinguish a `Date` value
 /// from a `String` value. WASM emits values raw (the bare string,
-/// number, or object), which is lossy. Marked `#[ignore]` until the
-/// WASM side adopts the tagged shape; tracked in #1200.
+/// number, or object), which is lossy. Tracked in #1207 with a fix
+/// plan to adopt the tagged shape on the WASM side.
 #[test]
-#[ignore = "WASM emits Custom.values raw (lossy); FFI-WASI uses tagged union — fix in a follow-up"]
+#[ignore = "WASM emits Custom.values raw (lossy); tagged union expected — tracked in #1207"]
 fn custom_directive_with_all_value_variants_equivalence() {
     let custom = Custom {
         date: naive_date(2024, 1, 1).unwrap(),
@@ -360,7 +441,11 @@ fn posting_with_cost_spec_equivalence() {
     let txn = Transaction::new(naive_date(2024, 1, 15).unwrap(), "buy")
         .with_posting(Spanned::synthesized(posting))
         .with_posting(fixture_posting("Assets:Cash", "-1500.00", "USD"));
-    assert_wire_equivalent("posting_with_cost_spec", &Directive::Transaction(txn));
+    let directive = Directive::Transaction(txn);
+    // Both bindings must actually emit the cost field, not just agree
+    // on dropping it.
+    assert_field_present("posting_with_cost_spec", &directive, "postings.0.cost");
+    assert_wire_equivalent("posting_with_cost_spec", &directive);
 }
 
 /// Posting with price annotation (`@` for per-unit, `@@` for total).
@@ -380,25 +465,29 @@ fn posting_with_price_annotation_equivalence() {
     let txn = Transaction::new(naive_date(2024, 6, 1).unwrap(), "fx")
         .with_posting(Spanned::synthesized(posting))
         .with_posting(fixture_posting("Assets:Cash", "-110.00", "USD"));
-    assert_wire_equivalent(
+    let directive = Directive::Transaction(txn);
+    // Both bindings must actually emit the price field.
+    assert_field_present(
         "posting_with_price_annotation",
-        &Directive::Transaction(txn),
+        &directive,
+        "postings.0.price",
     );
+    assert_wire_equivalent("posting_with_price_annotation", &directive);
 }
 
 /// Audit finding from issue #1200 item 3: WASM drops `Posting.flag`
 /// (the `!` flag on individual postings) entirely from its wire
 /// shape; FFI-WASI emits it. Same failure mode as the pre-#1199 meta
-/// drop — silently absent from one binding. Marked `#[ignore]`
-/// until WASM is fixed; tracked in #1200.
+/// drop — silently absent from one binding. Tracked in #1205 with a
+/// concrete fix plan for `PostingJson.flag`.
 #[test]
-#[ignore = "WASM drops Posting.flag — fix in a follow-up PR; tracked in #1200"]
+#[ignore = "WASM drops Posting.flag — tracked in #1205"]
 fn posting_with_flag_equivalence() {
-    let mut posting = Posting::new(
+    let posting = Posting::new(
         Account::new("Assets:Cash"),
         Amount::new(dec!(100), Currency::new("USD")),
-    );
-    posting.flag = Some('!');
+    )
+    .with_flag('!');
     let txn = Transaction::new(naive_date(2024, 1, 1).unwrap(), "pending")
         .with_posting(Spanned::synthesized(posting))
         .with_posting(fixture_posting("Expenses:Misc", "-100.00", "USD"));

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -82,16 +82,16 @@ fn strip_source_position_keys(json: &mut serde_json::Value) {
     }
 }
 
-/// Strip empty `meta` objects and explicit nulls from the **top level
-/// of the directive only** — never recurse into the `meta` object
-/// itself. Inside `meta`, `null` is a legitimate value: `MetaValue::None`
-/// serializes as `null` in both bindings, and the metadata-variant
-/// fixture deliberately includes a `none-key: null` entry to pin
-/// that variant's wire shape. Stripping nulls there would silently
-/// hide a future drop of the `None` variant.
+/// Strip empty `meta` objects and explicit nulls from the directive
+/// and its `postings` children. **Does not** recurse into the `meta`
+/// object itself: inside `meta`, `null` is a legitimate value —
+/// `MetaValue::None` serializes as `null` in both bindings, and the
+/// metadata-variant fixture deliberately includes a `none-key: null`
+/// entry to pin that variant's wire shape. Stripping nulls there
+/// would silently hide a future drop of the `None` variant.
 ///
 /// See divergences #2 and #3 in the module doc.
-fn strip_top_level_empty_meta_and_nulls(json: &mut serde_json::Value) {
+fn strip_empty_meta_and_directive_nulls(json: &mut serde_json::Value) {
     let Some(map) = json.as_object_mut() else {
         return;
     };
@@ -104,11 +104,12 @@ fn strip_top_level_empty_meta_and_nulls(json: &mut serde_json::Value) {
         }
         true
     });
-    // Recurse into postings (which can also carry null optional
-    // fields like `flag` per audit finding #1205) but NOT into `meta`.
+    // Descend into `postings` (each posting can also carry null
+    // optional fields like `flag` per audit finding #1205) but NOT
+    // into `meta`.
     if let Some(postings) = map.get_mut("postings").and_then(|p| p.as_array_mut()) {
         for posting in postings {
-            strip_top_level_empty_meta_and_nulls(posting);
+            strip_empty_meta_and_directive_nulls(posting);
         }
     }
 }
@@ -199,8 +200,8 @@ fn assert_wire_format(label: &str, directive: &Directive, required_fields: &[&st
 
     // Equivalence check after normalization.
     strip_source_position_keys(&mut ffi_wasi);
-    strip_top_level_empty_meta_and_nulls(&mut ffi_wasi);
-    strip_top_level_empty_meta_and_nulls(&mut wasm);
+    strip_empty_meta_and_directive_nulls(&mut ffi_wasi);
+    strip_empty_meta_and_directive_nulls(&mut wasm);
     assert_eq!(
         ffi_wasi, wasm,
         "wire-format divergence between FFI-WASI and WASM for fixture {label:?}",

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -1,0 +1,196 @@
+//! Cross-binding equivalence tests for the `Directive → JSON` wire format.
+//!
+//! Calls both bindings' actual `directive_to_json` functions
+//! ([`rustledger_ffi_wasi::convert::directive_to_json`] and
+//! [`rustledger_wasm::convert::directive_to_json`]) on a shared
+//! `Directive` fixture and asserts they produce structurally
+//! equivalent JSON.
+//!
+//! ## Why this exists
+//!
+//! Each binding has its own tests pinning its own wire shape in
+//! isolation — nothing asserts the two SHAPES AGREE. Issue #1168 was
+//! exactly that failure: WASM dropped directive metadata for the
+//! crate's entire lifetime, and the per-binding tests didn't catch
+//! it because each test only knew about its own DTO. See issue #1200
+//! for the broader audit/scaffold plan.
+//!
+//! ## Known divergences (normalized away in this test)
+//!
+//! Each divergence below should be converged in a follow-up PR (it's
+//! a JSON-RPC / JS API change; out of scope for landing this harness).
+//! The normalization step exists so the test can land in a useful
+//! state today and start catching *new* drift while the existing
+//! drift gets fixed in dedicated PRs.
+//!
+//! 1. **`meta` field internal shape**: FFI-WASI's `Meta` is a
+//!    flattened struct bundling `filename` / `lineno` / `hash` with
+//!    user metadata. WASM's `meta` is `HashMap<String, MetaValueJson>`
+//!    — user metadata only. Normalization strips
+//!    `filename`/`lineno`/`hash` from the FFI-WASI side. Converge by
+//!    moving source-position info to a sibling field on the FFI-WASI
+//!    directive.
+//!
+//! 2. **Empty-collection serialization**: WASM uses
+//!    `skip_serializing_if = "HashMap::is_empty"` on its `meta`
+//!    field; FFI-WASI emits `"meta": {}`. Normalization drops
+//!    `meta: {}` on both sides. Converge by adding
+//!    `skip_serializing_if` to the FFI-WASI side (or by always
+//!    emitting an explicit empty object on both — pick one rule).
+//!
+//! 3. **None vs absent**: WASM emits `"payee": null`, FFI-WASI uses
+//!    `skip_serializing_if = "Option::is_none"`. Normalization drops
+//!    explicit nulls. Converge by adding `skip_serializing_if` on
+//!    the WASM side.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{
+    Account, Amount, Currency, Directive, Link, MetaValue, Metadata, Open, Posting, Spanned, Tag,
+    Transaction, naive_date,
+};
+
+// =============================================================================
+// Normalization
+// =============================================================================
+
+/// Strip the FFI-WASI-specific source-position keys from `meta`.
+/// See divergence #1 in the module doc.
+fn strip_source_position_keys(json: &mut serde_json::Value) {
+    const SOURCE_POSITION_KEYS: &[&str] = &["filename", "lineno", "hash"];
+    if let Some(obj) = json.as_object_mut()
+        && let Some(meta) = obj.get_mut("meta").and_then(|m| m.as_object_mut())
+    {
+        for key in SOURCE_POSITION_KEYS {
+            meta.remove(*key);
+        }
+    }
+}
+
+/// Recursively strip empty objects keyed `"meta"` and explicit nulls.
+/// See divergences #2 and #3 in the module doc.
+fn strip_empty_meta_and_nulls(json: &mut serde_json::Value) {
+    match json {
+        serde_json::Value::Object(map) => {
+            map.retain(|key, value| {
+                if value.is_null() {
+                    return false;
+                }
+                if key == "meta" && value.as_object().is_some_and(serde_json::Map::is_empty) {
+                    return false;
+                }
+                true
+            });
+            for value in map.values_mut() {
+                strip_empty_meta_and_nulls(value);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                strip_empty_meta_and_nulls(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Run a `Directive` through both bindings' `directive_to_json` and
+/// assert the JSON outputs agree after normalization.
+///
+/// `label` is used in the assertion message so a failure points at
+/// the offending fixture.
+#[track_caller]
+fn assert_wire_equivalent(label: &str, directive: &Directive) {
+    let ffi_wasi_json = rustledger_ffi_wasi::convert::directive_to_json(directive, 1, "test.bean");
+    let mut ffi_wasi_value = serde_json::to_value(&ffi_wasi_json)
+        .expect("FFI-WASI DirectiveJson is always JSON-serializable");
+    strip_source_position_keys(&mut ffi_wasi_value);
+    strip_empty_meta_and_nulls(&mut ffi_wasi_value);
+
+    let wasm_json = rustledger_wasm::convert::directive_to_json(directive);
+    let mut wasm_value =
+        serde_json::to_value(&wasm_json).expect("WASM DirectiveJson is always JSON-serializable");
+    strip_empty_meta_and_nulls(&mut wasm_value);
+
+    assert_eq!(
+        ffi_wasi_value, wasm_value,
+        "wire-format divergence between FFI-WASI and WASM for fixture {label:?}",
+    );
+}
+
+// =============================================================================
+// Fixture builders
+// =============================================================================
+
+fn fixture_posting(account: &str, amount_str: &str, currency: &str) -> Spanned<Posting> {
+    Spanned::synthesized(Posting::new(
+        Account::new(account),
+        Amount::new(amount_str.parse().unwrap(), Currency::new(currency)),
+    ))
+}
+
+/// Build a `Metadata` with one entry per `MetaValue` variant. This
+/// fixture is what exercises the metadata wire-shape — every
+/// flavor (`String`, `Account`, `Currency`, `Tag`, `Link`, `Date`,
+/// `Number`, `Bool`, `Amount`, `None`) is present so the test
+/// catches a binding dropping a single variant.
+fn fixture_metadata_all_variants() -> Metadata {
+    let mut m = Metadata::default();
+    m.insert(
+        "string-key".to_string(),
+        MetaValue::String("hello".to_string()),
+    );
+    m.insert(
+        "account-key".to_string(),
+        MetaValue::Account(Account::new("Assets:Cash")),
+    );
+    m.insert(
+        "currency-key".to_string(),
+        MetaValue::Currency(Currency::new("USD")),
+    );
+    m.insert("tag-key".to_string(), MetaValue::Tag(Tag::new("trip")));
+    m.insert("link-key".to_string(), MetaValue::Link(Link::new("inv-42")));
+    m.insert(
+        "date-key".to_string(),
+        MetaValue::Date(naive_date(2024, 6, 15).unwrap()),
+    );
+    m.insert("number-key".to_string(), MetaValue::Number(dec!(123.456)));
+    m.insert("bool-key".to_string(), MetaValue::Bool(true));
+    m.insert(
+        "amount-key".to_string(),
+        MetaValue::Amount(Amount::new(dec!(99.99), Currency::new("EUR"))),
+    );
+    m.insert("none-key".to_string(), MetaValue::None);
+    m
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// Metadata equivalence — every `MetaValue` flavor produces the
+/// same JSON shape in both bindings. This is the original #1168
+/// motivation: WASM dropped the whole `meta` field for the crate's
+/// lifetime before #1199. The exhaustive-variants fixture means
+/// any future drop of a single variant is caught.
+#[test]
+fn metadata_equivalence_across_all_meta_value_variants() {
+    let txn = Transaction::new(naive_date(2024, 1, 15).unwrap(), "test")
+        .with_posting(fixture_posting("Assets:Cash", "100.00", "USD"))
+        .with_posting(fixture_posting("Expenses:Food", "-100.00", "USD"))
+        .with_tag(Tag::new("trip"));
+    let mut txn = txn;
+    txn.meta = fixture_metadata_all_variants();
+
+    let directive = Directive::Transaction(txn);
+    assert_wire_equivalent("transaction_with_all_meta_variants", &directive);
+}
+
+/// Smoke test that a minimal Open directive (no metadata, no
+/// optional fields) agrees between bindings. Establishes that the
+/// harness doesn't false-positive on a trivial case.
+#[test]
+fn open_directive_minimal_equivalence() {
+    let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
+        .with_currencies(vec![Currency::new("USD")]);
+    assert_wire_equivalent("open_minimal", &Directive::Open(open));
+}

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -67,30 +67,34 @@ fn strip_source_position_keys(json: &mut serde_json::Value) {
     }
 }
 
-/// Recursively strip empty objects keyed `"meta"` and explicit nulls.
+/// Strip empty `meta` objects and explicit nulls from the **top level
+/// of the directive only** — never recurse into the `meta` object
+/// itself. Inside `meta`, `null` is a legitimate value: `MetaValue::None`
+/// serializes as `null` in both bindings, and the metadata-variant
+/// fixture deliberately includes a `none-key: null` entry to pin
+/// that variant's wire shape. Stripping nulls there would silently
+/// hide a future drop of the `None` variant.
+///
 /// See divergences #2 and #3 in the module doc.
-fn strip_empty_meta_and_nulls(json: &mut serde_json::Value) {
-    match json {
-        serde_json::Value::Object(map) => {
-            map.retain(|key, value| {
-                if value.is_null() {
-                    return false;
-                }
-                if key == "meta" && value.as_object().is_some_and(serde_json::Map::is_empty) {
-                    return false;
-                }
-                true
-            });
-            for value in map.values_mut() {
-                strip_empty_meta_and_nulls(value);
-            }
+fn strip_top_level_empty_meta_and_nulls(json: &mut serde_json::Value) {
+    let Some(map) = json.as_object_mut() else {
+        return;
+    };
+    map.retain(|key, value| {
+        if value.is_null() {
+            return false;
         }
-        serde_json::Value::Array(arr) => {
-            for v in arr {
-                strip_empty_meta_and_nulls(v);
-            }
+        if key == "meta" && value.as_object().is_some_and(serde_json::Map::is_empty) {
+            return false;
         }
-        _ => {}
+        true
+    });
+    // Recurse into postings (which can also carry null optional
+    // fields like `flag` per audit finding #1205) but NOT into `meta`.
+    if let Some(postings) = map.get_mut("postings").and_then(|p| p.as_array_mut()) {
+        for posting in postings {
+            strip_top_level_empty_meta_and_nulls(posting);
+        }
     }
 }
 
@@ -105,12 +109,12 @@ fn assert_wire_equivalent(label: &str, directive: &Directive) {
     let mut ffi_wasi_value = serde_json::to_value(&ffi_wasi_json)
         .expect("FFI-WASI DirectiveJson is always JSON-serializable");
     strip_source_position_keys(&mut ffi_wasi_value);
-    strip_empty_meta_and_nulls(&mut ffi_wasi_value);
+    strip_top_level_empty_meta_and_nulls(&mut ffi_wasi_value);
 
     let wasm_json = rustledger_wasm::convert::directive_to_json(directive);
     let mut wasm_value =
         serde_json::to_value(&wasm_json).expect("WASM DirectiveJson is always JSON-serializable");
-    strip_empty_meta_and_nulls(&mut wasm_value);
+    strip_top_level_empty_meta_and_nulls(&mut wasm_value);
 
     assert_eq!(
         ffi_wasi_value, wasm_value,

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -17,15 +17,18 @@
 //!
 //! ## What this catches — and what it doesn't
 //!
-//! The harness catches **drift between bindings**: if one binding
-//! starts emitting a different shape than the other, the
+//! Equivalence alone catches **drift between bindings**: if one
+//! binding starts emitting a different shape than the other, the
 //! corresponding fixture fails. It does **not** catch
 //! **wrong-in-lockstep** bugs — if both bindings emit the same buggy
-//! shape, the test passes. Treat equivalence as a necessary but not
-//! sufficient condition for correctness. For audit fixtures that care
-//! about a specific field being present (not just symmetric across
-//! bindings), use [`assert_field_present`] to additionally pin the
-//! presence in the wire output.
+//! shape, the equivalence check passes silently.
+//!
+//! For audit fixtures that need to verify specific fields are
+//! actually present (and non-trivially-empty) in the wire shape,
+//! use [`assert_wire_format`] with the field paths listed. It
+//! combines presence + non-empty + equivalence in one call, computes
+//! both bindings' JSON exactly once, and catches both failure modes
+//! (field missing, field always-empty).
 //!
 //! ## Known divergences (normalized away in this test)
 //!
@@ -110,13 +113,11 @@ fn strip_top_level_empty_meta_and_nulls(json: &mut serde_json::Value) {
     }
 }
 
-/// Assert that a field appears in **both** bindings' JSON output.
-/// Used by audit fixtures that need to verify a specific field is
-/// actually present in the wire shape — equivalence alone wouldn't
-/// catch a both-binding drop. Walks the JSON object via dot-separated
-/// `path` (e.g. `"tags"`, `"postings.0.account"`).
-#[track_caller]
-fn assert_field_present(label: &str, directive: &Directive, path: &str) {
+/// Convert a `Directive` through both bindings' `directive_to_json`
+/// in one pass and return both raw JSON values (pre-normalization).
+/// Centralizes the conversion-site arguments so a future change to
+/// either binding's signature only edits one place.
+fn convert_through_both_bindings(directive: &Directive) -> (serde_json::Value, serde_json::Value) {
     let ffi_wasi = serde_json::to_value(rustledger_ffi_wasi::convert::directive_to_json(
         directive,
         1,
@@ -125,44 +126,83 @@ fn assert_field_present(label: &str, directive: &Directive, path: &str) {
     .expect("FFI-WASI DirectiveJson is always JSON-serializable");
     let wasm = serde_json::to_value(rustledger_wasm::convert::directive_to_json(directive))
         .expect("WASM DirectiveJson is always JSON-serializable");
+    (ffi_wasi, wasm)
+}
 
-    for (binding, value) in [("ffi-wasi", &ffi_wasi), ("wasm", &wasm)] {
-        let mut cursor = value;
-        for segment in path.split('.') {
-            cursor = if let Ok(idx) = segment.parse::<usize>() {
-                cursor.get(idx)
-            } else {
-                cursor.get(segment)
-            }
-            .unwrap_or_else(|| {
-                panic!(
-                    "fixture {label:?}: {binding} output missing field {path:?} (at segment {segment:?})\nfull output: {value:#}",
-                )
-            });
-        }
+/// Walk a JSON value via dot-separated `path` (e.g. `"tags"`,
+/// `"postings.0.account"`) and return the value at that location, or
+/// `None` if any segment is missing.
+///
+/// **Path syntax constraint**: segments split on `.` and `usize`-
+/// parseable segments index arrays. No escape mechanism for literal
+/// dots in keys — if a future fixture uses a metadata key like
+/// `"app.feature"`, this helper will misroute. Avoid such keys in
+/// fixtures (this is a test-only utility, not a public API).
+fn json_get_path<'v>(value: &'v serde_json::Value, path: &str) -> Option<&'v serde_json::Value> {
+    let mut cursor = value;
+    for segment in path.split('.') {
+        cursor = if let Ok(idx) = segment.parse::<usize>() {
+            cursor.get(idx)?
+        } else {
+            cursor.get(segment)?
+        };
+    }
+    Some(cursor)
+}
+
+/// Whether a JSON value is "trivially-default" — null, empty array,
+/// or empty object. Used by [`assert_wire_format`]'s field-presence
+/// checks to catch a binding that emits the field but always-empty
+/// (which would slip past a pure key-existence check).
+fn is_trivially_default(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => true,
+        serde_json::Value::Array(a) => a.is_empty(),
+        serde_json::Value::Object(o) => o.is_empty(),
+        _ => false,
     }
 }
 
-/// Run a `Directive` through both bindings' `directive_to_json` and
-/// assert the JSON outputs agree after normalization.
+/// One-call audit helper: compute both bindings' JSON once, assert
+/// every `required_field` is present **and non-trivially-default**
+/// in both outputs, then assert the normalized shapes are equivalent.
 ///
-/// `label` is used in the assertion message so a failure points at
-/// the offending fixture.
+/// Pass an empty `required_fields` slice for plain equivalence-only
+/// fixtures (smoke tests, variants where there's nothing field-
+/// specific to pin). Audit fixtures that care about specific fields
+/// being on the wire — and about a future regression that emits the
+/// field always-empty — list those fields' dot-paths.
+///
+/// "Non-trivially-default" means: not `null`, not `[]`, not `{}`.
+/// Catches both the field-missing failure mode (e.g. #1205 dropping
+/// `Posting.flag`) and the field-always-empty failure mode (e.g. a
+/// future regression that emits `"tags": []` regardless of input).
 #[track_caller]
-fn assert_wire_equivalent(label: &str, directive: &Directive) {
-    let ffi_wasi_json = rustledger_ffi_wasi::convert::directive_to_json(directive, 1, "test.bean");
-    let mut ffi_wasi_value = serde_json::to_value(&ffi_wasi_json)
-        .expect("FFI-WASI DirectiveJson is always JSON-serializable");
-    strip_source_position_keys(&mut ffi_wasi_value);
-    strip_top_level_empty_meta_and_nulls(&mut ffi_wasi_value);
+fn assert_wire_format(label: &str, directive: &Directive, required_fields: &[&str]) {
+    let (mut ffi_wasi, mut wasm) = convert_through_both_bindings(directive);
 
-    let wasm_json = rustledger_wasm::convert::directive_to_json(directive);
-    let mut wasm_value =
-        serde_json::to_value(&wasm_json).expect("WASM DirectiveJson is always JSON-serializable");
-    strip_top_level_empty_meta_and_nulls(&mut wasm_value);
+    // Presence + non-empty checks BEFORE normalization, so the
+    // assertion error message shows the actual binding output.
+    for path in required_fields {
+        for (binding, value) in [("ffi-wasi", &ffi_wasi), ("wasm", &wasm)] {
+            let found = json_get_path(value, path).unwrap_or_else(|| {
+                panic!(
+                    "fixture {label:?}: {binding} output missing field {path:?}\nfull output: {value:#}",
+                )
+            });
+            assert!(
+                !is_trivially_default(found),
+                "fixture {label:?}: {binding} output has field {path:?} but value is trivially default ({found:#}) — likely an always-empty regression\nfull output: {value:#}",
+            );
+        }
+    }
 
+    // Equivalence check after normalization.
+    strip_source_position_keys(&mut ffi_wasi);
+    strip_top_level_empty_meta_and_nulls(&mut ffi_wasi);
+    strip_top_level_empty_meta_and_nulls(&mut wasm);
     assert_eq!(
-        ffi_wasi_value, wasm_value,
+        ffi_wasi, wasm,
         "wire-format divergence between FFI-WASI and WASM for fixture {label:?}",
     );
 }
@@ -174,7 +214,12 @@ fn assert_wire_equivalent(label: &str, directive: &Directive) {
 fn fixture_posting(account: &str, amount_str: &str, currency: &str) -> Spanned<Posting> {
     Spanned::synthesized(Posting::new(
         Account::new(account),
-        Amount::new(amount_str.parse().unwrap(), Currency::new(currency)),
+        Amount::new(
+            amount_str
+                .parse()
+                .expect("fixture amount must parse as Decimal"),
+            Currency::new(currency),
+        ),
     ))
 }
 
@@ -232,8 +277,7 @@ fn metadata_equivalence_on_transaction_directive() {
     txn.meta = fixture_metadata_all_variants();
 
     let directive = Directive::Transaction(txn);
-    assert_field_present("transaction_with_all_meta_variants", &directive, "meta");
-    assert_wire_equivalent("transaction_with_all_meta_variants", &directive);
+    assert_wire_format("transaction_with_all_meta_variants", &directive, &["meta"]);
 }
 
 /// Metadata equivalence on an Open — same exhaustive `MetaValue`
@@ -246,8 +290,7 @@ fn metadata_equivalence_on_open_directive() {
         .with_currencies(vec![Currency::new("USD")])
         .with_meta(fixture_metadata_all_variants());
     let directive = Directive::Open(open);
-    assert_field_present("open_with_all_meta_variants", &directive, "meta");
-    assert_wire_equivalent("open_with_all_meta_variants", &directive);
+    assert_wire_format("open_with_all_meta_variants", &directive, &["meta"]);
 }
 
 /// Metadata equivalence on a Document — also covers the audit
@@ -263,8 +306,7 @@ fn metadata_equivalence_on_document_directive() {
         meta: fixture_metadata_all_variants(),
     };
     let directive = Directive::Document(document);
-    assert_field_present("document_with_all_meta_variants", &directive, "meta");
-    assert_wire_equivalent("document_with_all_meta_variants", &directive);
+    assert_wire_format("document_with_all_meta_variants", &directive, &["meta"]);
 }
 
 /// Smoke test that a minimal Open directive (no metadata, no
@@ -274,7 +316,7 @@ fn metadata_equivalence_on_document_directive() {
 fn open_directive_minimal_equivalence() {
     let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
         .with_currencies(vec![Currency::new("USD")]);
-    assert_wire_equivalent("open_minimal", &Directive::Open(open));
+    assert_wire_format("open_minimal", &Directive::Open(open), &[]);
 }
 
 #[test]
@@ -282,12 +324,10 @@ fn open_with_booking_method_equivalence() {
     let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
         .with_currencies(vec![Currency::new("USD")])
         .with_booking("STRICT");
-    let directive = Directive::Open(open);
     // Pin `booking` is present in both wire shapes — pre-#1199 WASM
     // emitted it as a Debug-formatted quoted string; the audit
     // confirmed the format is now standardized.
-    assert_field_present("open_with_booking", &directive, "booking");
-    assert_wire_equivalent("open_with_booking", &directive);
+    assert_wire_format("open_with_booking", &Directive::Open(open), &["booking"]);
 }
 
 #[test]
@@ -296,7 +336,7 @@ fn close_directive_equivalence() {
         naive_date(2024, 12, 31).unwrap(),
         Account::new("Assets:Cash"),
     );
-    assert_wire_equivalent("close_minimal", &Directive::Close(close));
+    assert_wire_format("close_minimal", &Directive::Close(close), &[]);
 }
 
 /// Audit finding from issue #1200 item 3: WASM drops `Balance.tolerance`
@@ -312,7 +352,11 @@ fn balance_directive_with_tolerance_equivalence() {
         Amount::new(dec!(1000.00), Currency::new("USD")),
     );
     balance.tolerance = Some(dec!(0.01));
-    assert_wire_equivalent("balance_with_tolerance", &Directive::Balance(balance));
+    assert_wire_format(
+        "balance_with_tolerance",
+        &Directive::Balance(balance),
+        &["tolerance"],
+    );
 }
 
 #[test]
@@ -322,13 +366,13 @@ fn pad_directive_equivalence() {
         Account::new("Assets:Cash"),
         Account::new("Equity:Opening-Balances"),
     );
-    assert_wire_equivalent("pad_basic", &Directive::Pad(pad));
+    assert_wire_format("pad_basic", &Directive::Pad(pad), &[]);
 }
 
 #[test]
 fn commodity_directive_equivalence() {
     let commodity = Commodity::new(naive_date(2024, 1, 1).unwrap(), Currency::new("USD"));
-    assert_wire_equivalent("commodity_basic", &Directive::Commodity(commodity));
+    assert_wire_format("commodity_basic", &Directive::Commodity(commodity), &[]);
 }
 
 #[test]
@@ -338,13 +382,13 @@ fn price_directive_equivalence() {
         Currency::new("AAPL"),
         Amount::new(dec!(195.50), Currency::new("USD")),
     );
-    assert_wire_equivalent("price_basic", &Directive::Price(price));
+    assert_wire_format("price_basic", &Directive::Price(price), &[]);
 }
 
 #[test]
 fn event_directive_equivalence() {
     let event = Event::new(naive_date(2024, 6, 1).unwrap(), "location", "Tokyo");
-    assert_wire_equivalent("event_basic", &Directive::Event(event));
+    assert_wire_format("event_basic", &Directive::Event(event), &[]);
 }
 
 #[test]
@@ -354,15 +398,15 @@ fn note_directive_equivalence() {
         Account::new("Assets:Cash"),
         "year-end reconciliation",
     );
-    assert_wire_equivalent("note_basic", &Directive::Note(note));
+    assert_wire_format("note_basic", &Directive::Note(note), &[]);
 }
 
 /// Audit finding from issue #1200 item 3 — caught by the
-/// `assert_field_present` helper, not by equivalence:
-/// **both bindings** drop `Document.tags` and `Document.links` from
-/// their wire shape (lockstep-wrong, so equivalence alone would
-/// have passed silently). Tracked in #1208 with a concrete fix
-/// plan for both bindings.
+/// `assert_wire_format` helper's field-presence check, not by
+/// equivalence: **both bindings** drop `Document.tags` and
+/// `Document.links` from their wire shape (lockstep-wrong, so
+/// equivalence alone would have passed silently). Tracked in #1208
+/// with a concrete fix plan for both bindings.
 #[test]
 #[ignore = "Both bindings drop Document.tags and Document.links — tracked in #1208"]
 fn document_directive_with_tags_and_links_equivalence() {
@@ -374,10 +418,11 @@ fn document_directive_with_tags_and_links_equivalence() {
         links: vec![Link::new("inv-2024-01")],
         meta: Metadata::default(),
     };
-    let directive = Directive::Document(document);
-    assert_field_present("document_with_tags_and_links", &directive, "tags");
-    assert_field_present("document_with_tags_and_links", &directive, "links");
-    assert_wire_equivalent("document_with_tags_and_links", &directive);
+    assert_wire_format(
+        "document_with_tags_and_links",
+        &Directive::Document(document),
+        &["tags", "links"],
+    );
 }
 
 #[test]
@@ -387,7 +432,7 @@ fn query_directive_equivalence() {
         "expenses",
         "SELECT account, sum(position)",
     );
-    assert_wire_equivalent("query_basic", &Directive::Query(query));
+    assert_wire_format("query_basic", &Directive::Query(query), &[]);
 }
 
 /// Audit finding from issue #1200 item 3: `Custom.values` is present
@@ -413,7 +458,11 @@ fn custom_directive_with_all_value_variants_equivalence() {
         ],
         meta: Metadata::default(),
     };
-    assert_wire_equivalent("custom_with_all_value_variants", &Directive::Custom(custom));
+    assert_wire_format(
+        "custom_with_all_value_variants",
+        &Directive::Custom(custom),
+        &["values"],
+    );
 }
 
 // =============================================================================
@@ -441,11 +490,11 @@ fn posting_with_cost_spec_equivalence() {
     let txn = Transaction::new(naive_date(2024, 1, 15).unwrap(), "buy")
         .with_posting(Spanned::synthesized(posting))
         .with_posting(fixture_posting("Assets:Cash", "-1500.00", "USD"));
-    let directive = Directive::Transaction(txn);
-    // Both bindings must actually emit the cost field, not just agree
-    // on dropping it.
-    assert_field_present("posting_with_cost_spec", &directive, "postings.0.cost");
-    assert_wire_equivalent("posting_with_cost_spec", &directive);
+    assert_wire_format(
+        "posting_with_cost_spec",
+        &Directive::Transaction(txn),
+        &["postings.0.cost"],
+    );
 }
 
 /// Posting with price annotation (`@` for per-unit, `@@` for total).
@@ -465,14 +514,11 @@ fn posting_with_price_annotation_equivalence() {
     let txn = Transaction::new(naive_date(2024, 6, 1).unwrap(), "fx")
         .with_posting(Spanned::synthesized(posting))
         .with_posting(fixture_posting("Assets:Cash", "-110.00", "USD"));
-    let directive = Directive::Transaction(txn);
-    // Both bindings must actually emit the price field.
-    assert_field_present(
+    assert_wire_format(
         "posting_with_price_annotation",
-        &directive,
-        "postings.0.price",
+        &Directive::Transaction(txn),
+        &["postings.0.price"],
     );
-    assert_wire_equivalent("posting_with_price_annotation", &directive);
 }
 
 /// Audit finding from issue #1200 item 3: WASM drops `Posting.flag`
@@ -491,5 +537,9 @@ fn posting_with_flag_equivalence() {
     let txn = Transaction::new(naive_date(2024, 1, 1).unwrap(), "pending")
         .with_posting(Spanned::synthesized(posting))
         .with_posting(fixture_posting("Expenses:Misc", "-100.00", "USD"));
-    assert_wire_equivalent("posting_with_flag", &Directive::Transaction(txn));
+    assert_wire_format(
+        "posting_with_flag",
+        &Directive::Transaction(txn),
+        &["postings.0.flag"],
+    );
 }

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -45,8 +45,9 @@
 
 use rust_decimal_macros::dec;
 use rustledger_core::{
-    Account, Amount, Currency, Directive, Link, MetaValue, Metadata, Open, Posting, Spanned, Tag,
-    Transaction, naive_date,
+    Account, Amount, Balance, Close, Commodity, CostNumber, CostSpec, Currency, Custom, Directive,
+    Document, Event, IncompleteAmount, Link, MetaValue, Metadata, Note, Open, Pad, Posting, Price,
+    PriceAnnotation, PriceKind, Query, Spanned, Tag, Transaction, naive_date,
 };
 
 // =============================================================================
@@ -193,4 +194,209 @@ fn open_directive_minimal_equivalence() {
     let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
         .with_currencies(vec![Currency::new("USD")]);
     assert_wire_equivalent("open_minimal", &Directive::Open(open));
+}
+
+#[test]
+fn open_with_booking_method_equivalence() {
+    let open = Open::new(naive_date(2024, 1, 1).unwrap(), Account::new("Assets:Cash"))
+        .with_currencies(vec![Currency::new("USD")])
+        .with_booking("STRICT");
+    assert_wire_equivalent("open_with_booking", &Directive::Open(open));
+}
+
+#[test]
+fn close_directive_equivalence() {
+    let close = Close::new(
+        naive_date(2024, 12, 31).unwrap(),
+        Account::new("Assets:Cash"),
+    );
+    assert_wire_equivalent("close_minimal", &Directive::Close(close));
+}
+
+/// Audit finding from issue #1200 item 3: WASM drops `Balance.tolerance`
+/// entirely from its wire shape; FFI-WASI emits it. Until WASM's
+/// `DirectiveJson::Balance` variant gains a `tolerance` field, this
+/// test stays `#[ignore]`d but documents the expected convergence
+/// target. Remove the `#[ignore]` once WASM is fixed.
+#[test]
+#[ignore = "WASM drops Balance.tolerance — fix in a follow-up PR; tracked in #1200"]
+fn balance_directive_with_tolerance_equivalence() {
+    let mut balance = Balance::new(
+        naive_date(2024, 6, 1).unwrap(),
+        Account::new("Assets:Cash"),
+        Amount::new(dec!(1000.00), Currency::new("USD")),
+    );
+    balance.tolerance = Some(dec!(0.01));
+    assert_wire_equivalent("balance_with_tolerance", &Directive::Balance(balance));
+}
+
+#[test]
+fn pad_directive_equivalence() {
+    let pad = Pad::new(
+        naive_date(2024, 1, 1).unwrap(),
+        Account::new("Assets:Cash"),
+        Account::new("Equity:Opening-Balances"),
+    );
+    assert_wire_equivalent("pad_basic", &Directive::Pad(pad));
+}
+
+#[test]
+fn commodity_directive_equivalence() {
+    let commodity = Commodity::new(naive_date(2024, 1, 1).unwrap(), Currency::new("USD"));
+    assert_wire_equivalent("commodity_basic", &Directive::Commodity(commodity));
+}
+
+#[test]
+fn price_directive_equivalence() {
+    let price = Price::new(
+        naive_date(2024, 1, 1).unwrap(),
+        Currency::new("AAPL"),
+        Amount::new(dec!(195.50), Currency::new("USD")),
+    );
+    assert_wire_equivalent("price_basic", &Directive::Price(price));
+}
+
+#[test]
+fn event_directive_equivalence() {
+    let event = Event::new(naive_date(2024, 6, 1).unwrap(), "location", "Tokyo");
+    assert_wire_equivalent("event_basic", &Directive::Event(event));
+}
+
+#[test]
+fn note_directive_equivalence() {
+    let note = Note::new(
+        naive_date(2024, 1, 1).unwrap(),
+        Account::new("Assets:Cash"),
+        "year-end reconciliation",
+    );
+    assert_wire_equivalent("note_basic", &Directive::Note(note));
+}
+
+/// Audit candidate from issue #1200 item 3: `Document.tags` /
+/// `Document.links` exist on the core type but were never plumbed
+/// through `plugin-types::DocumentData`. The plugin-types DTO is a
+/// separate wire shape — this test exercises the FFI-WASI/WASM
+/// JSON-RPC + JS API shapes specifically (both have `Document`
+/// variants in their `DirectiveJson` enums). If either binding
+/// drops `tags`/`links`, this fixture surfaces it.
+#[test]
+fn document_directive_with_tags_and_links_equivalence() {
+    let document = Document {
+        date: naive_date(2024, 1, 15).unwrap(),
+        account: Account::new("Assets:Bank"),
+        path: "statements/2024-01.pdf".to_string(),
+        tags: vec![Tag::new("statement"), Tag::new("bank")],
+        links: vec![Link::new("inv-2024-01")],
+        meta: Metadata::default(),
+    };
+    assert_wire_equivalent(
+        "document_with_tags_and_links",
+        &Directive::Document(document),
+    );
+}
+
+#[test]
+fn query_directive_equivalence() {
+    let query = Query::new(
+        naive_date(2024, 1, 1).unwrap(),
+        "expenses",
+        "SELECT account, sum(position)",
+    );
+    assert_wire_equivalent("query_basic", &Directive::Query(query));
+}
+
+/// Audit finding from issue #1200 item 3: `Custom.values` is present
+/// in both bindings (since #1199), but the **shape** diverges. FFI-WASI
+/// emits each value as a tagged union `{type: "...", value: ...}`,
+/// which is type-safe — a JS consumer can distinguish a `Date` value
+/// from a `String` value. WASM emits values raw (the bare string,
+/// number, or object), which is lossy. Marked `#[ignore]` until the
+/// WASM side adopts the tagged shape; tracked in #1200.
+#[test]
+#[ignore = "WASM emits Custom.values raw (lossy); FFI-WASI uses tagged union — fix in a follow-up"]
+fn custom_directive_with_all_value_variants_equivalence() {
+    let custom = Custom {
+        date: naive_date(2024, 1, 1).unwrap(),
+        custom_type: "budget".to_string(),
+        values: vec![
+            MetaValue::String("Q1".to_string()),
+            MetaValue::Account(Account::new("Expenses:Food")),
+            MetaValue::Amount(Amount::new(dec!(500.00), Currency::new("USD"))),
+            MetaValue::Date(naive_date(2024, 3, 31).unwrap()),
+            MetaValue::Number(dec!(0.85)),
+            MetaValue::Bool(true),
+        ],
+        meta: Metadata::default(),
+    };
+    assert_wire_equivalent("custom_with_all_value_variants", &Directive::Custom(custom));
+}
+
+// =============================================================================
+// Posting-level audits (issue #1200 item 3)
+// =============================================================================
+
+/// Posting with cost spec (`{...}` syntax). FFI-WASI and WASM both
+/// have to serialize the `CostSpec` shape, including the `kind`-
+/// tagged `CostNumber` enum that #1178 standardized.
+#[test]
+fn posting_with_cost_spec_equivalence() {
+    let posting = Posting::new(
+        Account::new("Assets:Stock:AAPL"),
+        Amount::new(dec!(10), Currency::new("AAPL")),
+    )
+    .with_cost(CostSpec {
+        number: Some(CostNumber::PerUnit {
+            value: dec!(150.00),
+        }),
+        currency: Some(Currency::new("USD")),
+        date: Some(naive_date(2024, 1, 15).unwrap()),
+        label: None,
+        merge: false,
+    });
+    let txn = Transaction::new(naive_date(2024, 1, 15).unwrap(), "buy")
+        .with_posting(Spanned::synthesized(posting))
+        .with_posting(fixture_posting("Assets:Cash", "-1500.00", "USD"));
+    assert_wire_equivalent("posting_with_cost_spec", &Directive::Transaction(txn));
+}
+
+/// Posting with price annotation (`@` for per-unit, `@@` for total).
+#[test]
+fn posting_with_price_annotation_equivalence() {
+    let posting = Posting::new(
+        Account::new("Assets:FX"),
+        Amount::new(dec!(100), Currency::new("EUR")),
+    )
+    .with_price(PriceAnnotation {
+        kind: PriceKind::Unit,
+        amount: Some(IncompleteAmount::Complete(Amount::new(
+            dec!(1.10),
+            Currency::new("USD"),
+        ))),
+    });
+    let txn = Transaction::new(naive_date(2024, 6, 1).unwrap(), "fx")
+        .with_posting(Spanned::synthesized(posting))
+        .with_posting(fixture_posting("Assets:Cash", "-110.00", "USD"));
+    assert_wire_equivalent(
+        "posting_with_price_annotation",
+        &Directive::Transaction(txn),
+    );
+}
+
+/// Audit finding from issue #1200 item 3: WASM drops `Posting.flag`
+/// (the `!` flag on individual postings) entirely from its wire
+/// shape; FFI-WASI emits it. Same failure mode as the pre-#1199 meta
+/// drop — silently absent from one binding. Marked `#[ignore]`
+/// until WASM is fixed; tracked in #1200.
+#[test]
+#[ignore = "WASM drops Posting.flag — fix in a follow-up PR; tracked in #1200"]
+fn posting_with_flag_equivalence() {
+    let mut posting = Posting::new(
+        Account::new("Assets:Cash"),
+        Amount::new(dec!(100), Currency::new("USD")),
+    );
+    posting.flag = Some('!');
+    let txn = Transaction::new(naive_date(2024, 1, 1).unwrap(), "pending")
+        .with_posting(Spanned::synthesized(posting))
+        .with_posting(fixture_posting("Expenses:Misc", "-100.00", "USD"));
+    assert_wire_equivalent("posting_with_flag", &Directive::Transaction(txn));
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -460,14 +460,6 @@ criteria = "safe-to-deploy"
 version = "0.15.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.hashbrown]]
-version = "0.16.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.hashbrown]]
-version = "0.17.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.hermit-abi]]
 version = "0.3.3"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3166,6 +3166,30 @@ version = "0.12.3"
 notes = "This version is used in rust's libstd, so effectively we're already trusting it"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.5 -> 0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.0 -> 0.16.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.1 -> 0.17.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.heck]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

Lands the cross-binding wire-format equivalence harness from issue #1200 item 1. New `rustledger-wire-format-tests` workspace crate depends on both `rustledger-ffi-wasi` and `rustledger-wasm` and asserts they emit structurally-equivalent JSON for the same `Directive` fixture.

This catches the #1168 failure mode (one binding silently drops a field the other emits) at CI time. Each audit finding from issue #1200 item 3 lands as an additional fixture row going forward.

## Priority order

Following the [revised priority](https://github.com/rustledger/rustledger/issues/1200#issuecomment-4557218690) — item 1 (harness) lands first, item 3 (audit findings) lands as fixture rows in this same crate, item 2 (TS generation) is its own design issue.

## What changed

- **`rustledger-ffi-wasi` gains a lib target.** The binary in `src/main.rs` was previously the only consumer of `convert`/`types`/etc. — they were private modules. Split out into:
  - `src/lib.rs` exposing `pub mod convert` + `pub mod jsonrpc` + DTOs re-exported at the crate root
  - `src/main.rs` slimmed to a 4-line shim calling `rustledger_ffi_wasi::jsonrpc::process_stdin()`
  - `commands`, `helpers`, and `types` are `pub(crate)` — internal to the JSON-RPC implementation
  - `#![allow(missing_docs)]` on the lib with a clear rationale comment (the DTOs' meaning is the JSON-RPC API doc; per-field rustdoc would duplicate it and drift; until item 2 of #1200 lands ts-rs generation, the rust-side type docs are shape-only)

- **`rustledger-wasm::convert`** module promoted from `mod` to `pub mod` so the test crate can call `directive_to_json`. JS consumers still use the `api`/`parsed_ledger` bindings.

- **New `crates/rustledger-wire-format-tests/`** with the equivalence harness:
  - `assert_wire_equivalent(label, directive)` helper calls both bindings, normalizes known divergences, and asserts JSON equality
  - `metadata_equivalence_across_all_meta_value_variants` — the direct #1168 regression test, exercises every `MetaValue` flavor (10 variants)
  - `open_directive_minimal_equivalence` — smoke test

## Known divergences caught immediately

The harness caught three real divergences on first run (documented in the test rustdoc, normalized for now, each deserves its own follow-up PR to converge):

1. **`meta` shape**: FFI-WASI bundles `filename`/`lineno`/`hash` with user metadata; WASM emits user metadata only.
2. **Empty `meta` serialization**: FFI-WASI emits `"meta": {}`; WASM uses `skip_serializing_if = "HashMap::is_empty"`.
3. **Optional fields**: WASM emits `"payee": null`; FFI-WASI uses `skip_serializing_if = "Option::is_none"`.

## Test plan

- [x] `cargo check --all-features --all-targets`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test -p rustledger-wire-format-tests` — 2/2 passing
- [x] `cargo test -p rustledger-ffi-wasi -p rustledger-wasm --all-features` — pre-existing tests unaffected by the lib-target split
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features`
- [x] `cargo fmt --all -- --check`

Tracks #1200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
