### PR TITLE
fix(wasm): emit Balance.tolerance on the wire (closes #1206)

### DIFF
--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -202,6 +202,8 @@ export interface BalanceData {
   account: string;
   /** Expected balance amount. */
   amount: Amount;
+  /** Explicit tolerance (e.g. "0.01" from `~ 0.01`), stringified for precision. */
+  tolerance?: string;
   /** Balance-directive metadata (issue #1168). */
   meta?: Record<string, MetaValueJson>;
 }

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -211,6 +211,8 @@ export interface BalanceDirective extends Directive {
     account: string;
     /** Expected balance amount */
     amount: Amount;
+    /** Explicit tolerance (e.g. "0.01" from `~ 0.01`), stringified for precision. */
+    tolerance?: string;
 }
 
 /**

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -118,6 +118,7 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
                 number: bal.amount.number.to_string(),
                 currency: bal.amount.currency.to_string(),
             },
+            tolerance: bal.tolerance.map(|t| t.to_string()),
             meta: metadata_to_json(&bal.meta),
         },
         Directive::Open(open) => DirectiveJson::Open {

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -163,6 +163,8 @@ export interface BalanceDirective extends BaseDirective {
     type: 'balance';
     account: string;
     amount: Amount;
+    /** Explicit tolerance (e.g. "0.01" from `~ 0.01`), stringified for precision. */
+    tolerance?: string;
 }
 
 /** Open account directive. */

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -131,6 +131,10 @@ pub enum DirectiveJson {
         date: String,
         account: String,
         amount: AmountValue,
+        /// Explicit tolerance from the `~ 0.01` annotation, stringified.
+        /// Mirrors `rustledger_core::Balance::tolerance`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tolerance: Option<String>,
         #[serde(skip_serializing_if = "HashMap::is_empty", default)]
         meta: HashMap<String, MetaValueJson>,
     },

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -340,12 +340,11 @@ fn close_directive_equivalence() {
     assert_wire_format("close_minimal", &Directive::Close(close), &[]);
 }
 
-/// Audit finding from issue #1200 item 3: WASM drops `Balance.tolerance`
-/// entirely from its wire shape; FFI-WASI emits it. Tracked in #1206
-/// with a concrete fix plan. Remove the `#[ignore]` once WASM emits
-/// the field — the test then pins the convergence going forward.
+/// Pins the fix from #1206: WASM previously dropped `Balance.tolerance`
+/// (the `~ 0.01` annotation on balance assertions) from its wire
+/// shape while FFI-WASI emitted it. After #1206 both bindings emit
+/// the field as an optional stringified decimal.
 #[test]
-#[ignore = "WASM drops Balance.tolerance — tracked in #1206"]
 fn balance_directive_with_tolerance_equivalence() {
     let mut balance = Balance::new(
         naive_date(2024, 6, 1).unwrap(),


### PR DESCRIPTION
## Summary

- Adds `tolerance: Option<String>` to WASM's `DirectiveJson::Balance` (mirrors FFI-WASI's shape at `crates/rustledger-ffi-wasi/src/types/output.rs:256`).
- Populates it from `bal.tolerance.map(|t| t.to_string())` in the WASM converter.
- Declares `tolerance?: string` on all three TS surfaces: `beancount_wasm.d.ts`, `beancount.d.ts`, and the `typescript_custom_section` embedded by wasm-bindgen.
- Removes the `#[ignore]` on `balance_directive_with_tolerance_equivalence` so the cross-binding harness from #1204 now guards convergence in CI.

Caught by the cross-binding wire-format harness (#1200 / #1204).

## Test plan

- [x] `cargo test -p rustledger-wire-format-tests balance_directive_with_tolerance_equivalence` — passes (was previously `#[ignore]`d)
- [x] `cargo test -p rustledger-wasm` — passes
- [x] `cargo clippy -p rustledger-wasm -p rustledger-wire-format-tests --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #1206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)