### PR TITLE
docs(wasm): align beancount_wasm.d.ts with the actual wire shape

### DIFF
--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -123,6 +123,8 @@ export interface Posting {
   units: Amount | null;
   /** Optional cost specification. */
   cost: CostSpec | null;
+  /** Price annotation (`@` per-unit or `@@` total). */
+  price?: Amount;
   /** Posting flag (e.g. "!" for pending). */
   flag?: string;
   /** Posting-level metadata (issue #1168). */

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -150,6 +150,9 @@ export interface TransactionDirective extends Directive {
 
 /**
  * A posting within a transaction.
+ *
+ * Field order mirrors `rustledger_wasm::types::PostingJson` so that
+ * the type definitions read in the same order as the JSON output.
  */
 export interface Posting {
     /** Account name */
@@ -158,7 +161,9 @@ export interface Posting {
     units?: Amount | null;
     /** Cost specification */
     cost?: CostSpec | null;
-    /** Posting flag */
+    /** Price annotation (`@` per-unit or `@@` total) */
+    price?: Amount;
+    /** Posting flag (e.g. "!" for pending) */
     flag?: string;
     /** Posting-level metadata (issue #1168) */
     meta?: Record<string, MetaValueJson>;
@@ -239,6 +244,84 @@ export interface PriceDirective extends Directive {
     currency: string;
     /** Price amount */
     amount: Amount;
+}
+
+/**
+ * A commodity declaration.
+ */
+export interface CommodityDirective extends Directive {
+    type: "commodity";
+    /** Currency being declared */
+    currency: string;
+}
+
+/**
+ * A pad directive — fills `account` from `source_account` to make the
+ * next balance assertion pass.
+ */
+export interface PadDirective extends Directive {
+    type: "pad";
+    /** Account being padded */
+    account: string;
+    /** Source account the pad draws from */
+    source_account: string;
+}
+
+/**
+ * An event directive — records a named state value at a date.
+ */
+export interface EventDirective extends Directive {
+    type: "event";
+    /** Event name (e.g. "location") */
+    event_type: string;
+    /** Event value */
+    value: string;
+}
+
+/**
+ * A note directive — attaches a free-form comment to an account.
+ */
+export interface NoteDirective extends Directive {
+    type: "note";
+    /** Account the note applies to */
+    account: string;
+    /** Comment text */
+    comment: string;
+}
+
+/**
+ * A document directive — links an account to an external file path.
+ */
+export interface DocumentDirective extends Directive {
+    type: "document";
+    /** Account the document applies to */
+    account: string;
+    /** Path to the document file */
+    path: string;
+}
+
+/**
+ * A query directive — embeds a named BQL query in the ledger.
+ */
+export interface QueryDirective extends Directive {
+    type: "query";
+    /** Query name */
+    name: string;
+    /** BQL query text */
+    query_string: string;
+}
+
+/**
+ * A custom directive — `custom TYPE arg1 arg2 ...`. `values` carries
+ * the positional arguments after the type keyword (absent when there
+ * are none); each value is a [`MetaValueJson`].
+ */
+export interface CustomDirective extends Directive {
+    type: "custom";
+    /** Custom type keyword (the first word after `custom`) */
+    custom_type: string;
+    /** Positional values after the type keyword */
+    values?: MetaValueJson[];
 }
 
 /**

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -110,6 +110,16 @@ export interface PostingCost {
     label?: string;
 }
 
+/**
+ * Metadata value (issue #1168). Untagged union: branch on `typeof v`
+ * (`'string'` / `'boolean'`) or object shape (`'number' in v` → Amount).
+ */
+export type MetaValueJson =
+    | string
+    | boolean
+    | { number: string; currency: string }
+    | null;
+
 /** A posting within a transaction. */
 export interface Posting {
     account: string;
@@ -118,11 +128,15 @@ export interface Posting {
     price?: Amount;
     /** Posting flag (e.g. "!" for pending). */
     flag?: string;
+    /** Posting-level metadata (issue #1168). */
+    meta?: Record<string, MetaValueJson>;
 }
 
 /** Base directive with date. */
 interface BaseDirective {
     date: string;
+    /** Directive-level metadata (issue #1168). */
+    meta?: Record<string, MetaValueJson>;
 }
 
 /** Transaction directive. */
@@ -165,20 +179,24 @@ export interface CloseDirective extends BaseDirective {
     account: string;
 }
 
-/** All directive types. */
+/**
+ * All directive types. Named variants inherit `date` and `meta?` from
+ * `BaseDirective`; the inline shapes below don't extend it, so they
+ * spell out both fields explicitly for parity with the wire shape.
+ */
 export type Directive =
     | TransactionDirective
     | BalanceDirective
     | OpenDirective
     | CloseDirective
-    | { type: 'commodity'; date: string; currency: string }
-    | { type: 'pad'; date: string; account: string; source_account: string }
-    | { type: 'event'; date: string; event_type: string; value: string }
-    | { type: 'note'; date: string; account: string; comment: string }
-    | { type: 'document'; date: string; account: string; path: string }
-    | { type: 'price'; date: string; currency: string; amount: Amount }
-    | { type: 'query'; date: string; name: string; query_string: string }
-    | { type: 'custom'; date: string; custom_type: string };
+    | { type: 'commodity'; date: string; currency: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'pad'; date: string; account: string; source_account: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'event'; date: string; event_type: string; value: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'note'; date: string; account: string; comment: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'document'; date: string; account: string; path: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'price'; date: string; currency: string; amount: Amount; meta?: Record<string, MetaValueJson> }
+    | { type: 'query'; date: string; name: string; query_string: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'custom'; date: string; custom_type: string; values?: MetaValueJson[]; meta?: Record<string, MetaValueJson> };
 
 /** Ledger options. */
 export interface LedgerOptions {


### PR DESCRIPTION
## Summary

Audit pass over `crates/rustledger-wasm/beancount_wasm.d.ts` surfaced drift between the hand-maintained TypeScript declarations and the actual Rust `DirectiveJson` / `PostingJson` shapes:

1. **`Posting` was missing `price?: Amount`** — the `@`/`@@` price annotation is emitted by the WASM binding but JS consumers could only access it via the base `Directive`'s `[key: string]: unknown` index signature.
2. **`Posting.flag` was in the wrong position** — declared between `cost` and `meta`, but the Rust struct (and the JSON output) puts it after `price`. Cosmetic.
3. **7 of 12 directive variants had no narrowed interface**: `commodity`, `pad`, `event`, `note`, `document`, `query`, `custom`. The `DirectiveType` union listed them but consumers had no IntelliSense for their fields. Added `CommodityDirective`, `PadDirective`, `EventDirective`, `NoteDirective`, `DocumentDirective`, `QueryDirective`, `CustomDirective` mirroring the corresponding `DirectiveJson` variants.

No runtime / wire-shape change — this is type-definitions only.

## Why hand-maintained?

The root cause of this whole class of drift is that the `.d.ts` is hand-written. The proper long-term fix is **#1200 item 2** (ts-rs generation from the Rust DTOs), which will make this kind of audit unnecessary. This PR is the tactical close on the current gaps.

## Test plan

- [x] No Rust tests touch the file; no Cargo target needed.
- [x] No formatter / linter rules apply to the `.d.ts` (verified `treefmt.toml`).
- [x] Eyeball: each new interface mirrors the matching `DirectiveJson` variant in `crates/rustledger-wasm/src/types.rs`.

Related: #1200, #1209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)