### PR TITLE
feat(wasm)!: Phase 2 — replace inline DTOs with include_str! (closes #1224)

### DIFF
--- a/crates/rustledger-wasm/CHANGELOG.md
+++ b/crates/rustledger-wasm/CHANGELOG.md
@@ -60,16 +60,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     EditorReference, EditorReferencesResult) -- keep their Rust
     names. 34 types in the bundle.
 
-  **Phase 2 caveat (deferred to a follow-up):** the inline
-  `typescript_custom_section` block in `src/lib.rs` -- which
-  wasm-bindgen embeds in the auto-generated `pkg/*.d.ts` that ships
-  with the npm package -- still has the **old** hand-maintained
-  shape (`TransactionDirective`, `Posting`, `Amount`, etc.). JS
-  consumers using only the wasm-bindgen-generated `.d.ts` will see
-  the old names; consumers importing the new `bindings/index.d.ts`
-  see the new ones. Phase 2 replaces `typescript_custom_section`
-  with `include_str!("../bindings/index.d.ts")` so both surfaces
-  converge. Tracked separately.
+- **TypeScript surfaces fully converged** (closes #1224, ADR-0004
+  Phase 2). The inline `typescript_custom_section` DTO block in
+  `src/lib.rs` (~300 lines of hand-maintained types) is replaced by
+  `include_str!("../bindings/index.d.ts")`, so the wasm-bindgen-
+  generated `pkg/*.d.ts` and the importable `bindings/index.d.ts` are
+  now the **same** types -- no duplication, no drift. JS consumers
+  using only the wasm-bindgen-generated `.d.ts` now see the same new
+  names that direct-bundle consumers got in Phase 1
+  (`DirectiveJson`, `PostingJson`, etc.). One additional rename: the
+  Rust DTO `Ledger` now emits `LedgerJson` on the TS side to avoid
+  colliding with the wasm-bindgen `Ledger` class (the runtime
+  wrapper). `LedgerJson` is the wire shape returned by `parse(...)`
+  and stored on `ParseResult.ledger`; `Ledger` is the class
+  instantiated via `Ledger.fromFiles(...)`.
+
+  Remaining inline TS in `src/lib.rs`: only the wasm-bindgen-managed
+  surface that **can't** go in the bundle -- the `ParsedLedger` and
+  `Ledger` classes, the `FileMap` utility type, and the standalone
+  function signatures (`parseMultiFile`, `validateMultiFile`,
+  `queryMultiFile`, `hashSources`). ~150 lines of necessary glue,
+  down from ~480.
 
 ## [0.13.0](https://github.com/rustledger/rustledger/compare/v0.12.0...v0.13.0) - 2026-04-21
 

--- a/crates/rustledger-wasm/bindings/index.d.ts
+++ b/crates/rustledger-wasm/bindings/index.d.ts
@@ -364,8 +364,15 @@ errors: Array<BeancountError>, };
 
 /**
  * A parsed Beancount ledger.
+ *
+ * **Renamed to `LedgerJson` on the TS side** to avoid colliding with
+ * the wasm-bindgen-exported `Ledger` class (the runtime wrapper that
+ * owns the parsed data). `LedgerJson` is the wire shape; `Ledger` is
+ * the class consumers instantiate via `Ledger.fromFiles(...)`. The
+ * Rust struct keeps the shorter name for internal use; the rename
+ * is applied via `#[ts(rename = ...)]`.
  */
-export type Ledger = { 
+export type LedgerJson = { 
 /**
  * All directives in the ledger.
  */
@@ -459,7 +466,7 @@ export type ParseResult = {
  * is always present on the wire (TS: `Ledger | null`, not
  * `ledger?`).
  */
-ledger: Ledger | null, 
+ledger: LedgerJson | null, 
 /**
  * Parse errors.
  */

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -73,308 +73,28 @@ use wasm_bindgen::prelude::*;
 // =============================================================================
 // TypeScript Type Definitions
 // =============================================================================
+//
+// **DTO types** come from the ts-rs-generated bundle at
+// `crates/rustledger-wasm/bindings/index.d.ts` (ADR-0004 Phase 2 / #1224).
+// We embed the bundle via `include_str!` so wasm-bindgen's
+// `pkg/*.d.ts` AND the hand-importable `bindings/index.d.ts` are the
+// same types -- no duplication, no drift.
+//
+// **Runtime classes and standalone function signatures** live in the
+// second `typescript_custom_section` below. These can't go in the
+// bundle (they're wasm-bindgen-managed, not serde DTOs). They
+// reference the bundle types by their generated names (`DirectiveJson`,
+// `LedgerJson`, etc.). If you rename a DTO via `#[ts(rename = ...)]`
+// in `src/types.rs`, update the references here too.
+//
+// Run `scripts/regen-ts-bindings.sh` after touching any DTO; the
+// `ts-bindings-fresh` CI job fails if the bundle drifts.
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_TYPES_DTOS: &'static str = include_str!("../bindings/index.d.ts");
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_TYPES: &'static str = r#"
-/** Error severity level. */
-export type Severity = 'error' | 'warning';
-
-/** Error with source location information. */
-export interface BeancountError {
-    message: string;
-    line?: number;
-    column?: number;
-    severity: Severity;
-}
-
-/** Amount with number and currency. */
-export interface Amount {
-    number: string;
-    currency: string;
-}
-
-/**
- * Posting cost number. Tagged enum mirroring `rustledger_core::CostNumber`.
- * Discriminate via the `kind` field; never probe for present-but-null fields.
- */
-export type CostNumber =
-    | { kind: 'per_unit'; value: string }
-    | { kind: 'total'; value: string }
-    | { kind: 'per_unit_from_total'; per_unit: string; total: string };
-
-/** Posting cost specification. */
-export interface PostingCost {
-    number?: CostNumber;
-    currency?: string;
-    date?: string;
-    label?: string;
-}
-
-/**
- * Metadata value (issue #1168). Untagged union: branch on `typeof v`
- * (`'string'` / `'boolean'`) or object shape (`'number' in v` → Amount).
- */
-export type MetaValueJson =
-    | string
-    | boolean
-    | { number: string; currency: string }
-    | null;
-
-/**
- * Tagged-union value used in the `custom` directive's `values` field
- * (issue #1207). Preserves the host `MetaValue` variant tag — unlike
- * `MetaValueJson`, which collapses `Date`/`String`/`Account` to a
- * single bare-string shape. Mirrors FFI-WASI's `TypedValue` exactly.
- *
- * Declared as a discriminated union so `switch (v.type)` (or
- * `if (v.type === 'amount')`) narrows `v.value` to the right payload
- * shape — see `tsc` issue: a single interface with union types on
- * both fields gives the cross-product, not the narrowing relationship.
- */
-export type TypedValue =
-    | { type: 'string'; value: string }
-    | { type: 'account'; value: string }
-    | { type: 'currency'; value: string }
-    | { type: 'tag'; value: string }
-    | { type: 'link'; value: string }
-    | { type: 'date'; value: string }
-    | { type: 'number'; value: string }
-    | { type: 'bool'; value: boolean }
-    | { type: 'amount'; value: { number: string; currency: string } }
-    | { type: 'null'; value: null };
-
-/** A posting within a transaction. */
-export interface Posting {
-    account: string;
-    units?: Amount;
-    cost?: PostingCost;
-    price?: Amount;
-    /** Posting flag (e.g. "!" for pending). */
-    flag?: string;
-    /** Posting-level metadata (issue #1168). */
-    meta?: Record<string, MetaValueJson>;
-}
-
-/** Base directive with date. */
-interface BaseDirective {
-    date: string;
-    /** Directive-level metadata (issue #1168). */
-    meta?: Record<string, MetaValueJson>;
-}
-
-/** Transaction directive. */
-export interface TransactionDirective extends BaseDirective {
-    type: 'transaction';
-    flag: string;
-    payee?: string;
-    narration?: string;
-    tags: string[];
-    links: string[];
-    /**
-     * Postings on this transaction. The host stores each posting in a
-     * `Spanned<Posting>` wrapper internally (with byte-offset source
-     * location), but the JS-facing shape is intentionally flattened to
-     * plain `Posting` — JS callers do not need source location for the
-     * current API surface. If source spans are ever exposed to JS, this
-     * type should change to `(Posting & { span?: ... })[]`.
-     */
-    postings: Posting[];
-}
-
-/** Balance assertion directive. */
-export interface BalanceDirective extends BaseDirective {
-    type: 'balance';
-    account: string;
-    amount: Amount;
-    /** Explicit tolerance (e.g. "0.01" from `~ 0.01`), stringified for precision. */
-    tolerance?: string;
-}
-
-/** Open account directive. */
-export interface OpenDirective extends BaseDirective {
-    type: 'open';
-    account: string;
-    currencies: string[];
-    booking?: string;
-}
-
-/** Close account directive. */
-export interface CloseDirective extends BaseDirective {
-    type: 'close';
-    account: string;
-}
-
-/**
- * All directive types. Named variants inherit `date` and `meta?` from
- * `BaseDirective`; the inline shapes below don't extend it, so they
- * spell out both fields explicitly for parity with the wire shape.
- */
-export type Directive =
-    | TransactionDirective
-    | BalanceDirective
-    | OpenDirective
-    | CloseDirective
-    | { type: 'commodity'; date: string; currency: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'pad'; date: string; account: string; source_account: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'event'; date: string; event_type: string; value: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'note'; date: string; account: string; comment: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'document'; date: string; account: string; path: string; tags?: string[]; links?: string[]; meta?: Record<string, MetaValueJson> }
-    | { type: 'price'; date: string; currency: string; amount: Amount; meta?: Record<string, MetaValueJson> }
-    | { type: 'query'; date: string; name: string; query_string: string; meta?: Record<string, MetaValueJson> }
-    | { type: 'custom'; date: string; custom_type: string; values?: TypedValue[]; meta?: Record<string, MetaValueJson> };
-
-/** Ledger options. */
-export interface LedgerOptions {
-    operating_currencies: string[];
-    title?: string;
-}
-
-/** Parsed ledger. */
-export interface Ledger {
-    directives: Directive[];
-    options: LedgerOptions;
-}
-
-/** Result of parsing a Beancount file. */
-export interface ParseResult {
-    ledger?: Ledger;
-    errors: BeancountError[];
-}
-
-/** Result of validation. */
-export interface ValidationResult {
-    valid: boolean;
-    errors: BeancountError[];
-}
-
-/** Cell value in query results. */
-export type CellValue =
-    | null
-    | string
-    | number
-    | boolean
-    | Amount
-    | { units: Amount; cost?: { number: string; currency: string; date?: string; label?: string } }
-    | { positions: Array<{ units: Amount }> }
-    | string[];
-
-/** Result of a BQL query. */
-export interface QueryResult {
-    columns: string[];
-    rows: CellValue[][];
-    errors: BeancountError[];
-}
-
-/** Result of formatting. */
-export interface FormatResult {
-    formatted?: string;
-    errors: BeancountError[];
-}
-
-/** Result of pad expansion. */
-export interface PadResult {
-    directives: Directive[];
-    padding_transactions: Directive[];
-    errors: BeancountError[];
-}
-
-/** Result of running a plugin. */
-export interface PluginResult {
-    directives: Directive[];
-    errors: BeancountError[];
-}
-
-/** Plugin information. */
-export interface PluginInfo {
-    name: string;
-    description: string;
-}
-
-/** BQL completion suggestion. */
-export interface Completion {
-    text: string;
-    category: string;
-    description?: string;
-}
-
-/** Result of BQL completion request. */
-export interface CompletionResult {
-    completions: Completion[];
-    context: string;
-}
-
-// =============================================================================
-// Editor Integration Types (LSP-like features)
-// =============================================================================
-
-/** The kind of a completion item. */
-export type EditorCompletionKind = 'keyword' | 'account' | 'accountsegment' | 'currency' | 'payee' | 'date' | 'text';
-
-/** A completion item for Beancount source editing. */
-export interface EditorCompletion {
-    label: string;
-    kind: EditorCompletionKind;
-    detail?: string;
-    insertText?: string;
-}
-
-/** Result of an editor completion request. */
-export interface EditorCompletionResult {
-    completions: EditorCompletion[];
-    context: string;
-}
-
-/** A range in the document. */
-export interface EditorRange {
-    start_line: number;
-    start_character: number;
-    end_line: number;
-    end_character: number;
-}
-
-/** Hover information for a symbol. */
-export interface EditorHoverInfo {
-    contents: string;
-    range?: EditorRange;
-}
-
-/** A location in the document. */
-export interface EditorLocation {
-    line: number;
-    character: number;
-}
-
-/** The kind of a symbol. */
-export type SymbolKind = 'transaction' | 'account' | 'balance' | 'commodity' | 'posting' | 'pad' | 'event' | 'note' | 'document' | 'price' | 'query' | 'custom';
-
-/** A document symbol for the outline view. */
-export interface EditorDocumentSymbol {
-    name: string;
-    detail?: string;
-    kind: SymbolKind;
-    range: EditorRange;
-    children?: EditorDocumentSymbol[];
-    deprecated?: boolean;
-}
-
-/** The kind of reference. */
-export type ReferenceKind = 'account' | 'currency' | 'payee';
-
-/** A reference to a symbol in the document. */
-export interface EditorReference {
-    range: EditorRange;
-    kind: ReferenceKind;
-    is_definition: boolean;
-    context?: string;
-}
-
-/** Result of a find-references request. */
-export interface EditorReferencesResult {
-    symbol: string;
-    kind: ReferenceKind;
-    references: EditorReference[];
-}
-
 /**
  * A parsed and validated ledger that caches the parse result.
  * Use this class when you need to perform multiple operations on the same
@@ -397,7 +117,7 @@ export class ParsedLedger {
     getValidationErrors(): BeancountError[];
 
     /** Get the parsed directives. */
-    getDirectives(): Directive[];
+    getDirectives(): DirectiveJson[];
 
     /** Get the ledger options. */
     getOptions(): LedgerOptions;
@@ -468,7 +188,7 @@ export class Ledger {
     getErrors(): BeancountError[];
 
     /** Get the parsed directives. */
-    getDirectives(): Directive[];
+    getDirectives(): DirectiveJson[];
 
     /** Get the ledger options. */
     getOptions(): LedgerOptions;

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -34,9 +34,19 @@ pub struct ParseResult {
 }
 
 /// A parsed Beancount ledger.
+///
+/// **Renamed to `LedgerJson` on the TS side** to avoid colliding with
+/// the wasm-bindgen-exported `Ledger` class (the runtime wrapper that
+/// owns the parsed data). `LedgerJson` is the wire shape; `Ledger` is
+/// the class consumers instantiate via `Ledger.fromFiles(...)`. The
+/// Rust struct keeps the shorter name for internal use; the rename
+/// is applied via `#[ts(rename = ...)]`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-export", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-export", ts(export, export_to = "bindings/"))]
+#[cfg_attr(
+    feature = "ts-export",
+    ts(export, export_to = "bindings/", rename = "LedgerJson")
+)]
 pub struct Ledger {
     /// All directives in the ledger.
     pub directives: Vec<DirectiveJson>,

--- a/docs/reference/adr/0004-ts-types-from-rust-dtos.md
+++ b/docs/reference/adr/0004-ts-types-from-rust-dtos.md
@@ -2,12 +2,16 @@
 
 ## Status
 
-Accepted — Phase 1 (May 2026). Spike landed in #1220; Phase 1
-implementation ships the per-DTO derives, the
+Accepted — Phase 1 + Phase 2 (May 2026). Spike landed in #1220;
+Phase 1 (#1223) shipped the per-DTO derives, the
 `scripts/regen-ts-bindings.sh` post-process, the generated
-`bindings/index.d.ts`, and the CI freshness gate. Phase 2 (replacing
-the inline `typescript_custom_section` with `include_str!` of the
-generated bundle) is deferred to a follow-up issue.
+`bindings/index.d.ts`, and the CI freshness gate. Phase 2 (this PR)
+replaces the inline `typescript_custom_section` DTO block in
+`src/lib.rs` with `include_str!("../bindings/index.d.ts")` so the
+wasm-bindgen-generated `pkg/*.d.ts` and the importable
+`bindings/index.d.ts` are the same types. The inline TS in
+`src/lib.rs` shrinks to ~150 lines covering only the wasm-bindgen-
+managed runtime classes and standalone function signatures.
 
 ## Context
 

--- a/docs/reference/adr/index.md
+++ b/docs/reference/adr/index.md
@@ -13,7 +13,7 @@ ADRs document significant architectural decisions made during rustledger develop
 | [ADR-0001](0001-crate-organization.md) | Crate Organization | Accepted |
 | [ADR-0002](0002-error-handling.md) | Error Handling | Accepted |
 | [ADR-0003](0003-parser-design.md) | Parser Design | Accepted |
-| [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate TypeScript types from Rust DTOs | Accepted (Phase 1) |
+| [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate TypeScript types from Rust DTOs | Accepted (Phase 1 + 2) |
 
 ## About ADRs
 


### PR DESCRIPTION
ADR-0004 Phase 2. The inline `typescript_custom_section` DTO block in `crates/rustledger-wasm/src/lib.rs` (~300 lines of hand-maintained types) is replaced with `include_str!("../bindings/index.d.ts")`. wasm-bindgen now embeds the ts-rs-generated bundle into the auto-generated `pkg/*.d.ts`, so the two TS surfaces (the hand-importable bundle and the wasm-bindgen npm-package types) are now the **same** types — no duplication, no drift.

**Breaking** for consumers using only the wasm-bindgen-generated `pkg/*.d.ts` — same rename set Phase 1 (#1223) brought to direct-bundle consumers, plus one new rename: `Ledger` (the wire-format DTO) now emits as `LedgerJson` on the TS side to avoid colliding with the `Ledger` runtime class.

## What's in the PR

- **`TS_TYPES_DTOS = include_str!("../bindings/index.d.ts");`** new wasm-bindgen typescript_custom_section block. wasm-bindgen embeds include_str! contents identically to a raw-string literal.
- **Inline `TS_TYPES` block now contains ONLY** the wasm-bindgen-managed surface:
  - `ParsedLedger` and `Ledger` runtime classes (with updated `getDirectives()` return type)
  - `FileMap` utility type
  - Standalone function signatures (`parseMultiFile`, `validateMultiFile`, `queryMultiFile`, `hashSources`)
- **~300 lines deleted** from `src/lib.rs`.
- **`#[ts(rename = "LedgerJson")]`** on the Rust `Ledger` struct; bundle regenerated.
- **`getDirectives()` returns `DirectiveJson[]`** in both classes (was `Directive[]`).
- **CHANGELOG entry** under \`[Unreleased] / ⚠ BREAKING CHANGES\`.
- **ADR-0004 status**: Phase 1 → Phase 1 + Phase 2.

## Why `LedgerJson`?

`Ledger` in TS_TYPES was both an interface (the wire shape) AND a class (the runtime wrapper). TS handled this via declaration merging. After Phase 2, the bundle's `Ledger` would be a `type` alias — which **can't** merge with a class, causing TS errors. Renaming the wire-shape type to `LedgerJson` keeps both surfaces clean:

- `LedgerJson` — wire shape returned by `parse(...)`, stored on `ParseResult.ledger`
- `Ledger` — runtime class instantiated via `Ledger.fromFiles(...)`

## Migration

```ts
// Old
import { Posting, Directive, Amount, Error } from "@rustledger/wasm";

// New
import {
  PostingJson, DirectiveJson, AmountValue, BeancountError
} from "@rustledger/wasm";
```

For ledger data vs the runtime class:

```ts
// Class (unchanged)
const ledger: Ledger = Ledger.fromFiles(files, "main.beancount");

// Wire shape from parse() (renamed)
const result: ParseResult = parse(source);
const data: LedgerJson | null = result.ledger;
```

## Test plan

- [x] `cargo test -p rustledger-wasm` (default): 80/80 pass
- [x] `cargo test -p rustledger-wasm --features ts-export --lib`: 114/114 pass
- [x] `cargo clippy -p rustledger-wasm --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] `RUSTLEDGER_TS_CHECK=1 scripts/regen-ts-bindings.sh`: OK

Closes #1224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)