### PR TITLE
fix(wasm): converge Transaction.payee/narration wire shape with FFI-WASI (closes #1221)

### DIFF
--- a/crates/rustledger-wasm/CHANGELOG.md
+++ b/crates/rustledger-wasm/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   positional values from `custom` directives must branch on `.type`
   and read `.value`.
 
+- **Transaction `payee` and `narration` shape change** (closes
+  #1221). Pre-fix: WASM emitted `"payee": null` when the transaction
+  had no payee, and `"narration": ""` when the narration was empty.
+  Post-fix: both fields are absent on the wire in their respective
+  empty cases, matching FFI-WASI's `skip_serializing_if`-driven
+  shape. JS consumers using `"payee" in t` (now `false` instead of
+  `true` when absent) or `t.narration === ""` (now `undefined`
+  instead of `""` when empty) must update. The hand-written `.d.ts`
+  files are updated to `payee?: string` and `narration?: string`.
+
 ## [0.13.0](https://github.com/rustledger/rustledger/compare/v0.12.0...v0.13.0) - 2026-04-21
 
 ### Bug Fixes

--- a/crates/rustledger-wasm/beancount.d.ts
+++ b/crates/rustledger-wasm/beancount.d.ts
@@ -123,10 +123,11 @@ export interface TransactionData {
   date: string;
   /** Transaction flag: "*" for complete, "!" for flagged. */
   flag: string;
-  /** Optional payee. */
-  payee: string | null;
-  /** Transaction description. */
-  narration: string;
+  /** Optional payee. Absent when the transaction has no payee. */
+  payee?: string;
+  /** Transaction description. Absent when the narration is empty
+   * (matches FFI-WASI's elision; see #1221). */
+  narration?: string;
   /** Tags (without # prefix). */
   tags: string[];
   /** Links (without ^ prefix). */

--- a/crates/rustledger-wasm/beancount_wasm.d.ts
+++ b/crates/rustledger-wasm/beancount_wasm.d.ts
@@ -163,10 +163,11 @@ export interface TransactionDirective extends Directive {
     type: "transaction";
     /** Transaction flag (* or !) */
     flag: string;
-    /** Optional payee */
+    /** Optional payee. Absent when the transaction has no payee. */
     payee?: string;
-    /** Transaction narration/description */
-    narration: string;
+    /** Transaction narration/description. Absent when the narration
+     * is empty (matches FFI-WASI's elision; see #1221). */
+    narration?: string;
     /** Transaction tags */
     tags: string[];
     /** Transaction links */

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -126,7 +126,17 @@ pub fn directive_to_json(directive: &Directive) -> DirectiveJson {
             date: txn.date.to_string(),
             flag: txn.flag.to_string(),
             payee: txn.payee.as_ref().map(ToString::to_string),
-            narration: Some(txn.narration.to_string()),
+            // Empty narration normalizes to `None` so it gets elided
+            // by `skip_serializing_if`, matching FFI-WASI's shape
+            // (closes #1221). Pre-#1221 this unconditionally wrapped
+            // in `Some(...)`, so an empty narration always emitted
+            // `"narration": ""` on the wire while FFI-WASI omitted
+            // the field entirely.
+            narration: if txn.narration.is_empty() {
+                None
+            } else {
+                Some(txn.narration.to_string())
+            },
             tags: txn.tags.iter().map(ToString::to_string).collect(),
             links: txn.links.iter().map(ToString::to_string).collect(),
             postings: txn
@@ -487,6 +497,53 @@ mod tests {
         assert!(
             !serialized.contains("\"meta\""),
             "empty meta must be omitted from JSON output; got: {serialized}",
+        );
+    }
+
+    /// Regression for #1221: WASM previously emitted `"payee": null`
+    /// when the transaction had no payee, and `"narration": ""` when
+    /// empty, while FFI-WASI omitted both fields via
+    /// `skip_serializing_if`. Post-fix both fields are absent on the
+    /// wire in their respective empty cases, matching FFI-WASI.
+    #[test]
+    fn transaction_omits_payee_and_empty_narration_1221() {
+        // No payee, empty narration -- both fields must be absent.
+        let source = "2024-01-01 *\n  Assets:Bank  10.00 USD\n  Income:Salary\n";
+        let result = parse_beancount(source);
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+        let json = directive_to_json(&result.directives[0].value);
+        let serialized = serde_json::to_string(&json).expect("serializes");
+        assert!(
+            !serialized.contains("\"payee\""),
+            "absent payee must be omitted from JSON; got: {serialized}",
+        );
+        assert!(
+            !serialized.contains("\"narration\""),
+            "empty narration must be omitted from JSON; got: {serialized}",
+        );
+    }
+
+    /// Regression for #1221: non-empty narration still emits.
+    /// Counterpoint to `transaction_omits_payee_and_empty_narration_1221`
+    /// so a future regression that elides the field unconditionally
+    /// also fails CI.
+    #[test]
+    fn transaction_emits_payee_and_nonempty_narration_1221() {
+        let source =
+            "2024-01-01 * \"Acme\" \"Coffee\"\n  Assets:Bank  -5.00 USD\n  Expenses:Food\n";
+        let result = parse_beancount(source);
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+
+        let json = directive_to_json(&result.directives[0].value);
+        let serialized = serde_json::to_string(&json).expect("serializes");
+        assert!(
+            serialized.contains("\"payee\":\"Acme\""),
+            "present payee must be on the wire; got: {serialized}",
+        );
+        assert!(
+            serialized.contains("\"narration\":\"Coffee\""),
+            "non-empty narration must be on the wire; got: {serialized}",
         );
     }
 

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -156,7 +156,14 @@ pub enum DirectiveJson {
     Transaction {
         date: String,
         flag: String,
+        /// Optional payee. Mirrors FFI-WASI's shape: absent on the
+        /// wire when `None` (closes #1221).
+        #[serde(skip_serializing_if = "Option::is_none")]
         payee: Option<String>,
+        /// Optional narration. Empty narrations are normalized to
+        /// `None` in `convert.rs` so the field is absent on the wire
+        /// in the empty case -- matches FFI-WASI's pattern (#1221).
+        #[serde(skip_serializing_if = "Option::is_none")]
         narration: Option<String>,
         tags: Vec<String>,
         links: Vec<String>,

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -53,10 +53,13 @@
 //!    `skip_serializing_if` to the FFI-WASI side (or by always
 //!    emitting an explicit empty object on both — pick one rule).
 //!
-//! 3. **None vs absent**: WASM emits `"payee": null`, FFI-WASI uses
-//!    `skip_serializing_if = "Option::is_none"`. Normalization drops
-//!    explicit nulls. Converge by adding `skip_serializing_if` on
-//!    the WASM side.
+//! 3. ~~**None vs absent**: WASM emits `"payee": null`, FFI-WASI uses
+//!    `skip_serializing_if = "Option::is_none"`.~~ **Converged in #1221** —
+//!    WASM now uses `skip_serializing_if` on `payee` and `narration`,
+//!    matching FFI-WASI. The null-stripping in
+//!    [`strip_empty_meta_and_directive_nulls`] is retained as a
+//!    defensive guard against future regression but no longer masks
+//!    any known divergence.
 
 use rust_decimal_macros::dec;
 use rustledger_core::{


### PR DESCRIPTION
## Summary

Surfaced by the ts-rs spike in #1220. FFI-WASI already uses \`skip_serializing_if = \"Option::is_none\"\` on both \`payee\` and \`narration\`; the WASM binding diverged on both fields:

- **\`payee\`**: WASM emitted \`\"payee\": null\` when None; FFI-WASI omitted.
- **\`narration\`**: WASM wrapped \`txn.narration\` unconditionally in \`Some(...)\`, so empty narration always emitted \`\"\"\` on the wire; FFI-WASI's converter normalized empty-string-to-None and elided via \`skip_serializing_if\`.

The harness from #1204 documented this exact convergence path in its module docstring (item 3) — the null-stripping normalization was masking the divergence so the equivalence test would pass while the underlying bug persisted.

## Changes

- \`types.rs\`: add \`skip_serializing_if = \"Option::is_none\"\` to both fields.
- \`convert.rs\`: empty narration → None (mirrors FFI-WASI's pattern at \`ffi-wasi/src/convert.rs:133-137\`).
- Three TS surfaces aligned:
  - \`beancount.d.ts\`: \`payee: string | null\` → \`payee?: string\`; \`narration: string\` → \`narration?: string\`.
  - \`beancount_wasm.d.ts\`: \`narration: string\` → \`narration?: string\` (payee was already correct).
  - \`typescript_custom_section\`: already had both as optional; no change needed.
- Harness module docstring updated — item 3 marked converged.

Two new regression tests pin both directions (omit-on-empty and emit-on-present).

## Test plan

- [x] \`cargo test -p rustledger-wasm\` — 80/80 pass (was 78; +2 new)
- [x] \`cargo test -p rustledger-wire-format-tests\` — 18/18 pass
- [x] \`cargo check --target wasm32-unknown-unknown -p rustledger-wasm --tests\` — clean (catches the JS-side test surface)
- [x] \`cargo clippy -p rustledger-wasm -p rustledger-wire-format-tests --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

## Notes

The .d.ts audit (#1210) didn't catch this because it looked for missing/extra fields, not type mismatches on existing fields. The ts-rs spike (#1220) surfaced it by comparing generated TS against the hand-written shape — concrete evidence for ADR-0004's CI gate proposal.

Closes #1221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)