### PR TITLE
fix(lsp): never emit balance code lenses with command:None (closes #1245)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -101,7 +101,9 @@ pub fn handle_code_lens(
                 });
             }
             Directive::Balance(bal) => {
-                // Store data for resolve - verification is deferred
+                // Store data for resolve: real verification is deferred to
+                // handle_code_lens_resolve because booking the full ledger
+                // is O(N) and the cost is paid per balance assertion.
                 let data = serde_json::json!({
                     "uri": uri,
                     "kind": "balance",
@@ -111,12 +113,34 @@ pub fn handle_code_lens(
                     "expected_currency": bal.amount.currency.to_string(),
                 });
 
+                // Placeholder command set on the initial response so
+                // clients never render the literal "Unresolved lens"
+                // string for balance lenses during the resolve
+                // round-trip window (issue #1245). If `codeLens/resolve`
+                // never lands (cancellation race in nvim's LSP client,
+                // dropped response, etc.), the user still sees a
+                // sensible title instead of "Unresolved lens".
+                //
+                // The resolve handler overwrites this with the real
+                // `✓ Balance: ... USD` title once the calculation
+                // completes, or leaves it in place if the assertion
+                // failed (diagnostics report the failure in that case;
+                // see issue #491).
+                let placeholder = Command {
+                    title: format!(
+                        "Balance: {} {} (checking…)",
+                        bal.amount.number, bal.amount.currency
+                    ),
+                    command: "rledger.noop".to_string(),
+                    arguments: None,
+                };
+
                 lenses.push(CodeLens {
                     range: Range {
                         start: Position::new(line, 0),
                         end: Position::new(line, 0),
                     },
-                    command: None, // Resolved lazily
+                    command: Some(placeholder),
                     data: Some(data),
                 });
             }
@@ -187,11 +211,19 @@ pub fn handle_code_lens_resolve(
             .copied()
             .unwrap_or_default();
 
-        // Only show codelens for passing balance assertions.
-        // Failed assertions are shown as diagnostics (standard IDE behavior).
-        // Showing both would duplicate information (issue #491).
-        if actual_amount == expected_amount {
-            resolved.command = Some(Command {
+        // On passing assertions, show the verified-balance lens.
+        // On failing assertions, the error is surfaced via diagnostics
+        // (standard IDE behavior; showing both would duplicate the
+        // information, see issue #491), so we replace the placeholder
+        // with a brief "(see diagnostic)" callout rather than letting
+        // it stand as a falsely-passing-looking string.
+        //
+        // Crucially, we ALWAYS set `resolved.command` here. The
+        // pre-#1245 path of leaving `command = None` for mismatches
+        // surfaced as nvim rendering the literal string "Unresolved
+        // lens" once the resolve response landed (issue #1245).
+        resolved.command = Some(if actual_amount == expected_amount {
+            Command {
                 title: format!("✓ Balance: {} {}", expected_amount, expected_currency),
                 command: "rledger.showBalanceDetails".to_string(),
                 arguments: Some(vec![serde_json::json!({
@@ -200,9 +232,17 @@ pub fn handle_code_lens_resolve(
                     "expected": format!("{} {}", expected_amount, expected_currency),
                     "actual": format!("{} {}", actual_amount, expected_currency),
                 })]),
-            });
-        }
-        // For mismatches, command stays None - diagnostic will show the error.
+            }
+        } else {
+            Command {
+                title: format!(
+                    "⚠ Balance: {} {} (see diagnostic)",
+                    expected_amount, expected_currency
+                ),
+                command: "rledger.noop".to_string(),
+                arguments: None,
+            }
+        });
     }
 
     // Ensure a command is set for non-balance lenses or malformed balance data.
@@ -363,16 +403,31 @@ mod tests {
         assert!(lenses.is_some());
 
         let lenses = lenses.unwrap();
-        // Balance lens should have data but no command (resolved lazily)
-        let balance_lens = lenses.iter().find(|l| {
-            l.data
-                .as_ref()
-                .and_then(|d| d.get("kind"))
-                .and_then(|v| v.as_str())
-                == Some("balance")
-        });
-        assert!(balance_lens.is_some());
-        assert!(balance_lens.unwrap().command.is_none());
+        // Balance lens carries data for deferred verification, plus a
+        // placeholder command set on the initial response so nvim
+        // never renders the literal "Unresolved lens" string during
+        // the resolve round-trip window (issue #1245). The real ✓ or
+        // ⚠ title lands once `codeLens/resolve` returns.
+        let balance_lens = lenses
+            .iter()
+            .find(|l| {
+                l.data
+                    .as_ref()
+                    .and_then(|d| d.get("kind"))
+                    .and_then(|v| v.as_str())
+                    == Some("balance")
+            })
+            .expect("balance lens emitted");
+        let cmd = balance_lens
+            .command
+            .as_ref()
+            .expect("balance lens carries placeholder command (issue #1245)");
+        assert!(
+            cmd.title.contains("checking"),
+            "placeholder title should mark the lens as still-resolving; got {:?}",
+            cmd.title
+        );
+        assert_eq!(cmd.command, "rledger.noop");
     }
 
     #[test]
@@ -436,12 +491,22 @@ mod tests {
 
         let resolved = handle_code_lens_resolve(lens, &result, None);
 
-        // For mismatched balances, codelens should NOT have a command.
-        // The error is shown via diagnostics instead (issue #491).
+        // Mismatched balances are surfaced via diagnostics (#491), so
+        // the lens still does NOT duplicate the amount/✓ marker. But
+        // it MUST carry SOME command, otherwise nvim renders the
+        // literal "Unresolved lens" string for the line (issue #1245).
+        // We use a "⚠ ... (see diagnostic)" callout that points the
+        // user at the diagnostic without duplicating its content.
+        let cmd = resolved
+            .command
+            .as_ref()
+            .expect("mismatched balance must carry a command (issue #1245)");
         assert!(
-            resolved.command.is_none(),
-            "Mismatched balance should not show codelens (diagnostic handles it)"
+            cmd.title.contains("see diagnostic"),
+            "mismatched balance lens should point at the diagnostic; got {:?}",
+            cmd.title
         );
+        assert_eq!(cmd.command, "rledger.noop");
     }
 
     #[test]
@@ -556,11 +621,20 @@ mod tests {
             })),
         };
 
-        // Without full ledger (single-file mode) - balance would be 5000, mismatch!
+        // Without full ledger (single-file mode) the balance comes out to
+        // 5000 (no offsetting -50 from credit_card.bean), so the assertion
+        // mismatches. Pre-#1245 this surfaced as `command: None`; now we
+        // emit the "⚠ ... (see diagnostic)" callout so nvim never renders
+        // the literal "Unresolved lens" string.
         let resolved_single = handle_code_lens_resolve(lens.clone(), &bank_result, None);
+        let single_cmd = resolved_single
+            .command
+            .as_ref()
+            .expect("mismatched balance must carry a command (issue #1245)");
         assert!(
-            resolved_single.command.is_none(),
-            "Single-file mode should see mismatch (5000 != 4950)"
+            single_cmd.title.contains("see diagnostic"),
+            "single-file mismatch should point at the diagnostic; got {:?}",
+            single_cmd.title
         );
 
         // With full ledger (multi-file mode) - balance is 5000 - 50 = 4950, match!
@@ -606,5 +680,82 @@ mod tests {
             resolved.command.is_some(),
             "Lens must always have a command after resolve"
         );
+    }
+
+    /// Regression for issue #1245: balance lenses must NEVER be emitted
+    /// with `command: None`, because nvim's LSP client renders that as
+    /// the literal string "Unresolved lens" until the resolve response
+    /// lands and is processed. If the resolve races with a cancellation
+    /// (or never lands), the lens stays visible as "Unresolved lens"
+    /// for the lifetime of the session. The placeholder command we emit
+    /// on the initial response, plus the always-set command on resolve,
+    /// together break that failure mode.
+    ///
+    /// The user's reproduction (`balance Assets:Bank:Checking 5 USD`
+    /// on date `2024-01-03` after a `+5 USD` posting on `2024-01-01`)
+    /// passes server-side for both `2024-01-02` and `2024-01-03`. The
+    /// observed inconsistency was a client-side timing artifact of the
+    /// `command: None` round-trip window; this test pins the invariant
+    /// that closes that window.
+    #[test]
+    fn issue_1245_balance_lens_always_has_command() {
+        // Sanity: both initial-emission and resolve paths must produce
+        // a command for both passing and failing balance assertions.
+        for (label, expected) in [
+            ("passing match", "5"),
+            ("mismatch", "999"), // forces mismatch path
+        ] {
+            let source = format!(
+                "2024-01-01 open Assets:Bank:Checking USD\n\
+                 2024-01-01 open Income:Salary\n\
+                 \n\
+                 2024-01-01 * \"Paycheck\"\n  \
+                   Assets:Bank:Checking  5 USD\n  \
+                   Income:Salary\n\
+                 \n\
+                 2024-01-03 balance Assets:Bank:Checking {expected} USD\n"
+            );
+            let parse_result = parse(&source);
+            let params = CodeLensParams {
+                text_document: lsp_types::TextDocumentIdentifier {
+                    uri: "file:///test.beancount".parse().unwrap(),
+                },
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            };
+
+            // 1. Initial emission must carry a placeholder command.
+            let lenses = handle_code_lens(
+                &params,
+                &source,
+                &parse_result,
+                super::PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted");
+            let balance_lens = lenses
+                .iter()
+                .find(|l| {
+                    l.data
+                        .as_ref()
+                        .and_then(|d| d.get("kind"))
+                        .and_then(|v| v.as_str())
+                        == Some("balance")
+                })
+                .unwrap_or_else(|| panic!("[{label}] balance lens emitted"))
+                .clone();
+            assert!(
+                balance_lens.command.is_some(),
+                "[{label}] initial balance lens must carry a placeholder command (issue #1245); \
+                 nvim renders `command: None` as the literal string \"Unresolved lens\""
+            );
+
+            // 2. After resolve, the command must remain set (replaced
+            //    with the real ✓ or ⚠ callout, never reset to None).
+            let resolved = handle_code_lens_resolve(balance_lens, &parse_result, None);
+            assert!(
+                resolved.command.is_some(),
+                "[{label}] resolved balance lens must carry a command (issue #1245)"
+            );
+        }
     }
 }

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -121,11 +121,14 @@ pub fn handle_code_lens(
                 // dropped response, etc.), the user still sees a
                 // sensible title instead of "Unresolved lens".
                 //
-                // The resolve handler overwrites this with the real
-                // `✓ Balance: ... USD` title once the calculation
-                // completes, or leaves it in place if the assertion
-                // failed (diagnostics report the failure in that case;
-                // see issue #491).
+                // The resolve handler overwrites this with either the
+                // real `✓ Balance: ... USD` title (passing assertion)
+                // or `⚠ Balance: ... USD (see diagnostic)` (failing
+                // assertion). For failing assertions the diagnostic
+                // remains the source of truth on the actual error
+                // (issue #491); the resolved lens title is a brief
+                // pointer so the lens stays meaningful instead of
+                // sitting forever on the "(checking…)" placeholder.
                 let placeholder = Command {
                     title: format!(
                         "Balance: {} {} (checking…)",
@@ -245,10 +248,17 @@ pub fn handle_code_lens_resolve(
         });
     }
 
-    // Ensure a command is set for non-balance lenses or malformed balance data.
-    // This prevents "Unresolved lens ..." from appearing in the editor.
-    // We don't apply this to processed balance assertions - those intentionally
-    // have no command when mismatched (shown via diagnostics instead).
+    // Ensure a command is set for non-balance lenses or malformed
+    // balance data — `command: None` makes nvim render the literal
+    // string "Unresolved lens" once the resolve response lands (see
+    // issue #1245). The `!processed_balance` guard is now mostly
+    // defensive: as of #1245, balance lenses ALWAYS receive a command
+    // in the kind == "balance" branch above (✓ on match, ⚠ on
+    // mismatch), so this fallback only fires for non-balance kinds or
+    // for balance data so malformed that we couldn't parse it. The
+    // guard prevents this fallback from overwriting the structured
+    // balance titles in the (impossible-today) case where the balance
+    // branch somehow left `command` unset.
     if !processed_balance && resolved.command.is_none() {
         resolved.command = Some(Command {
             title: "Balance assertion".to_string(),
@@ -741,7 +751,7 @@ mod tests {
                         .and_then(|v| v.as_str())
                         == Some("balance")
                 })
-                .unwrap_or_else(|| panic!("[{label}] balance lens emitted"))
+                .unwrap_or_else(|| panic!("[{label}] balance lens was not emitted"))
                 .clone();
             assert!(
                 balance_lens.command.is_some(),

--- a/crates/rustledger-lsp/src/handlers/execute_command.rs
+++ b/crates/rustledger-lsp/src/handlers/execute_command.rs
@@ -35,11 +35,21 @@ fn is_silent_invocation(arguments: &[serde_json::Value]) -> bool {
 }
 
 /// Available commands.
+///
+/// `rledger.noop` is a deliberate placeholder used by code-lens titles
+/// that exist purely to be RENDERED (e.g. the `Balance: X USD (checking…)`
+/// placeholder set by `handlers::code_lens` on balance lenses, and the
+/// `⚠ Balance: X USD (see diagnostic)` callout set by the resolve path
+/// on mismatched assertions — see issue #1245). We advertise it here so
+/// strict clients that only forward server-advertised commands will
+/// route clicks back to the server cleanly, where `handle_execute_command`
+/// silently no-ops.
 pub const COMMANDS: &[&str] = &[
     "rledger.insertDate",
     "rledger.sortTransactions",
     "rledger.alignAmounts",
     "rledger.showAccountBalance",
+    "rledger.noop",
 ];
 
 /// Result of an executeCommand handler.
@@ -122,6 +132,13 @@ pub fn handle_execute_command(
         "rledger.showAccountBalance" => {
             handle_show_account_balance(&params.arguments, parse_result)
         }
+        // Intentional no-op: backs the placeholder / "(see diagnostic)"
+        // titles that code-lens emits for balance assertions (#1245).
+        // The lens exists to be displayed; clicking it has nothing to
+        // do. Explicit arm (rather than falling through to the
+        // unknown-command warning) so a future contributor doesn't
+        // think the lens code is buggy when they grep for the command.
+        "rledger.noop" => ExecuteCommandResponse::none(),
         _ => {
             tracing::warn!("Unknown command: {}", params.command);
             ExecuteCommandResponse::none()


### PR DESCRIPTION
## Summary

Closes #1245. The user reported `Unresolved lens` markers persisting on balance assertion lines in nvim, with one specific date (`2024-01-03`) consistently showing the symptom while a one-day-earlier date (`2024-01-02`) did not, despite identical server-side calculation results.

## Root cause

`handle_code_lens` deliberately emitted balance lenses with `command: None`, deferring expensive verification to `codeLens/resolve` (the standard LSP lazy-resolve pattern). The LSP spec is fine with this, but nvim's built-in LSP client renders the literal string `"Unresolved lens"` for any code lens whose `command` is `null` until the resolve response lands AND is processed.

There is a window during which the lens is visible but unresolved. `codeLens/resolve` requests can race with nvim's cancellation logic (the user's LSP log showed two `"Cannot find request with id N whilst attempting to cancel"` warnings). When the race fires, the lens stays visible as `"Unresolved lens"` for the lifetime of the session. The 01-02 vs 01-03 inconsistency was a client-side timing artifact, not a calculation bug. Verified server-side with a programmatic reproduction: both dates produce `✓ Balance: 5 USD` from `handle_code_lens_resolve`.

Additionally, the resolve path itself reset `command` to `None` for *mismatched* balances (per the design choice in #491: "no lens, see diagnostic instead"). That re-introduced the same `"Unresolved lens"` symptom for any failing assertion, regardless of resolve timing.

## Fix

Two complementary changes in `crates/rustledger-lsp/src/handlers/code_lens.rs`:

### 1. `handle_code_lens` emits a placeholder command for balance lenses

Balance lenses now ship with a placeholder command titled `Balance: <amount> <ccy> (checking…)` instead of `command: None`. The data payload is unchanged, so `codeLens/resolve` still fires and still gets full lazy verification. But the lens is always visibly meaningful, even before resolve fires.

### 2. `handle_code_lens_resolve` always replaces the placeholder with a concrete command

| Outcome | Title |
|---|---|
| Passing assertion | `✓ Balance: <amount> <ccy>` (unchanged from before) |
| Failing assertion | `⚠ Balance: <amount> <ccy> (see diagnostic)` |

The failing-case title is a brief callout that points the user at the existing diagnostic without duplicating its content, preserving #491's design intent of not double-displaying the failure text.

The two paths together guarantee that a balance lens never has `command: None`, eliminating the nvim `"Unresolved lens"` symptom entirely.

## Testing

Added `issue_1245_balance_lens_always_has_command` regression test that pins both invariants (initial emission carries a command; resolve always sets a command) for both passing and failing assertions.

Updated the existing balance-related tests to match the new contract:

- `test_code_lens_balance`: now asserts the initial response carries the placeholder (`(checking)` in the title).
- `test_code_lens_resolve_balance_mismatch`: now asserts the mismatched lens carries the `(see diagnostic)` callout instead of `None`.
- `test_code_lens_resolve_multifile_balance`: same update for the single-file mismatch path.

## How to test

- `cargo test -p rustledger-lsp --all-features`: 193 passed, 0 failed
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features`: clean

## Test plan

- [x] All 193 LSP tests pass workspace-wide
- [x] New regression test fails on pre-fix `command: None` paths and passes on post-fix
- [x] Existing tests for passing balance (`test_code_lens_resolve_balance_match`, `test_code_lens_resolve_with_auto_filled_posting`, multi-file match path) still pass unchanged
- [x] Clippy `-D warnings`, fmt, rustdoc: clean

Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
