### PR TITLE
refactor(validate): typestate phase markers on ValidationSession (closes #1236)

### DIFF
--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -11,7 +11,7 @@ use rustledger_loader::Loader;
 use rustledger_plugin::{
     NativePluginRegistry, PluginInput, PluginOptions, directive_to_wrapper, wrapper_to_directive,
 };
-use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
+use rustledger_validate::{ValidationOptions, ValidationSession};
 
 use super::error::RpcError;
 use super::request::{
@@ -339,14 +339,11 @@ fn handle_validate(params: &serde_json::Value) -> Result<serde_json::Value, RpcE
     // architecture rationale.
     if parse_error_count == 0 {
         let today = jiff::Zoned::now().date();
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let mut validation_errors =
-            session.run_phase_spanned(&load.spanned_directives, Phase::Early, today);
-        validation_errors.extend(session.run_phase_spanned(
-            &load.spanned_directives,
-            Phase::Late,
-            today,
-        ));
+        let session = ValidationSession::new(ValidationOptions::default());
+        let (session, mut validation_errors) =
+            session.run_early_spanned(&load.spanned_directives, today);
+        let (session, late_errs) = session.run_late_spanned(&load.spanned_directives, today);
+        validation_errors.extend(late_errs);
         validation_errors.extend(session.finalize());
         for err in validation_errors {
             let mut e = Error::new(&err.message).validate_phase();

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -272,7 +272,7 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     let effective_booking_method = resolve_effective_booking_method(&raw, options);
 
     #[cfg(feature = "validation")]
-    let mut validation_session = if options.validate {
+    let validation_session = if options.validate {
         Some(rustledger_validate::ValidationSession::new(
             build_validation_options(&raw.options, &raw.source_map, effective_booking_method),
         ))
@@ -286,7 +286,7 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
     #[cfg(feature = "validation")]
     let today = jiff::Zoned::now().date();
 
-    let directives = crate::Directives::<crate::Raw>::from_parser(raw.directives)
+    let synthed = crate::Directives::<crate::Raw>::from_parser(raw.directives)
         .sort()
         .apply_synth_plugins(
             &raw.plugins,
@@ -294,15 +294,20 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
             options,
             &raw.source_map,
             &mut errors,
-        )?
-        .early_validate(
-            #[cfg(feature = "validation")]
-            validation_session.as_mut(),
-            #[cfg(feature = "validation")]
-            today,
-            &raw.source_map,
-            &mut errors,
-        );
+        )?;
+
+    // The validation feature changes `early_validate`'s shape: with
+    // it on we thread the `Option<ValidationSession<Pending>>` in and
+    // catch the returned `Option<ValidationSession<EarlyDone>>` for
+    // `late_validate` (typestate-moved per #1236); without it we just
+    // get the next-phase `Directives` back. Branching here keeps each
+    // cfg's signature small and prevents the call site from having to
+    // know the typestate phase parameters in the disabled case.
+    #[cfg(feature = "validation")]
+    let (directives, validation_session) =
+        synthed.early_validate(validation_session, today, &raw.source_map, &mut errors);
+    #[cfg(not(feature = "validation"))]
+    let directives = synthed.early_validate(&raw.source_map, &mut errors);
 
     let (booked, failed) = directives.book(
         #[cfg(feature = "booking")]
@@ -311,23 +316,21 @@ pub fn process(raw: LoadResult, options: &LoadOptions) -> Result<Ledger, Process
         &mut errors,
     );
 
-    let finalized = booked
-        .apply_regular_plugins(
-            &raw.plugins,
-            &raw.options,
-            options,
-            &raw.source_map,
-            &mut errors,
-        )?
-        .late_validate(
-            #[cfg(feature = "validation")]
-            validation_session,
-            #[cfg(feature = "validation")]
-            today,
-            &raw.source_map,
-            &mut errors,
-        )
-        .finalize(failed);
+    let regular_applied = booked.apply_regular_plugins(
+        &raw.plugins,
+        &raw.options,
+        options,
+        &raw.source_map,
+        &mut errors,
+    )?;
+
+    #[cfg(feature = "validation")]
+    let late_validated =
+        regular_applied.late_validate(validation_session, today, &raw.source_map, &mut errors);
+    #[cfg(not(feature = "validation"))]
+    let late_validated = regular_applied.late_validate(&raw.source_map, &mut errors);
+
+    let finalized = late_validated.finalize(failed);
 
     Ok(Ledger {
         directives: finalized.into_inner(),
@@ -460,28 +463,43 @@ impl crate::Directives<crate::Synthed> {
     /// match Python's "prune zero-interp postings" behavior without
     /// losing E1001 on the elided-zero-to-unopened-account case
     /// (rustledger#877).
+    #[cfg(feature = "validation")]
     pub(crate) fn early_validate(
         mut self,
-        #[cfg(feature = "validation")] validation_session: Option<
-            &mut rustledger_validate::ValidationSession,
+        validation_session: Option<
+            rustledger_validate::ValidationSession<rustledger_validate::Pending>,
         >,
-        #[cfg(feature = "validation")] today: rustledger_core::NaiveDate,
+        today: rustledger_core::NaiveDate,
+        source_map: &SourceMap,
+        errors: &mut Vec<LedgerError>,
+    ) -> (
+        crate::Directives<crate::EarlyValidated>,
+        Option<rustledger_validate::ValidationSession<rustledger_validate::EarlyDone>>,
+    ) {
+        // Typestate move: consume `Pending`, return `EarlyDone`. The
+        // session must be threaded by value rather than `&mut`-borrowed
+        // because the phase parameter on `ValidationSession<P>` changes
+        // as a result of the call (#1236). The caller in `process()`
+        // captures the returned session and passes it to
+        // `late_validate`.
+        let session_out = validation_session.map(|session| {
+            let (session, phase_errors) = session.run_early_spanned(self.as_slice(), today);
+            ledger_errors_extend(errors, phase_errors, source_map);
+            session
+        });
+        (
+            crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut())),
+            session_out,
+        )
+    }
+
+    #[cfg(not(feature = "validation"))]
+    pub(crate) fn early_validate(
+        mut self,
         source_map: &SourceMap,
         errors: &mut Vec<LedgerError>,
     ) -> crate::Directives<crate::EarlyValidated> {
-        #[cfg(feature = "validation")]
-        if let Some(session) = validation_session {
-            let phase_errors = session.run_phase_spanned(
-                self.as_slice(),
-                rustledger_validate::Phase::Early,
-                today,
-            );
-            ledger_errors_extend(errors, phase_errors, source_map);
-        }
-        #[cfg(not(feature = "validation"))]
-        {
-            let _ = (source_map, errors);
-        }
+        let _ = (source_map, errors);
         crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut()))
     }
 }
@@ -572,27 +590,38 @@ impl crate::Directives<crate::RegularPluginsApplied> {
     /// directives. Reuses the `ValidationSession` from
     /// `early_validate` so account / commodity / pad bookkeeping
     /// carries forward.
+    #[cfg(feature = "validation")]
     pub(crate) fn late_validate(
         mut self,
-        #[cfg(feature = "validation")] validation_session: Option<
-            rustledger_validate::ValidationSession,
+        validation_session: Option<
+            rustledger_validate::ValidationSession<rustledger_validate::EarlyDone>,
         >,
-        #[cfg(feature = "validation")] today: rustledger_core::NaiveDate,
+        today: rustledger_core::NaiveDate,
         source_map: &SourceMap,
         errors: &mut Vec<LedgerError>,
     ) -> crate::Directives<crate::LateValidated> {
-        #[cfg(feature = "validation")]
-        if let Some(mut session) = validation_session {
-            let phase_errors =
-                session.run_phase_spanned(self.as_slice(), rustledger_validate::Phase::Late, today);
+        // Typestate move: consume `EarlyDone`, drive through `LateDone`
+        // to `finalize()`. The compile-time enforcement here is that
+        // we cannot call `late_validate` with a fresh `Pending` session
+        // (no `From<Pending>` to `EarlyDone`), so the loader caller
+        // must have routed the session through `early_validate` first
+        // (#1236).
+        if let Some(session) = validation_session {
+            let (session, phase_errors) = session.run_late_spanned(self.as_slice(), today);
             ledger_errors_extend(errors, phase_errors, source_map);
             let finalize_errors = session.finalize();
             ledger_errors_extend(errors, finalize_errors, source_map);
         }
-        #[cfg(not(feature = "validation"))]
-        {
-            let _ = (source_map, errors);
-        }
+        crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut()))
+    }
+
+    #[cfg(not(feature = "validation"))]
+    pub(crate) fn late_validate(
+        mut self,
+        source_map: &SourceMap,
+        errors: &mut Vec<LedgerError>,
+    ) -> crate::Directives<crate::LateValidated> {
+        let _ = (source_map, errors);
         crate::Directives::new_unchecked(std::mem::take(self.as_vec_mut()))
     }
 }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -8,7 +8,7 @@ use rustledger_core::{BookingMethod, Directive};
 use rustledger_loader::{LoadOptions, Options as LoaderOptions, Plugin, SourceMap};
 use rustledger_parser::{ParseError, ParseResult, Span, Spanned};
 use rustledger_plugin::NativePluginRegistry;
-use rustledger_validate::{Phase, Severity, ValidationError, ValidationOptions, ValidationSession};
+use rustledger_validate::{Severity, ValidationError, ValidationOptions, ValidationSession};
 
 use super::utils::{LineIndex, PositionEncoding};
 use crate::ledger_state::LedgerState;
@@ -350,9 +350,10 @@ pub fn validation_errors_to_diagnostics(
     // against the same input. See `rustledger_validate::Phase` for the
     // architecture rationale.
     let today = jiff::Zoned::now().date();
-    let mut session = ValidationSession::new(validation_options);
-    let mut validation_errors = session.run_phase_spanned(&booked_directives, Phase::Early, today);
-    validation_errors.extend(session.run_phase_spanned(&booked_directives, Phase::Late, today));
+    let session = ValidationSession::new(validation_options);
+    let (session, mut validation_errors) = session.run_early_spanned(&booked_directives, today);
+    let (session, late_errs) = session.run_late_spanned(&booked_directives, today);
+    validation_errors.extend(late_errs);
     validation_errors.extend(session.finalize());
 
     // Filter errors to only those in the current file (if file_id filtering is enabled).

--- a/crates/rustledger-validate/benches/validate_bench.rs
+++ b/crates/rustledger-validate/benches/validate_bench.rs
@@ -9,15 +9,16 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use rust_decimal_macros::dec;
 use rustledger_core::NaiveDate;
 use rustledger_core::{Amount, Balance, Directive, Open, Posting, Transaction};
-use rustledger_validate::{Phase, ValidationError, ValidationOptions, ValidationSession};
+use rustledger_validate::{ValidationError, ValidationOptions, ValidationSession};
 
 /// Bench helper mirroring the deleted public `validate()`. Chains
 /// Early + Late + finalize through a single session.
 fn validate(directives: &[Directive]) -> Vec<ValidationError> {
     let today = rustledger_core::naive_date(2030, 1, 1).unwrap();
-    let mut session = ValidationSession::new(ValidationOptions::default());
-    let mut errors = session.run_phase(directives, Phase::Early, today);
-    errors.extend(session.run_phase(directives, Phase::Late, today));
+    let session = ValidationSession::new(ValidationOptions::default());
+    let (session, mut errors) = session.run_early(directives, today);
+    let (session, late_errs) = session.run_late(directives, today);
+    errors.extend(late_errs);
     errors.extend(session.finalize());
     errors
 }

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -663,170 +663,283 @@ fn build_document_exists_cache<D: ValidatableDirective>(
 //
 // The single supported entry to the validator is [`ValidationSession`].
 // Callers that just want "validate this list of directives, give me all
-// errors" wire three calls: `run_phase(_, Early, today)`,
-// `run_phase(_, Late, today)`, `finalize()`. The visible verbosity is
-// deliberate — it surfaces the phase split so callers can choose where
-// to insert booking between phases (the loader does this) or run both
-// back-to-back on already-booked input (LSP / FFI / tests do this).
+// errors" wire four calls: `run_early(_, today)` (consumes `Pending`,
+// produces `EarlyDone`), `run_late(_, today)` (consumes `EarlyDone`,
+// produces `LateDone`), `finalize()` (consumes `LateDone`). The visible
+// verbosity is deliberate: it surfaces the phase split so callers can
+// choose where to insert booking between phases (the loader does this)
+// or run all three back-to-back on already-booked input (LSP / FFI /
+// tests do this).
 //
 // Prior versions of this crate exposed `validate()`, `validate_with_options()`,
 // `validate_with_today()`, and spanned variants as free-function
 // shortcuts. They were removed in the validate-phase-split refactor
-// (#1115 / #1116) — see the migration note there for the pattern to
-// adopt.
+// (#1115 / #1116). The runtime phase-ordering bitmask + `debug_assert!`
+// were then replaced with the typestate-driven `Pending` / `EarlyDone`
+// / `LateDone` markers (#1236) so the phase invariant is checked at
+// compile time rather than at runtime.
+
+/// Phantom-typed phase markers for [`ValidationSession`].
+///
+/// These markers track the session's lifecycle position at the type
+/// level. The phase transitions [`ValidationSession::run_early`],
+/// [`ValidationSession::run_late`], and [`ValidationSession::finalize`]
+/// consume the session by value and produce one bound to the next
+/// marker. A caller cannot call `run_late` before `run_early`, cannot
+/// call either phase twice, and cannot call `finalize` before `run_late`
+/// because the relevant method does not exist on the wrong-phase type.
+///
+/// Pre-#1236 the same invariant was enforced at runtime via a bitmask
+/// on `ValidationSession` (`debug_assert!` in debug builds, silent
+/// no-op in release). Compile-time enforcement closes the release-mode
+/// gap and makes the contract self-documenting at call sites.
+///
+/// Known follow-up scope (see issue #1236): the typestate guards the
+/// session lifecycle, but the directive list itself is still a plain
+/// `&[Directive]` / `&[Spanned<Directive>]`. A caller can still pass
+/// pre-booking directives to [`ValidationSession::<EarlyDone>::run_late`]
+/// without a compile-time error. That gap requires phase markers on
+/// the directive collection (mirroring `rustledger-loader`'s
+/// `Directives<Phase>`), which would cross the validate/loader crate
+/// boundary; deferred to a follow-up PR.
+pub mod phase {
+    mod sealed {
+        pub trait Sealed {}
+    }
+
+    /// Marker trait for [`super::ValidationSession`] phase markers.
+    /// Sealed: only the markers in this module implement it.
+    pub trait SessionPhase: sealed::Sealed {}
+
+    macro_rules! define_phase {
+        ($name:ident, $doc:expr) => {
+            #[doc = $doc]
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            pub struct $name;
+            impl sealed::Sealed for $name {}
+            impl SessionPhase for $name {}
+        };
+    }
+
+    define_phase!(
+        Pending,
+        "Neither phase has run yet; the session was just constructed by [`super::ValidationSession::new`]."
+    );
+    define_phase!(
+        EarlyDone,
+        "[`super::Phase::Early`] has run; [`super::ValidationSession::run_late`] is the only legal next step."
+    );
+    define_phase!(
+        LateDone,
+        "Both phases have run; [`super::ValidationSession::finalize`] is the only legal next step."
+    );
+}
+
+pub use phase::{EarlyDone, LateDone, Pending, SessionPhase};
 
 /// Stateful two-phase validation harness for callers (like the loader)
 /// that need to interleave validation with other pipeline steps.
 ///
-/// Typical use: run [`run_phase`](Self::run_phase) with [`Phase::Early`]
-/// AFTER plugins but BEFORE booking, then [`Phase::Late`] AFTER booking.
-/// Call [`finalize`](Self::finalize) at the end to flush deferred checks
-/// (e.g., unused pads).
+/// The session's phase is tracked at the type level via `P:`
+/// [`SessionPhase`] (see the [`phase`] module for the marker types and
+/// the rationale). The standard sequence is:
 ///
-/// Standalone callers that don't run booking between phases (e.g.
-/// LSP, FFI, tests) run the three calls back-to-back against the same
-/// directive list. The verbosity is intentional — it surfaces the
+/// 1. [`ValidationSession::new`] returns `ValidationSession<Pending>`.
+/// 2. [`run_early`](Self::run_early) consumes `Pending` and returns
+///    `(ValidationSession<EarlyDone>, Vec<ValidationError>)`.
+/// 3. Booking (and the post-booking plugin pass) runs externally on
+///    the directive list.
+/// 4. [`run_late`](Self::run_late) consumes `EarlyDone` and returns
+///    `(ValidationSession<LateDone>, Vec<ValidationError>)`.
+/// 5. [`finalize`](Self::finalize) consumes `LateDone` and returns the
+///    deferred E2003 unused-pad warnings.
+///
+/// Standalone callers that don't run booking between phases (LSP,
+/// FFI, tests) run all four calls back-to-back against the same
+/// directive list. The verbosity is intentional: it surfaces the
 /// phase split so callers explicitly choose whether to interleave
 /// booking between Early and Late.
 ///
-/// # Migration from pre-#1116
+/// # Spanned vs. unspanned
 ///
-/// The free-function shortcuts `validate`, `validate_with_options`,
-/// `validate_with_today`, `validate_spanned_with_options`, and
-/// `validate_spanned_with_today` were removed. Replace each call site
-/// with the three-step `ValidationSession` sequence shown below.
+/// Each transition has a `_spanned` variant
+/// ([`run_early_spanned`](ValidationSession::<Pending>::run_early_spanned),
+/// [`run_late_spanned`](ValidationSession::<EarlyDone>::run_late_spanned))
+/// for `&[Spanned<Directive>]` input. The spanned variants preserve
+/// source-location info on emitted errors so callers (LSP, loader,
+/// FFI) can render `file:line:column` diagnostics directly.
 ///
-/// # Preconditions
+/// # Migration from pre-#1236
 ///
-/// Each session is single-use:
-/// - Call [`Phase::Early`] at most once.
-/// - Call [`Phase::Late`] at most once, and only AFTER `Early`.
-/// - Call [`finalize`](Self::finalize) at most once, and only AFTER both phases.
+/// Replace:
 ///
-/// In debug builds, violating this contract panics. In release builds
-/// the duplicate / out-of-order call is a no-op that returns an empty
-/// error list — this is deliberate so a buggy caller can't silently
-/// corrupt the shared `LedgerState` (inventories are additive, so a
-/// second `Late` pass would double-book every transaction).
+/// ```ignore
+/// let mut session = ValidationSession::new(options);
+/// let mut errors = session.run_phase(&directives, Phase::Early, today);
+/// errors.extend(session.run_phase(&directives, Phase::Late, today));
+/// errors.extend(session.finalize());
+/// ```
+///
+/// with:
+///
+/// ```ignore
+/// let session = ValidationSession::new(options);
+/// let (session, mut errors) = session.run_early(&directives, today);
+/// let (session, late_errors) = session.run_late(&directives, today);
+/// errors.extend(late_errors);
+/// errors.extend(session.finalize());
+/// ```
+///
+/// The compile-time enforcement replaces the pre-#1236 runtime
+/// `debug_assert!` + release-mode no-op for phase ordering.
 ///
 /// # Example
 ///
 /// ```
-/// use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
+/// use rustledger_validate::{ValidationOptions, ValidationSession};
 /// use rustledger_core::{Directive, naive_date};
 ///
 /// let directives: Vec<Directive> = vec![];
 /// let today = naive_date(2030, 1, 1).unwrap();
 ///
-/// let mut session = ValidationSession::new(ValidationOptions::default());
-/// let mut errors = session.run_phase(&directives, Phase::Early, today);
+/// let session = ValidationSession::new(ValidationOptions::default());
+/// let (session, mut errors) = session.run_early(&directives, today);
 /// // ... booking runs here; plugins ran BEFORE Early ...
-/// errors.extend(session.run_phase(&directives, Phase::Late, today));
+/// let (session, late_errors) = session.run_late(&directives, today);
+/// errors.extend(late_errors);
 /// errors.extend(session.finalize());
 /// ```
-pub struct ValidationSession {
+pub struct ValidationSession<P: SessionPhase = Pending> {
     state: LedgerState,
-    /// Bitmask of phases that have already executed. Bit 0 = Early,
-    /// bit 1 = Late. Used to detect re-runs and out-of-order calls.
-    /// `finalize` is guarded by `self`-by-move on its signature, so it
-    /// doesn't need a bit.  See type-level docs § Preconditions.
-    phases_run: u8,
+    _phase: std::marker::PhantomData<P>,
 }
 
-impl ValidationSession {
-    const PHASE_EARLY_BIT: u8 = 1 << 0;
-    const PHASE_LATE_BIT: u8 = 1 << 1;
-
-    /// Create a new session with the given validation options.
+impl ValidationSession<Pending> {
+    /// Create a new session with the given validation options. The
+    /// returned session is bound to the [`Pending`] marker; the only
+    /// legal next step is [`run_early`](Self::run_early) (or its
+    /// spanned variant).
     #[must_use]
     pub fn new(options: ValidationOptions) -> Self {
         Self {
             state: LedgerState::with_options(options),
-            phases_run: 0,
+            _phase: std::marker::PhantomData,
         }
     }
 
-    /// Run one validation phase over a slice of raw [`Directive`]s.
+    /// Run [`Phase::Early`] over a slice of raw [`Directive`]s.
     ///
-    /// `Early` runs account/structural checks that don't need
-    /// filled-in amounts. `Late` runs balance/inventory/currency
-    /// checks that do. The session's internal `LedgerState` is updated
-    /// by each phase so subsequent calls see the accumulated state.
+    /// `Early` runs account/structural checks that don't need filled-in
+    /// amounts. The session's internal `LedgerState` is updated so
+    /// [`run_late`](ValidationSession::<EarlyDone>::run_late) sees the
+    /// accumulated state (open accounts, commodities, pending pads).
     ///
-    /// # Panics (debug only)
-    ///
-    /// Panics in debug builds if called out of order — `Phase::Late`
-    /// before `Phase::Early`, or either phase invoked twice. In release
-    /// builds the offending call is a no-op returning an empty `Vec`.
-    /// See the type-level "Preconditions" section.
-    pub fn run_phase(
-        &mut self,
+    /// Consumes the session and returns it bound to [`EarlyDone`]
+    /// alongside the errors collected during the phase. The new phase
+    /// marker prevents a second `run_early` call at compile time.
+    #[must_use = "ValidationSession::run_early returns the next-phase session; dropping it loses the LedgerState built up during Early and any deferred state for Late/finalize"]
+    pub fn run_early(
+        self,
         directives: &[Directive],
-        phase: Phase,
         today: NaiveDate,
-    ) -> Vec<ValidationError> {
-        if !self.check_phase_ordering(phase) {
-            return Vec::new();
-        }
-        validate_phase_inner(directives, &mut self.state, phase, today)
+    ) -> (ValidationSession<EarlyDone>, Vec<ValidationError>) {
+        self.run_phase_internal(directives, Phase::Early, today)
     }
 
-    /// Variant of [`run_phase`](Self::run_phase) for `Spanned<Directive>`
-    /// slices. Preserves source-location info on emitted errors so
-    /// callers (LSP, loader, FFI) can render `file:line:column`
-    /// diagnostics directly.
-    ///
-    /// Same phase-ordering preconditions as [`run_phase`](Self::run_phase).
-    pub fn run_phase_spanned(
-        &mut self,
+    /// Variant of [`run_early`](Self::run_early) for
+    /// `Spanned<Directive>` slices. Preserves source-location info on
+    /// emitted errors.
+    #[must_use = "ValidationSession::run_early_spanned returns the next-phase session; dropping it loses the LedgerState built up during Early and any deferred state for Late/finalize"]
+    pub fn run_early_spanned(
+        self,
         directives: &[Spanned<Directive>],
-        phase: Phase,
         today: NaiveDate,
-    ) -> Vec<ValidationError> {
-        if !self.check_phase_ordering(phase) {
-            return Vec::new();
-        }
-        validate_phase_inner(directives, &mut self.state, phase, today)
+    ) -> (ValidationSession<EarlyDone>, Vec<ValidationError>) {
+        self.run_phase_internal(directives, Phase::Early, today)
     }
 
-    /// Flush deferred end-of-validation checks. Currently emits unused
-    /// pad warnings (E2003). Call once after both phases have run —
-    /// dropping the returned `Vec` discards those warnings.
+    /// Internal: run a validation phase and advance to [`EarlyDone`].
     ///
-    /// Consumes the session because deferred state is per-session;
-    /// re-running `finalize` on the same state would re-emit the same
-    /// errors.
+    /// Threads the underlying `LedgerState` from `Pending` into
+    /// `EarlyDone` through the shared `validate_phase_inner` engine.
+    /// The `phase` parameter is always [`Phase::Early`] here; it's
+    /// passed through so `validate_phase_inner` can dispatch per-phase
+    /// validator selection inside.
+    fn run_phase_internal<D: ValidatableDirective>(
+        mut self,
+        directives: &[D],
+        phase: Phase,
+        today: NaiveDate,
+    ) -> (ValidationSession<EarlyDone>, Vec<ValidationError>) {
+        let errors = validate_phase_inner(directives, &mut self.state, phase, today);
+        (
+            ValidationSession {
+                state: self.state,
+                _phase: std::marker::PhantomData,
+            },
+            errors,
+        )
+    }
+}
+
+impl ValidationSession<EarlyDone> {
+    /// Run [`Phase::Late`] over a slice of raw [`Directive`]s.
+    ///
+    /// `Late` runs balance/inventory/currency checks that need
+    /// filled-in amounts. Must be called AFTER booking has run on the
+    /// directive list (and after the post-booking plugin pass, if any).
+    ///
+    /// Consumes the session and returns it bound to [`LateDone`]
+    /// alongside the errors collected during the phase. The new phase
+    /// marker prevents a second `run_late` call at compile time.
+    #[must_use = "ValidationSession::run_late returns the next-phase session; dropping it discards the deferred E2003 unused-pad warnings that `finalize` would surface"]
+    pub fn run_late(
+        self,
+        directives: &[Directive],
+        today: NaiveDate,
+    ) -> (ValidationSession<LateDone>, Vec<ValidationError>) {
+        self.run_phase_internal(directives, Phase::Late, today)
+    }
+
+    /// Variant of [`run_late`](Self::run_late) for
+    /// `Spanned<Directive>` slices. Preserves source-location info on
+    /// emitted errors.
+    #[must_use = "ValidationSession::run_late_spanned returns the next-phase session; dropping it discards the deferred E2003 unused-pad warnings that `finalize` would surface"]
+    pub fn run_late_spanned(
+        self,
+        directives: &[Spanned<Directive>],
+        today: NaiveDate,
+    ) -> (ValidationSession<LateDone>, Vec<ValidationError>) {
+        self.run_phase_internal(directives, Phase::Late, today)
+    }
+
+    /// Internal: run a validation phase and advance to [`LateDone`].
+    /// See [`ValidationSession::<Pending>::run_phase_internal`] for the
+    /// rationale on the inner-engine dispatch shape.
+    fn run_phase_internal<D: ValidatableDirective>(
+        mut self,
+        directives: &[D],
+        phase: Phase,
+        today: NaiveDate,
+    ) -> (ValidationSession<LateDone>, Vec<ValidationError>) {
+        let errors = validate_phase_inner(directives, &mut self.state, phase, today);
+        (
+            ValidationSession {
+                state: self.state,
+                _phase: std::marker::PhantomData,
+            },
+            errors,
+        )
+    }
+}
+
+impl ValidationSession<LateDone> {
+    /// Flush deferred end-of-validation checks. Currently emits unused
+    /// pad warnings (E2003). Consumes the session because deferred
+    /// state is per-session.
     #[must_use]
     pub fn finalize(self) -> Vec<ValidationError> {
         check_unused_pads(&self.state)
-    }
-
-    /// Validate the requested phase against the session's run history.
-    /// Returns `true` if the caller may proceed, `false` if the call
-    /// should no-op. In debug builds, violations panic instead.
-    fn check_phase_ordering(&mut self, phase: Phase) -> bool {
-        let bit = match phase {
-            Phase::Early => Self::PHASE_EARLY_BIT,
-            Phase::Late => Self::PHASE_LATE_BIT,
-        };
-        if self.phases_run & bit != 0 {
-            debug_assert!(
-                false,
-                "ValidationSession::run_phase{{,_spanned}} called twice for {phase:?}; \
-                 each phase must run exactly once per session"
-            );
-            return false;
-        }
-        if matches!(phase, Phase::Late) && self.phases_run & Self::PHASE_EARLY_BIT == 0 {
-            debug_assert!(
-                false,
-                "ValidationSession::run_phase{{,_spanned}}(Phase::Late) called before Phase::Early; \
-                 Late depends on state Early builds (open accounts, commodities, pending pads)"
-            );
-            return false;
-        }
-        self.phases_run |= bit;
-        true
     }
 }
 
@@ -895,9 +1008,10 @@ mod tests {
         options: ValidationOptions,
         today: NaiveDate,
     ) -> Vec<ValidationError> {
-        let mut session = ValidationSession::new(options);
-        let mut errors = session.run_phase(directives, Phase::Early, today);
-        errors.extend(session.run_phase(directives, Phase::Late, today));
+        let session = ValidationSession::new(options);
+        let (session, mut errors) = session.run_early(directives, today);
+        let (session, late_errors) = session.run_late(directives, today);
+        errors.extend(late_errors);
         errors.extend(session.finalize());
         errors
     }
@@ -2634,8 +2748,8 @@ mod tests {
             ),
         ];
 
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let errors = session.run_phase(&directives, Phase::Early, date(2026, 1, 1));
+        let session = ValidationSession::new(ValidationOptions::default());
+        let (_session, errors) = session.run_early(&directives, date(2026, 1, 1));
 
         assert!(
             errors.iter().any(|e| e.code == ErrorCode::AccountNotOpen
@@ -2664,9 +2778,9 @@ mod tests {
             ),
         ];
 
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let early = session.run_phase(&directives, Phase::Early, date(2026, 1, 1));
-        let late = session.run_phase(&directives, Phase::Late, date(2026, 1, 1));
+        let session = ValidationSession::new(ValidationOptions::default());
+        let (session, early) = session.run_early(&directives, date(2026, 1, 1));
+        let (_session, late) = session.run_late(&directives, date(2026, 1, 1));
 
         let early_e1001 = early
             .iter()
@@ -2718,9 +2832,10 @@ mod tests {
         let chained = validate(&directives);
 
         // Explicit phase split.
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let mut explicit = session.run_phase(&directives, Phase::Early, date(2026, 1, 1));
-        explicit.extend(session.run_phase(&directives, Phase::Late, date(2026, 1, 1)));
+        let session = ValidationSession::new(ValidationOptions::default());
+        let (session, mut explicit) = session.run_early(&directives, date(2026, 1, 1));
+        let (session, late_errs) = session.run_late(&directives, date(2026, 1, 1));
+        explicit.extend(late_errs);
         explicit.extend(session.finalize());
 
         // Same set of (code, date, message) tuples in the same order.
@@ -2846,32 +2961,51 @@ mod tests {
         );
     }
 
-    // These `#[should_panic]` tests assert the `debug_assert!` calls in
-    // `ValidationSession::check_phase_ordering` fire on misuse. Since
-    // `debug_assert!` is a no-op in release builds, gate the tests on
-    // `cfg(debug_assertions)` so `cargo test --release` (Nix builds via
-    // crane, packagers, etc.) doesn't see a `should_panic` test that
-    // can't panic. The phase-ordering check still no-ops correctly in
-    // release builds — that's the documented "release builds gracefully
-    // ignore the violation" behavior on `ValidationSession`.
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "called twice for Late")]
-    fn test_run_phase_duplicate_late_panics_in_debug() {
-        let directives = vec![Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank"))];
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let _ = session.run_phase(&directives, Phase::Early, date(2030, 1, 1));
-        let _ = session.run_phase(&directives, Phase::Late, date(2030, 1, 1));
-        // Second Late: should panic via debug_assert.
-        let _ = session.run_phase(&directives, Phase::Late, date(2030, 1, 1));
-    }
+    // Pre-#1236 these were two `#[should_panic]` tests that asserted
+    // the `debug_assert!` calls in `ValidationSession::check_phase_ordering`
+    // fired on out-of-order or duplicate phase calls. The typestate
+    // refactor moved that enforcement to the type system: calling
+    // `run_late` before `run_early`, or either phase twice, is now a
+    // compile error rather than a runtime panic. The compile-fail
+    // doctests on the `ValidationSession` struct pin the new contract.
+    //
+    // We deliberately do not keep the runtime panic-tests as a parallel
+    // safety net — there is no longer a runtime code path that could
+    // panic, so a runtime test would simply be unreachable.
 
-    #[cfg(debug_assertions)]
+    /// Compile-time pin for the typestate ordering: `run_late` is not
+    /// callable on a `ValidationSession<Pending>` (the only `new()`
+    /// output). This test is type-level only and runs at compile time.
     #[test]
-    #[should_panic(expected = "Phase::Late) called before Phase::Early")]
-    fn test_run_phase_late_before_early_panics_in_debug() {
-        let directives = vec![Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank"))];
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let _ = session.run_phase(&directives, Phase::Late, date(2030, 1, 1));
+    fn typestate_pins_phase_ordering_at_compile_time() {
+        // A `Pending` session has `run_early` but not `run_late`. The
+        // following commented-out lines would fail to compile if
+        // uncommented; they're documentation, not executable code.
+        //
+        //     let session = ValidationSession::new(ValidationOptions::default());
+        //     let (_, _) = session.run_late(&[], date(2024, 1, 1));
+        //     // error[E0599]: no method named `run_late` found for struct
+        //     //               `ValidationSession<Pending>` in the current scope
+        //
+        // The actual gate sits in
+        // `crates/rustledger-validate/tests/typestate_compile_fail.rs`
+        // as `trybuild`-style compile_fail tests (added in this PR).
+        // Here we just assert the happy path produces the expected
+        // phase types at compile time via type-checking.
+        fn _expect_pending_returns_early(
+            s: ValidationSession<Pending>,
+        ) -> ValidationSession<EarlyDone> {
+            let (s, _errors) = s.run_early(&[] as &[Directive], date(2024, 1, 1));
+            s
+        }
+        fn _expect_early_returns_late(
+            s: ValidationSession<EarlyDone>,
+        ) -> ValidationSession<LateDone> {
+            let (s, _errors) = s.run_late(&[] as &[Directive], date(2024, 1, 1));
+            s
+        }
+        fn _expect_late_finalizes(s: ValidationSession<LateDone>) -> Vec<ValidationError> {
+            s.finalize()
+        }
     }
 }

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -663,13 +663,14 @@ fn build_document_exists_cache<D: ValidatableDirective>(
 //
 // The single supported entry to the validator is [`ValidationSession`].
 // Callers that just want "validate this list of directives, give me all
-// errors" wire four calls: `run_early(_, today)` (consumes `Pending`,
-// produces `EarlyDone`), `run_late(_, today)` (consumes `EarlyDone`,
-// produces `LateDone`), `finalize()` (consumes `LateDone`). The visible
-// verbosity is deliberate: it surfaces the phase split so callers can
-// choose where to insert booking between phases (the loader does this)
-// or run all three back-to-back on already-booked input (LSP / FFI /
-// tests do this).
+// errors" wire four calls: `ValidationSession::new(options)` (constructs
+// `Pending`), `run_early(_, today)` (consumes `Pending`, produces
+// `EarlyDone`), `run_late(_, today)` (consumes `EarlyDone`, produces
+// `LateDone`), `finalize()` (consumes `LateDone`). The visible verbosity
+// is deliberate: it surfaces the phase split so callers can choose
+// where to insert booking between phases (the loader does this) or run
+// all four back-to-back on already-booked input (LSP / FFI / tests do
+// this).
 //
 // Prior versions of this crate exposed `validate()`, `validate_with_options()`,
 // `validate_with_today()`, and spanned variants as free-function
@@ -2966,16 +2967,26 @@ mod tests {
     // fired on out-of-order or duplicate phase calls. The typestate
     // refactor moved that enforcement to the type system: calling
     // `run_late` before `run_early`, or either phase twice, is now a
-    // compile error rather than a runtime panic. The compile-fail
-    // doctests on the `ValidationSession` struct pin the new contract.
+    // compile error rather than a runtime panic.
     //
     // We deliberately do not keep the runtime panic-tests as a parallel
-    // safety net — there is no longer a runtime code path that could
+    // safety net: there is no longer a runtime code path that could
     // panic, so a runtime test would simply be unreachable.
 
     /// Compile-time pin for the typestate ordering: `run_late` is not
     /// callable on a `ValidationSession<Pending>` (the only `new()`
     /// output). This test is type-level only and runs at compile time.
+    ///
+    /// Coverage is limited to the happy-path direction: the helper
+    /// functions below assert that the by-value transitions resolve to
+    /// the documented next-phase types. Compiler rejection of the
+    /// inverse misuse (`run_late` on `Pending`, double-`run_early`,
+    /// `finalize` on `EarlyDone`, etc.) is exercised today by ordinary
+    /// development — the missing methods produce E0599 the moment a
+    /// caller tries them. Pinning these as `trybuild`-style `compile_fail`
+    /// tests is a candidate follow-up; the dependency adds rustc-version-
+    /// sensitive `.stderr` snapshots that aren't justified by the
+    /// already-structural type-system enforcement.
     #[test]
     fn typestate_pins_phase_ordering_at_compile_time() {
         // A `Pending` session has `run_early` but not `run_late`. The
@@ -2987,11 +2998,8 @@ mod tests {
         //     // error[E0599]: no method named `run_late` found for struct
         //     //               `ValidationSession<Pending>` in the current scope
         //
-        // The actual gate sits in
-        // `crates/rustledger-validate/tests/typestate_compile_fail.rs`
-        // as `trybuild`-style compile_fail tests (added in this PR).
-        // Here we just assert the happy path produces the expected
-        // phase types at compile time via type-checking.
+        // The helper functions below pin the happy-path transitions
+        // via signatures the type-checker validates at compile time.
         fn _expect_pending_returns_early(
             s: ValidationSession<Pending>,
         ) -> ValidationSession<EarlyDone> {

--- a/crates/rustledger-validate/tests/common/mod.rs
+++ b/crates/rustledger-validate/tests/common/mod.rs
@@ -60,9 +60,14 @@ pub fn validate_spanned_with_options(
     directives: &[Spanned<Directive>],
     options: ValidationOptions,
 ) -> Vec<ValidationError> {
+    // Anchor "today" once so both phases agree on the same wall-clock
+    // reference (matches the loader/LSP/FFI pattern of computing `today`
+    // once at the top of `process()`/`all_diagnostics()` and threading
+    // the same value through Early and Late).
+    let today = test_today();
     let session = ValidationSession::new(options);
-    let (session, mut errors) = session.run_early_spanned(directives, test_today());
-    let (session, late_errs) = session.run_late_spanned(directives, test_today());
+    let (session, mut errors) = session.run_early_spanned(directives, today);
+    let (session, late_errs) = session.run_late_spanned(directives, today);
     errors.extend(late_errs);
     errors.extend(session.finalize());
     errors

--- a/crates/rustledger-validate/tests/common/mod.rs
+++ b/crates/rustledger-validate/tests/common/mod.rs
@@ -14,7 +14,7 @@
 
 use rustledger_core::{Directive, NaiveDate};
 use rustledger_parser::Spanned;
-use rustledger_validate::{Phase, ValidationError, ValidationOptions, ValidationSession};
+use rustledger_validate::{ValidationError, ValidationOptions, ValidationSession};
 
 /// Default "today" for tests that don't otherwise care. Set in the
 /// future relative to most fixtures so the future-date warning
@@ -47,9 +47,10 @@ pub fn validate_with_today(
     options: ValidationOptions,
     today: NaiveDate,
 ) -> Vec<ValidationError> {
-    let mut session = ValidationSession::new(options);
-    let mut errors = session.run_phase(directives, Phase::Early, today);
-    errors.extend(session.run_phase(directives, Phase::Late, today));
+    let session = ValidationSession::new(options);
+    let (session, mut errors) = session.run_early(directives, today);
+    let (session, late_errs) = session.run_late(directives, today);
+    errors.extend(late_errs);
     errors.extend(session.finalize());
     errors
 }
@@ -59,9 +60,10 @@ pub fn validate_spanned_with_options(
     directives: &[Spanned<Directive>],
     options: ValidationOptions,
 ) -> Vec<ValidationError> {
-    let mut session = ValidationSession::new(options);
-    let mut errors = session.run_phase_spanned(directives, Phase::Early, test_today());
-    errors.extend(session.run_phase_spanned(directives, Phase::Late, test_today()));
+    let session = ValidationSession::new(options);
+    let (session, mut errors) = session.run_early_spanned(directives, test_today());
+    let (session, late_errs) = session.run_late_spanned(directives, test_today());
+    errors.extend(late_errs);
     errors.extend(session.finalize());
     errors
 }

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -107,7 +107,7 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
 
 /// Run validation on a loaded ledger and return validation errors.
 pub fn run_validation(load: &ProcessedLedger) -> Vec<Error> {
-    use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
+    use rustledger_validate::{ValidationOptions, ValidationSession};
 
     if !load.errors.is_empty() {
         return Vec::new();
@@ -127,9 +127,10 @@ pub fn run_validation(load: &ProcessedLedger) -> Vec<Error> {
     // legacy `validate()` shortcut also didn't fire these warnings
     // unless `warn_future_dates` was explicitly enabled (it isn't here).
     let today = rustledger_core::naive_date(2999, 12, 31).unwrap();
-    let mut session = ValidationSession::new(ValidationOptions::default());
-    let mut errors = session.run_phase(&load.directives, Phase::Early, today);
-    errors.extend(session.run_phase(&load.directives, Phase::Late, today));
+    let session = ValidationSession::new(ValidationOptions::default());
+    let (session, mut errors) = session.run_early(&load.directives, today);
+    let (session, late_errs) = session.run_late(&load.directives, today);
+    errors.extend(late_errs);
     errors.extend(session.finalize());
 
     errors

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -297,7 +297,7 @@ pub fn init() {
 mod tests {
     use super::*;
     use rustledger_parser::parse as parse_beancount;
-    use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
+    use rustledger_validate::{ValidationOptions, ValidationSession};
 
     /// Test helper mirroring the deleted public `validate()`. Chains
     /// Early + Late + finalize through a single session against the
@@ -306,9 +306,10 @@ mod tests {
         directives: &[rustledger_core::Directive],
     ) -> Vec<rustledger_validate::ValidationError> {
         let today = rustledger_core::naive_date(2999, 12, 31).unwrap();
-        let mut session = ValidationSession::new(ValidationOptions::default());
-        let mut errors = session.run_phase(directives, Phase::Early, today);
-        errors.extend(session.run_phase(directives, Phase::Late, today));
+        let session = ValidationSession::new(ValidationOptions::default());
+        let (session, mut errors) = session.run_early(directives, today);
+        let (session, late_errs) = session.run_late(directives, today);
+        errors.extend(late_errs);
         errors.extend(session.finalize());
         errors
     }

--- a/crates/rustledger/benches/pipeline_bench.rs
+++ b/crates/rustledger/benches/pipeline_bench.rs
@@ -12,15 +12,16 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use rustledger_booking::interpolate;
 use rustledger_core::Directive;
 use rustledger_parser::parse;
-use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
+use rustledger_validate::{ValidationOptions, ValidationSession};
 
 /// Bench helper: run both validation phases through a single session,
 /// mirroring what the LSP / FFI do on already-booked input.
 fn validate(directives: &[Directive]) -> Vec<rustledger_validate::ValidationError> {
     let today = jiff::Zoned::now().date();
-    let mut session = ValidationSession::new(ValidationOptions::default());
-    let mut errors = session.run_phase(directives, Phase::Early, today);
-    errors.extend(session.run_phase(directives, Phase::Late, today));
+    let session = ValidationSession::new(ValidationOptions::default());
+    let (session, mut errors) = session.run_early(directives, today);
+    let (session, late_errs) = session.run_late(directives, today);
+    errors.extend(late_errs);
     errors.extend(session.finalize());
     errors
 }


### PR DESCRIPTION
## Summary

Closes #1236, scoped to the validation Early/Late subsystem (the issue's recommended starting point).

Pre-#1236 the `ValidationSession` enforced phase ordering at *runtime* via a `phases_run: u8` bitmask: `debug_assert!` in debug builds, silent no-op (returning `Vec::new()`) in release builds. The release-mode gap meant a misuse compiled and shipped without complaint; the `LedgerState` double-update risk was masked.

This PR moves the same invariant to the type system, mirroring `rustledger-loader/src/phase.rs` from #1201 / #1202.

## What changes

### New `phase` module in `rustledger-validate`

Sealed `Pending`, `EarlyDone`, `LateDone` zero-sized markers and a `SessionPhase` trait. Documented in module rustdoc with the rationale and the known follow-up scope.

### `ValidationSession<P: SessionPhase = Pending>`

Phantom-typed wrapper around `LedgerState`. Transitions are by-value, mirroring the loader's `Directives<P>` pattern:

```rust
let session = ValidationSession::new(options);                       // Pending
let (session, mut errors) = session.run_early(&directives, today);   // -> EarlyDone
// ... booking runs here for the loader; LSP/FFI skip straight ahead ...
let (session, late_errors) = session.run_late(&directives, today);   // -> LateDone
errors.extend(late_errors);
errors.extend(session.finalize());                                   // consumes
```

Each phase has a `_spanned` variant (`run_early_spanned`, `run_late_spanned`) for `&[Spanned<Directive>]` input, preserving source-location info for the LSP / loader / FFI consumers.

### Removed

- The runtime `phases_run` bitmask and `check_phase_ordering` helper.
- The `debug_assert!` panics on out-of-order or duplicate calls.
- The two `#[should_panic]` tests that exercised those debug asserts. The corresponding misuse is now unrepresentable in the type system; a type-level test `typestate_pins_phase_ordering_at_compile_time` documents the new invariant via three private functions whose signatures the type-checker validates.

### Caller migration

8 production sites + 4 test/bench helpers:

- **`rustledger-loader::process()`**: `early_validate` had to be split per `cfg(feature = "validation")` because the function's return shape differs (a tuple with the typestated session vs a single `Directives`). The per-parameter `#[cfg]` pattern the rest of the pipeline uses doesn't generalize here. `late_validate` takes `Option<ValidationSession<EarlyDone>>` by value and drives it through `LateDone` to `finalize()` internally.
- **LSP `handlers/diagnostics.rs`**, **FFI `jsonrpc/router.rs`**, **wasm `helpers.rs` + `lib.rs`**, **validate `tests/common/mod.rs` + `benches/validate_bench.rs`**, **rustledger `benches/pipeline_bench.rs`**: each replaces the `run_phase(_, Phase::Early, today) → run_phase(_, Phase::Late, today) → finalize` triple with `run_early(_, today) → run_late(_, today) → finalize`, threading the session by value through the three calls. `Phase` is no longer imported at these sites.

### Kept

`Phase` (the existing `Early` / `Late` enum) and the inner `validate_phase_inner` helper remain. The typestate methods dispatch through them internally, and `Phase` is still useful inside the validator implementations (they consult it to gate per-phase checks).

## Known follow-up (not in scope)

The typestate guards the **session**'s lifecycle. The **directive list** passed to each phase is still a plain `&[Directive]` / `&[Spanned<Directive>]`, so a caller can still pass pre-booking directives to `run_late` without a compile-time error. Closing that gap requires phase markers on the directive collection that cross the validate/loader crate boundary (mirroring the loader's `Directives<P>`).

Issue #1236 also proposes typestate refactors for the **query executor** and the **LSP request lifecycle**; both are explicitly larger scopes than this PR. The issue can stay open for those, or be split into separate issues per subsystem.

## How to test

- `cargo test --workspace --all-features` -> 2900+ tests, zero failures
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` -> clean
- `cargo fmt --all -- --check` -> clean
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features` -> clean

## Test plan

- [x] Workspace tests pass (zero failures across 47 test suites)
- [x] Clippy `-D warnings`: clean
- [x] fmt check: clean
- [x] rustdoc with `-Dwarnings`: clean
- [x] Loader / LSP / FFI / wasm / bench sites all migrated; behavior preserved
- [x] Type-level test pins the new invariant

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
