### PR TITLE
fix(wasm): emit Posting.flag on the wire (closes #1205)

### DIFF
--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -123,6 +123,8 @@ export interface Posting {
   units: Amount | null;
   /** Optional cost specification. */
   cost: CostSpec | null;
+  /** Posting flag (e.g. "!" for pending). */
+  flag?: string;
   /** Posting-level metadata (issue #1168). */
   meta?: Record<string, MetaValueJson>;
 }

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -105,6 +105,7 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
                         label: c.label.clone(),
                     }),
                     price: p.price.as_ref().and_then(price_annotation_to_amount),
+                    flag: p.flag.map(|c| c.to_string()),
                     meta: metadata_to_json(&p.meta),
                 })
                 .collect(),

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -116,6 +116,8 @@ export interface Posting {
     units?: Amount;
     cost?: PostingCost;
     price?: Amount;
+    /** Posting flag (e.g. "!" for pending). */
+    flag?: string;
 }
 
 /** Base directive with date. */

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -287,6 +287,10 @@ pub struct PostingJson {
     /// Price annotation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub price: Option<AmountValue>,
+    /// Posting-level flag (e.g., `"!"` for pending). Mirrors
+    /// `rustledger_core::Posting::flag`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flag: Option<String>,
     /// Posting-level metadata (issue #1168). Empty when the posting
     /// has no explicit metadata.
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -522,13 +522,11 @@ fn posting_with_price_annotation_equivalence() {
     );
 }
 
-/// Audit finding from issue #1200 item 3: WASM drops `Posting.flag`
-/// (the `!` flag on individual postings) entirely from its wire
-/// shape; FFI-WASI emits it. Same failure mode as the pre-#1199 meta
-/// drop — silently absent from one binding. Tracked in #1205 with a
-/// concrete fix plan for `PostingJson.flag`.
+/// Pins the fix from #1205: WASM previously dropped `Posting.flag`
+/// (the `!` flag on individual postings) from its wire shape while
+/// FFI-WASI emitted it. After #1205 both bindings emit the field as
+/// an optional stringified char (`"!"`, `"*"`).
 #[test]
-#[ignore = "WASM drops Posting.flag — tracked in #1205"]
 fn posting_with_flag_equivalence() {
     let posting = Posting::new(
         Account::new("Assets:Cash"),


### PR DESCRIPTION
## Summary

- Adds `flag: Option<String>` to WASM's `PostingJson` (mirrors FFI-WASI's shape at `crates/rustledger-ffi-wasi/src/types/output.rs:217`).
- Populates it from `posting.flag.map(|c| c.to_string())` in the WASM converter.
- Removes the `#[ignore]` on `posting_with_flag_equivalence` so the cross-binding harness from #1204 now guards convergence in CI.

The TypeScript declaration in `beancount_wasm.d.ts` already had `flag?: string` on the `Posting` interface, so this fix aligns the Rust side with what JS consumers were already typed against.

Caught by the cross-binding wire-format harness (#1200 / #1204).

## Test plan

- [x] `cargo test -p rustledger-wasm` — 78/78 pass
- [x] `cargo test -p rustledger-wire-format-tests posting_with_flag_equivalence` — passes (was previously `#[ignore]`d)
- [x] `cargo clippy -p rustledger-wasm -p rustledger-wire-format-tests --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #1205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)