### PR TITLE
fix(ffi-wasi,wasm): emit Document.tags and Document.links (closes #1208)

### DIFF
--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -303,6 +303,8 @@ pub fn directive_to_json(directive: &Directive, line: u32, filename: &str) -> Di
                 date: d.date.to_string(),
                 account: d.account.to_string(),
                 path: d.path.clone(),
+                tags: d.tags.iter().map(ToString::to_string).collect(),
+                links: d.links.iter().map(ToString::to_string).collect(),
                 meta,
             }
         }

--- a/crates/rustledger-ffi-wasi/src/types/output.rs
+++ b/crates/rustledger-ffi-wasi/src/types/output.rs
@@ -289,6 +289,12 @@ pub enum DirectiveJson {
         date: String,
         account: String,
         path: String,
+        /// Tags attached to the document directive (issue #1144).
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        tags: Vec<String>,
+        /// Links attached to the document directive (issue #1144).
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        links: Vec<String>,
         meta: Meta,
     },
     Query {

--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -272,6 +272,10 @@ export interface DocumentData {
   account: string;
   /** Path to document file. */
   path: string;
+  /** Tags attached to the document (issue #1144). Absent when empty. */
+  tags?: string[];
+  /** Links attached to the document (issue #1144). Absent when empty. */
+  links?: string[];
   /** Document-directive metadata (issue #1168). */
   meta?: Record<string, MetaValueJson>;
 }

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -300,6 +300,10 @@ export interface DocumentDirective extends Directive {
     account: string;
     /** Path to the document file */
     path: string;
+    /** Tags attached to the document (issue #1144). Absent when empty. */
+    tags?: string[];
+    /** Links attached to the document (issue #1144). Absent when empty. */
+    links?: string[];
 }
 
 /**

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -165,6 +165,8 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
             date: doc.date.to_string(),
             account: doc.account.to_string(),
             path: doc.path.clone(),
+            tags: doc.tags.iter().map(ToString::to_string).collect(),
+            links: doc.links.iter().map(ToString::to_string).collect(),
             meta: metadata_to_json(&doc.meta),
         },
         Directive::Price(price) => DirectiveJson::Price {

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -195,7 +195,7 @@ export type Directive =
     | { type: 'pad'; date: string; account: string; source_account: string; meta?: Record<string, MetaValueJson> }
     | { type: 'event'; date: string; event_type: string; value: string; meta?: Record<string, MetaValueJson> }
     | { type: 'note'; date: string; account: string; comment: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'document'; date: string; account: string; path: string; meta?: Record<string, MetaValueJson> }
+    | { type: 'document'; date: string; account: string; path: string; tags?: string[]; links?: string[]; meta?: Record<string, MetaValueJson> }
     | { type: 'price'; date: string; currency: string; amount: Amount; meta?: Record<string, MetaValueJson> }
     | { type: 'query'; date: string; name: string; query_string: string; meta?: Record<string, MetaValueJson> }
     | { type: 'custom'; date: string; custom_type: string; values?: MetaValueJson[]; meta?: Record<string, MetaValueJson> };

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -198,6 +198,12 @@ pub enum DirectiveJson {
         date: String,
         account: String,
         path: String,
+        /// Tags attached to the document directive (issue #1144).
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        tags: Vec<String>,
+        /// Links attached to the document directive (issue #1144).
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        links: Vec<String>,
         #[serde(skip_serializing_if = "HashMap::is_empty", default)]
         meta: HashMap<String, MetaValueJson>,
     },

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -401,14 +401,13 @@ fn note_directive_equivalence() {
     assert_wire_format("note_basic", &Directive::Note(note), &[]);
 }
 
-/// Audit finding from issue #1200 item 3 — caught by the
-/// `assert_wire_format` helper's field-presence check, not by
-/// equivalence: **both bindings** drop `Document.tags` and
-/// `Document.links` from their wire shape (lockstep-wrong, so
-/// equivalence alone would have passed silently). Tracked in #1208
-/// with a concrete fix plan for both bindings.
+/// Pins the fix from #1208. Both bindings previously dropped
+/// `Document.tags` and `Document.links` from their wire shape — a
+/// lockstep-wrong drop that equivalence alone would have missed.
+/// The harness's `assert_wire_format` field-presence check (PR #1204)
+/// was specifically designed to catch this class of bug; after #1208
+/// both bindings emit the fields and the test guards convergence.
 #[test]
-#[ignore = "Both bindings drop Document.tags and Document.links — tracked in #1208"]
 fn document_directive_with_tags_and_links_equivalence() {
     let document = Document {
         date: naive_date(2024, 1, 15).unwrap(),


### PR DESCRIPTION
## Summary

Both `rustledger-ffi-wasi` and `rustledger-wasm`'s `DirectiveJson::Document` variants dropped `tags` and `links` from the wire output. The fields were added to `rustledger_core::Document` in #1144 but never plumbed through to either binding's wire DTO. This is a **lockstep-wrong drop** — equivalence alone would have missed it, but the new field-presence helper from #1204 caught it on first run.

- Add `tags: Vec<String>` and `links: Vec<String>` (with `skip_serializing_if = "Vec::is_empty"`) to both bindings' `Document` variants.
- Populate via `d.tags.iter().map(ToString::to_string).collect()` — mirrors how `Transaction.tags`/`links` are converted.
- Declare `tags?: string[]` / `links?: string[]` on all three TS surfaces: `beancount_wasm.d.ts`, `beancount.d.ts`, `typescript_custom_section`.
- Remove the `#[ignore]` on `document_directive_with_tags_and_links_equivalence` so the cross-binding harness from #1204 now guards convergence in CI.

## Why `skip_serializing_if` (not always-emit like Transaction)

`Transaction.tags`/`links` always emit as `[]` when empty — but Document's tags/links are absent from today's wire output entirely, so JS consumers parsing Document directives don't see those fields at all. `skip-if-empty` is backward-compatible: documents without tags continue to emit no `tags` field; documents with tags now emit them. Always-emit would add `"tags": []` to every Document, which is a larger contract change for an audit fix.

## Test plan

- [x] `cargo test -p rustledger-wire-format-tests document_directive` — both Document fixtures pass
- [x] `cargo test -p rustledger-wasm` — 78/78 pass
- [x] `cargo test -p rustledger-ffi-wasi` — 56/56 pass
- [x] `cargo clippy -p rustledger-wasm -p rustledger-ffi-wasi -p rustledger-wire-format-tests --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)