### PR TITLE
fix(wasm)!: emit Custom.values as tagged union (closes #1207)

### DIFF
--- a/crates/rustledger-wasm/CHANGELOG.md
+++ b/crates/rustledger-wasm/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠ BREAKING CHANGES
+
+- **Wire shape of `Custom.values`** is now a tagged union
+  `{type, value}` instead of raw values (closes #1207). Pre-fix WASM
+  emitted each `MetaValue` as its bare JSON form, which made
+  `Date`/`String`/`Account`/`Tag`/`Link`/`Number` indistinguishable on
+  the wire (all collapsed to JSON strings). Post-fix the shape mirrors
+  `rustledger-ffi-wasi`'s `TypedValue`, e.g.
+  `{type: "date", value: "2024-03-31"}`. The new `TypedValue` interface
+  is exported from the TypeScript declarations. JS consumers reading
+  positional values from `custom` directives must branch on `.type`
+  and read `.value`.
+
 ## [0.13.0](https://github.com/rustledger/rustledger/compare/v0.12.0...v0.13.0) - 2026-04-21
 
 ### Bug Fixes

--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -75,6 +75,21 @@ export type MetaValueJson =
   | null;
 
 /**
+ * Tagged-union value used in `CustomData.values` (issue #1207).
+ *
+ * Unlike `MetaValueJson` (untagged, lossy for primitive variants),
+ * `TypedValue` preserves the host `MetaValue` variant tag so JS
+ * consumers can tell apart a `Date`, a `String`, and an `Account`
+ * (all of which would otherwise collapse to bare strings).
+ *
+ * Mirrors FFI-WASI's `TypedValue` shape exactly.
+ */
+export interface TypedValue {
+  type: "string" | "account" | "currency" | "tag" | "link" | "date" | "number" | "bool" | "amount" | "null";
+  value: string | boolean | { number: string; currency: string } | null;
+}
+
+/**
  * Possible directive types.
  */
 export type DirectiveType =
@@ -317,10 +332,14 @@ export interface CustomData {
   /** Custom type name. */
   custom_type: string;
   /**
-   * Positional values after the custom type keyword (issue #1168).
-   * Pre-#1168 these were dropped entirely from the JSON output.
+   * Positional values after the custom type keyword.
+   *
+   * Pre-#1168: dropped entirely from the JSON output.
+   * Pre-#1207: present but emitted raw (lossy for primitive variants).
+   * Post-#1207: each value is a tagged-union [`TypedValue`] so the
+   * variant tag survives the wire crossing.
    */
-  values?: MetaValueJson[];
+  values?: TypedValue[];
   /** Custom-directive metadata (issue #1168). */
   meta?: Record<string, MetaValueJson>;
 }

--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -82,12 +82,21 @@ export type MetaValueJson =
  * consumers can tell apart a `Date`, a `String`, and an `Account`
  * (all of which would otherwise collapse to bare strings).
  *
- * Mirrors FFI-WASI's `TypedValue` shape exactly.
+ * Mirrors FFI-WASI's `TypedValue` shape exactly. Declared as a
+ * **discriminated union** so `switch (v.type)` (or
+ * `if (v.type === 'amount')`) narrows `v.value` to the right shape.
  */
-export interface TypedValue {
-  type: "string" | "account" | "currency" | "tag" | "link" | "date" | "number" | "bool" | "amount" | "null";
-  value: string | boolean | { number: string; currency: string } | null;
-}
+export type TypedValue =
+  | { type: "string"; value: string }
+  | { type: "account"; value: string }
+  | { type: "currency"; value: string }
+  | { type: "tag"; value: string }
+  | { type: "link"; value: string }
+  | { type: "date"; value: string }
+  | { type: "number"; value: string }
+  | { type: "bool"; value: boolean }
+  | { type: "amount"; value: { number: string; currency: string } }
+  | { type: "null"; value: null };
 
 /**
  * Possible directive types.

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -113,6 +113,29 @@ export type MetaValueJson =
     | null;
 
 /**
+ * Tagged-union value used in `CustomDirective.values` (issue #1207).
+ *
+ * Unlike [`MetaValueJson`] (untagged, lossy for primitive-typed
+ * variants), `TypedValue` preserves the host `MetaValue` variant tag
+ * so JS consumers can distinguish a `Date` from a `String` from an
+ * `Account` — all of which would otherwise collapse to bare strings.
+ *
+ * Mirrors FFI-WASI's `TypedValue` shape exactly so portable consumers
+ * see identical envelopes across both bindings.
+ *
+ * `type` is one of: `"string"`, `"account"`, `"currency"`, `"tag"`,
+ * `"link"`, `"date"`, `"number"`, `"bool"`, `"amount"`, `"null"`.
+ *
+ * `value`'s shape depends on `type`: string for string-flavored
+ * variants; boolean for `bool`; `{number, currency}` for `amount`;
+ * `null` for `null`.
+ */
+export interface TypedValue {
+    type: "string" | "account" | "currency" | "tag" | "link" | "date" | "number" | "bool" | "amount" | "null";
+    value: string | boolean | { number: string; currency: string } | null;
+}
+
+/**
  * Valid directive types.
  */
 export type DirectiveType =
@@ -320,14 +343,15 @@ export interface QueryDirective extends Directive {
 /**
  * A custom directive — `custom TYPE arg1 arg2 ...`. `values` carries
  * the positional arguments after the type keyword (absent when there
- * are none); each value is a [`MetaValueJson`].
+ * are none). Each value is a [`TypedValue`] — the tagged shape that
+ * preserves the host `MetaValue` variant (issue #1207).
  */
 export interface CustomDirective extends Directive {
     type: "custom";
     /** Custom type keyword (the first word after `custom`) */
     custom_type: string;
-    /** Positional values after the type keyword */
-    values?: MetaValueJson[];
+    /** Positional values after the type keyword (tagged union; see [`TypedValue`]) */
+    values?: TypedValue[];
 }
 
 /**

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -123,17 +123,21 @@ export type MetaValueJson =
  * Mirrors FFI-WASI's `TypedValue` shape exactly so portable consumers
  * see identical envelopes across both bindings.
  *
- * `type` is one of: `"string"`, `"account"`, `"currency"`, `"tag"`,
- * `"link"`, `"date"`, `"number"`, `"bool"`, `"amount"`, `"null"`.
- *
- * `value`'s shape depends on `type`: string for string-flavored
- * variants; boolean for `bool`; `{number, currency}` for `amount`;
- * `null` for `null`.
+ * Declared as a **discriminated union** rather than a single
+ * interface so `switch (v.type)` (or `if (v.type === 'amount')`)
+ * narrows `v.value` to the right payload shape.
  */
-export interface TypedValue {
-    type: "string" | "account" | "currency" | "tag" | "link" | "date" | "number" | "bool" | "amount" | "null";
-    value: string | boolean | { number: string; currency: string } | null;
-}
+export type TypedValue =
+    | { type: "string"; value: string }
+    | { type: "account"; value: string }
+    | { type: "currency"; value: string }
+    | { type: "tag"; value: string }
+    | { type: "link"; value: string }
+    | { type: "date"; value: string }
+    | { type: "number"; value: string }
+    | { type: "bool"; value: boolean }
+    | { type: "amount"; value: { number: string; currency: string } }
+    | { type: "null"; value: null };
 
 /**
  * Valid directive types.

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -6,7 +6,7 @@ use rustledger_core::{Directive, MetaValue, Metadata};
 
 use crate::types::{
     AmountValue, CellValue, CostNumberJson, CostValue, DirectiveJson, MetaValueJson, PositionValue,
-    PostingCostJson, PostingJson,
+    PostingCostJson, PostingJson, TypedValueJson,
 };
 
 /// Lower a host [`MetaValue`] to the wire [`MetaValueJson`].
@@ -44,6 +44,65 @@ fn metadata_to_json(meta: &Metadata) -> HashMap<String, MetaValueJson> {
     meta.iter()
         .map(|(k, v)| (k.clone(), meta_value_to_json(v)))
         .collect()
+}
+
+/// Lower a host [`MetaValue`] to the tagged-union wire shape
+/// [`TypedValueJson`].
+///
+/// Used **only** for `Custom.values` — the positional values list
+/// where preserving the host variant tag matters (a `Date` must be
+/// distinguishable from a `String` or an `Account`). Mirrors
+/// `rustledger-ffi-wasi`'s `TypedValue::from_meta_value` so the two
+/// bindings emit identical tagged-union envelopes.
+///
+/// Stringified-decimal handling matches [`meta_value_to_json`] — JSON
+/// numbers can't represent `rust_decimal::Decimal` losslessly.
+fn meta_value_to_typed_json(value: &MetaValue) -> TypedValueJson {
+    match value {
+        MetaValue::String(s) => TypedValueJson {
+            value_type: "string".into(),
+            value: MetaValueJson::String(s.clone()),
+        },
+        MetaValue::Account(a) => TypedValueJson {
+            value_type: "account".into(),
+            value: MetaValueJson::String(a.to_string()),
+        },
+        MetaValue::Currency(c) => TypedValueJson {
+            value_type: "currency".into(),
+            value: MetaValueJson::String(c.to_string()),
+        },
+        MetaValue::Tag(t) => TypedValueJson {
+            value_type: "tag".into(),
+            value: MetaValueJson::String(t.to_string()),
+        },
+        MetaValue::Link(l) => TypedValueJson {
+            value_type: "link".into(),
+            value: MetaValueJson::String(l.to_string()),
+        },
+        MetaValue::Date(d) => TypedValueJson {
+            value_type: "date".into(),
+            value: MetaValueJson::String(d.to_string()),
+        },
+        MetaValue::Number(n) => TypedValueJson {
+            value_type: "number".into(),
+            value: MetaValueJson::String(n.to_string()),
+        },
+        MetaValue::Bool(b) => TypedValueJson {
+            value_type: "bool".into(),
+            value: MetaValueJson::Bool(*b),
+        },
+        MetaValue::Amount(a) => TypedValueJson {
+            value_type: "amount".into(),
+            value: MetaValueJson::Amount {
+                number: a.number.to_string(),
+                currency: a.currency.to_string(),
+            },
+        },
+        MetaValue::None => TypedValueJson {
+            value_type: "null".into(),
+            value: MetaValueJson::Null,
+        },
+    }
 }
 
 /// Convert a Directive to its JSON representation.
@@ -187,7 +246,7 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
         Directive::Custom(custom) => DirectiveJson::Custom {
             date: custom.date.to_string(),
             custom_type: custom.custom_type.clone(),
-            values: custom.values.iter().map(meta_value_to_json).collect(),
+            values: custom.values.iter().map(meta_value_to_typed_json).collect(),
             meta: metadata_to_json(&custom.meta),
         },
     }
@@ -433,9 +492,9 @@ mod tests {
 
     #[test]
     fn custom_directive_carries_values_1168() {
-        // Pre-fix the Custom variant dropped both `values` AND `meta`.
-        // Pin the `values` round-trip (and verify the value shape
-        // matches `MetaValueJson`).
+        // Pre-#1168 the Custom variant dropped both `values` AND
+        // `meta`. Pre-#1207 the values were emitted raw (lossy).
+        // Pin the tagged-union round-trip here.
         let source = r#"2024-01-01 custom "budget" "monthly" 100.00 USD TRUE
 "#;
         let result = parse_beancount(source);
@@ -451,18 +510,18 @@ mod tests {
         };
 
         // The fixture has 4 positional values: "monthly", 100.00,
-        // USD, TRUE — types preserved via MetaValueJson.
+        // USD, TRUE — each emitted as a `TypedValueJson` so the
+        // variant tag survives the wire crossing.
         assert!(!values.is_empty(), "Custom values must not be empty");
         assert!(
-            values
-                .iter()
-                .any(|v| matches!(v, MetaValueJson::String(s) if s == "monthly")),
+            values.iter().any(|v| v.value_type == "string"
+                && matches!(v.value, MetaValueJson::String(ref s) if s == "monthly")),
             "values should include `monthly` string: {values:?}",
         );
         assert!(
             values
                 .iter()
-                .any(|v| matches!(v, MetaValueJson::Bool(true))),
+                .any(|v| v.value_type == "bool" && matches!(v.value, MetaValueJson::Bool(true))),
             "values should include `TRUE` bool: {values:?}",
         );
     }
@@ -564,9 +623,14 @@ mod tests {
 
     /// `Custom.values` is a positional list — a `MetaValue::None` in
     /// the middle of the list must keep its position so JS consumers
-    /// see `[..., null, ...]` rather than the position silently
-    /// collapsing. The plugin-types side of this is filed in #1200's
-    /// audit; pin the WASM wire shape here independently.
+    /// see `[..., {type:"null", value:null}, ...]` rather than the
+    /// position silently collapsing. The plugin-types side of this is
+    /// filed in #1200's audit; pin the WASM wire shape here
+    /// independently.
+    ///
+    /// Post-#1207: values are emitted as tagged unions so the variant
+    /// tag (`string` vs `number` vs `null`) is preserved, not just the
+    /// presence of a value.
     #[test]
     fn custom_values_preserve_null_position_1168() {
         use rustledger_core::{Custom, Decimal};
@@ -589,11 +653,14 @@ mod tests {
         };
 
         assert_eq!(values.len(), 3, "all three values must survive: {values:?}");
-        assert!(matches!(values[0], MetaValueJson::String(ref s) if s == "monthly"));
-        assert!(
-            matches!(values[1], MetaValueJson::Null),
+        assert_eq!(values[0].value_type, "string");
+        assert!(matches!(values[0].value, MetaValueJson::String(ref s) if s == "monthly"));
+        assert_eq!(
+            values[1].value_type, "null",
             "middle Null must keep position {values:?}",
         );
-        assert!(matches!(values[2], MetaValueJson::String(ref s) if s == "100.00"));
+        assert!(matches!(values[1].value, MetaValueJson::Null));
+        assert_eq!(values[2].value_type, "number");
+        assert!(matches!(values[2].value, MetaValueJson::String(ref s) if s == "100.00"));
     }
 }

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -120,6 +120,17 @@ export type MetaValueJson =
     | { number: string; currency: string }
     | null;
 
+/**
+ * Tagged-union value used in the `custom` directive's `values` field
+ * (issue #1207). Preserves the host `MetaValue` variant tag — unlike
+ * `MetaValueJson`, which collapses `Date`/`String`/`Account` to a
+ * single bare-string shape. Mirrors FFI-WASI's `TypedValue` exactly.
+ */
+export interface TypedValue {
+    type: 'string' | 'account' | 'currency' | 'tag' | 'link' | 'date' | 'number' | 'bool' | 'amount' | 'null';
+    value: string | boolean | { number: string; currency: string } | null;
+}
+
 /** A posting within a transaction. */
 export interface Posting {
     account: string;
@@ -198,7 +209,7 @@ export type Directive =
     | { type: 'document'; date: string; account: string; path: string; tags?: string[]; links?: string[]; meta?: Record<string, MetaValueJson> }
     | { type: 'price'; date: string; currency: string; amount: Amount; meta?: Record<string, MetaValueJson> }
     | { type: 'query'; date: string; name: string; query_string: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'custom'; date: string; custom_type: string; values?: MetaValueJson[]; meta?: Record<string, MetaValueJson> };
+    | { type: 'custom'; date: string; custom_type: string; values?: TypedValue[]; meta?: Record<string, MetaValueJson> };
 
 /** Ledger options. */
 export interface LedgerOptions {

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -125,11 +125,23 @@ export type MetaValueJson =
  * (issue #1207). Preserves the host `MetaValue` variant tag — unlike
  * `MetaValueJson`, which collapses `Date`/`String`/`Account` to a
  * single bare-string shape. Mirrors FFI-WASI's `TypedValue` exactly.
+ *
+ * Declared as a discriminated union so `switch (v.type)` (or
+ * `if (v.type === 'amount')`) narrows `v.value` to the right payload
+ * shape — see `tsc` issue: a single interface with union types on
+ * both fields gives the cross-product, not the narrowing relationship.
  */
-export interface TypedValue {
-    type: 'string' | 'account' | 'currency' | 'tag' | 'link' | 'date' | 'number' | 'bool' | 'amount' | 'null';
-    value: string | boolean | { number: string; currency: string } | null;
-}
+export type TypedValue =
+    | { type: 'string'; value: string }
+    | { type: 'account'; value: string }
+    | { type: 'currency'; value: string }
+    | { type: 'tag'; value: string }
+    | { type: 'link'; value: string }
+    | { type: 'date'; value: string }
+    | { type: 'number'; value: string }
+    | { type: 'bool'; value: boolean }
+    | { type: 'amount'; value: { number: string; currency: string } }
+    | { type: 'null'; value: null };
 
 /** A posting within a transaction. */
 export interface Posting {

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -99,6 +99,45 @@ pub enum MetaValueJson {
     Null,
 }
 
+/// Tagged-union wire-format for a [`MetaValue`] that preserves the
+/// host's variant tag.
+///
+/// Used **only** in `DirectiveJson::Custom`'s `values` field, where
+/// callers genuinely need to distinguish (for example) a `Date` from
+/// a `String` or an `Account` — all three of which collapse to a bare
+/// JSON string under the untagged [`MetaValueJson`] shape.
+///
+/// Wire shape: `{"type": "<variant>", "value": ...}` — mirrors
+/// `rustledger-ffi-wasi::TypedValue` (see
+/// `crates/rustledger-ffi-wasi/src/types/output.rs::TypedValue`) so
+/// portable JS consumers see identical envelopes across both bindings.
+///
+/// **Why `value: MetaValueJson` and not `serde_json::Value`** —
+/// `serde_json` is intentionally a host-only dev-dependency for this
+/// crate (the runtime build avoids it to keep the wasm32 dep chain
+/// small). [`MetaValueJson`] already covers every payload shape
+/// FFI-WASI's `TypedValue` emits: `String` for the string-flavored
+/// variants, `Bool` for `bool`, `Amount` for `amount`, `Null` for
+/// `null`. The serialized JSON is bit-identical to FFI-WASI's.
+///
+/// `MetaValueJson` (untagged) is retained for the `meta` map of every
+/// directive — there the lossy shape is intentional and matches what
+/// FFI-WASI's metadata side also emits.
+///
+/// **Breaking change from #1199** for the WASM binding: pre-#1207
+/// `Custom.values` emitted raw `MetaValueJson` values (lossy). Closes
+/// #1207.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypedValueJson {
+    /// Variant tag — one of `"string"`, `"account"`, `"currency"`,
+    /// `"tag"`, `"link"`, `"date"`, `"number"`, `"bool"`, `"amount"`,
+    /// `"null"`. Matches FFI-WASI's tag strings exactly.
+    #[serde(rename = "type")]
+    pub value_type: String,
+    /// Variant payload (see [`MetaValueJson`] for the four shapes).
+    pub value: MetaValueJson,
+}
+
 /// A directive in JSON-serializable form.
 ///
 /// Each variant corresponds to a Beancount directive type, with fields
@@ -241,8 +280,14 @@ pub enum DirectiveJson {
     Custom {
         date: String,
         custom_type: String,
+        /// Positional values after the `custom TYPE` keyword. Each
+        /// entry is a [`TypedValueJson`] (`{type, value}`) — the
+        /// tagged shape preserves the host `MetaValue` variant tag so
+        /// JS consumers can distinguish a `Date` from a `String` from
+        /// an `Account` (closes #1207). Mirrors FFI-WASI's
+        /// `Vec<TypedValue>` exactly.
         #[serde(skip_serializing_if = "Vec::is_empty", default)]
-        values: Vec<MetaValueJson>,
+        values: Vec<TypedValueJson>,
         #[serde(skip_serializing_if = "HashMap::is_empty", default)]
         meta: HashMap<String, MetaValueJson>,
     },

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -267,9 +267,17 @@ pub enum DirectiveJson {
     /// Custom directive.
     ///
     /// `values` carries the positional arguments after the type
-    /// keyword (pre-#1168 these were dropped entirely from the JSON
-    /// output). Each value follows the same `MetaValueJson` shape as
-    /// metadata — strings, bools, amounts, or null.
+    /// keyword. Each value is a [`TypedValueJson`] tagged union
+    /// (`{type, value}`) that preserves the host `MetaValue`
+    /// variant tag, so JS consumers can distinguish (for example)
+    /// a `Date` from a `String` from an `Account` — all of which
+    /// would otherwise collapse to bare JSON strings under the
+    /// untagged `MetaValueJson` shape.
+    ///
+    /// Pre-#1168: `values` was dropped entirely from the JSON output.
+    /// Pre-#1207: present but emitted raw via `MetaValueJson` (lossy).
+    /// Post-#1207: emitted via `TypedValueJson` (this variant), mirroring
+    /// FFI-WASI's `Vec<TypedValue>`.
     ///
     /// Both `values` and `meta` use `skip_serializing_if` to omit
     /// the field when empty (consistent shape: a Custom directive

--- a/crates/rustledger-wasm/tests/wasm_meta.rs
+++ b/crates/rustledger-wasm/tests/wasm_meta.rs
@@ -285,9 +285,11 @@ fn open_booking_is_clean_string_in_js() {
 
 #[wasm_bindgen_test]
 fn custom_directive_values_exposed_1168() {
-    // Pre-#1168 the `Custom` directive's positional values were
-    // dropped entirely from JSON output. Pin the new wire shape:
-    // a JS array, preserving order and per-arg type.
+    // Pre-#1168: the `Custom` directive's positional values were
+    // dropped entirely from JSON output.
+    // Pre-#1207: present but emitted raw (lossy for primitive variants).
+    // Post-#1207: each value is a tagged-union `{type, value}` so the
+    // host `MetaValue` variant tag survives the wire crossing.
     let source = r#"2024-01-01 custom "budget" "monthly" TRUE
 "#;
     let result = rustledger_wasm::parse(source).expect("parse should not throw");
@@ -306,10 +308,31 @@ fn custom_directive_values_exposed_1168() {
         2,
         "Custom values array must carry both positional args",
     );
-    assert_eq!(values_arr.get(0).as_string().as_deref(), Some("monthly"));
+
+    // First value: `"monthly"` parses as MetaValue::String — tagged
+    // as `{type: "string", value: "monthly"}` on the wire.
+    let first = values_arr.get(0);
     assert_eq!(
-        values_arr.get(1),
+        get_field(&first, "type"),
+        JsValue::from_str("string"),
+        "first value's variant tag must be `string`: {first:?}",
+    );
+    assert_eq!(
+        get_field(&first, "value").as_string().as_deref(),
+        Some("monthly"),
+    );
+
+    // Second value: `TRUE` parses as MetaValue::Bool — tagged as
+    // `{type: "bool", value: true}` on the wire.
+    let second = values_arr.get(1);
+    assert_eq!(
+        get_field(&second, "type"),
+        JsValue::from_str("bool"),
+        "second value's variant tag must be `bool`: {second:?}",
+    );
+    assert_eq!(
+        get_field(&second, "value"),
         JsValue::TRUE,
-        "TRUE arg must be a JS boolean",
+        "TRUE arg must surface as a JS boolean inside `value`",
     );
 }

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -434,15 +434,13 @@ fn query_directive_equivalence() {
     assert_wire_format("query_basic", &Directive::Query(query), &[]);
 }
 
-/// Audit finding from issue #1200 item 3: `Custom.values` is present
-/// in both bindings (since #1199), but the **shape** diverges. FFI-WASI
-/// emits each value as a tagged union `{type: "...", value: ...}`,
-/// which is type-safe — a JS consumer can distinguish a `Date` value
-/// from a `String` value. WASM emits values raw (the bare string,
-/// number, or object), which is lossy. Tracked in #1207 with a fix
-/// plan to adopt the tagged shape on the WASM side.
+/// Pins the fix from #1207. WASM previously emitted `Custom.values`
+/// raw (lossy — a `Date` was indistinguishable from a `String` or
+/// `Account` on the wire); FFI-WASI emitted each value as a tagged
+/// union `{type: "...", value: ...}`. After #1207 the WASM side
+/// adopts the same tagged shape so every `MetaValue` variant
+/// round-trips with its variant tag intact.
 #[test]
-#[ignore = "WASM emits Custom.values raw (lossy); tagged union expected — tracked in #1207"]
 fn custom_directive_with_all_value_variants_equivalence() {
     let custom = Custom {
         date: naive_date(2024, 1, 1).unwrap(),


### PR DESCRIPTION
## Summary

**Breaking change** to the WASM binding's `Custom.values` wire shape — adopts FFI-WASI's tagged-union representation so JS consumers can distinguish a `Date` from a `String` from an `Account` (all of which previously collapsed to bare JSON strings).

Before:
```json
"values": ["Q1", "Expenses:Food", "2024-03-31", "0.85", true]
```

After:
```json
"values": [
  {"type": "string",  "value": "Q1"},
  {"type": "account", "value": "Expenses:Food"},
  {"type": "date",    "value": "2024-03-31"},
  {"type": "number",  "value": "0.85"},
  {"type": "bool",    "value": true}
]
```

## Implementation

- New `TypedValueJson` struct mirrors `rustledger-ffi-wasi::TypedValue` exactly. The `value` field is typed as `MetaValueJson` rather than `serde_json::Value` because `serde_json` is intentionally a host-only dev-dep for the WASM crate; `MetaValueJson`'s four variants cover every payload shape FFI-WASI emits, and the serialized JSON is bit-identical.
- New `meta_value_to_typed_json` in `convert.rs` mirrors FFI-WASI's `TypedValue::from_meta_value` 1:1.
- All three TS surfaces (`beancount_wasm.d.ts`, `beancount.d.ts`, `typescript_custom_section`) declare a new `TypedValue` interface and update `Custom.values` to use it.
- Harness's `custom_directive_with_all_value_variants_equivalence` un-ignored — every `MetaValue` variant now round-trips identically across both bindings.
- Two existing convert.rs tests rewritten to assert the tagged shape.
- BREAKING CHANGE entry added to `crates/rustledger-wasm/CHANGELOG.md`.

## Test plan

- [x] `cargo test -p rustledger-wasm` — 78/78 pass
- [x] `cargo test -p rustledger-wire-format-tests custom_directive_with_all_value_variants` — passes (was `#[ignore]`d)
- [x] `cargo clippy -p rustledger-wasm -p rustledger-wire-format-tests --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Migration

JS consumers reading `custom.values` must branch on `.type` and read `.value`:

```js
// Before
const value = custom.values[0];  // string | number | boolean | ...

// After
const v = custom.values[0];      // { type, value }
switch (v.type) {
  case 'date':   // v.value is YYYY-MM-DD
  case 'amount': // v.value is { number, currency }
  case 'bool':   // v.value is boolean
  // ...
}
```

Closes #1207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)