### PR TITLE
fix(plugin): bump async_stack_size headroom to 2 MiB and fix doc attribution

### DIFF
--- a/crates/rustledger-plugin/src/python/runtime.rs
+++ b/crates/rustledger-plugin/src/python/runtime.rs
@@ -291,15 +291,27 @@ with open('/work/output.json', 'w') as f:
 /// `max_wasm_stack` of 512 KiB is too small for `CPython`'s recursive AST
 /// visitor, so this raises it to 16 MiB.
 ///
-/// When the `async` feature is compiled in (which it is, transitively, via
-/// `wasmtime-wasi`), wasmtime enforces `max_wasm_stack <= async_stack_size`
-/// at [`Engine::new`] time, and the default `async_stack_size` of 2 MiB is
-/// smaller than our 16 MiB wasm stack. Without bumping it, engine creation
-/// fails with `"max_wasm_stack size cannot exceed the async_stack_size"`.
-/// We add 1 MiB of headroom on top of the wasm stack for host frames.
+/// When the `async` feature is compiled in (which it is: `wasmtime`'s
+/// `default` feature set includes `"async"`, and the workspace's
+/// `wasmtime = "45.0.0"` dep uses default features), wasmtime enforces
+/// `max_wasm_stack <= async_stack_size` at [`Engine::new`] time, and the
+/// default `async_stack_size` of 2 MiB is smaller than our 16 MiB wasm
+/// stack. Without bumping it, engine creation fails with
+/// `"max_wasm_stack size cannot exceed the async_stack_size"`.
+///
+/// `ASYNC_STACK_HEADROOM` is the stack space reserved for host frames
+/// running on the async stack: wasmtime's docs state "the amount of stack
+/// space guaranteed for host functions is `async_stack_size - max_wasm_stack`,
+/// so take care not to set these two values close to one another". We
+/// pick 2 MiB to match the stock default difference (default
+/// `async_stack_size` 2 MiB minus default `max_wasm_stack` 512 KiB gives
+/// ~1.5 MiB of host headroom; rounding up to 2 MiB is comfortable). The
+/// Python runtime here is sync-only (it uses [`wasmtime_wasi::p1`], no
+/// `.await`), so the async stack is never actually allocated at runtime;
+/// this value purely satisfies wasmtime's config validator.
 fn engine_config() -> Config {
     const WASM_STACK: usize = 16 * 1024 * 1024;
-    const ASYNC_STACK_HEADROOM: usize = 1024 * 1024;
+    const ASYNC_STACK_HEADROOM: usize = 2 * 1024 * 1024;
 
     let mut config = Config::new();
     config.consume_fuel(true);

--- a/crates/rustledger-plugin/src/python/runtime.rs
+++ b/crates/rustledger-plugin/src/python/runtime.rs
@@ -292,8 +292,8 @@ with open('/work/output.json', 'w') as f:
 /// visitor, so this raises it to 16 MiB.
 ///
 /// When the `async` feature is compiled in (which it is: `wasmtime`'s
-/// `default` feature set includes `"async"`, and the workspace's
-/// `wasmtime = "45.0.0"` dep uses default features), wasmtime enforces
+/// `default` feature set includes "async", and the workspace depends on
+/// `wasmtime` with default features enabled), wasmtime enforces
 /// `max_wasm_stack <= async_stack_size` at [`Engine::new`] time, and the
 /// default `async_stack_size` of 2 MiB is smaller than our 16 MiB wasm
 /// stack. Without bumping it, engine creation fails with


### PR DESCRIPTION
## Summary

Follow-up to #1243 (now merged). Two small tweaks to the wasmtime engine config:

### 1. Bump `ASYNC_STACK_HEADROOM` from 1 MiB to 2 MiB

Wasmtime's `Config::async_stack_size` rustdoc (`wasmtime-45.0.0/src/config.rs:812-815`):

> The amount of stack space guaranteed for host functions is `async_stack_size - max_wasm_stack`, so take care not to set these two values close to one another; doing so may cause host functions to overflow the stack and abort the process.

Stock defaults give `2 MiB - 512 KiB = 1.5 MiB` of host-frame headroom. #1243 ended at `17 MiB - 16 MiB = 1 MiB`, which is *below* the stock guarantee. Rounding up to 2 MiB matches the wasmtime default difference comfortably.

Cost is zero in practice: the Python runtime in `runtime.rs` is sync-only (uses `wasmtime_wasi::p1`, no `.await` anywhere in the file), so the async stack is never actually allocated. This value purely satisfies the config validator with more breathing room.

### 2. Fix the rustdoc attribution

#1243's comment said `async` is enabled "transitively, via `wasmtime-wasi`". Checking `wasmtime-wasi-45/Cargo.toml`:

```toml
[dependencies.wasmtime]
version = "45.0.0"
features = ["runtime", "std"]
default-features = false
```

`wasmtime-wasi` actually opts *out* of wasmtime's default features. The `async` feature reaches us via the workspace's own `wasmtime = "45.0.0"` dep (which uses default features), and `wasmtime`'s `default` feature set includes `"async"`. Cargo unions feature sets so the result is the same, but the comment slightly miscredited the source. The new doc explains the actual path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Changes

Single file, single function, two diffs:

- `ASYNC_STACK_HEADROOM`: `1024 * 1024` -> `2 * 1024 * 1024`
- Doc comment on `engine_config()` rewritten to credit `wasmtime`'s default features rather than `wasmtime-wasi`, and to call out that the Python runtime is sync-only so the async stack is never actually allocated.

The existing `test_engine_config_satisfies_async_stack_constraint` test continues to gate the wasmtime config-validator invariant.

## Testing

- [x] `cargo test -p rustledger-plugin --features python-plugins --lib test_engine_config_satisfies_async_stack_constraint` passes
- [x] `cargo clippy -p rustledger-plugin --features python-plugins --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc -p rustledger-plugin --features python-plugins --no-deps` clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (the function's rustdoc)
- [x] My changes don't introduce new warnings

Follow-up to #1243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
