### PR TITLE
fix(plugin): plumb Document.tags/links through plugin round-trip (closes #1214)

### DIFF
--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -823,6 +823,14 @@ pub struct DocumentData {
     pub account: String,
     /// Document path.
     pub path: String,
+    /// Tags attached to the document directive. Added to core
+    /// `Document` in #1144; plumbed through the plugin layer in
+    /// #1214 (was previously dropped on both legs of the round-trip).
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Links attached to the document directive (issue #1144).
+    #[serde(default)]
+    pub links: Vec<String>,
     /// Metadata key-value pairs.
     #[serde(default)]
     pub metadata: Vec<(String, MetaValueData)>,

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -391,8 +391,8 @@ pub(super) fn data_to_document(data: &DocumentData, date: NaiveDate) -> Document
         date,
         account: data.account.clone().into(),
         path: data.path.clone(),
-        tags: Vec::new(),
-        links: Vec::new(),
+        tags: data.tags.iter().map(|t| t.as_str().into()).collect(),
+        links: data.links.iter().map(|l| l.as_str().into()).collect(),
         meta: data
             .metadata
             .iter()

--- a/crates/rustledger-plugin/src/convert/mod.rs
+++ b/crates/rustledger-plugin/src/convert/mod.rs
@@ -357,6 +357,44 @@ mod tests {
         }
     }
 
+    /// Regression for #1214: Document directives must carry tags
+    /// and links through both legs of the plugin round-trip. Pre-fix
+    /// both `document_to_data` (way out) and `data_to_document` (way
+    /// back in) dropped these fields to empty vectors, meaning any
+    /// document passing through a plugin lost its tags/links.
+    #[test]
+    fn test_roundtrip_document_tags_and_links_1214() {
+        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
+        let doc = Document {
+            date,
+            account: "Assets:Bank".into(),
+            path: "statements/2024-01.pdf".to_string(),
+            tags: vec!["statement".into(), "bank".into()],
+            links: vec!["inv-2024-01".into()],
+            meta: Metadata::default(),
+        };
+
+        let directive = Directive::Document(doc);
+        let wrapper = directive_to_wrapper(&directive);
+        let roundtrip = wrapper_to_directive(&wrapper).unwrap();
+
+        if let (Directive::Document(orig), Directive::Document(rt)) = (&directive, &roundtrip) {
+            assert_eq!(orig.date, rt.date);
+            assert_eq!(orig.account, rt.account);
+            assert_eq!(orig.path, rt.path);
+            assert_eq!(
+                orig.tags, rt.tags,
+                "Document.tags must survive the plugin round-trip",
+            );
+            assert_eq!(
+                orig.links, rt.links,
+                "Document.links must survive the plugin round-trip",
+            );
+        } else {
+            panic!("Expected Document directive");
+        }
+    }
+
     #[test]
     fn test_roundtrip_all_directive_types() {
         let date = rustledger_core::naive_date(2024, 1, 1).unwrap();

--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -237,6 +237,8 @@ pub(super) fn document_to_data(doc: &Document) -> DocumentData {
     DocumentData {
         account: doc.account.to_string(),
         path: doc.path.clone(),
+        tags: doc.tags.iter().map(ToString::to_string).collect(),
+        links: doc.links.iter().map(ToString::to_string).collect(),
         metadata: doc
             .meta
             .iter()

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -264,6 +264,8 @@ fn scan_documents(
                                 data: DirectiveData::Document(DocumentData {
                                     account,
                                     path: full_path,
+                                    tags: vec![],
+                                    links: vec![],
                                     metadata: vec![],
                                 }),
                             });

--- a/crates/rustledger-plugin/wit/world.wit
+++ b/crates/rustledger-plugin/wit/world.wit
@@ -146,6 +146,10 @@ interface types {
         date: string,
         account: string,
         path: string,
+        /// Tags (without `#` prefix). Added in #1214.
+        tags: list<string>,
+        /// Links (without `^` prefix). Added in #1214.
+        links: list<string>,
     }
 
     /// Price directive.


### PR DESCRIPTION
## Summary

The plugin layer dropped `Document.tags` and `Document.links` on **both legs** of the round-trip, meaning any Document passing through a plugin (even a no-op) lost its tags/links, and plugins synthesizing Document directives couldn't attach them. Surfaced during the #1212 deep review; same `#1144`-cascade as #1213, but with wider plumbing.

Four sites:

1. **`DocumentData` DTO** (`rustledger-plugin-types`) — add `tags`/`links` with `#[serde(default)]` for backward-compat with serialized plugin state.
2. **`document_to_data`** (`rustledger-plugin/convert/to_wrapper.rs`) — propagate from core `Document`; same pattern Transaction uses one site above.
3. **`data_to_document`** (`rustledger-plugin/convert/from_wrapper.rs`) — reconstruct on the way back; mirror Transaction's reverse path.
4. **WIT `record document`** (`rustledger-plugin/wit/world.wit`) — add `tags: list<string>, links: list<string>` so non-Rust Component Model plugins see the fields.

Drive-by: `document_discovery.rs` constructs `DocumentData` directly; updated to fill empty `tags`/`links` (no source for them in a filesystem-discovery plugin).

Adds `test_roundtrip_document_tags_and_links_1214` — pre-fix it would fail at both legs.

## Test plan

- [x] `cargo test -p rustledger-plugin -p rustledger-plugin-types` — all suites pass (126 + 176 + integration)
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #1214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)