### PR TITLE
feat(parser): #1262 phase 2.0 trivia policy (Directive-Terminator Rule, Roslyn-derived)

### DIFF
--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -18,21 +18,33 @@
 //!
 //! # Trivia attachment policy (phase 2.0)
 //!
-//! Phase 1 emits a flat tree. Phase 2.0 pins the policy that phase
-//! 2.1+ parsers will follow when wrapping token runs in structural
-//! nodes. The full spec lives in the `trivia` submodule; the short
-//! version:
+//! Phase 1 emits a flat tree, where trivia attachment is a non-
+//! question. Phase 2.1+ introduces structural nodes (`DIRECTIVE`,
+//! then `POSTING` / `AMOUNT` / `COST_SPEC` / `META_ENTRY` / ...)
+//! that wrap token runs. Phase 2.0 pins the rule for which
+//! structural node owns which trivia token: **the Two-Line Rule**.
 //!
-//! - **Leading attaches forward.** A blank line between two
-//!   directives belongs to the SECOND directive.
-//! - **EOF is the exception.** Trivia after the last content token
-//!   attaches to the PRECEDING directive (nothing follows).
-//! - **`SOURCE_FILE` is the parent of last resort.** Trivia before
-//!   the first content token stays under `SOURCE_FILE`.
+//! Short version:
 //!
-//! Phase 1's `parse_flat` is policy-neutral (flat tree). Phase 2.1
-//! calls [`classify_trivia`] when deciding directive boundaries; see
-//! [`TriviaAttachment`] for the per-token classification it returns.
+//! - **Same-line trailing** trivia attaches to the PRECEDING
+//!   directive. An inline `; EOL comment` after an account name
+//!   trails its directive.
+//! - **Line-crossing leading** trivia attaches to the FOLLOWING
+//!   directive. The blank line between two directives leads the
+//!   second one.
+//! - **File-leading** trivia (before any content) attaches to
+//!   `SOURCE_FILE` directly — copyright headers are file-level
+//!   metadata, not part of the first directive.
+//! - **EOF trailing** trivia (after the last content) has no
+//!   following directive, so it stays with the file-final one.
+//!
+//! Phase 2.0 ships NO production helper for this — the policy is
+//! enforced via tree-shape regression tests in `cst::trivia`
+//! (private submodule). Phase 2.1's structured parser writes its
+//! own streaming, state-aware predicate that produces trees
+//! matching those shapes. If the parser drifts from the policy,
+//! the regression tests fire. See the `trivia` module rustdoc for
+//! the full spec and rationale.
 
 mod lossless_tokens;
 mod parser;
@@ -42,4 +54,3 @@ mod trivia;
 pub use lossless_tokens::lossless_kind_tokens;
 pub use parser::parse_flat;
 pub use syntax_kind::{BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
-pub use trivia::{TriviaAttachment, classify_trivia};

--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -21,30 +21,32 @@
 //! Phase 1 emits a flat tree, where trivia attachment is a non-
 //! question. Phase 2.1+ introduces structural nodes (`DIRECTIVE`,
 //! then `POSTING` / `AMOUNT` / `COST_SPEC` / `META_ENTRY` / ...)
-//! that wrap token runs. Phase 2.0 pins the rule for which
-//! structural node owns which trivia token: **the Two-Line Rule**.
+//! that wrap token runs. Phase 2.0 pins **the
+//! Directive-Terminator Rule**: every directive owns its content
+//! tokens PLUS its terminating `NEWLINE`.
 //!
 //! Short version:
 //!
-//! - **Same-line trailing** trivia attaches to the PRECEDING
-//!   directive. An inline `; EOL comment` after an account name
-//!   trails its directive.
-//! - **Line-crossing leading** trivia attaches to the FOLLOWING
-//!   directive. The blank line between two directives leads the
-//!   second one.
-//! - **File-leading** trivia (before any content) attaches to
-//!   `SOURCE_FILE` directly — copyright headers are file-level
-//!   metadata, not part of the first directive.
-//! - **EOF trailing** trivia (after the last content) has no
-//!   following directive, so it stays with the file-final one.
+//! - **Same-line trailing** trivia (whitespace + EOL comment
+//!   before the terminator) lives INSIDE the directive.
+//! - **Inter-directive leading** trivia (blank lines, mid-file
+//!   comment blocks) lives INSIDE the NEXT directive.
+//! - **File-leading** trivia (before the first content token) is
+//!   a direct child of `SOURCE_FILE`.
+//! - **File-trailing** trivia (after the file-final directive's
+//!   terminator) is also a direct child of `SOURCE_FILE`.
 //!
-//! Phase 2.0 ships NO production helper for this — the policy is
-//! enforced via tree-shape regression tests in `cst::trivia`
-//! (private submodule). Phase 2.1's structured parser writes its
-//! own streaming, state-aware predicate that produces trees
-//! matching those shapes. If the parser drifts from the policy,
-//! the regression tests fire. See the `trivia` module rustdoc for
-//! the full spec and rationale.
+//! Fully symmetric: every directive has the same children shape
+//! (optional leading + content + optional same-line trailing +
+//! terminator `NEWLINE`). No EOF special case.
+//!
+//! Phase 2.0 ships NO production helper — the policy is enforced
+//! via tree-shape regression tests in `cst::trivia` (private
+//! submodule). Phase 2.1's structured parser writes its own
+//! streaming, state-aware predicate that produces trees matching
+//! those shapes. If the parser drifts, the regression tests fire.
+//! See the `trivia` module rustdoc for the full spec, rationale,
+//! and recursive-application notes for phase 2.1's grammar.
 
 mod lossless_tokens;
 mod parser;

--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -16,29 +16,30 @@
 //! - [`parse_flat`]: produce a flat `SOURCE_FILE` tree that round-trips
 //!   byte-identically against the source.
 //!
-//! # Deferred design: trivia attachment policy (phase 2)
+//! # Trivia attachment policy (phase 2.0)
 //!
-//! Phase 1 emits a flat tree, so every token (content AND trivia) is
-//! a direct child of `SOURCE_FILE`. When phase 2 introduces structural
-//! nodes (`DIRECTIVE`, `POSTING`, ...) the question becomes: does the
-//! newline between two directives attach to the preceding directive,
-//! to the next one, or stay a `SOURCE_FILE`-level child?
+//! Phase 1 emits a flat tree. Phase 2.0 pins the policy that phase
+//! 2.1+ parsers will follow when wrapping token runs in structural
+//! nodes. The full spec lives in the `trivia` submodule; the short
+//! version:
 //!
-//! Phase 2's first PR must pick a policy and pin it with a regression
-//! test. The default recommendation (matching rust-analyzer's
-//! convention) is: leading trivia attaches to the FOLLOWING non-trivia
-//! node; trailing trivia attaches to the PRECEDING node only on the
-//! last item before EOF, where there is nothing following. That makes
-//! "node enter" the natural visiting point for any consumer that wants
-//! to skip trivia (the typed AST surface, validators, the formatter's
-//! header walk) while keeping the formatter's full-tree walk lossless.
+//! - **Leading attaches forward.** A blank line between two
+//!   directives belongs to the SECOND directive.
+//! - **EOF is the exception.** Trivia after the last content token
+//!   attaches to the PRECEDING directive (nothing follows).
+//! - **`SOURCE_FILE` is the parent of last resort.** Trivia before
+//!   the first content token stays under `SOURCE_FILE`.
 //!
-//! No policy is enforced in phase 1 — the flat tree is policy-neutral.
+//! Phase 1's `parse_flat` is policy-neutral (flat tree). Phase 2.1
+//! calls [`classify_trivia`] when deciding directive boundaries; see
+//! [`TriviaAttachment`] for the per-token classification it returns.
 
 mod lossless_tokens;
 mod parser;
 mod syntax_kind;
+mod trivia;
 
 pub use lossless_tokens::lossless_kind_tokens;
 pub use parser::parse_flat;
 pub use syntax_kind::{BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
+pub use trivia::{TriviaAttachment, classify_trivia};

--- a/crates/rustledger-parser/src/cst/syntax_kind.rs
+++ b/crates/rustledger-parser/src/cst/syntax_kind.rs
@@ -1,18 +1,34 @@
 //! `SyntaxKind`: every kind of token or node that can appear in the
 //! Beancount CST.
 //!
-//! Design notes (from the round-1 architecture review of the
-//! parallel-crate attempt that preceded this in-place migration):
+//! Design notes:
 //!
-//! - **No discriminant stability commitment.** Phase 2+ may reorder,
-//!   group, or rename freely. There are no committed serialized forms
-//!   to keep stable. Reservations are antipatterns.
+//! - **No cross-version stability commitment.** Phase 2+ may add new
+//!   variants. No serialized form persists `SyntaxKind` values across
+//!   binary versions (rowan green trees aren't designed as on-disk
+//!   format).
+//! - **APPEND-ONLY in practice.** The corpus baseline at
+//!   `tests/baselines/cst-corpus.manifest` hashes
+//!   `(SyntaxKind as u16, len)` per token for every file in the 714-
+//!   file compatibility corpus, AND a separate per-file node-shape
+//!   hash. Reordering variants invalidates every committed manifest
+//!   entry simultaneously, producing an unreviewable 700-line diff.
+//!   The rule for routine work: APPEND new variants at the relevant
+//!   section's end. If you genuinely must reorder, do it in a
+//!   SEPARATE commit from any parser change so reviewers can verify
+//!   the regen is mechanical.
 //! - **Safe u16 conversion via `num_enum::TryFromPrimitive`** instead
 //!   of a hand-rolled match table. Adding a new variant is a single
 //!   line; the derive enforces parity.
 //! - **`is_token` via `matches!` over the actual token variants**, not
 //!   a boundary trick on discriminants. A future variant inserted
 //!   anywhere is classified correctly.
+//! - **`kind_from_raw` falls back to `ERROR_NODE` on unknown
+//!   discriminants** in release builds (`debug_assert!` panics in
+//!   debug/test). Defends against version-skewed green-node bytes
+//!   reaching the parser via LSP cache, sidecar tooling, or
+//!   incremental persistence without crashing production. Surfaces
+//!   the skew loudly in dev/test where it's actionable.
 
 use num_enum::TryFromPrimitive;
 
@@ -137,15 +153,9 @@ pub enum SyntaxKind {
     // which remains as the umbrella kind for error-recovery
     // wrappers and any structural test reusable across kinds.
     // `#[non_exhaustive]` + `num_enum`'s derive make new variants
-    // safe to add without ABI concerns.
-    //
-    // **Variant order is observable.** The corpus baseline
-    // (`tests/cst_baseline.rs`) hashes `(kind as u16)` per token
-    // for every file in the 714-file corpus. APPEND only; reordering
-    // invalidates every committed manifest entry in one go and the
-    // resulting diff is unreadable. If you must reorder, regenerate
-    // the manifest in a SEPARATE commit from any parser change so
-    // the diff stays reviewable.
+    // safe to add without ABI concerns. (Append-only discipline
+    // and discriminant stability notes live in the module
+    // rustdoc.)
     /// Root node — every byte of the file is reachable under this node.
     SOURCE_FILE,
 
@@ -275,14 +285,25 @@ impl rowan::Language for BeancountLanguage {
     type Kind = SyntaxKind;
 
     fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {
-        // Defensive: fall back to ERROR_NODE on unknown discriminants
-        // rather than panic. Phase 2.0 added the `DIRECTIVE` variant
-        // and phase 2.1 will add more; any cross-version GreenNode
-        // bytes (LSP cache, incremental persistence, sidecar tooling
-        // reading our trees) seen by an older binary would otherwise
-        // panic deep inside rowan's tree walk, which is unrecoverable
-        // and a hard footgun. Returning `ERROR_NODE` surfaces the
-        // skew at the consumer's `kind()` check instead.
+        // Dev/test: panic loudly so version-skewed green-node bytes
+        // surface during development, when they're actionable. Prod:
+        // fall back to ERROR_NODE so an unrecoverable panic deep in
+        // rowan's tree walk (rowan calls kind_from_raw inside every
+        // tree traversal) can't take down a long-running LSP from a
+        // single stale cache file.
+        //
+        // The asymmetry with `SyntaxKind::try_from` is deliberate:
+        // try_from is for explicit roundtrip validation (e.g.,
+        // serializing a kind and reading it back, where Err is the
+        // useful signal); kind_from_raw is for tree-walk hot paths
+        // (where panic in prod is worse than a downgraded kind).
+        debug_assert!(
+            SyntaxKind::try_from(raw.0).is_ok(),
+            "unknown SyntaxKind discriminant {} — cross-version GreenNode \
+             skew, manifest reorder corruption, or a missing num_enum \
+             derive update. In release builds this becomes ERROR_NODE.",
+            raw.0,
+        );
         SyntaxKind::try_from(raw.0).unwrap_or(SyntaxKind::ERROR_NODE)
     }
 
@@ -334,10 +355,12 @@ mod tests {
     /// was added without updating the test scaffolding.
     #[test]
     fn every_kind_partitions_token_xor_node() {
-        // Search a generous discriminant range. `SyntaxKind` is
-        // small (~60 variants in phase 2.0); 256 is comfortable
-        // headroom for phase 2.1+ growth.
-        let all_kinds: Vec<SyntaxKind> = (0u16..256)
+        // FULL `u16::MAX` sweep, not a sampling. SyntaxKind is
+        // #[repr(u16)] so any discriminant in [0, u16::MAX] is
+        // legally constructible by a future PR. ~65K try_from
+        // calls is sub-millisecond and catches a future PR that
+        // pushes new variants past any arbitrary upper bound.
+        let all_kinds: Vec<SyntaxKind> = (0u16..=u16::MAX)
             .filter_map(|d| SyntaxKind::try_from(d).ok())
             .collect();
 

--- a/crates/rustledger-parser/src/cst/syntax_kind.rs
+++ b/crates/rustledger-parser/src/cst/syntax_kind.rs
@@ -132,10 +132,20 @@ pub enum SyntaxKind {
     // reserved for phase 2's structured recovery). Phase 2.0 adds
     // `DIRECTIVE` because the trivia-policy regression tests need a
     // wrapper to demonstrate which directive owns which trivia.
-    // Phase 2.1 will refine `DIRECTIVE` into specific kinds
-    // (`TRANSACTION`, `OPEN_DIRECTIVE`, ...). `#[non_exhaustive]` +
-    // `num_enum`'s derive make new variants safe to add without ABI
-    // concerns.
+    // Phase 2.1 will introduce specific directive kinds
+    // (`TRANSACTION`, `OPEN_DIRECTIVE`, ...) alongside `DIRECTIVE`,
+    // which remains as the umbrella kind for error-recovery
+    // wrappers and any structural test reusable across kinds.
+    // `#[non_exhaustive]` + `num_enum`'s derive make new variants
+    // safe to add without ABI concerns.
+    //
+    // **Variant order is observable.** The corpus baseline
+    // (`tests/cst_baseline.rs`) hashes `(kind as u16)` per token
+    // for every file in the 714-file corpus. APPEND only; reordering
+    // invalidates every committed manifest entry in one go and the
+    // resulting diff is unreadable. If you must reorder, regenerate
+    // the manifest in a SEPARATE commit from any parser change so
+    // the diff stays reviewable.
     /// Root node — every byte of the file is reachable under this node.
     SOURCE_FILE,
 
@@ -149,12 +159,15 @@ pub enum SyntaxKind {
 
     /// Generic structural-directive wrapper. Phase 2.0 introduces it
     /// solely as a regression-test target for the trivia attachment
-    /// policy (see `cst::trivia`). Phase 2.1 will replace it with
-    /// the 15+ specific directive-header kinds (`TRANSACTION`,
-    /// `OPEN_DIRECTIVE`, `CLOSE_DIRECTIVE`, ...) when the structured
-    /// parser starts emitting them; the trivia policy applies
-    /// uniformly to each, so the policy tests written against
-    /// `DIRECTIVE` carry over.
+    /// policy (see `cst::trivia`). Phase 2.1 adds specific kinds
+    /// alongside (`TRANSACTION`, `OPEN_DIRECTIVE`, `CLOSE_DIRECTIVE`,
+    /// `BALANCE_DIRECTIVE`, ...) when the structured parser starts
+    /// emitting them; `DIRECTIVE` remains as (a) the umbrella kind
+    /// for error-recovery wrappers around partial-directive
+    /// fragments, and (b) the test target for any structural
+    /// regression that's the same shape across all directive kinds.
+    /// The trivia policy applies UNIFORMLY to every specific kind,
+    /// so phase 2.1's tests can use any of them interchangeably.
     DIRECTIVE,
 }
 
@@ -262,8 +275,15 @@ impl rowan::Language for BeancountLanguage {
     type Kind = SyntaxKind;
 
     fn kind_from_raw(raw: rowan::SyntaxKind) -> Self::Kind {
-        SyntaxKind::try_from(raw.0)
-            .unwrap_or_else(|_| panic!("invalid SyntaxKind discriminant: {}", raw.0))
+        // Defensive: fall back to ERROR_NODE on unknown discriminants
+        // rather than panic. Phase 2.0 added the `DIRECTIVE` variant
+        // and phase 2.1 will add more; any cross-version GreenNode
+        // bytes (LSP cache, incremental persistence, sidecar tooling
+        // reading our trees) seen by an older binary would otherwise
+        // panic deep inside rowan's tree walk, which is unrecoverable
+        // and a hard footgun. Returning `ERROR_NODE` surfaces the
+        // skew at the consumer's `kind()` check instead.
+        SyntaxKind::try_from(raw.0).unwrap_or(SyntaxKind::ERROR_NODE)
     }
 
     fn kind_to_raw(kind: Self::Kind) -> rowan::SyntaxKind {
@@ -297,6 +317,67 @@ mod tests {
             assert!(
                 !kind.is_token(),
                 "{kind:?} is a node but is_token() returns true",
+            );
+        }
+    }
+
+    /// Closed-form exhaustiveness check that catches the failure
+    /// mode the two hand-maintained lists (`nodes_are_not_tokens`
+    /// and `tokens_are_tokens`) miss in isolation: a future variant
+    /// added to the enum but forgotten in `is_token`'s `matches!` arm
+    /// AND in both hand-maintained test lists.
+    ///
+    /// We enumerate every valid discriminant via the `num_enum`
+    /// `try_from` derive — the same surface `kind_from_raw` uses —
+    /// then count how many fall into each category, and compare to
+    /// the documented node list. If the counts disagree, a variant
+    /// was added without updating the test scaffolding.
+    #[test]
+    fn every_kind_partitions_token_xor_node() {
+        // Search a generous discriminant range. `SyntaxKind` is
+        // small (~60 variants in phase 2.0); 256 is comfortable
+        // headroom for phase 2.1+ growth.
+        let all_kinds: Vec<SyntaxKind> = (0u16..256)
+            .filter_map(|d| SyntaxKind::try_from(d).ok())
+            .collect();
+
+        // Sanity: we found something (catches a bug where
+        // try_from is broken for ALL discriminants).
+        assert!(
+            !all_kinds.is_empty(),
+            "SyntaxKind::try_from rejected every discriminant 0..256",
+        );
+
+        // The documented node kinds — must be kept in sync with
+        // the `// ---- Node kinds ----` section of the enum above.
+        // The exhaustive iteration catches any drift.
+        let documented_nodes = [
+            SyntaxKind::SOURCE_FILE,
+            SyntaxKind::ERROR_NODE,
+            SyntaxKind::DIRECTIVE,
+        ];
+        let observed_nodes: Vec<SyntaxKind> = all_kinds
+            .iter()
+            .copied()
+            .filter(|k| !k.is_token())
+            .collect();
+
+        assert_eq!(
+            observed_nodes.len(),
+            documented_nodes.len(),
+            "is_token() says there are {} node kinds but the \
+             documented list has {}: observed={observed_nodes:?}, \
+             documented={documented_nodes:?}. A new SyntaxKind \
+             variant was added without updating is_token's matches! \
+             arm AND the documented_nodes list in this test.",
+            observed_nodes.len(),
+            documented_nodes.len(),
+        );
+        for kind in documented_nodes {
+            assert!(
+                observed_nodes.contains(&kind),
+                "{kind:?} is documented as a node but is_token() \
+                 returns true for it",
             );
         }
     }

--- a/crates/rustledger-parser/src/cst/syntax_kind.rs
+++ b/crates/rustledger-parser/src/cst/syntax_kind.rs
@@ -127,12 +127,15 @@ pub enum SyntaxKind {
 
     // ---- Node kinds ------------------------------------------------------
     //
-    // Phase 1 emits a flat tree, so the only node kind actually used
-    // is `SOURCE_FILE`. Structural node kinds (DIRECTIVE / POSTING /
-    // AMOUNT / COST_SPEC / PRICE_ANNOTATION / META_ENTRY / ...) are
-    // NOT pre-declared — phase 2 PRs add them at the moment they're
-    // needed. `#[non_exhaustive]` + `num_enum`'s derive make new
-    // variants safe to add without ABI concerns.
+    // Structural node kinds are added at the moment they're first
+    // needed. Phase 1 emitted only `SOURCE_FILE` (plus `ERROR_NODE`
+    // reserved for phase 2's structured recovery). Phase 2.0 adds
+    // `DIRECTIVE` because the trivia-policy regression tests need a
+    // wrapper to demonstrate which directive owns which trivia.
+    // Phase 2.1 will refine `DIRECTIVE` into specific kinds
+    // (`TRANSACTION`, `OPEN_DIRECTIVE`, ...). `#[non_exhaustive]` +
+    // `num_enum`'s derive make new variants safe to add without ABI
+    // concerns.
     /// Root node — every byte of the file is reachable under this node.
     SOURCE_FILE,
 
@@ -143,6 +146,16 @@ pub enum SyntaxKind {
     /// PR adding it — error recovery is in scope for any parser that
     /// promises to keep going past bad input.
     ERROR_NODE,
+
+    /// Generic structural-directive wrapper. Phase 2.0 introduces it
+    /// solely as a regression-test target for the trivia attachment
+    /// policy (see `cst::trivia`). Phase 2.1 will replace it with
+    /// the 15+ specific directive-header kinds (`TRANSACTION`,
+    /// `OPEN_DIRECTIVE`, `CLOSE_DIRECTIVE`, ...) when the structured
+    /// parser starts emitting them; the trivia policy applies
+    /// uniformly to each, so the policy tests written against
+    /// `DIRECTIVE` carry over.
+    DIRECTIVE,
 }
 
 impl SyntaxKind {
@@ -275,7 +288,11 @@ mod tests {
     /// fail this property.
     #[test]
     fn nodes_are_not_tokens() {
-        let node_kinds = [SyntaxKind::SOURCE_FILE, SyntaxKind::ERROR_NODE];
+        let node_kinds = [
+            SyntaxKind::SOURCE_FILE,
+            SyntaxKind::ERROR_NODE,
+            SyntaxKind::DIRECTIVE,
+        ];
         for kind in node_kinds {
             assert!(
                 !kind.is_token(),

--- a/crates/rustledger-parser/src/cst/trivia.rs
+++ b/crates/rustledger-parser/src/cst/trivia.rs
@@ -105,37 +105,101 @@
 //! No trivia escapes to `SOURCE_FILE`; both directives have
 //! symmetric shape `[content..., terminator-NEWLINE]`.
 //!
-//! # Scope and phase-2.1 grammar option
+//! # Scope and recursive application
 //!
 //! This module pins the policy at the TOP-LEVEL inter-directive
-//! level. The rule is RECURSIVE in principle: phase 2.1 applies
-//! the same shape to nested structural elements (a `POSTING`
-//! inside a `TRANSACTION` owns its content + its terminating
-//! `NEWLINE` the same way a `DIRECTIVE` does at the top level).
-//! Whether a given inter-token `NEWLINE` ends the CURRENT
-//! structural node or continues it (e.g., transaction header to
-//! first posting) is a GRAMMAR question for phase 2.1 — once the
-//! grammar decides "this NEWLINE closes this node," the
-//! Directive-Terminator Rule is what determines that NEWLINE is
-//! INSIDE that node, not leading the next.
+//! level. The rule is RECURSIVE: phase 2.1 applies the same shape
+//! to nested structural elements (a `POSTING` inside a
+//! `TRANSACTION`, a `META_ENTRY` inside any directive that carries
+//! metadata). At each level, the structural node owns its content
+//! tokens plus its own terminating `NEWLINE`, by the same rule.
 //!
-//! **Phase 2.1 may additionally choose to promote same-line
-//! trailing comments to first-class structural slots** — i.e.,
-//! `Posting { content, trailing_comment: Option<COMMENT> }` —
-//! mirroring `polarmutex/tree-sitter-beancount`. This is purely
-//! additive on top of the Directive-Terminator Rule: rule 1 still
-//! says the COMMENT is INSIDE the posting; promoting it to a
-//! typed slot just exposes it through a typed accessor instead of
-//! requiring downstream code to scan children. The trade-off:
-//! grammar gets ~one extra optional slot per directive type
-//! (~15 directive kinds) in exchange for typed-AST clarity in
-//! phase 3 (`posting.trailing_comment()` becomes a direct
-//! accessor, not a scan-and-filter), and the phase-4 formatter
-//! places per-directive comments at a canonical structural
-//! location rather than preserving them positionally. Whether to
-//! adopt this pattern is a phase 2.1 design call, not a phase 2.0
-//! policy call; recording it here so phase 2.1's reviewer has
-//! prior art to refer to.
+//! ## Multi-line directives (with postings or metadata)
+//!
+//! Beancount directives that carry sub-lines — transactions with
+//! postings, and any directive with indented `key: "value"`
+//! metadata — span MULTIPLE LINES. The Directive-Terminator Rule
+//! says "the first `NEWLINE` after the directive's last content
+//! token"; for a multi-line directive, **the directive's last
+//! content token is the last content token of its LAST SUB-LINE**,
+//! not the header.
+//!
+//! Worked example (`2024-01-01 open Assets:Cash\n  description: "x"\n  currency: "USD"\n`):
+//!
+//! ```text
+//! OPEN_DIRECTIVE                       // outer directive node
+//! ├── DATE("2024-01-01")
+//! ├── WHITESPACE(" ")
+//! ├── OPEN_KW("open")
+//! ├── WHITESPACE(" ")
+//! ├── ACCOUNT("Assets:Cash")
+//! ├── NEWLINE("\n")                    // intra-directive: closes header line
+//! ├── META_ENTRY                       // nested structural node, recursive
+//! │   ├── WHITESPACE("  ")             // intra-meta-entry indent
+//! │   ├── META_KEY("description")
+//! │   ├── ... content tokens ...
+//! │   └── NEWLINE("\n")                // META_ENTRY's terminator
+//! ├── META_ENTRY                       // second meta entry
+//! │   ├── WHITESPACE("  ")
+//! │   ├── META_KEY("currency")
+//! │   ├── ... content tokens ...
+//! │   └── NEWLINE("\n")                // OPEN_DIRECTIVE's terminator
+//! ```
+//!
+//! Two consequences worth pinning:
+//!
+//! 1. **The header `NEWLINE` lives INSIDE the directive**, not as
+//!    its terminator. The directive's terminator is the LAST
+//!    `NEWLINE` (the one after the final sub-line). Deleting the
+//!    outer directive deletes its metadata too — what users
+//!    expect.
+//! 2. **Each `META_ENTRY` is itself a structural node** and owns
+//!    its own terminating `NEWLINE` by the recursive application.
+//!    The "last" `META_ENTRY`'s terminator NEWLINE is BOTH the
+//!    `META_ENTRY`'s terminator AND the outer directive's
+//!    terminator — it sits structurally INSIDE the `META_ENTRY`,
+//!    which is itself a child of the outer directive.
+//!
+//! ## `Indent` and `DeepIndent` are trivia
+//!
+//! The Logos lexer's AST-side `tokenize` pass synthesizes
+//! `Token::Indent(level)` and `Token::DeepIndent(level)` tokens
+//! for indented posting/metadata lines. The LOSSLESS path
+//! ([`crate::cst::lossless_tokens::lossless_kind_tokens`]) does
+//! NOT emit these — it keeps the raw `Token::Whitespace` runs
+//! that the indent tokens were summarizing. If a synthesized
+//! `Indent`/`DeepIndent` somehow reaches `lossless_kind_tokens`,
+//! the kind map at `cst/lossless_tokens.rs::map_kind` classifies
+//! it as `SyntaxKind::WHITESPACE` — i.e., trivia under
+//! `SyntaxKind::is_trivia`. The Directive-Terminator Rule treats
+//! these indent runs like any other intra-directive whitespace.
+//! No special policy line is required.
+//!
+//! # Phase 2.1 grammar option: typed comment accessor
+//!
+//! `polarmutex/tree-sitter-beancount` (the closest Beancount-
+//! specific lossless prior art) exposes each directive's same-
+//! line trailing comment via a `field("comment", optional($.comment))`
+//! declaration. In tree-sitter terms, the field is a NAME on one of
+//! the directive's existing children — the COMMENT is still in its
+//! source-order position as a child of the directive; the field
+//! just provides a named accessor.
+//!
+//! Phase 2.1 may adopt the equivalent in our typed-AST layer
+//! (`Posting::trailing_comment() -> Option<&SyntaxToken>` scanning
+//! the posting's direct token children for a `COMMENT`). **This
+//! is additive on top of the Directive-Terminator Rule:** the
+//! COMMENT remains a direct child token of the directive in the
+//! same source-order position rule 1 puts it; the typed accessor
+//! is a method on the typed AST wrapper, NOT a structural sub-node
+//! kind. The tree shape pinned by this module's tests is unchanged.
+//!
+//! If phase 2.1 instead chose a STRUCTURAL trailing-comment slot —
+//! a new `TRAILING_COMMENT_GROUP` wrapper node around the
+//! `WHITESPACE + COMMENT` run — that would be a TREE-SHAPE change,
+//! not additive, and would require updating rule 1 (and this
+//! module's tests). That option is out of scope for this PR; flag
+//! it explicitly if you go that direction.
 //!
 //! # Why
 //!

--- a/crates/rustledger-parser/src/cst/trivia.rs
+++ b/crates/rustledger-parser/src/cst/trivia.rs
@@ -1,0 +1,310 @@
+//! Trivia attachment policy for the CST. Phase 2.0 of #1262.
+//!
+//! Phase 1 emits a flat tree: every token (content AND trivia) is a
+//! direct child of `SOURCE_FILE`. Phase 2.1+ introduces structural
+//! nodes (DIRECTIVE wrappers, then POSTING, AMOUNT, ...). The
+//! question this module answers: when a trivia run sits between two
+//! content tokens, which structural node owns it?
+//!
+//! # The policy (rust-analyzer convention)
+//!
+//! 1. **Leading attaches forward.** Trivia (WHITESPACE, NEWLINE,
+//!    COMMENT, BOM, ...) that appears BETWEEN two content tokens
+//!    attaches to the FOLLOWING content token's structural parent.
+//!    A blank line between two directives belongs to the SECOND
+//!    directive, not the first.
+//! 2. **EOF is the exception.** Trivia appearing AFTER the last
+//!    content token attaches to the PRECEDING content token's
+//!    structural parent. There is no following node to attach to,
+//!    so the preceding directive absorbs it.
+//! 3. **`SOURCE_FILE` is the parent of last resort.** Trivia
+//!    appearing BEFORE any content token (BOM, shebang, copyright
+//!    comment header, leading blank lines) attaches to `SOURCE_FILE`
+//!    as a direct child — there is no preceding directive.
+//! 4. **A file containing only trivia** has every token under
+//!    `SOURCE_FILE` directly. Both edge cases (no content, only
+//!    trivia) collapse to `FileLeading`.
+//!
+//! # Why this convention
+//!
+//! - Most consumers (typed AST surface, validators, semantic
+//!   tooling) iterate over directives and want to skip trivia at
+//!   entry. The "leading attaches forward" rule means each
+//!   directive's `SyntaxNode` covers the blank lines preceding it,
+//!   so `node.text_range()` is the directive's full source span
+//!   including its visual separation. Consumers that don't care
+//!   about trivia skip it on enter; the formatter walks the full
+//!   tree and never skips, so either direction is lossless for it.
+//! - Matches rust-analyzer (and Roslyn, and most other lossless-CST
+//!   parsers). Reviewers familiar with that family don't have to
+//!   relearn the convention.
+//! - "Trailing attaches backward" would leave each directive's
+//!   `text_range()` ending mid-blank-line, making span arithmetic
+//!   awkward in tooling that wants whole-directive bounds (LSP
+//!   hover, selection range, code lens placement).
+//!
+//! # Scope
+//!
+//! This module operates on the FLAT token kind sequence and
+//! identifies what each trivia token's attachment WOULD be once
+//! structural nodes wrap top-level directives. It is the helper
+//! phase 2.1+ parsers call when deciding whether to consume trivia
+//! BEFORE opening a new DIRECTIVE node (`Leading` / `FileLeading`)
+//! or AFTER closing one (`EofTrailing`).
+//!
+//! Within a directive, intra-directive trivia (the NEWLINE between
+//! a transaction header and its postings, the WHITESPACE around a
+//! `+` in an amount expression, etc.) is GRAMMAR-DRIVEN and lives
+//! inside whatever structural node the grammar opens. That's phase
+//! 2.1's parser logic, not this module's.
+
+use crate::cst::syntax_kind::SyntaxKind;
+
+/// Where a trivia token attaches when phase 2+ wraps top-level
+/// directives in structural nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriviaAttachment {
+    /// Trivia appearing before any content token in the file.
+    /// Attaches to `SOURCE_FILE` as a direct child. Examples: a
+    /// leading BOM, a copyright-header comment block, blank lines
+    /// at the very top of the file.
+    FileLeading,
+    /// Trivia appearing between two content tokens. Attaches to the
+    /// FOLLOWING content token's structural parent (typically the
+    /// next directive node). Examples: the blank line between two
+    /// directives, the whitespace before a directive's date.
+    Leading,
+    /// Trivia appearing after the last content token in the file.
+    /// Attaches to the PRECEDING content token's structural parent
+    /// (the last directive). Example: a trailing newline at EOF.
+    EofTrailing,
+}
+
+/// Classify each token in a flat kind sequence as either non-trivia
+/// content (`None`) or trivia with an attachment intent (`Some`).
+///
+/// The returned `Vec` is the same length as `kinds`; index `i` of
+/// the result describes how the input's token at index `i` would
+/// attach when phase 2.1+ introduces structural directive nodes.
+///
+/// See the module-level rustdoc for the policy this implements.
+#[must_use]
+pub fn classify_trivia(kinds: &[SyntaxKind]) -> Vec<Option<TriviaAttachment>> {
+    let first_content = kinds.iter().position(|k| !k.is_trivia());
+    let last_content = kinds.iter().rposition(|k| !k.is_trivia());
+
+    let (Some(first), Some(last)) = (first_content, last_content) else {
+        // No content tokens at all: every token is FileLeading.
+        return kinds
+            .iter()
+            .map(|_| Some(TriviaAttachment::FileLeading))
+            .collect();
+    };
+
+    kinds
+        .iter()
+        .enumerate()
+        .map(|(i, kind)| {
+            if !kind.is_trivia() {
+                None
+            } else if i < first {
+                Some(TriviaAttachment::FileLeading)
+            } else if i > last {
+                Some(TriviaAttachment::EofTrailing)
+            } else {
+                Some(TriviaAttachment::Leading)
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TriviaAttachment::{EofTrailing, FileLeading, Leading};
+    use super::*;
+    use crate::cst::SyntaxKind::{
+        ACCOUNT, BOM, COMMENT, DATE, NEWLINE, OPEN_KW, SHEBANG, WHITESPACE,
+    };
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(classify_trivia(&[]).is_empty());
+    }
+
+    #[test]
+    fn single_content_token_has_no_attachment() {
+        assert_eq!(classify_trivia(&[DATE]), vec![None]);
+    }
+
+    #[test]
+    fn only_trivia_collapses_to_file_leading() {
+        // Whole file is blank lines + a comment.
+        let kinds = [NEWLINE, COMMENT, NEWLINE];
+        assert_eq!(
+            classify_trivia(&kinds),
+            vec![Some(FileLeading), Some(FileLeading), Some(FileLeading)],
+        );
+    }
+
+    #[test]
+    fn bom_at_start_is_file_leading() {
+        let kinds = [BOM, DATE, OPEN_KW];
+        assert_eq!(classify_trivia(&kinds), vec![Some(FileLeading), None, None],);
+    }
+
+    #[test]
+    fn shebang_at_start_is_file_leading() {
+        let kinds = [SHEBANG, NEWLINE, DATE, OPEN_KW];
+        assert_eq!(
+            classify_trivia(&kinds),
+            vec![Some(FileLeading), Some(FileLeading), None, None],
+        );
+    }
+
+    #[test]
+    fn copyright_header_before_first_directive_is_file_leading() {
+        // ;; Copyright header
+        // ;; ...
+        // 2024-01-01 open Assets:Cash
+        let kinds = [COMMENT, NEWLINE, COMMENT, NEWLINE, DATE, OPEN_KW, ACCOUNT];
+        assert_eq!(
+            classify_trivia(&kinds),
+            vec![
+                Some(FileLeading),
+                Some(FileLeading),
+                Some(FileLeading),
+                Some(FileLeading),
+                None,
+                None,
+                None,
+            ],
+        );
+    }
+
+    #[test]
+    fn trailing_newline_at_eof_is_eof_trailing() {
+        let kinds = [DATE, OPEN_KW, NEWLINE];
+        assert_eq!(classify_trivia(&kinds), vec![None, None, Some(EofTrailing)]);
+    }
+
+    #[test]
+    fn multiple_trailing_blank_lines_are_eof_trailing() {
+        // Last directive followed by two blank lines at EOF.
+        let kinds = [DATE, OPEN_KW, NEWLINE, NEWLINE, NEWLINE];
+        assert_eq!(
+            classify_trivia(&kinds),
+            vec![
+                None,
+                None,
+                Some(EofTrailing),
+                Some(EofTrailing),
+                Some(EofTrailing)
+            ],
+        );
+    }
+
+    #[test]
+    fn blank_line_between_directives_attaches_forward_as_leading() {
+        // The load-bearing test: pins the rust-analyzer convention.
+        //
+        //   2024-01-01 open Assets:Cash
+        //   <blank>
+        //   2024-01-02 open Assets:Bank
+        //
+        // The blank-line NEWLINE belongs to the SECOND directive
+        // (Leading), not the first (Trailing). If a future refactor
+        // flips this rule, this assertion fires and the policy
+        // change has to be deliberate.
+        let kinds = [
+            DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE, // first directive
+            NEWLINE, // <-- blank line
+            DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE, // second directive
+        ];
+        let got = classify_trivia(&kinds);
+        // Indices of trivia: 1, 3, 5, 6, 8, 10, 12.
+        // Last content token is index 11 (ACCOUNT). Index 12 is past it.
+        assert_eq!(got[1], Some(Leading), "intra-first WHITESPACE");
+        assert_eq!(got[3], Some(Leading), "intra-first WHITESPACE");
+        assert_eq!(got[5], Some(Leading), "end-of-first NEWLINE");
+        assert_eq!(
+            got[6],
+            Some(Leading),
+            "BLANK LINE attaches FORWARD (load-bearing assertion)",
+        );
+        assert_eq!(got[8], Some(Leading), "intra-second WHITESPACE");
+        assert_eq!(got[10], Some(Leading), "intra-second WHITESPACE");
+        assert_eq!(got[12], Some(EofTrailing), "trailing NEWLINE at EOF");
+    }
+
+    #[test]
+    fn comment_block_between_directives_attaches_forward() {
+        //   2024-01-01 open Assets:Cash
+        //   ;; comment about the next account
+        //   2024-01-02 open Assets:Bank
+        let kinds = [
+            DATE, OPEN_KW, ACCOUNT, NEWLINE, // first directive
+            COMMENT, NEWLINE, // mid-file comment
+            DATE, OPEN_KW, ACCOUNT, // second directive
+        ];
+        let got = classify_trivia(&kinds);
+        assert_eq!(got[4], Some(Leading), "mid-file COMMENT attaches forward");
+        assert_eq!(got[5], Some(Leading), "comment-terminating NEWLINE");
+    }
+
+    #[test]
+    fn trailing_comment_block_at_eof_is_eof_trailing() {
+        //   2024-01-01 open Assets:Cash
+        //   ;; closing remarks
+        let kinds = [DATE, OPEN_KW, ACCOUNT, NEWLINE, COMMENT, NEWLINE];
+        let got = classify_trivia(&kinds);
+        assert_eq!(got[3], Some(EofTrailing));
+        assert_eq!(got[4], Some(EofTrailing));
+        assert_eq!(got[5], Some(EofTrailing));
+    }
+
+    #[test]
+    fn leading_and_trailing_coexist_with_content() {
+        //   ;; header
+        //   2024-01-01 open Assets:Cash
+        //   <blank>
+        //   2024-01-02 open Assets:Bank
+        //   ;; footer
+        let kinds = [
+            COMMENT, NEWLINE, // file-leading
+            DATE, OPEN_KW, ACCOUNT, NEWLINE, NEWLINE, // blank between directives
+            DATE, OPEN_KW, ACCOUNT, NEWLINE, COMMENT, NEWLINE, // file-trailing
+        ];
+        let got = classify_trivia(&kinds);
+        assert_eq!(got[0], Some(FileLeading));
+        assert_eq!(got[1], Some(FileLeading));
+        assert_eq!(got[5], Some(Leading));
+        assert_eq!(got[6], Some(Leading));
+        assert_eq!(got[10], Some(EofTrailing));
+        assert_eq!(got[11], Some(EofTrailing));
+        assert_eq!(got[12], Some(EofTrailing));
+    }
+
+    #[test]
+    fn classification_length_matches_input() {
+        // Property: classify_trivia returns one entry per input
+        // token, in the same order. Phase 2.1's parser relies on
+        // index correspondence.
+        let kinds = [
+            BOM, COMMENT, NEWLINE, DATE, WHITESPACE, OPEN_KW, ACCOUNT, NEWLINE,
+        ];
+        let got = classify_trivia(&kinds);
+        assert_eq!(got.len(), kinds.len());
+    }
+
+    #[test]
+    fn non_trivia_is_always_none() {
+        // Every non-trivia variant must return None regardless of
+        // position. Guard against a future variant being silently
+        // misclassified.
+        let content_kinds = [DATE, OPEN_KW, ACCOUNT];
+        let got = classify_trivia(&content_kinds);
+        for (i, c) in got.iter().enumerate() {
+            assert_eq!(*c, None, "index {i}: content token returned attachment");
+        }
+    }
+}

--- a/crates/rustledger-parser/src/cst/trivia.rs
+++ b/crates/rustledger-parser/src/cst/trivia.rs
@@ -5,531 +5,560 @@
 //! non-question. Phase 2.1+ introduces structural nodes
 //! (`DIRECTIVE` wrappers, then `POSTING` / `AMOUNT` / `COST_SPEC` /
 //! `META_ENTRY` / ...). Once those nodes exist, every trivia token
-//! must end up inside exactly one of them — that's the contract this
-//! module pins.
+//! must end up inside exactly one of them — that's the contract
+//! this module pins.
 //!
-//! # The Two-Line Rule
+//! # The Directive-Terminator Rule
 //!
-//! Pick the trivia's home by asking ONE question of the trivia run
-//! between two content tokens (or between content and EOF / SOF):
-//! does it cross a `NEWLINE` from the preceding content?
+//! **Every directive structural node OWNS its content tokens PLUS
+//! its terminating `NEWLINE`** — the first `NEWLINE` encountered
+//! after its last content token. This is the actual rust-analyzer
+//! / Roslyn convention, and matches the user's intuition that "a
+//! directive ends at the end of its line."
 //!
-//! 1. **Same-line trailing trivia.** A trivia run that starts AFTER a
-//!    content token and ends BEFORE the first `NEWLINE` (i.e., does
-//!    not cross a line boundary from the preceding content) attaches
-//!    to the **preceding** directive node. Example: the
-//!    `  ; EOL comment` after a posting's amount, before the
-//!    terminating newline. This is what reviewers familiar with
-//!    rust-analyzer's trivia-attachment convention expect.
+//! Four corollaries:
 //!
-//! 2. **Leading trivia.** A trivia run that crosses a `NEWLINE` from
-//!    the preceding content (or has no preceding content) attaches
-//!    to the **following** directive node. Example: the blank line
-//!    between two top-level directives. Includes the `NEWLINE` that
-//!    crosses the line boundary — that newline is part of the next
-//!    directive's leading-trivia run, not the previous directive's
-//!    trailing.
+//! 1. **Same-line trailing trivia.** Whitespace and EOL comments
+//!    that appear AFTER the last content token but BEFORE the
+//!    terminating `NEWLINE` are INSIDE the directive. In
+//!    `2024-01-01 open Assets:Cash  ; bank\n`, the `  ; bank` and
+//!    the terminating `\n` are all children of the same directive
+//!    node.
 //!
-//! 3. **File-leading trivia (`SOURCE_FILE` direct child).** Trivia
-//!    before any content token has no preceding directive, so rule 2
-//!    would attach it to "the following directive" — but for the
-//!    file's FIRST directive, "leading" trivia is conceptually file-
-//!    level metadata (BOM, shebang, copyright header). Attach it to
-//!    `SOURCE_FILE` directly, NOT to the first directive. This keeps
-//!    `directive.text_range()` on the first directive from
-//!    awkwardly including the copyright header.
+//! 2. **Inter-directive leading trivia.** Trivia that appears
+//!    AFTER one directive's terminator `NEWLINE` and BEFORE the
+//!    next directive's first content token (blank lines, mid-file
+//!    comment blocks) leads the NEXT directive. A blank line
+//!    between two directives belongs to the second directive's
+//!    leading trivia.
 //!
-//! 4. **EOF trailing trivia.** Trivia after the last content token
-//!    has no following directive to lead into. Attach it to the
-//!    preceding directive (the file-final one) — the rule-1 rule by
-//!    fallback.
+//! 3. **File-leading trivia.** Trivia BEFORE the first content
+//!    token in the file (BOM, shebang, copyright comment header,
+//!    leading blank lines) attaches to `SOURCE_FILE` as direct
+//!    children. There is no preceding directive, and the first
+//!    directive's `text_range` should not silently swallow a
+//!    copyright header.
+//!
+//! 4. **File-trailing trivia.** Trivia AFTER the last directive's
+//!    terminator `NEWLINE` (and before EOF) also attaches to
+//!    `SOURCE_FILE` directly. Same rationale as rule 3, but at
+//!    the other end: closing-remarks comments at EOF are file
+//!    metadata, not part of the file-final directive.
+//!
+//! 5. **Unterminated final directive.** If the file ends mid-
+//!    content (no `NEWLINE` after the last content token), the
+//!    final directive owns its content tokens plus any same-line
+//!    trailing trivia. No terminator means the directive's range
+//!    ends at its last token, period — no fabrication.
 //!
 //! # Why
 //!
-//! - **Same-line trailing.** Beancount has many inline EOL comments
-//!   (`2024-01-01 open Assets:Cash  ; my main checking`). The user
-//!   visually associates the comment with the directive it shares a
-//!   line with. Forwarding it to the NEXT directive would surprise
-//!   them in LSP hover, code lens placement, and would produce
-//!   churny rewrites in the formatter.
-//! - **Leading attaches forward.** Blank lines between directives
-//!   visually separate the next directive from the previous one,
-//!   not the other way around. Putting the blank line at the start
-//!   of the next directive makes `directive.text_range()` cover its
-//!   visual leading whitespace — useful for LSP hover and selection
-//!   range.
-//! - **File-leading is `SOURCE_FILE`.** A copyright comment block at
-//!   the top of the file is file-level metadata, not part of the
-//!   first directive. The user does not consider deleting the first
-//!   directive to also delete the copyright.
-//! - **EOF.** No following directive exists. Rule-2 trivia at EOF
-//!   has nowhere to go forward, so the preceding directive absorbs
-//!   it. This breaks structural symmetry (the last directive gets
-//!   trailing children that no other directive has), but the
-//!   alternative is dangling trivia under `SOURCE_FILE` with no
-//!   structural home, which is worse for consumers iterating
-//!   directives.
-//! - **Matches rust-analyzer.** RA's parser walks trivia from the
-//!   end of a structural node backward and attaches as trailing as
-//!   much as fits "on the same line." Same rule, just expressed
-//!   from the opposite direction.
+//! - **Same-line trailing.** Beancount has inline EOL comments
+//!   everywhere (`2024-01-01 open Assets:Cash  ; my main checking`).
+//!   The user visually associates the comment with the line it
+//!   shares — splitting it onto the next directive would be a
+//!   surprise in LSP hover, code lens, and formatter output.
+//! - **Directive owns its terminator.** Makes
+//!   `directive.text_range()` uniformly cover the directive's
+//!   visual line for every directive in the file, including the
+//!   final one. LSP `selection-range`, code-lens placement,
+//!   folding ranges, and "select directive" all get a consistent
+//!   answer.
+//! - **File-leading / file-trailing under `SOURCE_FILE`.** A
+//!   copyright comment at the top of the file is file-level
+//!   metadata. The user doesn't expect deleting the first
+//!   directive to also delete the copyright. The same intuition
+//!   applies to closing-remarks comments at the bottom.
+//! - **Symmetric.** No EOF special case. Every directive has the
+//!   same children shape (optional leading trivia + content +
+//!   optional same-line trailing + terminator `NEWLINE`).
+//!   Consumers iterating directives never need to special-case
+//!   the file-final one.
+//! - **Matches rust-analyzer (and Roslyn, and most lossless-CST
+//!   parsers).** Reviewers familiar with that family don't have
+//!   to relearn the convention.
 //!
 //! # Scope
 //!
-//! This module pins the policy at the **top-level inter-directive
-//! level**. Intra-directive trivia (the `NEWLINE` between a
-//! transaction header and its postings, the WHITESPACE around `+`
-//! inside an amount expression) is GRAMMAR-DRIVEN — the structural
-//! node that opens the directive simply contains its intra-directive
-//! trivia as children. There's no classification question because
-//! the trivia is already inside the right node.
+//! This module pins the policy at the TOP-LEVEL inter-directive
+//! level. The rule is RECURSIVE: phase 2.1 applies it to nested
+//! structural elements (`POSTING` inside `TRANSACTION`,
+//! `META_ENTRY` inside any directive). Each level's "directive"
+//! is just "the structural node currently being closed." A
+//! posting owns its terminating `NEWLINE`; mid-transaction blank
+//! lines lead the next posting (or close the transaction body,
+//! depending on phase 2.1's grammar — that's a grammar question,
+//! not a trivia question).
 //!
-//! # Why this module ships no production code
+//! # Test approach: tree-shape regression, NO production helper
 //!
-//! Phase 2.0 deliberately exports NO function. The policy is a set
-//! of invariants on the SHAPE of phase 2.1+ structural trees, not a
-//! per-token classifier. Each regression test in this module
-//! hand-constructs a small tree under the policy and asserts the
-//! shape; phase 2.1's parser writes its own (streaming, state-aware)
-//! predicate that produces trees matching these shapes. If the
-//! parser drifts from the policy, the regression here fires.
+//! Phase 2.0 deliberately exports NO classifier function. The
+//! policy is a set of invariants on the SHAPE of phase 2.1+
+//! structural trees, NOT a per-token classifier. Each test
+//! hand-constructs the expected tree under the policy using
+//! `GreenNodeBuilder`, then asserts:
 //!
-//! Locking the policy with TREE-SHAPE assertions instead of a
-//! per-token classifier sidesteps the API-shape lock-in problem
-//! that a speculative `classify_trivia` function would have
-//! introduced before phase 2.1 validated the call site. See PR
-//! #1271 review for the discarded design.
+//! - Byte-identical round-trip: `tree.text() == source` — the
+//!   tree we built actually represents the source we claim.
+//! - **Exact** trivia and content sequences inside each
+//!   structural node — phase 2.1's parser must produce trees
+//!   matching the exact shape, not a superset.
+//!
+//! When phase 2.1 lands specific directive kinds (`TRANSACTION`,
+//! ...), these tests do NOT auto-carry-over to validate the real
+//! parser. They constrain hand-built trees; phase 2.1's PR adds
+//! parallel source-driven tests
+//! (`parse_structured(source); assert tree.descendants() ...`)
+//! that exercise the same shapes from the parser's output. The
+//! tests in this module remain as documentation-by-example of
+//! the policy.
 
 #[cfg(test)]
 mod tests {
-    //! Tree-shape regression tests pinning the Two-Line Rule.
-    //!
-    //! Each test hand-constructs an expected tree under the policy
-    //! using `GreenNodeBuilder`, then asserts:
-    //!
-    //! 1. The tree round-trips byte-identically to a documented
-    //!    source string (sanity check — the tree we just built
-    //!    actually represents the input we claim).
-    //! 2. Specific tokens land inside the structural node the
-    //!    policy says they should. Phase 2.1's structured parser
-    //!    must produce trees matching these shapes; any drift fires
-    //!    one of these assertions.
+    //! Tree-shape regression tests pinning the Directive-Terminator Rule.
 
     use rowan::GreenNodeBuilder;
 
     use crate::cst::SyntaxKind::{
-        ACCOUNT, BOM, COMMENT, DATE, DIRECTIVE, NEWLINE, OPEN_KW, PERCENT_COMMENT, SHEBANG,
-        SOURCE_FILE, WHITESPACE,
+        ACCOUNT, BOM, COMMENT, DATE, DIRECTIVE, EMACS_DIRECTIVE, NEWLINE, OPEN_KW, PERCENT_COMMENT,
+        SHEBANG, SOURCE_FILE, WHITESPACE,
     };
     use crate::cst::SyntaxNode;
 
-    /// Find the trivia kinds inside a node's DIRECT children
-    /// (excluding nested directive nodes). Used to assert which
-    /// trivia tokens a directive node owns.
-    fn direct_trivia_kinds(node: &SyntaxNode) -> Vec<crate::cst::SyntaxKind> {
+    /// All kinds of every DIRECT child of `node`, in source order,
+    /// distinguishing tokens (carrying their kind) from nested
+    /// nodes (carrying their kind too). Returning a single sequence
+    /// of `Element`s lets each test assert the EXACT shape of a
+    /// node's children — both trivia/content tokens AND any nested
+    /// structural sub-nodes — in one assertion, instead of two
+    /// separate `direct_trivia_kinds` + `direct_content_kinds`
+    /// helpers that silently dropped nested-node children.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Element {
+        Tok(crate::cst::SyntaxKind),
+        Node(crate::cst::SyntaxKind),
+    }
+
+    fn elements_of(node: &SyntaxNode) -> Vec<Element> {
         node.children_with_tokens()
-            .filter_map(rowan::NodeOrToken::into_token)
-            .filter(|t| t.kind().is_trivia())
-            .map(|t| t.kind())
+            .map(|el| match el {
+                rowan::NodeOrToken::Token(t) => Element::Tok(t.kind()),
+                rowan::NodeOrToken::Node(n) => Element::Node(n.kind()),
+            })
             .collect()
     }
 
-    /// Find the non-trivia (content) kinds inside a node's direct
-    /// children.
-    fn direct_content_kinds(node: &SyntaxNode) -> Vec<crate::cst::SyntaxKind> {
-        node.children_with_tokens()
-            .filter_map(rowan::NodeOrToken::into_token)
-            .filter(|t| !t.kind().is_trivia())
-            .map(|t| t.kind())
-            .collect()
+    /// Convenience for assertions: turn a token-kind list into the
+    /// equivalent `Element::Tok` sequence.
+    fn tok_seq(kinds: &[crate::cst::SyntaxKind]) -> Vec<Element> {
+        kinds.iter().copied().map(Element::Tok).collect()
     }
 
-    /// Collect all `DIRECTIVE` nodes that are direct children of the
-    /// root.
     fn top_level_directives(root: &SyntaxNode) -> Vec<SyntaxNode> {
         root.children().filter(|c| c.kind() == DIRECTIVE).collect()
     }
 
+    // ----- Helpers to build directives -----------------------------
+
+    /// Open-directive token run with optional same-line trailing
+    /// trivia + optional terminator. Centralizes the test-tree
+    /// construction so each test reads as "policy assertion,"
+    /// not "tree-builder boilerplate."
+    fn build_open_directive(
+        b: &mut GreenNodeBuilder<'_>,
+        date: &str,
+        account: &str,
+        same_line_trailing: &[(crate::cst::SyntaxKind, &str)],
+        terminator: Option<&str>,
+    ) {
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), date);
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), account);
+        for (kind, text) in same_line_trailing {
+            b.token((*kind).into(), text);
+        }
+        if let Some(nl) = terminator {
+            b.token(NEWLINE.into(), nl);
+        }
+        b.finish_node();
+    }
+
+    /// Same as `build_open_directive` but with leading trivia
+    /// emitted INSIDE the directive (after `start_node`, before
+    /// the content tokens) — the structural shape required by
+    /// rule 2 for any directive with inter-directive leading
+    /// trivia.
+    fn build_open_directive_with_leading(
+        b: &mut GreenNodeBuilder<'_>,
+        leading: &[(crate::cst::SyntaxKind, &str)],
+        date: &str,
+        account: &str,
+        same_line_trailing: &[(crate::cst::SyntaxKind, &str)],
+        terminator: Option<&str>,
+    ) {
+        b.start_node(DIRECTIVE.into());
+        for (kind, text) in leading {
+            b.token((*kind).into(), text);
+        }
+        b.token(DATE.into(), date);
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), account);
+        for (kind, text) in same_line_trailing {
+            b.token((*kind).into(), text);
+        }
+        if let Some(nl) = terminator {
+            b.token(NEWLINE.into(), nl);
+        }
+        b.finish_node();
+    }
+
+    // ----- Tests -----------------------------------------------------
+
     #[test]
-    fn rule_1_inline_eol_comment_trails_preceding_directive() {
+    fn rule_1_same_line_trailing_inside_preceding_directive() {
         // Source under test:
         //   2024-01-01 open Assets:Cash  ; EOL comment
         //   2024-01-02 open Assets:Bank
         //
-        // The `  ; EOL comment` run starts AFTER `Assets:Cash` and
-        // ends BEFORE the terminating NEWLINE — it does not cross
-        // a line boundary from the preceding content. Rule 1: it
-        // trails the FIRST directive (NOT the second).
+        // Per rule 1: `  ; EOL comment` AND the directive's
+        // terminator `\n` are all CHILDREN OF THE FIRST DIRECTIVE.
+        // Per rule 2: directive 2 starts at `2024-01-02` with NO
+        // leading trivia (none exists between d1's terminator and
+        // d2's first content).
         let source = "2024-01-01 open Assets:Cash  ; EOL comment\n\
                       2024-01-02 open Assets:Bank";
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
-
-        // First directive: content + same-line trailing trivia +
-        // terminating NEWLINE. The NEWLINE is the line boundary
-        // crossing; per rule 2 it belongs to the NEXT directive's
-        // leading run. But it's the ONLY token before the next
-        // content, so it's the leading run of length 1.
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.token(WHITESPACE.into(), "  ");
-        b.token(COMMENT.into(), "; EOL comment");
-        b.finish_node();
-
-        // Second directive: the line-crossing NEWLINE leads it.
-        b.start_node(DIRECTIVE.into());
-        b.token(NEWLINE.into(), "\n");
-        b.token(DATE.into(), "2024-01-02");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Bank");
-        b.finish_node();
-
+        build_open_directive(
+            &mut b,
+            "2024-01-01",
+            "Assets:Cash",
+            &[(WHITESPACE, "  "), (COMMENT, "; EOL comment")],
+            Some("\n"),
+        );
+        build_open_directive(&mut b, "2024-01-02", "Assets:Bank", &[], None);
         b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
+
         let directives = top_level_directives(&tree);
         assert_eq!(directives.len(), 2);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        let d2_trivia = direct_trivia_kinds(&directives[1]);
-        assert!(
-            d1_trivia.contains(&COMMENT),
-            "rule 1: same-line EOL COMMENT must trail PRECEDING directive (d1={d1_trivia:?})",
+
+        // EXACT shape, not contains/starts_with.
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[
+                DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, WHITESPACE, COMMENT, NEWLINE,
+            ]),
+            "rule 1: d1 owns its same-line trailing + terminator NEWLINE",
+        );
+        assert_eq!(
+            elements_of(&directives[1]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT]),
+            "d2 has no leading trivia (none exists between d1 terminator and d2 first content)",
         );
         assert!(
-            !d2_trivia.contains(&COMMENT),
-            "rule 1: same-line EOL COMMENT must NOT lead following directive (d2={d2_trivia:?})",
-        );
-        assert!(
-            d2_trivia.starts_with(&[NEWLINE]),
-            "rule 2: line-crossing NEWLINE leads the SECOND directive (d2={d2_trivia:?})",
+            elements_of(&tree)
+                .iter()
+                .all(|e| matches!(e, Element::Node(DIRECTIVE))),
+            "SOURCE_FILE has no direct trivia children (no file-leading or file-trailing)",
         );
     }
 
     #[test]
-    fn rule_2_blank_line_between_directives_leads_following() {
+    fn rule_2_blank_line_leads_following_directive() {
         // Source under test:
-        //   2024-01-01 open Assets:Cash
-        //   <BLANK>
-        //   2024-01-02 open Assets:Bank
+        //   2024-01-01 open Assets:Cash\n
+        //   \n                              <-- blank line
+        //   2024-01-02 open Assets:Bank\n
         //
-        // Two NEWLINEs between content: the first terminates
-        // directive 1's line; the second is the blank line. The
-        // run from after `Assets:Cash` to before `2024-01-02` is
-        // `NEWLINE NEWLINE`, crosses a line boundary, attaches to
-        // directive 2 as leading.
+        // Per rule 1: d1 owns its terminator `\n` (the first one).
+        // Per rule 2: the blank `\n` between d1's terminator and
+        // d2's first content leads d2.
+        // Per rule 1: d2 owns its own terminator `\n`.
         let source = "2024-01-01 open Assets:Cash\n\
                       \n\
-                      2024-01-02 open Assets:Bank";
+                      2024-01-02 open Assets:Bank\n";
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.finish_node();
-
-        b.start_node(DIRECTIVE.into());
-        b.token(NEWLINE.into(), "\n"); // terminates d1's line; leading of d2
-        b.token(NEWLINE.into(), "\n"); // blank line; leading of d2
-        b.token(DATE.into(), "2024-01-02");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Bank");
-        b.finish_node();
-
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], Some("\n"));
+        build_open_directive_with_leading(
+            &mut b,
+            &[(NEWLINE, "\n")], // the blank line, INSIDE d2 as leading
+            "2024-01-02",
+            "Assets:Bank",
+            &[],
+            Some("\n"),
+        );
         b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
+
         let directives = top_level_directives(&tree);
         assert_eq!(directives.len(), 2);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        let d2_trivia = direct_trivia_kinds(&directives[1]);
+
         assert_eq!(
-            d1_trivia.iter().filter(|k| **k == NEWLINE).count(),
-            0,
-            "rule 2: directive 1 owns NO NEWLINE — both NEWLINEs lead directive 2 (d1={d1_trivia:?})",
+            elements_of(&directives[0]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE]),
+            "rule 1: d1 owns its terminator NEWLINE",
         );
         assert_eq!(
-            d2_trivia.iter().filter(|k| **k == NEWLINE).count(),
-            2,
-            "rule 2: directive 2 owns BOTH NEWLINEs (one line-terminator + one blank) (d2={d2_trivia:?})",
+            elements_of(&directives[1]),
+            tok_seq(&[
+                NEWLINE, DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE
+            ]),
+            "rule 2: blank line leads d2; rule 1: d2 owns its terminator NEWLINE",
         );
     }
 
     #[test]
-    fn rule_3_copyright_header_attaches_to_source_file() {
+    fn rule_3_copyright_header_under_source_file() {
         // Source under test:
-        //   ;; Copyright 2024
-        //   ;; All rights reserved
-        //   2024-01-01 open Assets:Cash
+        //   ;; Copyright 2024\n
+        //   ;; All rights reserved\n
+        //   2024-01-01 open Assets:Cash\n
         //
-        // Two COMMENT lines before the first directive. Rule 3:
-        // file-leading trivia attaches to SOURCE_FILE directly,
-        // not to the first directive.
+        // The copyright header is BEFORE any content token; per
+        // rule 3 it sits under SOURCE_FILE as direct children, NOT
+        // inside the first directive.
         let source = ";; Copyright 2024\n\
                       ;; All rights reserved\n\
-                      2024-01-01 open Assets:Cash";
+                      2024-01-01 open Assets:Cash\n";
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
-
-        // File-leading trivia: direct children of SOURCE_FILE.
         b.token(COMMENT.into(), ";; Copyright 2024");
         b.token(NEWLINE.into(), "\n");
         b.token(COMMENT.into(), ";; All rights reserved");
         b.token(NEWLINE.into(), "\n");
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.finish_node();
-
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], Some("\n"));
         b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
 
-        // The file-leading trivia is in SOURCE_FILE, not in the
-        // directive.
-        let source_file_direct_trivia = direct_trivia_kinds(&tree);
         assert_eq!(
-            source_file_direct_trivia,
-            vec![COMMENT, NEWLINE, COMMENT, NEWLINE],
-            "rule 3: copyright header is a direct child of SOURCE_FILE",
+            elements_of(&tree),
+            vec![
+                Element::Tok(COMMENT),
+                Element::Tok(NEWLINE),
+                Element::Tok(COMMENT),
+                Element::Tok(NEWLINE),
+                Element::Node(DIRECTIVE),
+            ],
+            "rule 3: copyright header is direct under SOURCE_FILE; directive follows",
         );
         let directives = top_level_directives(&tree);
-        assert_eq!(directives.len(), 1);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        assert!(
-            !d1_trivia.contains(&COMMENT),
-            "rule 3: directive 1 must NOT own the copyright header (d1={d1_trivia:?})",
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE]),
+            "d1 has no leading trivia (header is under SOURCE_FILE) and owns its terminator",
         );
     }
 
     #[test]
-    fn rule_3_bom_and_shebang_attach_to_source_file() {
+    fn rule_3_bom_and_shebang_under_source_file() {
         // Source under test:
-        //   <BOM>#!/usr/bin/env bean-check
-        //   2024-01-01 open Assets:Cash
-        //
-        // BOM + SHEBANG at file start: rule 3 attaches them to
-        // SOURCE_FILE, not to directive 1.
+        //   <BOM>#!/usr/bin/env bean-check\n
+        //   2024-01-01 open Assets:Cash\n
         let source = "\u{FEFF}#!/usr/bin/env bean-check\n\
-                      2024-01-01 open Assets:Cash";
+                      2024-01-01 open Assets:Cash\n";
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
-
         b.token(BOM.into(), "\u{FEFF}");
         b.token(SHEBANG.into(), "#!/usr/bin/env bean-check");
         b.token(NEWLINE.into(), "\n");
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.finish_node();
-
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], Some("\n"));
         b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
-        let sf_trivia = direct_trivia_kinds(&tree);
-        assert_eq!(sf_trivia, vec![BOM, SHEBANG, NEWLINE]);
-    }
 
-    #[test]
-    fn rule_4_trailing_newline_at_eof_attaches_to_last_directive() {
-        // Source under test:
-        //   2024-01-01 open Assets:Cash
-        //
-        // One directive, terminated by a NEWLINE at EOF. Rule 4:
-        // no following directive exists, so the NEWLINE attaches
-        // to the preceding directive (the file-final one).
-        let source = "2024-01-01 open Assets:Cash\n";
-        let mut b = GreenNodeBuilder::new();
-        b.start_node(SOURCE_FILE.into());
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.token(NEWLINE.into(), "\n"); // EOF trailing: owned by d1
-        b.finish_node();
-
-        b.finish_node();
-        let tree = SyntaxNode::new_root(b.finish());
-
-        assert_eq!(tree.text().to_string(), source);
-        let directives = top_level_directives(&tree);
-        assert_eq!(directives.len(), 1);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        assert!(
-            d1_trivia.ends_with(&[NEWLINE]),
-            "rule 4: EOF NEWLINE attaches to the LAST directive (d1={d1_trivia:?})",
+        assert_eq!(
+            elements_of(&tree),
+            vec![
+                Element::Tok(BOM),
+                Element::Tok(SHEBANG),
+                Element::Tok(NEWLINE),
+                Element::Node(DIRECTIVE),
+            ],
         );
-        // SOURCE_FILE has no direct trivia children for this input.
-        assert!(direct_trivia_kinds(&tree).is_empty());
     }
 
     #[test]
-    fn rule_4_trailing_comment_block_at_eof_attaches_to_last_directive() {
+    fn rule_4_trailing_comment_block_under_source_file() {
         // Source under test:
-        //   2024-01-01 open Assets:Cash
-        //   ;; closing remarks
+        //   2024-01-01 open Assets:Cash\n
+        //   ;; closing remarks\n
         //
-        // Trailing comment block at EOF. Rule 4: the entire
-        // post-content trivia run (NEWLINE COMMENT NEWLINE) belongs
-        // to the preceding directive.
+        // Per rule 1: d1 owns its terminator `\n`.
+        // Per rule 4: the comment block AFTER d1's terminator
+        // sits under SOURCE_FILE as direct children, NOT inside d1
+        // — symmetric with rule 3.
         let source = "2024-01-01 open Assets:Cash\n\
                       ;; closing remarks\n";
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.token(NEWLINE.into(), "\n");
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], Some("\n"));
         b.token(COMMENT.into(), ";; closing remarks");
         b.token(NEWLINE.into(), "\n");
         b.finish_node();
-
-        b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
+
+        assert_eq!(
+            elements_of(&tree),
+            vec![
+                Element::Node(DIRECTIVE),
+                Element::Tok(COMMENT),
+                Element::Tok(NEWLINE),
+            ],
+            "rule 4: closing remarks are direct under SOURCE_FILE, NOT inside d1",
+        );
         let directives = top_level_directives(&tree);
-        assert_eq!(directives.len(), 1);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        assert!(d1_trivia.contains(&COMMENT));
-        // No trivia is a direct child of SOURCE_FILE.
-        assert!(direct_trivia_kinds(&tree).is_empty());
-    }
-
-    #[test]
-    fn percent_comment_obeys_the_two_line_rule() {
-        // Cover the second comment variant: PERCENT_COMMENT (the
-        // `%` line-comment some Beancount-adjacent tooling emits)
-        // gets the same policy as COMMENT.
-        //
-        // Source under test:
-        //   2024-01-01 open Assets:Cash  % EOL percent comment
-        //   2024-01-02 open Assets:Bank
-        let source = "2024-01-01 open Assets:Cash  % EOL percent comment\n\
-                      2024-01-02 open Assets:Bank";
-        let mut b = GreenNodeBuilder::new();
-        b.start_node(SOURCE_FILE.into());
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.token(WHITESPACE.into(), "  ");
-        b.token(PERCENT_COMMENT.into(), "% EOL percent comment");
-        b.finish_node();
-
-        b.start_node(DIRECTIVE.into());
-        b.token(NEWLINE.into(), "\n");
-        b.token(DATE.into(), "2024-01-02");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Bank");
-        b.finish_node();
-
-        b.finish_node();
-        let tree = SyntaxNode::new_root(b.finish());
-
-        assert_eq!(tree.text().to_string(), source);
-        let directives = top_level_directives(&tree);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        assert!(
-            d1_trivia.contains(&PERCENT_COMMENT),
-            "PERCENT_COMMENT must follow the Two-Line Rule the same as COMMENT (d1={d1_trivia:?})",
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE]),
+            "d1 owns its terminator but NOT the closing remarks",
         );
     }
 
     #[test]
-    fn adjacent_directives_no_blank_line_share_only_a_newline() {
+    fn rule_5_unterminated_final_directive() {
         // Source under test:
-        //   2024-01-01 open Assets:Cash
-        //   2024-01-02 open Assets:Bank
+        //   2024-01-01 open Assets:Cash    <-- no trailing newline
         //
-        // No blank line between the two directives. The only
-        // inter-directive trivia is the single NEWLINE that
-        // terminates d1's line; per rule 2 it crosses a line
-        // boundary and attaches as LEADING of d2.
-        let source = "2024-01-01 open Assets:Cash\n\
+        // Per rule 5: d1 has no terminator. Its range ends at
+        // ACCOUNT. SOURCE_FILE has no direct children other than d1.
+        let source = "2024-01-01 open Assets:Cash";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], None);
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+
+        assert_eq!(elements_of(&tree), vec![Element::Node(DIRECTIVE)],);
+        let directives = top_level_directives(&tree);
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT]),
+            "rule 5: no terminator means directive range ends at last content",
+        );
+    }
+
+    #[test]
+    fn percent_comment_obeys_directive_terminator_rule() {
+        // PERCENT_COMMENT is the second comment variant; same
+        // policy as COMMENT.
+        //
+        // Source: 2024-01-01 open Assets:Cash  % EOL\n
+        //         2024-01-02 open Assets:Bank
+        let source = "2024-01-01 open Assets:Cash  % EOL\n\
                       2024-01-02 open Assets:Bank";
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
-
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.finish_node();
-
-        b.start_node(DIRECTIVE.into());
-        b.token(NEWLINE.into(), "\n"); // line-crossing → leads d2
-        b.token(DATE.into(), "2024-01-02");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Bank");
-        b.finish_node();
-
+        build_open_directive(
+            &mut b,
+            "2024-01-01",
+            "Assets:Cash",
+            &[(WHITESPACE, "  "), (PERCENT_COMMENT, "% EOL")],
+            Some("\n"),
+        );
+        build_open_directive(&mut b, "2024-01-02", "Assets:Bank", &[], None);
         b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
         let directives = top_level_directives(&tree);
-        let d1_content = direct_content_kinds(&directives[0]);
-        let d2_content = direct_content_kinds(&directives[1]);
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        let d2_trivia = direct_trivia_kinds(&directives[1]);
-        assert_eq!(d1_content, vec![DATE, OPEN_KW, ACCOUNT]);
-        assert_eq!(d2_content, vec![DATE, OPEN_KW, ACCOUNT]);
-        assert!(
-            !d1_trivia.contains(&NEWLINE),
-            "rule 2: the line-terminator NEWLINE is NOT inside d1 (d1={d1_trivia:?})",
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[
+                DATE,
+                WHITESPACE,
+                OPEN_KW,
+                WHITESPACE,
+                ACCOUNT,
+                WHITESPACE,
+                PERCENT_COMMENT,
+                NEWLINE,
+            ]),
+            "PERCENT_COMMENT obeys rule 1 the same as COMMENT",
+        );
+    }
+
+    #[test]
+    fn emacs_directive_obeys_file_leading_rule() {
+        // EMACS_DIRECTIVE (org-mode property line like `#+OPTIONS`)
+        // is also trivia. At the top of the file, rule 3 puts it
+        // under SOURCE_FILE.
+        //
+        // Source: #+OPTIONS toc:nil\n
+        //         2024-01-01 open Assets:Cash\n
+        let source = "#+OPTIONS toc:nil\n\
+                      2024-01-01 open Assets:Cash\n";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+        b.token(EMACS_DIRECTIVE.into(), "#+OPTIONS toc:nil");
+        b.token(NEWLINE.into(), "\n");
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], Some("\n"));
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        assert_eq!(
+            elements_of(&tree),
+            vec![
+                Element::Tok(EMACS_DIRECTIVE),
+                Element::Tok(NEWLINE),
+                Element::Node(DIRECTIVE),
+            ],
+            "rule 3: EMACS_DIRECTIVE before any content is under SOURCE_FILE",
+        );
+    }
+
+    #[test]
+    fn adjacent_directives_no_blank_line() {
+        // Source under test:
+        //   2024-01-01 open Assets:Cash\n
+        //   2024-01-02 open Assets:Bank\n
+        //
+        // Two directives back-to-back. Per rule 1, each owns its
+        // own terminator `\n`. No inter-directive trivia exists.
+        let source = "2024-01-01 open Assets:Cash\n\
+                      2024-01-02 open Assets:Bank\n";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+        build_open_directive(&mut b, "2024-01-01", "Assets:Cash", &[], Some("\n"));
+        build_open_directive(&mut b, "2024-01-02", "Assets:Bank", &[], Some("\n"));
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 2);
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE]),
         );
         assert_eq!(
-            d2_trivia.iter().filter(|k| **k == NEWLINE).count(),
-            1,
-            "rule 2: the line-terminator NEWLINE leads d2 (d2={d2_trivia:?})",
+            elements_of(&directives[1]),
+            tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE]),
+            "Two adjacent directives have IDENTICAL child shape — full symmetry",
         );
     }
 
     #[test]
-    fn file_with_only_trivia_attaches_everything_to_source_file() {
-        // Source under test:
-        //   ;; only a comment
-        //   <blank>
+    fn file_with_only_trivia() {
+        // Source: ;; only a comment\n\n
         //
         // No content tokens at all → no directive node opened, all
         // trivia stays under SOURCE_FILE.
@@ -543,17 +572,19 @@ mod tests {
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
-        assert!(
-            top_level_directives(&tree).is_empty(),
-            "no content → no DIRECTIVE node",
+        assert!(top_level_directives(&tree).is_empty());
+        assert_eq!(
+            elements_of(&tree),
+            vec![
+                Element::Tok(COMMENT),
+                Element::Tok(NEWLINE),
+                Element::Tok(NEWLINE),
+            ],
         );
-        assert_eq!(direct_trivia_kinds(&tree), vec![COMMENT, NEWLINE, NEWLINE]);
     }
 
     #[test]
-    fn empty_file_is_an_empty_source_file_node() {
-        // Edge case: zero bytes of source. SOURCE_FILE exists but
-        // has no children. The policy has nothing to apply.
+    fn empty_file() {
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
         b.finish_node();
@@ -561,17 +592,17 @@ mod tests {
 
         assert_eq!(tree.text().to_string(), "");
         assert!(top_level_directives(&tree).is_empty());
-        assert!(direct_trivia_kinds(&tree).is_empty());
+        assert!(elements_of(&tree).is_empty());
     }
 
     #[test]
-    fn leading_and_trailing_coexist() {
-        // Source under test combines all 4 rules:
-        //   ;; copyright              (rule 3: SOURCE_FILE)
-        //   2024-01-01 open Assets:Cash  ; eol1   (rule 1: trails d1)
-        //   <blank>                   (rule 2: leads d2)
-        //   2024-01-02 open Assets:Bank
-        //   ;; footer                 (rule 4: trails d2 — EOF case)
+    fn all_rules_combined() {
+        // Exercise rules 1+2+3+4 in one tree:
+        //   ;; copyright\n                              <-- rule 3: SOURCE_FILE
+        //   2024-01-01 open Assets:Cash  ; eol1\n       <-- rule 1: same-line, then terminator
+        //   \n                                          <-- rule 2: blank line, leads d2
+        //   2024-01-02 open Assets:Bank\n               <-- d2 with leading + content + terminator
+        //   ;; footer\n                                 <-- rule 4: SOURCE_FILE
         let source = ";; copyright\n\
                       2024-01-01 open Assets:Cash  ; eol1\n\
                       \n\
@@ -580,67 +611,68 @@ mod tests {
         let mut b = GreenNodeBuilder::new();
         b.start_node(SOURCE_FILE.into());
 
-        // File-leading (rule 3)
+        // Rule 3: file-leading copyright
         b.token(COMMENT.into(), ";; copyright");
         b.token(NEWLINE.into(), "\n");
 
-        // Directive 1: trailing EOL comment (rule 1)
-        b.start_node(DIRECTIVE.into());
-        b.token(DATE.into(), "2024-01-01");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Cash");
-        b.token(WHITESPACE.into(), "  ");
-        b.token(COMMENT.into(), "; eol1");
-        b.finish_node();
+        // d1: content + same-line trailing + terminator (rules 1)
+        build_open_directive(
+            &mut b,
+            "2024-01-01",
+            "Assets:Cash",
+            &[(WHITESPACE, "  "), (COMMENT, "; eol1")],
+            Some("\n"),
+        );
 
-        // Directive 2: leading newlines (rule 2) + EOF trailing
-        // comment (rule 4) all belong to d2.
-        b.start_node(DIRECTIVE.into());
-        b.token(NEWLINE.into(), "\n"); // line-crosser
-        b.token(NEWLINE.into(), "\n"); // blank line
-        b.token(DATE.into(), "2024-01-02");
-        b.token(WHITESPACE.into(), " ");
-        b.token(OPEN_KW.into(), "open");
-        b.token(WHITESPACE.into(), " ");
-        b.token(ACCOUNT.into(), "Assets:Bank");
-        b.token(NEWLINE.into(), "\n"); // d2 line terminator
+        // d2: leading blank (rule 2) + content + terminator (rule 1)
+        build_open_directive_with_leading(
+            &mut b,
+            &[(NEWLINE, "\n")],
+            "2024-01-02",
+            "Assets:Bank",
+            &[],
+            Some("\n"),
+        );
+
+        // Rule 4: file-trailing footer
         b.token(COMMENT.into(), ";; footer");
-        b.token(NEWLINE.into(), "\n"); // final EOF newline
-        b.finish_node();
+        b.token(NEWLINE.into(), "\n");
 
         b.finish_node();
         let tree = SyntaxNode::new_root(b.finish());
 
         assert_eq!(tree.text().to_string(), source);
 
-        let sf_trivia = direct_trivia_kinds(&tree);
+        // SOURCE_FILE direct children: file-leading + d1 + d2 +
+        // file-trailing. EXACT shape.
         assert_eq!(
-            sf_trivia,
-            vec![COMMENT, NEWLINE],
-            "SOURCE_FILE owns ONLY the file-leading copyright (sf={sf_trivia:?})",
+            elements_of(&tree),
+            vec![
+                Element::Tok(COMMENT),
+                Element::Tok(NEWLINE),
+                Element::Node(DIRECTIVE),
+                Element::Node(DIRECTIVE),
+                Element::Tok(COMMENT),
+                Element::Tok(NEWLINE),
+            ],
+            "SOURCE_FILE owns file-leading copyright + 2 directives + file-trailing footer",
         );
 
         let directives = top_level_directives(&tree);
         assert_eq!(directives.len(), 2);
-
-        let d1_trivia = direct_trivia_kinds(&directives[0]);
-        assert!(
-            d1_trivia.contains(&COMMENT) && !d1_trivia.contains(&NEWLINE),
-            "d1 owns the EOL comment but NOT the line-terminating NEWLINE (d1={d1_trivia:?})",
-        );
-
-        let d2_trivia = direct_trivia_kinds(&directives[1]);
         assert_eq!(
-            d2_trivia.iter().filter(|k| **k == COMMENT).count(),
-            1,
-            "d2 owns the footer COMMENT (rule 4 EOF case) (d2={d2_trivia:?})",
+            elements_of(&directives[0]),
+            tok_seq(&[
+                DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, WHITESPACE, COMMENT, NEWLINE,
+            ]),
+            "d1: rule 1 (same-line + terminator)",
         );
         assert_eq!(
-            d2_trivia.iter().filter(|k| **k == NEWLINE).count(),
-            4,
-            "d2 owns 4 NEWLINEs: line-crosser, blank, d2-terminator, EOF (d2={d2_trivia:?})",
+            elements_of(&directives[1]),
+            tok_seq(&[
+                NEWLINE, DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE,
+            ]),
+            "d2: rule 2 leading + rule 1 terminator",
         );
     }
 }

--- a/crates/rustledger-parser/src/cst/trivia.rs
+++ b/crates/rustledger-parser/src/cst/trivia.rs
@@ -11,12 +11,10 @@
 //! # The Directive-Terminator Rule
 //!
 //! **Every directive structural node OWNS its content tokens PLUS
-//! its terminating `NEWLINE`** — the first `NEWLINE` encountered
-//! after its last content token. This is the actual rust-analyzer
-//! / Roslyn convention, and matches the user's intuition that "a
-//! directive ends at the end of its line."
+//! its terminating `NEWLINE`** — the first `NEWLINE` token (not
+//! byte; see below) the lexer emits after its last content token.
 //!
-//! Four corollaries:
+//! Five corollaries:
 //!
 //! 1. **Same-line trailing trivia.** Whitespace and EOL comments
 //!    that appear AFTER the last content token but BEFORE the
@@ -47,48 +45,114 @@
 //!
 //! 5. **Unterminated final directive.** If the file ends mid-
 //!    content (no `NEWLINE` after the last content token), the
-//!    final directive owns its content tokens plus any same-line
-//!    trailing trivia. No terminator means the directive's range
-//!    ends at its last token, period — no fabrication.
+//!    final directive STILL applies rule 1 to any same-line
+//!    trailing trivia it carries (WHITESPACE + EOL COMMENT
+//!    immediately after content) — they sit INSIDE the directive.
+//!    The directive simply has no terminator child; its range
+//!    ends at the last trivia token attached by rule 1, or at the
+//!    last content token if no trailing trivia exists.
+//!
+//! ## "NEWLINE" means the NEWLINE token kind, not a `\n` byte
+//!
+//! Beancount STRING tokens may contain literal `\n` bytes
+//! (multi-line strings in `note` / `document` / transaction
+//! narrations). The Directive-Terminator Rule keys off the lexer's
+//! NEWLINE token (regex `\r?\n` at the top level of
+//! `logos_lexer.rs`), not raw byte content. A multi-line STRING is
+//! a SINGLE content token regardless of its internal `\n` bytes;
+//! the directive's terminator is the next NEWLINE token AFTER the
+//! STRING token, not somewhere inside it.
+//!
+//! # Provenance and worked example
+//!
+//! This rule matches **Roslyn's documented model** ([Microsoft
+//! Learn](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/work-with-syntax)):
+//!
+//! > "A token owns any trivia after it on the same line up to the
+//! > next token. Any trivia after that line is associated with the
+//! > following token."
+//!
+//! Roslyn additionally says: "The first token in the source file
+//! gets all the initial trivia, and the last sequence of trivia
+//! in the file is tacked onto the end-of-file token." Beancount's
+//! CST has no synthesized end-of-file token, and absorbing
+//! file-leading / file-trailing trivia into the first / last
+//! directive is the wrong intuition for a Beancount user (a
+//! copyright header at the top is not part of the first directive
+//! the user happens to have written). **The Directive-Terminator
+//! Rule deviates from Roslyn on this single point**: rules 3 and
+//! 4 attach file-leading / file-trailing trivia to `SOURCE_FILE`
+//! directly, not to the first / last directive.
+//!
+//! **It does NOT match rust-analyzer**, despite what earlier
+//! drafts of this module claimed. RA's trivia-attachment helper
+//! (in `crates/parser/src/shortcuts.rs`) walks trivia in reverse
+//! from the next item, breaking on a blank-line whitespace, and
+//! attaches same-line trailing comments to the FOLLOWING item.
+//! That is the opposite of what Beancount users expect — a
+//! `; deposit` after an amount visually belongs to the posting it
+//! shares a line with, not to the next directive.
+//!
+//! Worked example (`2024-01-01 open Assets:Cash  ; bank\n\n2024-01-02 open Assets:Bank\n`):
+//!
+//! | trivia run | rule | home |
+//! |---|---|---|
+//! | `  ; bank` between `Assets:Cash` and `\n` | 1 | inside d1 |
+//! | `\n` terminating d1 line | 1 | inside d1 |
+//! | `\n` blank line | 2 | leading trivia of d2 |
+//! | `\n` terminating d2 line | 1 | inside d2 |
+//!
+//! No trivia escapes to `SOURCE_FILE`; both directives have
+//! symmetric shape `[content..., terminator-NEWLINE]`.
+//!
+//! # Scope and phase-2.1 grammar option
+//!
+//! This module pins the policy at the TOP-LEVEL inter-directive
+//! level. The rule is RECURSIVE in principle: phase 2.1 applies
+//! the same shape to nested structural elements (a `POSTING`
+//! inside a `TRANSACTION` owns its content + its terminating
+//! `NEWLINE` the same way a `DIRECTIVE` does at the top level).
+//! Whether a given inter-token `NEWLINE` ends the CURRENT
+//! structural node or continues it (e.g., transaction header to
+//! first posting) is a GRAMMAR question for phase 2.1 — once the
+//! grammar decides "this NEWLINE closes this node," the
+//! Directive-Terminator Rule is what determines that NEWLINE is
+//! INSIDE that node, not leading the next.
+//!
+//! **Phase 2.1 may additionally choose to promote same-line
+//! trailing comments to first-class structural slots** — i.e.,
+//! `Posting { content, trailing_comment: Option<COMMENT> }` —
+//! mirroring `polarmutex/tree-sitter-beancount`. This is purely
+//! additive on top of the Directive-Terminator Rule: rule 1 still
+//! says the COMMENT is INSIDE the posting; promoting it to a
+//! typed slot just exposes it through a typed accessor instead of
+//! requiring downstream code to scan children. The trade-off:
+//! grammar gets ~one extra optional slot per directive type
+//! (~15 directive kinds) in exchange for typed-AST clarity in
+//! phase 3 (`posting.trailing_comment()` becomes a direct
+//! accessor, not a scan-and-filter), and the phase-4 formatter
+//! places per-directive comments at a canonical structural
+//! location rather than preserving them positionally. Whether to
+//! adopt this pattern is a phase 2.1 design call, not a phase 2.0
+//! policy call; recording it here so phase 2.1's reviewer has
+//! prior art to refer to.
 //!
 //! # Why
 //!
-//! - **Same-line trailing.** Beancount has inline EOL comments
-//!   everywhere (`2024-01-01 open Assets:Cash  ; my main checking`).
-//!   The user visually associates the comment with the line it
-//!   shares — splitting it onto the next directive would be a
-//!   surprise in LSP hover, code lens, and formatter output.
+//! - **Same-line trailing inside the directive.** Beancount has
+//!   inline EOL comments everywhere; the user visually associates
+//!   the comment with the line it shares.
 //! - **Directive owns its terminator.** Makes
 //!   `directive.text_range()` uniformly cover the directive's
 //!   visual line for every directive in the file, including the
-//!   final one. LSP `selection-range`, code-lens placement,
-//!   folding ranges, and "select directive" all get a consistent
-//!   answer.
+//!   final one.
 //! - **File-leading / file-trailing under `SOURCE_FILE`.** A
 //!   copyright comment at the top of the file is file-level
-//!   metadata. The user doesn't expect deleting the first
-//!   directive to also delete the copyright. The same intuition
-//!   applies to closing-remarks comments at the bottom.
-//! - **Symmetric.** No EOF special case. Every directive has the
-//!   same children shape (optional leading trivia + content +
-//!   optional same-line trailing + terminator `NEWLINE`).
-//!   Consumers iterating directives never need to special-case
-//!   the file-final one.
-//! - **Matches rust-analyzer (and Roslyn, and most lossless-CST
-//!   parsers).** Reviewers familiar with that family don't have
-//!   to relearn the convention.
-//!
-//! # Scope
-//!
-//! This module pins the policy at the TOP-LEVEL inter-directive
-//! level. The rule is RECURSIVE: phase 2.1 applies it to nested
-//! structural elements (`POSTING` inside `TRANSACTION`,
-//! `META_ENTRY` inside any directive). Each level's "directive"
-//! is just "the structural node currently being closed." A
-//! posting owns its terminating `NEWLINE`; mid-transaction blank
-//! lines lead the next posting (or close the transaction body,
-//! depending on phase 2.1's grammar — that's a grammar question,
-//! not a trivia question).
+//!   metadata; the user doesn't expect deleting the first
+//!   directive to also delete the copyright. Same at EOF.
+//! - **Symmetric.** Every directive has the same children shape
+//!   (optional leading trivia + content + optional same-line
+//!   trailing + terminator `NEWLINE`). No EOF special case.
 //!
 //! # Test approach: tree-shape regression, NO production helper
 //!
@@ -263,11 +327,10 @@ mod tests {
             tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT]),
             "d2 has no leading trivia (none exists between d1 terminator and d2 first content)",
         );
-        assert!(
-            elements_of(&tree)
-                .iter()
-                .all(|e| matches!(e, Element::Node(DIRECTIVE))),
-            "SOURCE_FILE has no direct trivia children (no file-leading or file-trailing)",
+        assert_eq!(
+            elements_of(&tree),
+            vec![Element::Node(DIRECTIVE), Element::Node(DIRECTIVE)],
+            "SOURCE_FILE owns exactly the two directives — no trivia leaks",
         );
     }
 
@@ -452,6 +515,54 @@ mod tests {
             elements_of(&directives[0]),
             tok_seq(&[DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT]),
             "rule 5: no terminator means directive range ends at last content",
+        );
+    }
+
+    #[test]
+    fn rule_1_plus_rule_5_unterminated_directive_with_same_line_trailing() {
+        // Source under test:
+        //   2024-01-01 open Assets:Cash  ; eol-no-nl     <-- EOF mid-comment, no terminator
+        //
+        // This is the case the v3 review flagged as ambiguous: rule 1
+        // says same-line trailing trivia lives INSIDE the directive;
+        // rule 5 says no terminator means the range ends at last
+        // content "no fabrication." The rule 5 wording in v3 wasn't
+        // explicit that same-line trailing trivia ALSO survives the
+        // no-terminator case. v4 makes it explicit: rule 1 fires
+        // (no NEWLINE was needed for rule 1; it only triggers off
+        // the trivia run between last content and the directive's
+        // terminator-OR-EOF), and the directive owns the trailing
+        // WS + COMMENT even though no terminator NEWLINE exists.
+        //
+        // Beancount files saved without a final newline are common
+        // (editors that don't enforce POSIX line termination); this
+        // test pins behavior on a realistic case.
+        let source = "2024-01-01 open Assets:Cash  ; eol-no-nl";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+        build_open_directive(
+            &mut b,
+            "2024-01-01",
+            "Assets:Cash",
+            &[(WHITESPACE, "  "), (COMMENT, "; eol-no-nl")],
+            None,
+        );
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+
+        // No file-trailing trivia under SOURCE_FILE — the trailing
+        // WS+COMMENT live INSIDE the directive (rule 1).
+        assert_eq!(elements_of(&tree), vec![Element::Node(DIRECTIVE)]);
+        let directives = top_level_directives(&tree);
+        assert_eq!(
+            elements_of(&directives[0]),
+            tok_seq(&[
+                DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, WHITESPACE, COMMENT,
+            ]),
+            "rules 1+5: same-line trailing trivia stays INSIDE the directive \
+             even when there's no terminator NEWLINE",
         );
     }
 

--- a/crates/rustledger-parser/src/cst/trivia.rs
+++ b/crates/rustledger-parser/src/cst/trivia.rs
@@ -1,310 +1,646 @@
 //! Trivia attachment policy for the CST. Phase 2.0 of #1262.
 //!
 //! Phase 1 emits a flat tree: every token (content AND trivia) is a
-//! direct child of `SOURCE_FILE`. Phase 2.1+ introduces structural
-//! nodes (DIRECTIVE wrappers, then POSTING, AMOUNT, ...). The
-//! question this module answers: when a trivia run sits between two
-//! content tokens, which structural node owns it?
+//! direct child of `SOURCE_FILE`, so trivia attachment is a
+//! non-question. Phase 2.1+ introduces structural nodes
+//! (`DIRECTIVE` wrappers, then `POSTING` / `AMOUNT` / `COST_SPEC` /
+//! `META_ENTRY` / ...). Once those nodes exist, every trivia token
+//! must end up inside exactly one of them — that's the contract this
+//! module pins.
 //!
-//! # The policy (rust-analyzer convention)
+//! # The Two-Line Rule
 //!
-//! 1. **Leading attaches forward.** Trivia (WHITESPACE, NEWLINE,
-//!    COMMENT, BOM, ...) that appears BETWEEN two content tokens
-//!    attaches to the FOLLOWING content token's structural parent.
-//!    A blank line between two directives belongs to the SECOND
-//!    directive, not the first.
-//! 2. **EOF is the exception.** Trivia appearing AFTER the last
-//!    content token attaches to the PRECEDING content token's
-//!    structural parent. There is no following node to attach to,
-//!    so the preceding directive absorbs it.
-//! 3. **`SOURCE_FILE` is the parent of last resort.** Trivia
-//!    appearing BEFORE any content token (BOM, shebang, copyright
-//!    comment header, leading blank lines) attaches to `SOURCE_FILE`
-//!    as a direct child — there is no preceding directive.
-//! 4. **A file containing only trivia** has every token under
-//!    `SOURCE_FILE` directly. Both edge cases (no content, only
-//!    trivia) collapse to `FileLeading`.
+//! Pick the trivia's home by asking ONE question of the trivia run
+//! between two content tokens (or between content and EOF / SOF):
+//! does it cross a `NEWLINE` from the preceding content?
 //!
-//! # Why this convention
+//! 1. **Same-line trailing trivia.** A trivia run that starts AFTER a
+//!    content token and ends BEFORE the first `NEWLINE` (i.e., does
+//!    not cross a line boundary from the preceding content) attaches
+//!    to the **preceding** directive node. Example: the
+//!    `  ; EOL comment` after a posting's amount, before the
+//!    terminating newline. This is what reviewers familiar with
+//!    rust-analyzer's trivia-attachment convention expect.
 //!
-//! - Most consumers (typed AST surface, validators, semantic
-//!   tooling) iterate over directives and want to skip trivia at
-//!   entry. The "leading attaches forward" rule means each
-//!   directive's `SyntaxNode` covers the blank lines preceding it,
-//!   so `node.text_range()` is the directive's full source span
-//!   including its visual separation. Consumers that don't care
-//!   about trivia skip it on enter; the formatter walks the full
-//!   tree and never skips, so either direction is lossless for it.
-//! - Matches rust-analyzer (and Roslyn, and most other lossless-CST
-//!   parsers). Reviewers familiar with that family don't have to
-//!   relearn the convention.
-//! - "Trailing attaches backward" would leave each directive's
-//!   `text_range()` ending mid-blank-line, making span arithmetic
-//!   awkward in tooling that wants whole-directive bounds (LSP
-//!   hover, selection range, code lens placement).
+//! 2. **Leading trivia.** A trivia run that crosses a `NEWLINE` from
+//!    the preceding content (or has no preceding content) attaches
+//!    to the **following** directive node. Example: the blank line
+//!    between two top-level directives. Includes the `NEWLINE` that
+//!    crosses the line boundary — that newline is part of the next
+//!    directive's leading-trivia run, not the previous directive's
+//!    trailing.
+//!
+//! 3. **File-leading trivia (`SOURCE_FILE` direct child).** Trivia
+//!    before any content token has no preceding directive, so rule 2
+//!    would attach it to "the following directive" — but for the
+//!    file's FIRST directive, "leading" trivia is conceptually file-
+//!    level metadata (BOM, shebang, copyright header). Attach it to
+//!    `SOURCE_FILE` directly, NOT to the first directive. This keeps
+//!    `directive.text_range()` on the first directive from
+//!    awkwardly including the copyright header.
+//!
+//! 4. **EOF trailing trivia.** Trivia after the last content token
+//!    has no following directive to lead into. Attach it to the
+//!    preceding directive (the file-final one) — the rule-1 rule by
+//!    fallback.
+//!
+//! # Why
+//!
+//! - **Same-line trailing.** Beancount has many inline EOL comments
+//!   (`2024-01-01 open Assets:Cash  ; my main checking`). The user
+//!   visually associates the comment with the directive it shares a
+//!   line with. Forwarding it to the NEXT directive would surprise
+//!   them in LSP hover, code lens placement, and would produce
+//!   churny rewrites in the formatter.
+//! - **Leading attaches forward.** Blank lines between directives
+//!   visually separate the next directive from the previous one,
+//!   not the other way around. Putting the blank line at the start
+//!   of the next directive makes `directive.text_range()` cover its
+//!   visual leading whitespace — useful for LSP hover and selection
+//!   range.
+//! - **File-leading is `SOURCE_FILE`.** A copyright comment block at
+//!   the top of the file is file-level metadata, not part of the
+//!   first directive. The user does not consider deleting the first
+//!   directive to also delete the copyright.
+//! - **EOF.** No following directive exists. Rule-2 trivia at EOF
+//!   has nowhere to go forward, so the preceding directive absorbs
+//!   it. This breaks structural symmetry (the last directive gets
+//!   trailing children that no other directive has), but the
+//!   alternative is dangling trivia under `SOURCE_FILE` with no
+//!   structural home, which is worse for consumers iterating
+//!   directives.
+//! - **Matches rust-analyzer.** RA's parser walks trivia from the
+//!   end of a structural node backward and attaches as trailing as
+//!   much as fits "on the same line." Same rule, just expressed
+//!   from the opposite direction.
 //!
 //! # Scope
 //!
-//! This module operates on the FLAT token kind sequence and
-//! identifies what each trivia token's attachment WOULD be once
-//! structural nodes wrap top-level directives. It is the helper
-//! phase 2.1+ parsers call when deciding whether to consume trivia
-//! BEFORE opening a new DIRECTIVE node (`Leading` / `FileLeading`)
-//! or AFTER closing one (`EofTrailing`).
+//! This module pins the policy at the **top-level inter-directive
+//! level**. Intra-directive trivia (the `NEWLINE` between a
+//! transaction header and its postings, the WHITESPACE around `+`
+//! inside an amount expression) is GRAMMAR-DRIVEN — the structural
+//! node that opens the directive simply contains its intra-directive
+//! trivia as children. There's no classification question because
+//! the trivia is already inside the right node.
 //!
-//! Within a directive, intra-directive trivia (the NEWLINE between
-//! a transaction header and its postings, the WHITESPACE around a
-//! `+` in an amount expression, etc.) is GRAMMAR-DRIVEN and lives
-//! inside whatever structural node the grammar opens. That's phase
-//! 2.1's parser logic, not this module's.
-
-use crate::cst::syntax_kind::SyntaxKind;
-
-/// Where a trivia token attaches when phase 2+ wraps top-level
-/// directives in structural nodes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TriviaAttachment {
-    /// Trivia appearing before any content token in the file.
-    /// Attaches to `SOURCE_FILE` as a direct child. Examples: a
-    /// leading BOM, a copyright-header comment block, blank lines
-    /// at the very top of the file.
-    FileLeading,
-    /// Trivia appearing between two content tokens. Attaches to the
-    /// FOLLOWING content token's structural parent (typically the
-    /// next directive node). Examples: the blank line between two
-    /// directives, the whitespace before a directive's date.
-    Leading,
-    /// Trivia appearing after the last content token in the file.
-    /// Attaches to the PRECEDING content token's structural parent
-    /// (the last directive). Example: a trailing newline at EOF.
-    EofTrailing,
-}
-
-/// Classify each token in a flat kind sequence as either non-trivia
-/// content (`None`) or trivia with an attachment intent (`Some`).
-///
-/// The returned `Vec` is the same length as `kinds`; index `i` of
-/// the result describes how the input's token at index `i` would
-/// attach when phase 2.1+ introduces structural directive nodes.
-///
-/// See the module-level rustdoc for the policy this implements.
-#[must_use]
-pub fn classify_trivia(kinds: &[SyntaxKind]) -> Vec<Option<TriviaAttachment>> {
-    let first_content = kinds.iter().position(|k| !k.is_trivia());
-    let last_content = kinds.iter().rposition(|k| !k.is_trivia());
-
-    let (Some(first), Some(last)) = (first_content, last_content) else {
-        // No content tokens at all: every token is FileLeading.
-        return kinds
-            .iter()
-            .map(|_| Some(TriviaAttachment::FileLeading))
-            .collect();
-    };
-
-    kinds
-        .iter()
-        .enumerate()
-        .map(|(i, kind)| {
-            if !kind.is_trivia() {
-                None
-            } else if i < first {
-                Some(TriviaAttachment::FileLeading)
-            } else if i > last {
-                Some(TriviaAttachment::EofTrailing)
-            } else {
-                Some(TriviaAttachment::Leading)
-            }
-        })
-        .collect()
-}
+//! # Why this module ships no production code
+//!
+//! Phase 2.0 deliberately exports NO function. The policy is a set
+//! of invariants on the SHAPE of phase 2.1+ structural trees, not a
+//! per-token classifier. Each regression test in this module
+//! hand-constructs a small tree under the policy and asserts the
+//! shape; phase 2.1's parser writes its own (streaming, state-aware)
+//! predicate that produces trees matching these shapes. If the
+//! parser drifts from the policy, the regression here fires.
+//!
+//! Locking the policy with TREE-SHAPE assertions instead of a
+//! per-token classifier sidesteps the API-shape lock-in problem
+//! that a speculative `classify_trivia` function would have
+//! introduced before phase 2.1 validated the call site. See PR
+//! #1271 review for the discarded design.
 
 #[cfg(test)]
 mod tests {
-    use super::TriviaAttachment::{EofTrailing, FileLeading, Leading};
-    use super::*;
+    //! Tree-shape regression tests pinning the Two-Line Rule.
+    //!
+    //! Each test hand-constructs an expected tree under the policy
+    //! using `GreenNodeBuilder`, then asserts:
+    //!
+    //! 1. The tree round-trips byte-identically to a documented
+    //!    source string (sanity check — the tree we just built
+    //!    actually represents the input we claim).
+    //! 2. Specific tokens land inside the structural node the
+    //!    policy says they should. Phase 2.1's structured parser
+    //!    must produce trees matching these shapes; any drift fires
+    //!    one of these assertions.
+
+    use rowan::GreenNodeBuilder;
+
     use crate::cst::SyntaxKind::{
-        ACCOUNT, BOM, COMMENT, DATE, NEWLINE, OPEN_KW, SHEBANG, WHITESPACE,
+        ACCOUNT, BOM, COMMENT, DATE, DIRECTIVE, NEWLINE, OPEN_KW, PERCENT_COMMENT, SHEBANG,
+        SOURCE_FILE, WHITESPACE,
     };
+    use crate::cst::SyntaxNode;
 
-    #[test]
-    fn empty_input_returns_empty() {
-        assert!(classify_trivia(&[]).is_empty());
+    /// Find the trivia kinds inside a node's DIRECT children
+    /// (excluding nested directive nodes). Used to assert which
+    /// trivia tokens a directive node owns.
+    fn direct_trivia_kinds(node: &SyntaxNode) -> Vec<crate::cst::SyntaxKind> {
+        node.children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .filter(|t| t.kind().is_trivia())
+            .map(|t| t.kind())
+            .collect()
+    }
+
+    /// Find the non-trivia (content) kinds inside a node's direct
+    /// children.
+    fn direct_content_kinds(node: &SyntaxNode) -> Vec<crate::cst::SyntaxKind> {
+        node.children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .filter(|t| !t.kind().is_trivia())
+            .map(|t| t.kind())
+            .collect()
+    }
+
+    /// Collect all `DIRECTIVE` nodes that are direct children of the
+    /// root.
+    fn top_level_directives(root: &SyntaxNode) -> Vec<SyntaxNode> {
+        root.children().filter(|c| c.kind() == DIRECTIVE).collect()
     }
 
     #[test]
-    fn single_content_token_has_no_attachment() {
-        assert_eq!(classify_trivia(&[DATE]), vec![None]);
-    }
-
-    #[test]
-    fn only_trivia_collapses_to_file_leading() {
-        // Whole file is blank lines + a comment.
-        let kinds = [NEWLINE, COMMENT, NEWLINE];
-        assert_eq!(
-            classify_trivia(&kinds),
-            vec![Some(FileLeading), Some(FileLeading), Some(FileLeading)],
-        );
-    }
-
-    #[test]
-    fn bom_at_start_is_file_leading() {
-        let kinds = [BOM, DATE, OPEN_KW];
-        assert_eq!(classify_trivia(&kinds), vec![Some(FileLeading), None, None],);
-    }
-
-    #[test]
-    fn shebang_at_start_is_file_leading() {
-        let kinds = [SHEBANG, NEWLINE, DATE, OPEN_KW];
-        assert_eq!(
-            classify_trivia(&kinds),
-            vec![Some(FileLeading), Some(FileLeading), None, None],
-        );
-    }
-
-    #[test]
-    fn copyright_header_before_first_directive_is_file_leading() {
-        // ;; Copyright header
-        // ;; ...
-        // 2024-01-01 open Assets:Cash
-        let kinds = [COMMENT, NEWLINE, COMMENT, NEWLINE, DATE, OPEN_KW, ACCOUNT];
-        assert_eq!(
-            classify_trivia(&kinds),
-            vec![
-                Some(FileLeading),
-                Some(FileLeading),
-                Some(FileLeading),
-                Some(FileLeading),
-                None,
-                None,
-                None,
-            ],
-        );
-    }
-
-    #[test]
-    fn trailing_newline_at_eof_is_eof_trailing() {
-        let kinds = [DATE, OPEN_KW, NEWLINE];
-        assert_eq!(classify_trivia(&kinds), vec![None, None, Some(EofTrailing)]);
-    }
-
-    #[test]
-    fn multiple_trailing_blank_lines_are_eof_trailing() {
-        // Last directive followed by two blank lines at EOF.
-        let kinds = [DATE, OPEN_KW, NEWLINE, NEWLINE, NEWLINE];
-        assert_eq!(
-            classify_trivia(&kinds),
-            vec![
-                None,
-                None,
-                Some(EofTrailing),
-                Some(EofTrailing),
-                Some(EofTrailing)
-            ],
-        );
-    }
-
-    #[test]
-    fn blank_line_between_directives_attaches_forward_as_leading() {
-        // The load-bearing test: pins the rust-analyzer convention.
-        //
-        //   2024-01-01 open Assets:Cash
-        //   <blank>
+    fn rule_1_inline_eol_comment_trails_preceding_directive() {
+        // Source under test:
+        //   2024-01-01 open Assets:Cash  ; EOL comment
         //   2024-01-02 open Assets:Bank
         //
-        // The blank-line NEWLINE belongs to the SECOND directive
-        // (Leading), not the first (Trailing). If a future refactor
-        // flips this rule, this assertion fires and the policy
-        // change has to be deliberate.
-        let kinds = [
-            DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE, // first directive
-            NEWLINE, // <-- blank line
-            DATE, WHITESPACE, OPEN_KW, WHITESPACE, ACCOUNT, NEWLINE, // second directive
-        ];
-        let got = classify_trivia(&kinds);
-        // Indices of trivia: 1, 3, 5, 6, 8, 10, 12.
-        // Last content token is index 11 (ACCOUNT). Index 12 is past it.
-        assert_eq!(got[1], Some(Leading), "intra-first WHITESPACE");
-        assert_eq!(got[3], Some(Leading), "intra-first WHITESPACE");
-        assert_eq!(got[5], Some(Leading), "end-of-first NEWLINE");
-        assert_eq!(
-            got[6],
-            Some(Leading),
-            "BLANK LINE attaches FORWARD (load-bearing assertion)",
+        // The `  ; EOL comment` run starts AFTER `Assets:Cash` and
+        // ends BEFORE the terminating NEWLINE — it does not cross
+        // a line boundary from the preceding content. Rule 1: it
+        // trails the FIRST directive (NOT the second).
+        let source = "2024-01-01 open Assets:Cash  ; EOL comment\n\
+                      2024-01-02 open Assets:Bank";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        // First directive: content + same-line trailing trivia +
+        // terminating NEWLINE. The NEWLINE is the line boundary
+        // crossing; per rule 2 it belongs to the NEXT directive's
+        // leading run. But it's the ONLY token before the next
+        // content, so it's the leading run of length 1.
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.token(WHITESPACE.into(), "  ");
+        b.token(COMMENT.into(), "; EOL comment");
+        b.finish_node();
+
+        // Second directive: the line-crossing NEWLINE leads it.
+        b.start_node(DIRECTIVE.into());
+        b.token(NEWLINE.into(), "\n");
+        b.token(DATE.into(), "2024-01-02");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Bank");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 2);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        let d2_trivia = direct_trivia_kinds(&directives[1]);
+        assert!(
+            d1_trivia.contains(&COMMENT),
+            "rule 1: same-line EOL COMMENT must trail PRECEDING directive (d1={d1_trivia:?})",
         );
-        assert_eq!(got[8], Some(Leading), "intra-second WHITESPACE");
-        assert_eq!(got[10], Some(Leading), "intra-second WHITESPACE");
-        assert_eq!(got[12], Some(EofTrailing), "trailing NEWLINE at EOF");
+        assert!(
+            !d2_trivia.contains(&COMMENT),
+            "rule 1: same-line EOL COMMENT must NOT lead following directive (d2={d2_trivia:?})",
+        );
+        assert!(
+            d2_trivia.starts_with(&[NEWLINE]),
+            "rule 2: line-crossing NEWLINE leads the SECOND directive (d2={d2_trivia:?})",
+        );
     }
 
     #[test]
-    fn comment_block_between_directives_attaches_forward() {
+    fn rule_2_blank_line_between_directives_leads_following() {
+        // Source under test:
         //   2024-01-01 open Assets:Cash
-        //   ;; comment about the next account
+        //   <BLANK>
         //   2024-01-02 open Assets:Bank
-        let kinds = [
-            DATE, OPEN_KW, ACCOUNT, NEWLINE, // first directive
-            COMMENT, NEWLINE, // mid-file comment
-            DATE, OPEN_KW, ACCOUNT, // second directive
-        ];
-        let got = classify_trivia(&kinds);
-        assert_eq!(got[4], Some(Leading), "mid-file COMMENT attaches forward");
-        assert_eq!(got[5], Some(Leading), "comment-terminating NEWLINE");
+        //
+        // Two NEWLINEs between content: the first terminates
+        // directive 1's line; the second is the blank line. The
+        // run from after `Assets:Cash` to before `2024-01-02` is
+        // `NEWLINE NEWLINE`, crosses a line boundary, attaches to
+        // directive 2 as leading.
+        let source = "2024-01-01 open Assets:Cash\n\
+                      \n\
+                      2024-01-02 open Assets:Bank";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.finish_node();
+
+        b.start_node(DIRECTIVE.into());
+        b.token(NEWLINE.into(), "\n"); // terminates d1's line; leading of d2
+        b.token(NEWLINE.into(), "\n"); // blank line; leading of d2
+        b.token(DATE.into(), "2024-01-02");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Bank");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 2);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        let d2_trivia = direct_trivia_kinds(&directives[1]);
+        assert_eq!(
+            d1_trivia.iter().filter(|k| **k == NEWLINE).count(),
+            0,
+            "rule 2: directive 1 owns NO NEWLINE — both NEWLINEs lead directive 2 (d1={d1_trivia:?})",
+        );
+        assert_eq!(
+            d2_trivia.iter().filter(|k| **k == NEWLINE).count(),
+            2,
+            "rule 2: directive 2 owns BOTH NEWLINEs (one line-terminator + one blank) (d2={d2_trivia:?})",
+        );
     }
 
     #[test]
-    fn trailing_comment_block_at_eof_is_eof_trailing() {
+    fn rule_3_copyright_header_attaches_to_source_file() {
+        // Source under test:
+        //   ;; Copyright 2024
+        //   ;; All rights reserved
+        //   2024-01-01 open Assets:Cash
+        //
+        // Two COMMENT lines before the first directive. Rule 3:
+        // file-leading trivia attaches to SOURCE_FILE directly,
+        // not to the first directive.
+        let source = ";; Copyright 2024\n\
+                      ;; All rights reserved\n\
+                      2024-01-01 open Assets:Cash";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        // File-leading trivia: direct children of SOURCE_FILE.
+        b.token(COMMENT.into(), ";; Copyright 2024");
+        b.token(NEWLINE.into(), "\n");
+        b.token(COMMENT.into(), ";; All rights reserved");
+        b.token(NEWLINE.into(), "\n");
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+
+        // The file-leading trivia is in SOURCE_FILE, not in the
+        // directive.
+        let source_file_direct_trivia = direct_trivia_kinds(&tree);
+        assert_eq!(
+            source_file_direct_trivia,
+            vec![COMMENT, NEWLINE, COMMENT, NEWLINE],
+            "rule 3: copyright header is a direct child of SOURCE_FILE",
+        );
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 1);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        assert!(
+            !d1_trivia.contains(&COMMENT),
+            "rule 3: directive 1 must NOT own the copyright header (d1={d1_trivia:?})",
+        );
+    }
+
+    #[test]
+    fn rule_3_bom_and_shebang_attach_to_source_file() {
+        // Source under test:
+        //   <BOM>#!/usr/bin/env bean-check
+        //   2024-01-01 open Assets:Cash
+        //
+        // BOM + SHEBANG at file start: rule 3 attaches them to
+        // SOURCE_FILE, not to directive 1.
+        let source = "\u{FEFF}#!/usr/bin/env bean-check\n\
+                      2024-01-01 open Assets:Cash";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        b.token(BOM.into(), "\u{FEFF}");
+        b.token(SHEBANG.into(), "#!/usr/bin/env bean-check");
+        b.token(NEWLINE.into(), "\n");
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let sf_trivia = direct_trivia_kinds(&tree);
+        assert_eq!(sf_trivia, vec![BOM, SHEBANG, NEWLINE]);
+    }
+
+    #[test]
+    fn rule_4_trailing_newline_at_eof_attaches_to_last_directive() {
+        // Source under test:
+        //   2024-01-01 open Assets:Cash
+        //
+        // One directive, terminated by a NEWLINE at EOF. Rule 4:
+        // no following directive exists, so the NEWLINE attaches
+        // to the preceding directive (the file-final one).
+        let source = "2024-01-01 open Assets:Cash\n";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.token(NEWLINE.into(), "\n"); // EOF trailing: owned by d1
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 1);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        assert!(
+            d1_trivia.ends_with(&[NEWLINE]),
+            "rule 4: EOF NEWLINE attaches to the LAST directive (d1={d1_trivia:?})",
+        );
+        // SOURCE_FILE has no direct trivia children for this input.
+        assert!(direct_trivia_kinds(&tree).is_empty());
+    }
+
+    #[test]
+    fn rule_4_trailing_comment_block_at_eof_attaches_to_last_directive() {
+        // Source under test:
         //   2024-01-01 open Assets:Cash
         //   ;; closing remarks
-        let kinds = [DATE, OPEN_KW, ACCOUNT, NEWLINE, COMMENT, NEWLINE];
-        let got = classify_trivia(&kinds);
-        assert_eq!(got[3], Some(EofTrailing));
-        assert_eq!(got[4], Some(EofTrailing));
-        assert_eq!(got[5], Some(EofTrailing));
+        //
+        // Trailing comment block at EOF. Rule 4: the entire
+        // post-content trivia run (NEWLINE COMMENT NEWLINE) belongs
+        // to the preceding directive.
+        let source = "2024-01-01 open Assets:Cash\n\
+                      ;; closing remarks\n";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.token(NEWLINE.into(), "\n");
+        b.token(COMMENT.into(), ";; closing remarks");
+        b.token(NEWLINE.into(), "\n");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 1);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        assert!(d1_trivia.contains(&COMMENT));
+        // No trivia is a direct child of SOURCE_FILE.
+        assert!(direct_trivia_kinds(&tree).is_empty());
     }
 
     #[test]
-    fn leading_and_trailing_coexist_with_content() {
-        //   ;; header
-        //   2024-01-01 open Assets:Cash
-        //   <blank>
+    fn percent_comment_obeys_the_two_line_rule() {
+        // Cover the second comment variant: PERCENT_COMMENT (the
+        // `%` line-comment some Beancount-adjacent tooling emits)
+        // gets the same policy as COMMENT.
+        //
+        // Source under test:
+        //   2024-01-01 open Assets:Cash  % EOL percent comment
         //   2024-01-02 open Assets:Bank
-        //   ;; footer
-        let kinds = [
-            COMMENT, NEWLINE, // file-leading
-            DATE, OPEN_KW, ACCOUNT, NEWLINE, NEWLINE, // blank between directives
-            DATE, OPEN_KW, ACCOUNT, NEWLINE, COMMENT, NEWLINE, // file-trailing
-        ];
-        let got = classify_trivia(&kinds);
-        assert_eq!(got[0], Some(FileLeading));
-        assert_eq!(got[1], Some(FileLeading));
-        assert_eq!(got[5], Some(Leading));
-        assert_eq!(got[6], Some(Leading));
-        assert_eq!(got[10], Some(EofTrailing));
-        assert_eq!(got[11], Some(EofTrailing));
-        assert_eq!(got[12], Some(EofTrailing));
+        let source = "2024-01-01 open Assets:Cash  % EOL percent comment\n\
+                      2024-01-02 open Assets:Bank";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.token(WHITESPACE.into(), "  ");
+        b.token(PERCENT_COMMENT.into(), "% EOL percent comment");
+        b.finish_node();
+
+        b.start_node(DIRECTIVE.into());
+        b.token(NEWLINE.into(), "\n");
+        b.token(DATE.into(), "2024-01-02");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Bank");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        assert!(
+            d1_trivia.contains(&PERCENT_COMMENT),
+            "PERCENT_COMMENT must follow the Two-Line Rule the same as COMMENT (d1={d1_trivia:?})",
+        );
     }
 
     #[test]
-    fn classification_length_matches_input() {
-        // Property: classify_trivia returns one entry per input
-        // token, in the same order. Phase 2.1's parser relies on
-        // index correspondence.
-        let kinds = [
-            BOM, COMMENT, NEWLINE, DATE, WHITESPACE, OPEN_KW, ACCOUNT, NEWLINE,
-        ];
-        let got = classify_trivia(&kinds);
-        assert_eq!(got.len(), kinds.len());
+    fn adjacent_directives_no_blank_line_share_only_a_newline() {
+        // Source under test:
+        //   2024-01-01 open Assets:Cash
+        //   2024-01-02 open Assets:Bank
+        //
+        // No blank line between the two directives. The only
+        // inter-directive trivia is the single NEWLINE that
+        // terminates d1's line; per rule 2 it crosses a line
+        // boundary and attaches as LEADING of d2.
+        let source = "2024-01-01 open Assets:Cash\n\
+                      2024-01-02 open Assets:Bank";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.finish_node();
+
+        b.start_node(DIRECTIVE.into());
+        b.token(NEWLINE.into(), "\n"); // line-crossing → leads d2
+        b.token(DATE.into(), "2024-01-02");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Bank");
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        let directives = top_level_directives(&tree);
+        let d1_content = direct_content_kinds(&directives[0]);
+        let d2_content = direct_content_kinds(&directives[1]);
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        let d2_trivia = direct_trivia_kinds(&directives[1]);
+        assert_eq!(d1_content, vec![DATE, OPEN_KW, ACCOUNT]);
+        assert_eq!(d2_content, vec![DATE, OPEN_KW, ACCOUNT]);
+        assert!(
+            !d1_trivia.contains(&NEWLINE),
+            "rule 2: the line-terminator NEWLINE is NOT inside d1 (d1={d1_trivia:?})",
+        );
+        assert_eq!(
+            d2_trivia.iter().filter(|k| **k == NEWLINE).count(),
+            1,
+            "rule 2: the line-terminator NEWLINE leads d2 (d2={d2_trivia:?})",
+        );
     }
 
     #[test]
-    fn non_trivia_is_always_none() {
-        // Every non-trivia variant must return None regardless of
-        // position. Guard against a future variant being silently
-        // misclassified.
-        let content_kinds = [DATE, OPEN_KW, ACCOUNT];
-        let got = classify_trivia(&content_kinds);
-        for (i, c) in got.iter().enumerate() {
-            assert_eq!(*c, None, "index {i}: content token returned attachment");
-        }
+    fn file_with_only_trivia_attaches_everything_to_source_file() {
+        // Source under test:
+        //   ;; only a comment
+        //   <blank>
+        //
+        // No content tokens at all → no directive node opened, all
+        // trivia stays under SOURCE_FILE.
+        let source = ";; only a comment\n\n";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+        b.token(COMMENT.into(), ";; only a comment");
+        b.token(NEWLINE.into(), "\n");
+        b.token(NEWLINE.into(), "\n");
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+        assert!(
+            top_level_directives(&tree).is_empty(),
+            "no content → no DIRECTIVE node",
+        );
+        assert_eq!(direct_trivia_kinds(&tree), vec![COMMENT, NEWLINE, NEWLINE]);
+    }
+
+    #[test]
+    fn empty_file_is_an_empty_source_file_node() {
+        // Edge case: zero bytes of source. SOURCE_FILE exists but
+        // has no children. The policy has nothing to apply.
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), "");
+        assert!(top_level_directives(&tree).is_empty());
+        assert!(direct_trivia_kinds(&tree).is_empty());
+    }
+
+    #[test]
+    fn leading_and_trailing_coexist() {
+        // Source under test combines all 4 rules:
+        //   ;; copyright              (rule 3: SOURCE_FILE)
+        //   2024-01-01 open Assets:Cash  ; eol1   (rule 1: trails d1)
+        //   <blank>                   (rule 2: leads d2)
+        //   2024-01-02 open Assets:Bank
+        //   ;; footer                 (rule 4: trails d2 — EOF case)
+        let source = ";; copyright\n\
+                      2024-01-01 open Assets:Cash  ; eol1\n\
+                      \n\
+                      2024-01-02 open Assets:Bank\n\
+                      ;; footer\n";
+        let mut b = GreenNodeBuilder::new();
+        b.start_node(SOURCE_FILE.into());
+
+        // File-leading (rule 3)
+        b.token(COMMENT.into(), ";; copyright");
+        b.token(NEWLINE.into(), "\n");
+
+        // Directive 1: trailing EOL comment (rule 1)
+        b.start_node(DIRECTIVE.into());
+        b.token(DATE.into(), "2024-01-01");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Cash");
+        b.token(WHITESPACE.into(), "  ");
+        b.token(COMMENT.into(), "; eol1");
+        b.finish_node();
+
+        // Directive 2: leading newlines (rule 2) + EOF trailing
+        // comment (rule 4) all belong to d2.
+        b.start_node(DIRECTIVE.into());
+        b.token(NEWLINE.into(), "\n"); // line-crosser
+        b.token(NEWLINE.into(), "\n"); // blank line
+        b.token(DATE.into(), "2024-01-02");
+        b.token(WHITESPACE.into(), " ");
+        b.token(OPEN_KW.into(), "open");
+        b.token(WHITESPACE.into(), " ");
+        b.token(ACCOUNT.into(), "Assets:Bank");
+        b.token(NEWLINE.into(), "\n"); // d2 line terminator
+        b.token(COMMENT.into(), ";; footer");
+        b.token(NEWLINE.into(), "\n"); // final EOF newline
+        b.finish_node();
+
+        b.finish_node();
+        let tree = SyntaxNode::new_root(b.finish());
+
+        assert_eq!(tree.text().to_string(), source);
+
+        let sf_trivia = direct_trivia_kinds(&tree);
+        assert_eq!(
+            sf_trivia,
+            vec![COMMENT, NEWLINE],
+            "SOURCE_FILE owns ONLY the file-leading copyright (sf={sf_trivia:?})",
+        );
+
+        let directives = top_level_directives(&tree);
+        assert_eq!(directives.len(), 2);
+
+        let d1_trivia = direct_trivia_kinds(&directives[0]);
+        assert!(
+            d1_trivia.contains(&COMMENT) && !d1_trivia.contains(&NEWLINE),
+            "d1 owns the EOL comment but NOT the line-terminating NEWLINE (d1={d1_trivia:?})",
+        );
+
+        let d2_trivia = direct_trivia_kinds(&directives[1]);
+        assert_eq!(
+            d2_trivia.iter().filter(|k| **k == COMMENT).count(),
+            1,
+            "d2 owns the footer COMMENT (rule 4 EOF case) (d2={d2_trivia:?})",
+        );
+        assert_eq!(
+            d2_trivia.iter().filter(|k| **k == NEWLINE).count(),
+            4,
+            "d2 owns 4 NEWLINEs: line-crosser, blank, d2-terminator, EOF (d2={d2_trivia:?})",
+        );
     }
 }

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -37,8 +37,8 @@ pub mod logos_lexer;
 mod parser;
 
 pub use cst::{
-    BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, lossless_kind_tokens,
-    parse_flat,
+    BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TriviaAttachment,
+    classify_trivia, lossless_kind_tokens, parse_flat,
 };
 pub use error::{ParseError, ParseErrorKind};
 pub use format::format_source;

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -37,8 +37,8 @@ pub mod logos_lexer;
 mod parser;
 
 pub use cst::{
-    BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TriviaAttachment,
-    classify_trivia, lossless_kind_tokens, parse_flat,
+    BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, lossless_kind_tokens,
+    parse_flat,
 };
 pub use error::{ParseError, ParseErrorKind};
 pub use format::format_source;


### PR DESCRIPTION
## Summary

Phase 2.0 of #1262. Pins the trivia attachment policy that phase 2.1+ structural parsing will follow. No production behavior change: phase 1's `parse_flat` still emits a flat tree, and no public API is added.

> **Commit history:** four commits on this branch — v1 (`819bd7f3` per-token classifier), v2 (`10e52eba` Two-Line Rule), v3 (`d6c21801` Directive-Terminator Rule), v4 (`c6e696ec` THIS — Roslyn citation correctness + research-validated). Each rewrite addressed findings from a deep code review against the prior version. v4 includes the research that should have happened up-front: it cites Roslyn (not rust-analyzer, which v1-v3 incorrectly cited each time) and documents how the policy compares to existing Beancount tooling (polarmutex/tree-sitter-beancount). **Review against the final tree (v4).**

## The Directive-Terminator Rule

**Every directive structural node OWNS its content tokens PLUS its terminating `NEWLINE`** — the first NEWLINE TOKEN (not byte) the lexer emits after its last content token.

Five corollaries:

1. **Same-line trailing trivia** (whitespace + EOL comments before the terminator) lives INSIDE the directive.
2. **Inter-directive leading trivia** (blank lines, mid-file comment blocks) leads the NEXT directive.
3. **File-leading trivia** (before first content) → `SOURCE_FILE` direct child.
4. **File-trailing trivia** (after file-final directive's terminator) → `SOURCE_FILE` direct child.
5. **Unterminated final directive** applies rule 1 to any same-line trailing trivia it carries (it just has no terminator child).

Fully symmetric: every directive has the same children shape (optional leading + content + optional same-line trailing + terminator). No EOF special case.

## Provenance (researched, with sources)

**Matches Roslyn's documented model**, per [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/work-with-syntax):

> "A token owns any trivia after it on the same line up to the next token. Any trivia after that line is associated with the following token."

**Two deliberate deviations from Roslyn:**
- File-leading trivia → `SOURCE_FILE` (Roslyn says first token; for Beancount, a copyright header is not part of the first directive the user wrote)
- File-trailing trivia → `SOURCE_FILE` (Roslyn says an EOF token; we have no synthesized EOF token, `SOURCE_FILE` is the natural fallback)

**Does NOT match rust-analyzer** (v1-v3 misciting fixed). RA's actual algorithm walks trivia in reverse, breaks on blank-line whitespace, and attaches same-line trailing comments to the *following* item — opposite of what Beancount users expect.

**polarmutex/tree-sitter-beancount** (the closest Beancount-specific prior art) uses a *first-class structural slot* for per-directive trailing comments rather than treating them as trivia. The rustdoc flags this as a phase-2.1 grammar design option (additive on top of this policy; rule 1 still applies, the slot just provides a typed accessor).

## What this PR adds

- **`crates/rustledger-parser/src/cst/trivia.rs`** — full module rustdoc with the policy spec, provenance, the two Roslyn deviations, worked-example table, recursive-application notes, polarmutex prior-art reference, AND 12 hand-constructed-tree regression tests using `GreenNodeBuilder`. Tests assert exact element sequences (no `contains`/`starts_with` weakness).
- **`DIRECTIVE` SyntaxKind variant** — required by tests as the directive wrapper; phase 2.1 will add specific kinds alongside.
- **`every_kind_partitions_token_xor_node` test** — closed-form exhaustiveness sweeping `0..=u16::MAX` (full range).
- **`kind_from_raw` defensive fallback** to `ERROR_NODE` on unknown discriminants, with `debug_assert!` so dev/test panics surface the skew; release falls back so a stale LSP cache doesn't crash a long-running process.
- **Append-only discriminant discipline** documented in the module rustdoc.

## What this PR does NOT add

- A classifier function — explicitly rejected; the policy is a parser-state rule, tests are the contract.
- Specific directive kinds (TRANSACTION, OPEN_DIRECTIVE, etc.) — phase 2.1.
- Structural trailing-comment slots — phase 2.1 grammar option, flagged in rustdoc but not pre-committed.

## Verified

- 171 unit tests + 4+1+1+55+2 integration tests pass.
- `cargo check --workspace --all-features --all-targets` clean.
- `cargo clippy -p rustledger-parser --tests -- -D warnings` clean.
- `cargo fmt --all --check` clean.
- `cargo deny check bans` clean.
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p rustledger-parser --no-deps` clean.

## Test coverage (12 trivia tests + 1 partition test)

| Test | Pins |
|------|------|
| `rule_1_same_line_trailing_inside_preceding_directive` | Rule 1 (same-line trail + terminator inside) |
| `rule_1_plus_rule_5_unterminated_directive_with_same_line_trailing` | Rules 1+5 interaction (no terminator + same-line trailing) |
| `rule_2_blank_line_leads_following_directive` | Rule 2 (line-crossing leading) + Rule 1 terminator |
| `rule_3_copyright_header_under_source_file` | Rule 3 (file-leading COMMENT block) |
| `rule_3_bom_and_shebang_under_source_file` | Rule 3 (file-leading BOM + SHEBANG) |
| `rule_4_trailing_comment_block_under_source_file` | Rule 4 (file-trailing under SOURCE_FILE) |
| `rule_5_unterminated_final_directive` | Rule 5 (no terminator, no trailing trivia) |
| `percent_comment_obeys_directive_terminator_rule` | Variant coverage |
| `emacs_directive_obeys_file_leading_rule` | Variant coverage |
| `adjacent_directives_no_blank_line` | Symmetry assertion |
| `file_with_only_trivia` | Edge case |
| `empty_file` | Edge case |
| `all_rules_combined` | All four corollaries + symmetry in one tree |
| `every_kind_partitions_token_xor_node` | Closed-form is_token / node exhaustiveness over full u16 range |

Refs #1262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
