### PR TITLE
ci: read Node version from .nvmrc in ts-bindings-fresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
-      # Node 24 for the prettier pass in `scripts/regen-ts-bindings.sh`
-      # (#1226). Pin the major so future runner image updates don't
-      # surprise us.
+      # Node for the prettier pass in `scripts/regen-ts-bindings.sh`
+      # (#1226). Read from `.nvmrc` to keep the version in one place --
+      # matches the convention in `wasm.yml` (single source of truth).
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
       # sccache is set as RUSTC_WRAPPER at the workflow level (line 21),
       # so every job that compiles Rust must install the action -- without
       # it, cargo's `-vV` probe fails with "could not execute process


### PR DESCRIPTION
## Summary

Follow-up to #1228 addressing Copilot's review note.

`wasm.yml:88` already uses `node-version-file: '.nvmrc'`, and `.nvmrc` pins `24`. Hardcoding `node-version: '24'` in the `ts-bindings-fresh` job introduced a second source of truth that could drift from `.nvmrc`. Switch to `node-version-file: '.nvmrc'` so the version lives in one place.

## Why

#1228 merged before the review feedback could be folded in. No behavioral change -- Node 24 is still what runs -- but removes a drift risk.

## Test plan

- [x] `.nvmrc` contains `24` (verified)
- [x] `wasm.yml:88` already follows this convention
- [ ] CI: `ts-bindings-fresh` runs with the same Node version

🤖 Generated with [Claude Code](https://claude.com/claude-code)