### PR TITLE
chore(wasm): spike ts-rs TypeScript generation + ADR-0004 (#1218)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 /target/
 **/*.rs.bk
 
+# Generated TypeScript bindings (ts-rs spike #1218). The spike example
+# `crates/rustledger-wasm/examples/tsrs_spike.rs` exports per-type .d.ts
+# into this directory; regenerable via `cargo test --example tsrs_spike
+# -p rustledger-wasm --features ts-rs-spike`.
+crates/rustledger-wasm/bindings/
+
 # Editor files
 *.swp
 *.swo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2 0.11.0",
+ "ts-rs",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -4817,6 +4818,28 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "ts-rs"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
+dependencies = [
+ "thiserror 2.0.18",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
 ]
 
 [[package]]

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -22,7 +22,10 @@ plugins = ["dep:rustledger-plugin"]
 ## Include BQL query completions (bqlCompletions)
 completions = []
 ## Spike (#1218) -- enables the `tsrs_spike` example. Pulls in ts-rs as
-## an optional host-only dep. Not part of any default build.
+## an optional host-only dep (declared under `[target.'cfg(not(...))'.dependencies]`
+## below, so `cargo build --target wasm32-unknown-unknown --features ts-rs-spike`
+## hard-fails on the missing `ts-rs` crate -- intentional, the spike is
+## host-only by design). Not part of any default build.
 ts-rs-spike = ["dep:ts-rs"]
 
 # The `tsrs_spike` example needs the optional ts-rs dep; declare the

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -62,9 +62,9 @@ js-sys = "0.3"
 # Spike (#1218): ts-rs for TypeScript type generation prototype.
 # Host-only optional dep, opt-in via the `ts-rs-spike` feature above.
 # Used by the `tsrs_spike` example to export per-struct .d.ts to
-# `target/ts-rs-spike/` so we can eyeball what ts-rs produces for
-# our existing wire-format DTO shapes. Not pulled into normal builds
-# or the wasm32 target.
+# `crates/rustledger-wasm/bindings/bindings/` (gitignored) so we can
+# eyeball what ts-rs produces for our existing wire-format DTO
+# shapes. Not pulled into normal builds or the wasm32 target.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ts-rs = { version = "12.0.1", optional = true }
 

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -21,6 +21,18 @@ default = ["plugins", "completions"]
 plugins = ["dep:rustledger-plugin"]
 ## Include BQL query completions (bqlCompletions)
 completions = []
+## Spike (#1218) -- enables the `tsrs_spike` example. Pulls in ts-rs as
+## an optional host-only dep. Not part of any default build.
+ts-rs-spike = ["dep:ts-rs"]
+
+# The `tsrs_spike` example needs the optional ts-rs dep; declare the
+# feature requirement so `cargo build --workspace --all-targets`
+# skips the example unless `ts-rs-spike` is on. Without this, CI's
+# default-feature workspace check tries to build the example without
+# its dep and fails.
+[[example]]
+name = "tsrs_spike"
+required-features = ["ts-rs-spike"]
 
 [dependencies]
 rustledger-core.workspace = true
@@ -44,6 +56,15 @@ console_error_panic_hook = "0.1"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 js-sys = "0.3"
+# Spike (#1218): ts-rs for TypeScript type generation prototype.
+# Host-only optional dep, opt-in via the `ts-rs-spike` feature above.
+# Used by the `tsrs_spike` example to export per-struct .d.ts to
+# `target/ts-rs-spike/` so we can eyeball what ts-rs produces for
+# our existing wire-format DTO shapes. Not pulled into normal builds
+# or the wasm32 target.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ts-rs = { version = "12.0.1", optional = true }
+
 
 # Host-only dev-dep: the wire-format tests that need it are
 # `#[cfg(not(target_arch = "wasm32"))]` since they only validate

--- a/crates/rustledger-wasm/examples/tsrs_spike.rs
+++ b/crates/rustledger-wasm/examples/tsrs_spike.rs
@@ -17,8 +17,11 @@
 //! ship by hand, without committing to the derive in the real DTOs
 //! before the design decision is made.
 //!
-//! Output lands in `crates/rustledger-wasm/bindings/` (ts-rs default).
-//! Eyeball:
+//! Output lands in `crates/rustledger-wasm/bindings/bindings/`
+//! (ts-rs's `export_to = "bindings/"` puts files in a nested
+//! `bindings/` under the crate root — the inner directory comes from
+//! the attribute string, the outer from ts-rs's per-crate output
+//! root). Eyeball:
 //!
 //! 1. Does the `DirectiveJson` discriminated union narrow correctly?
 //! 2. Is the `TypedValueJson` payload's `MetaValueJson` substituted by
@@ -184,6 +187,6 @@ fn main() {
     println!("ts-rs spike binary compiled cleanly.");
     println!(
         "Run `cargo test --example tsrs_spike --features ts-rs-spike` to emit \
-         the .d.ts files into crates/rustledger-wasm/bindings/."
+         the .d.ts files into crates/rustledger-wasm/bindings/bindings/."
     );
 }

--- a/crates/rustledger-wasm/examples/tsrs_spike.rs
+++ b/crates/rustledger-wasm/examples/tsrs_spike.rs
@@ -5,9 +5,12 @@
 //! Run via:
 //!
 //! ```bash
-//! cargo run --example tsrs_spike \
+//! cargo test --example tsrs_spike \
 //!   -p rustledger-wasm --features ts-rs-spike
 //! ```
+//!
+//! (ts-rs emits the `.d.ts` files from auto-generated unit tests, not
+//! from `main()` — `cargo run` compiles but doesn't export.)
 //!
 //! The four DTOs below MIRROR the structs in `src/types.rs` exactly —
 //! same fields, same serde attributes, same doc comments — but with
@@ -87,12 +90,16 @@ pub enum CostNumberJson {
 #[ts(export, export_to = "bindings/")]
 pub struct PostingCostJson {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub number: Option<CostNumberJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub currency: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub label: Option<String>,
 }
 
@@ -146,6 +153,7 @@ pub enum DirectiveJson {
         account: String,
         amount: AmountValue,
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         tolerance: Option<String>,
         #[serde(skip_serializing_if = "HashMap::is_empty", default)]
         meta: HashMap<String, MetaValueJson>,

--- a/crates/rustledger-wasm/examples/tsrs_spike.rs
+++ b/crates/rustledger-wasm/examples/tsrs_spike.rs
@@ -1,0 +1,189 @@
+//! Spike for #1218 — prototype `ts-rs` against the wire-format DTOs
+//! to see whether the emitted `.d.ts` preserves the load-bearing
+//! shape details the hand-written declarations carry today.
+//!
+//! Run via:
+//!
+//! ```bash
+//! cargo run --example tsrs_spike \
+//!   -p rustledger-wasm --features ts-rs-spike
+//! ```
+//!
+//! The four DTOs below MIRROR the structs in `src/types.rs` exactly —
+//! same fields, same serde attributes, same doc comments — but with
+//! `#[derive(TS)]` added so ts-rs can introspect them. They're a copy
+//! rather than a feature-gated derive on the production types because
+//! the spike's goal is to compare what ts-rs emits against what we
+//! ship by hand, without committing to the derive in the real DTOs
+//! before the design decision is made.
+//!
+//! Output lands in `crates/rustledger-wasm/bindings/` (ts-rs default).
+//! Eyeball:
+//!
+//! 1. Does the `DirectiveJson` discriminated union narrow correctly?
+//! 2. Is the `TypedValueJson` payload's `MetaValueJson` substituted by
+//!    the right TS shape, or does it become `any` / `unknown`?
+//! 3. Do the doc comments translate to JSDoc?
+//! 4. Do `skip_serializing_if = "Option::is_none"` fields become
+//!    optional (`field?: T`)?
+//! 5. How does `Vec<TypedValueJson>` render — `TypedValueJson[]` or
+//!    `Array<TypedValueJson>`?
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+// =============================================================================
+// 1. MetaValueJson — untagged union, four shapes (string, bool, amount, null)
+// =============================================================================
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(untagged)]
+#[ts(export, export_to = "bindings/")]
+pub enum MetaValueJson {
+    String(String),
+    Bool(bool),
+    Amount { number: String, currency: String },
+    Null,
+}
+
+// =============================================================================
+// 2. TypedValueJson — tagged union for Custom.values (issue #1207)
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "bindings/")]
+pub struct TypedValueJson {
+    #[serde(rename = "type")]
+    pub value_type: String,
+    pub value: MetaValueJson,
+}
+
+// =============================================================================
+// 3. PostingJson — has skip_serializing_if optionals + flag (#1209)
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "bindings/")]
+pub struct AmountValue {
+    pub number: String,
+    pub currency: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[ts(export, export_to = "bindings/")]
+pub enum CostNumberJson {
+    PerUnit { value: String },
+    Total { value: String },
+    PerUnitFromTotal { per_unit: String, total: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "bindings/")]
+pub struct PostingCostJson {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<CostNumberJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "bindings/")]
+pub struct PostingJson {
+    pub account: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub units: Option<AmountValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub cost: Option<PostingCostJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub price: Option<AmountValue>,
+    /// Posting-level flag (e.g. `"!"` for pending). Mirrors
+    /// `rustledger_core::Posting::flag`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub flag: Option<String>,
+    /// Posting-level metadata (issue #1168). Empty when the posting
+    /// has no explicit metadata.
+    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+    pub meta: HashMap<String, MetaValueJson>,
+}
+
+// =============================================================================
+// 4. DirectiveJson — discriminated union with tag="type" (the big one)
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[serde(tag = "type")]
+#[ts(export, export_to = "bindings/")]
+pub enum DirectiveJson {
+    #[serde(rename = "transaction")]
+    Transaction {
+        date: String,
+        flag: String,
+        payee: Option<String>,
+        narration: Option<String>,
+        tags: Vec<String>,
+        links: Vec<String>,
+        postings: Vec<PostingJson>,
+        #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+        meta: HashMap<String, MetaValueJson>,
+    },
+    #[serde(rename = "balance")]
+    Balance {
+        date: String,
+        account: String,
+        amount: AmountValue,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tolerance: Option<String>,
+        #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+        meta: HashMap<String, MetaValueJson>,
+    },
+    #[serde(rename = "document")]
+    Document {
+        date: String,
+        account: String,
+        path: String,
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        tags: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        links: Vec<String>,
+        #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+        meta: HashMap<String, MetaValueJson>,
+    },
+    #[serde(rename = "custom")]
+    Custom {
+        date: String,
+        custom_type: String,
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        values: Vec<TypedValueJson>,
+        #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+        meta: HashMap<String, MetaValueJson>,
+    },
+}
+
+fn main() {
+    // ts-rs writes one .d.ts per exported type into `bindings/`
+    // when this binary runs. The `#[ts(export)]` attribute on each
+    // struct/enum triggers the write — `main()` only has to exist so
+    // the binary compiles.
+    //
+    // Confusingly, ts-rs's actual export mechanism is to write the
+    // files when the `#[test]` it auto-generates runs — so running
+    // `cargo test --example tsrs_spike --features ts-rs-spike` is
+    // what actually produces the `.d.ts`. The `cargo run` path is a
+    // no-op confirmation that the types compile.
+    println!("ts-rs spike binary compiled cleanly.");
+    println!(
+        "Run `cargo test --example tsrs_spike --features ts-rs-spike` to emit \
+         the .d.ts files into crates/rustledger-wasm/bindings/."
+    );
+}

--- a/docs/reference/adr/0004-ts-types-from-rust-dtos.md
+++ b/docs/reference/adr/0004-ts-types-from-rust-dtos.md
@@ -26,7 +26,9 @@ Prototype landed in PR #1218 via `crates/rustledger-wasm/examples/tsrs_spike.rs`
 cargo test --example tsrs_spike -p rustledger-wasm --features ts-rs-spike
 ```
 
-ts-rs writes per-type `.d.ts` files under `crates/rustledger-wasm/bindings/bindings/`.
+ts-rs writes per-type `.d.ts` files under `crates/rustledger-wasm/bindings/bindings/` (the outer `bindings/` is ts-rs's per-crate output root; the inner one comes from the `export_to = "bindings/"` attribute on each derive).
+
+**The spike is intentionally a snapshot of the production DTOs at the moment of writing.** It does not track future changes to `src/types.rs`. When Phase 1 lands, the production DTOs gain the `#[derive(TS)]` and the spike example is deleted — the spike's job is to inform the design decision, not stay current.
 
 ### What ts-rs got right
 

--- a/docs/reference/adr/0004-ts-types-from-rust-dtos.md
+++ b/docs/reference/adr/0004-ts-types-from-rust-dtos.md
@@ -1,0 +1,127 @@
+# ADR-0004: Generate TypeScript types from Rust DTOs
+
+## Status
+
+Proposed (May 2026) — spike landed in #1218; awaiting decision before implementation.
+
+## Context
+
+`crates/rustledger-wasm/` ships **three hand-maintained TypeScript surfaces**:
+
+- `beancount.d.ts` (494 lines)
+- `beancount_wasm.d.ts` (398 lines)
+- `typescript_custom_section` block inside `src/lib.rs` (wasm-bindgen embeds it in the generated `.d.ts` that ships with the npm package)
+
+Each gets out of sync with the Rust DTOs independently. PRs #1209, #1210, #1211, #1212, #1215, #1216 all had to update all three surfaces in lockstep. PR #1210 was an audit pass that found 7 directive variants entirely missing from one surface and `Posting.price` missing from another.
+
+#1200's audit cascade (8 PRs over ~3 days) closed the wire-format-drift backlog but didn't solve the *structural* problem: any future wire-format field will need three TS updates and a manual audit to confirm all three actually got updated.
+
+This ADR records the design decision for a structural fix.
+
+## Spike
+
+Prototype landed in PR #1218 via `crates/rustledger-wasm/examples/tsrs_spike.rs`. The four DTOs that matter for the audit (`MetaValueJson`, `TypedValueJson`, `PostingJson`, `DirectiveJson`, plus supporting types) were mirrored verbatim into the spike with `#[derive(TS)]` added. Run with:
+
+```bash
+cargo test --example tsrs_spike -p rustledger-wasm --features ts-rs-spike
+```
+
+ts-rs writes per-type `.d.ts` files under `crates/rustledger-wasm/bindings/bindings/`.
+
+### What ts-rs got right
+
+1. **Discriminated unions narrow correctly.** `DirectiveJson` emits
+   ```ts
+   export type DirectiveJson =
+     | { "type": "transaction", ..., postings: Array<PostingJson>, ... }
+     | { "type": "balance", ..., tolerance: string | null, ... }
+     | ...
+   ```
+   so `switch (d.type) { case "balance": d.tolerance ... }` narrows. Same for `CostNumberJson` with its `kind` discriminator.
+
+2. **Untagged unions render exactly.** `MetaValueJson` becomes `string | boolean | { number: string, currency: string } | null` — identical to what we ship by hand.
+
+3. **Doc comments translate to JSDoc.** Rustdoc on a field shows up as `/** ... */` above the TS field.
+
+4. **Cross-file imports compose cleanly.** Per-type files reference each other via `import type { MetaValueJson } from "./MetaValueJson"`.
+
+5. **`#[ts(optional)]` solves the `Option<T> + skip_serializing_if = "Option::is_none"` mismatch.** Without it, ts-rs emits `field: T | null` (present-but-null); with it, `field?: T` (optional, matching wire absence). One attribute per Option field.
+
+### Where ts-rs falls short
+
+1. **`TypedValueJson` discriminated narrowing is lost.** The Rust DTO is `struct TypedValueJson { value_type: String, value: MetaValueJson }` — a struct with two fields. ts-rs emits the corresponding wide TS:
+   ```ts
+   export type TypedValueJson = { type: string, value: MetaValueJson };
+   ```
+   The hand-written shape we ship today (post-#1215) is narrower:
+   ```ts
+   export type TypedValue =
+     | { type: "string"; value: string }
+     | { type: "amount"; value: { number: string; currency: string } }
+     | ...
+   ```
+   This is a **structural Rust-side limitation**, not a ts-rs bug. The hand-written TS encodes per-variant payload constraints (`type: "amount"` implies `value` is an `AmountValue`) that the Rust DTO doesn't express. Restructuring the Rust DTO as a serde-tagged enum is awkward because the `null` variant needs `value: ()` (which doesn't serialize cleanly) or a custom `Deserialize` impl.
+
+2. **Per-type file output** doesn't directly produce our two `.d.ts` files (`beancount.d.ts`, `beancount_wasm.d.ts`). Needs a collation step.
+
+3. **Cosmetic differences** — `Array<T>` instead of `T[]`; trailing commas in object types. tsc accepts both; ESLint may complain but it's a one-line `.eslintrc` exception.
+
+## Decision
+
+**Adopt ts-rs with the following design constraints:**
+
+### 1. Per-struct derives on the production DTOs
+
+Add `#[cfg_attr(feature = "ts-export", derive(ts_rs::TS))]` to the wire-format DTOs in `crates/rustledger-wasm/src/types.rs` (and equivalent FFI-WASI types if we generate those too). Behind a feature flag so the default build doesn't pull in `ts-rs`. The CI gate runs `cargo test -p rustledger-wasm --features ts-export` and `git diff --exit-code crates/rustledger-wasm/bindings/`.
+
+### 2. Generated files replace `beancount.d.ts` and `beancount_wasm.d.ts`
+
+The two hand-written files are deleted and replaced by:
+
+- **`bindings/index.d.ts`** — concatenation of all per-type files into a single shippable surface, written by a small post-processing script that runs alongside the ts-rs export. Replaces both current `.d.ts` files.
+- The npm package exports `bindings/index.d.ts` as the type entry.
+
+This is a **breaking change to the TS API surface** in terms of file layout (consumers importing from `beancount_wasm.d.ts` directly will need to update), but the type *shapes* are identical or narrower than what we ship today.
+
+### 3. Keep the `typescript_custom_section` inline shape — for now
+
+The `typescript_custom_section` block in `src/lib.rs` is what wasm-bindgen embeds in its generated `.d.ts`. We can't drop it without breaking wasm-bindgen's TS integration. **Phase 2** (a follow-up issue) replaces this block with an `include_str!` of the generated `bindings/index.d.ts` so it stays in sync automatically. For Phase 1, we keep it hand-written but the audit burden drops from three surfaces to one (since the other two go away entirely).
+
+### 4. Keep `TypedValueJson` narrowing hand-tuned
+
+For Phase 1, ts-rs outputs the wide `{ type: string, value: MetaValueJson }` for `TypedValueJson`. The post-processing script detects this specific type and replaces it with the narrower discriminated union we ship today. Document the override in the script so future contributors don't lose it during a generator-version bump.
+
+**Phase 2 alternative**: restructure `TypedValueJson` as a tagged Rust enum with a custom `Deserialize` for the `null` variant. This becomes worthwhile if more types need the same narrowing trick; for now, one type doesn't justify the FFI-WASI refactor.
+
+### 5. Python `.pyi` stubs — explicitly out of scope
+
+`crates/rustledger-ffi-wasi/python/compat.py` is a manual wrapper. Auto-generating Python stubs from the same Rust DTOs is interesting but the spike target is JS/TS. File a separate issue if Python stub generation becomes a priority; until then, the Python compat layer stays hand-maintained.
+
+## Consequences
+
+### Positive
+
+- **Single source of truth** for the wire shape. Adding a field to a Rust DTO automatically updates the TS — no audit pass required.
+- **CI catches drift** at the `git diff --exit-code` step. The "forgot to regenerate" failure mode becomes a CI failure, not a silent ship.
+- **Narrowing is preserved** for the load-bearing cases (`DirectiveJson` discriminated union, `CostNumberJson::kind`, `MetaValueJson` untagged union).
+- **`#[ts(optional)]` is a one-attribute fix** for the only widespread mismatch ts-rs introduced.
+
+### Negative
+
+- **`TypedValueJson` needs a hand-tuned override** in the post-processing script. This is documented but adds a small ongoing maintenance burden.
+- **Breaking change to the file layout** of `crates/rustledger-wasm/*.d.ts`. The npm package exports change; downstream consumers importing the explicit file paths must update. Mitigation: ship both files as re-exports of `bindings/index.d.ts` for one release cycle, then deprecate.
+- **New dep**: `ts-rs` 12.x. Active maintenance, MIT-licensed, no known cargo-deny findings. Worth checking `cargo deny check` before merge.
+- **Wasm-bindgen integration unchanged** in Phase 1 — the `typescript_custom_section` is still hand-maintained. Phase 2 closes that gap.
+
+## Alternatives considered
+
+- **`tsify` / `wasm-bindgen-derive`**: tighter wasm-bindgen integration but couples to wasm-bindgen, which means `rustledger-plugin-types` (wasm-bindgen-free) can't participate. ts-rs is generator-agnostic, which keeps the door open for plugin-types generation later.
+- **`specta`**: supports multiple target languages (TS, Python, Rust). Heavier dep, less Rust-ecosystem mindshare than ts-rs. Worth revisiting if/when Python stub generation becomes interesting.
+- **Status quo with a `.d.ts` audit checklist**: relies on humans never forgetting. The PR #1210 audit was specifically the failure mode of this approach.
+
+## Related
+
+- #1200 — tracking issue this work was split out of (closed).
+- #1218 — this design issue.
+- PRs #1209, #1210, #1211, #1212, #1215, #1216 — the audit cascade that motivated this work.
+- `crates/rustledger-wasm/examples/tsrs_spike.rs` — the spike code this ADR is based on.

--- a/docs/reference/adr/index.md
+++ b/docs/reference/adr/index.md
@@ -13,6 +13,7 @@ ADRs document significant architectural decisions made during rustledger develop
 | [ADR-0001](0001-crate-organization.md) | Crate Organization | Accepted |
 | [ADR-0002](0002-error-handling.md) | Error Handling | Accepted |
 | [ADR-0003](0003-parser-design.md) | Parser Design | Accepted |
+| [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate TypeScript types from Rust DTOs | Proposed |
 
 ## About ADRs
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1100,6 +1100,14 @@ criteria = "safe-to-deploy"
 version = "0.3.23"
 criteria = "safe-to-deploy"
 
+[[exemptions.ts-rs]]
+version = "12.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ts-rs-macros]]
+version = "12.0.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.typed-path]]
 version = "0.12.3"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Re-opening of #1219 after a branch rename (`spike/...` failed the workspace's allowed-types regex). Same content, plus the deep-review fixes applied as a follow-up commit:

- `bindings/` path docstring corrected to `bindings/bindings/` in both the spike file and ADR.
- Cargo.toml feature comment now spells out why `ts-rs-spike` and the target-gated `ts-rs` dep are deliberately split.
- ADR explicitly notes the spike is a snapshot of the production DTOs and won't track future changes.

## Summary

Spike + design doc for #1218. Item 2 of the closed #1200 tracking issue, deferred for design because it had substantial open questions.

This PR lands:
- `crates/rustledger-wasm/examples/tsrs_spike.rs` — prototype that mirrors the four key wire-format DTOs (MetaValueJson, TypedValueJson, PostingJson, DirectiveJson + supporting types) with `#[derive(TS)]`. Run with `cargo test --example tsrs_spike -p rustledger-wasm --features ts-rs-spike`.
- `docs/reference/adr/0004-ts-types-from-rust-dtos.md` — proposed ADR with concrete recommendations.

`bindings/` output is gitignored; regenerable from the spike.

## Spike findings

**ts-rs got these right:**
- DirectiveJson discriminated union — narrows correctly on `switch (d.type)`.
- CostNumberJson with `tag = "kind"` — same, narrowing-friendly.
- MetaValueJson untagged union — bit-identical to hand-written.
- Doc comments → JSDoc.
- Cross-file imports compose.

**One solvable friction:**
- `Option<T> + skip_serializing_if = "Option::is_none"` emits `field: T | null` by default. The `#[ts(optional)]` attribute fixes this to `field?: T`. Verified in the spike.

**One structural limitation:**
- TypedValueJson's TS-side narrowing is lost. The Rust DTO is `struct { value_type: String, value: MetaValueJson }`; ts-rs faithfully emits the wide TS. The hand-written narrowed `type TypedValue = { type: "string"; value: string } | { type: "amount"; value: AmountValue } | ...` is more precise than the Rust struct can express. ADR proposes hand-tuning this one type via a post-process step.

## ADR-0004 recommendation

Adopt ts-rs with these constraints:
1. `#[ts(optional)]` on skip-if-none fields.
2. Replace `beancount.d.ts` + `beancount_wasm.d.ts` with a generated `bindings/index.d.ts` (post-process concat).
3. Keep `typescript_custom_section` hand-maintained in Phase 1; replace with `include_str!` of the bundle in a follow-up.
4. Hand-tune TypedValueJson narrowing in the post-process step.
5. Python `.pyi` stubs explicitly out of scope.

## Verification

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo deny check` — clean (ts-rs 12.0.1 has no advisories)
- [x] `ts-rs-spike` feature gates the optional dep; default build unaffected

Relates to #1218. Supersedes #1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)