### PR TITLE
fix(lsp): balance lens reads validator's verdict instead of re-deriving (closes #1264)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -36,12 +36,14 @@
 //! resolution.
 
 use lsp_types::{
-    CodeLens, CodeLensParams, Command, Diagnostic, DiagnosticSeverity, Position, Range,
+    CodeLens, CodeLensParams, Command, Diagnostic, DiagnosticSeverity, NumberOrString, Position,
+    Range,
 };
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
+use super::diagnostics::validation_would_run;
 use super::utils::{LineIndex, PositionEncoding};
 
 /// Handle a code lens request.
@@ -56,6 +58,13 @@ use super::utils::{LineIndex, PositionEncoding};
 /// between server initialization and the first `publish_diagnostics`
 /// call). The balance lens then renders neutrally — never claiming a
 /// verdict the lens cannot back up.
+///
+/// The balance lens ALSO renders neutrally when validation would have
+/// been skipped for this buffer (parse errors elsewhere in the file,
+/// or `source.len() > MAX_VALIDATION_FILE_SIZE`). Without this, the
+/// diagnostic cache reads `Some(&[])` and the lens would render `✓`
+/// for assertions the validator never evaluated — the inverse-symmetric
+/// failure of #1264.
 pub fn handle_code_lens(
     params: &CodeLensParams,
     source: &str,
@@ -66,6 +75,15 @@ pub fn handle_code_lens(
     let line_index = LineIndex::new(source, encoding);
     let mut lenses = Vec::new();
     let uri = params.text_document.uri.as_str();
+    // Even with a populated cache, the validator may have declined to
+    // run (large file, or parse errors elsewhere). Treat that as cold-
+    // start for the lens: the cache is `Some(&[])` not because the
+    // assertion holds but because no balance verdict was computed.
+    let verdict_diagnostics = if validation_would_run(source, parse_result) {
+        cached_diagnostics
+    } else {
+        None
+    };
 
     // Collect account usage statistics
     let account_stats = collect_account_stats(parse_result);
@@ -147,7 +165,7 @@ pub fn handle_code_lens(
                     bal.amount.number,
                     bal.amount.currency.as_ref(),
                     line,
-                    cached_diagnostics,
+                    verdict_diagnostics,
                 );
                 lenses.push(CodeLens {
                     range: Range {
@@ -184,20 +202,42 @@ pub fn handle_code_lens(
     }
 }
 
+/// Error codes the lens treats as a balance-arithmetic failure on a
+/// balance directive's line:
+///
+/// - `E2001`: balance assertion failed (asserted amount != actual)
+/// - `E2002`: balance exceeds explicit tolerance
+///
+/// Other ERROR diagnostics that may also land on a balance directive's
+/// line — `E1001 AccountNotOpen`, parse errors, plugin errors patched
+/// onto the balance span — describe a different problem. Showing
+/// `⚠ Balance: X USD (see diagnostic)` for those misattributes the
+/// failure category: the user clicks the lens expecting a balance
+/// arithmetic explanation and finds something unrelated. The lens
+/// renders neutrally for those instead, letting the diagnostic itself
+/// speak.
+const BALANCE_ERROR_CODES: &[&str] = &["E2001", "E2002"];
+
 /// Render the balance lens title for a balance directive on `line`.
 ///
 /// `cached_diagnostics` is the validator's last-computed verdict for
-/// this URI:
+/// this URI (after [`validation_would_run`] confirmed the validator
+/// actually ran):
 ///
-/// - `None`: the validator hasn't run yet for this file (cold start).
-///   Render neutrally — `Balance: X USD` with no ✓/⚠ symbol. Never
-///   claim a verdict we can't back up.
-/// - `Some(diags)` with no error overlapping `line`: validator says the
-///   assertion holds. Render `✓ Balance: X USD`.
-/// - `Some(diags)` with an error overlapping `line`: validator already
-///   surfaced the failure. Render `⚠ Balance: X USD (see diagnostic)` —
-///   "see diagnostic" is a true link because the diagnostic exists by
-///   construction.
+/// - `None`: the validator hasn't run yet for this file (cold start)
+///   OR validation was skipped (parse errors, file too large). Render
+///   neutrally — `Balance: X USD` with no ✓/⚠ symbol. Never claim a
+///   verdict we can't back up.
+/// - `Some(diags)` with a `BALANCE_ERROR_CODES` entry at `line`: the
+///   validator emitted a real balance-arithmetic failure. Render
+///   `⚠ Balance: X USD (see diagnostic)` — "see diagnostic" is a true
+///   link by construction.
+/// - `Some(diags)` with some OTHER ERROR at `line` (e.g., `E1001`
+///   AccountNotOpen) but NO `BALANCE_ERROR_CODES`: a non-balance
+///   diagnostic happens to anchor here. Render neutrally; don't
+///   misattribute it as a balance failure.
+/// - `Some(diags)` with no ERROR at all at `line`: the validator
+///   says the assertion holds. Render `✓ Balance: X USD`.
 fn balance_lens_title(
     amount: rustledger_core::Decimal,
     currency: &str,
@@ -205,31 +245,49 @@ fn balance_lens_title(
     cached_diagnostics: Option<&[Diagnostic]>,
 ) -> String {
     let amount_str = format!("Balance: {amount} {currency}");
-    match cached_diagnostics {
-        None => amount_str,
-        Some(diags) => {
-            if has_error_at_line(diags, line) {
-                format!("⚠ {amount_str} (see diagnostic)")
-            } else {
-                format!("✓ {amount_str}")
-            }
-        }
+    let Some(diags) = cached_diagnostics else {
+        return amount_str;
+    };
+    if has_balance_error_at_line(diags, line) {
+        format!("⚠ {amount_str} (see diagnostic)")
+    } else if has_non_balance_error_at_line(diags, line) {
+        // A diagnostic at this line is about something else; let it
+        // surface independently. Don't claim ✓ (the assertion's
+        // verdict is uncertain in the presence of an account/parse
+        // error here) and don't claim ⚠ (the asserted arithmetic
+        // isn't what failed).
+        amount_str
+    } else {
+        format!("✓ {amount_str}")
     }
 }
 
-/// Does the diagnostic slice contain an ERROR-severity entry whose
-/// range starts on `line`?
-///
-/// The validator emits balance-assertion failures with their range
-/// anchored on the balance directive's line. Match on
-/// `range.start.line` only (not full Range overlap) so a multi-line
-/// diagnostic at this line still matches. Severity filter on `ERROR`
-/// excludes Hint / Information entries (e.g., code-action suggestions)
-/// that would otherwise mark a clean assertion as ⚠.
-fn has_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
-    diagnostics
-        .iter()
-        .any(|d| d.range.start.line == line && d.severity == Some(DiagnosticSeverity::ERROR))
+/// Does the diagnostic slice contain an ERROR with one of the
+/// balance-arithmetic error codes anchored at `line.start`?
+fn has_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
+    diagnostics.iter().any(|d| {
+        d.range.start.line == line
+            && d.severity == Some(DiagnosticSeverity::ERROR)
+            && is_balance_error_code(d.code.as_ref())
+    })
+}
+
+/// Does the diagnostic slice contain an ERROR at `line.start` whose
+/// code is NOT one of the balance-arithmetic codes? (Used to decide
+/// whether to render neutrally instead of ✓.)
+fn has_non_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
+    diagnostics.iter().any(|d| {
+        d.range.start.line == line
+            && d.severity == Some(DiagnosticSeverity::ERROR)
+            && !is_balance_error_code(d.code.as_ref())
+    })
+}
+
+fn is_balance_error_code(code: Option<&NumberOrString>) -> bool {
+    match code {
+        Some(NumberOrString::String(s)) => BALANCE_ERROR_CODES.contains(&s.as_str()),
+        _ => false,
+    }
 }
 
 /// Handle a `codeLens/resolve` request.
@@ -306,25 +364,31 @@ mod tests {
             .expect("balance lens emitted")
     }
 
-    /// Synthetic ERROR diagnostic at the given zero-based line. Mirrors
-    /// what `all_diagnostics` produces for a failed balance assertion;
-    /// the lens treats anything matching this shape as the validator
-    /// saying "this balance is wrong."
-    fn error_at_line(line: u32) -> Diagnostic {
+    /// Synthetic ERROR diagnostic at the given zero-based line with
+    /// the given LSP error code. Source string matches what the
+    /// validator emits in production (`"rustledger"`, see
+    /// `diagnostics.rs:145`) so any future filter on `source` would
+    /// behave the same in tests and production.
+    fn error_with_code_at_line(code: &str, line: u32) -> Diagnostic {
         Diagnostic {
             range: Range {
                 start: Position::new(line, 0),
                 end: Position::new(line, 80),
             },
             severity: Some(DiagnosticSeverity::ERROR),
-            code: Some(NumberOrString::String("E2001".into())),
+            code: Some(NumberOrString::String(code.into())),
             code_description: None,
-            source: Some("rledger".into()),
-            message: "Balance assertion failed".into(),
+            source: Some("rustledger".into()),
+            message: format!("{code} test diagnostic"),
             related_information: None,
             tags: None,
             data: None,
         }
+    }
+
+    /// Default-case: a balance-assertion-failed diagnostic at `line`.
+    fn error_at_line(line: u32) -> Diagnostic {
+        error_with_code_at_line("E2001", line)
     }
 
     #[test]
@@ -525,6 +589,90 @@ mod tests {
              the structural property that fixes #1264's effective_date \
              false positive: the validator runs plugins, the lens \
              trusts the validator. got {:?}",
+            cmd.title
+        );
+    }
+
+    /// When the buffer has parse errors elsewhere, `all_diagnostics`
+    /// (diagnostics.rs:554) skips validation entirely; the cache for
+    /// the URI then contains only parse-error diagnostics — none of
+    /// which sit at the balance line. The lens MUST render neutrally
+    /// in this case, not ✓: the validator did not evaluate the
+    /// assertion. This is the inverse-symmetric failure of the #1264
+    /// dead-link UX (silent ✓ instead of silent ⚠) — both come from
+    /// the lens asserting verdicts it cannot back up.
+    #[test]
+    fn balance_lens_neutral_when_parse_errors_skip_validation() {
+        // First non-comment line is a syntax error (stray garbage),
+        // forcing parse_result.errors to be non-empty.
+        let source = r#"!!! syntax garbage on line 0
+2024-01-01 open Assets:Bank USD
+2024-01-31 balance Assets:Bank 100.00 USD
+"#;
+        let result = parse(source);
+        assert!(
+            !result.errors.is_empty(),
+            "test setup: source must produce a parse error to exercise \
+             the validation-skip branch. got errors = {:?}",
+            result.errors,
+        );
+        let params = code_lens_params();
+
+        // Diagnostic cache populated and contains nothing at the
+        // balance line. Pre-fix the lens would have read this as
+        // "validator approved" and rendered ✓.
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, Some(&[]), PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            !cmd.title.contains('✓') && !cmd.title.contains('⚠'),
+            "parse-error skip path: lens must not claim a verdict the \
+             validator never computed. got {:?}",
+            cmd.title
+        );
+        assert!(cmd.title.starts_with("Balance:"));
+    }
+
+    /// A non-balance ERROR diagnostic at the balance directive's line
+    /// (e.g., `E1001 AccountNotOpen`) must NOT render as
+    /// `⚠ Balance: X USD (see diagnostic)`. The user clicking that
+    /// lens would expect a balance-arithmetic explanation and instead
+    /// see something unrelated. The lens renders neutrally; the
+    /// non-balance diagnostic surfaces independently with its own
+    /// (correct) message.
+    #[test]
+    fn balance_lens_neutral_on_non_balance_error_at_line() {
+        let source = r#"2024-01-31 balance Assets:NeverOpened 0 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        // E1001 (account never opened) at the balance directive's line.
+        let diags = vec![error_with_code_at_line("E1001", 0)];
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&diags),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            !cmd.title.contains('⚠') && !cmd.title.contains("see diagnostic"),
+            "non-balance error (E1001) at the balance line must not \
+             render as a balance arithmetic failure. got {:?}",
+            cmd.title
+        );
+        assert!(
+            !cmd.title.contains('✓'),
+            "lens must not claim ✓ when an unrelated error blankets \
+             the assertion's line — the assertion's status is uncertain. \
+             got {:?}",
             cmd.title
         );
     }

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -3,55 +3,64 @@
 //! Provides code lenses above:
 //! - Account open directives (showing transaction count)
 //! - Transactions (showing posting count and currencies)
-//! - Balance assertions (with verification status)
+//! - Balance assertions (with verification status, sourced from the
+//!   validator's already-computed diagnostic for the same file).
 //!
-//! # Eager resolution
+//! # Verdict source: the validator's diagnostic cache
 //!
-//! Balance lenses are computed eagerly inside [`handle_code_lens`].
-//! Pre-#1253, balance lenses shipped with `command: None` plus a `data`
-//! payload that [`handle_code_lens_resolve`] consulted on a subsequent
-//! `codeLens/resolve` round-trip. That deferred-resolve pattern was
-//! standard LSP, but it exposed the lens to a known race in nvim's
-//! built-in LSP client: when the resolve response races with a
-//! cancellation (visible in the user's LSP log as
-//! `"Cannot find request with id N whilst attempting to cancel"`),
-//! the response is silently discarded and the lens stays on whatever
-//! placeholder shipped with the initial response. #1245 surfaced this
-//! as `"Unresolved lens"`; #1249 mitigated by introducing a
-//! `"Balance: X USD (checking…)"` placeholder, but the stuck-checking
-//! symptom (#1253) showed the race was still observable. The right
-//! fix is to skip the resolve round-trip entirely: ship the final
-//! `✓` or `⚠` title on the initial response.
+//! Pre-#1264 the balance lens ran its own evaluator —
+//! `parse → sort → book` over the parse result, without applying
+//! plugins. That second pipeline silently disagreed with `rledger check`
+//! on every ledger that relied on plugin output (`effective_date`,
+//! `lazy_balance`, any user plugin that rewrites postings post-booking).
+//! The dead-link UX was the symptom: `⚠ ... (see diagnostic)` while no
+//! diagnostic existed because the validator (running the full pipeline)
+//! agreed the assertion held.
 //!
-//! Cost: one booking pass per `textDocument/codeLens` request. M
-//! balance assertions cost O(N + M) total (book once, iterate M
-//! times) instead of the previous O(M × N) (book per resolve).
-//! [`handle_code_lens_resolve`] is kept as a defensive fallback for
-//! any future lens kind that genuinely needs deferred resolution.
+//! The fix is structural: stop having a second pipeline. The lens reads
+//! `MainLoopState::diagnostics[uri]`, which `publish_diagnostics`
+//! populates by running the validator over the same full pipeline
+//! `rledger check` uses (synth-plugins → Early → book → regular-plugins
+//! → Late). If the validator emitted an error at a balance directive's
+//! line, the lens shows `⚠`; otherwise `✓`. When the cache hasn't been
+//! populated yet (cold start before the first `publish_diagnostics`),
+//! the lens shows a neutral `Balance: X USD` rather than lying.
+//!
+//! # Eager resolution (preserved from #1253)
+//!
+//! Lenses still ship with `command: Some(...)` and `data: None` on the
+//! initial `textDocument/codeLens` response. No `codeLens/resolve`
+//! round-trip, so no exposure to nvim's resolve-cancellation race
+//! (#1245 / #1253). [`handle_code_lens_resolve`] remains as a defensive
+//! fallback for any future lens kind that genuinely needs deferred
+//! resolution.
 
-use lsp_types::{CodeLens, CodeLensParams, Command, Position, Range};
-use rustledger_booking::BookingEngine;
-use rustledger_core::{BookingMethod, Decimal, Directive, NaiveDate, is_subaccount_or_equal};
-use rustledger_loader::Options as LoaderOptions;
-use rustledger_parser::{ParseResult, Spanned};
-use rustledger_validate::balance_tolerance;
+use lsp_types::{
+    CodeLens, CodeLensParams, Command, Diagnostic, DiagnosticSeverity, Position, Range,
+};
+use rustledger_core::Directive;
+use rustledger_parser::ParseResult;
 use std::collections::HashMap;
 
 use super::utils::{LineIndex, PositionEncoding};
 
 /// Handle a code lens request.
 ///
-/// `ledger_directives` is the full multi-file ledger snapshot (taken
-/// on the main loop while locks are cheap). When provided, balance
-/// assertions are validated against the full ledger; when `None`, the
-/// validator falls back to the current file's parse result. This is
-/// the same multi-file behavior the pre-#1253 resolve path supported
-/// (issue #470).
+/// `cached_diagnostics` is the validator's last-computed diagnostic
+/// vector for this URI (held in `MainLoopState::diagnostics`). It
+/// reflects the full-pipeline verdict the user would see from
+/// `rledger check`. The lens consults it instead of running a parallel
+/// evaluator.
+///
+/// `None` means the validator hasn't run for this file yet (cold start
+/// between server initialization and the first `publish_diagnostics`
+/// call). The balance lens then renders neutrally — never claiming a
+/// verdict the lens cannot back up.
 pub fn handle_code_lens(
     params: &CodeLensParams,
     source: &str,
     parse_result: &ParseResult,
-    ledger_directives: Option<&[Spanned<Directive>]>,
+    cached_diagnostics: Option<&[Diagnostic]>,
     encoding: PositionEncoding,
 ) -> Option<Vec<CodeLens>> {
     let line_index = LineIndex::new(source, encoding);
@@ -60,65 +69,6 @@ pub fn handle_code_lens(
 
     // Collect account usage statistics
     let account_stats = collect_account_stats(parse_result);
-
-    // Book the directives ONCE. The booked result feeds every balance
-    // lens lookup in this request (booking is O(N), each lookup is
-    // O(N), total O(N + M*N) for M assertions; pre-#1253 each resolve
-    // re-booked, so the same total but per-lens latency dropped).
-    // `None` ledger_directives falls back to the current file's
-    // parse_result, matching the resolve path's behavior in
-    // single-file mode.
-    //
-    // Fast path: skip booking entirely when the file has no balance
-    // directives. Open/transaction lenses don't read `booked_directives`,
-    // so for the common-case file (zero balance assertions) we save
-    // an O(N) booking pass on every codeLens request. The caller in
-    // `main_loop.rs` does the same pre-scan to skip cloning the full
-    // ledger directives vector under the read lock.
-    let has_balance = parse_result
-        .directives
-        .iter()
-        .any(|s| matches!(s.value, Directive::Balance(_)));
-
-    // Build an `Options` from the file's raw `option` directives so
-    // we read `booking_method`, `tolerance_multiplier`, and
-    // `inferred_tolerance_multiplier` via the same parser the loader
-    // uses. Without this the lens hard-codes the workspace defaults
-    // and disagrees with the validator on any file that overrides
-    // them. We don't run the full loader pipeline here (no plugins,
-    // no validation), only its option-string-to-typed-field parse.
-    let loader_options = build_loader_options(parse_result);
-    let booking_method = loader_options
-        .booking_method
-        .parse()
-        .unwrap_or(BookingMethod::Strict);
-    let tolerance_multiplier = loader_options.inferred_tolerance_multiplier;
-
-    // In multi-file mode (`ledger_directives` is Some), the snapshot
-    // already went through the loader's full pipeline (synth-plugins,
-    // booking, regular plugins) — see `LedgerState::load`. Re-booking
-    // it would be wasted work at best, and could disagree with the
-    // loader on edge cases (a different default booking method, a
-    // plugin that ran after booking). Use the snapshot as-is.
-    //
-    // In single-file mode the lens approximates: parse → sort → book
-    // with the file's `option "booking_method"`. We deliberately do
-    // NOT run synth-plugins (auto_accounts, document_discovery,
-    // user plugins) here because they require a `SourceMap` +
-    // `LoadOptions` we don't have, AND because running them on every
-    // keystroke would dominate codeLens latency. Consequence: in
-    // single-file mode the lens can disagree with `rledger check`
-    // on ledgers that rely on plugin-synthesized directives. The
-    // validator remains the source of truth; the lens is a fast
-    // local approximation. This limitation is documented in
-    // `docs/development/lsp-support.md`.
-    let booked_directives: Vec<Spanned<Directive>> = if !has_balance {
-        Vec::new()
-    } else if let Some(snapshot) = ledger_directives {
-        snapshot.to_vec()
-    } else {
-        book_directives_once(&parse_result.directives, booking_method)
-    };
 
     for spanned in &parse_result.directives {
         let (line, _) = line_index.offset_to_position(spanned.span.start);
@@ -191,63 +141,28 @@ pub fn handle_code_lens(
                 });
             }
             Directive::Balance(bal) => {
-                // Eagerly verify the assertion against the booked
-                // directives. No data payload + no resolve round-trip
-                // means no exposure to nvim's resolve-cancellation
-                // race (issues #1245 / #1253); the user sees the
-                // final ✓ or ⚠ title on the initial response.
-                let actual_amount =
-                    balance_at_date_from_booked(&booked_directives, &bal.account, Some(bal.date))
-                        .get(bal.amount.currency.as_ref())
-                        .copied()
-                        .unwrap_or_default();
-
-                // Match the validator's tolerance comparison
-                // (validators/balance.rs:222-247). Strict equality
-                // here would emit a ⚠ for an amount the validator
-                // accepts (e.g. 99.999 vs 100.00 USD at the default
-                // ±0.005 tolerance), which would point the user at a
-                // diagnostic that doesn't exist — the same dead-link
-                // UX #1253 set out to prevent.
-                let tolerance =
-                    balance_tolerance(bal.amount.number, bal.tolerance, tolerance_multiplier);
-                let difference = (actual_amount - bal.amount.number).abs();
-
-                let command = if difference <= tolerance {
-                    // Passing assertion: informational title, no
-                    // click action. Uses `rledger.noop` (matching the
-                    // failing branch below and the pre-eager path) so
-                    // strict clients that filter on advertised
-                    // commands don't dead-link the lens. A future
-                    // "show balance details" command can be added
-                    // here once its handler is registered in
-                    // `execute_command::COMMANDS`.
-                    Command {
-                        title: format!("✓ Balance: {} {}", bal.amount.number, bal.amount.currency),
-                        command: "rledger.noop".to_string(),
-                        arguments: None,
-                    }
-                } else {
-                    // Failing assertions: the real error is surfaced
-                    // via diagnostics (issue #491). The lens title
-                    // points the user at the diagnostic rather than
-                    // duplicating its content.
-                    Command {
-                        title: format!(
-                            "⚠ Balance: {} {} (see diagnostic)",
-                            bal.amount.number, bal.amount.currency
-                        ),
-                        command: "rledger.noop".to_string(),
-                        arguments: None,
-                    }
-                };
-
+                // Consult the validator's cached verdict; never re-derive.
+                // See module rustdoc.
+                let title = balance_lens_title(
+                    bal.amount.number,
+                    bal.amount.currency.as_ref(),
+                    line,
+                    cached_diagnostics,
+                );
                 lenses.push(CodeLens {
                     range: Range {
                         start: Position::new(line, 0),
                         end: Position::new(line, 0),
                     },
-                    command: Some(command),
+                    command: Some(Command {
+                        title,
+                        command: "rledger.noop".to_string(),
+                        arguments: None,
+                    }),
+                    // No data payload: the lens ships fully-resolved on
+                    // the initial response. Preserves the #1253 invariant
+                    // that there is no resolve round-trip nvim could
+                    // race against cancellation.
                     data: None,
                 });
             }
@@ -267,6 +182,54 @@ pub fn handle_code_lens(
     } else {
         Some(lenses)
     }
+}
+
+/// Render the balance lens title for a balance directive on `line`.
+///
+/// `cached_diagnostics` is the validator's last-computed verdict for
+/// this URI:
+///
+/// - `None`: the validator hasn't run yet for this file (cold start).
+///   Render neutrally — `Balance: X USD` with no ✓/⚠ symbol. Never
+///   claim a verdict we can't back up.
+/// - `Some(diags)` with no error overlapping `line`: validator says the
+///   assertion holds. Render `✓ Balance: X USD`.
+/// - `Some(diags)` with an error overlapping `line`: validator already
+///   surfaced the failure. Render `⚠ Balance: X USD (see diagnostic)` —
+///   "see diagnostic" is a true link because the diagnostic exists by
+///   construction.
+fn balance_lens_title(
+    amount: rustledger_core::Decimal,
+    currency: &str,
+    line: u32,
+    cached_diagnostics: Option<&[Diagnostic]>,
+) -> String {
+    let amount_str = format!("Balance: {amount} {currency}");
+    match cached_diagnostics {
+        None => amount_str,
+        Some(diags) => {
+            if has_error_at_line(diags, line) {
+                format!("⚠ {amount_str} (see diagnostic)")
+            } else {
+                format!("✓ {amount_str}")
+            }
+        }
+    }
+}
+
+/// Does the diagnostic slice contain an ERROR-severity entry whose
+/// range starts on `line`?
+///
+/// The validator emits balance-assertion failures with their range
+/// anchored on the balance directive's line. Match on
+/// `range.start.line` only (not full Range overlap) so a multi-line
+/// diagnostic at this line still matches. Severity filter on `ERROR`
+/// excludes Hint / Information entries (e.g., code-action suggestions)
+/// that would otherwise mark a clean assertion as ⚠.
+fn has_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
+    diagnostics
+        .iter()
+        .any(|d| d.range.start.line == line && d.severity == Some(DiagnosticSeverity::ERROR))
 }
 
 /// Handle a `codeLens/resolve` request.
@@ -294,142 +257,6 @@ pub fn handle_code_lens_resolve(lens: CodeLens) -> CodeLens {
     resolved
 }
 
-/// Sort + book a directive list once, returning the full directive
-/// list in chronological order with each transaction booked and
-/// interpolated in place.
-///
-/// Non-transaction directives pass through unchanged. The returned
-/// vector is suitable for any number of subsequent
-/// [`balance_at_date_from_booked`] lookups, which is how
-/// [`handle_code_lens`] amortizes booking cost across all balance
-/// lenses in a file (O(N) booking + O(M) lookups, vs O(M*N) for the
-/// pre-#1253 per-resolve approach).
-///
-/// Booking matches the validator's behavior; without it, auto-filled
-/// postings (Income:Salary with no explicit amount, etc.) wouldn't
-/// be counted toward the asserted account's balance.
-///
-/// `default_method` is the workspace default (driven by
-/// `option "booking_method" "..."` if set, else
-/// `BookingMethod::Strict`). Per-account methods declared on `Open`
-/// directives are layered on top by `register_account_methods`, so
-/// the only thing this argument controls is what FIFO/LIFO/AVERAGE
-/// accounts WITHOUT an explicit per-account method use.
-fn book_directives_once(
-    directives_in: &[Spanned<Directive>],
-    default_method: BookingMethod,
-) -> Vec<Spanned<Directive>> {
-    let mut directives: Vec<Spanned<Directive>> = directives_in.to_vec();
-    directives.sort_by_cached_key(|d| {
-        (
-            d.value.date(),
-            d.value.priority(),
-            d.value.has_cost_reduction(),
-        )
-    });
-
-    let mut booking_engine = BookingEngine::with_method(default_method);
-    booking_engine.register_account_methods(directives.iter().map(|s| &s.value));
-    for spanned in &mut directives {
-        if let Directive::Transaction(txn) = &mut spanned.value
-            && let Ok(result) = booking_engine.book_and_interpolate(txn)
-        {
-            booking_engine.apply(&result.transaction);
-            *txn = result.transaction;
-        }
-    }
-
-    directives
-}
-
-/// Options keys the codeLens path needs from
-/// [`LoaderOptions`]. Filtered tightly because:
-/// - `Options::set("documents", v)` calls `Path::new(v).exists()` —
-///   a filesystem syscall on every codeLens request. NFS-mounted
-///   document roots make this user-visible latency.
-/// - Other options (operating_currency, account_*, plugin_*) parse
-///   into FxHashMap inserts the lens never reads.
-///
-/// Only `booking_method`, `tolerance_multiplier`, and the deprecated
-/// alias `inferred_tolerance_multiplier` flow into the lens verdict.
-/// Adding to this list is the deliberate gate when the lens grows a
-/// new option-dependent decision.
-const LENS_OPTION_KEYS: &[&str] = &[
-    "booking_method",
-    "tolerance_multiplier",
-    "inferred_tolerance_multiplier",
-];
-
-/// Build a [`LoaderOptions`] populated only with the keys the lens
-/// needs. The parser exposes `option` entries as raw `(key, value,
-/// span)` tuples; for each entry whose key is in [`LENS_OPTION_KEYS`]
-/// we call [`LoaderOptions::set`], which handles the deprecated
-/// alias mapping and value validation identically to the loader's
-/// own option-parse pass.
-///
-/// The narrow filter prevents `Options::set` side effects we don't
-/// want on the hot path: `path.exists()` for `documents`, deprecation
-/// warnings into `self.warnings`, FxHashMap inserts for unrelated
-/// per-key state. A malformed lens-relevant value still produces a
-/// diagnostic via the regular validation pass; we don't double-report
-/// here.
-fn build_loader_options(parse_result: &ParseResult) -> LoaderOptions {
-    let mut options = LoaderOptions::new();
-    for (key, value, _span) in &parse_result.options {
-        if LENS_OPTION_KEYS.contains(&key.as_str()) {
-            options.set(key, value);
-        }
-    }
-    options
-}
-
-/// Sum postings to `account` from `booked` whose transaction date is
-/// strictly before `date` (the Beancount semantic for balance
-/// assertions: the asserted value is checked at the START of the
-/// asserted day).
-///
-/// Caller is responsible for passing already-[`book_directives_once`]
-/// output. Returns a per-currency map so a multi-currency account can
-/// be validated against the asserted currency without losing the
-/// others.
-fn balance_at_date_from_booked(
-    booked: &[Spanned<Directive>],
-    account: &str,
-    date: Option<NaiveDate>,
-) -> HashMap<String, Decimal> {
-    let mut balances: HashMap<String, Decimal> = HashMap::new();
-    for spanned in booked {
-        if let Directive::Transaction(txn) = &spanned.value {
-            if let Some(d) = date
-                && txn.date >= d
-            {
-                continue;
-            }
-            for posting in &txn.postings {
-                // Beancount semantic: `balance Assets:Bank` includes
-                // postings to `Assets:Bank` AND any sub-account
-                // (`Assets:Bank:Checking`, `Assets:Bank:Savings`, ...).
-                // The validator at
-                // `rustledger-validate::validators::balance::sum_account_and_subaccounts`
-                // does the same prefix-match; the lens used to do
-                // exact-account-match, which silently diverged from the
-                // validator on every ledger with sub-accounts.
-                let posting_account = posting.account.as_ref();
-                if !is_subaccount_or_equal(posting_account, account) {
-                    continue;
-                }
-                if let Some(units) = &posting.units
-                    && let Some(number) = units.number()
-                {
-                    let currency = units.currency().unwrap_or("???").to_string();
-                    *balances.entry(currency).or_default() += number;
-                }
-            }
-        }
-    }
-    balances
-}
-
 /// Statistics for an account.
 #[derive(Default)]
 struct AccountStats {
@@ -455,490 +282,8 @@ fn collect_account_stats(parse_result: &ParseResult) -> HashMap<String, AccountS
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lsp_types::{DiagnosticSeverity, NumberOrString};
     use rustledger_parser::parse;
-
-    /// Drift guard for [`LENS_OPTION_KEYS`]: every key the lens reads
-    /// from the resulting `LoaderOptions` must be in the allowlist,
-    /// and exercising each key end-to-end must produce a field
-    /// change the lens actually consumes. If a future contributor
-    /// adds a lens-relevant option to `LoaderOptions` without
-    /// updating `LENS_OPTION_KEYS`, this test fails: their option
-    /// won't appear in the filter list AND the build_loader_options
-    /// output won't carry the value through.
-    ///
-    /// The verification approach: for each documented key, build a
-    /// source string that sets the option, parse it, and verify the
-    /// helper produces the expected typed value. New lens-relevant
-    /// options must be added here AND to `LENS_OPTION_KEYS`.
-    #[test]
-    fn lens_option_keys_are_threaded_end_to_end() {
-        // booking_method: file-level override flows through.
-        let result = parse("option \"booking_method\" \"AVERAGE\"\n");
-        let opts = build_loader_options(&result);
-        assert_eq!(
-            opts.booking_method, "AVERAGE",
-            "booking_method must thread through; key missing from \
-             LENS_OPTION_KEYS or LoaderOptions::set wiring drifted"
-        );
-
-        // tolerance_multiplier (canonical name): overrides default.
-        let result = parse("option \"tolerance_multiplier\" \"1.0\"\n");
-        let opts = build_loader_options(&result);
-        assert_eq!(
-            opts.inferred_tolerance_multiplier,
-            Decimal::new(10, 1), // 1.0
-            "tolerance_multiplier must override the 0.5 default"
-        );
-
-        // inferred_tolerance_multiplier (deprecated alias): same field.
-        let result = parse("option \"inferred_tolerance_multiplier\" \"2.0\"\n");
-        let opts = build_loader_options(&result);
-        assert_eq!(
-            opts.inferred_tolerance_multiplier,
-            Decimal::new(20, 1), // 2.0
-            "deprecated alias inferred_tolerance_multiplier must \
-             map to the same field as tolerance_multiplier"
-        );
-
-        // Default (no options): values are what ValidationOptions
-        // sees in the validator path, so the lens and validator
-        // agree on a file with no `option` directives.
-        let result = parse("2024-01-01 open Assets:Bank USD\n");
-        let opts = build_loader_options(&result);
-        assert_eq!(opts.booking_method, "STRICT");
-        assert_eq!(opts.inferred_tolerance_multiplier, Decimal::new(5, 1)); // 0.5
-
-        // Sanity: an unrelated option (e.g., "title") does NOT
-        // flow through. If this assertion ever fails, the filter
-        // has been broken; the lens would start paying for
-        // Options::set's path.exists() on documents, etc.
-        let result = parse("option \"title\" \"My Ledger\"\n");
-        let opts = build_loader_options(&result);
-        assert_eq!(
-            opts.title, None,
-            "title option must NOT be set via build_loader_options; \
-             the filter has drifted and unrelated options are now \
-             on the codeLens hot path"
-        );
-    }
-
-    #[test]
-    fn test_code_lens_accounts() {
-        let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-15 * "Coffee"
-  Assets:Bank  -5.00 USD
-  Expenses:Food
-2024-01-16 * "Lunch"
-  Assets:Bank  -10.00 USD
-  Expenses:Food
-"#;
-        let result = parse(source);
-        let params = CodeLensParams {
-            text_document: lsp_types::TextDocumentIdentifier {
-                uri: "file:///test.beancount".parse().unwrap(),
-            },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
-        };
-
-        let lenses = handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16);
-        assert!(lenses.is_some());
-
-        let lenses = lenses.unwrap();
-        // Should have: 1 open + 2 transactions = 3 lenses
-        assert_eq!(lenses.len(), 3);
-
-        // First lens is for the open directive
-        assert!(
-            lenses[0]
-                .command
-                .as_ref()
-                .unwrap()
-                .title
-                .contains("2 transactions")
-        );
-    }
-
-    #[test]
-    fn test_code_lens_balance_match_ships_resolved() {
-        // Passing assertion: lens ships with `✓ Balance: ... USD` on
-        // the initial textDocument/codeLens response. No data payload,
-        // no resolve round-trip (issue #1253).
-        let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-01 open Income:Salary
-2024-01-15 * "Deposit"
-  Assets:Bank  100.00 USD
-  Income:Salary
-2024-01-31 balance Assets:Bank 100.00 USD
-"#;
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved (issue #1253)");
-        assert!(
-            cmd.title.contains('✓'),
-            "passing assertion should ship with ✓; got {:?}",
-            cmd.title
-        );
-        assert!(cmd.title.contains("100"));
-        assert!(
-            balance_lens.data.is_none(),
-            "eager-resolved balance lens carries no resolve-data payload; \
-             pre-#1253 the data payload triggered a codeLens/resolve \
-             round-trip that nvim's client could race against \
-             cancellation. got data = {:?}",
-            balance_lens.data
-        );
-    }
-
-    #[test]
-    fn test_code_lens_balance_mismatch_ships_resolved() {
-        // Failing assertion: lens ships with the `⚠ ... (see diagnostic)`
-        // callout on the initial response. The actual error lives in
-        // the diagnostic (#491); the lens points at it without
-        // duplicating its content.
-        let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-01 open Income:Salary
-2024-01-15 * "Deposit"
-  Assets:Bank  50.00 USD
-  Income:Salary
-2024-01-31 balance Assets:Bank 100 USD
-"#;
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved");
-        assert!(
-            cmd.title.contains("see diagnostic"),
-            "failing assertion should ship with `(see diagnostic)`; got {:?}",
-            cmd.title
-        );
-        assert_eq!(cmd.command, "rledger.noop");
-    }
-
-    #[test]
-    fn test_code_lens_balance_with_auto_filled_posting() {
-        // Booking runs as part of the eager balance computation, so a
-        // posting elided to be auto-filled (Income:Salary with no
-        // explicit amount) still gets counted. Pre-eager-resolve this
-        // lived in handle_code_lens_resolve; same coverage, new path.
-        let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-01 open Income:Salary USD
-2024-01-15 * "Deposit"
-  Assets:Bank  100.00 USD
-  Income:Salary
-2024-01-31 balance Assets:Bank 100 USD
-"#;
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved");
-        assert!(
-            cmd.title.contains('✓'),
-            "auto-filled posting should book to 100 USD, passing the assertion; got {:?}",
-            cmd.title
-        );
-    }
-
-    /// Regression for the post-#1253 follow-up review: the eager
-    /// balance check must mirror the validator's tolerance logic.
-    /// Pre-fix this used strict `==`; the validator at
-    /// `rustledger-validate/src/validators/balance.rs:222-247` accepts
-    /// `(actual - expected).abs() <= tolerance`. For a 2-decimal
-    /// amount like `100.00 USD`, default tolerance is
-    /// `0.5 * 2 * 0.01 = 0.01`. An actual of `99.999 USD` (off by
-    /// 0.001) is well within tolerance.
-    ///
-    /// If the lens reverted to strict equality, this test would fail:
-    /// the balance would render `⚠ (see diagnostic)` while the
-    /// validator passes silently, reintroducing the dead-link UX
-    /// #1253 originally set out to prevent.
-    #[test]
-    fn balance_lens_honors_validator_tolerance() {
-        // Choose actual amounts that round to slightly off the
-        // asserted value. Three penny-fractional postings of
-        // 33.333 USD sum to 99.999 USD; the assertion expects
-        // 100.00 USD. The validator accepts (under tolerance);
-        // the lens must too.
-        let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-01 open Income:Misc
-2024-01-02 * "A"
-  Assets:Bank  33.333 USD
-  Income:Misc
-2024-01-02 * "B"
-  Assets:Bank  33.333 USD
-  Income:Misc
-2024-01-02 * "C"
-  Assets:Bank  33.333 USD
-  Income:Misc
-2024-01-31 balance Assets:Bank 100.00 USD
-"#;
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved");
-        assert!(
-            cmd.title.contains('✓'),
-            "actual 99.999 USD is within the default ±0.01 tolerance \
-             of asserted 100.00 USD; lens must show ✓ to match the \
-             validator. got {:?}",
-            cmd.title
-        );
-    }
-
-    /// Beancount semantic: `balance Assets:Bank` includes postings
-    /// to sub-accounts (`Assets:Bank:Checking`, etc.). The validator
-    /// at `sum_account_and_subaccounts` does this prefix match;
-    /// pre-fix the lens did exact-account-match only, silently
-    /// diverging on every ledger with sub-accounts.
-    #[test]
-    fn balance_lens_includes_subaccount_postings() {
-        let source = r#"2024-01-01 open Assets:Bank:Checking USD
-2024-01-01 open Income:Misc
-2024-01-15 * "Salary"
-  Assets:Bank:Checking  1000 USD
-  Income:Misc
-2024-01-31 balance Assets:Bank 1000 USD
-"#;
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved");
-        assert!(
-            cmd.title.contains('✓'),
-            "asserted Assets:Bank must sum sub-account postings to \
-             Assets:Bank:Checking, matching the validator. got {:?}",
-            cmd.title
-        );
-    }
-
-    /// Companion to [`balance_lens_includes_subaccount_postings`]:
-    /// a non-prefix account that happens to start with the parent's
-    /// name must NOT be summed. `Assets:Bank` does not include
-    /// `Assets:BankAlias`; the segment boundary requires a `:`.
-    #[test]
-    fn balance_lens_does_not_match_non_subaccount_prefix() {
-        let source = r#"2024-01-01 open Assets:Bank USD
-2024-01-01 open Assets:BankAlias USD
-2024-01-01 open Income:Misc
-2024-01-15 * "Bank deposit"
-  Assets:Bank  1000 USD
-  Income:Misc
-2024-01-16 * "Alias deposit (should not count toward Assets:Bank)"
-  Assets:BankAlias  500 USD
-  Income:Misc
-2024-01-31 balance Assets:Bank 1000 USD
-"#;
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved");
-        assert!(
-            cmd.title.contains('✓'),
-            "asserted Assets:Bank should equal only its own postings; \
-             Assets:BankAlias must NOT be summed. got {:?}",
-            cmd.title
-        );
-    }
-
-    #[test]
-    fn test_code_lens_balance_uses_full_ledger_in_multi_file_mode() {
-        // Issue #470 coverage: when ledger_directives carries the
-        // full multi-file view, balance assertions whose offsetting
-        // transaction lives in a different file resolve correctly.
-        // Pre-#1253 this was tested through handle_code_lens_resolve;
-        // post-#1253 the eager path in handle_code_lens consumes the
-        // same multi-file snapshot.
-        let bank_source = r#"2024-01-01 open Assets:Bank:Checking USD
-2024-01-01 open Income:Salary
-2024-01-01 open Liabilities:Credit-Card
-2024-01-15 * "Paycheck"
-  Assets:Bank:Checking  5000 USD
-  Income:Salary
-2024-01-21 balance Assets:Bank:Checking 4950 USD
-"#;
-        let bank_result = parse(bank_source);
-        let credit_card_source = r#"2024-01-20 * "Pay off credit card"
-  Assets:Bank:Checking  -50 USD
-  Liabilities:Credit-Card
-"#;
-        let credit_card_result = parse(credit_card_source);
-        let mut full_directives = bank_result.directives.clone();
-        full_directives.extend(credit_card_result.directives.clone());
-
-        let params = code_lens_params();
-
-        // Single-file view: the -50 offset isn't visible, balance
-        // appears to mismatch.
-        let single_lens = find_balance_lens(
-            handle_code_lens(
-                &params,
-                bank_source,
-                &bank_result,
-                None,
-                PositionEncoding::Utf16,
-            )
-            .expect("lenses emitted"),
-        );
-        let single_cmd = single_lens.command.as_ref().expect("ships resolved");
-        assert!(
-            single_cmd.title.contains("see diagnostic"),
-            "single-file mismatch should point at the diagnostic; got {:?}",
-            single_cmd.title
-        );
-
-        // Multi-file view: the -50 offset is visible, balance matches.
-        let multi_lens = find_balance_lens(
-            handle_code_lens(
-                &params,
-                bank_source,
-                &bank_result,
-                Some(&full_directives),
-                PositionEncoding::Utf16,
-            )
-            .expect("lenses emitted"),
-        );
-        let multi_cmd = multi_lens.command.as_ref().expect("ships resolved");
-        assert!(
-            multi_cmd.title.contains('✓') && multi_cmd.title.contains("4950"),
-            "multi-file match should ship `✓ Balance: 4950 USD`; got {:?}",
-            multi_cmd.title
-        );
-    }
-
-    #[test]
-    fn test_code_lens_resolve_fallback_for_command_none_lens() {
-        // Defensive fallback inside handle_code_lens_resolve: even
-        // though no lens kind emitted by handle_code_lens ships with
-        // command:None today (eager resolution since #1253), if a
-        // future contributor adds a resolve-using lens kind and forgets
-        // to handle it, the fallback guarantees the client renders a
-        // sensible string instead of nvim's literal "Unresolved lens".
-        let lens = CodeLens {
-            range: Range {
-                start: Position::new(0, 0),
-                end: Position::new(0, 0),
-            },
-            command: None,
-            data: None,
-        };
-        let resolved = handle_code_lens_resolve(lens);
-        let cmd = resolved
-            .command
-            .as_ref()
-            .expect("fallback must populate command");
-        assert_eq!(cmd.command, "rledger.noop");
-    }
-
-    /// Regression for issue #1253 / #1245: balance lenses must ship
-    /// FULLY-RESOLVED on the initial `textDocument/codeLens` response
-    /// (no `data` payload, no placeholder, no resolve round-trip).
-    ///
-    /// Pre-#1253 the lens shipped with a `(checking…)` placeholder
-    /// command and a `data: { kind: "balance", ... }` payload; the
-    /// real `✓` / `⚠` title was filled in by `codeLens/resolve`.
-    /// Under nvim's resolve-cancellation race (visible in #1253's
-    /// LSP log as `"Cannot find request with id N whilst attempting
-    /// to cancel"`) the resolve response was silently discarded and
-    /// the lens stayed on the placeholder forever. Eager resolution
-    /// removes the round-trip and makes the race unreachable.
-    ///
-    /// This test pins both invariants: the final title shows the
-    /// real status (no `(checking…)`), and there is no `data` field
-    /// asking the client to re-resolve.
-    #[test]
-    fn issue_1253_balance_lens_ships_eagerly_resolved() {
-        // The user's reproduction from #1253: salary posts 1000 USD
-        // on 02-01, balance assertion on 02-02 expects 1000 USD.
-        let source = "\
-2012-01-01 open Assets:Bank
-2012-01-01 open Income:Employment
-
-2012-02-01 * \"Salary\"
-  Assets:Bank                   1000 USD
-  Income:Employment
-
-2012-02-02 balance Assets:Bank  1000 USD
-";
-        let result = parse(source);
-        let params = code_lens_params();
-
-        let balance_lens = find_balance_lens(
-            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
-                .expect("lenses emitted"),
-        );
-
-        // 1. The final ✓ title is set on the initial response.
-        let cmd = balance_lens
-            .command
-            .as_ref()
-            .expect("balance lens ships fully-resolved");
-        assert!(
-            cmd.title.contains('✓'),
-            "issue #1253: passing assertion must ship with the real ✓ \
-             title on the initial response, not a `(checking…)` \
-             placeholder that nvim could leave stuck. got {:?}",
-            cmd.title
-        );
-        assert!(
-            !cmd.title.contains("checking"),
-            "issue #1253: title must not contain the `(checking…)` \
-             placeholder; that's the stuck-state symptom. got {:?}",
-            cmd.title
-        );
-
-        // 2. No `data` payload means no codeLens/resolve round-trip,
-        //    which means no race window for nvim to cancel.
-        assert!(
-            balance_lens.data.is_none(),
-            "issue #1253: balance lens must not carry a resolve-data \
-             payload; the resolve round-trip is what nvim could race \
-             against cancellation. got data = {:?}",
-            balance_lens.data
-        );
-    }
 
     fn code_lens_params() -> CodeLensParams {
         CodeLensParams {
@@ -959,5 +304,305 @@ mod tests {
                     .is_some_and(|c| c.title.contains("Balance:"))
             })
             .expect("balance lens emitted")
+    }
+
+    /// Synthetic ERROR diagnostic at the given zero-based line. Mirrors
+    /// what `all_diagnostics` produces for a failed balance assertion;
+    /// the lens treats anything matching this shape as the validator
+    /// saying "this balance is wrong."
+    fn error_at_line(line: u32) -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position::new(line, 0),
+                end: Position::new(line, 80),
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(NumberOrString::String("E2001".into())),
+            code_description: None,
+            source: Some("rledger".into()),
+            message: "Balance assertion failed".into(),
+            related_information: None,
+            tags: None,
+            data: None,
+        }
+    }
+
+    #[test]
+    fn test_code_lens_accounts() {
+        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-15 * "Coffee"
+  Assets:Bank  -5.00 USD
+  Expenses:Food
+2024-01-16 * "Lunch"
+  Assets:Bank  -10.00 USD
+  Expenses:Food
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let lenses = handle_code_lens(&params, source, &result, Some(&[]), PositionEncoding::Utf16);
+        let lenses = lenses.expect("lenses emitted");
+        // Should have: 1 open + 2 transactions = 3 lenses
+        assert_eq!(lenses.len(), 3);
+
+        // First lens is for the open directive
+        assert!(
+            lenses[0]
+                .command
+                .as_ref()
+                .unwrap()
+                .title
+                .contains("2 transactions")
+        );
+    }
+
+    /// Cold-start case: no diagnostics have been computed yet for this
+    /// URI. The lens MUST render the balance amount without a verdict
+    /// symbol. Pre-#1264 the lens computed its own verdict locally and
+    /// would emit ✓ or ⚠ based on its (plugin-less) approximation;
+    /// post-#1264 it never claims a verdict it didn't get from the
+    /// validator.
+    #[test]
+    fn balance_lens_neutral_when_diagnostics_not_yet_computed() {
+        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-01 open Income:Salary
+2024-01-15 * "Deposit"
+  Assets:Bank  100.00 USD
+  Income:Salary
+2024-01-31 balance Assets:Bank 100.00 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, None, PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            !cmd.title.contains('✓') && !cmd.title.contains('⚠'),
+            "cold start: lens must not claim a verdict before the \
+             validator has run. got {:?}",
+            cmd.title
+        );
+        assert!(cmd.title.starts_with("Balance:"));
+        assert!(cmd.title.contains("100"));
+    }
+
+    /// Validator says PASS (empty diagnostics): lens shows ✓.
+    #[test]
+    fn balance_lens_shows_check_when_validator_passes() {
+        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-31 balance Assets:Bank 100.00 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, Some(&[]), PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(cmd.title.contains('✓'), "got {:?}", cmd.title);
+        assert!(cmd.title.contains("100"));
+        assert!(
+            balance_lens.data.is_none(),
+            "eager-resolved balance lens carries no resolve-data payload; \
+             pre-#1253 the data payload triggered a codeLens/resolve \
+             round-trip that nvim's client could race against \
+             cancellation. got data = {:?}",
+            balance_lens.data
+        );
+    }
+
+    /// Validator emitted an ERROR at the balance line: lens shows ⚠.
+    /// The "see diagnostic" link is now true by construction — the
+    /// diagnostic exists because we read it from the cache.
+    #[test]
+    fn balance_lens_shows_warning_when_validator_fails() {
+        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-31 balance Assets:Bank 100 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        // `2024-01-31 balance ...` is on line index 1 (zero-based) of
+        // the source above.
+        let diags = vec![error_at_line(1)];
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&diags),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            cmd.title.contains('⚠') && cmd.title.contains("see diagnostic"),
+            "got {:?}",
+            cmd.title
+        );
+        assert_eq!(cmd.command, "rledger.noop");
+    }
+
+    /// The lens MUST follow the diagnostic cache, not the parse result.
+    /// Pre-#1264 a passing parse + missing-plugin pipeline could
+    /// disagree with the validator (the bug in #1264). The new code path
+    /// is verdict-from-cache; we pin that by feeding a parse whose
+    /// "naive" answer would be ✓ together with an error diagnostic and
+    /// asserting the lens shows ⚠ regardless.
+    #[test]
+    fn balance_lens_follows_diagnostic_cache_not_local_eval() {
+        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-01 open Income:Salary
+2024-01-15 * "Deposit"
+  Assets:Bank  100.00 USD
+  Income:Salary
+2024-01-31 balance Assets:Bank 100.00 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        // Locally this balance assertion would pass (deposit = 100,
+        // assertion = 100). Feed an error diagnostic anyway and verify
+        // the lens follows the diagnostic, not the parse.
+        let diags = vec![error_at_line(5)];
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&diags),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            cmd.title.contains('⚠'),
+            "lens must follow validator's verdict, not re-derive from \
+             parse_result. got {:?}",
+            cmd.title
+        );
+    }
+
+    /// Inverse of the previous test: a parse whose naive evaluation
+    /// would say ⚠ (mismatched amounts), but no diagnostic in the
+    /// cache, must render ✓. This is the #1264 repro reduced to a unit
+    /// test: the lens's old evaluator would have ⚠'d here, but the
+    /// validator (running plugins) is right and the lens follows it.
+    #[test]
+    fn balance_lens_shows_check_when_parse_disagrees_but_validator_passes() {
+        // Parse-time arithmetic says 1000 - 100 = 900, assertion claims
+        // 1000. The OLD evaluator would emit ⚠. The new lens consults
+        // the diagnostic cache; empty diagnostics mean validator passed.
+        let source = r#"2024-01-01 open Assets:Bank USD
+2024-01-01 open Income:Salary
+2024-01-01 open Expenses:Food
+2024-02-01 * "Salary"
+  Assets:Bank  1000 USD
+  Income:Salary
+2024-02-03 * "Food"
+  Assets:Bank  -100 USD
+  Expenses:Food
+2024-02-04 balance Assets:Bank 1000 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, Some(&[]), PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            cmd.title.contains('✓'),
+            "lens must trust the validator (empty diagnostics) even \
+             when a naive parse-only reading would disagree. This is \
+             the structural property that fixes #1264's effective_date \
+             false positive: the validator runs plugins, the lens \
+             trusts the validator. got {:?}",
+            cmd.title
+        );
+    }
+
+    /// Defensive fallback inside handle_code_lens_resolve: even
+    /// though no lens kind emitted by handle_code_lens ships with
+    /// command:None today (eager resolution since #1253), if a
+    /// future contributor adds a resolve-using lens kind and forgets
+    /// to handle it, the fallback guarantees the client renders a
+    /// sensible string instead of nvim's literal "Unresolved lens".
+    #[test]
+    fn test_code_lens_resolve_fallback_for_command_none_lens() {
+        let lens = CodeLens {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            command: None,
+            data: None,
+        };
+        let resolved = handle_code_lens_resolve(lens);
+        let cmd = resolved
+            .command
+            .as_ref()
+            .expect("fallback must populate command");
+        assert_eq!(cmd.command, "rledger.noop");
+    }
+
+    /// Regression for issue #1253 / #1245: balance lenses must ship
+    /// FULLY-RESOLVED on the initial `textDocument/codeLens` response
+    /// (no `data` payload, no placeholder, no resolve round-trip).
+    /// The #1264 refactor changed WHAT data the eager response carries
+    /// (validator's verdict instead of a local re-derivation) but kept
+    /// the eager-ship invariant.
+    #[test]
+    fn issue_1253_balance_lens_ships_eagerly_resolved() {
+        let source = "\
+2012-01-01 open Assets:Bank
+2012-01-01 open Income:Employment
+
+2012-02-01 * \"Salary\"
+  Assets:Bank                   1000 USD
+  Income:Employment
+
+2012-02-02 balance Assets:Bank  1000 USD
+";
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let balance_lens = find_balance_lens(
+            handle_code_lens(&params, source, &result, Some(&[]), PositionEncoding::Utf16)
+                .expect("lenses emitted"),
+        );
+
+        let cmd = balance_lens
+            .command
+            .as_ref()
+            .expect("balance lens ships fully-resolved");
+        assert!(
+            cmd.title.contains('✓'),
+            "issue #1253: passing assertion must ship with the real ✓ \
+             title on the initial response, not a `(checking…)` \
+             placeholder that nvim could leave stuck. got {:?}",
+            cmd.title
+        );
+        assert!(
+            !cmd.title.contains("checking"),
+            "issue #1253: title must not contain the `(checking…)` \
+             placeholder; that's the stuck-state symptom. got {:?}",
+            cmd.title
+        );
+
+        assert!(
+            balance_lens.data.is_none(),
+            "issue #1253: balance lens must not carry a resolve-data \
+             payload; the resolve round-trip is what nvim could race \
+             against cancellation. got data = {:?}",
+            balance_lens.data
+        );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -327,9 +327,20 @@ fn has_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
 /// code-action suggestions; treating them as "something is wrong"
 /// would surface ✓-disqualifying noise on every code-action-eligible
 /// line.
+///
+/// Diagnostics with a zero-width range anchored at `(0, 0)..(0, 0)`
+/// are ALSO excluded: that's the sentinel for "I have no source span"
+/// used by the plugin-error emitter at
+/// `handlers/diagnostics.rs:325-329` (and any future spanless
+/// diagnostic source). Treating them as anchored on line 0 would make
+/// every balance directive on line 0 — common in scratch buffers and
+/// include-only files — render neutral whenever a plugin happens to
+/// fail. Keep the lens focused on directive-anchored diagnostics; the
+/// global ones surface independently in the problems panel.
 fn has_non_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
     diagnostics.iter().any(|d| {
         d.range.start.line == line
+            && !is_global_sentinel_range(&d.range)
             && matches!(
                 d.severity,
                 Some(DiagnosticSeverity::ERROR)
@@ -338,6 +349,17 @@ fn has_non_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool 
             )
             && !is_balance_error_code(d.code.as_ref())
     })
+}
+
+/// Returns true for the `(0, 0)..(0, 0)` sentinel that spanless
+/// diagnostic emitters (plugin errors today) use when they have no
+/// source location to attach. A diagnostic with this exact range is
+/// "global to the file," not anchored on line 0.
+fn is_global_sentinel_range(range: &Range) -> bool {
+    range.start.line == 0
+        && range.start.character == 0
+        && range.end.line == 0
+        && range.end.character == 0
 }
 
 fn is_balance_error_code(code: Option<&NumberOrString>) -> bool {
@@ -462,13 +484,12 @@ mod tests {
         }
     }
 
-    fn error_with_code_at_line(code: &str, line: u32) -> Diagnostic {
-        diagnostic_with_code_severity_at_line(code, DiagnosticSeverity::ERROR, line)
-    }
-
-    /// Default-case: a balance-assertion-failed diagnostic at `line`.
+    /// Default-case: a balance-assertion-failed (E2001) ERROR
+    /// diagnostic at `line`. The most common test fixture; non-default
+    /// shapes go through `diagnostic_with_code_severity_at_line`
+    /// directly so the chosen severity is visible at the call site.
     fn error_at_line(line: u32) -> Diagnostic {
-        error_with_code_at_line("E2001", line)
+        diagnostic_with_code_severity_at_line("E2001", DiagnosticSeverity::ERROR, line)
     }
 
     #[test]
@@ -734,7 +755,11 @@ mod tests {
         let params = code_lens_params();
 
         // E1001 (account never opened) at the balance directive's line.
-        let diags = vec![error_with_code_at_line("E1001", 0)];
+        let diags = vec![diagnostic_with_code_severity_at_line(
+            "E1001",
+            DiagnosticSeverity::ERROR,
+            0,
+        )];
         let balance_lens = find_balance_lens(
             handle_code_lens(
                 &params,
@@ -868,6 +893,60 @@ mod tests {
             cmd.title.contains('✓'),
             "HINT-severity must not disqualify ✓ — code-action hints \
              routinely anchor on directives. got {:?}",
+            cmd.title
+        );
+    }
+
+    /// Plugin errors (and any future spanless diagnostic) are emitted
+    /// with the global sentinel range `(0,0)..(0,0)` per
+    /// `handlers/diagnostics.rs:325-329`. A balance directive that
+    /// happens to land on line 0 must NOT be marked neutral just
+    /// because a plugin failed elsewhere in the file. The sentinel
+    /// range exclusion keeps the lens focused on directive-anchored
+    /// diagnostics; the global plugin error surfaces independently in
+    /// the problems panel.
+    #[test]
+    fn balance_lens_ignores_global_sentinel_range_diagnostic() {
+        // Balance directive IS on line 0 — the case where a naive
+        // line-only filter would conflate the global plugin error with
+        // a directive-anchored one.
+        let source = "2024-01-31 balance Assets:Bank 100 USD\n";
+        let result = parse(source);
+        let params = code_lens_params();
+
+        // Plugin-shaped diagnostic: ERROR severity, range (0,0)..(0,0),
+        // non-balance code. Mirrors what diagnostics.rs:325-329 emits.
+        let plugin_error = Diagnostic {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 0),
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(NumberOrString::String("PluginLoadFailed".into())),
+            code_description: None,
+            source: Some("rustledger".into()),
+            message: "plugin failed to load".into(),
+            related_information: None,
+            tags: None,
+            data: None,
+        };
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&[plugin_error]),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            cmd.title.contains('✓'),
+            "global-sentinel-range diagnostic (plugin error with no \
+             source span) must not disqualify ✓ on a line-0 balance \
+             directive; the sentinel range means 'global', not \
+             'anchored on line 0'. got {:?}",
             cmd.title
         );
     }

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -207,9 +207,24 @@ pub fn handle_code_lens(
 /// balance directive's line.
 ///
 /// Pulled from [`ErrorCode`] (`pub const fn code() -> &'static str`)
-/// instead of hardcoding the strings, so renumbering on the validator
-/// side breaks the lens build rather than silently mislabelling every
-/// balance failure as a non-balance ERROR. The codes themselves:
+/// instead of hardcoding the strings, so:
+///
+/// - **Renaming a variant** (e.g., `BalanceAssertionFailed` →
+///   `BalanceMismatch`) breaks the lens build — the const-fn call
+///   resolves a symbol that no longer exists.
+/// - **Renumbering the string returned by `code()`** (e.g., `"E2001"`
+///   → `"E2099"`) is detected and propagated automatically — the
+///   lens build still passes and `BALANCE_ERROR_CODES` picks up the
+///   new string, so the runtime match against the validator's
+///   emitted code stays in sync without any manual update.
+///
+/// Hardcoding `&["E2001", "E2002", "E2004"]` would have given the
+/// opposite property: renaming would have compiled silently, and only
+/// renumbering at the validator side (without a corresponding lens
+/// update) would have produced runtime drift. The const-fn bridge
+/// trades the cheaper failure mode for the more expensive one.
+///
+/// The codes themselves:
 ///
 /// - `E2001` ([`ErrorCode::BalanceAssertionFailed`]): asserted amount
 ///   != actual.
@@ -252,12 +267,15 @@ const BALANCE_ERROR_CODES: &[&str] = &[
 ///   validator emitted a real balance-arithmetic failure. Render
 ///   `⚠ Balance: X USD (see diagnostic)` — "see diagnostic" is a true
 ///   link by construction.
-/// - `Some(diags)` with some OTHER ERROR at `line` (e.g., `E1001`
-///   AccountNotOpen) but NO `BALANCE_ERROR_CODES`: a non-balance
-///   diagnostic happens to anchor here. Render neutrally; don't
-///   misattribute it as a balance failure.
-/// - `Some(diags)` with no ERROR at all at `line`: the validator
-///   says the assertion holds. Render `✓ Balance: X USD`.
+/// - `Some(diags)` with some OTHER non-HINT diagnostic at `line`
+///   (e.g., `E1001` AccountNotOpen ERROR, `FutureDate` WARNING,
+///   `DateOutOfOrder` INFORMATION) but NO `BALANCE_ERROR_CODES`:
+///   the validator has something to say about this directive but
+///   it isn't a balance-arithmetic failure. Render neutrally; don't
+///   misattribute it as a balance failure AND don't claim ✓ on a
+///   directive the validator is actively flagging.
+/// - `Some(diags)` with no relevant diagnostic at `line`: the
+///   validator says the assertion holds. Render `✓ Balance: X USD`.
 fn balance_lens_title(
     amount: rustledger_core::Decimal,
     currency: &str,
@@ -292,13 +310,32 @@ fn has_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
     })
 }
 
-/// Does the diagnostic slice contain an ERROR at `line.start` whose
-/// code is NOT one of the balance-arithmetic codes? (Used to decide
-/// whether to render neutrally instead of ✓.)
+/// Does the diagnostic slice contain ANY non-balance diagnostic
+/// (ERROR, WARNING, or INFORMATION severity) anchored at `line.start`?
+///
+/// Severity matters: a balance directive can carry a WARNING-severity
+/// diagnostic (`FutureDate` E6004, `DateOutOfOrder` E6005, etc.) that
+/// gets the balance directive's span patched onto it via
+/// `validate/lib.rs:548-562`. If we filtered on ERROR only, the lens
+/// would render `✓ Balance: X USD` for a directive the validator is
+/// actively warning about — the same false-confidence pattern #1264
+/// closed for plugins, just transposed to severity-filtering. Any
+/// non-balance diagnostic at the line tells us "the validator has
+/// something to say about this directive" and disqualifies the ✓.
+///
+/// HINT severity is excluded because hints are routinely produced as
+/// code-action suggestions; treating them as "something is wrong"
+/// would surface ✓-disqualifying noise on every code-action-eligible
+/// line.
 fn has_non_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
     diagnostics.iter().any(|d| {
         d.range.start.line == line
-            && d.severity == Some(DiagnosticSeverity::ERROR)
+            && matches!(
+                d.severity,
+                Some(DiagnosticSeverity::ERROR)
+                    | Some(DiagnosticSeverity::WARNING)
+                    | Some(DiagnosticSeverity::INFORMATION)
+            )
             && !is_balance_error_code(d.code.as_ref())
     })
 }
@@ -399,18 +436,22 @@ mod tests {
             .expect("balance lens emitted")
     }
 
-    /// Synthetic ERROR diagnostic at the given zero-based line with
-    /// the given LSP error code. Source string matches what the
+    /// Synthetic diagnostic at the given zero-based line with the given
+    /// LSP error code and severity. Source string matches what the
     /// validator emits in production (`"rustledger"`, see
     /// `diagnostics.rs:145`) so any future filter on `source` would
     /// behave the same in tests and production.
-    fn error_with_code_at_line(code: &str, line: u32) -> Diagnostic {
+    fn diagnostic_with_code_severity_at_line(
+        code: &str,
+        severity: DiagnosticSeverity,
+        line: u32,
+    ) -> Diagnostic {
         Diagnostic {
             range: Range {
                 start: Position::new(line, 0),
                 end: Position::new(line, 80),
             },
-            severity: Some(DiagnosticSeverity::ERROR),
+            severity: Some(severity),
             code: Some(NumberOrString::String(code.into())),
             code_description: None,
             source: Some("rustledger".into()),
@@ -419,6 +460,10 @@ mod tests {
             tags: None,
             data: None,
         }
+    }
+
+    fn error_with_code_at_line(code: &str, line: u32) -> Diagnostic {
+        diagnostic_with_code_severity_at_line(code, DiagnosticSeverity::ERROR, line)
     }
 
     /// Default-case: a balance-assertion-failed diagnostic at `line`.
@@ -712,6 +757,115 @@ mod tests {
             "lens must not claim ✓ when an unrelated error blankets \
              the assertion's line — the assertion's status is uncertain. \
              got {:?}",
+            cmd.title
+        );
+    }
+
+    /// WARNING-severity diagnostics that anchor on the balance line —
+    /// `FutureDate`, `DateOutOfOrder`, `AccountCloseNotEmpty` —
+    /// disqualify ✓. Without this, the lens claims the assertion holds
+    /// while the validator is actively flagging the directive's date or
+    /// account state, which is the same false-confidence pattern #1264
+    /// closed for plugins, just transposed to severity filtering.
+    #[test]
+    fn balance_lens_neutral_on_non_balance_warning_at_line() {
+        let source = r#"2099-01-31 balance Assets:Bank 100 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        // E6004 (or any non-balance code) at WARNING severity.
+        let diags = vec![diagnostic_with_code_severity_at_line(
+            "E6004",
+            DiagnosticSeverity::WARNING,
+            0,
+        )];
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&diags),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            !cmd.title.contains('✓') && !cmd.title.contains('⚠'),
+            "warning at the balance line must disqualify ✓; lens must \
+             not claim a verdict while the validator is flagging the \
+             directive. got {:?}",
+            cmd.title
+        );
+    }
+
+    /// INFORMATION-severity diagnostics at the balance line also
+    /// disqualify ✓ — same rationale as WARNING, applied to
+    /// `DateOutOfOrder` and similar advisory-level findings the
+    /// validator anchors via the span-patch path.
+    #[test]
+    fn balance_lens_neutral_on_information_severity_at_line() {
+        let source = r#"2024-01-31 balance Assets:Bank 100 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let diags = vec![diagnostic_with_code_severity_at_line(
+            "E6005",
+            DiagnosticSeverity::INFORMATION,
+            0,
+        )];
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&diags),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            !cmd.title.contains('✓') && !cmd.title.contains('⚠'),
+            "information-severity diagnostic at the balance line must \
+             disqualify ✓. got {:?}",
+            cmd.title
+        );
+    }
+
+    /// HINT-severity diagnostics are excluded from the ✓-disqualifying
+    /// set — code-action hints routinely anchor on directives, and
+    /// treating them as "validator flagged this" would produce neutral
+    /// titles on every code-action-eligible balance line.
+    #[test]
+    fn balance_lens_keeps_check_when_only_hint_at_line() {
+        let source = r#"2024-01-31 balance Assets:Bank 100 USD
+"#;
+        let result = parse(source);
+        let params = code_lens_params();
+
+        let diags = vec![diagnostic_with_code_severity_at_line(
+            "H1001",
+            DiagnosticSeverity::HINT,
+            0,
+        )];
+        let balance_lens = find_balance_lens(
+            handle_code_lens(
+                &params,
+                source,
+                &result,
+                Some(&diags),
+                PositionEncoding::Utf16,
+            )
+            .expect("lenses emitted"),
+        );
+        let cmd = balance_lens.command.as_ref().expect("ships resolved");
+        assert!(
+            cmd.title.contains('✓'),
+            "HINT-severity must not disqualify ✓ — code-action hints \
+             routinely anchor on directives. got {:?}",
             cmd.title
         );
     }

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -314,7 +314,7 @@ fn has_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool {
 /// (ERROR, WARNING, or INFORMATION severity) anchored at `line.start`?
 ///
 /// Severity matters: a balance directive can carry a WARNING-severity
-/// diagnostic (`FutureDate` E6004, `DateOutOfOrder` E6005, etc.) that
+/// diagnostic (`FutureDate` E10002, `DateOutOfOrder` E10001, etc.) that
 /// gets the balance directive's span patched onto it via
 /// `validate/lib.rs:548-562`. If we filtered on ERROR only, the lens
 /// would render `✓ Balance: X USD` for a directive the validator is
@@ -774,9 +774,11 @@ mod tests {
         let result = parse(source);
         let params = code_lens_params();
 
-        // E6004 (or any non-balance code) at WARNING severity.
+        // E10002 (FutureDate) at WARNING severity — what the
+        // validator actually emits for a balance directive dated
+        // after `today`.
         let diags = vec![diagnostic_with_code_severity_at_line(
-            "E6004",
+            "E10002",
             DiagnosticSeverity::WARNING,
             0,
         )];
@@ -812,7 +814,7 @@ mod tests {
         let params = code_lens_params();
 
         let diags = vec![diagnostic_with_code_severity_at_line(
-            "E6005",
+            "E10001",
             DiagnosticSeverity::INFORMATION,
             0,
         )];

--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -41,6 +41,7 @@ use lsp_types::{
 };
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
+use rustledger_validate::ErrorCode;
 use std::collections::HashMap;
 
 use super::diagnostics::validation_would_run;
@@ -203,20 +204,39 @@ pub fn handle_code_lens(
 }
 
 /// Error codes the lens treats as a balance-arithmetic failure on a
-/// balance directive's line:
+/// balance directive's line.
 ///
-/// - `E2001`: balance assertion failed (asserted amount != actual)
-/// - `E2002`: balance exceeds explicit tolerance
+/// Pulled from [`ErrorCode`] (`pub const fn code() -> &'static str`)
+/// instead of hardcoding the strings, so renumbering on the validator
+/// side breaks the lens build rather than silently mislabelling every
+/// balance failure as a non-balance ERROR. The codes themselves:
 ///
-/// Other ERROR diagnostics that may also land on a balance directive's
-/// line — `E1001 AccountNotOpen`, parse errors, plugin errors patched
-/// onto the balance span — describe a different problem. Showing
+/// - `E2001` ([`ErrorCode::BalanceAssertionFailed`]): asserted amount
+///   != actual.
+/// - `E2002` ([`ErrorCode::BalanceToleranceExceeded`]): difference is
+///   beyond the explicit `~` tolerance.
+/// - `E2004` ([`ErrorCode::MultiplePadForBalance`]): two effective
+///   pads before the assertion. The validator's lib.rs:548-562 patches
+///   the balance directive's span onto this error (it's constructed
+///   with `bal.date` and no span of its own), so the diagnostic anchors
+///   on the balance line — same as E2001/E2002. The user-facing failure
+///   IS that the asserted balance can't be unambiguously verified.
+///
+/// Codes that may land at the balance line but describe a different
+/// problem (`E1001 AccountNotOpen`, parse errors, plugin errors
+/// patched onto the span) are deliberately excluded. Showing
 /// `⚠ Balance: X USD (see diagnostic)` for those misattributes the
 /// failure category: the user clicks the lens expecting a balance
 /// arithmetic explanation and finds something unrelated. The lens
-/// renders neutrally for those instead, letting the diagnostic itself
-/// speak.
-const BALANCE_ERROR_CODES: &[&str] = &["E2001", "E2002"];
+/// renders neutrally for those, letting the diagnostic itself speak.
+///
+/// `E2003 PadWithoutBalance` anchors on the pad directive, not the
+/// balance directive, so it's not relevant to this list.
+const BALANCE_ERROR_CODES: &[&str] = &[
+    ErrorCode::BalanceAssertionFailed.code(),
+    ErrorCode::BalanceToleranceExceeded.code(),
+    ErrorCode::MultiplePadForBalance.code(),
+];
 
 /// Render the balance lens title for a balance directive on `line`.
 ///
@@ -286,7 +306,22 @@ fn has_non_balance_error_at_line(diagnostics: &[Diagnostic], line: u32) -> bool 
 fn is_balance_error_code(code: Option<&NumberOrString>) -> bool {
     match code {
         Some(NumberOrString::String(s)) => BALANCE_ERROR_CODES.contains(&s.as_str()),
-        _ => false,
+        Some(NumberOrString::Number(n)) => {
+            // Today every validator-emitted diagnostic code is a
+            // String (see `validation_error_to_diagnostic` at
+            // diagnostics.rs:~420). If a future contributor adds a
+            // Number-coded path, this branch fires — debug builds get
+            // a loud signal so the lens's filter can be updated;
+            // release builds default to "not a balance code" to avoid
+            // a spurious ⚠ on an unknown numeric code.
+            debug_assert!(
+                false,
+                "lens received an unexpected numeric diagnostic code: {n}; \
+                 update `is_balance_error_code` or normalize at the emitter",
+            );
+            false
+        }
+        None => false,
     }
 }
 
@@ -603,11 +638,15 @@ mod tests {
     /// the lens asserting verdicts it cannot back up.
     #[test]
     fn balance_lens_neutral_when_parse_errors_skip_validation() {
-        // First non-comment line is a syntax error (stray garbage),
-        // forcing parse_result.errors to be non-empty.
-        let source = r#"!!! syntax garbage on line 0
-2024-01-01 open Assets:Bank USD
+        // Open + balance directives come first (cleanly parsed, so the
+        // balance lens is always emitted regardless of how the parser
+        // recovers from the trailing garbage). The malformed line at
+        // the END forces `parse_result.errors` to be non-empty without
+        // making the test depend on parser-recovery behavior at the
+        // top of the file.
+        let source = r#"2024-01-01 open Assets:Bank USD
 2024-01-31 balance Assets:Bank 100.00 USD
+!!! syntax garbage on a trailing line
 "#;
         let result = parse(source);
         assert!(

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -562,181 +562,187 @@ pub fn all_diagnostics(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = parse_errors_to_diagnostics(result, source, encoding);
 
-    // Only run validation if:
-    // 1. There are no parse errors (validation on partial parses is confusing)
-    // 2. File is not too large (to keep LSP responsive)
-    if result.errors.is_empty() {
-        if source.len() <= MAX_VALIDATION_FILE_SIZE {
-            // Get full directives from ledger state if available, then
-            // apply a live overlay of every fresh in-memory parse we have.
-            //
-            // See `build_live_directive_overlay` for why the overlay is
-            // necessary (#685 / #760: without it, diagnostics lag behind
-            // in-memory buffer edits because the ledger state is only
-            // refreshed on file-watcher save events).
-            //
-            // We build the overlay list inline from the current file's
-            // fresh parse plus any other open buffers the caller handed
-            // in. The current file is always first so that a caller
-            // passing duplicate entries in `other_buffer_overlays`
-            // (shouldn't happen, but is harmless) doesn't shadow it.
-            let full_directives_raw = ledger_state.and_then(|ls| ls.directives());
+    // [`validation_would_run`] is the single source of truth for whether
+    // the validator runs (no parse errors AND under the size cap). It's
+    // re-used by `handle_code_lens` to render the balance lens neutrally
+    // when validation was skipped, instead of mistaking an empty
+    // diagnostic vec for "validator approved." Calling it here keeps
+    // the two sites structurally locked-step instead of relying on a
+    // humans-must-remember comment.
+    if validation_would_run(source, result) {
+        // Get full directives from ledger state if available, then
+        // apply a live overlay of every fresh in-memory parse we have.
+        //
+        // See `build_live_directive_overlay` for why the overlay is
+        // necessary (#685 / #760: without it, diagnostics lag behind
+        // in-memory buffer edits because the ledger state is only
+        // refreshed on file-watcher save events).
+        //
+        // We build the overlay list inline from the current file's
+        // fresh parse plus any other open buffers the caller handed
+        // in. The current file is always first so that a caller
+        // passing duplicate entries in `other_buffer_overlays`
+        // (shouldn't happen, but is harmless) doesn't shadow it.
+        let full_directives_raw = ledger_state.and_then(|ls| ls.directives());
 
-            // Build the list of overlays to apply to the ledger snapshot.
-            // Always include the current file's fresh parse first, then
-            // append any other open buffers the caller handed in (#760).
-            let mut overlay_entries: Vec<(u16, &[Spanned<Directive>])> =
-                Vec::with_capacity(1 + other_buffer_overlays.len());
-            if let Some(fid) = current_file_id {
-                overlay_entries.push((fid, result.directives.as_slice()));
-            }
-            overlay_entries.extend_from_slice(other_buffer_overlays);
-            let overlay = build_live_directive_overlay(&overlay_entries, full_directives_raw);
+        // Build the list of overlays to apply to the ledger snapshot.
+        // Always include the current file's fresh parse first, then
+        // append any other open buffers the caller handed in (#760).
+        let mut overlay_entries: Vec<(u16, &[Spanned<Directive>])> =
+            Vec::with_capacity(1 + other_buffer_overlays.len());
+        if let Some(fid) = current_file_id {
+            overlay_entries.push((fid, result.directives.as_slice()));
+        }
+        overlay_entries.extend_from_slice(other_buffer_overlays);
+        let overlay = build_live_directive_overlay(&overlay_entries, full_directives_raw);
 
-            // Construct the owned directive list for validation. Moving
-            // the overlay in by value saves a second clone on the
-            // multi-file overlay path (the overlay is already an owned
-            // Vec; handing it to `validation_errors_to_diagnostics` by
-            // value avoids the `.to_vec()` that used to happen inside
-            // that function). Other paths still pay one clone, same as
-            // before. See #758 for the single-file version of this
-            // optimization.
-            let booked_directives: Vec<Spanned<Directive>> = if let Some(owned) = overlay {
-                owned
-            } else if let Some(full) = full_directives_raw
-                && current_file_id.is_some()
-            {
-                full.to_vec()
-            } else {
-                result.directives.clone()
-            };
+        // Construct the owned directive list for validation. Moving
+        // the overlay in by value saves a second clone on the
+        // multi-file overlay path (the overlay is already an owned
+        // Vec; handing it to `validation_errors_to_diagnostics` by
+        // value avoids the `.to_vec()` that used to happen inside
+        // that function). Other paths still pay one clone, same as
+        // before. See #758 for the single-file version of this
+        // optimization.
+        let booked_directives: Vec<Spanned<Directive>> = if let Some(owned) = overlay {
+            owned
+        } else if let Some(full) = full_directives_raw
+            && current_file_id.is_some()
+        {
+            full.to_vec()
+        } else {
+            result.directives.clone()
+        };
 
-            // Build validation options with custom account type names.
-            // Use ledger-wide options when a ledger is loaded (handles multi-file
-            // ledgers where name_* options may be in included files); fall back
-            // to per-file options for single-file validation.
-            let validation_options = if let Some(ls) = ledger_state
-                && let Some(ledger) = ls.ledger()
-            {
-                let base_dir = ledger
-                    .source_map
-                    .files()
-                    .first()
-                    .and_then(|f| f.path.parent())
-                    .unwrap_or_else(|| std::path::Path::new("."));
-                build_validation_options_from_loader(&ledger.options, base_dir)
-            } else {
-                // Single-file: resolve relative document dirs against the
-                // current file's parent directory so they don't end up being
-                // interpreted relative to the LSP process CWD.
-                let base_dir = current_file_path.and_then(|p| p.parent());
-                build_validation_options_from_file(&result.options, base_dir)
-            };
+        // Build validation options with custom account type names.
+        // Use ledger-wide options when a ledger is loaded (handles multi-file
+        // ledgers where name_* options may be in included files); fall back
+        // to per-file options for single-file validation.
+        let validation_options = if let Some(ls) = ledger_state
+            && let Some(ledger) = ls.ledger()
+        {
+            let base_dir = ledger
+                .source_map
+                .files()
+                .first()
+                .and_then(|f| f.path.parent())
+                .unwrap_or_else(|| std::path::Path::new("."));
+            build_validation_options_from_loader(&ledger.options, base_dir)
+        } else {
+            // Single-file: resolve relative document dirs against the
+            // current file's parent directory so they don't end up being
+            // interpreted relative to the LSP process CWD.
+            let base_dir = current_file_path.and_then(|p| p.parent());
+            build_validation_options_from_file(&result.options, base_dir)
+        };
 
-            // Build plugin context for running plugins before validation.
-            // Multi-file: merge ledger plugins with fresh buffer plugins (so
-            // unsaved edits to plugin directives take effect immediately).
-            // Single-file: build entirely from ParseResult's plugin declarations.
-            //
-            // Helper closure to convert ParseResult plugins to Plugin structs.
-            let parse_result_to_plugins =
-                |plugins: &[(String, Option<String>, Span)], file_id: usize| -> Vec<Plugin> {
-                    plugins
-                        .iter()
-                        .map(|(name, config, span)| {
-                            let (actual_name, force_python) =
-                                if let Some(stripped) = name.strip_prefix("python:") {
-                                    (stripped.to_string(), true)
-                                } else {
-                                    (name.clone(), false)
-                                };
-                            Plugin {
-                                name: actual_name,
-                                config: config.clone(),
-                                span: *span,
-                                file_id,
-                                force_python,
-                            }
-                        })
-                        .collect()
-                };
-
-            let merged_plugins: Vec<Plugin>;
-            let single_file_options: LoaderOptions;
-            let single_file_source_map: SourceMap;
-
-            let plugin_ctx = if let Some(ls) = ledger_state
-                && let Some(ledger) = ls.ledger()
-            {
-                // Merge: keep ledger plugins from OTHER files, replace current
-                // file's plugins with the fresh parse (mirrors directive overlay).
-                let current_fid = current_file_id.unwrap_or(0) as usize;
-                merged_plugins = ledger
-                    .plugins
+        // Build plugin context for running plugins before validation.
+        // Multi-file: merge ledger plugins with fresh buffer plugins (so
+        // unsaved edits to plugin directives take effect immediately).
+        // Single-file: build entirely from ParseResult's plugin declarations.
+        //
+        // Helper closure to convert ParseResult plugins to Plugin structs.
+        let parse_result_to_plugins =
+            |plugins: &[(String, Option<String>, Span)], file_id: usize| -> Vec<Plugin> {
+                plugins
                     .iter()
-                    .filter(|p| p.file_id != current_fid)
-                    .cloned()
-                    .chain(parse_result_to_plugins(&result.plugins, current_fid))
-                    .collect();
-
-                if merged_plugins.is_empty() {
-                    None
-                } else {
-                    Some(PluginContext {
-                        plugins: &merged_plugins,
-                        file_options: &ledger.options,
-                        source_map: &ledger.source_map,
+                    .map(|(name, config, span)| {
+                        let (actual_name, force_python) =
+                            if let Some(stripped) = name.strip_prefix("python:") {
+                                (stripped.to_string(), true)
+                            } else {
+                                (name.clone(), false)
+                            };
+                        Plugin {
+                            name: actual_name,
+                            config: config.clone(),
+                            span: *span,
+                            file_id,
+                            force_python,
+                        }
                     })
-                }
-            } else if !result.plugins.is_empty() {
-                // Single-file mode: build plugin list from ParseResult
-                merged_plugins = parse_result_to_plugins(&result.plugins, 0);
-                single_file_options = {
-                    let mut opts = LoaderOptions::new();
-                    for (key, value, _span) in &result.options {
-                        opts.set(key, value);
-                    }
-                    opts
-                };
-                // Build a SourceMap with the current buffer so run_plugins()
-                // can attach filename/line info to wrappers and reconstruct
-                // spans when converting back. Use an absolute path so that
-                // document directory resolution in run_plugins (which uses
-                // the first file's parent as base_dir) doesn't produce an
-                // empty path.
-                single_file_source_map = {
-                    let mut sm = SourceMap::new();
-                    sm.add_file(
-                        std::path::PathBuf::from("/tmp/rustledger-lsp-buffer.beancount"),
-                        Arc::from(source),
-                    );
-                    sm
-                };
+                    .collect()
+            };
+
+        let merged_plugins: Vec<Plugin>;
+        let single_file_options: LoaderOptions;
+        let single_file_source_map: SourceMap;
+
+        let plugin_ctx = if let Some(ls) = ledger_state
+            && let Some(ledger) = ls.ledger()
+        {
+            // Merge: keep ledger plugins from OTHER files, replace current
+            // file's plugins with the fresh parse (mirrors directive overlay).
+            let current_fid = current_file_id.unwrap_or(0) as usize;
+            merged_plugins = ledger
+                .plugins
+                .iter()
+                .filter(|p| p.file_id != current_fid)
+                .cloned()
+                .chain(parse_result_to_plugins(&result.plugins, current_fid))
+                .collect();
+
+            if merged_plugins.is_empty() {
+                None
+            } else {
                 Some(PluginContext {
                     plugins: &merged_plugins,
-                    file_options: &single_file_options,
-                    source_map: &single_file_source_map,
+                    file_options: &ledger.options,
+                    source_map: &ledger.source_map,
                 })
-            } else {
-                None
+            }
+        } else if !result.plugins.is_empty() {
+            // Single-file mode: build plugin list from ParseResult
+            merged_plugins = parse_result_to_plugins(&result.plugins, 0);
+            single_file_options = {
+                let mut opts = LoaderOptions::new();
+                for (key, value, _span) in &result.options {
+                    opts.set(key, value);
+                }
+                opts
             };
-
-            let validation_diagnostics = validation_errors_to_diagnostics(
-                booked_directives,
-                source,
-                validation_options,
-                current_file_id,
-                plugin_ctx.as_ref(),
-                encoding,
-            );
-            diagnostics.extend(validation_diagnostics);
+            // Build a SourceMap with the current buffer so run_plugins()
+            // can attach filename/line info to wrappers and reconstruct
+            // spans when converting back. Use an absolute path so that
+            // document directory resolution in run_plugins (which uses
+            // the first file's parent as base_dir) doesn't produce an
+            // empty path.
+            single_file_source_map = {
+                let mut sm = SourceMap::new();
+                sm.add_file(
+                    std::path::PathBuf::from("/tmp/rustledger-lsp-buffer.beancount"),
+                    Arc::from(source),
+                );
+                sm
+            };
+            Some(PluginContext {
+                plugins: &merged_plugins,
+                file_options: &single_file_options,
+                source_map: &single_file_source_map,
+            })
         } else {
-            tracing::debug!(
-                "Skipping validation for large file ({} bytes > {} limit)",
-                source.len(),
-                MAX_VALIDATION_FILE_SIZE
-            );
-        }
+            None
+        };
+
+        let validation_diagnostics = validation_errors_to_diagnostics(
+            booked_directives,
+            source,
+            validation_options,
+            current_file_id,
+            plugin_ctx.as_ref(),
+            encoding,
+        );
+        diagnostics.extend(validation_diagnostics);
+    } else if source.len() > MAX_VALIDATION_FILE_SIZE {
+        // The size-specific log is the only signal a human gets when
+        // a giant file silently stops validating. Skipped-because-of-
+        // parse-errors is self-evident: the parse-error diagnostics
+        // are already in `diagnostics`.
+        tracing::debug!(
+            "Skipping validation for large file ({} bytes > {} limit)",
+            source.len(),
+            MAX_VALIDATION_FILE_SIZE
+        );
     }
 
     // Emit option warnings (E7001–E7006).

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -434,6 +434,20 @@ pub fn validation_error_to_diagnostic(
 /// 500KB is a generous limit - most beancount files are much smaller.
 const MAX_VALIDATION_FILE_SIZE: usize = 500 * 1024;
 
+/// Returns true iff [`all_diagnostics`] will actually invoke the
+/// validator (rather than emit only parse-error diagnostics or nothing).
+///
+/// The codeLens path uses this to distinguish "validator ran and found
+/// no errors at this line" (render `✓`) from "validator declined to run"
+/// (render neutrally, never `✓`). Without this check a balance lens
+/// would silently mislabel an unvalidated assertion as passing — the
+/// inverse of the dead-link UX that #1264 closed. Keep these conditions
+/// in lock-step with the two `if` guards inside `all_diagnostics`.
+#[must_use]
+pub fn validation_would_run(source: &str, parse_result: &ParseResult) -> bool {
+    parse_result.errors.is_empty() && source.len() <= MAX_VALIDATION_FILE_SIZE
+}
+
 /// Build the effective directive list for validation by overlaying one or
 /// more fresh in-memory parses onto a potentially-stale ledger snapshot.
 ///

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -437,14 +437,26 @@ const MAX_VALIDATION_FILE_SIZE: usize = 500 * 1024;
 /// Returns true iff [`all_diagnostics`] will actually invoke the
 /// validator (rather than emit only parse-error diagnostics or nothing).
 ///
-/// The codeLens path uses this to distinguish "validator ran and found
-/// no errors at this line" (render `✓`) from "validator declined to run"
-/// (render neutrally, never `✓`). Without this check a balance lens
+/// Called by [`all_diagnostics`] to gate the validator AND by
+/// [`super::code_lens::handle_code_lens`] to gate the verdict source
+/// fed into the balance lens. Both call sites are structurally
+/// locked-step: changes to the predicate flow into the validator
+/// pipeline AND the lens's "cache trustable?" check together, with no
+/// duplicated-condition drift.
+///
+/// `pub(crate)` because the two callers above are the only legitimate
+/// consumers. External callers (FFI, hypothetical future crates) that
+/// imported this predicate would tie themselves to an internal
+/// contract whose semantics may shift as the validator's skip
+/// conditions evolve.
+///
+/// The codeLens path needs this to distinguish "validator ran and
+/// found no errors at this line" (render `✓`) from "validator declined
+/// to run" (render neutrally, never `✓`). Without it a balance lens
 /// would silently mislabel an unvalidated assertion as passing — the
-/// inverse of the dead-link UX that #1264 closed. Keep these conditions
-/// in lock-step with the two `if` guards inside `all_diagnostics`.
+/// inverse of the dead-link UX that #1264 closed.
 #[must_use]
-pub fn validation_would_run(source: &str, parse_result: &ParseResult) -> bool {
+pub(crate) fn validation_would_run(source: &str, parse_result: &ParseResult) -> bool {
     parse_result.errors.is_empty() && source.len() <= MAX_VALIDATION_FILE_SIZE
 }
 
@@ -733,11 +745,15 @@ pub fn all_diagnostics(
             encoding,
         );
         diagnostics.extend(validation_diagnostics);
-    } else if source.len() > MAX_VALIDATION_FILE_SIZE {
+    } else if result.errors.is_empty() && source.len() > MAX_VALIDATION_FILE_SIZE {
         // The size-specific log is the only signal a human gets when
         // a giant file silently stops validating. Skipped-because-of-
         // parse-errors is self-evident: the parse-error diagnostics
-        // are already in `diagnostics`.
+        // are already in `diagnostics`. Guard on `result.errors.is_empty()`
+        // so the log fires ONLY when the size cap is the sole reason —
+        // pre-refactor the outer `if errors.is_empty()` provided the
+        // same gating; replicate it here so an operator chasing the
+        // skip cause isn't pointed at the wrong remediation.
         tracing::debug!(
             "Skipping validation for large file ({} bytes > {} limit)",
             source.len(),

--- a/crates/rustledger-lsp/src/main.rs
+++ b/crates/rustledger-lsp/src/main.rs
@@ -41,9 +41,21 @@ fn main() -> ExitCode {
         .with_writer(std::io::stderr)
         .init();
 
-    // Run the server
+    // Run the server. `start_stdio` drains the writer thread before
+    // returning, so by the time we convert the code into an ExitCode
+    // the client has already received the shutdown response.
+    // `process::exit` would still work, but returning ExitCode lets
+    // Rust's main runtime do any final cleanup it has.
     match rustledger_lsp::start_stdio() {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(0) => ExitCode::SUCCESS,
+        Ok(code) => {
+            // `code` is the exit code the client requested via the
+            // `exit` notification (1 = exit without prior shutdown,
+            // per LSP spec). Truncating to u8 mirrors what process::exit
+            // would do — exit codes outside 0..=255 are not portable.
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            ExitCode::from(code as u8)
+        }
         Err(e) => {
             tracing::error!("Server error: {}", e);
             ExitCode::FAILURE

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -174,6 +174,20 @@ pub struct MainLoopState {
     pub diagnostics: HashMap<Uri, Vec<lsp_types::Diagnostic>>,
     /// Whether shutdown was requested.
     pub shutdown_requested: bool,
+    /// Set by the `exit` notification handler. The main loop checks
+    /// this after each event and breaks when it's `Some(_)`, returning
+    /// the code from `run_main_loop_with_exit_action` so the caller
+    /// (`server.rs::start_stdio` in production) can drain the writer
+    /// thread via `io_threads.join()` BEFORE `process::exit`. Without
+    /// this, the production exit_action was `process::exit(code)`
+    /// directly — which terminates the process before the writer
+    /// thread flushes the shutdown response queued in its channel.
+    /// On a slow CI runner the writer can't keep up, the test
+    /// observes only the initialize response on stdout, and
+    /// `stdio_smoke` fails. See the `handle_notification` "exit"
+    /// arm and `run_main_loop_with_exit_action`'s return-value
+    /// documentation.
+    pub pending_exit_code: Option<i32>,
     /// LSP position encoding negotiated at initialization (UTF-8 or
     /// UTF-16). Handler code emitting `Position`s must consult this
     /// so positions align with what the client expects.
@@ -251,6 +265,7 @@ impl MainLoopState {
             sender,
             diagnostics: HashMap::new(),
             shutdown_requested: false,
+            pending_exit_code: None,
             // Conservative default: UTF-16 (the LSP spec default).
             // `server.rs::run` overrides this with the negotiated
             // encoding after `initialize`. Construction without
@@ -262,7 +277,15 @@ impl MainLoopState {
             task_receiver,
             job_sender,
             revision: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            exit_action: Some(Box::new(|code| std::process::exit(code))),
+            // Production used to wire this to `process::exit(code)`,
+            // which terminated before `io_threads.join()` could drain
+            // the writer — losing the shutdown response on slow runners
+            // (the stdio_smoke flake). The exit notification now
+            // signals via `pending_exit_code` instead, and the loop
+            // breaks normally; the caller then joins io_threads and
+            // exits with the propagated code. `exit_action` is kept
+            // for side effects (test harnesses use a no-op).
+            exit_action: Some(Box::new(|_code| {})),
         }
     }
 
@@ -1348,11 +1371,14 @@ impl MainLoopState {
             "exit" => {
                 tracing::info!("Exit notification received");
                 let code = if self.shutdown_requested { 0 } else { 1 };
-                // Pull the configured exit action; production wires
-                // this to `process::exit` (terminates immediately),
-                // tests pass a no-op. If the action returns (test
-                // path), the main loop continues running until the
-                // channel closes — which is what the harness wants.
+                // Signal the main loop to break with this code; the
+                // caller will drain the writer thread before exiting.
+                // See `pending_exit_code` field rustdoc.
+                self.pending_exit_code = Some(code);
+                // Invoke any caller-supplied side effect (test harnesses
+                // pass a no-op; production passes a no-op too post-fix
+                // because the actual process::exit is now done by the
+                // outer caller AFTER io_threads.join()).
                 if let Some(action) = self.exit_action.take() {
                     action(code);
                 }
@@ -1669,18 +1695,39 @@ impl MainLoopState {
 /// loop responsive while expensive requests run in parallel.
 ///
 /// # Arguments
+///
 /// * `receiver` - Channel to receive LSP messages from the client
 /// * `sender` - Channel to send LSP messages to the client
 /// * `journal_file` - Optional path to the root journal file for multi-file support
+///
+/// # Returns
+///
+/// The exit code from the `exit` notification (after the loop breaks
+/// cleanly), or `0` if the channel was closed before an `exit`
+/// notification arrived. The caller is expected to drain any IO
+/// threads (e.g., `lsp_server::Connection::stdio()`'s
+/// `io_threads.join()`) AFTER this returns and BEFORE terminating the
+/// process — otherwise the shutdown response queued in the writer
+/// thread's channel never reaches the client, which is the bug behind
+/// the `stdio_smoke` CI flake.
+#[must_use]
 pub fn run_main_loop(
     receiver: Receiver<lsp_server::Message>,
     sender: Sender<lsp_server::Message>,
     journal_file: Option<PathBuf>,
     position_encoding: crate::handlers::utils::PositionEncoding,
-) {
-    run_main_loop_with_exit_action(receiver, sender, journal_file, position_encoding, |code| {
-        std::process::exit(code)
-    });
+) -> i32 {
+    // No-op exit_action: the actual process termination (if any) is
+    // the caller's responsibility, performed AFTER io_threads.join()
+    // has drained the writer. The returned code is the source of
+    // truth.
+    run_main_loop_with_exit_action(
+        receiver,
+        sender,
+        journal_file,
+        position_encoding,
+        |_code| {},
+    )
 }
 
 /// Same as [`run_main_loop`] but with a caller-supplied `exit_action`
@@ -1714,13 +1761,15 @@ pub fn run_main_loop(
 /// // ... drive `client` with LSP messages ...
 /// drop(client); // closes the channel; the server thread exits.
 /// ```
+#[must_use]
 pub fn run_main_loop_with_exit_action<F>(
     receiver: Receiver<lsp_server::Message>,
     sender: Sender<lsp_server::Message>,
     journal_file: Option<PathBuf>,
     position_encoding: crate::handlers::utils::PositionEncoding,
     exit_action: F,
-) where
+) -> i32
+where
     F: FnOnce(i32) + Send + 'static,
 {
     let mut state = MainLoopState::new(sender, journal_file).with_exit_action(exit_action);
@@ -1729,12 +1778,12 @@ pub fn run_main_loop_with_exit_action<F>(
 
     tracing::info!("Main loop started");
 
-    loop {
+    let exit_code = loop {
         crossbeam_channel::select! {
             recv(receiver) -> msg => {
                 let msg = match msg {
                     Ok(msg) => msg,
-                    Err(_) => break, // Channel closed
+                    Err(_) => break 0, // Channel closed without an `exit` notification.
                 };
                 let event = match msg {
                     lsp_server::Message::Request(req) => Event::Message(Message::Request(req)),
@@ -1751,9 +1800,19 @@ pub fn run_main_loop_with_exit_action<F>(
                 }
             }
         }
-    }
+        // The `exit` notification handler signals via `pending_exit_code`
+        // instead of calling `process::exit` directly. Break here so
+        // the caller can drain the writer thread before terminating
+        // the process; otherwise the queued shutdown response can be
+        // lost on slow IO. See the field's rustdoc and the
+        // `stdio_smoke` flake discussion.
+        if let Some(code) = state.pending_exit_code {
+            break code;
+        }
+    };
 
-    tracing::info!("Main loop ended");
+    tracing::info!("Main loop ended (exit code {exit_code})");
+    exit_code
 }
 
 #[cfg(test)]

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1072,62 +1072,23 @@ impl MainLoopState {
         let uri = &params.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        // Snapshot the multi-file ledger directives ONLY when the
-        // current file has at least one balance assertion. The eager
-        // balance check inside `handle_code_lens` (#1253) is the only
-        // consumer of the snapshot; open/transaction lenses don't
-        // read it. Files with zero balance directives — the vast
-        // majority — would otherwise pay an O(N) deep clone of the
-        // full ledger under a read lock on every codeLens request.
-        // Editors fire codeLens frequently (post-edit, post-scroll),
-        // so the snapshot was the dominant cost on the hot path.
-        let has_balance = parse_result
-            .directives
-            .iter()
-            .any(|s| matches!(s.value, Directive::Balance(_)));
-        // Snapshot the ledger ONLY when (a) the file has balance
-        // directives that need cross-file lookup AND (b) the current
-        // file is actually part of the loaded journal. Without the
-        // contains_file check, opening an unrelated scratch
-        // .beancount file while a journal is loaded would feed the
-        // scratch lens the WRONG ledger's bookkeeping, producing
-        // nonsense ⚠ markers for assertions that are valid in the
-        // file the user is editing.
-        //
-        // Known limitation (Q3 from the architecture review): when
-        // the current file IS in the journal but has unsaved
-        // changes, the snapshot reflects the on-disk state, not the
-        // buffer. didChange doesn't trigger a journal reload (full
-        // pipeline is too expensive per keystroke). Result: balance
-        // lenses on the current file can be stale relative to the
-        // user's edits until they save. The validator's overlay
-        // path (see `validate_phase` around line 1499) does compute
-        // a buffer-overlaid view; lifting that into codeLens is a
-        // follow-up. The validator is the source of truth in the
-        // meantime, and the diagnostic (which DOES use the overlay)
-        // surfaces the real verdict.
-        // One read-lock acquisition guards both the contains_file
-        // check and the directives snapshot. Splitting them across
-        // two `.read()` calls left a window where a journal reload
-        // could remove the file between the membership check and
-        // the snapshot read, producing a wrong-ledger lens for a
-        // file no longer in the journal.
-        let ledger_directives = if has_balance {
-            let path = uri_to_path(uri);
-            let guard = self.ledger_state.read();
-            match path {
-                Some(p) if guard.contains_file(&p) => guard.directives().map(|d| d.to_vec()),
-                _ => None,
-            }
-        } else {
-            None
-        };
+        // The balance lens reads the validator's last-computed verdict
+        // for this URI from `self.diagnostics` (#1264). Pre-#1264 we
+        // snapshotted `ledger_state` so the lens could run its own
+        // evaluator; that evaluator dropped plugins (effective_date,
+        // lazy_balance, ...) and silently disagreed with `rledger check`
+        // on every ledger that used them. The new lens consults the
+        // diagnostic cache instead — diagnostics ARE the validator's
+        // verdict after the full pipeline. None means cold start
+        // (no `publish_diagnostics` for this URI yet); the lens renders
+        // a neutral title and never claims a verdict it can't back up.
+        let cached_diagnostics = self.diagnostics.get(uri).map(Vec::as_slice);
 
         let response = handle_code_lens(
             &params,
             &text,
             &parse_result,
-            ledger_directives.as_deref(),
+            cached_diagnostics,
             self.position_encoding,
         );
 

--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -46,8 +46,14 @@ impl Server {
         }
     }
 
-    /// Run the server's main loop.
-    pub fn run(self) {
+    /// Run the server's main loop. Returns the exit code produced by
+    /// the `exit` notification (or 0 if the channel closed without
+    /// one). The caller is responsible for draining IO threads
+    /// (`io_threads.join()`) before terminating the process — without
+    /// that drain, the writer can lose the shutdown response queued
+    /// when the loop broke.
+    #[must_use]
+    pub fn run(self) -> i32 {
         tracing::info!("Starting Beancount Language Server v{}", crate::VERSION);
 
         // Resolve journal file path relative to workspace root if needed
@@ -67,9 +73,10 @@ impl Server {
         // and the negotiated position encoding (so handlers emit
         // positions in the encoding the client expects).
         let (sender, receiver) = (self.connection.sender, self.connection.receiver);
-        run_main_loop(receiver, sender, journal_file, self.position_encoding);
+        let code = run_main_loop(receiver, sender, journal_file, self.position_encoding);
 
-        tracing::info!("Server shutdown complete");
+        tracing::info!("Server shutdown complete (exit code {code})");
+        code
     }
 
     /// Resolve the journal file path, making it absolute if necessary.
@@ -147,7 +154,18 @@ impl Server {
 }
 
 /// Start the LSP server using stdio transport.
-pub fn start_stdio() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+///
+/// Returns the exit code that the `exit` notification supplied (0 for
+/// a clean shutdown, 1 for exit-without-prior-shutdown per LSP spec).
+/// If the channel closed without an `exit` notification, returns 0.
+///
+/// Critically, `io_threads.join()` is called BEFORE returning, so the
+/// shutdown response queued in the writer thread's channel is fully
+/// flushed to stdout. Previously the production exit path called
+/// `process::exit(code)` from inside the main loop, which terminated
+/// the process before the writer could flush — losing the shutdown
+/// response on slow runners (the `stdio_smoke` CI flake).
+pub fn start_stdio() -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     tracing::info!("Starting LSP server on stdio");
 
     // Create connection using stdio
@@ -300,10 +318,16 @@ pub fn start_stdio() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Create and run server with the handler-facing position encoding
     // (derived above at the negotiation site).
     let server = Server::new(connection, init_params, handler_encoding);
-    server.run();
+    let exit_code = server.run();
 
-    // Wait for IO threads to finish
+    // Drain the writer thread BEFORE returning. The main loop has
+    // already broken (either via the `exit` notification or because
+    // the channel closed), but the writer may still be flushing the
+    // shutdown response queued just before. Without this drain, a
+    // subsequent `process::exit` in `main()` would kill the writer
+    // mid-flush; with it, the response reaches stdout before main
+    // tears down.
     io_threads.join()?;
 
-    Ok(())
+    Ok(exit_code)
 }

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -414,14 +414,28 @@ plugin \"beancount_reds_plugins.effective_date.effective_date\" \"{\n\
     let lenses = lenses.expect("lenses emitted on a non-empty document");
 
     // Latest diagnostics for our URI (the server may publish multiple
-    // times; the last one is the authoritative current state).
-    let latest_diags = diagnostic_payloads
+    // times; the last one is the authoritative current state). Fail
+    // loudly if no publishDiagnostics arrived for the URI — otherwise
+    // a URI-canonicalization mismatch (`p.uri.as_str()` vs the test's
+    // `uri: String`) could silently fall through to an empty slice,
+    // and a regression that emits ⚠ lenses without diagnostics could
+    // still pass the assertion vacuously.
+    let latest_payload = diagnostic_payloads
         .iter()
         .rev()
         .find(|p| p.uri.as_str() == uri)
-        .map(|p| p.diagnostics.as_slice())
-        .unwrap_or(&[]);
-    let error_lines: std::collections::HashSet<u32> = latest_diags
+        .unwrap_or_else(|| {
+            panic!(
+                "no publishDiagnostics arrived for {uri}; captured \
+                 payloads: {:?}",
+                diagnostic_payloads
+                    .iter()
+                    .map(|p| p.uri.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    let error_lines: std::collections::HashSet<u32> = latest_payload
+        .diagnostics
         .iter()
         .filter(|d| d.severity == Some(lsp_types::DiagnosticSeverity::ERROR))
         .map(|d| d.range.start.line)
@@ -445,6 +459,273 @@ plugin \"beancount_reds_plugins.effective_date.effective_date\" \"{\n\
          ERROR diagnostic exists at the same line(s). This is exactly \
          the dead-link UX the issue reported. error lines: {error_lines:?}, \
          dead-link lenses: {dead_links:?}"
+    );
+}
+
+/// Companion to `issue_1264_no_balance_lens_without_matching_diagnostic`:
+/// the opposite direction. A real balance-arithmetic failure (validator
+/// emits `E2001`) MUST surface as `⚠ Balance: X USD (see diagnostic)`
+/// on the lens, with a matching diagnostic at the same line.
+///
+/// Without this assertion, a future regression where the lens reads
+/// the wrong cache key, URI canonicalization drifts, or the new
+/// `validation_would_run` gate is misconfigured would silently
+/// downgrade every failing assertion to ✓ — the inverse of #1264 and
+/// just as misleading. The one-direction test (`issue_1264_*`) only
+/// catches the false-⚠ class; this catches the false-✓ class.
+#[test]
+fn real_balance_failure_round_trips_to_warning_lens() {
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let uri = test_uri("real_balance_failure.beancount");
+    // Deposit 50, assert 100 — guaranteed to fail balance-arithmetic.
+    let source = "2024-01-01 open Assets:Bank USD\n\
+2024-01-01 open Income:Salary\n\
+2024-01-15 * \"Deposit\"\n  \
+  Assets:Bank  50.00 USD\n  \
+  Income:Salary\n\
+2024-01-31 balance Assets:Bank 100 USD\n";
+    client.open_document(&uri, source);
+
+    let id = client.next_request_id();
+    let req = lsp_server::Request {
+        id: id.clone(),
+        method: <CodeLensRequest as lsp_types::request::Request>::METHOD.to_string(),
+        params: serde_json::to_value(CodeLensParams {
+            text_document: TextDocumentIdentifier {
+                uri: uri.parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .unwrap(),
+    };
+    client.raw_send_request(req).expect("send codeLens request");
+
+    let mut diagnostic_payloads: Vec<lsp_types::PublishDiagnosticsParams> = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let resp = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let msg = client
+            .recv_with_timeout(remaining)
+            .expect("timed out waiting for codeLens response");
+        match msg {
+            lsp_server::Message::Response(r) if r.id == id => break r,
+            lsp_server::Message::Notification(n)
+                if n.method == "textDocument/publishDiagnostics" =>
+            {
+                let p: lsp_types::PublishDiagnosticsParams =
+                    serde_json::from_value(n.params).unwrap();
+                diagnostic_payloads.push(p);
+            }
+            _ => {}
+        }
+    };
+
+    let result = resp.result.expect("codeLens returned a result");
+    let lenses: Option<Vec<lsp_types::CodeLens>> = serde_json::from_value(result).unwrap();
+    let lenses = lenses.expect("lenses emitted on a non-empty document");
+
+    // Verify the validator emitted an E2001 (balance assertion failed)
+    // diagnostic — otherwise the test premise is broken.
+    let latest_payload = diagnostic_payloads
+        .iter()
+        .rev()
+        .find(|p| p.uri.as_str() == uri)
+        .unwrap_or_else(|| {
+            panic!(
+                "no publishDiagnostics arrived for {uri}; captured \
+                 payloads: {:?}",
+                diagnostic_payloads
+                    .iter()
+                    .map(|p| p.uri.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    let balance_error = latest_payload.diagnostics.iter().find(|d| {
+        d.severity == Some(lsp_types::DiagnosticSeverity::ERROR)
+            && matches!(
+                &d.code,
+                Some(lsp_types::NumberOrString::String(s)) if s == "E2001",
+            )
+    });
+    let balance_error = balance_error.unwrap_or_else(|| {
+        panic!(
+            "test premise: validator must emit an E2001 for `balance \
+             Assets:Bank 100 USD` against a 50 USD deposit. captured \
+             diagnostics: {:?}",
+            latest_payload.diagnostics
+        )
+    });
+
+    // The balance lens for that line must be ⚠.
+    let balance_lens = lenses
+        .iter()
+        .find(|l| {
+            l.range.start.line == balance_error.range.start.line
+                && l.command
+                    .as_ref()
+                    .is_some_and(|c| c.title.contains("Balance:"))
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "no balance lens emitted at line {} (where the E2001 \
+                 lives). lenses: {:?}",
+                balance_error.range.start.line, lenses
+            )
+        });
+    let cmd = balance_lens.command.as_ref().expect("ships resolved");
+    assert!(
+        cmd.title.contains('⚠') && cmd.title.contains("see diagnostic"),
+        "real validator failure (E2001) MUST surface as ⚠ on the \
+         balance lens. got {:?}",
+        cmd.title
+    );
+}
+
+/// Replacement for the unit-level
+/// `test_code_lens_balance_uses_full_ledger_in_multi_file_mode` deleted
+/// in #1265. That test fed the old lens a multi-file directives
+/// snapshot directly and asserted the lens used cross-file aggregation
+/// (issue #470 coverage). The new lens reads from the validator's
+/// diagnostic cache; cross-file aggregation now lives in the validator,
+/// not the lens.
+///
+/// This protocol test pins the end-to-end story: a journal that
+/// includes two files, where file A asserts a balance that's only
+/// correct when file B's offsetting transaction is considered, must
+/// produce a `✓` lens on file A. Without multi-file aggregation, the
+/// validator would emit `E2001` on file A and the lens would render
+/// `⚠`. The test passing means the validator's cross-file overlay
+/// AND the lens's verdict propagation both work.
+#[test]
+fn multi_file_balance_lens_reflects_cross_file_aggregation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let bank_path = tmp.path().join("bank.beancount");
+    let credit_card_path = tmp.path().join("credit_card.beancount");
+
+    // bank.beancount asserts 4950 USD — only correct if credit_card.beancount's
+    // -50 USD transfer is visible.
+    std::fs::write(
+        &bank_path,
+        "2024-01-01 open Assets:Bank:Checking USD\n\
+         2024-01-01 open Income:Salary\n\
+         2024-01-15 * \"Paycheck\"\n  \
+           Assets:Bank:Checking   5000 USD\n  \
+           Income:Salary\n\
+         2024-01-21 balance Assets:Bank:Checking 4950 USD\n",
+    )
+    .expect("write bank.beancount");
+    std::fs::write(
+        &credit_card_path,
+        "2024-01-01 open Liabilities:Credit-Card\n\
+         2024-01-20 * \"Pay off credit card\"\n  \
+           Assets:Bank:Checking  -50 USD\n  \
+           Liabilities:Credit-Card\n",
+    )
+    .expect("write credit_card.beancount");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            bank_path.display(),
+            credit_card_path.display()
+        ),
+    )
+    .expect("write journal.beancount");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+
+    let bank_uri = format!("file://{}", bank_path.display());
+    let source = std::fs::read_to_string(&bank_path).expect("read bank");
+    client.open_document(&bank_uri, &source);
+
+    let id = client.next_request_id();
+    let req = lsp_server::Request {
+        id: id.clone(),
+        method: <CodeLensRequest as lsp_types::request::Request>::METHOD.to_string(),
+        params: serde_json::to_value(CodeLensParams {
+            text_document: TextDocumentIdentifier {
+                uri: bank_uri.parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .unwrap(),
+    };
+    client.raw_send_request(req).expect("send codeLens request");
+
+    let mut diagnostic_payloads: Vec<lsp_types::PublishDiagnosticsParams> = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let resp = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let msg = client
+            .recv_with_timeout(remaining)
+            .expect("timed out waiting for codeLens response");
+        match msg {
+            lsp_server::Message::Response(r) if r.id == id => break r,
+            lsp_server::Message::Notification(n)
+                if n.method == "textDocument/publishDiagnostics" =>
+            {
+                let p: lsp_types::PublishDiagnosticsParams =
+                    serde_json::from_value(n.params).unwrap();
+                diagnostic_payloads.push(p);
+            }
+            _ => {}
+        }
+    };
+
+    let result = resp.result.expect("codeLens returned a result");
+    let lenses: Option<Vec<lsp_types::CodeLens>> = serde_json::from_value(result).unwrap();
+    let lenses = lenses.expect("lenses emitted");
+
+    // bank.beancount's diagnostics must contain no E2001 for the
+    // balance: the validator saw both files via the journal and
+    // accepted the assertion.
+    let bank_diags = diagnostic_payloads
+        .iter()
+        .rev()
+        .find(|p| p.uri.as_str() == bank_uri)
+        .unwrap_or_else(|| {
+            panic!(
+                "no publishDiagnostics for {bank_uri}; captured: {:?}",
+                diagnostic_payloads
+                    .iter()
+                    .map(|p| p.uri.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    let unexpected_balance_error = bank_diags.diagnostics.iter().find(|d| {
+        d.severity == Some(lsp_types::DiagnosticSeverity::ERROR)
+            && matches!(
+                &d.code,
+                Some(lsp_types::NumberOrString::String(s)) if s == "E2001",
+            )
+    });
+    assert!(
+        unexpected_balance_error.is_none(),
+        "multi-file validator should have aggregated the -50 USD from \
+         credit_card.beancount; got an unexpected E2001 on bank.beancount: {:?}",
+        unexpected_balance_error,
+    );
+
+    let balance_lens = lenses
+        .iter()
+        .find(|l| {
+            l.command
+                .as_ref()
+                .is_some_and(|c| c.title.contains("Balance:"))
+        })
+        .expect("balance lens emitted");
+    let cmd = balance_lens.command.as_ref().expect("ships resolved");
+    assert!(
+        cmd.title.contains('✓') && cmd.title.contains("4950"),
+        "multi-file aggregation makes the assertion hold; lens must \
+         reflect the validator's ✓ verdict. got {:?}",
+        cmd.title
     );
 }
 

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -599,6 +599,18 @@ fn real_balance_failure_round_trips_to_warning_lens() {
 /// validator would emit `E2001` on file A and the lens would render
 /// `⚠`. The test passing means the validator's cross-file overlay
 /// AND the lens's verdict propagation both work.
+///
+/// Gated on `cfg(unix)`: the `file://{path}` URI assembly below assumes
+/// the path starts with `/` (POSIX absolute), so on Windows it would
+/// produce `file://C:\...` (only two slashes plus drive letter) and
+/// fail Uri parsing — or worse, parse to a non-canonical URI that the
+/// server rejects and falls into single-file mode, producing a
+/// misleading `⚠` for "balance assertion failed" instead of a clean
+/// platform skip. `main_loop.rs` cfg-splits its URI assembly between
+/// Unix (`file://{}`) and Windows (`file:///{}`); a Windows-portable
+/// variant of this test would mirror that. Today CI is Linux-only, so
+/// the gate is a guardrail for the future.
+#[cfg(unix)]
 #[test]
 fn multi_file_balance_lens_reflects_cross_file_aggregation() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -316,6 +316,138 @@ fn code_lens_resolve_round_trip_through_async_dispatch() {
     );
 }
 
+/// Regression for issue #1264: a balance lens carrying
+/// `⚠ ... (see diagnostic)` MUST correspond to a real ERROR diagnostic
+/// at the same line. Pre-#1264 the lens ran its own evaluator that
+/// dropped plugins (`effective_date`, `lazy_balance`, ...) and
+/// silently disagreed with `rledger check` — producing the dead-link
+/// UX of a ⚠ lens pointing at a diagnostic that didn't exist.
+///
+/// The structural fix is for the lens to consult the validator's
+/// diagnostic cache instead of re-deriving. This test pins the
+/// dead-link-impossibility invariant at the protocol level:
+/// drain all publishDiagnostics, request codeLens, and verify every
+/// ⚠ lens line is matched by an ERROR diagnostic line. The test
+/// doesn't need the effective_date plugin to actually load — the
+/// invariant holds regardless of what the validator computes, because
+/// the lens now follows the validator.
+///
+/// The document used is the exact reproduction from the issue.
+#[test]
+fn issue_1264_no_balance_lens_without_matching_diagnostic() {
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let uri = test_uri("issue_1264.beancount");
+    // Exact bytes from the issue: effective_date plugin shifts the
+    // 2012-02-03 food purchase to 2012-02-05, so balance assertions
+    // on 02-03 through 02-04 pass at 1000 USD (validator's verdict).
+    let source = "option \"operating_currency\" \"USD\"\n\
+\n\
+2012-01-01 open Assets:Bank\n\
+2012-01-01 open Equity:Transfer\n\
+2012-01-01 open Expenses:Food\n\
+2012-01-01 open Income:Employment\n\
+\n\
+plugin \"beancount_reds_plugins.effective_date.effective_date\" \"{\n\
+  'Assets':   {'earlier': 'Equity:Transfer', 'later': 'Equity:Transfer'},\n\
+}\"\n\
+\n\
+2012-02-01 * \"Salary\"\n  \
+  Assets:Bank                   1000 USD\n  \
+  Income:Employment\n\
+\n\
+2012-02-02 balance Assets:Bank  1000 USD\n\
+\n\
+2012-02-03 * \"Delayed food purchase\"\n  \
+  Expenses:Food                  100 USD\n  \
+  Assets:Bank                   -100 USD\n    \
+    effective_date: 2012-02-05\n\
+\n\
+2012-02-03 balance Assets:Bank  1000 USD\n\
+2012-02-04 balance Assets:Bank  1000 USD\n\
+2012-02-05 balance Assets:Bank  1000 USD\n\
+2012-02-06 balance Assets:Bank   900 USD\n";
+    client.open_document(&uri, source);
+
+    // Issue the codeLens request and drain everything until the
+    // response arrives, capturing every publishDiagnostics on the way.
+    // Same drain pattern as the #1253 test — guarantees we capture
+    // the diagnostic state matching the codeLens response.
+    let id = client.next_request_id();
+    let req = lsp_server::Request {
+        id: id.clone(),
+        method: <CodeLensRequest as lsp_types::request::Request>::METHOD.to_string(),
+        params: serde_json::to_value(CodeLensParams {
+            text_document: TextDocumentIdentifier {
+                uri: uri.parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .unwrap(),
+    };
+    client.raw_send_request(req).expect("send codeLens request");
+
+    let mut diagnostic_payloads: Vec<lsp_types::PublishDiagnosticsParams> = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let resp = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let msg = client
+            .recv_with_timeout(remaining)
+            .expect("timed out waiting for codeLens response");
+        match msg {
+            lsp_server::Message::Response(r) if r.id == id => break r,
+            lsp_server::Message::Notification(n)
+                if n.method == "textDocument/publishDiagnostics" =>
+            {
+                let p: lsp_types::PublishDiagnosticsParams =
+                    serde_json::from_value(n.params).unwrap();
+                diagnostic_payloads.push(p);
+            }
+            _ => {}
+        }
+    };
+
+    let result = resp.result.expect("codeLens returned a result");
+    let lenses: Option<Vec<lsp_types::CodeLens>> = serde_json::from_value(result).unwrap();
+    let lenses = lenses.expect("lenses emitted on a non-empty document");
+
+    // Latest diagnostics for our URI (the server may publish multiple
+    // times; the last one is the authoritative current state).
+    let latest_diags = diagnostic_payloads
+        .iter()
+        .rev()
+        .find(|p| p.uri.as_str() == uri)
+        .map(|p| p.diagnostics.as_slice())
+        .unwrap_or(&[]);
+    let error_lines: std::collections::HashSet<u32> = latest_diags
+        .iter()
+        .filter(|d| d.severity == Some(lsp_types::DiagnosticSeverity::ERROR))
+        .map(|d| d.range.start.line)
+        .collect();
+
+    // The dead-link-impossibility invariant: every ⚠ balance lens
+    // (which says "see diagnostic") must have a real ERROR diagnostic
+    // at the same line.
+    let dead_links: Vec<_> = lenses
+        .iter()
+        .filter(|l| {
+            let title = l.command.as_ref().map(|c| c.title.as_str()).unwrap_or("");
+            title.contains("Balance:") && title.contains("see diagnostic")
+        })
+        .filter(|l| !error_lines.contains(&l.range.start.line))
+        .collect();
+
+    assert!(
+        dead_links.is_empty(),
+        "issue #1264: balance lens(es) carry `(see diagnostic)` but no \
+         ERROR diagnostic exists at the same line(s). This is exactly \
+         the dead-link UX the issue reported. error lines: {error_lines:?}, \
+         dead-link lenses: {dead_links:?}"
+    );
+}
+
 /// Regression for F1 from the round-3 deep review: when a journal is
 /// loaded AND the user opens a `.beancount` file that is NOT part of
 /// the journal, `handle_code_lens_request`'s `contains_file` gate

--- a/crates/rustledger-lsp/tests/lsp_protocol/harness.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol/harness.rs
@@ -137,9 +137,11 @@ impl LspTestClient {
             }
 
             // No-op exit action: the `exit` notification will not
-            // terminate the test process. After the action returns,
-            // the main loop keeps running until the connection drops.
-            run_main_loop_with_exit_action(
+            // terminate the test process. The loop breaks cleanly via
+            // the new `pending_exit_code` path (post-stdio-flake fix);
+            // the returned code is discarded — the harness lets the
+            // test process keep running.
+            let _exit_code = run_main_loop_with_exit_action(
                 server.receiver,
                 server.sender,
                 journal_file,

--- a/docs/development/lsp-support.md
+++ b/docs/development/lsp-support.md
@@ -26,15 +26,27 @@ diagnostic vector for the file — and renders one of:
   the full list and the rationale for excluded codes (E1001, parse
   errors, plugin errors at the line — those describe a different
   failure and surface independently).
-- `Balance: X USD` (neutral, no symbol) in any of three cases:
+- `Balance: X USD` (neutral, no symbol) in any of three user-facing
+  conditions:
   - Cold start, before the first `publish_diagnostics` for the file.
   - Validation was skipped this turn (file > 500 KB or buffer has
     parse errors elsewhere — see `validation_would_run`).
-  - A non-balance ERROR (e.g., `E1001 AccountNotOpen`) anchors on the
-    balance directive's line — the diagnostic explains a different
-    problem; claiming `⚠ Balance` would misattribute the failure.
+  - A non-balance non-HINT diagnostic (e.g., `E1001 AccountNotOpen`
+    ERROR, `FutureDate` WARNING, `DateOutOfOrder` INFORMATION) anchors
+    on the balance directive's line — the diagnostic explains a
+    different problem; claiming `⚠ Balance` would misattribute the
+    failure and claiming `✓` would dismiss a real concern.
   In every neutral case the lens declines to claim a verdict it
   cannot back up.
+
+  Internally, the first two conditions are folded into
+  `verdict_diagnostics = None` by `handle_code_lens` before
+  `balance_lens_title` sees them — the title function itself only
+  distinguishes `None` (neutral) from `Some(diags)` with the three
+  diag-content branches (balance code → ⚠, non-balance/non-HINT → 
+  neutral, nothing → ✓). HINT-severity diagnostics are intentionally
+  ignored: code-action hints routinely anchor on directives and would
+  otherwise produce neutral noise on every code-action-eligible line.
 
 The validator runs the full pipeline (synth-plugins → Early → book →
 regular-plugins → Late) on every `didOpen` / `didChange` / `didSave`,

--- a/docs/development/lsp-support.md
+++ b/docs/development/lsp-support.md
@@ -9,44 +9,33 @@ balance-lens regressions caused by client/server protocol-interaction
 bugs that handler-level tests structurally could not catch). The
 layered testing approach below closes that gap.
 
-## Known limitations
+## Lens verdict source
 
-Two cases where the lens verdict can differ from the validator:
+The balance code lens does not compute its own verdict. It reads
+`MainLoopState::diagnostics[uri]` — the validator's last-computed
+diagnostic vector for the file — and renders:
 
-1. **Single-file mode skips synthesizer plugins.** Files outside the
-   journal (scratch buffers, files not yet `include`d) parse without
-   running `auto_accounts` / `document_discovery` / user plugins.
-   Ledgers that rely on plugin-synthesized directives see lens
-   verdicts that disagree with `rledger check`.
+- `✓ Balance: X USD` when no ERROR diagnostic overlaps the balance
+  directive's line.
+- `⚠ Balance: X USD (see diagnostic)` when one does. "see diagnostic"
+  is a true link by construction: the diagnostic the lens points at
+  is the diagnostic the lens consulted.
+- `Balance: X USD` (neutral, no symbol) on cold start, before the
+  first `publish_diagnostics` for the file. Never lies about a
+  verdict the lens has not computed.
 
-2. **Multi-file mode uses the on-disk snapshot.** When the journal
-   is loaded, the lens reads the post-pipeline directives from
-   `LedgerState`. `didChange` does NOT trigger a journal reload (the
-   full pipeline is too expensive per keystroke), so balance lenses
-   on a file with unsaved edits reflect the last-saved state, not
-   the current buffer. Save the file to refresh.
+The validator runs the full pipeline (synth-plugins → Early → book →
+regular-plugins → Late) on every `didOpen` / `didChange` / `didSave`,
+producing the same verdict `rledger check` does. The lens follows
+that verdict.
 
-In both cases the diagnostic is authoritative; the lens is a fast
-local approximation. A follow-up that splices the buffer into the
-multi-file snapshot (like the diagnostic overlay does) would close
-limitation 2.
-
-## Validator vs lens divergence (single-file mode)
-
-The balance code lens computes ✓ / ⚠ by booking the current file
-locally. It deliberately does NOT run synthesizer plugins
-(`auto_accounts`, `document_discovery`, user plugins) on every
-codeLens request: running them per keystroke would dominate lens
-latency. Consequence: in **single-file mode**, the lens can disagree
-with `rledger check` on ledgers that rely on plugin-synthesized
-directives.
-
-In **multi-file mode** the lens uses the snapshot the LSP loaded via
-`LedgerState::load`, which DID run the full pipeline. Multi-file lens
-verdicts match the validator exactly (modulo bugs in either path).
-
-When the lens diverges from the diagnostic, the diagnostic is the
-source of truth. The lens is a fast local approximation.
+Pre-#1264 the lens ran a separate `parse → sort → book` evaluator
+that silently dropped plugins. The classic symptom was a `⚠ ...
+(see diagnostic)` lens on a file `rledger check` accepted — the
+"see diagnostic" link pointed nowhere because the validator (running
+plugins) had not emitted one. That entire failure mode is structurally
+unreachable now: the lens and the diagnostic come from the same
+computation.
 
 ## Supported clients
 

--- a/docs/development/lsp-support.md
+++ b/docs/development/lsp-support.md
@@ -13,16 +13,28 @@ layered testing approach below closes that gap.
 
 The balance code lens does not compute its own verdict. It reads
 `MainLoopState::diagnostics[uri]` — the validator's last-computed
-diagnostic vector for the file — and renders:
+diagnostic vector for the file — and renders one of:
 
-- `✓ Balance: X USD` when no ERROR diagnostic overlaps the balance
-  directive's line.
-- `⚠ Balance: X USD (see diagnostic)` when one does. "see diagnostic"
-  is a true link by construction: the diagnostic the lens points at
-  is the diagnostic the lens consulted.
-- `Balance: X USD` (neutral, no symbol) on cold start, before the
-  first `publish_diagnostics` for the file. Never lies about a
-  verdict the lens has not computed.
+- `✓ Balance: X USD` when the validator ran AND no ERROR diagnostic
+  anchors on the balance directive's line.
+- `⚠ Balance: X USD (see diagnostic)` when an ERROR diagnostic with a
+  balance-arithmetic error code (`E2001` BalanceAssertionFailed,
+  `E2002` BalanceToleranceExceeded, `E2004` MultiplePadForBalance)
+  anchors on the line. "see diagnostic" is a true link by construction:
+  the diagnostic the lens points at is the diagnostic the lens
+  consulted. See `BALANCE_ERROR_CODES` in `handlers/code_lens.rs` for
+  the full list and the rationale for excluded codes (E1001, parse
+  errors, plugin errors at the line — those describe a different
+  failure and surface independently).
+- `Balance: X USD` (neutral, no symbol) in any of three cases:
+  - Cold start, before the first `publish_diagnostics` for the file.
+  - Validation was skipped this turn (file > 500 KB or buffer has
+    parse errors elsewhere — see `validation_would_run`).
+  - A non-balance ERROR (e.g., `E1001 AccountNotOpen`) anchors on the
+    balance directive's line — the diagnostic explains a different
+    problem; claiming `⚠ Balance` would misattribute the failure.
+  In every neutral case the lens declines to claim a verdict it
+  cannot back up.
 
 The validator runs the full pipeline (synth-plugins → Early → book →
 regular-plugins → Late) on every `didOpen` / `didChange` / `didSave`,


### PR DESCRIPTION
## Summary

- The balance code lens stops running its own evaluator and instead reads `MainLoopState::diagnostics[uri]` — the verdict the validator already computed via the full pipeline (synth-plugins → Early → book → regular-plugins → Late).
- The "dead-link" UX (⚠ lens pointing at no diagnostic) becomes structurally impossible: the diagnostic the lens points at is the diagnostic the lens consulted.
- Closes #1264: `effective_date` (and any other post-booking plugin) no longer trips a false ⚠. Net **−273 LOC**.

## Why

Pre-fix the lens ran a parallel pipeline (`parse → sort → book`) without plugins. That second pipeline silently disagreed with `rledger check` on every ledger that relied on plugin output. The issue's `effective_date` reproduction is one instance of a structural problem; prior fixes (eager resolution, tolerance match, sub-account match) patched specific divergences without removing the second pipeline.

The fix: the lens stops being an evaluator. `publish_diagnostics` already runs the validator and caches the result per URI. The lens reads that cache and renders a title consistent with it.

## What changed

- `handle_code_lens` signature: `cached_diagnostics: Option<&[Diagnostic]>` replaces `ledger_directives: Option<&[Spanned<Directive>]>`.
- Deleted: `book_directives_once`, `balance_at_date_from_booked`, `build_loader_options`, `LENS_OPTION_KEYS`, and their drift-guard tests (they existed because the lens re-derived; they evaporate now that it doesn't).
- `handle_code_lens_request`: replaced the `has_balance` pre-scan + ledger snapshot path with one `self.diagnostics.get(uri)` lookup.
- Three rendering cases: `✓` (no error at line), `⚠` (error at line), neutral `Balance: X USD` (cold start — never claims a verdict the lens can't back up).

## Invariants preserved

- **Eager resolution (#1253):** lens still ships with `command: Some(...)` and `data: None`. No resolve round-trip, no exposure to nvim's resolve-cancellation race. The `issue_1253_*` test passes unchanged.
- **No new latency on the codeLens hot path.** HashMap lookup + linear scan over a tiny diagnostic vec replaces a sort + booking pass + per-balance lookup.

## Test plan

- [x] Unit tests in `code_lens.rs` (5 new, covering pass / fail / cold-start / "follows diagnostic not parse").
- [x] Integration test `issue_1264_no_balance_lens_without_matching_diagnostic` drives the LSP with the issue's exact reproduction file and asserts every ⚠ lens line has a matching ERROR diagnostic line (the dead-link-impossibility invariant).
- [x] All 206 LSP tests pass locally (192 unit + 7 protocol + 1 stdio_smoke + 6 encoding_coverage).
- [x] `cargo clippy --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc -p rustledger-lsp --no-deps` clean.
- [x] `cargo check --workspace --all-features --all-targets` clean.
- [ ] Manual nvim smoke: open the issue's reproduction file, verify all balance lenses show ✓ (or no symbol on cold start), none show `(see diagnostic)`.

## Docs

`docs/development/lsp-support.md` updated: the "Validator vs lens divergence (single-file mode)" and "Known limitations" sections describing the parallel-pipeline approximation are replaced by a "Lens verdict source" section describing the new diagnostic-cache architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)