### PR TITLE
fix(core): silence clippy::manual_option_zip in naive_date

### DIFF
--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -94,11 +94,10 @@ pub use rust_decimal::Decimal;
 /// Returns `None` if the date is invalid.
 #[must_use]
 pub fn naive_date(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
-    i16::try_from(year)
-        .ok()
-        .and_then(|y| i8::try_from(month).ok().map(|m| (y, m)))
-        .and_then(|(y, m)| i8::try_from(day).ok().map(|d| (y, m, d)))
-        .and_then(|(y, m, d)| NaiveDate::new(y, m, d).ok())
+    let y = i16::try_from(year).ok()?;
+    let m = i8::try_from(month).ok()?;
+    let d = i8::try_from(day).ok()?;
+    NaiveDate::new(y, m, d).ok()
 }
 
 // Re-export rkyv wrappers when feature is enabled


### PR DESCRIPTION
## Summary

rust-clippy 1.96.0 (rolled with the latest stable toolchain in CI) turned on `manual_option_zip`. The chain in `crates/rustledger-core/src/lib.rs:97-101`:

```rust
i16::try_from(year)
    .ok()
    .and_then(|y| i8::try_from(month).ok().map(|m| (y, m)))
    .and_then(|(y, m)| i8::try_from(day).ok().map(|d| (y, m, d)))
    .and_then(|(y, m, d)| NaiveDate::new(y, m, d).ok())
```

is the canonical `Option::zip` shape — first `and_then` line matches the lint exactly. CI's `Clippy` job is red on main as a result.

## Fix

Rewrite using the `?` operator on `Option`, which the function's return type (`Option<NaiveDate>`) already supports:

```rust
let y = i16::try_from(year).ok()?;
let m = i8::try_from(month).ok()?;
let d = i8::try_from(day).ok()?;
NaiveDate::new(y, m, d).ok()
```

Shorter, idiomatic, lint-free. Behavior is identical: same conversion order, fail-fast on first `None`, same final `NaiveDate::new(...).ok()` check.

## Test plan

- [ ] CI: `Clippy` job back to green
- [x] No public API change (`pub fn naive_date(year: i32, month: u32, day: u32) -> Option<NaiveDate>` unchanged)
- [x] Behavior preserved (verified by inspection — same control flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)