### PR TITLE
feat(cst): phase 1 of #1262 — rustledger-cst crate + byte-identical round-trip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,7 +889,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -1628,7 +1634,7 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags 2.11.1",
  "debugid",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1872,6 +1878,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -3541,7 +3553,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -3712,6 +3724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +3767,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3832,7 +3862,7 @@ dependencies = [
  "proptest",
  "rust_decimal",
  "rust_decimal_macros",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustledger-core",
  "thiserror 2.0.18",
 ]
@@ -3848,7 +3878,7 @@ dependencies = [
  "rkyv 0.8.16",
  "rust_decimal",
  "rust_decimal_macros",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "smallvec",
@@ -3856,11 +3886,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustledger-cst"
+version = "0.15.0"
+dependencies = [
+ "rowan",
+ "rustledger-parser",
+]
+
+[[package]]
 name = "rustledger-ffi-wasi"
 version = "0.15.0"
 dependencies = [
  "jiff",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustledger-booking",
  "rustledger-core",
  "rustledger-loader",
@@ -3909,7 +3947,7 @@ dependencies = [
  "rkyv 0.8.16",
  "rust_decimal",
  "rust_decimal_macros",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustledger-booking",
  "rustledger-core",
  "rustledger-parser",
@@ -4026,7 +4064,7 @@ dependencies = [
  "regex",
  "rust_decimal",
  "rust_decimal_macros",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustledger-core",
  "rustledger-loader",
  "rustledger-parser",
@@ -4044,7 +4082,7 @@ dependencies = [
  "rayon",
  "rust_decimal",
  "rust_decimal_macros",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustledger-booking",
  "rustledger-core",
  "rustledger-parser",
@@ -4630,6 +4668,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
   "crates/rustledger-core",
   "crates/rustledger-parser",
+  "crates/rustledger-cst",
   "crates/rustledger-loader",
   "crates/rustledger-booking",
   "crates/rustledger-validate",
@@ -21,6 +22,7 @@ members = [
 default-members = [
   "crates/rustledger-core",
   "crates/rustledger-parser",
+  "crates/rustledger-cst",
   "crates/rustledger-loader",
   "crates/rustledger-booking",
   "crates/rustledger-validate",
@@ -71,6 +73,9 @@ format_num_pattern = { version = "0.9.5", features = ["rust_decimal"] }
 chumsky = "1.0.0-alpha.7"
 miette = { version = "7", features = ["fancy"] }
 logos = "0.16"
+# Lossless syntax tree (rust-analyzer's library). Used by
+# `rustledger-cst` as phase 1 of the CST migration tracked in #1262.
+rowan = "0.16"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -175,6 +180,7 @@ parking_lot = "0.12"
 # Internal crates
 rustledger-core = { version = "0.15.0", path = "crates/rustledger-core" }
 rustledger-parser = { version = "0.15.0", path = "crates/rustledger-parser" }
+rustledger-cst = { version = "0.15.0", path = "crates/rustledger-cst" }
 rustledger-loader = { version = "0.15.0", path = "crates/rustledger-loader" }
 rustledger-booking = { version = "0.15.0", path = "crates/rustledger-booking" }
 rustledger-validate = { version = "0.15.0", path = "crates/rustledger-validate" }

--- a/crates/rustledger-cst/Cargo.toml
+++ b/crates/rustledger-cst/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rustledger-cst"
+description = "Lossless concrete syntax tree (CST) for Beancount, built on rowan. Phase 1 of #1262."
+version = "0.15.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+authors.workspace = true
+readme = "README.md"
+
+[lib]
+bench = false
+
+[dependencies]
+rowan.workspace = true
+# Phase-1 reuses the existing Logos lexer via `rustledger_parser::tokenize`.
+# Phase 2+ may absorb the lexer outright; for now we lean on it to keep
+# the new crate purely additive (zero changes to existing code paths).
+rustledger-parser.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rustledger-cst/README.md
+++ b/crates/rustledger-cst/README.md
@@ -1,0 +1,29 @@
+# rustledger-cst
+
+Lossless concrete syntax tree (CST) for Beancount, built on
+[`rowan`](https://crates.io/crates/rowan).
+
+Phase 1 of the parser-CST migration tracked in
+[#1262](https://github.com/rustledger/rustledger/issues/1262). This
+crate provides:
+
+- `SyntaxKind`: every token and node kind in the Beancount grammar.
+- `SyntaxNode` / `SyntaxToken`: `rowan` type aliases specialized to
+  the Beancount language.
+- `lossless_tokens(source)`: trivia-preserving adapter over
+  `rustledger_parser::logos_lexer::tokenize`.
+- `parse_flat(source)`: produce a flat `SOURCE_FILE` rowan tree whose
+  text round-trips byte-identically with the input.
+
+## Invariants
+
+- For every input `source`, `parse_flat(source).text().to_string() == source`
+  byte-for-byte. Exercised over the full ~700-file compatibility corpus
+  in `tests/round_trip.rs`.
+- The phase-1 tree is FLAT — every token is a direct child of
+  `SOURCE_FILE`. Phase 2 will replace this driver with a structured
+  parser that nests tokens under typed directive / posting / amount
+  nodes, without changing the byte-preservation property.
+
+See [#1262](https://github.com/rustledger/rustledger/issues/1262) for
+the full migration plan, decision register, and phase-by-phase scope.

--- a/crates/rustledger-cst/src/lib.rs
+++ b/crates/rustledger-cst/src/lib.rs
@@ -1,0 +1,28 @@
+//! Lossless concrete syntax tree (CST) for Beancount.
+//!
+//! Phase 1 of the parser-CST migration tracked in #1262. This crate
+//! provides:
+//!
+//! - [`SyntaxKind`]: every token and node kind in the Beancount grammar.
+//! - [`SyntaxNode`] / [`SyntaxToken`]: `rowan` type aliases specialized
+//!   to the Beancount language.
+//! - [`lossless_tokens::lossless_tokens`]: trivia-preserving adapter
+//!   over `rustledger_parser::logos_lexer::tokenize`.
+//! - [`parse_flat`]: produce a flat `SOURCE_FILE` rowan tree whose
+//!   text round-trips byte-identically with the input.
+//!
+//! Phase 2 will add structured node kinds (`DIRECTIVE`, `POSTING`,
+//! `AMOUNT_NODE`, ...) and a parser that nests tokens under them. The
+//! flat phase-1 tree is the foundation: byte-preservation is proved
+//! against the full compatibility corpus, and phase 2's structured
+//! parser can be developed in parallel against the same primitives.
+//!
+//! See #1262 for the full plan.
+
+pub mod lossless_tokens;
+pub mod parser;
+pub mod syntax_kind;
+
+pub use lossless_tokens::lossless_tokens;
+pub use parser::parse_flat;
+pub use syntax_kind::{BeancountLanguage, SyntaxKind, SyntaxNode, SyntaxToken};

--- a/crates/rustledger-cst/src/lossless_tokens.rs
+++ b/crates/rustledger-cst/src/lossless_tokens.rs
@@ -1,0 +1,289 @@
+//! Trivia-preserving adapter over the existing Logos lexer.
+//!
+//! The existing `rustledger_parser::logos_lexer::tokenize` returns
+//! `Vec<(Token, Span)>` where:
+//!
+//! - Content tokens (Date, String, Account, ...) carry real source
+//!   bytes via their span.
+//! - Some trivia (`Newline`, `Comment`, `PercentComment`, `Shebang`,
+//!   `EmacsDirective`, `Indent`, `DeepIndent`) are first-class tokens with
+//!   real spans.
+//! - **Horizontal whitespace between content tokens is silently
+//!   dropped** via the lexer's `#[logos(skip r"[ \t]+")]` attribute.
+//! - **The leading UTF-8 BOM is stripped pre-lexer** in
+//!   `rustledger_parser::bom::strip_leading` and never seen by the
+//!   lexer.
+//!
+//! This adapter recovers both gaps. The principle: for every byte of
+//! `source` in `[0, source.len())`, there is exactly one emitted
+//! `(SyntaxKind, Range<usize>)` covering it. Concatenating the
+//! covered slices in order reproduces `source` byte-for-byte.
+//!
+//! See the lexer audit notes in #1262's Phase 1 PR for why this
+//! approach was chosen over modifying the existing lexer.
+
+use std::ops::Range;
+
+use rustledger_parser::bom::strip_leading;
+use rustledger_parser::logos_lexer::{Token, tokenize};
+
+use crate::syntax_kind::SyntaxKind;
+
+/// UTF-8 byte sequence for the byte-order mark (`U+FEFF`).
+const UTF8_BOM_LEN: usize = 3;
+
+/// Tokenize `source` losslessly: every byte of input is covered by
+/// exactly one emitted `(SyntaxKind, Range<usize>)`, in source order.
+///
+/// Reuses `rustledger_parser::logos_lexer::tokenize` for the heavy
+/// lifting (literal recognition, post-processing of indent and
+/// line-start `#` comments) and adds:
+///
+/// - A synthetic `BOM` token at `0..3` when the source starts with
+///   the UTF-8 byte-order mark. The production parser strips the BOM
+///   at the `parse()` boundary BEFORE calling `tokenize`; doing the
+///   same here keeps the lexer's mid-file-BOM error path intact while
+///   recovering the leading BOM as a first-class token. The
+///   lexer-returned spans are shifted by `+UTF8_BOM_LEN` so they
+///   reference the ORIGINAL (BOM-included) source bytes.
+/// - Synthetic `WHITESPACE` tokens covering every byte gap between
+///   consecutive lexer-emitted token spans (the lexer drops mid-line
+///   `[ \t]+` via `#[logos(skip ...)]`).
+///
+/// The returned vector is the token stream that
+/// [`crate::parse_flat`] feeds into a `GreenNodeBuilder`.
+#[must_use]
+pub fn lossless_tokens(source: &str) -> Vec<(SyntaxKind, Range<usize>)> {
+    let mut out: Vec<(SyntaxKind, Range<usize>)> = Vec::new();
+    let mut cursor = 0usize;
+
+    // Strip the BOM (if any) the same way the production parser
+    // does, then emit a synthetic BOM token at offset 0..3 and shift
+    // the lexer's spans by the BOM length so they reference the
+    // original source's byte offsets.
+    let (lexer_source, had_bom) = strip_leading(source);
+    let offset = if had_bom {
+        out.push((SyntaxKind::BOM, 0..UTF8_BOM_LEN));
+        cursor = UTF8_BOM_LEN;
+        UTF8_BOM_LEN
+    } else {
+        0
+    };
+
+    for (token, span) in tokenize(lexer_source) {
+        let start = span.start + offset;
+        let end = span.end + offset;
+
+        // Two reasons `start` could lag `cursor` ≠ 0:
+        //
+        // - The skipped horizontal whitespace this adapter exists for
+        //   (start > cursor). Emit a WHITESPACE filler.
+        // - The lexer post-processes line-start `#` comments by
+        //   FAST-FORWARDING through other tokens until the next
+        //   newline, then emitting the entire line as one Comment.
+        //   Subsequent tokens (the `Newline` after the comment) have
+        //   `start == cursor`, so no gap. Nothing to do.
+        if start > cursor {
+            out.push((SyntaxKind::WHITESPACE, cursor..start));
+        }
+
+        // Defensive: the lexer should never emit a token whose start
+        // precedes the previous token's end. If it ever does (e.g., a
+        // future post-processing rewrite of spans), the assertion
+        // surfaces the bug instead of silently producing duplicate
+        // bytes in the round-trip.
+        debug_assert!(
+            start >= cursor,
+            "tokenize emitted an out-of-order span: cursor={cursor}, token_start={start}",
+        );
+
+        out.push((map_token_kind(&token), start..end));
+        cursor = end;
+    }
+
+    // Trailing bytes (e.g., a file that doesn't end with a newline
+    // and finishes mid-whitespace, or any future tokenize quirk). The
+    // round-trip contract — "every input byte is covered by exactly
+    // one output entry" — requires us to emit something for them.
+    if cursor < source.len() {
+        out.push((SyntaxKind::WHITESPACE, cursor..source.len()));
+    }
+
+    out
+}
+
+/// Map a `rustledger_parser::logos_lexer::Token` variant to its
+/// `SyntaxKind`. The mapping is 1:1 for content/keyword/punctuation
+/// tokens and forwards trivia (`Newline`, `Comment`, ...) to their
+/// dedicated `SyntaxKind` variants.
+///
+/// Token payloads (the `&str` arguments of `Date`, `Number`, ...) are
+/// not consulted — phase 1's lossless tokens carry source bytes via
+/// spans, not via the variant payload.
+#[allow(clippy::too_many_lines)]
+const fn map_token_kind(token: &Token<'_>) -> SyntaxKind {
+    match token {
+        // Literals
+        Token::Date(_) => SyntaxKind::DATE,
+        Token::Number(_) => SyntaxKind::NUMBER,
+        Token::String(_) => SyntaxKind::STRING,
+        Token::Account(_) => SyntaxKind::ACCOUNT,
+        Token::Currency(_) => SyntaxKind::CURRENCY,
+        Token::Tag(_) => SyntaxKind::TAG,
+        Token::Link(_) => SyntaxKind::LINK,
+        Token::MetaKey(_) => SyntaxKind::META_KEY,
+        Token::Flag(_) => SyntaxKind::FLAG,
+        Token::True => SyntaxKind::BOOL_TRUE,
+        Token::False => SyntaxKind::BOOL_FALSE,
+        Token::Null => SyntaxKind::NULL_KW,
+
+        // Keywords
+        Token::Txn => SyntaxKind::TXN_KW,
+        Token::Balance => SyntaxKind::BALANCE_KW,
+        Token::Open => SyntaxKind::OPEN_KW,
+        Token::Close => SyntaxKind::CLOSE_KW,
+        Token::Commodity => SyntaxKind::COMMODITY_KW,
+        Token::Pad => SyntaxKind::PAD_KW,
+        Token::Event => SyntaxKind::EVENT_KW,
+        Token::Query => SyntaxKind::QUERY_KW,
+        Token::Note => SyntaxKind::NOTE_KW,
+        Token::Document => SyntaxKind::DOCUMENT_KW,
+        Token::Price => SyntaxKind::PRICE_KW,
+        Token::Custom => SyntaxKind::CUSTOM_KW,
+        Token::Option_ => SyntaxKind::OPTION_KW,
+        Token::Include => SyntaxKind::INCLUDE_KW,
+        Token::Plugin => SyntaxKind::PLUGIN_KW,
+        Token::Pushtag => SyntaxKind::PUSHTAG_KW,
+        Token::Poptag => SyntaxKind::POPTAG_KW,
+        Token::Pushmeta => SyntaxKind::PUSHMETA_KW,
+        Token::Popmeta => SyntaxKind::POPMETA_KW,
+        Token::Pending => SyntaxKind::PENDING_KW,
+
+        // Punctuation
+        Token::LBrace => SyntaxKind::L_BRACE,
+        Token::RBrace => SyntaxKind::R_BRACE,
+        Token::LDoubleBrace => SyntaxKind::L_DOUBLE_BRACE,
+        Token::RDoubleBrace => SyntaxKind::R_DOUBLE_BRACE,
+        Token::LBraceHash => SyntaxKind::L_BRACE_HASH,
+        Token::LParen => SyntaxKind::L_PAREN,
+        Token::RParen => SyntaxKind::R_PAREN,
+        Token::At => SyntaxKind::AT,
+        Token::AtAt => SyntaxKind::AT_AT,
+        Token::Colon => SyntaxKind::COLON,
+        Token::Comma => SyntaxKind::COMMA,
+        Token::Tilde => SyntaxKind::TILDE,
+        Token::Pipe => SyntaxKind::PIPE,
+        Token::Plus => SyntaxKind::PLUS,
+        Token::Minus => SyntaxKind::MINUS,
+        Token::Star => SyntaxKind::STAR,
+        Token::Slash => SyntaxKind::SLASH,
+        Token::Hash => SyntaxKind::HASH,
+
+        // Trivia
+        Token::Newline => SyntaxKind::NEWLINE,
+        Token::Comment(_) => SyntaxKind::COMMENT,
+        Token::PercentComment(_) => SyntaxKind::PERCENT_COMMENT,
+        Token::Shebang(_) => SyntaxKind::SHEBANG,
+        Token::EmacsDirective(_) => SyntaxKind::EMACS_DIRECTIVE,
+        Token::Indent(_) => SyntaxKind::INDENT,
+        Token::DeepIndent(_) => SyntaxKind::DEEP_INDENT,
+
+        // Errors
+        Token::Error(_) => SyntaxKind::ERROR_TOKEN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Covering-and-disjoint property: for every byte of source, there
+    /// is exactly one emitted `(kind, range)` whose range contains it.
+    /// The simplest way to assert this is to walk the emitted entries
+    /// and verify they tile `[0, source.len())` with no overlap.
+    fn assert_tiles_source(source: &str, entries: &[(SyntaxKind, Range<usize>)]) {
+        let mut cursor = 0usize;
+        for (i, (_kind, range)) in entries.iter().enumerate() {
+            assert_eq!(
+                range.start, cursor,
+                "entry {i} starts at {} but cursor is {cursor} (gap or overlap)",
+                range.start,
+            );
+            assert!(
+                range.end >= range.start,
+                "entry {i} has end < start: {range:?}",
+            );
+            cursor = range.end;
+        }
+        assert_eq!(
+            cursor,
+            source.len(),
+            "entries don't cover the full source (covered {cursor} of {} bytes)",
+            source.len(),
+        );
+    }
+
+    #[test]
+    fn empty_source_tiles_trivially() {
+        let entries = lossless_tokens("");
+        assert!(entries.is_empty());
+        assert_tiles_source("", &entries);
+    }
+
+    #[test]
+    fn whitespace_only_source_is_filled() {
+        let source = "    \t  ";
+        let entries = lossless_tokens(source);
+        // The lexer emits nothing for whitespace-only input; the
+        // trailing-bytes case covers everything as one WHITESPACE.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, SyntaxKind::WHITESPACE);
+        assert_tiles_source(source, &entries);
+    }
+
+    #[test]
+    fn bom_is_recovered_as_first_token() {
+        let source = "\u{FEFF}2024-01-01 open Assets:Bank\n";
+        let entries = lossless_tokens(source);
+        assert_eq!(entries[0].0, SyntaxKind::BOM);
+        assert_eq!(entries[0].1, 0..UTF8_BOM_LEN);
+        assert_tiles_source(source, &entries);
+    }
+
+    #[test]
+    fn horizontal_whitespace_between_tokens_is_recovered() {
+        // The `tokenize` lexer skips the spaces between Date, Open,
+        // Account. Lossless adapter must recover them.
+        let source = "2024-01-01 open Assets:Bank\n";
+        let entries = lossless_tokens(source);
+        assert_tiles_source(source, &entries);
+        // Sanity: at least one WHITESPACE entry exists.
+        assert!(entries.iter().any(|(k, _)| *k == SyntaxKind::WHITESPACE));
+    }
+
+    #[test]
+    fn full_directive_tiles_source() {
+        let source = "\
+2024-01-01 open Assets:Bank USD
+2024-01-15 * \"Coffee\"
+  Assets:Bank  -5.00 USD
+  Expenses:Food
+";
+        let entries = lossless_tokens(source);
+        assert_tiles_source(source, &entries);
+        // And the concatenation reproduces the source.
+        let reconstructed: String = entries
+            .iter()
+            .map(|(_kind, range)| &source[range.clone()])
+            .collect();
+        assert_eq!(reconstructed, source);
+    }
+
+    #[test]
+    fn line_comment_keeps_its_own_span() {
+        let source = "; preamble\n2024-01-01 open Assets:Bank\n";
+        let entries = lossless_tokens(source);
+        assert_eq!(entries[0].0, SyntaxKind::COMMENT);
+        assert_tiles_source(source, &entries);
+    }
+}

--- a/crates/rustledger-cst/src/parser.rs
+++ b/crates/rustledger-cst/src/parser.rs
@@ -1,0 +1,106 @@
+//! Phase 1 flat parser: produce a `SOURCE_FILE` node containing every
+//! lossless token as a direct child, in source order.
+//!
+//! No structural nesting — every token is a leaf under the root. The
+//! tree round-trips byte-identically to the source; phase 2 will add
+//! structural node kinds (`DIRECTIVE`, `POSTING`, `AMOUNT_NODE`, ...)
+//! by reorganizing the same token stream into nested nodes.
+
+use rowan::GreenNodeBuilder;
+
+use crate::lossless_tokens::lossless_tokens;
+use crate::syntax_kind::{SyntaxKind, SyntaxNode};
+
+/// Parse `source` to a flat lossless CST.
+///
+/// Every byte of `source` is reachable from the returned root node;
+/// `parse_flat(source).text().to_string() == source` holds for every
+/// input. The round-trip property is exercised over the full
+/// compatibility corpus in `tests/round_trip.rs`.
+///
+/// Phase 2 of #1262 will replace this single-pass driver with a
+/// structured parser that emits typed directive nodes. Until then,
+/// `parse_flat` is the entry point for any consumer wanting a
+/// byte-preserving view of beancount source (formatter, refactor,
+/// rename).
+#[must_use]
+pub fn parse_flat(source: &str) -> SyntaxNode {
+    let mut builder = GreenNodeBuilder::new();
+    builder.start_node(SyntaxKind::SOURCE_FILE.into());
+
+    for (kind, range) in lossless_tokens(source) {
+        // `rowan::GreenNodeBuilder::token` takes the kind plus the
+        // textual bytes. We slice them out of the source by the
+        // adapter's range. The slice's lifetime is tied to `source`
+        // for the duration of the call; rowan copies the bytes into
+        // its own arena, so no borrow escapes.
+        builder.token(kind.into(), &source[range]);
+    }
+
+    builder.finish_node();
+    SyntaxNode::new_root(builder.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip invariant for hand-picked sources.
+    ///
+    /// `tests/round_trip.rs` exercises the same property over the
+    /// full compatibility corpus. The unit tests here cover edge
+    /// cases that don't need the corpus to be downloaded.
+    fn assert_round_trips(source: &str) {
+        let tree = parse_flat(source);
+        let reconstructed = tree.text().to_string();
+        assert_eq!(
+            reconstructed, source,
+            "phase-1 flat CST must round-trip byte-identically",
+        );
+    }
+
+    #[test]
+    fn empty_source_round_trips() {
+        assert_round_trips("");
+    }
+
+    #[test]
+    fn whitespace_only_round_trips() {
+        assert_round_trips("    \t  ");
+    }
+
+    #[test]
+    fn bom_round_trips() {
+        assert_round_trips("\u{FEFF}2024-01-01 open Assets:Bank\n");
+    }
+
+    #[test]
+    fn full_directive_round_trips() {
+        assert_round_trips(
+            "\
+2024-01-01 open Assets:Bank USD
+2024-01-15 * \"Coffee\"
+  Assets:Bank  -5.00 USD
+  Expenses:Food
+",
+        );
+    }
+
+    #[test]
+    fn line_comment_round_trips() {
+        assert_round_trips("; preamble\n2024-01-01 open Assets:Bank\n");
+    }
+
+    #[test]
+    fn trailing_no_newline_round_trips() {
+        // A file that doesn't end with a newline — tests the trailing
+        // adapter branch (cursor < source.len() when tokenize ends).
+        assert_round_trips("2024-01-01 open Assets:Bank");
+    }
+
+    #[test]
+    fn root_node_kind_is_source_file() {
+        let tree = parse_flat("");
+        assert_eq!(tree.kind(), SyntaxKind::SOURCE_FILE);
+    }
+}

--- a/crates/rustledger-cst/src/syntax_kind.rs
+++ b/crates/rustledger-cst/src/syntax_kind.rs
@@ -1,0 +1,404 @@
+//! Lossless syntax-tree kinds for the Beancount CST.
+//!
+//! Phase 1 of the parser-CST migration (#1262). Every byte of source
+//! is reachable from the tree: content tokens (Date, String, Account,
+//! ...) carry their own bytes, and structural trivia (whitespace,
+//! newlines, comments, BOM) lives as first-class tokens too. The
+//! formatter and any future refactor / rename / structural-search
+//! consumer walks the tree without needing access to the original
+//! source.
+//!
+//! # Phase 1 scope
+//!
+//! Phase 1 emits a FLAT CST — every token is a direct child of a
+//! single [`SyntaxKind::SOURCE_FILE`] node. Phase 2 will introduce
+//! the structural node kinds (`DIRECTIVE`, `POSTING`, `AMOUNT_NODE`,
+//! ...) and the parser logic that nests tokens under them. The
+//! placeholders for those node kinds are pre-allocated below so the
+//! phase 2 PR is purely additive (no `SyntaxKind` discriminant
+//! renumbering — which would invalidate any serialized form, see
+//! decision §3.11 of #1262 about wire stability).
+//!
+//! # Discriminant stability
+//!
+//! `SyntaxKind` discriminants ARE part of the public ABI: `rowan`
+//! stores them as a `u16` inside every green token / node. Reordering
+//! the enum, removing a variant, or inserting one mid-stream all
+//! change the integer mapping. For phase 1 the discriminants are
+//! freely renumberable because nothing is yet persisted; once any
+//! consumer caches `GreenNode`s on disk (or a wire format ships) the
+//! discriminants become a stability surface that future PRs must
+//! preserve.
+
+#![allow(non_camel_case_types)]
+// Variant naming follows rust-analyzer / rowan conventions (SCREAMING_SNAKE_CASE).
+// Clippy's standard "type names use CamelCase" lint flags every variant; the
+// `allow` is the project-wide pattern for this style.
+#![allow(missing_docs)]
+// Most variants are self-documenting one-to-one mirrors of the Logos
+// lexer's `Token` enum (keywords like `OPEN_KW`, punctuation like
+// `L_BRACE`); the doc on the parent enum and the [`crate::lossless_tokens`]
+// mapping function are the canonical references. Variants that DO need
+// commentary (trivia, structural-node reservations) carry their own
+// doc comments below.
+
+/// Every kind of node or token that can appear in a Beancount CST.
+///
+/// The variants split into three groups:
+///
+/// - **Tokens** (`*` or content-named) are LEAF nodes that carry source
+///   bytes.
+/// - **Trivia tokens** (`WHITESPACE`, `NEWLINE`, `COMMENT`, ...) are
+///   semantically uninteresting but byte-significant. The typed AST in
+///   phase 2 will skip them; the formatter walks them.
+/// - **Node kinds** (`SOURCE_FILE`, `DIRECTIVE`, ...) are non-leaf
+///   nodes. Phase 1 only uses `SOURCE_FILE`; the rest are pre-
+///   allocated for phase 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(u16)]
+pub enum SyntaxKind {
+    // --- Trivia tokens -----------------------------------------------------
+    /// 3-byte UTF-8 byte-order mark at the very start of a file.
+    /// Stripped pre-lexer in `rustledger_parser::bom`; phase 1 synthesizes
+    /// a token for it so the round-trip stays byte-identical.
+    BOM,
+    /// Horizontal whitespace (`[ \t]+`). The existing Logos lexer
+    /// silently drops these between content tokens via
+    /// `#[logos(skip ...)]`; phase 1's lossless adapter recovers them
+    /// from the byte gaps between consecutive token spans.
+    WHITESPACE,
+    /// `\r?\n`.
+    NEWLINE,
+    /// `; ...` to end-of-line.
+    COMMENT,
+    /// `% ...` to end-of-line (ledger-compat).
+    PERCENT_COMMENT,
+    /// `#! ...` (org-mode shebang at top of file).
+    SHEBANG,
+    /// `#+ ...` (org-mode property line).
+    EMACS_DIRECTIVE,
+    /// Leading whitespace at line start when a content token follows
+    /// (1-2 spaces). Span covers the whitespace bytes.
+    INDENT,
+    /// Leading whitespace at line start, 3+ spaces (posting-metadata
+    /// indentation level).
+    DEEP_INDENT,
+
+    // --- Literal tokens ----------------------------------------------------
+    /// `YYYY-MM-DD` or `YYYY/M/D`.
+    DATE,
+    /// Integer or decimal literal (may carry thousands commas).
+    NUMBER,
+    /// Double-quoted string with escape sequences.
+    STRING,
+    /// Account name (`Assets:Bank:Checking`).
+    ACCOUNT,
+    /// Currency symbol (`USD`, `/GAINS`).
+    CURRENCY,
+    /// `#tag`.
+    TAG,
+    /// `^link`.
+    LINK,
+    /// `meta-key:` at line start.
+    META_KEY,
+    /// Single-character flag token (`*`, `!`, etc. introducing a transaction).
+    FLAG,
+    /// `TRUE` / `True` / `true`.
+    BOOL_TRUE,
+    /// `FALSE` / `False` / `false`.
+    BOOL_FALSE,
+    /// `NULL`.
+    NULL_KW,
+
+    // --- Keyword tokens ----------------------------------------------------
+    TXN_KW,
+    BALANCE_KW,
+    OPEN_KW,
+    CLOSE_KW,
+    COMMODITY_KW,
+    PAD_KW,
+    EVENT_KW,
+    QUERY_KW,
+    NOTE_KW,
+    DOCUMENT_KW,
+    PRICE_KW,
+    CUSTOM_KW,
+    OPTION_KW,
+    INCLUDE_KW,
+    PLUGIN_KW,
+    PUSHTAG_KW,
+    POPTAG_KW,
+    PUSHMETA_KW,
+    POPMETA_KW,
+    /// `P` pending flag.
+    PENDING_KW,
+
+    // --- Punctuation tokens ------------------------------------------------
+    L_BRACE,
+    R_BRACE,
+    L_DOUBLE_BRACE,
+    R_DOUBLE_BRACE,
+    L_BRACE_HASH,
+    L_PAREN,
+    R_PAREN,
+    AT,
+    AT_AT,
+    COLON,
+    COMMA,
+    TILDE,
+    PIPE,
+    PLUS,
+    MINUS,
+    STAR,
+    SLASH,
+    /// Bare `#` (cost-spec date separator; line-start `#` is folded
+    /// into COMMENT by the lexer post-processing pass).
+    HASH,
+
+    // --- Error tokens ------------------------------------------------------
+    /// Lexer error (invalid bytes preserved in span for diagnostics).
+    ERROR_TOKEN,
+
+    // --- Node kinds (non-leaf) ---------------------------------------------
+    /// Root node — every byte of the file is reachable under this node.
+    SOURCE_FILE,
+
+    // The following node kinds are RESERVED for phase 2's structural
+    // parser. They are not emitted by phase 1's flat parser. Listed
+    // here so the discriminants stay stable when phase 2 starts using
+    // them.
+    DIRECTIVE,
+    POSTING,
+    POSTING_LIST,
+    AMOUNT_NODE,
+    COST_SPEC,
+    PRICE_ANNOTATION,
+    META_ENTRY,
+    META_BLOCK,
+    TAG_LINK_LIST,
+    /// Generic structural error recovery node.
+    ERROR_NODE,
+}
+
+impl SyntaxKind {
+    /// Returns true if the kind is a leaf token (carries source bytes)
+    /// rather than a parent node.
+    #[must_use]
+    pub const fn is_token(self) -> bool {
+        // Discriminants for token-shaped kinds come strictly before
+        // the SOURCE_FILE node-shaped boundary. Keep this in lock-step
+        // with the enum order above.
+        (self as u16) < (Self::SOURCE_FILE as u16)
+    }
+
+    /// Returns true if the kind is trivia (whitespace, newline,
+    /// comment, BOM) that the typed AST in phase 2 will skip when
+    /// walking the tree.
+    #[must_use]
+    pub const fn is_trivia(self) -> bool {
+        matches!(
+            self,
+            Self::BOM
+                | Self::WHITESPACE
+                | Self::NEWLINE
+                | Self::COMMENT
+                | Self::PERCENT_COMMENT
+                | Self::SHEBANG
+                | Self::EMACS_DIRECTIVE
+                | Self::INDENT
+                | Self::DEEP_INDENT
+        )
+    }
+}
+
+impl From<SyntaxKind> for rowan::SyntaxKind {
+    fn from(kind: SyntaxKind) -> Self {
+        Self(kind as u16)
+    }
+}
+
+/// The Beancount language tag for `rowan`. A zero-variant enum because
+/// rowan only ever uses the type for its `Language` impl — no values
+/// are ever constructed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum BeancountLanguage {}
+
+impl rowan::Language for BeancountLanguage {
+    type Kind = SyntaxKind;
+
+    fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {
+        kind_from_raw(raw.0)
+            .unwrap_or_else(|| panic!("rowan::SyntaxKind({}) is not a valid SyntaxKind", raw.0))
+    }
+
+    fn kind_to_raw(kind: Self::Kind) -> rowan::SyntaxKind {
+        kind.into()
+    }
+}
+
+/// Safe u16 → `SyntaxKind` conversion. The workspace forbids `unsafe`
+/// (per the `forbid-unsafe-code` invariant verified by the pre-push
+/// hook), so the canonical rust-analyzer-style `transmute` isn't an
+/// option. A match expression compiles to the same jump table at
+/// optimization levels we care about.
+///
+/// Keep in sync with the [`SyntaxKind`] enum order. The test
+/// `rowan_language_round_trip` exercises a representative sample, but
+/// a missing arm would silently return `None` and surface as a panic
+/// inside rowan if (and only if) a green tree carrying that
+/// discriminant were ever decoded. Update this function AND
+/// `is_token`'s SOURCE_FILE-boundary check together when adding kinds.
+#[allow(clippy::too_many_lines)]
+const fn kind_from_raw(raw: u16) -> Option<SyntaxKind> {
+    let kind = match raw {
+        0 => SyntaxKind::BOM,
+        1 => SyntaxKind::WHITESPACE,
+        2 => SyntaxKind::NEWLINE,
+        3 => SyntaxKind::COMMENT,
+        4 => SyntaxKind::PERCENT_COMMENT,
+        5 => SyntaxKind::SHEBANG,
+        6 => SyntaxKind::EMACS_DIRECTIVE,
+        7 => SyntaxKind::INDENT,
+        8 => SyntaxKind::DEEP_INDENT,
+        9 => SyntaxKind::DATE,
+        10 => SyntaxKind::NUMBER,
+        11 => SyntaxKind::STRING,
+        12 => SyntaxKind::ACCOUNT,
+        13 => SyntaxKind::CURRENCY,
+        14 => SyntaxKind::TAG,
+        15 => SyntaxKind::LINK,
+        16 => SyntaxKind::META_KEY,
+        17 => SyntaxKind::FLAG,
+        18 => SyntaxKind::BOOL_TRUE,
+        19 => SyntaxKind::BOOL_FALSE,
+        20 => SyntaxKind::NULL_KW,
+        21 => SyntaxKind::TXN_KW,
+        22 => SyntaxKind::BALANCE_KW,
+        23 => SyntaxKind::OPEN_KW,
+        24 => SyntaxKind::CLOSE_KW,
+        25 => SyntaxKind::COMMODITY_KW,
+        26 => SyntaxKind::PAD_KW,
+        27 => SyntaxKind::EVENT_KW,
+        28 => SyntaxKind::QUERY_KW,
+        29 => SyntaxKind::NOTE_KW,
+        30 => SyntaxKind::DOCUMENT_KW,
+        31 => SyntaxKind::PRICE_KW,
+        32 => SyntaxKind::CUSTOM_KW,
+        33 => SyntaxKind::OPTION_KW,
+        34 => SyntaxKind::INCLUDE_KW,
+        35 => SyntaxKind::PLUGIN_KW,
+        36 => SyntaxKind::PUSHTAG_KW,
+        37 => SyntaxKind::POPTAG_KW,
+        38 => SyntaxKind::PUSHMETA_KW,
+        39 => SyntaxKind::POPMETA_KW,
+        40 => SyntaxKind::PENDING_KW,
+        41 => SyntaxKind::L_BRACE,
+        42 => SyntaxKind::R_BRACE,
+        43 => SyntaxKind::L_DOUBLE_BRACE,
+        44 => SyntaxKind::R_DOUBLE_BRACE,
+        45 => SyntaxKind::L_BRACE_HASH,
+        46 => SyntaxKind::L_PAREN,
+        47 => SyntaxKind::R_PAREN,
+        48 => SyntaxKind::AT,
+        49 => SyntaxKind::AT_AT,
+        50 => SyntaxKind::COLON,
+        51 => SyntaxKind::COMMA,
+        52 => SyntaxKind::TILDE,
+        53 => SyntaxKind::PIPE,
+        54 => SyntaxKind::PLUS,
+        55 => SyntaxKind::MINUS,
+        56 => SyntaxKind::STAR,
+        57 => SyntaxKind::SLASH,
+        58 => SyntaxKind::HASH,
+        59 => SyntaxKind::ERROR_TOKEN,
+        60 => SyntaxKind::SOURCE_FILE,
+        61 => SyntaxKind::DIRECTIVE,
+        62 => SyntaxKind::POSTING,
+        63 => SyntaxKind::POSTING_LIST,
+        64 => SyntaxKind::AMOUNT_NODE,
+        65 => SyntaxKind::COST_SPEC,
+        66 => SyntaxKind::PRICE_ANNOTATION,
+        67 => SyntaxKind::META_ENTRY,
+        68 => SyntaxKind::META_BLOCK,
+        69 => SyntaxKind::TAG_LINK_LIST,
+        70 => SyntaxKind::ERROR_NODE,
+        _ => return None,
+    };
+    Some(kind)
+}
+
+/// Type alias for rowan's `SyntaxNode` specialized to `BeancountLanguage`.
+pub type SyntaxNode = rowan::SyntaxNode<BeancountLanguage>;
+/// Type alias for rowan's `SyntaxToken` specialized to `BeancountLanguage`.
+pub type SyntaxToken = rowan::SyntaxToken<BeancountLanguage>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_token_partitions_correctly() {
+        // Spot-check the boundary: WHITESPACE is a token, SOURCE_FILE
+        // is not, DIRECTIVE (reserved for phase 2) is not.
+        assert!(SyntaxKind::WHITESPACE.is_token());
+        assert!(SyntaxKind::DATE.is_token());
+        assert!(SyntaxKind::ERROR_TOKEN.is_token());
+        assert!(!SyntaxKind::SOURCE_FILE.is_token());
+        assert!(!SyntaxKind::DIRECTIVE.is_token());
+        assert!(!SyntaxKind::ERROR_NODE.is_token());
+    }
+
+    #[test]
+    fn is_trivia_covers_byte_significant_but_uninteresting_kinds() {
+        assert!(SyntaxKind::WHITESPACE.is_trivia());
+        assert!(SyntaxKind::NEWLINE.is_trivia());
+        assert!(SyntaxKind::COMMENT.is_trivia());
+        assert!(SyntaxKind::BOM.is_trivia());
+        assert!(!SyntaxKind::DATE.is_trivia());
+        assert!(!SyntaxKind::SOURCE_FILE.is_trivia());
+    }
+
+    #[test]
+    fn rowan_language_round_trip() {
+        for kind in [
+            SyntaxKind::WHITESPACE,
+            SyntaxKind::DATE,
+            SyntaxKind::SOURCE_FILE,
+            SyntaxKind::ERROR_NODE,
+        ] {
+            let raw: rowan::SyntaxKind = kind.into();
+            let back = <BeancountLanguage as rowan::Language>::kind_from_raw(raw);
+            assert_eq!(kind, back);
+        }
+    }
+
+    /// Exhaustive parity: every variant from BOM (discriminant 0) up
+    /// to and including `ERROR_NODE` survives a round-trip through
+    /// `kind_from_raw`. Drift between the enum order and the match
+    /// table is the most likely failure mode when adding new kinds
+    /// (e.g., for phase 2's structural nodes); this test catches it
+    /// before any green tree carrying the new discriminant exists.
+    #[test]
+    fn every_discriminant_round_trips() {
+        // The highest valid discriminant is ERROR_NODE. We walk 0..=N
+        // and verify each maps back to the kind whose `as u16` equals
+        // the raw value.
+        let max = SyntaxKind::ERROR_NODE as u16;
+        for raw in 0..=max {
+            let kind = kind_from_raw(raw).unwrap_or_else(|| {
+                panic!("kind_from_raw({raw}) returned None but raw is within ERROR_NODE bound")
+            });
+            assert_eq!(
+                kind as u16, raw,
+                "kind_from_raw({raw}) returned {kind:?} (discriminant {})",
+                kind as u16,
+            );
+        }
+        // And the boundary: anything above is rejected.
+        assert!(
+            kind_from_raw(max + 1).is_none(),
+            "kind_from_raw({}) should reject out-of-range",
+            max + 1,
+        );
+    }
+}

--- a/crates/rustledger-cst/tests/round_trip.rs
+++ b/crates/rustledger-cst/tests/round_trip.rs
@@ -1,0 +1,200 @@
+//! Byte-identical round-trip test for the phase-1 flat CST.
+//!
+//! For every `.beancount` file in the compatibility corpus, parse
+//! with [`rustledger_cst::parse_flat`] and assert that the green
+//! tree's text serialization equals the source byte-for-byte. The
+//! round-trip property is the foundational invariant of #1262: it
+//! means every byte of source is reachable from the CST, which
+//! enables the formatter (phase 4) to produce byte-preserving
+//! output and the refactor / rename / structural-search consumers
+//! to operate without ambiguity.
+//!
+//! # Skip-when-corpus-absent
+//!
+//! Mirrors the parser baseline's behavior: the test treats the
+//! corpus directory as not-downloaded when it contains fewer than
+//! [`MIN_FULL_CORPUS_SIZE`] files and either:
+//!
+//! - Skips silently (default mode) — local devs without
+//!   `./scripts/fetch-compat-test-files.sh` see the test pass with a
+//!   warning on stderr.
+//! - Fails loudly (`STRICT_BASELINE=1`) — CI uses this to ensure the
+//!   gate is load-bearing.
+//!
+//! # Why no manifest
+//!
+//! Unlike the parser baseline this test compares input == output
+//! pointwise; it has no committed expected hashes to drift against.
+//! Phase 2 may add a baseline for the structural-CST output, but
+//! phase 1 only needs the round-trip property.
+
+use std::path::{Path, PathBuf};
+
+use rustledger_cst::parse_flat;
+
+const CORPUS_ROOT: &str = "tests/compatibility/files";
+const MIN_FULL_CORPUS_SIZE: usize = 100;
+
+/// Walk up from the test's `CARGO_MANIFEST_DIR` to the workspace
+/// root. The marker is `tests/compatibility/files` (a directory) AND
+/// a `Cargo.toml` containing a `[workspace]` table at line start.
+fn repo_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if p.join(CORPUS_ROOT).is_dir() && has_workspace_table(&p) {
+            return p;
+        }
+        assert!(
+            p.pop(),
+            "could not locate repo root from {}",
+            env!("CARGO_MANIFEST_DIR"),
+        );
+    }
+}
+
+fn has_workspace_table(dir: &Path) -> bool {
+    let Ok(toml) = std::fs::read_to_string(dir.join("Cargo.toml")) else {
+        return false;
+    };
+    toml.lines()
+        .any(|line| line.trim_start().starts_with("[workspace]"))
+}
+
+fn discover_corpus_files(root: &Path) -> Vec<PathBuf> {
+    let corpus_dir = root.join(CORPUS_ROOT);
+    let mut out = Vec::new();
+    if !corpus_dir.is_dir() {
+        return out;
+    }
+    walk(&corpus_dir, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    // Panic on FS errors: a corpus discovery failure is exactly the
+    // class of CI flake we want to surface, not absorb.
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("read_dir({}) failed: {e}", dir.display()));
+    for entry in entries {
+        let entry =
+            entry.unwrap_or_else(|e| panic!("read_dir entry under {} failed: {e}", dir.display()));
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("beancount") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn phase_1_flat_cst_round_trips_every_corpus_file() {
+    let root = repo_root();
+    let files = discover_corpus_files(&root);
+    let strict = std::env::var_os("STRICT_BASELINE").is_some();
+
+    if files.len() < MIN_FULL_CORPUS_SIZE {
+        assert!(
+            !strict,
+            "STRICT_BASELINE: corpus has {} files (need at least \
+             {MIN_FULL_CORPUS_SIZE}). Did `./scripts/fetch-compat-test-files.sh` run?",
+            files.len(),
+        );
+        eprintln!(
+            "corpus at `{CORPUS_ROOT}` has only {} files (need at least \
+             {MIN_FULL_CORPUS_SIZE}). Run `./scripts/fetch-compat-test-files.sh`; \
+             skipping phase-1 round-trip check. CI uses STRICT_BASELINE=1.",
+            files.len(),
+        );
+        return;
+    }
+
+    let mut failures: Vec<(PathBuf, String)> = Vec::new();
+    let mut read_errors: Vec<(PathBuf, String)> = Vec::new();
+    for path in &files {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                // Files that aren't valid UTF-8 (e.g.,
+                // `fava/tests_data_invalid-unicode.beancount`) can't
+                // be `&str`-typed and therefore can't be round-tripped
+                // through `parse_flat`. The parser baseline records
+                // them as `read-error:InvalidData` sentinels rather
+                // than failing; we do the same — these fixtures exist
+                // to test the parser's invalid-input handling, not
+                // its byte-preservation property.
+                read_errors.push((path.clone(), format!("read-error: {e}")));
+                continue;
+            }
+        };
+        // `parse_flat` shouldn't panic, but if a future change to the
+        // lexer's post-processing produces a span the adapter doesn't
+        // expect, the round-trip check below would still fail with a
+        // clear diff. catch_unwind here so one bad file doesn't abort
+        // the entire corpus run.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            parse_flat(&source).text().to_string()
+        }));
+        match outcome {
+            Ok(reconstructed) if reconstructed == source => {}
+            Ok(reconstructed) => {
+                // Show a useful diff in the failure: the first byte
+                // offset where they diverge, plus a small window of
+                // context.
+                let diverge = source
+                    .as_bytes()
+                    .iter()
+                    .zip(reconstructed.as_bytes())
+                    .position(|(a, b)| a != b)
+                    .unwrap_or_else(|| source.len().min(reconstructed.len()));
+                failures.push((
+                    path.clone(),
+                    format!(
+                        "round-trip drift at byte {diverge} (source len {}, \
+                         reconstructed len {})",
+                        source.len(),
+                        reconstructed.len(),
+                    ),
+                ));
+            }
+            Err(payload) => {
+                let msg = payload
+                    .downcast_ref::<&'static str>()
+                    .map(|s| (*s).to_string())
+                    .or_else(|| payload.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "<non-string panic payload>".to_string());
+                failures.push((path.clone(), format!("panic: {msg}")));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        let mut report = String::new();
+        for (p, msg) in failures.iter().take(10) {
+            use std::fmt::Write;
+            // Append directly into the report buffer instead of
+            // collecting per-line `format!()` Strings (clippy's
+            // `format_collect`).
+            let _ = writeln!(&mut report, "  {}: {msg}", p.display());
+        }
+        panic!(
+            "phase-1 round-trip failed on {} of {} corpus files (first 10):\n{report}",
+            failures.len(),
+            files.len(),
+        );
+    }
+
+    if !read_errors.is_empty() {
+        eprintln!(
+            "info: {} of {} corpus files were skipped due to read errors \
+             (typically invalid-UTF-8 fixtures that exist to exercise the \
+              parser's error-handling path):",
+            read_errors.len(),
+            files.len(),
+        );
+        for (path, msg) in read_errors.iter().take(5) {
+            eprintln!("  {}: {msg}", path.display());
+        }
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -101,6 +101,7 @@ skip = [
   { crate = "object" },           # backtrace vs gimli
   { crate = "rand" },             # 0.8 (num-complex via faer/ferrolearn-bayes) vs 0.9 (faer's own) vs 0.10 (wasmtime 45 stack)
   { crate = "rand_core" },        # paired with rand — 0.6 vs 0.9 vs 0.10 same skew
+  { crate = "rustc-hash" },       # rowan (via hashbrown) ships 1.x; workspace is 2.x
   { crate = "rustix" },           # 0.38 vs 1.x
   { crate = "sha2" },             # 0.9 vs 0.10
   { crate = "syn" },              # 1.x (proc-macro ecosystem legacy) vs 2.x

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -216,6 +216,10 @@ criteria = "safe-to-deploy"
 version = "0.22.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.countme]]
+version = "3.0.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.cpp_demangle]]
 version = "0.4.5"
 criteria = "safe-to-deploy"
@@ -454,6 +458,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.half]]
 version = "2.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hashbrown]]
+version = "0.14.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
@@ -956,6 +964,10 @@ criteria = "safe-to-deploy"
 version = "1.6.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.rowan]]
+version = "0.16.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.rust_decimal]]
 version = "1.42.0"
 criteria = "safe-to-deploy"
@@ -1094,6 +1106,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.terminal_size]]
 version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.text-size]]
+version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3341,6 +3341,13 @@ As far as I can tell, it does not have any file IO or network access.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.rustc-hash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Straightforward crate with no unsafe code, does what it says on the tin."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.seahash]]
 who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3707,6 +3714,13 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/sup
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.3.2 -> 0.3.3"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.hashbrown]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.2 -> 0.14.5"
+notes = "I did not thoroughly check the safety argument for fold_impl, but it at least seems to be well documented."
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.hermit-abi]]


### PR DESCRIPTION
## Summary

- Stands up the new `rustledger-cst` crate (rowan-based lossless syntax tree).
- Provides `SyntaxKind`, `BeancountLanguage`, `lossless_tokens`, and `parse_flat` — enough surface for phase 2's structured parser to land on top incrementally.
- Round-trips byte-identically against the full ~700-file compatibility corpus (713 of 714 files; the skip is an invalid-UTF-8 fixture the parser baseline records the same way).
- Zero changes to any existing crate.

## What this PR adds

- `crates/rustledger-cst/Cargo.toml` + `README.md`.
- `src/syntax_kind.rs`: `SyntaxKind` enum (~80 variants) covering all `rustledger_parser` Token kinds plus trivia (`BOM`, `WHITESPACE`, `NEWLINE`, `COMMENT`, ...) plus pre-allocated phase-2 structural node kinds (`DIRECTIVE`, `POSTING`, `AMOUNT_NODE`, ...). Discriminants are stable from this PR onward.
- `src/syntax_kind.rs`: `BeancountLanguage` impl + safe (no-`unsafe`) `kind_from_raw` conversion. Exhaustive parity test asserts every discriminant round-trips.
- `src/lossless_tokens.rs`: trivia-preserving adapter over `rustledger_parser::logos_lexer::tokenize`. Recovers:
  - The leading UTF-8 BOM (stripped pre-lexer by `rustledger_parser::bom::strip_leading`).
  - Mid-line horizontal whitespace dropped by the lexer's `#[logos(skip ...)]`.
- `src/parser.rs::parse_flat`: drives `lossless_tokens` into a single `SOURCE_FILE` rowan node.
- `tests/round_trip.rs`: walks every `.beancount` file in `tests/compatibility/files/` and asserts the parsed tree's text serialization equals the source byte-for-byte. Skips silently when corpus is absent; CI uses `STRICT_BASELINE=1` to gate.

## Lexer audit conclusion

The existing Logos lexer already emits tokens for newlines, comments, shebangs, org-mode markers, and indent/deep-indent with real source spans. Only mid-line horizontal whitespace is dropped. The adapter recovers it without touching the existing lexer, parser, or any downstream crate.

## Test plan

- [x] 17 unit tests in `rustledger-cst` pass.
- [x] Corpus round-trip test passes: 713 of 714 files round-trip byte-identically (the 1 skip is `fava/tests_data_invalid-unicode.beancount`).
- [x] Clippy clean (`-D warnings`).
- [x] `cargo fmt --check` clean.
- [x] `cargo doc -p rustledger-cst -- -D warnings` clean.
- [x] `cargo check --workspace --all-features --all-targets` clean.

## What this PR does NOT do (phase 2 scope)

- No structural nesting yet — the phase-1 tree is FLAT (every token is a direct child of `SOURCE_FILE`).
- No typed AST surface (`Transaction::date()`, etc.).
- No formatter rewrite — `rustledger_parser::format_source` is unchanged.

Phase 2 will add structural node kinds and the parser that nests tokens under them, without changing the byte-preservation property.

Refs #1262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)