### PR TITLE
fix(lsp): eagerly resolve balance lenses, defeat nvim's resolve-cancellation race (closes #1253)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -5,22 +5,51 @@
 //! - Transactions (showing posting count and currencies)
 //! - Balance assertions (with verification status)
 //!
-//! Supports resolve for lazy-loading expensive balance calculations.
+//! # Eager resolution
+//!
+//! Balance lenses are computed eagerly inside [`handle_code_lens`].
+//! Pre-#1253, balance lenses shipped with `command: None` plus a `data`
+//! payload that [`handle_code_lens_resolve`] consulted on a subsequent
+//! `codeLens/resolve` round-trip. That deferred-resolve pattern was
+//! standard LSP, but it exposed the lens to a known race in nvim's
+//! built-in LSP client: when the resolve response races with a
+//! cancellation (visible in the user's LSP log as
+//! `"Cannot find request with id N whilst attempting to cancel"`),
+//! the response is silently discarded and the lens stays on whatever
+//! placeholder shipped with the initial response. #1245 surfaced this
+//! as `"Unresolved lens"`; #1249 mitigated by introducing a
+//! `"Balance: X USD (checking…)"` placeholder, but the stuck-checking
+//! symptom (#1253) showed the race was still observable. The right
+//! fix is to skip the resolve round-trip entirely: ship the final
+//! `✓` or `⚠` title on the initial response.
+//!
+//! Cost: one booking pass per `textDocument/codeLens` request. M
+//! balance assertions cost O(N + M) total (book once, iterate M
+//! times) instead of the previous O(M × N) (book per resolve).
+//! [`handle_code_lens_resolve`] is kept as a defensive fallback for
+//! any future lens kind that genuinely needs deferred resolution.
 
 use lsp_types::{CodeLens, CodeLensParams, Command, Position, Range};
 use rustledger_booking::BookingEngine;
-use rustledger_core::NaiveDate;
-use rustledger_core::{BookingMethod, Decimal, Directive};
+use rustledger_core::{BookingMethod, Decimal, Directive, NaiveDate};
 use rustledger_parser::{ParseResult, Spanned};
 use std::collections::HashMap;
 
 use super::utils::{LineIndex, PositionEncoding};
 
 /// Handle a code lens request.
+///
+/// `ledger_directives` is the full multi-file ledger snapshot (taken
+/// on the main loop while locks are cheap). When provided, balance
+/// assertions are validated against the full ledger; when `None`, the
+/// validator falls back to the current file's parse result. This is
+/// the same multi-file behavior the pre-#1253 resolve path supported
+/// (issue #470).
 pub fn handle_code_lens(
     params: &CodeLensParams,
     source: &str,
     parse_result: &ParseResult,
+    ledger_directives: Option<&[Spanned<Directive>]>,
     encoding: PositionEncoding,
 ) -> Option<Vec<CodeLens>> {
     let line_index = LineIndex::new(source, encoding);
@@ -29,6 +58,15 @@ pub fn handle_code_lens(
 
     // Collect account usage statistics
     let account_stats = collect_account_stats(parse_result);
+
+    // Book the directives ONCE. The booked result feeds every balance
+    // lens lookup in this request (M assertions cost O(N + M) total
+    // instead of O(M * N) for the pre-#1253 per-resolve booking).
+    // `None` ledger_directives falls back to the current file's
+    // parse_result, matching the resolve path's behavior in
+    // single-file mode.
+    let booked_directives =
+        book_directives_once(ledger_directives.unwrap_or(&parse_result.directives));
 
     for spanned in &parse_result.directives {
         let (line, _) = line_index.offset_to_position(spanned.span.start);
@@ -101,41 +139,41 @@ pub fn handle_code_lens(
                 });
             }
             Directive::Balance(bal) => {
-                // Store data for resolve: real verification is deferred to
-                // handle_code_lens_resolve because booking the full ledger
-                // is O(N) and the cost is paid per balance assertion.
-                let data = serde_json::json!({
-                    "uri": uri,
-                    "kind": "balance",
-                    "account": bal.account.to_string(),
-                    "date": bal.date.to_string(),
-                    "expected_amount": bal.amount.number.to_string(),
-                    "expected_currency": bal.amount.currency.to_string(),
-                });
+                // Eagerly verify the assertion against the booked
+                // directives. No data payload + no resolve round-trip
+                // means no exposure to nvim's resolve-cancellation
+                // race (issues #1245 / #1253); the user sees the
+                // final ✓ or ⚠ title on the initial response.
+                let actual_amount =
+                    balance_at_date_from_booked(&booked_directives, &bal.account, Some(bal.date))
+                        .get(bal.amount.currency.as_ref())
+                        .copied()
+                        .unwrap_or_default();
 
-                // Placeholder command set on the initial response so
-                // clients never render the literal "Unresolved lens"
-                // string for balance lenses during the resolve
-                // round-trip window (issue #1245). If `codeLens/resolve`
-                // never lands (cancellation race in nvim's LSP client,
-                // dropped response, etc.), the user still sees a
-                // sensible title instead of "Unresolved lens".
-                //
-                // The resolve handler overwrites this with either the
-                // real `✓ Balance: ... USD` title (passing assertion)
-                // or `⚠ Balance: ... USD (see diagnostic)` (failing
-                // assertion). For failing assertions the diagnostic
-                // remains the source of truth on the actual error
-                // (issue #491); the resolved lens title is a brief
-                // pointer so the lens stays meaningful instead of
-                // sitting forever on the "(checking…)" placeholder.
-                let placeholder = Command {
-                    title: format!(
-                        "Balance: {} {} (checking…)",
-                        bal.amount.number, bal.amount.currency
-                    ),
-                    command: "rledger.noop".to_string(),
-                    arguments: None,
+                let command = if actual_amount == bal.amount.number {
+                    Command {
+                        title: format!("✓ Balance: {} {}", bal.amount.number, bal.amount.currency),
+                        command: "rledger.showBalanceDetails".to_string(),
+                        arguments: Some(vec![serde_json::json!({
+                            "account": bal.account.to_string(),
+                            "status": "verified",
+                            "expected": format!("{} {}", bal.amount.number, bal.amount.currency),
+                            "actual": format!("{} {}", actual_amount, bal.amount.currency),
+                        })]),
+                    }
+                } else {
+                    // Failing assertions: the real error is surfaced
+                    // via diagnostics (issue #491). The lens title
+                    // points the user at the diagnostic rather than
+                    // duplicating its content.
+                    Command {
+                        title: format!(
+                            "⚠ Balance: {} {} (see diagnostic)",
+                            bal.amount.number, bal.amount.currency
+                        ),
+                        command: "rledger.noop".to_string(),
+                        arguments: None,
+                    }
                 };
 
                 lenses.push(CodeLens {
@@ -143,8 +181,8 @@ pub fn handle_code_lens(
                         start: Position::new(line, 0),
                         end: Position::new(line, 0),
                     },
-                    command: Some(placeholder),
-                    data: Some(data),
+                    command: Some(command),
+                    data: None,
                 });
             }
             _ => {}
@@ -165,124 +203,46 @@ pub fn handle_code_lens(
     }
 }
 
-/// Handle a code lens resolve request.
-/// Computes expensive balance verification on demand.
+/// Handle a `codeLens/resolve` request.
 ///
-/// When `ledger_directives` is provided (multi-file mode), the balance calculation
-/// considers all transactions from the full ledger, not just the current file.
-/// This fixes issue #470 where balance assertions depending on transactions in
-/// other included files would incorrectly show as unresolved.
+/// As of #1253 every lens kind [`handle_code_lens`] emits ships
+/// fully-resolved (balance lenses included — see the eager-resolve
+/// rationale in this module's rustdoc). This handler is therefore
+/// defensive: if any future lens kind ever ships with
+/// `command: None`, the fallback below guarantees the client renders
+/// something sensible rather than nvim's literal `"Unresolved lens"`
+/// string. `ledger_directives` is unused today but kept on the
+/// signature so a future resolve-using lens kind can opt back in
+/// without a churn-inducing API change.
 pub fn handle_code_lens_resolve(
     lens: CodeLens,
-    parse_result: &ParseResult,
-    ledger_directives: Option<&[Spanned<Directive>]>,
+    _parse_result: &ParseResult,
+    _ledger_directives: Option<&[Spanned<Directive>]>,
 ) -> CodeLens {
-    let mut resolved = lens.clone();
-    let mut processed_balance = false;
-
-    if let Some(data) = &lens.data
-        && data.get("kind").and_then(|v| v.as_str()) == Some("balance")
-    {
-        processed_balance = true;
-
-        let account = data.get("account").and_then(|v| v.as_str()).unwrap_or("");
-        let date_str = data.get("date").and_then(|v| v.as_str()).unwrap_or("");
-        let expected_amount = data
-            .get("expected_amount")
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse::<Decimal>().ok())
-            .unwrap_or_default();
-        let expected_currency = data
-            .get("expected_currency")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-
-        // Parse the date
-        let date = date_str.parse::<NaiveDate>().ok();
-
-        // Calculate actual balance up to this date.
-        // Use full ledger directives if available (multi-file mode), otherwise fall back
-        // to single-file directives.
-        // TODO: Consider caching booked directives in LedgerState for large ledgers.
-        let actual_balance = calculate_balance_at_date(
-            ledger_directives.unwrap_or(&parse_result.directives),
-            account,
-            date,
-        );
-        let actual_amount = actual_balance
-            .get(expected_currency)
-            .copied()
-            .unwrap_or_default();
-
-        // On passing assertions, show the verified-balance lens.
-        // On failing assertions, the error is surfaced via diagnostics
-        // (standard IDE behavior; showing both would duplicate the
-        // information, see issue #491), so we replace the placeholder
-        // with a brief "(see diagnostic)" callout rather than letting
-        // it stand as a falsely-passing-looking string.
-        //
-        // Crucially, we ALWAYS set `resolved.command` here. The
-        // pre-#1245 path of leaving `command = None` for mismatches
-        // surfaced as nvim rendering the literal string "Unresolved
-        // lens" once the resolve response landed (issue #1245).
-        resolved.command = Some(if actual_amount == expected_amount {
-            Command {
-                title: format!("✓ Balance: {} {}", expected_amount, expected_currency),
-                command: "rledger.showBalanceDetails".to_string(),
-                arguments: Some(vec![serde_json::json!({
-                    "account": account,
-                    "status": "verified",
-                    "expected": format!("{} {}", expected_amount, expected_currency),
-                    "actual": format!("{} {}", actual_amount, expected_currency),
-                })]),
-            }
-        } else {
-            Command {
-                title: format!(
-                    "⚠ Balance: {} {} (see diagnostic)",
-                    expected_amount, expected_currency
-                ),
-                command: "rledger.noop".to_string(),
-                arguments: None,
-            }
-        });
-    }
-
-    // Ensure a command is set for non-balance lenses or malformed
-    // balance data — `command: None` makes nvim render the literal
-    // string "Unresolved lens" once the resolve response lands (see
-    // issue #1245). The `!processed_balance` guard is now mostly
-    // defensive: as of #1245, balance lenses ALWAYS receive a command
-    // in the kind == "balance" branch above (✓ on match, ⚠ on
-    // mismatch), so this fallback only fires for non-balance kinds or
-    // for balance data so malformed that we couldn't parse it. The
-    // guard prevents this fallback from overwriting the structured
-    // balance titles in the (impossible-today) case where the balance
-    // branch somehow left `command` unset.
-    if !processed_balance && resolved.command.is_none() {
+    let mut resolved = lens;
+    if resolved.command.is_none() {
         resolved.command = Some(Command {
-            title: "Balance assertion".to_string(),
+            title: "rledger lens".to_string(),
             command: "rledger.noop".to_string(),
             arguments: None,
         });
     }
-
     resolved
 }
 
-/// Calculate the balance of an account at a specific date.
+/// Sort + book a directive list once, returning the booked
+/// transactions in chronological order.
 ///
-/// This function runs booking/interpolation before calculating balances,
-/// matching the behavior of validation. Without booking, auto-filled postings
-/// would not be counted in the balance.
+/// Output is suitable for any number of subsequent
+/// [`balance_at_date_from_booked`] lookups, which is how
+/// [`handle_code_lens`] amortizes booking cost across all balance
+/// lenses in a file (O(N) booking + O(M) lookups, vs O(M*N) for the
+/// pre-#1253 per-resolve approach).
 ///
-/// Accepts directives directly to support both single-file and multi-file modes.
-fn calculate_balance_at_date(
-    directives_in: &[Spanned<Directive>],
-    account: &str,
-    date: Option<rustledger_core::NaiveDate>,
-) -> HashMap<String, Decimal> {
-    // Clone and sort directives by date (required for correct booking)
+/// Booking matches the validator's behavior; without it, auto-filled
+/// postings (Income:Salary with no explicit amount, etc.) wouldn't
+/// be counted toward the asserted account's balance.
+fn book_directives_once(directives_in: &[Spanned<Directive>]) -> Vec<Spanned<Directive>> {
     let mut directives: Vec<Spanned<Directive>> = directives_in.to_vec();
     directives.sort_by_cached_key(|d| {
         (
@@ -292,7 +252,6 @@ fn calculate_balance_at_date(
         )
     });
 
-    // Run booking/interpolation to fill in missing amounts
     let mut booking_engine = BookingEngine::with_method(BookingMethod::Strict);
     booking_engine.register_account_methods(directives.iter().map(|s| &s.value));
     for spanned in &mut directives {
@@ -304,18 +263,31 @@ fn calculate_balance_at_date(
         }
     }
 
-    // Calculate balance from booked transactions
-    let mut balances: HashMap<String, Decimal> = HashMap::new();
+    directives
+}
 
-    for spanned in &directives {
+/// Sum postings to `account` from `booked` whose transaction date is
+/// strictly before `date` (the Beancount semantic for balance
+/// assertions: the asserted value is checked at the START of the
+/// asserted day).
+///
+/// Caller is responsible for passing already-[`book_directives_once`]
+/// output. Returns a per-currency map so a multi-currency account can
+/// be validated against the asserted currency without losing the
+/// others.
+fn balance_at_date_from_booked(
+    booked: &[Spanned<Directive>],
+    account: &str,
+    date: Option<NaiveDate>,
+) -> HashMap<String, Decimal> {
+    let mut balances: HashMap<String, Decimal> = HashMap::new();
+    for spanned in booked {
         if let Directive::Transaction(txn) = &spanned.value {
-            // Only include transactions before the balance date
             if let Some(d) = date
                 && txn.date >= d
             {
                 continue;
             }
-
             for posting in &txn.postings {
                 if posting.account.as_ref() == account
                     && let Some(units) = &posting.units
@@ -327,7 +299,6 @@ fn calculate_balance_at_date(
             }
         }
     }
-
     balances
 }
 
@@ -377,7 +348,7 @@ mod tests {
             partial_result_params: Default::default(),
         };
 
-        let lenses = handle_code_lens(&params, source, &result, PositionEncoding::Utf16);
+        let lenses = handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16);
         assert!(lenses.is_some());
 
         let lenses = lenses.unwrap();
@@ -396,134 +367,82 @@ mod tests {
     }
 
     #[test]
-    fn test_code_lens_balance() {
+    fn test_code_lens_balance_match_ships_resolved() {
+        // Passing assertion: lens ships with `✓ Balance: ... USD` on
+        // the initial textDocument/codeLens response. No data payload,
+        // no resolve round-trip (issue #1253).
         let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-31 balance Assets:Bank 100 USD
-"#;
-        let result = parse(source);
-        let params = CodeLensParams {
-            text_document: lsp_types::TextDocumentIdentifier {
-                uri: "file:///test.beancount".parse().unwrap(),
-            },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        };
-
-        let lenses = handle_code_lens(&params, source, &result, PositionEncoding::Utf16);
-        assert!(lenses.is_some());
-
-        let lenses = lenses.unwrap();
-        // Balance lens carries data for deferred verification, plus a
-        // placeholder command set on the initial response so nvim
-        // never renders the literal "Unresolved lens" string during
-        // the resolve round-trip window (issue #1245). The real ✓ or
-        // ⚠ title lands once `codeLens/resolve` returns.
-        let balance_lens = lenses
-            .iter()
-            .find(|l| {
-                l.data
-                    .as_ref()
-                    .and_then(|d| d.get("kind"))
-                    .and_then(|v| v.as_str())
-                    == Some("balance")
-            })
-            .expect("balance lens emitted");
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens carries placeholder command (issue #1245)");
-        assert!(
-            cmd.title.contains("checking"),
-            "placeholder title should mark the lens as still-resolving; got {:?}",
-            cmd.title
-        );
-        assert_eq!(cmd.command, "rledger.noop");
-    }
-
-    #[test]
-    fn test_code_lens_resolve_balance_match() {
-        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-01 open Income:Salary
 2024-01-15 * "Deposit"
   Assets:Bank  100.00 USD
   Income:Salary
-2024-01-31 balance Assets:Bank 100 USD
+2024-01-31 balance Assets:Bank 100.00 USD
 "#;
         let result = parse(source);
+        let params = code_lens_params();
 
-        // Create a code lens like what handle_code_lens would return
-        let lens = CodeLens {
-            range: Range {
-                start: Position::new(4, 0),
-                end: Position::new(4, 0),
-            },
-            command: None,
-            data: Some(serde_json::json!({
-                "kind": "balance",
-                "account": "Assets:Bank",
-                "date": "2024-01-31",
-                "expected_amount": "100",
-                "expected_currency": "USD",
-            })),
-        };
-
-        let resolved = handle_code_lens_resolve(lens, &result, None);
-        assert!(resolved.command.is_some());
-
-        let cmd = resolved.command.unwrap();
-        assert!(cmd.title.contains("✓")); // Should show checkmark for match
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+        let cmd = balance_lens
+            .command
+            .as_ref()
+            .expect("balance lens ships fully-resolved (issue #1253)");
+        assert!(
+            cmd.title.contains('✓'),
+            "passing assertion should ship with ✓; got {:?}",
+            cmd.title
+        );
         assert!(cmd.title.contains("100"));
+        assert!(
+            balance_lens.data.is_none(),
+            "eager-resolved balance lens carries no resolve-data payload; \
+             pre-#1253 the data payload triggered a codeLens/resolve \
+             round-trip that nvim's client could race against \
+             cancellation. got data = {:?}",
+            balance_lens.data
+        );
     }
 
     #[test]
-    fn test_code_lens_resolve_balance_mismatch() {
+    fn test_code_lens_balance_mismatch_ships_resolved() {
+        // Failing assertion: lens ships with the `⚠ ... (see diagnostic)`
+        // callout on the initial response. The actual error lives in
+        // the diagnostic (#491); the lens points at it without
+        // duplicating its content.
         let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-01 open Income:Salary
 2024-01-15 * "Deposit"
   Assets:Bank  50.00 USD
   Income:Salary
 2024-01-31 balance Assets:Bank 100 USD
 "#;
         let result = parse(source);
+        let params = code_lens_params();
 
-        let lens = CodeLens {
-            range: Range {
-                start: Position::new(4, 0),
-                end: Position::new(4, 0),
-            },
-            command: None,
-            data: Some(serde_json::json!({
-                "kind": "balance",
-                "account": "Assets:Bank",
-                "date": "2024-01-31",
-                "expected_amount": "100",
-                "expected_currency": "USD",
-            })),
-        };
-
-        let resolved = handle_code_lens_resolve(lens, &result, None);
-
-        // Mismatched balances are surfaced via diagnostics (#491), so
-        // the lens still does NOT duplicate the amount/✓ marker. But
-        // it MUST carry SOME command, otherwise nvim renders the
-        // literal "Unresolved lens" string for the line (issue #1245).
-        // We use a "⚠ ... (see diagnostic)" callout that points the
-        // user at the diagnostic without duplicating its content.
-        let cmd = resolved
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+        let cmd = balance_lens
             .command
             .as_ref()
-            .expect("mismatched balance must carry a command (issue #1245)");
+            .expect("balance lens ships fully-resolved");
         assert!(
             cmd.title.contains("see diagnostic"),
-            "mismatched balance lens should point at the diagnostic; got {:?}",
+            "failing assertion should ship with `(see diagnostic)`; got {:?}",
             cmd.title
         );
         assert_eq!(cmd.command, "rledger.noop");
     }
 
     #[test]
-    fn test_code_lens_resolve_with_auto_filled_posting() {
-        // This tests that booking is run before balance calculation.
-        // The Income:Salary posting has no amount - it should be auto-filled to -100 USD.
-        // After booking, Assets:Bank should have 100 USD and balance should pass.
+    fn test_code_lens_balance_with_auto_filled_posting() {
+        // Booking runs as part of the eager balance computation, so a
+        // posting elided to be auto-filled (Income:Salary with no
+        // explicit amount) still gets counted. Pre-eager-resolve this
+        // lived in handle_code_lens_resolve; same coverage, new path.
         let source = r#"2024-01-01 open Assets:Bank USD
 2024-01-01 open Income:Salary USD
 2024-01-15 * "Deposit"
@@ -532,46 +451,97 @@ mod tests {
 2024-01-31 balance Assets:Bank 100 USD
 "#;
         let result = parse(source);
+        let params = code_lens_params();
 
-        let lens = CodeLens {
-            range: Range {
-                start: Position::new(5, 0),
-                end: Position::new(5, 0),
-            },
-            command: None,
-            data: Some(serde_json::json!({
-                "kind": "balance",
-                "account": "Assets:Bank",
-                "date": "2024-01-31",
-                "expected_amount": "100",
-                "expected_currency": "USD",
-            })),
-        };
-
-        let resolved = handle_code_lens_resolve(lens, &result, None);
-
-        // With booking, the auto-filled posting is counted and balance should pass
-        assert!(
-            resolved.command.is_some(),
-            "Balance with auto-filled posting should pass after booking"
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
+                .expect("lenses emitted"),
         );
-
-        let cmd = resolved.command.unwrap();
+        let cmd = balance_lens
+            .command
+            .as_ref()
+            .expect("balance lens ships fully-resolved");
         assert!(
-            cmd.title.contains("✓"),
-            "Should show checkmark for passing balance. Got: {}",
+            cmd.title.contains('✓'),
+            "auto-filled posting should book to 100 USD, passing the assertion; got {:?}",
             cmd.title
         );
     }
 
     #[test]
-    fn test_code_lens_resolve_missing_data() {
-        // Test that resolve always returns a command, even with missing/malformed data.
-        // This prevents "Unresolved lens ..." from appearing in the editor.
-        let source = r#"2024-01-01 open Assets:Bank USD"#;
-        let result = parse(source);
+    fn test_code_lens_balance_uses_full_ledger_in_multi_file_mode() {
+        // Issue #470 coverage: when ledger_directives carries the
+        // full multi-file view, balance assertions whose offsetting
+        // transaction lives in a different file resolve correctly.
+        // Pre-#1253 this was tested through handle_code_lens_resolve;
+        // post-#1253 the eager path in handle_code_lens consumes the
+        // same multi-file snapshot.
+        let bank_source = r#"2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary
+2024-01-01 open Liabilities:Credit-Card
+2024-01-15 * "Paycheck"
+  Assets:Bank:Checking  5000 USD
+  Income:Salary
+2024-01-21 balance Assets:Bank:Checking 4950 USD
+"#;
+        let bank_result = parse(bank_source);
+        let credit_card_source = r#"2024-01-20 * "Pay off credit card"
+  Assets:Bank:Checking  -50 USD
+  Liabilities:Credit-Card
+"#;
+        let credit_card_result = parse(credit_card_source);
+        let mut full_directives = bank_result.directives.clone();
+        full_directives.extend(credit_card_result.directives.clone());
 
-        // Lens with no data at all
+        let params = code_lens_params();
+
+        // Single-file view: the -50 offset isn't visible, balance
+        // appears to mismatch.
+        let single_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                bank_source,
+                &bank_result,
+                None,
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let single_cmd = single_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            single_cmd.title.contains("see diagnostic"),
+            "single-file mismatch should point at the diagnostic; got {:?}",
+            single_cmd.title
+        );
+
+        // Multi-file view: the -50 offset is visible, balance matches.
+        let multi_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                bank_source,
+                &bank_result,
+                Some(&full_directives),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let multi_cmd = multi_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            multi_cmd.title.contains('✓') && multi_cmd.title.contains("4950"),
+            "multi-file match should ship `✓ Balance: 4950 USD`; got {:?}",
+            multi_cmd.title
+        );
+    }
+
+    #[test]
+    fn test_code_lens_resolve_fallback_for_command_none_lens() {
+        // Defensive fallback inside handle_code_lens_resolve: even
+        // though no lens kind emitted by handle_code_lens ships with
+        // command:None today (eager resolution since #1253), if a
+        // future contributor adds a resolve-using lens kind and forgets
+        // to handle it, the fallback guarantees the client renders a
+        // sensible string instead of nvim's literal "Unresolved lens".
+        let result = parse("2024-01-01 open Assets:Bank USD");
         let lens = CodeLens {
             range: Range {
                 start: Position::new(0, 0),
@@ -580,192 +550,100 @@ mod tests {
             command: None,
             data: None,
         };
-
         let resolved = handle_code_lens_resolve(lens, &result, None);
-        assert!(
-            resolved.command.is_some(),
-            "Lens must always have a command after resolve"
-        );
-    }
-
-    #[test]
-    fn test_code_lens_resolve_multifile_balance() {
-        // Test that balance verification uses full ledger directives when provided.
-        // This is the fix for issue #470: balance assertions that depend on
-        // transactions in other included files should verify correctly.
-
-        // The "current file" (bank.bean) has a balance assertion for 4950 USD
-        let bank_source = r#"2024-01-01 open Assets:Bank:Checking USD
-2024-01-15 * "Paycheck"
-  Assets:Bank:Checking  5000 USD
-  Income:Salary
-2024-01-21 balance Assets:Bank:Checking 4950 USD
-"#;
-        let bank_result = parse(bank_source);
-
-        // The "other file" (credit_card.bean) has the -50 USD transaction
-        let credit_card_source = r#"2024-01-01 open Liabilities:Credit-Card
-2024-01-20 * "Pay off credit card"
-  Assets:Bank:Checking  -50 USD
-  Liabilities:Credit-Card
-"#;
-        let credit_card_result = parse(credit_card_source);
-
-        // Combine directives as the loader would
-        let mut full_directives = bank_result.directives.clone();
-        full_directives.extend(credit_card_result.directives.clone());
-
-        // Create a lens for the balance assertion on line 4 (0-indexed)
-        let lens = CodeLens {
-            range: Range {
-                start: Position::new(4, 0),
-                end: Position::new(4, 0),
-            },
-            command: None,
-            data: Some(serde_json::json!({
-                "kind": "balance",
-                "account": "Assets:Bank:Checking",
-                "date": "2024-01-21",
-                "expected_amount": "4950",
-                "expected_currency": "USD",
-            })),
-        };
-
-        // Without full ledger (single-file mode) the balance comes out to
-        // 5000 (no offsetting -50 from credit_card.bean), so the assertion
-        // mismatches. Pre-#1245 this surfaced as `command: None`; now we
-        // emit the "⚠ ... (see diagnostic)" callout so nvim never renders
-        // the literal "Unresolved lens" string.
-        let resolved_single = handle_code_lens_resolve(lens.clone(), &bank_result, None);
-        let single_cmd = resolved_single
+        let cmd = resolved
             .command
             .as_ref()
-            .expect("mismatched balance must carry a command (issue #1245)");
-        assert!(
-            single_cmd.title.contains("see diagnostic"),
-            "single-file mismatch should point at the diagnostic; got {:?}",
-            single_cmd.title
-        );
-
-        // With full ledger (multi-file mode) - balance is 5000 - 50 = 4950, match!
-        let resolved_multi = handle_code_lens_resolve(lens, &bank_result, Some(&full_directives));
-        assert!(
-            resolved_multi.command.is_some(),
-            "Multi-file mode should see match (5000 - 50 = 4950)"
-        );
-
-        let cmd = resolved_multi.command.unwrap();
-        assert!(
-            cmd.title.contains("✓"),
-            "Should show checkmark. Got: {}",
-            cmd.title
-        );
-        assert!(
-            cmd.title.contains("4950"),
-            "Should show correct balance. Got: {}",
-            cmd.title
-        );
+            .expect("fallback must populate command");
+        assert_eq!(cmd.command, "rledger.noop");
     }
 
-    #[test]
-    fn test_code_lens_resolve_wrong_kind() {
-        // Test that resolve handles data with wrong/missing "kind" field
-        let source = r#"2024-01-01 open Assets:Bank USD"#;
-        let result = parse(source);
-
-        let lens = CodeLens {
-            range: Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, 0),
-            },
-            command: None,
-            data: Some(serde_json::json!({
-                "kind": "unknown",
-                "account": "Assets:Bank",
-            })),
-        };
-
-        let resolved = handle_code_lens_resolve(lens, &result, None);
-        assert!(
-            resolved.command.is_some(),
-            "Lens must always have a command after resolve"
-        );
-    }
-
-    /// Regression for issue #1245: balance lenses must NEVER be emitted
-    /// with `command: None`, because nvim's LSP client renders that as
-    /// the literal string "Unresolved lens" until the resolve response
-    /// lands and is processed. If the resolve races with a cancellation
-    /// (or never lands), the lens stays visible as "Unresolved lens"
-    /// for the lifetime of the session. The placeholder command we emit
-    /// on the initial response, plus the always-set command on resolve,
-    /// together break that failure mode.
+    /// Regression for issue #1253 / #1245: balance lenses must ship
+    /// FULLY-RESOLVED on the initial `textDocument/codeLens` response
+    /// (no `data` payload, no placeholder, no resolve round-trip).
     ///
-    /// The user's reproduction (`balance Assets:Bank:Checking 5 USD`
-    /// on date `2024-01-03` after a `+5 USD` posting on `2024-01-01`)
-    /// passes server-side for both `2024-01-02` and `2024-01-03`. The
-    /// observed inconsistency was a client-side timing artifact of the
-    /// `command: None` round-trip window; this test pins the invariant
-    /// that closes that window.
+    /// Pre-#1253 the lens shipped with a `(checking…)` placeholder
+    /// command and a `data: { kind: "balance", ... }` payload; the
+    /// real `✓` / `⚠` title was filled in by `codeLens/resolve`.
+    /// Under nvim's resolve-cancellation race (visible in #1253's
+    /// LSP log as `"Cannot find request with id N whilst attempting
+    /// to cancel"`) the resolve response was silently discarded and
+    /// the lens stayed on the placeholder forever. Eager resolution
+    /// removes the round-trip and makes the race unreachable.
+    ///
+    /// This test pins both invariants: the final title shows the
+    /// real status (no `(checking…)`), and there is no `data` field
+    /// asking the client to re-resolve.
     #[test]
-    fn issue_1245_balance_lens_always_has_command() {
-        // Sanity: both initial-emission and resolve paths must produce
-        // a command for both passing and failing balance assertions.
-        for (label, expected) in [
-            ("passing match", "5"),
-            ("mismatch", "999"), // forces mismatch path
-        ] {
-            let source = format!(
-                "2024-01-01 open Assets:Bank:Checking USD\n\
-                 2024-01-01 open Income:Salary\n\
-                 \n\
-                 2024-01-01 * \"Paycheck\"\n  \
-                   Assets:Bank:Checking  5 USD\n  \
-                   Income:Salary\n\
-                 \n\
-                 2024-01-03 balance Assets:Bank:Checking {expected} USD\n"
-            );
-            let parse_result = parse(&source);
-            let params = CodeLensParams {
-                text_document: lsp_types::TextDocumentIdentifier {
-                    uri: "file:///test.beancount".parse().unwrap(),
-                },
-                work_done_progress_params: Default::default(),
-                partial_result_params: Default::default(),
-            };
+    fn issue_1253_balance_lens_ships_eagerly_resolved() {
+        // The user's reproduction from #1253: salary posts 1000 USD
+        // on 02-01, balance assertion on 02-02 expects 1000 USD.
+        let source = "\
+2012-01-01 open Assets:Bank
+2012-01-01 open Income:Employment
 
-            // 1. Initial emission must carry a placeholder command.
-            let lenses = handle_code_lens(
-                &params,
-                &source,
-                &parse_result,
-                super::PositionEncoding::Utf16,
-            )
-            .expect("lenses emitted");
-            let balance_lens = lenses
-                .iter()
-                .find(|l| {
-                    l.data
-                        .as_ref()
-                        .and_then(|d| d.get("kind"))
-                        .and_then(|v| v.as_str())
-                        == Some("balance")
-                })
-                .unwrap_or_else(|| panic!("[{label}] balance lens was not emitted"))
-                .clone();
-            assert!(
-                balance_lens.command.is_some(),
-                "[{label}] initial balance lens must carry a placeholder command (issue #1245); \
-                 nvim renders `command: None` as the literal string \"Unresolved lens\""
-            );
+2012-02-01 * \"Salary\"
+  Assets:Bank                   1000 USD
+  Income:Employment
 
-            // 2. After resolve, the command must remain set (replaced
-            //    with the real ✓ or ⚠ callout, never reset to None).
-            let resolved = handle_code_lens_resolve(balance_lens, &parse_result, None);
-            assert!(
-                resolved.command.is_some(),
-                "[{label}] resolved balance lens must carry a command (issue #1245)"
-            );
+2012-02-02 balance Assets:Bank  1000 USD
+";
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+
+        // 1. The final ✓ title is set on the initial response.
+        let cmd = balance_lens
+            .command
+            .as_ref()
+            .expect("balance lens ships fully-resolved");
+        assert!(
+            cmd.title.contains('✓'),
+            "issue #1253: passing assertion must ship with the real ✓ \
+             title on the initial response, not a `(checking…)` \
+             placeholder that nvim could leave stuck. got {:?}",
+            cmd.title
+        );
+        assert!(
+            !cmd.title.contains("checking"),
+            "issue #1253: title must not contain the `(checking…)` \
+             placeholder; that's the stuck-state symptom. got {:?}",
+            cmd.title
+        );
+
+        // 2. No `data` payload means no codeLens/resolve round-trip,
+        //    which means no race window for nvim to cancel.
+        assert!(
+            balance_lens.data.is_none(),
+            "issue #1253: balance lens must not carry a resolve-data \
+             payload; the resolve round-trip is what nvim could race \
+             against cancellation. got data = {:?}",
+            balance_lens.data
+        );
+    }
+
+    fn code_lens_params() -> CodeLensParams {
+        CodeLensParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
         }
+    }
+
+    fn find_balance_lens(lenses: Vec<CodeLens>) -> CodeLens {
+        lenses
+            .into_iter()
+            .find(|l| {
+                l.command
+                    .as_ref()
+                    .is_some_and(|c| c.title.contains("Balance:"))
+            })
+            .expect("balance lens emitted")
     }
 }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -990,7 +990,23 @@ impl MainLoopState {
         let uri = &params.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        let response = handle_code_lens(&params, &text, &parse_result, self.position_encoding);
+        // Snapshot the multi-file ledger directives so the eager
+        // balance verification inside `handle_code_lens` (#1253) sees
+        // the same multi-file view that `codeLens/resolve` used to
+        // see. Matches the snapshot pattern in `try_dispatch_async`'s
+        // CodeLensResolve branch.
+        let ledger_directives = {
+            let guard = self.ledger_state.read();
+            guard.directives().map(<[_]>::to_vec)
+        };
+
+        let response = handle_code_lens(
+            &params,
+            &text,
+            &parse_result,
+            ledger_directives.as_deref(),
+            self.position_encoding,
+        );
 
         serde_json::to_value(response).map_err(|e| e.to_string())
     }

--- a/scripts/lsp-cancel-race-repro.sh
+++ b/scripts/lsp-cancel-race-repro.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Ad-hoc verification that balance lenses ship fully-resolved on the
+# initial `textDocument/codeLens` response, defeating the nvim resolve-
+# cancellation race that surfaced as issues #1245 and #1253.
+#
+# This script:
+#   1. Builds rledger-lsp (release-equivalent debug for speed)
+#   2. Pipes a hand-crafted LSP initialize + didOpen + codeLens session
+#      to its stdin
+#   3. Sends a `$/cancelRequest` for the codeLens request id, mirroring
+#      the nvim client behavior visible in #1253's LSP log
+#   4. Parses the responses and exits non-zero unless:
+#        - the codeLens response carries a balance lens with a final ✓ or ⚠
+#          title (no "(checking…)" placeholder, no command:None)
+#        - the lens has no `data` payload (no resolve round-trip required)
+#
+# A full Rust integration harness is the right next step (see the
+# discussion on #1253); this script is the smaller, faster check that
+# can run from a developer's shell and from CI as a one-off.
+#
+# Usage: bash scripts/lsp-cancel-race-repro.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+echo ">> Building rledger-lsp..."
+cargo build --quiet -p rustledger-lsp --bin rledger-lsp
+
+BIN="$ROOT/target/debug/rledger-lsp"
+[[ -x "$BIN" ]] || {
+    echo "ERROR: rledger-lsp binary not found at $BIN" >&2
+    exit 1
+}
+
+# The exact reproduction from issue #1253. The balance assertion is valid:
+# the 02-01 transaction posts 1000 USD, so the 02-02 balance check passes.
+FIXTURE='2012-01-01 open Assets:Bank
+2012-01-01 open Income:Employment
+
+2012-02-01 * "Salary"
+  Assets:Bank                   1000 USD
+  Income:Employment
+
+2012-02-02 balance Assets:Bank  1000 USD
+'
+
+# Helper: emit an LSP message with the proper `Content-Length` header.
+emit() {
+    local body="$1"
+    printf 'Content-Length: %d\r\n\r\n%s' "${#body}" "$body"
+}
+
+# Build the message stream:
+#   1. initialize
+#   2. initialized notification
+#   3. textDocument/didOpen
+#   4. textDocument/codeLens (id 100)
+#   5. $/cancelRequest for id 100 (the nvim race we want to defeat)
+#   6. shutdown
+#   7. exit notification
+#
+# The escaped-newline-laden didOpen payload is required because the LSP
+# JSON wants the full source as a single string literal.
+DIDOPEN_TEXT=${FIXTURE//$'\n'/\\n}
+DIDOPEN_TEXT=${DIDOPEN_TEXT//\"/\\\"}
+
+REQUESTS=""
+REQUESTS+=$(emit '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}')
+REQUESTS+=$(emit '{"jsonrpc":"2.0","method":"initialized","params":{}}')
+REQUESTS+=$(emit "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file:///repro.beancount\",\"languageId\":\"beancount\",\"version\":1,\"text\":\"${DIDOPEN_TEXT}\"}}}")
+REQUESTS+=$(emit '{"jsonrpc":"2.0","id":100,"method":"textDocument/codeLens","params":{"textDocument":{"uri":"file:///repro.beancount"}}}')
+REQUESTS+=$(emit '{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":100}}')
+REQUESTS+=$(emit '{"jsonrpc":"2.0","id":999,"method":"shutdown"}')
+REQUESTS+=$(emit '{"jsonrpc":"2.0","method":"exit"}')
+
+# Run the session. The server may respond to the codeLens request even
+# after the cancel arrives (the race we are explicitly checking is OK on
+# our side: we ship resolved on the initial response, no round-trip).
+echo ">> Driving rledger-lsp..."
+RESPONSE=$(printf '%s' "$REQUESTS" | "$BIN" 2>/dev/null || true)
+
+# The codeLens response is one of the JSON messages in the framed
+# stream. Extract the body of the id=100 response and inspect it.
+# We use python because portable shell JSON parsing is misery.
+RESULT=$(printf '%s' "$RESPONSE" | python3 -c '
+import sys, json, re
+
+raw = sys.stdin.buffer.read()
+# Framed messages: "Content-Length: N\r\n\r\n<N bytes of JSON>"
+i = 0
+codelens_response = None
+while i < len(raw):
+    m = re.match(rb"Content-Length: (\d+)\r\n\r\n", raw[i:])
+    if not m:
+        i += 1
+        continue
+    n = int(m.group(1))
+    body_start = i + m.end()
+    body = raw[body_start:body_start + n]
+    i = body_start + n
+    try:
+        msg = json.loads(body)
+    except Exception:
+        continue
+    if msg.get("id") == 100 and "result" in msg:
+        codelens_response = msg
+        break
+
+if codelens_response is None:
+    print("FAIL: no codeLens response with id 100 (server dropped the request?)")
+    sys.exit(1)
+
+lenses = codelens_response["result"] or []
+balance_lens = next(
+    (l for l in lenses if (l.get("command") or {}).get("title", "").startswith("Balance:")
+                       or (l.get("command") or {}).get("title", "").startswith(("✓", "⚠"))),
+    None,
+)
+
+if balance_lens is None:
+    print(f"FAIL: no balance lens in response. lenses = {lenses}")
+    sys.exit(1)
+
+cmd = balance_lens.get("command") or {}
+title = cmd.get("title", "")
+data = balance_lens.get("data")
+
+if "(checking" in title:
+    print(f"FAIL (issue #1253 regression): balance lens shipped with the `(checking)` placeholder. title = {title!r}")
+    sys.exit(1)
+if "✓" not in title and "⚠" not in title:
+    print(f"FAIL: balance lens did not ship with a ✓ or ⚠ status marker. title = {title!r}")
+    sys.exit(1)
+if data is not None:
+    print(f"FAIL: balance lens carries a resolve-data payload, exposing it to the resolve race. data = {data!r}")
+    sys.exit(1)
+
+print(f"OK: balance lens shipped fully-resolved. title = {title!r}")
+') || {
+    echo "$RESULT" >&2
+    exit 1
+}
+
+echo "$RESULT"


### PR DESCRIPTION
## Summary

Closes #1253, supersedes #1249. Eagerly resolves balance code lenses so the `(checking…)` placeholder is unreachable and nvim's resolve-cancellation race becomes a non-issue.

### Root cause

Issue #1253's symptom (`Balance: 1000 USD (checking…)` stuck forever) is the same race I diagnosed for #1245: nvim's built-in LSP client races `codeLens/resolve` responses against `$/cancelRequest` notifications. When the race fires (visible in the user's LSP log as `"Cannot find request with id N whilst attempting to cancel"`), the resolve response is discarded silently and the lens stays on whatever placeholder shipped with the initial response. #1249 only changed which placeholder string the user got stuck on; the race itself was still observable.

### Fix

Skip the resolve round-trip entirely for balance lenses. They ship with their final `✓ Balance: ...` (passing) or `⚠ Balance: ... (see diagnostic)` (failing) title on the initial `textDocument/codeLens` response.

### What changes

- **`handle_code_lens` now ships balance lenses fully-resolved.** Books the directive list ONCE per codeLens request (replaces the M-times-rebooking pattern in resolve), then looks up each balance assertion against the booked inventory at its date. Cost goes from `O(M × N)` to `O(N + M)` per request.
- **No `data` payload on balance lenses.** Without it, no client will ever send `codeLens/resolve` for them, so no race window exists.
- **`handle_code_lens` gains `ledger_directives` parameter** mirroring the resolve dispatcher's snapshot pattern. Issue #470's multi-file balance behavior moves to the eager path uniformly.
- **`calculate_balance_at_date` split into `book_directives_once` + `balance_at_date_from_booked`.** Amortizes booking across all balance assertions in a single request.
- **`handle_code_lens_resolve` simplified to a defensive fallback.** No lens kind ships with `command: None` today; the fallback only fires if a future contributor adds a resolve-using lens kind.
- **`main_loop::handle_code_lens_request`** snapshots `ledger_directives` before calling `handle_code_lens`.

### Tests rewritten

Removed four obsolete `test_code_lens_resolve_*` tests (they tested the per-resolve booking path that no longer exists).

Added/updated:
- `test_code_lens_balance_match_ships_resolved` - pins the `✓` invariant on initial response.
- `test_code_lens_balance_mismatch_ships_resolved` - pins the `(see diagnostic)` callout.
- `test_code_lens_balance_with_auto_filled_posting` - auto-fill coverage preserved in the eager path.
- `test_code_lens_balance_uses_full_ledger_in_multi_file_mode` - issue #470 coverage moved to the eager path.
- `test_code_lens_resolve_fallback_for_command_none_lens` - defensive resolve fallback.
- `issue_1253_balance_lens_ships_eagerly_resolved` - regression on the user's exact reproduction.

### New ad-hoc verification script

`scripts/lsp-cancel-race-repro.sh` builds rledger-lsp, pipes a hand-crafted LSP session to its stdin (initialize + didOpen + codeLens id=100 + `$/cancelRequest`(100) + shutdown + exit), parses the framed responses, and exits non-zero if the balance lens shipped with `(checking)` in its title or with a non-null `data` payload. Verified via mutation (mutating the title format to the `(checking)` placeholder makes the script fail; reverting restores the OK exit).

This is the **smaller alternative** from the design discussion: not a full Rust integration harness, but a reproducible, CI-runnable check of this specific bug. The full harness is a follow-up PR.

## How to test

- `cargo test -p rustledger-lsp --all-features` - 191 + 0 + 6 + 0 passed, 0 failed
- `bash scripts/lsp-cancel-race-repro.sh` - `OK: balance lens shipped fully-resolved. title = '✓ Balance: 1000 USD'`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p rustledger-lsp --no-deps --all-features` - clean

## Test plan

- [x] All LSP tests pass
- [x] cancel-race-repro.sh succeeds against post-fix; verified to fail against the pre-fix placeholder via mutation
- [x] Clippy, fmt, rustdoc all clean
- [x] No regression to non-balance code lenses (Open / Transaction / import lenses unchanged)

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
