### PR TITLE
feat(parser): #1262 phase 3 typed-AST wrappers over the lossless CST

### DIFF
--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -33,6 +33,12 @@
 
 use crate::cst::syntax_kind::{SyntaxKind, SyntaxNode, SyntaxToken};
 
+/// Re-export of rowan's `SyntaxText` — a rope view over a
+/// `SyntaxNode`'s text without allocation. Returned by
+/// [`ErrorNode::text`] so consumers don't need a direct
+/// `rowan` dependency.
+pub use rowan::SyntaxText;
+
 /// Typed wrapper around a `SyntaxNode` of a specific
 /// `SyntaxKind`.
 pub trait AstNode: Sized {
@@ -250,65 +256,75 @@ pub enum TransactionFlagKind {
 /// (ticker-letter flag, e.g. `T`). Use [`Self::classify`] for
 /// exhaustive `match` ergonomics, or the `is_*` predicates for
 /// boolean checks.
+///
+/// **Note**: [`Self::cast`] is position-AGNOSTIC — it accepts any
+/// token of a flag-eligible kind regardless of where it sits in
+/// the tree. To get the leading flag of a transaction, use
+/// [`Transaction::flag`] (which scopes the search to the
+/// pre-content header region).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TransactionFlag(SyntaxToken);
+pub struct TransactionFlag {
+    token: SyntaxToken,
+    classification: TransactionFlagKind,
+}
 
 impl TransactionFlag {
     /// Wrap the token if its kind is a valid transaction flag.
     /// For `CURRENCY`, only single-character forms qualify.
+    ///
+    /// Single source of truth: this match also derives
+    /// [`Self::classify`]'s result, so cast + classify cannot
+    /// drift.
     pub fn cast(token: SyntaxToken) -> Option<Self> {
-        match token.kind() {
-            SyntaxKind::STAR
-            | SyntaxKind::PENDING_KW
-            | SyntaxKind::FLAG
-            | SyntaxKind::HASH
-            | SyntaxKind::TXN_KW => Some(Self(token)),
-            SyntaxKind::CURRENCY if token.text().len() == 1 => Some(Self(token)),
-            _ => None,
-        }
-    }
-
-    pub const fn syntax(&self) -> &SyntaxToken {
-        &self.0
-    }
-    pub fn kind(&self) -> SyntaxKind {
-        self.0.kind()
-    }
-    pub fn text(&self) -> &str {
-        self.0.text()
-    }
-
-    /// Exhaustive classification — pair with a `match` for
-    /// compiler-checked coverage of every variant.
-    pub fn classify(&self) -> TransactionFlagKind {
-        match self.kind() {
+        let classification = match token.kind() {
             SyntaxKind::STAR => TransactionFlagKind::Star,
             SyntaxKind::PENDING_KW => TransactionFlagKind::Pending,
             SyntaxKind::FLAG => TransactionFlagKind::Letter,
             SyntaxKind::HASH => TransactionFlagKind::Hash,
             SyntaxKind::TXN_KW => TransactionFlagKind::Txn,
-            SyntaxKind::CURRENCY => TransactionFlagKind::CurrencyLetter,
-            _ => unreachable!("TransactionFlag invariant — guarded by cast()"),
-        }
+            SyntaxKind::CURRENCY if token.text().len() == 1 => TransactionFlagKind::CurrencyLetter,
+            _ => return None,
+        };
+        Some(Self {
+            token,
+            classification,
+        })
     }
 
-    pub fn is_star(&self) -> bool {
-        self.kind() == SyntaxKind::STAR
+    pub const fn syntax(&self) -> &SyntaxToken {
+        &self.token
     }
-    pub fn is_pending(&self) -> bool {
-        self.kind() == SyntaxKind::PENDING_KW
+    pub fn kind(&self) -> SyntaxKind {
+        self.token.kind()
     }
-    pub fn is_hash(&self) -> bool {
-        self.kind() == SyntaxKind::HASH
+    pub fn text(&self) -> &str {
+        self.token.text()
     }
-    pub fn is_txn(&self) -> bool {
-        self.kind() == SyntaxKind::TXN_KW
+
+    /// Exhaustive classification — pair with a `match` for
+    /// compiler-checked coverage of every variant. Cached at
+    /// `cast()` time; no runtime panic risk.
+    pub const fn classify(&self) -> TransactionFlagKind {
+        self.classification
     }
-    pub fn is_letter_flag(&self) -> bool {
-        self.kind() == SyntaxKind::FLAG
+
+    pub const fn is_star(&self) -> bool {
+        matches!(self.classification, TransactionFlagKind::Star)
     }
-    pub fn is_currency_letter(&self) -> bool {
-        self.kind() == SyntaxKind::CURRENCY
+    pub const fn is_pending(&self) -> bool {
+        matches!(self.classification, TransactionFlagKind::Pending)
+    }
+    pub const fn is_hash(&self) -> bool {
+        matches!(self.classification, TransactionFlagKind::Hash)
+    }
+    pub const fn is_txn(&self) -> bool {
+        matches!(self.classification, TransactionFlagKind::Txn)
+    }
+    pub const fn is_letter_flag(&self) -> bool {
+        matches!(self.classification, TransactionFlagKind::Letter)
+    }
+    pub const fn is_currency_letter(&self) -> bool {
+        matches!(self.classification, TransactionFlagKind::CurrencyLetter)
     }
 }
 
@@ -328,57 +344,63 @@ pub enum PostingFlagKind {
 /// [`TransactionFlag`] minus the `TXN_KW` variant (postings can't
 /// carry the `txn` keyword). Use [`Self::classify`] for
 /// exhaustive `match` ergonomics.
+///
+/// **Note**: [`Self::cast`] is position-AGNOSTIC. To get the
+/// leading flag of a posting, use [`Posting::flag`] (which
+/// scopes the search to the pre-ACCOUNT region of the posting).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PostingFlag(SyntaxToken);
+pub struct PostingFlag {
+    token: SyntaxToken,
+    classification: PostingFlagKind,
+}
 
 impl PostingFlag {
+    /// Single source of truth for cast + classify — drift impossible.
     pub fn cast(token: SyntaxToken) -> Option<Self> {
-        match token.kind() {
-            SyntaxKind::STAR | SyntaxKind::PENDING_KW | SyntaxKind::FLAG | SyntaxKind::HASH => {
-                Some(Self(token))
-            }
-            SyntaxKind::CURRENCY if token.text().len() == 1 => Some(Self(token)),
-            _ => None,
-        }
-    }
-
-    pub const fn syntax(&self) -> &SyntaxToken {
-        &self.0
-    }
-    pub fn kind(&self) -> SyntaxKind {
-        self.0.kind()
-    }
-    pub fn text(&self) -> &str {
-        self.0.text()
-    }
-
-    /// Exhaustive classification — pair with a `match` for
-    /// compiler-checked coverage.
-    pub fn classify(&self) -> PostingFlagKind {
-        match self.kind() {
+        let classification = match token.kind() {
             SyntaxKind::STAR => PostingFlagKind::Star,
             SyntaxKind::PENDING_KW => PostingFlagKind::Pending,
             SyntaxKind::FLAG => PostingFlagKind::Letter,
             SyntaxKind::HASH => PostingFlagKind::Hash,
-            SyntaxKind::CURRENCY => PostingFlagKind::CurrencyLetter,
-            _ => unreachable!("PostingFlag invariant — guarded by cast()"),
-        }
+            SyntaxKind::CURRENCY if token.text().len() == 1 => PostingFlagKind::CurrencyLetter,
+            _ => return None,
+        };
+        Some(Self {
+            token,
+            classification,
+        })
     }
 
-    pub fn is_star(&self) -> bool {
-        self.kind() == SyntaxKind::STAR
+    pub const fn syntax(&self) -> &SyntaxToken {
+        &self.token
     }
-    pub fn is_pending(&self) -> bool {
-        self.kind() == SyntaxKind::PENDING_KW
+    pub fn kind(&self) -> SyntaxKind {
+        self.token.kind()
     }
-    pub fn is_hash(&self) -> bool {
-        self.kind() == SyntaxKind::HASH
+    pub fn text(&self) -> &str {
+        self.token.text()
     }
-    pub fn is_letter_flag(&self) -> bool {
-        self.kind() == SyntaxKind::FLAG
+
+    /// Exhaustive classification — cached at `cast()` time;
+    /// no runtime panic risk.
+    pub const fn classify(&self) -> PostingFlagKind {
+        self.classification
     }
-    pub fn is_currency_letter(&self) -> bool {
-        self.kind() == SyntaxKind::CURRENCY
+
+    pub const fn is_star(&self) -> bool {
+        matches!(self.classification, PostingFlagKind::Star)
+    }
+    pub const fn is_pending(&self) -> bool {
+        matches!(self.classification, PostingFlagKind::Pending)
+    }
+    pub const fn is_hash(&self) -> bool {
+        matches!(self.classification, PostingFlagKind::Hash)
+    }
+    pub const fn is_letter_flag(&self) -> bool {
+        matches!(self.classification, PostingFlagKind::Letter)
+    }
+    pub const fn is_currency_letter(&self) -> bool {
+        matches!(self.classification, PostingFlagKind::CurrencyLetter)
     }
 }
 
@@ -442,12 +464,39 @@ impl SourceFile {
     }
 }
 
-// Sum-type Directive enum + AstNode impl, derived from a single
-// variant list so can_cast, cast, and syntax() are guaranteed to
-// agree. Adding a new directive variant requires editing exactly
-// one line; drift between can_cast and cast is impossible.
+// Sum-type Directive enum + AstNode impl + per-variant struct
+// declarations, all derived from a single variant list. The
+// macro is the single source of truth for "what directives
+// exist": adding a new directive requires editing exactly one
+// line. Drift between any of {can_cast, cast, syntax, per-variant
+// struct decl, per-variant AstNode impl} is structurally
+// impossible.
+//
+// Per-variant accessor methods (date(), account(), etc.) stay
+// in separate `impl SomeDirective { ... }` blocks below.
 macro_rules! directive_enum {
-    ($($variant:ident($struct:ident, $kind:ident)),* $(,)?) => {
+    ($($(#[$variant_meta:meta])* $variant:ident($struct:ident, $kind:ident)),* $(,)?) => {
+        // Per-variant struct + AstNode impl, formerly emitted via
+        // `ast_node!` invocations. Folded into directive_enum! so
+        // the variant list is the only source of truth.
+        $(
+            $(#[$variant_meta])*
+            #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+            pub struct $struct(SyntaxNode);
+
+            impl AstNode for $struct {
+                fn can_cast(kind: SyntaxKind) -> bool {
+                    kind == SyntaxKind::$kind
+                }
+                fn cast(syntax: SyntaxNode) -> Option<Self> {
+                    Self::can_cast(syntax.kind()).then_some(Self(syntax))
+                }
+                fn syntax(&self) -> &SyntaxNode {
+                    &self.0
+                }
+            }
+        )*
+
         /// Sum type over every recognized top-level directive wrapper.
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         pub enum Directive {
@@ -476,24 +525,49 @@ macro_rules! directive_enum {
 }
 
 directive_enum!(
+    /// `DATE open ACCOUNT [CURRENCY[,CURRENCY]*] ["BOOKING"]`.
     Open(OpenDirective, OPEN_DIRECTIVE),
+    /// `DATE close ACCOUNT`.
     Close(CloseDirective, CLOSE_DIRECTIVE),
+    /// `DATE balance ACCOUNT AMOUNT_TOKENS`. Amount stays flat
+    /// (phase 2.2c scopes AMOUNT wrapping to POSTING only); walk
+    /// `number()` and `currency()` to read it.
     Balance(BalanceDirective, BALANCE_DIRECTIVE),
+    /// `DATE pad ACCOUNT_TARGET ACCOUNT_SOURCE`.
     Pad(PadDirective, PAD_DIRECTIVE),
+    /// `DATE event "TYPE" "VALUE"`.
     Event(EventDirective, EVENT_DIRECTIVE),
+    /// `DATE query "NAME" "QUERY"`.
     Query(QueryDirective, QUERY_DIRECTIVE),
+    /// `DATE note ACCOUNT "TEXT"`.
     Note(NoteDirective, NOTE_DIRECTIVE),
+    /// `DATE document ACCOUNT "PATH"`.
     Document(DocumentDirective, DOCUMENT_DIRECTIVE),
+    /// `DATE price CURRENCY NUMBER CURRENCY`.
     Price(PriceDirective, PRICE_DIRECTIVE),
+    /// `DATE commodity CURRENCY`.
     Commodity(CommodityDirective, COMMODITY_DIRECTIVE),
+    /// `pushtag #TAG`.
     Pushtag(PushtagDirective, PUSHTAG_DIRECTIVE),
+    /// `poptag #TAG`.
     Poptag(PoptagDirective, POPTAG_DIRECTIVE),
+    /// `pushmeta KEY: VALUE`.
     Pushmeta(PushmetaDirective, PUSHMETA_DIRECTIVE),
+    /// `popmeta KEY:`.
     Popmeta(PopmetaDirective, POPMETA_DIRECTIVE),
+    /// `option "KEY" "VALUE"`.
     Option(OptionDirective, OPTION_DIRECTIVE),
+    /// `include "PATH"`.
     Include(IncludeDirective, INCLUDE_DIRECTIVE),
+    /// `plugin "MODULE" ["CONFIG"]`.
     Plugin(PluginDirective, PLUGIN_DIRECTIVE),
+    /// `DATE custom "TYPE" values...`. Heterogeneous value list
+    /// stays flat (phase 2.3); walk the raw token sequence
+    /// via `syntax().children_with_tokens()`.
     Custom(CustomDirective, CUSTOM_DIRECTIVE),
+    /// `DATE FLAG ["PAYEE"] "NARRATION" #TAG... ^LINK...`
+    /// followed by indented `POSTING` lines and `META_ENTRY`
+    /// sub-lines.
     Transaction(Transaction, TRANSACTION),
 );
 
@@ -514,22 +588,22 @@ ast_node!(
 );
 
 impl ErrorNode {
-    /// The raw bytes of the malformed region as a rowan
-    /// [`rowan::SyntaxText`] (a rope view). Zero allocation; use
-    /// `.to_string()` on the result if you need an owned
-    /// `String`, or `format!`/`Display` for direct output.
+    /// The raw bytes of the malformed region as a [`SyntaxText`]
+    /// rope view. Zero allocation; use `.to_string()` on the
+    /// result if you need an owned `String`, or `format!` /
+    /// `Display` for direct output.
     #[must_use]
-    pub fn text(&self) -> rowan::SyntaxText {
+    pub fn text(&self) -> SyntaxText {
         self.syntax().text()
     }
 }
 
 // ---- 10 dated single-line directives (PR 2.1a) -----------------
+//
+// The 19 directive struct declarations + AstNode impls are
+// generated by the `directive_enum!` macro invocation above.
+// Per-variant accessor methods live in the `impl` blocks below.
 
-ast_node!(
-    /// `DATE open ACCOUNT [CURRENCY[,CURRENCY]*] ["BOOKING"]`.
-    OpenDirective, OPEN_DIRECTIVE
-);
 impl OpenDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -547,10 +621,6 @@ impl OpenDirective {
     }
 }
 
-ast_node!(
-    /// `DATE close ACCOUNT`.
-    CloseDirective, CLOSE_DIRECTIVE
-);
 impl CloseDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -560,12 +630,6 @@ impl CloseDirective {
     }
 }
 
-ast_node!(
-    /// `DATE balance ACCOUNT AMOUNT_TOKENS`. Amount stays flat
-    /// (phase 2.2c scopes AMOUNT wrapping to POSTING only) — walk
-    /// `number()` and `currency()` to read it.
-    BalanceDirective, BALANCE_DIRECTIVE
-);
 impl BalanceDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -581,10 +645,6 @@ impl BalanceDirective {
     }
 }
 
-ast_node!(
-    /// `DATE pad ACCOUNT_TARGET ACCOUNT_SOURCE`.
-    PadDirective, PAD_DIRECTIVE
-);
 impl PadDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -597,10 +657,6 @@ impl PadDirective {
     }
 }
 
-ast_node!(
-    /// `DATE event "TYPE" "VALUE"`.
-    EventDirective, EVENT_DIRECTIVE
-);
 impl EventDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -613,10 +669,6 @@ impl EventDirective {
     }
 }
 
-ast_node!(
-    /// `DATE query "NAME" "QUERY"`.
-    QueryDirective, QUERY_DIRECTIVE
-);
 impl QueryDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -629,10 +681,6 @@ impl QueryDirective {
     }
 }
 
-ast_node!(
-    /// `DATE note ACCOUNT "TEXT"`.
-    NoteDirective, NOTE_DIRECTIVE
-);
 impl NoteDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -645,10 +693,6 @@ impl NoteDirective {
     }
 }
 
-ast_node!(
-    /// `DATE document ACCOUNT "PATH"`.
-    DocumentDirective, DOCUMENT_DIRECTIVE
-);
 impl DocumentDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -661,10 +705,6 @@ impl DocumentDirective {
     }
 }
 
-ast_node!(
-    /// `DATE price CURRENCY NUMBER CURRENCY`.
-    PriceDirective, PRICE_DIRECTIVE
-);
 impl PriceDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -680,10 +720,6 @@ impl PriceDirective {
     }
 }
 
-ast_node!(
-    /// `DATE commodity CURRENCY`.
-    CommodityDirective, COMMODITY_DIRECTIVE
-);
 impl CommodityDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -695,40 +731,24 @@ impl CommodityDirective {
 
 // ---- 4 standalone-keyword directives (PR 2.1a) -----------------
 
-ast_node!(
-    /// `pushtag #TAG`.
-    PushtagDirective, PUSHTAG_DIRECTIVE
-);
 impl PushtagDirective {
     pub fn tag(&self) -> Option<Tag> {
         first_token(self.syntax(), SyntaxKind::TAG).and_then(Tag::cast)
     }
 }
 
-ast_node!(
-    /// `poptag #TAG`.
-    PoptagDirective, POPTAG_DIRECTIVE
-);
 impl PoptagDirective {
     pub fn tag(&self) -> Option<Tag> {
         first_token(self.syntax(), SyntaxKind::TAG).and_then(Tag::cast)
     }
 }
 
-ast_node!(
-    /// `pushmeta KEY: VALUE`.
-    PushmetaDirective, PUSHMETA_DIRECTIVE
-);
 impl PushmetaDirective {
     pub fn key(&self) -> Option<MetaKey> {
         first_token(self.syntax(), SyntaxKind::META_KEY).and_then(MetaKey::cast)
     }
 }
 
-ast_node!(
-    /// `popmeta KEY:`.
-    PopmetaDirective, POPMETA_DIRECTIVE
-);
 impl PopmetaDirective {
     pub fn key(&self) -> Option<MetaKey> {
         first_token(self.syntax(), SyntaxKind::META_KEY).and_then(MetaKey::cast)
@@ -737,10 +757,6 @@ impl PopmetaDirective {
 
 // ---- 4 edge directives (PR 2.3) --------------------------------
 
-ast_node!(
-    /// `option "KEY" "VALUE"`.
-    OptionDirective, OPTION_DIRECTIVE
-);
 impl OptionDirective {
     pub fn key(&self) -> Option<StringLit> {
         first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
@@ -750,20 +766,12 @@ impl OptionDirective {
     }
 }
 
-ast_node!(
-    /// `include "PATH"`.
-    IncludeDirective, INCLUDE_DIRECTIVE
-);
 impl IncludeDirective {
     pub fn path(&self) -> Option<StringLit> {
         first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
     }
 }
 
-ast_node!(
-    /// `plugin "MODULE" ["CONFIG"]`.
-    PluginDirective, PLUGIN_DIRECTIVE
-);
 impl PluginDirective {
     pub fn module(&self) -> Option<StringLit> {
         first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
@@ -773,12 +781,6 @@ impl PluginDirective {
     }
 }
 
-ast_node!(
-    /// `DATE custom "TYPE" values...`. Heterogeneous value list
-    /// stays flat (phase 2.3); walk `values()` for the raw token
-    /// sequence.
-    CustomDirective, CUSTOM_DIRECTIVE
-);
 impl CustomDirective {
     pub fn date(&self) -> Option<Date> {
         first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
@@ -791,13 +793,6 @@ impl CustomDirective {
 }
 
 // ---- TRANSACTION + body sub-nodes ------------------------------
-
-ast_node!(
-    /// `DATE FLAG ["PAYEE"] "NARRATION" #TAG... ^LINK...`
-    /// followed by indented `POSTING` lines and `META_ENTRY`
-    /// sub-lines.
-    Transaction, TRANSACTION
-);
 
 impl Transaction {
     /// Direct-child tokens of TRANSACTION up to (but not

--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -56,9 +56,11 @@ pub trait AstToken: Sized {
     fn cast(token: SyntaxToken) -> Option<Self>;
     fn syntax(&self) -> &SyntaxToken;
 
-    /// The raw token text (bytes from the source).
-    fn text(&self) -> String {
-        self.syntax().text().to_string()
+    /// The raw token text (borrowed from the green tree, zero
+    /// allocation). Tokens are always contiguous, so a `&str`
+    /// slice is well-defined.
+    fn text(&self) -> &str {
+        self.syntax().text()
     }
 }
 
@@ -161,13 +163,14 @@ ast_token!(
 impl StringLit {
     /// String content with surrounding `"` stripped. Returns
     /// `None` if the raw text isn't a well-formed quoted string.
-    pub fn text_unquoted(&self) -> Option<String> {
+    /// Borrowed from the green tree (zero allocation).
+    pub fn text_unquoted(&self) -> Option<&str> {
         let raw = self.text();
         let bytes = raw.as_bytes();
         if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
             return None;
         }
-        Some(raw[1..raw.len() - 1].to_string())
+        Some(&raw[1..raw.len() - 1])
     }
 }
 
@@ -182,10 +185,11 @@ ast_token!(
 );
 
 impl MetaKey {
-    /// Key name with the trailing `:` stripped.
-    pub fn text_without_colon(&self) -> String {
+    /// Key name with the trailing `:` stripped. Borrowed from the
+    /// green tree (zero allocation).
+    pub fn text_without_colon(&self) -> &str {
         let raw = self.text();
-        raw.strip_suffix(':').unwrap_or(&raw).to_string()
+        raw.strip_suffix(':').unwrap_or(raw)
     }
 }
 
@@ -205,6 +209,136 @@ ast_token!(
     /// `BOOL_FALSE` token literal.
     BoolFalse, BOOL_FALSE
 );
+
+// ---- Heterogeneous flag/sign token wrappers --------------------
+//
+// These wrap a SyntaxToken whose kind is one of several possibilities
+// (a transaction flag may be STAR, PENDING_KW, FLAG letter, HASH,
+// TXN_KW, or single-char CURRENCY). We deliberately do NOT implement
+// AstToken for them, since AstToken::can_cast is kind-only and the
+// CURRENCY case needs a length check. Inherent cast() does the full
+// check; downstream code discriminates via the is_*() predicates or
+// kind().
+
+/// Typed wrapper for the transaction-header flag token.
+///
+/// May be `STAR` (`*`), `PENDING_KW` (`!`), `FLAG` (letter),
+/// `HASH` (`#`), `TXN_KW` (`txn`), or single-character `CURRENCY`
+/// (ticker-letter flag, e.g. `T`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TransactionFlag(SyntaxToken);
+
+impl TransactionFlag {
+    /// Wrap the token if its kind is a valid transaction flag.
+    /// For `CURRENCY`, only single-character forms qualify.
+    pub fn cast(token: SyntaxToken) -> Option<Self> {
+        match token.kind() {
+            SyntaxKind::STAR
+            | SyntaxKind::PENDING_KW
+            | SyntaxKind::FLAG
+            | SyntaxKind::HASH
+            | SyntaxKind::TXN_KW => Some(Self(token)),
+            SyntaxKind::CURRENCY if token.text().len() == 1 => Some(Self(token)),
+            _ => None,
+        }
+    }
+
+    pub const fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    pub fn kind(&self) -> SyntaxKind {
+        self.0.kind()
+    }
+    pub fn text(&self) -> &str {
+        self.0.text()
+    }
+    pub fn is_star(&self) -> bool {
+        self.kind() == SyntaxKind::STAR
+    }
+    pub fn is_pending(&self) -> bool {
+        self.kind() == SyntaxKind::PENDING_KW
+    }
+    pub fn is_hash(&self) -> bool {
+        self.kind() == SyntaxKind::HASH
+    }
+    pub fn is_txn(&self) -> bool {
+        self.kind() == SyntaxKind::TXN_KW
+    }
+    pub fn is_letter_flag(&self) -> bool {
+        self.kind() == SyntaxKind::FLAG
+    }
+    pub fn is_currency_letter(&self) -> bool {
+        self.kind() == SyntaxKind::CURRENCY
+    }
+}
+
+/// Typed wrapper for a posting-line flag token. Same as
+/// [`TransactionFlag`] minus the `TXN_KW` variant (postings can't
+/// carry the `txn` keyword).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PostingFlag(SyntaxToken);
+
+impl PostingFlag {
+    pub fn cast(token: SyntaxToken) -> Option<Self> {
+        match token.kind() {
+            SyntaxKind::STAR | SyntaxKind::PENDING_KW | SyntaxKind::FLAG | SyntaxKind::HASH => {
+                Some(Self(token))
+            }
+            SyntaxKind::CURRENCY if token.text().len() == 1 => Some(Self(token)),
+            _ => None,
+        }
+    }
+
+    pub const fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    pub fn kind(&self) -> SyntaxKind {
+        self.0.kind()
+    }
+    pub fn text(&self) -> &str {
+        self.0.text()
+    }
+    pub fn is_star(&self) -> bool {
+        self.kind() == SyntaxKind::STAR
+    }
+    pub fn is_pending(&self) -> bool {
+        self.kind() == SyntaxKind::PENDING_KW
+    }
+    pub fn is_hash(&self) -> bool {
+        self.kind() == SyntaxKind::HASH
+    }
+    pub fn is_letter_flag(&self) -> bool {
+        self.kind() == SyntaxKind::FLAG
+    }
+    pub fn is_currency_letter(&self) -> bool {
+        self.kind() == SyntaxKind::CURRENCY
+    }
+}
+
+/// Typed wrapper for an amount sign token (`PLUS` or `MINUS`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Sign(SyntaxToken);
+
+impl Sign {
+    pub fn cast(token: SyntaxToken) -> Option<Self> {
+        matches!(token.kind(), SyntaxKind::PLUS | SyntaxKind::MINUS).then_some(Self(token))
+    }
+    pub const fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    pub fn kind(&self) -> SyntaxKind {
+        self.0.kind()
+    }
+    pub fn text(&self) -> &str {
+        self.0.text()
+    }
+    pub fn is_plus(&self) -> bool {
+        self.kind() == SyntaxKind::PLUS
+    }
+    pub fn is_minus(&self) -> bool {
+        self.kind() == SyntaxKind::MINUS
+    }
+}
 
 // ---- Source file root + Directive enum ------------------------
 
@@ -257,11 +391,33 @@ pub enum Directive {
     Transaction(Transaction),
 }
 
-impl Directive {
-    /// Cast a `SyntaxNode` to a typed directive if it's a
-    /// recognized directive kind.
-    #[must_use]
-    pub fn cast(node: SyntaxNode) -> Option<Self> {
+impl AstNode for Directive {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        matches!(
+            kind,
+            SyntaxKind::OPEN_DIRECTIVE
+                | SyntaxKind::CLOSE_DIRECTIVE
+                | SyntaxKind::BALANCE_DIRECTIVE
+                | SyntaxKind::PAD_DIRECTIVE
+                | SyntaxKind::EVENT_DIRECTIVE
+                | SyntaxKind::QUERY_DIRECTIVE
+                | SyntaxKind::NOTE_DIRECTIVE
+                | SyntaxKind::DOCUMENT_DIRECTIVE
+                | SyntaxKind::PRICE_DIRECTIVE
+                | SyntaxKind::COMMODITY_DIRECTIVE
+                | SyntaxKind::PUSHTAG_DIRECTIVE
+                | SyntaxKind::POPTAG_DIRECTIVE
+                | SyntaxKind::PUSHMETA_DIRECTIVE
+                | SyntaxKind::POPMETA_DIRECTIVE
+                | SyntaxKind::OPTION_DIRECTIVE
+                | SyntaxKind::INCLUDE_DIRECTIVE
+                | SyntaxKind::PLUGIN_DIRECTIVE
+                | SyntaxKind::CUSTOM_DIRECTIVE
+                | SyntaxKind::TRANSACTION
+        )
+    }
+
+    fn cast(node: SyntaxNode) -> Option<Self> {
         Some(match node.kind() {
             SyntaxKind::OPEN_DIRECTIVE => Self::Open(OpenDirective(node)),
             SyntaxKind::CLOSE_DIRECTIVE => Self::Close(CloseDirective(node)),
@@ -286,9 +442,7 @@ impl Directive {
         })
     }
 
-    /// The underlying `SyntaxNode` regardless of variant.
-    #[must_use]
-    pub fn syntax(&self) -> &SyntaxNode {
+    fn syntax(&self) -> &SyntaxNode {
         match self {
             Self::Open(d) => d.syntax(),
             Self::Close(d) => d.syntax(),
@@ -311,7 +465,9 @@ impl Directive {
             Self::Transaction(d) => d.syntax(),
         }
     }
+}
 
+impl Directive {
     /// Metadata sub-lines attached to this directive (phase 2.2a
     /// `META_ENTRY` wrapping). Every directive wrapper may carry
     /// indented metadata.
@@ -617,47 +773,48 @@ impl Transaction {
 
     /// Transaction flag token. May be `STAR` (`*`), `PENDING_KW`
     /// (`!`), `FLAG` letter, `HASH` (`#`), `TXN_KW`
-    /// (the `txn` keyword), single-char `CURRENCY`, or absent
-    /// (implied via a leading `STRING` payee/narration).
-    pub fn flag(&self) -> Option<SyntaxToken> {
+    /// (the `txn` keyword), single-char `CURRENCY` (ticker-letter
+    /// flag), or absent (implied via a leading `STRING`
+    /// payee/narration).
+    pub fn flag(&self) -> Option<TransactionFlag> {
         self.syntax()
             .children_with_tokens()
             .filter_map(rowan::NodeOrToken::into_token)
-            .find(|t| {
-                matches!(
-                    t.kind(),
-                    SyntaxKind::STAR
-                        | SyntaxKind::PENDING_KW
-                        | SyntaxKind::FLAG
-                        | SyntaxKind::HASH
-                        | SyntaxKind::TXN_KW
-                )
-            })
+            .find_map(TransactionFlag::cast)
+    }
+
+    /// All `STRING` tokens in the header, in source order. The
+    /// 2-string convention (`"payee" "narration"`) is the
+    /// canonical form; [`Self::payee`] and [`Self::narration`]
+    /// follow it strictly. For 3+ strings (malformed but
+    /// losslessly parsed), use this method to surface every
+    /// header string.
+    pub fn strings(&self) -> impl Iterator<Item = StringLit> + '_ {
+        tokens_of_kind(self.syntax(), SyntaxKind::STRING).filter_map(StringLit::cast)
     }
 
     /// The payee string, if a separate payee + narration pair is
-    /// present. With two `STRING` children, the first is the
-    /// payee. With only one `STRING`, the entire string is
-    /// considered narration.
+    /// present. Returns `Some(first)` ONLY when exactly two
+    /// `STRING` tokens appear in the header (the canonical
+    /// `"payee" "narration"` shape). With 0, 1, or 3+ strings
+    /// the convention is ambiguous and this returns `None` —
+    /// use [`Self::strings`] for lossless access.
     pub fn payee(&self) -> Option<StringLit> {
-        let strings: Vec<StringLit> = tokens_of_kind(self.syntax(), SyntaxKind::STRING)
-            .filter_map(StringLit::cast)
-            .collect();
-        if strings.len() >= 2 {
-            Some(strings.into_iter().next().unwrap())
-        } else {
-            None
-        }
+        let strings: Vec<StringLit> = self.strings().collect();
+        (strings.len() == 2).then(|| strings.into_iter().next().unwrap())
     }
 
-    /// The narration string. The last `STRING` child of the
-    /// header line (handles both the payee+narration and
-    /// narration-only cases).
+    /// The narration string. Returns `Some(only)` for a single
+    /// string and `Some(last)` for the 2-string `"payee"
+    /// "narration"` form. Returns `None` for 0 or 3+ strings —
+    /// use [`Self::strings`] for lossless access on malformed
+    /// headers.
     pub fn narration(&self) -> Option<StringLit> {
-        let mut strings: Vec<StringLit> = tokens_of_kind(self.syntax(), SyntaxKind::STRING)
-            .filter_map(StringLit::cast)
-            .collect();
-        strings.pop()
+        let mut strings: Vec<StringLit> = self.strings().collect();
+        match strings.len() {
+            1 | 2 => strings.pop(),
+            _ => None,
+        }
     }
 
     /// All `#TAG` tokens attached to the transaction header.
@@ -688,22 +845,18 @@ ast_node!(
 );
 
 impl Posting {
-    /// Posting flag (optional). Same kinds as `Transaction::flag`
-    /// but indicates whether THIS posting is pending, etc.
-    pub fn flag(&self) -> Option<SyntaxToken> {
-        // Walk children up to the ACCOUNT; any flag-kind token
-        // before ACCOUNT is the posting flag.
+    /// Posting flag (optional). Same kinds as
+    /// [`TransactionFlag`] minus `TXN_KW` — indicates whether
+    /// THIS posting is pending, marked, etc.
+    pub fn flag(&self) -> Option<PostingFlag> {
+        // Walk children up to the ACCOUNT; the first non-whitespace
+        // token is the flag iff it's a valid PostingFlag kind.
         for el in self.syntax().children_with_tokens() {
             if let rowan::NodeOrToken::Token(t) = el {
                 match t.kind() {
                     SyntaxKind::WHITESPACE => {}
                     SyntaxKind::ACCOUNT => return None,
-                    SyntaxKind::STAR
-                    | SyntaxKind::PENDING_KW
-                    | SyntaxKind::FLAG
-                    | SyntaxKind::HASH => return Some(t),
-                    SyntaxKind::CURRENCY if t.text().len() == 1 => return Some(t),
-                    _ => return None,
+                    _ => return PostingFlag::cast(t),
                 }
             }
         }
@@ -748,14 +901,15 @@ ast_node!(
 impl Amount {
     /// Sign token (`MINUS` or `PLUS`), if present as the FIRST
     /// non-whitespace child of AMOUNT. Returns `None` if no
-    /// sign or if the sign is inside an arithmetic-expression
-    /// inner operand.
-    pub fn sign(&self) -> Option<SyntaxToken> {
+    /// sign or if the leading non-whitespace token is something
+    /// else (e.g., `L_PAREN`, `NUMBER`, `CURRENCY`).
+    pub fn sign(&self) -> Option<Sign> {
         let first = self
             .syntax()
             .children_with_tokens()
-            .find_map(rowan::NodeOrToken::into_token)?;
-        matches!(first.kind(), SyntaxKind::MINUS | SyntaxKind::PLUS).then_some(first)
+            .filter_map(rowan::NodeOrToken::into_token)
+            .find(|t| t.kind() != SyntaxKind::WHITESPACE)?;
+        Sign::cast(first)
     }
 
     /// First `NUMBER` child token (the leading operand). For an
@@ -765,16 +919,34 @@ impl Amount {
         first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
     }
 
-    /// The trailing currency. For `100 USD` or `100USD` or
-    /// `(1+2) USD`, this is `USD`. For bare currency-only
-    /// `AMOUNT(CURRENCY)`, it's the same token.
+    /// The trailing currency at paren-depth 0. For `100 USD` or
+    /// `100USD` or `(1+2) USD`, this is the trailing `USD`. For
+    /// bare currency-only `AMOUNT(CURRENCY)`, it's the same
+    /// token. For malformed `AMOUNT( CURRENCY )` (no trailing
+    /// currency outside the parens), returns `None` rather than
+    /// silently picking the paren-internal token.
     pub fn currency(&self) -> Option<CurrencyName> {
-        // The currency is the LAST direct-child CURRENCY token
-        // (a paren-expression interior may contain currency-shaped
-        // tokens that we want to ignore for the typed accessor).
-        tokens_of_kind(self.syntax(), SyntaxKind::CURRENCY)
-            .last()
-            .and_then(CurrencyName::cast)
+        // Walk tokens in reverse with paren-depth tracking; the
+        // first CURRENCY we hit at depth 0 is the trailing one.
+        // emit_amount_operand keeps paren contents flat under
+        // AMOUNT (no PAREN_EXPR sub-node), so internal currency
+        // tokens are direct children too — depth tracking is
+        // the only structural disambiguator.
+        let tokens: Vec<SyntaxToken> = self
+            .syntax()
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .collect();
+        let mut depth: i32 = 0;
+        for t in tokens.iter().rev() {
+            match t.kind() {
+                SyntaxKind::R_PAREN => depth += 1,
+                SyntaxKind::L_PAREN => depth -= 1,
+                SyntaxKind::CURRENCY if depth == 0 => return CurrencyName::cast(t.clone()),
+                _ => {}
+            }
+        }
+        None
     }
 
     /// Returns true iff the amount contains an arithmetic operator
@@ -840,10 +1012,28 @@ impl CostSpec {
         first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
     }
 
-    /// Returns true iff the cost spec contains a `*` merge marker.
+    /// Returns true iff the opener is immediately followed by a
+    /// `*` merge marker (e.g., `{*}` or `{* 500 USD}`). A STAR
+    /// elsewhere in the cost spec is the multiplication operator
+    /// (e.g., `{500 * 2 USD}`), NOT a merge marker; position
+    /// matters.
     #[must_use]
     pub fn is_merge(&self) -> bool {
-        first_token(self.syntax(), SyntaxKind::STAR).is_some()
+        let mut past_opener = false;
+        for el in self.syntax().children_with_tokens() {
+            if let rowan::NodeOrToken::Token(t) = el {
+                match t.kind() {
+                    SyntaxKind::L_BRACE | SyntaxKind::L_DOUBLE_BRACE | SyntaxKind::L_BRACE_HASH => {
+                        past_opener = true;
+                    }
+                    SyntaxKind::WHITESPACE if past_opener => {}
+                    SyntaxKind::STAR if past_opener => return true,
+                    _ if past_opener => return false,
+                    _ => {}
+                }
+            }
+        }
+        false
     }
 }
 

--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -1,0 +1,919 @@
+//! Typed AST wrappers over the lossless CST.
+//!
+//! Phase 3 of #1262. The CST (phase 1-2) preserves every byte of
+//! the source as an untyped tree of `SyntaxKind` nodes and tokens.
+//! This module adds a thin typed layer on top: newtype wrappers
+//! around `SyntaxNode` / `SyntaxToken` with `kind()`-gated
+//! constructors (`cast`) and structural accessors (`date()`,
+//! `account()`, `amount()`, etc.).
+//!
+//! Two traits anchor the surface:
+//!
+//! - [`AstNode`]: typed wrapper around a `SyntaxNode`. Each wrapper
+//!   pins its expected `SyntaxKind` via `can_cast` and offers
+//!   accessors that walk direct children.
+//! - [`AstToken`]: typed wrapper around a `SyntaxToken`. Provides
+//!   `text()` for the raw bytes; specific token wrappers (`Date`,
+//!   `Account`, `Number`, ...) can layer parsing on top.
+//!
+//! The wrappers are zero-cost — they store a `SyntaxNode` /
+//! `SyntaxToken` by value and forward to it. Cloning is cheap
+//! (rowan's nodes/tokens are `Arc`-backed). All accessors return
+//! `Option<_>` because the CST is lossless: a malformed input
+//! still produces a tree, just one with missing children.
+//!
+//! # Round-trip
+//!
+//! Every wrapper exposes `syntax()` returning the underlying
+//! `SyntaxNode`/`SyntaxToken`, whose `text()` reproduces the
+//! original bytes exactly. Typed-AST consumers that want to
+//! modify the source can therefore navigate via accessors and
+//! splice via raw text ranges.
+#![allow(missing_docs)] // Accessors are self-documenting via function name + return type.
+
+use crate::cst::syntax_kind::{SyntaxKind, SyntaxNode, SyntaxToken};
+
+/// Typed wrapper around a `SyntaxNode` of a specific
+/// `SyntaxKind`.
+pub trait AstNode: Sized {
+    /// Returns true iff `kind` is the wrapper's expected node
+    /// kind. Used by `cast` and by enum dispatch.
+    fn can_cast(kind: SyntaxKind) -> bool;
+
+    /// Wrap `syntax` if its kind matches; otherwise `None`.
+    fn cast(syntax: SyntaxNode) -> Option<Self>;
+
+    /// The underlying CST node. `text()` reproduces the original
+    /// bytes; `children()` / `children_with_tokens()` walk the
+    /// tree.
+    fn syntax(&self) -> &SyntaxNode;
+}
+
+/// Typed wrapper around a `SyntaxToken` of a specific
+/// `SyntaxKind`. Like [`AstNode`] but for leaf tokens.
+pub trait AstToken: Sized {
+    fn can_cast(kind: SyntaxKind) -> bool;
+    fn cast(token: SyntaxToken) -> Option<Self>;
+    fn syntax(&self) -> &SyntaxToken;
+
+    /// The raw token text (bytes from the source).
+    fn text(&self) -> String {
+        self.syntax().text().to_string()
+    }
+}
+
+// ---- Helpers --------------------------------------------------
+
+/// First direct-child token of `kind` under `node`, or `None`.
+fn first_token(node: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
+    node.children_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .find(|t| t.kind() == kind)
+}
+
+/// Nth (0-indexed) direct-child token of `kind` under `node`.
+fn nth_token(node: &SyntaxNode, kind: SyntaxKind, n: usize) -> Option<SyntaxToken> {
+    node.children_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .filter(|t| t.kind() == kind)
+        .nth(n)
+}
+
+/// All direct-child tokens of `kind` under `node`.
+fn tokens_of_kind(node: &SyntaxNode, kind: SyntaxKind) -> impl Iterator<Item = SyntaxToken> + '_ {
+    node.children_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .filter(move |t| t.kind() == kind)
+}
+
+/// First direct-child node castable to `N`.
+fn first_child<N: AstNode>(node: &SyntaxNode) -> Option<N> {
+    node.children().find_map(N::cast)
+}
+
+/// All direct-child nodes castable to `N`.
+fn children<'a, N: AstNode + 'a>(node: &'a SyntaxNode) -> impl Iterator<Item = N> + 'a {
+    node.children().filter_map(N::cast)
+}
+
+// ---- Macros ---------------------------------------------------
+
+macro_rules! ast_node {
+    ($(#[$meta:meta])* $name:ident, $kind:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name(SyntaxNode);
+
+        impl AstNode for $name {
+            fn can_cast(kind: SyntaxKind) -> bool {
+                kind == SyntaxKind::$kind
+            }
+            fn cast(syntax: SyntaxNode) -> Option<Self> {
+                Self::can_cast(syntax.kind()).then_some(Self(syntax))
+            }
+            fn syntax(&self) -> &SyntaxNode {
+                &self.0
+            }
+        }
+    };
+}
+
+macro_rules! ast_token {
+    ($(#[$meta:meta])* $name:ident, $kind:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name(SyntaxToken);
+
+        impl AstToken for $name {
+            fn can_cast(kind: SyntaxKind) -> bool {
+                kind == SyntaxKind::$kind
+            }
+            fn cast(token: SyntaxToken) -> Option<Self> {
+                Self::can_cast(token.kind()).then_some(Self(token))
+            }
+            fn syntax(&self) -> &SyntaxToken {
+                &self.0
+            }
+        }
+    };
+}
+
+// ---- Token wrappers -------------------------------------------
+
+ast_token!(
+    /// `DATE` token (e.g., `2024-01-15`).
+    Date, DATE
+);
+ast_token!(
+    /// `ACCOUNT` token (e.g., `Assets:Cash`).
+    Account, ACCOUNT
+);
+ast_token!(
+    /// `CURRENCY` token (e.g., `USD`).
+    CurrencyName, CURRENCY
+);
+ast_token!(
+    /// `STRING` literal (e.g., `"Coffee"`). `text()` includes the
+    /// surrounding quotes; use `text_unquoted()` for the content.
+    StringLit, STRING
+);
+
+impl StringLit {
+    /// String content with surrounding `"` stripped. Returns
+    /// `None` if the raw text isn't a well-formed quoted string.
+    pub fn text_unquoted(&self) -> Option<String> {
+        let raw = self.text();
+        let bytes = raw.as_bytes();
+        if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
+            return None;
+        }
+        Some(raw[1..raw.len() - 1].to_string())
+    }
+}
+
+ast_token!(
+    /// `NUMBER` token (e.g., `100.00`).
+    Number, NUMBER
+);
+ast_token!(
+    /// `META_KEY` token (e.g., `note:`). Note the trailing colon
+    /// is part of the token; use `text_without_colon()` to strip it.
+    MetaKey, META_KEY
+);
+
+impl MetaKey {
+    /// Key name with the trailing `:` stripped.
+    pub fn text_without_colon(&self) -> String {
+        let raw = self.text();
+        raw.strip_suffix(':').unwrap_or(&raw).to_string()
+    }
+}
+
+ast_token!(
+    /// `TAG` token (e.g., `#trip`).
+    Tag, TAG
+);
+ast_token!(
+    /// `LINK` token (e.g., `^expense-123`).
+    Link, LINK
+);
+ast_token!(
+    /// `BOOL_TRUE` token literal.
+    BoolTrue, BOOL_TRUE
+);
+ast_token!(
+    /// `BOOL_FALSE` token literal.
+    BoolFalse, BOOL_FALSE
+);
+
+// ---- Source file root + Directive enum ------------------------
+
+ast_node!(
+    /// Root of a parsed Beancount file. `SourceFile::parse(src)` is
+    /// the typed-AST entry point — it wraps `parse_structured`.
+    SourceFile, SOURCE_FILE
+);
+
+impl SourceFile {
+    /// Parse `source` into a typed source-file tree.
+    #[must_use]
+    pub fn parse(source: &str) -> Self {
+        let node = crate::cst::parser::parse_structured(source);
+        Self::cast(node).expect("parse_structured always returns a SOURCE_FILE")
+    }
+
+    /// All recognized directives, in source order.
+    pub fn directives(&self) -> impl Iterator<Item = Directive> + '_ {
+        self.syntax().children().filter_map(Directive::cast)
+    }
+
+    /// All `ERROR_NODE` wrappers (unrecognized / malformed lines).
+    pub fn errors(&self) -> impl Iterator<Item = ErrorNode> + '_ {
+        self.syntax().children().filter_map(ErrorNode::cast)
+    }
+}
+
+/// Sum type over every recognized top-level directive wrapper.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Directive {
+    Open(OpenDirective),
+    Close(CloseDirective),
+    Balance(BalanceDirective),
+    Pad(PadDirective),
+    Event(EventDirective),
+    Query(QueryDirective),
+    Note(NoteDirective),
+    Document(DocumentDirective),
+    Price(PriceDirective),
+    Commodity(CommodityDirective),
+    Pushtag(PushtagDirective),
+    Poptag(PoptagDirective),
+    Pushmeta(PushmetaDirective),
+    Popmeta(PopmetaDirective),
+    Option(OptionDirective),
+    Include(IncludeDirective),
+    Plugin(PluginDirective),
+    Custom(CustomDirective),
+    Transaction(Transaction),
+}
+
+impl Directive {
+    /// Cast a `SyntaxNode` to a typed directive if it's a
+    /// recognized directive kind.
+    #[must_use]
+    pub fn cast(node: SyntaxNode) -> Option<Self> {
+        Some(match node.kind() {
+            SyntaxKind::OPEN_DIRECTIVE => Self::Open(OpenDirective(node)),
+            SyntaxKind::CLOSE_DIRECTIVE => Self::Close(CloseDirective(node)),
+            SyntaxKind::BALANCE_DIRECTIVE => Self::Balance(BalanceDirective(node)),
+            SyntaxKind::PAD_DIRECTIVE => Self::Pad(PadDirective(node)),
+            SyntaxKind::EVENT_DIRECTIVE => Self::Event(EventDirective(node)),
+            SyntaxKind::QUERY_DIRECTIVE => Self::Query(QueryDirective(node)),
+            SyntaxKind::NOTE_DIRECTIVE => Self::Note(NoteDirective(node)),
+            SyntaxKind::DOCUMENT_DIRECTIVE => Self::Document(DocumentDirective(node)),
+            SyntaxKind::PRICE_DIRECTIVE => Self::Price(PriceDirective(node)),
+            SyntaxKind::COMMODITY_DIRECTIVE => Self::Commodity(CommodityDirective(node)),
+            SyntaxKind::PUSHTAG_DIRECTIVE => Self::Pushtag(PushtagDirective(node)),
+            SyntaxKind::POPTAG_DIRECTIVE => Self::Poptag(PoptagDirective(node)),
+            SyntaxKind::PUSHMETA_DIRECTIVE => Self::Pushmeta(PushmetaDirective(node)),
+            SyntaxKind::POPMETA_DIRECTIVE => Self::Popmeta(PopmetaDirective(node)),
+            SyntaxKind::OPTION_DIRECTIVE => Self::Option(OptionDirective(node)),
+            SyntaxKind::INCLUDE_DIRECTIVE => Self::Include(IncludeDirective(node)),
+            SyntaxKind::PLUGIN_DIRECTIVE => Self::Plugin(PluginDirective(node)),
+            SyntaxKind::CUSTOM_DIRECTIVE => Self::Custom(CustomDirective(node)),
+            SyntaxKind::TRANSACTION => Self::Transaction(Transaction(node)),
+            _ => return None,
+        })
+    }
+
+    /// The underlying `SyntaxNode` regardless of variant.
+    #[must_use]
+    pub fn syntax(&self) -> &SyntaxNode {
+        match self {
+            Self::Open(d) => d.syntax(),
+            Self::Close(d) => d.syntax(),
+            Self::Balance(d) => d.syntax(),
+            Self::Pad(d) => d.syntax(),
+            Self::Event(d) => d.syntax(),
+            Self::Query(d) => d.syntax(),
+            Self::Note(d) => d.syntax(),
+            Self::Document(d) => d.syntax(),
+            Self::Price(d) => d.syntax(),
+            Self::Commodity(d) => d.syntax(),
+            Self::Pushtag(d) => d.syntax(),
+            Self::Poptag(d) => d.syntax(),
+            Self::Pushmeta(d) => d.syntax(),
+            Self::Popmeta(d) => d.syntax(),
+            Self::Option(d) => d.syntax(),
+            Self::Include(d) => d.syntax(),
+            Self::Plugin(d) => d.syntax(),
+            Self::Custom(d) => d.syntax(),
+            Self::Transaction(d) => d.syntax(),
+        }
+    }
+
+    /// Metadata sub-lines attached to this directive (phase 2.2a
+    /// `META_ENTRY` wrapping). Every directive wrapper may carry
+    /// indented metadata.
+    pub fn meta_entries(&self) -> impl Iterator<Item = MetaEntry> + '_ {
+        children(self.syntax())
+    }
+}
+
+ast_node!(
+    /// Wrapper for unrecognized / malformed top-level content
+    /// (PR 2.4 `ERROR_NODE`). Typed-AST consumers can use this to
+    /// surface error regions to users (e.g., LSP diagnostics).
+    ErrorNode, ERROR_NODE
+);
+
+impl ErrorNode {
+    /// The raw bytes of the malformed region.
+    #[must_use]
+    pub fn text(&self) -> String {
+        self.syntax().text().to_string()
+    }
+}
+
+// ---- 10 dated single-line directives (PR 2.1a) -----------------
+
+ast_node!(
+    /// `DATE open ACCOUNT [CURRENCY[,CURRENCY]*] ["BOOKING"]`.
+    OpenDirective, OPEN_DIRECTIVE
+);
+impl OpenDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+    /// Comma-separated currency constraint list (may be empty).
+    pub fn currencies(&self) -> impl Iterator<Item = CurrencyName> + '_ {
+        tokens_of_kind(self.syntax(), SyntaxKind::CURRENCY).filter_map(CurrencyName::cast)
+    }
+    /// Optional booking-method string (e.g., `"STRICT"`).
+    pub fn booking_method(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE close ACCOUNT`.
+    CloseDirective, CLOSE_DIRECTIVE
+);
+impl CloseDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE balance ACCOUNT AMOUNT_TOKENS`. Amount stays flat
+    /// (phase 2.2c scopes AMOUNT wrapping to POSTING only) — walk
+    /// `number()` and `currency()` to read it.
+    BalanceDirective, BALANCE_DIRECTIVE
+);
+impl BalanceDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+    pub fn number(&self) -> Option<Number> {
+        first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
+    }
+    pub fn currency(&self) -> Option<CurrencyName> {
+        first_token(self.syntax(), SyntaxKind::CURRENCY).and_then(CurrencyName::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE pad ACCOUNT_TARGET ACCOUNT_SOURCE`.
+    PadDirective, PAD_DIRECTIVE
+);
+impl PadDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn target_account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+    pub fn source_account(&self) -> Option<Account> {
+        nth_token(self.syntax(), SyntaxKind::ACCOUNT, 1).and_then(Account::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE event "TYPE" "VALUE"`.
+    EventDirective, EVENT_DIRECTIVE
+);
+impl EventDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn event_type(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+    pub fn value(&self) -> Option<StringLit> {
+        nth_token(self.syntax(), SyntaxKind::STRING, 1).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE query "NAME" "QUERY"`.
+    QueryDirective, QUERY_DIRECTIVE
+);
+impl QueryDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn name(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+    pub fn query(&self) -> Option<StringLit> {
+        nth_token(self.syntax(), SyntaxKind::STRING, 1).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE note ACCOUNT "TEXT"`.
+    NoteDirective, NOTE_DIRECTIVE
+);
+impl NoteDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+    pub fn text(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE document ACCOUNT "PATH"`.
+    DocumentDirective, DOCUMENT_DIRECTIVE
+);
+impl DocumentDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+    pub fn path(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE price CURRENCY NUMBER CURRENCY`.
+    PriceDirective, PRICE_DIRECTIVE
+);
+impl PriceDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn base_currency(&self) -> Option<CurrencyName> {
+        first_token(self.syntax(), SyntaxKind::CURRENCY).and_then(CurrencyName::cast)
+    }
+    pub fn number(&self) -> Option<Number> {
+        first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
+    }
+    pub fn quote_currency(&self) -> Option<CurrencyName> {
+        nth_token(self.syntax(), SyntaxKind::CURRENCY, 1).and_then(CurrencyName::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE commodity CURRENCY`.
+    CommodityDirective, COMMODITY_DIRECTIVE
+);
+impl CommodityDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    pub fn currency(&self) -> Option<CurrencyName> {
+        first_token(self.syntax(), SyntaxKind::CURRENCY).and_then(CurrencyName::cast)
+    }
+}
+
+// ---- 4 standalone-keyword directives (PR 2.1a) -----------------
+
+ast_node!(
+    /// `pushtag #TAG`.
+    PushtagDirective, PUSHTAG_DIRECTIVE
+);
+impl PushtagDirective {
+    pub fn tag(&self) -> Option<Tag> {
+        first_token(self.syntax(), SyntaxKind::TAG).and_then(Tag::cast)
+    }
+}
+
+ast_node!(
+    /// `poptag #TAG`.
+    PoptagDirective, POPTAG_DIRECTIVE
+);
+impl PoptagDirective {
+    pub fn tag(&self) -> Option<Tag> {
+        first_token(self.syntax(), SyntaxKind::TAG).and_then(Tag::cast)
+    }
+}
+
+ast_node!(
+    /// `pushmeta KEY: VALUE`.
+    PushmetaDirective, PUSHMETA_DIRECTIVE
+);
+impl PushmetaDirective {
+    pub fn key(&self) -> Option<MetaKey> {
+        first_token(self.syntax(), SyntaxKind::META_KEY).and_then(MetaKey::cast)
+    }
+}
+
+ast_node!(
+    /// `popmeta KEY:`.
+    PopmetaDirective, POPMETA_DIRECTIVE
+);
+impl PopmetaDirective {
+    pub fn key(&self) -> Option<MetaKey> {
+        first_token(self.syntax(), SyntaxKind::META_KEY).and_then(MetaKey::cast)
+    }
+}
+
+// ---- 4 edge directives (PR 2.3) --------------------------------
+
+ast_node!(
+    /// `option "KEY" "VALUE"`.
+    OptionDirective, OPTION_DIRECTIVE
+);
+impl OptionDirective {
+    pub fn key(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+    pub fn value(&self) -> Option<StringLit> {
+        nth_token(self.syntax(), SyntaxKind::STRING, 1).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `include "PATH"`.
+    IncludeDirective, INCLUDE_DIRECTIVE
+);
+impl IncludeDirective {
+    pub fn path(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `plugin "MODULE" ["CONFIG"]`.
+    PluginDirective, PLUGIN_DIRECTIVE
+);
+impl PluginDirective {
+    pub fn module(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+    pub fn config(&self) -> Option<StringLit> {
+        nth_token(self.syntax(), SyntaxKind::STRING, 1).and_then(StringLit::cast)
+    }
+}
+
+ast_node!(
+    /// `DATE custom "TYPE" values...`. Heterogeneous value list
+    /// stays flat (phase 2.3); walk `values()` for the raw token
+    /// sequence.
+    CustomDirective, CUSTOM_DIRECTIVE
+);
+impl CustomDirective {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+    /// The type-name string (always the first `STRING` after the
+    /// `custom` keyword).
+    pub fn custom_type(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+}
+
+// ---- TRANSACTION + body sub-nodes ------------------------------
+
+ast_node!(
+    /// `DATE FLAG ["PAYEE"] "NARRATION" #TAG... ^LINK...`
+    /// followed by indented `POSTING` lines and `META_ENTRY`
+    /// sub-lines.
+    Transaction, TRANSACTION
+);
+
+impl Transaction {
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+
+    /// Transaction flag token. May be `STAR` (`*`), `PENDING_KW`
+    /// (`!`), `FLAG` letter, `HASH` (`#`), `TXN_KW`
+    /// (the `txn` keyword), single-char `CURRENCY`, or absent
+    /// (implied via a leading `STRING` payee/narration).
+    pub fn flag(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .find(|t| {
+                matches!(
+                    t.kind(),
+                    SyntaxKind::STAR
+                        | SyntaxKind::PENDING_KW
+                        | SyntaxKind::FLAG
+                        | SyntaxKind::HASH
+                        | SyntaxKind::TXN_KW
+                )
+            })
+    }
+
+    /// The payee string, if a separate payee + narration pair is
+    /// present. With two `STRING` children, the first is the
+    /// payee. With only one `STRING`, the entire string is
+    /// considered narration.
+    pub fn payee(&self) -> Option<StringLit> {
+        let strings: Vec<StringLit> = tokens_of_kind(self.syntax(), SyntaxKind::STRING)
+            .filter_map(StringLit::cast)
+            .collect();
+        if strings.len() >= 2 {
+            Some(strings.into_iter().next().unwrap())
+        } else {
+            None
+        }
+    }
+
+    /// The narration string. The last `STRING` child of the
+    /// header line (handles both the payee+narration and
+    /// narration-only cases).
+    pub fn narration(&self) -> Option<StringLit> {
+        let mut strings: Vec<StringLit> = tokens_of_kind(self.syntax(), SyntaxKind::STRING)
+            .filter_map(StringLit::cast)
+            .collect();
+        strings.pop()
+    }
+
+    /// All `#TAG` tokens attached to the transaction header.
+    pub fn tags(&self) -> impl Iterator<Item = Tag> + '_ {
+        tokens_of_kind(self.syntax(), SyntaxKind::TAG).filter_map(Tag::cast)
+    }
+
+    /// All `^LINK` tokens attached to the transaction header.
+    pub fn links(&self) -> impl Iterator<Item = Link> + '_ {
+        tokens_of_kind(self.syntax(), SyntaxKind::LINK).filter_map(Link::cast)
+    }
+
+    /// All `POSTING` sub-lines, in source order.
+    pub fn postings(&self) -> impl Iterator<Item = Posting> + '_ {
+        children(self.syntax())
+    }
+
+    /// Transaction-level `META_ENTRY` sub-lines (at the standard
+    /// indent, NOT the deeper posting-attached metadata).
+    pub fn meta_entries(&self) -> impl Iterator<Item = MetaEntry> + '_ {
+        children(self.syntax())
+    }
+}
+
+ast_node!(
+    /// `WS [(FLAG | STAR | PENDING_KW | HASH | single-char CURRENCY) WS] ACCOUNT [AMOUNT] [COST_SPEC] [PRICE_ANNOTATION]`.
+    Posting, POSTING
+);
+
+impl Posting {
+    /// Posting flag (optional). Same kinds as `Transaction::flag`
+    /// but indicates whether THIS posting is pending, etc.
+    pub fn flag(&self) -> Option<SyntaxToken> {
+        // Walk children up to the ACCOUNT; any flag-kind token
+        // before ACCOUNT is the posting flag.
+        for el in self.syntax().children_with_tokens() {
+            if let rowan::NodeOrToken::Token(t) = el {
+                match t.kind() {
+                    SyntaxKind::WHITESPACE => {}
+                    SyntaxKind::ACCOUNT => return None,
+                    SyntaxKind::STAR
+                    | SyntaxKind::PENDING_KW
+                    | SyntaxKind::FLAG
+                    | SyntaxKind::HASH => return Some(t),
+                    SyntaxKind::CURRENCY if t.text().len() == 1 => return Some(t),
+                    _ => return None,
+                }
+            }
+        }
+        None
+    }
+
+    pub fn account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+
+    /// Units `AMOUNT` (optional — auto postings have none).
+    pub fn amount(&self) -> Option<Amount> {
+        first_child(self.syntax())
+    }
+
+    /// `COST_SPEC` annotation, if present.
+    pub fn cost_spec(&self) -> Option<CostSpec> {
+        first_child(self.syntax())
+    }
+
+    /// `PRICE_ANNOTATION`, if present.
+    pub fn price_annotation(&self) -> Option<PriceAnnotation> {
+        first_child(self.syntax())
+    }
+
+    /// Posting-attached metadata (strictly deeper-indent
+    /// `META_ENTRY` sub-lines following the posting line).
+    pub fn meta_entries(&self) -> impl Iterator<Item = MetaEntry> + '_ {
+        children(self.syntax())
+    }
+}
+
+// ---- AMOUNT / COST_SPEC / PRICE_ANNOTATION / META_ENTRY --------
+
+ast_node!(
+    /// Units amount: `[sign] (NUMBER | PAREN_EXPR) ([WS] op
+    /// [WS] [sign] (NUMBER | PAREN_EXPR))* [WS CURRENCY]`, or a
+    /// bare `CURRENCY`. Phase 2.4 extension supports arithmetic.
+    Amount, AMOUNT
+);
+
+impl Amount {
+    /// Sign token (`MINUS` or `PLUS`), if present as the FIRST
+    /// non-whitespace child of AMOUNT. Returns `None` if no
+    /// sign or if the sign is inside an arithmetic-expression
+    /// inner operand.
+    pub fn sign(&self) -> Option<SyntaxToken> {
+        let first = self
+            .syntax()
+            .children_with_tokens()
+            .find_map(rowan::NodeOrToken::into_token)?;
+        matches!(first.kind(), SyntaxKind::MINUS | SyntaxKind::PLUS).then_some(first)
+    }
+
+    /// First `NUMBER` child token (the leading operand). For an
+    /// arithmetic expression like `10+5 USD`, this is `10`; for
+    /// a bare CURRENCY amount this is `None`.
+    pub fn number(&self) -> Option<Number> {
+        first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
+    }
+
+    /// The trailing currency. For `100 USD` or `100USD` or
+    /// `(1+2) USD`, this is `USD`. For bare currency-only
+    /// `AMOUNT(CURRENCY)`, it's the same token.
+    pub fn currency(&self) -> Option<CurrencyName> {
+        // The currency is the LAST direct-child CURRENCY token
+        // (a paren-expression interior may contain currency-shaped
+        // tokens that we want to ignore for the typed accessor).
+        tokens_of_kind(self.syntax(), SyntaxKind::CURRENCY)
+            .last()
+            .and_then(CurrencyName::cast)
+    }
+
+    /// Returns true iff the amount contains an arithmetic operator
+    /// (`+`, `-` between operands, `*`, `/`) or a parenthesized
+    /// sub-expression — useful for typed-AST consumers that need
+    /// to defer to expression evaluation.
+    #[must_use]
+    pub fn is_arithmetic(&self) -> bool {
+        let mut seen_first_operand = false;
+        for el in self.syntax().children_with_tokens() {
+            if let rowan::NodeOrToken::Token(t) = el {
+                match t.kind() {
+                    SyntaxKind::NUMBER => seen_first_operand = true,
+                    SyntaxKind::L_PAREN | SyntaxKind::R_PAREN => return true,
+                    SyntaxKind::STAR | SyntaxKind::SLASH => return true,
+                    SyntaxKind::PLUS | SyntaxKind::MINUS if seen_first_operand => return true,
+                    _ => {}
+                }
+            }
+        }
+        false
+    }
+}
+
+ast_node!(
+    /// Bracketed cost annotation: `{...}` (per-unit), `{#...}`
+    /// (per-unit + total), or `{{...}}` (total-only). Contents
+    /// stay flat (phase 2.2c); accessors scan the children.
+    CostSpec, COST_SPEC
+);
+
+impl CostSpec {
+    /// Returns true iff the opener is `{{` (total-cost form).
+    #[must_use]
+    pub fn is_total(&self) -> bool {
+        first_token(self.syntax(), SyntaxKind::L_DOUBLE_BRACE).is_some()
+    }
+
+    /// Returns true iff the opener is `{#` (per-unit + total
+    /// form).
+    #[must_use]
+    pub fn is_per_unit_plus_total(&self) -> bool {
+        first_token(self.syntax(), SyntaxKind::L_BRACE_HASH).is_some()
+    }
+
+    /// Cost number (first NUMBER child token).
+    pub fn number(&self) -> Option<Number> {
+        first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
+    }
+
+    /// Cost currency (first CURRENCY child token).
+    pub fn currency(&self) -> Option<CurrencyName> {
+        first_token(self.syntax(), SyntaxKind::CURRENCY).and_then(CurrencyName::cast)
+    }
+
+    /// Cost date (first DATE child token), if present.
+    pub fn date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+
+    /// Cost label (first STRING child token), if present.
+    pub fn label(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+
+    /// Returns true iff the cost spec contains a `*` merge marker.
+    #[must_use]
+    pub fn is_merge(&self) -> bool {
+        first_token(self.syntax(), SyntaxKind::STAR).is_some()
+    }
+}
+
+ast_node!(
+    /// Price annotation: `AT [WS AMOUNT]` (per-unit) or
+    /// `AT_AT [WS AMOUNT]` (total).
+    PriceAnnotation, PRICE_ANNOTATION
+);
+
+impl PriceAnnotation {
+    /// Returns true iff the opener is `@@` (total-price form).
+    #[must_use]
+    pub fn is_total(&self) -> bool {
+        first_token(self.syntax(), SyntaxKind::AT_AT).is_some()
+    }
+
+    /// The price's inner `AMOUNT`, if present.
+    pub fn amount(&self) -> Option<Amount> {
+        first_child(self.syntax())
+    }
+}
+
+ast_node!(
+    /// Metadata sub-line: `WS META_KEY ... (NEWLINE | EOF)`.
+    /// Key is the `META_KEY` token; value is the remaining flat
+    /// content tokens. Use `key()` and `value_*()` accessors.
+    MetaEntry, META_ENTRY
+);
+
+impl MetaEntry {
+    pub fn key(&self) -> Option<MetaKey> {
+        first_token(self.syntax(), SyntaxKind::META_KEY).and_then(MetaKey::cast)
+    }
+
+    /// Value as a typed STRING, if the value is a quoted string.
+    pub fn value_string(&self) -> Option<StringLit> {
+        first_token(self.syntax(), SyntaxKind::STRING).and_then(StringLit::cast)
+    }
+
+    /// Value as a NUMBER token, if the value is numeric.
+    pub fn value_number(&self) -> Option<Number> {
+        first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
+    }
+
+    /// Value as a DATE token, if the value is a date literal.
+    pub fn value_date(&self) -> Option<Date> {
+        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+    }
+
+    /// Value as an ACCOUNT token.
+    pub fn value_account(&self) -> Option<Account> {
+        first_token(self.syntax(), SyntaxKind::ACCOUNT).and_then(Account::cast)
+    }
+
+    /// Value as a CURRENCY token.
+    pub fn value_currency(&self) -> Option<CurrencyName> {
+        first_token(self.syntax(), SyntaxKind::CURRENCY).and_then(CurrencyName::cast)
+    }
+
+    /// Value as a boolean (true / false token).
+    pub fn value_bool(&self) -> Option<bool> {
+        for el in self.syntax().children_with_tokens() {
+            if let rowan::NodeOrToken::Token(t) = el {
+                match t.kind() {
+                    SyntaxKind::BOOL_TRUE => return Some(true),
+                    SyntaxKind::BOOL_FALSE => return Some(false),
+                    _ => {}
+                }
+            }
+        }
+        None
+    }
+}

--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -212,19 +212,44 @@ ast_token!(
 
 // ---- Heterogeneous flag/sign token wrappers --------------------
 //
-// These wrap a SyntaxToken whose kind is one of several possibilities
-// (a transaction flag may be STAR, PENDING_KW, FLAG letter, HASH,
-// TXN_KW, or single-char CURRENCY). We deliberately do NOT implement
-// AstToken for them, since AstToken::can_cast is kind-only and the
-// CURRENCY case needs a length check. Inherent cast() does the full
-// check; downstream code discriminates via the is_*() predicates or
-// kind().
+// These wrap a SyntaxToken whose kind is one of several
+// possibilities (a transaction flag may be STAR, PENDING_KW, FLAG
+// letter, HASH, TXN_KW, or single-char CURRENCY). We deliberately
+// do NOT implement AstToken for them: AstToken::can_cast is
+// kind-only, and the CURRENCY case needs a length check (only
+// single-character CURRENCY counts as a ticker-letter flag).
+// Inherent cast() runs the full check.
+//
+// Downstream code that needs exhaustive matching should use the
+// `kind()` method paired with the dedicated `*FlagKind` enum
+// returned by `classify()` (or `Sign::classify()`), which is
+// pinned to the same variant set as `cast`.
+
+/// Exhaustive classification of a [`TransactionFlag`] token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TransactionFlagKind {
+    /// `*` token.
+    Star,
+    /// `!` (the `PENDING_KW` token).
+    Pending,
+    /// Single-letter `FLAG` token (e.g. `P` from `posti P`).
+    Letter,
+    /// `#` token.
+    Hash,
+    /// `txn` keyword.
+    Txn,
+    /// Single-character `CURRENCY` token used as the
+    /// ticker-letter flag.
+    CurrencyLetter,
+}
 
 /// Typed wrapper for the transaction-header flag token.
 ///
 /// May be `STAR` (`*`), `PENDING_KW` (`!`), `FLAG` (letter),
 /// `HASH` (`#`), `TXN_KW` (`txn`), or single-character `CURRENCY`
-/// (ticker-letter flag, e.g. `T`).
+/// (ticker-letter flag, e.g. `T`). Use [`Self::classify`] for
+/// exhaustive `match` ergonomics, or the `is_*` predicates for
+/// boolean checks.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TransactionFlag(SyntaxToken);
 
@@ -252,6 +277,21 @@ impl TransactionFlag {
     pub fn text(&self) -> &str {
         self.0.text()
     }
+
+    /// Exhaustive classification — pair with a `match` for
+    /// compiler-checked coverage of every variant.
+    pub fn classify(&self) -> TransactionFlagKind {
+        match self.kind() {
+            SyntaxKind::STAR => TransactionFlagKind::Star,
+            SyntaxKind::PENDING_KW => TransactionFlagKind::Pending,
+            SyntaxKind::FLAG => TransactionFlagKind::Letter,
+            SyntaxKind::HASH => TransactionFlagKind::Hash,
+            SyntaxKind::TXN_KW => TransactionFlagKind::Txn,
+            SyntaxKind::CURRENCY => TransactionFlagKind::CurrencyLetter,
+            _ => unreachable!("TransactionFlag invariant — guarded by cast()"),
+        }
+    }
+
     pub fn is_star(&self) -> bool {
         self.kind() == SyntaxKind::STAR
     }
@@ -272,9 +312,22 @@ impl TransactionFlag {
     }
 }
 
+/// Exhaustive classification of a [`PostingFlag`] token.
+/// Same as [`TransactionFlagKind`] minus `Txn` (postings cannot
+/// carry the `txn` keyword).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PostingFlagKind {
+    Star,
+    Pending,
+    Letter,
+    Hash,
+    CurrencyLetter,
+}
+
 /// Typed wrapper for a posting-line flag token. Same as
 /// [`TransactionFlag`] minus the `TXN_KW` variant (postings can't
-/// carry the `txn` keyword).
+/// carry the `txn` keyword). Use [`Self::classify`] for
+/// exhaustive `match` ergonomics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PostingFlag(SyntaxToken);
 
@@ -298,6 +351,20 @@ impl PostingFlag {
     pub fn text(&self) -> &str {
         self.0.text()
     }
+
+    /// Exhaustive classification — pair with a `match` for
+    /// compiler-checked coverage.
+    pub fn classify(&self) -> PostingFlagKind {
+        match self.kind() {
+            SyntaxKind::STAR => PostingFlagKind::Star,
+            SyntaxKind::PENDING_KW => PostingFlagKind::Pending,
+            SyntaxKind::FLAG => PostingFlagKind::Letter,
+            SyntaxKind::HASH => PostingFlagKind::Hash,
+            SyntaxKind::CURRENCY => PostingFlagKind::CurrencyLetter,
+            _ => unreachable!("PostingFlag invariant — guarded by cast()"),
+        }
+    }
+
     pub fn is_star(&self) -> bool {
         self.kind() == SyntaxKind::STAR
     }
@@ -316,6 +383,14 @@ impl PostingFlag {
 }
 
 /// Typed wrapper for an amount sign token (`PLUS` or `MINUS`).
+///
+/// `Sign::cast` is a position-AGNOSTIC kind check: it accepts ANY
+/// `PLUS` or `MINUS` token, including operator-position signs
+/// inside arithmetic (e.g., the `-` in `10 + -5 USD`). To get the
+/// LEADING sign of an `Amount`, use [`Amount::sign`] which scopes
+/// to the first non-whitespace token of `AMOUNT`. Calling
+/// `Sign::cast` on an arbitrary token does not imply the token
+/// occupies the leading-sign position.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Sign(SyntaxToken);
 
@@ -367,105 +442,60 @@ impl SourceFile {
     }
 }
 
-/// Sum type over every recognized top-level directive wrapper.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Directive {
-    Open(OpenDirective),
-    Close(CloseDirective),
-    Balance(BalanceDirective),
-    Pad(PadDirective),
-    Event(EventDirective),
-    Query(QueryDirective),
-    Note(NoteDirective),
-    Document(DocumentDirective),
-    Price(PriceDirective),
-    Commodity(CommodityDirective),
-    Pushtag(PushtagDirective),
-    Poptag(PoptagDirective),
-    Pushmeta(PushmetaDirective),
-    Popmeta(PopmetaDirective),
-    Option(OptionDirective),
-    Include(IncludeDirective),
-    Plugin(PluginDirective),
-    Custom(CustomDirective),
-    Transaction(Transaction),
-}
-
-impl AstNode for Directive {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(
-            kind,
-            SyntaxKind::OPEN_DIRECTIVE
-                | SyntaxKind::CLOSE_DIRECTIVE
-                | SyntaxKind::BALANCE_DIRECTIVE
-                | SyntaxKind::PAD_DIRECTIVE
-                | SyntaxKind::EVENT_DIRECTIVE
-                | SyntaxKind::QUERY_DIRECTIVE
-                | SyntaxKind::NOTE_DIRECTIVE
-                | SyntaxKind::DOCUMENT_DIRECTIVE
-                | SyntaxKind::PRICE_DIRECTIVE
-                | SyntaxKind::COMMODITY_DIRECTIVE
-                | SyntaxKind::PUSHTAG_DIRECTIVE
-                | SyntaxKind::POPTAG_DIRECTIVE
-                | SyntaxKind::PUSHMETA_DIRECTIVE
-                | SyntaxKind::POPMETA_DIRECTIVE
-                | SyntaxKind::OPTION_DIRECTIVE
-                | SyntaxKind::INCLUDE_DIRECTIVE
-                | SyntaxKind::PLUGIN_DIRECTIVE
-                | SyntaxKind::CUSTOM_DIRECTIVE
-                | SyntaxKind::TRANSACTION
-        )
-    }
-
-    fn cast(node: SyntaxNode) -> Option<Self> {
-        Some(match node.kind() {
-            SyntaxKind::OPEN_DIRECTIVE => Self::Open(OpenDirective(node)),
-            SyntaxKind::CLOSE_DIRECTIVE => Self::Close(CloseDirective(node)),
-            SyntaxKind::BALANCE_DIRECTIVE => Self::Balance(BalanceDirective(node)),
-            SyntaxKind::PAD_DIRECTIVE => Self::Pad(PadDirective(node)),
-            SyntaxKind::EVENT_DIRECTIVE => Self::Event(EventDirective(node)),
-            SyntaxKind::QUERY_DIRECTIVE => Self::Query(QueryDirective(node)),
-            SyntaxKind::NOTE_DIRECTIVE => Self::Note(NoteDirective(node)),
-            SyntaxKind::DOCUMENT_DIRECTIVE => Self::Document(DocumentDirective(node)),
-            SyntaxKind::PRICE_DIRECTIVE => Self::Price(PriceDirective(node)),
-            SyntaxKind::COMMODITY_DIRECTIVE => Self::Commodity(CommodityDirective(node)),
-            SyntaxKind::PUSHTAG_DIRECTIVE => Self::Pushtag(PushtagDirective(node)),
-            SyntaxKind::POPTAG_DIRECTIVE => Self::Poptag(PoptagDirective(node)),
-            SyntaxKind::PUSHMETA_DIRECTIVE => Self::Pushmeta(PushmetaDirective(node)),
-            SyntaxKind::POPMETA_DIRECTIVE => Self::Popmeta(PopmetaDirective(node)),
-            SyntaxKind::OPTION_DIRECTIVE => Self::Option(OptionDirective(node)),
-            SyntaxKind::INCLUDE_DIRECTIVE => Self::Include(IncludeDirective(node)),
-            SyntaxKind::PLUGIN_DIRECTIVE => Self::Plugin(PluginDirective(node)),
-            SyntaxKind::CUSTOM_DIRECTIVE => Self::Custom(CustomDirective(node)),
-            SyntaxKind::TRANSACTION => Self::Transaction(Transaction(node)),
-            _ => return None,
-        })
-    }
-
-    fn syntax(&self) -> &SyntaxNode {
-        match self {
-            Self::Open(d) => d.syntax(),
-            Self::Close(d) => d.syntax(),
-            Self::Balance(d) => d.syntax(),
-            Self::Pad(d) => d.syntax(),
-            Self::Event(d) => d.syntax(),
-            Self::Query(d) => d.syntax(),
-            Self::Note(d) => d.syntax(),
-            Self::Document(d) => d.syntax(),
-            Self::Price(d) => d.syntax(),
-            Self::Commodity(d) => d.syntax(),
-            Self::Pushtag(d) => d.syntax(),
-            Self::Poptag(d) => d.syntax(),
-            Self::Pushmeta(d) => d.syntax(),
-            Self::Popmeta(d) => d.syntax(),
-            Self::Option(d) => d.syntax(),
-            Self::Include(d) => d.syntax(),
-            Self::Plugin(d) => d.syntax(),
-            Self::Custom(d) => d.syntax(),
-            Self::Transaction(d) => d.syntax(),
+// Sum-type Directive enum + AstNode impl, derived from a single
+// variant list so can_cast, cast, and syntax() are guaranteed to
+// agree. Adding a new directive variant requires editing exactly
+// one line; drift between can_cast and cast is impossible.
+macro_rules! directive_enum {
+    ($($variant:ident($struct:ident, $kind:ident)),* $(,)?) => {
+        /// Sum type over every recognized top-level directive wrapper.
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub enum Directive {
+            $($variant($struct),)*
         }
-    }
+
+        impl AstNode for Directive {
+            fn can_cast(kind: SyntaxKind) -> bool {
+                matches!(kind, $(SyntaxKind::$kind)|*)
+            }
+
+            fn cast(node: SyntaxNode) -> Option<Self> {
+                Some(match node.kind() {
+                    $(SyntaxKind::$kind => Self::$variant($struct(node)),)*
+                    _ => return None,
+                })
+            }
+
+            fn syntax(&self) -> &SyntaxNode {
+                match self {
+                    $(Self::$variant(d) => d.syntax(),)*
+                }
+            }
+        }
+    };
 }
+
+directive_enum!(
+    Open(OpenDirective, OPEN_DIRECTIVE),
+    Close(CloseDirective, CLOSE_DIRECTIVE),
+    Balance(BalanceDirective, BALANCE_DIRECTIVE),
+    Pad(PadDirective, PAD_DIRECTIVE),
+    Event(EventDirective, EVENT_DIRECTIVE),
+    Query(QueryDirective, QUERY_DIRECTIVE),
+    Note(NoteDirective, NOTE_DIRECTIVE),
+    Document(DocumentDirective, DOCUMENT_DIRECTIVE),
+    Price(PriceDirective, PRICE_DIRECTIVE),
+    Commodity(CommodityDirective, COMMODITY_DIRECTIVE),
+    Pushtag(PushtagDirective, PUSHTAG_DIRECTIVE),
+    Poptag(PoptagDirective, POPTAG_DIRECTIVE),
+    Pushmeta(PushmetaDirective, PUSHMETA_DIRECTIVE),
+    Popmeta(PopmetaDirective, POPMETA_DIRECTIVE),
+    Option(OptionDirective, OPTION_DIRECTIVE),
+    Include(IncludeDirective, INCLUDE_DIRECTIVE),
+    Plugin(PluginDirective, PLUGIN_DIRECTIVE),
+    Custom(CustomDirective, CUSTOM_DIRECTIVE),
+    Transaction(Transaction, TRANSACTION),
+);
 
 impl Directive {
     /// Metadata sub-lines attached to this directive (phase 2.2a
@@ -484,10 +514,13 @@ ast_node!(
 );
 
 impl ErrorNode {
-    /// The raw bytes of the malformed region.
+    /// The raw bytes of the malformed region as a rowan
+    /// [`rowan::SyntaxText`] (a rope view). Zero allocation; use
+    /// `.to_string()` on the result if you need an owned
+    /// `String`, or `format!`/`Display` for direct output.
     #[must_use]
-    pub fn text(&self) -> String {
-        self.syntax().text().to_string()
+    pub fn text(&self) -> rowan::SyntaxText {
+        self.syntax().text()
     }
 }
 
@@ -767,8 +800,37 @@ ast_node!(
 );
 
 impl Transaction {
+    /// Direct-child tokens of TRANSACTION up to (but not
+    /// including) the first NEWLINE — i.e., the header region.
+    /// Body content (`POSTING` / `META_ENTRY` nodes; flat tokens
+    /// emitted by `emit_transaction_body`'s catch-all for
+    /// malformed indented lines) is excluded, so accessors using
+    /// this helper can't mistake body content for header content.
+    fn header_tokens(&self) -> impl Iterator<Item = SyntaxToken> + '_ {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .take_while(|t| t.kind() != SyntaxKind::NEWLINE)
+    }
+
+    /// Header tokens BEFORE the first STRING/TAG/LINK — i.e., the
+    /// flag-position region (between DATE and the first header
+    /// content token). Used by [`Self::flag`] to scope its search.
+    fn flag_region_tokens(&self) -> impl Iterator<Item = SyntaxToken> + '_ {
+        self.header_tokens().take_while(|t| {
+            !matches!(
+                t.kind(),
+                SyntaxKind::STRING | SyntaxKind::TAG | SyntaxKind::LINK
+            )
+        })
+    }
+
     pub fn date(&self) -> Option<Date> {
-        first_token(self.syntax(), SyntaxKind::DATE).and_then(Date::cast)
+        // DATE is in the header, so first_token over the whole node
+        // is fine — but for symmetry, scope to header_tokens.
+        self.header_tokens()
+            .find(|t| t.kind() == SyntaxKind::DATE)
+            .and_then(Date::cast)
     }
 
     /// Transaction flag token. May be `STAR` (`*`), `PENDING_KW`
@@ -776,55 +838,85 @@ impl Transaction {
     /// (the `txn` keyword), single-char `CURRENCY` (ticker-letter
     /// flag), or absent (implied via a leading `STRING`
     /// payee/narration).
+    ///
+    /// Scoped to the flag-position region (between `DATE` and the
+    /// first `STRING`/`TAG`/`LINK`) so a stray trailing
+    /// single-char `CURRENCY` after the narration is NOT
+    /// misclassified as a flag.
     pub fn flag(&self) -> Option<TransactionFlag> {
-        self.syntax()
-            .children_with_tokens()
-            .filter_map(rowan::NodeOrToken::into_token)
-            .find_map(TransactionFlag::cast)
+        self.flag_region_tokens().find_map(TransactionFlag::cast)
     }
 
-    /// All `STRING` tokens in the header, in source order. The
-    /// 2-string convention (`"payee" "narration"`) is the
+    /// All `STRING` tokens in the header, in source order.
+    ///
+    /// Scoped to the header (tokens before the terminating
+    /// `NEWLINE`), so `STRING` tokens emitted into TRANSACTION by
+    /// `emit_transaction_body`'s catch-all for malformed indented
+    /// body lines are excluded.
+    ///
+    /// The 2-string convention (`"payee" "narration"`) is the
     /// canonical form; [`Self::payee`] and [`Self::narration`]
     /// follow it strictly. For 3+ strings (malformed but
     /// losslessly parsed), use this method to surface every
     /// header string.
     pub fn strings(&self) -> impl Iterator<Item = StringLit> + '_ {
-        tokens_of_kind(self.syntax(), SyntaxKind::STRING).filter_map(StringLit::cast)
+        self.header_tokens()
+            .filter(|t| t.kind() == SyntaxKind::STRING)
+            .filter_map(StringLit::cast)
     }
 
     /// The payee string, if a separate payee + narration pair is
     /// present. Returns `Some(first)` ONLY when exactly two
-    /// `STRING` tokens appear in the header (the canonical
+    /// header `STRING` tokens appear (the canonical
     /// `"payee" "narration"` shape). With 0, 1, or 3+ strings
     /// the convention is ambiguous and this returns `None` —
     /// use [`Self::strings`] for lossless access.
     pub fn payee(&self) -> Option<StringLit> {
-        let strings: Vec<StringLit> = self.strings().collect();
-        (strings.len() == 2).then(|| strings.into_iter().next().unwrap())
+        // Take up to 3 to disambiguate 2 from 3+ without
+        // allocating the whole sequence.
+        let mut iter = self.strings();
+        let first = iter.next()?;
+        let second = iter.next()?;
+        if iter.next().is_some() {
+            None
+        } else {
+            // Exactly 2 strings; first is payee.
+            let _ = second;
+            Some(first)
+        }
     }
 
     /// The narration string. Returns `Some(only)` for a single
-    /// string and `Some(last)` for the 2-string `"payee"
-    /// "narration"` form. Returns `None` for 0 or 3+ strings —
-    /// use [`Self::strings`] for lossless access on malformed
-    /// headers.
+    /// header string and `Some(last)` for the 2-string
+    /// `"payee" "narration"` form. Returns `None` for 0 or 3+
+    /// strings — use [`Self::strings`] for lossless access on
+    /// malformed headers.
     pub fn narration(&self) -> Option<StringLit> {
-        let mut strings: Vec<StringLit> = self.strings().collect();
-        match strings.len() {
-            1 | 2 => strings.pop(),
+        let mut iter = self.strings();
+        let first = iter.next()?;
+        let second = iter.next();
+        let third = iter.next();
+        match (second, third) {
+            (None, _) => Some(first),
+            (Some(s2), None) => Some(s2),
             _ => None,
         }
     }
 
     /// All `#TAG` tokens attached to the transaction header.
+    /// Scoped to the header region (excludes body tokens).
     pub fn tags(&self) -> impl Iterator<Item = Tag> + '_ {
-        tokens_of_kind(self.syntax(), SyntaxKind::TAG).filter_map(Tag::cast)
+        self.header_tokens()
+            .filter(|t| t.kind() == SyntaxKind::TAG)
+            .filter_map(Tag::cast)
     }
 
     /// All `^LINK` tokens attached to the transaction header.
+    /// Scoped to the header region (excludes body tokens).
     pub fn links(&self) -> impl Iterator<Item = Link> + '_ {
-        tokens_of_kind(self.syntax(), SyntaxKind::LINK).filter_map(Link::cast)
+        self.header_tokens()
+            .filter(|t| t.kind() == SyntaxKind::LINK)
+            .filter_map(Link::cast)
     }
 
     /// All `POSTING` sub-lines, in source order.
@@ -919,34 +1011,40 @@ impl Amount {
         first_token(self.syntax(), SyntaxKind::NUMBER).and_then(Number::cast)
     }
 
-    /// The trailing currency at paren-depth 0. For `100 USD` or
-    /// `100USD` or `(1+2) USD`, this is the trailing `USD`. For
-    /// bare currency-only `AMOUNT(CURRENCY)`, it's the same
-    /// token. For malformed `AMOUNT( CURRENCY )` (no trailing
-    /// currency outside the parens), returns `None` rather than
-    /// silently picking the paren-internal token.
+    /// The trailing currency at paren-depth 0.
+    ///
+    /// For `100 USD`, `100USD`, `(1+2) USD`: returns the trailing
+    /// `USD`. For bare currency-only `AMOUNT(CURRENCY)`: returns
+    /// the same token. For malformed `(1 USD)` (CURRENCY inside
+    /// parens, no outer trailing currency): returns `None`. For
+    /// unclosed `(1 USD\n` or stray-closer `1 USD)` (unbalanced
+    /// parens): returns `None`, refusing to surface a possibly
+    /// paren-internal currency.
+    ///
+    /// Single forward pass with paren-depth tracking; no
+    /// allocation. `emit_amount_operand` keeps paren contents
+    /// flat under AMOUNT (no `PAREN_EXPR` sub-node), so depth
+    /// tracking is the only structural disambiguator.
     pub fn currency(&self) -> Option<CurrencyName> {
-        // Walk tokens in reverse with paren-depth tracking; the
-        // first CURRENCY we hit at depth 0 is the trailing one.
-        // emit_amount_operand keeps paren contents flat under
-        // AMOUNT (no PAREN_EXPR sub-node), so internal currency
-        // tokens are direct children too — depth tracking is
-        // the only structural disambiguator.
-        let tokens: Vec<SyntaxToken> = self
-            .syntax()
-            .children_with_tokens()
-            .filter_map(rowan::NodeOrToken::into_token)
-            .collect();
         let mut depth: i32 = 0;
-        for t in tokens.iter().rev() {
+        let mut last_at_depth_0: Option<SyntaxToken> = None;
+        for el in self.syntax().children_with_tokens() {
+            let rowan::NodeOrToken::Token(t) = el else {
+                continue;
+            };
             match t.kind() {
-                SyntaxKind::R_PAREN => depth += 1,
-                SyntaxKind::L_PAREN => depth -= 1,
-                SyntaxKind::CURRENCY if depth == 0 => return CurrencyName::cast(t.clone()),
+                SyntaxKind::L_PAREN => depth += 1,
+                SyntaxKind::R_PAREN => depth -= 1,
+                SyntaxKind::CURRENCY if depth == 0 => last_at_depth_0 = Some(t),
                 _ => {}
             }
         }
-        None
+        // Unbalanced parens (unclosed or stray closer): refuse to
+        // surface a currency rather than guess.
+        if depth != 0 {
+            return None;
+        }
+        last_at_depth_0.and_then(CurrencyName::cast)
     }
 
     /// Returns true iff the amount contains an arithmetic operator

--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -48,6 +48,7 @@
 //! See the `trivia` module rustdoc for the full spec, rationale,
 //! and recursive-application notes for phase 2.1's grammar.
 
+pub mod ast;
 mod lossless_tokens;
 mod parser;
 mod syntax_kind;

--- a/crates/rustledger-parser/tests/ast.rs
+++ b/crates/rustledger-parser/tests/ast.rs
@@ -35,8 +35,11 @@ fn open_directive_accessors() {
     };
     assert_eq!(d.date().unwrap().text(), "2024-01-01");
     assert_eq!(d.account().unwrap().text(), "Assets:Cash");
-    let curs: Vec<String> = d.currencies().map(|c| c.text()).collect();
+    let curs: Vec<String> = d.currencies().map(|c| c.text().to_string()).collect();
     assert_eq!(curs, vec!["USD", "EUR"]);
+    // accessor still returns &str when called on a bound value
+    let acct = d.account().unwrap();
+    let _: &str = acct.text();
     assert_eq!(
         d.booking_method().unwrap().text_unquoted().unwrap(),
         "STRICT"
@@ -236,9 +239,9 @@ fn transaction_with_payee_narration_tags_links() {
         t.narration().unwrap().text_unquoted().unwrap(),
         "Morning coffee"
     );
-    let tags: Vec<String> = t.tags().map(|tg| tg.text()).collect();
+    let tags: Vec<String> = t.tags().map(|tg| tg.text().to_string()).collect();
     assert_eq!(tags, vec!["#daily"]);
-    let links: Vec<String> = t.links().map(|l| l.text()).collect();
+    let links: Vec<String> = t.links().map(|l| l.text().to_string()).collect();
     assert_eq!(links, vec!["^trip1"]);
     assert_eq!(t.postings().count(), 2);
 }
@@ -430,4 +433,154 @@ fn public_re_exports_exist() {
     t::<Link>();
     t::<CostSpec>();
     t::<PriceAnnotation>();
+    t::<rustledger_parser::cst::ast::TransactionFlag>();
+    t::<rustledger_parser::cst::ast::PostingFlag>();
+    t::<rustledger_parser::cst::ast::Sign>();
+}
+
+// ---- Review-fix regressions --------------------------------------
+
+#[test]
+fn transaction_flag_recognizes_single_char_currency_letter() {
+    // The ticker-letter transaction flag form (e.g. `T`). The CST
+    // builder classifies single-char CURRENCY in the flag position
+    // as a TRANSACTION; the typed accessor must surface it.
+    let f = parse("2024-01-15 T \"AT&T dividend\"\n  Assets:Brokerage  10 T\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let flag = t.flag().expect("flag present");
+    assert!(flag.is_currency_letter());
+    assert_eq!(flag.text(), "T");
+}
+
+#[test]
+fn transaction_flag_typed_discriminators() {
+    let f = parse("2024-01-15 ! \"x\"\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let flag = t.flag().unwrap();
+    assert!(flag.is_pending());
+    assert!(!flag.is_star());
+}
+
+#[test]
+fn posting_flag_typed_discriminators() {
+    let f = parse("2024-01-15 * \"x\"\n  ! Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let p = t.postings().next().unwrap();
+    let flag = p.flag().unwrap();
+    assert!(flag.is_pending());
+    assert_eq!(flag.text(), "!");
+}
+
+#[test]
+fn amount_sign_typed_discriminators() {
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let amt = t.postings().next().unwrap().amount().unwrap();
+    let sign = amt.sign().unwrap();
+    assert!(sign.is_minus());
+    assert!(!sign.is_plus());
+}
+
+#[test]
+fn cost_spec_is_merge_only_for_leading_star() {
+    // `{*}` — leading STAR is a merge marker.
+    let f = parse(
+        "2024-01-15 * \"x\"\n\
+         \x20\x20Assets:Inv  10 HOOL {*}\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let cost = t.postings().next().unwrap().cost_spec().unwrap();
+    assert!(cost.is_merge(), "leading STAR should be merge marker");
+}
+
+#[test]
+fn cost_spec_is_not_merge_for_multiplication_star() {
+    // `{500 * 2 USD}` — STAR is multiplication, NOT a merge
+    // marker. This is the bug fixed in the review pass.
+    let f = parse(
+        "2024-01-15 * \"x\"\n\
+         \x20\x20Assets:Inv  10 HOOL {500 * 2 USD}\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let cost = t.postings().next().unwrap().cost_spec().unwrap();
+    assert!(
+        !cost.is_merge(),
+        "multiplication * inside cost must not be classified as merge"
+    );
+}
+
+#[test]
+fn transaction_three_strings_payee_and_narration_return_none() {
+    // 3+ strings is ambiguous; both accessors return None.
+    // strings() exposes all three for lossless access.
+    let f = parse("2024-01-15 * \"A\" \"B\" \"C\"\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    assert!(t.payee().is_none(), "3+ strings: payee ambiguous");
+    assert!(t.narration().is_none(), "3+ strings: narration ambiguous");
+    let all: Vec<String> = t
+        .strings()
+        .map(|s| s.text_unquoted().unwrap().to_string())
+        .collect();
+    assert_eq!(all, vec!["A", "B", "C"]);
+}
+
+#[test]
+fn directive_implements_ast_node_trait() {
+    use rustledger_parser::cst::SyntaxKind;
+    // Generic over AstNode: confirms Directive participates in the
+    // trait, not just its variant structs.
+    fn syntax_kind_of<N: AstNode>(n: &N) -> SyntaxKind {
+        n.syntax().kind()
+    }
+    let file = parse("2024-01-01 open Assets:Cash\n");
+    let dir = single_directive(&file);
+    assert_eq!(syntax_kind_of(&dir), SyntaxKind::OPEN_DIRECTIVE);
+    // can_cast on the enum's trait
+    assert!(Directive::can_cast(SyntaxKind::OPEN_DIRECTIVE));
+    assert!(Directive::can_cast(SyntaxKind::TRANSACTION));
+    assert!(!Directive::can_cast(SyntaxKind::POSTING));
+}
+
+#[test]
+fn ast_token_text_is_borrowed_not_allocated() {
+    // The trait method should return &str borrowed from the token,
+    // confirming no per-call allocation. Compile-only check that
+    // the return type is &str.
+    let file = parse("2024-01-01 open Assets:Cash\n");
+    let Directive::Open(open) = single_directive(&file) else {
+        unreachable!()
+    };
+    let date = open.date().unwrap();
+    let date_text: &str = date.text();
+    assert_eq!(date_text, "2024-01-01");
+    // text_unquoted returns Option<&str>
+    let file2 = parse("option \"k\" \"v\"\n");
+    let Directive::Option(opt) = single_directive(&file2) else {
+        unreachable!()
+    };
+    let key = opt.key().unwrap();
+    let key_text: &str = key.text_unquoted().unwrap();
+    assert_eq!(key_text, "k");
+    // text_without_colon returns &str
+    let file3 = parse("pushmeta location:\n");
+    let Directive::Pushmeta(pmeta) = single_directive(&file3) else {
+        unreachable!()
+    };
+    let mkey = pmeta.key().unwrap();
+    let stripped: &str = mkey.text_without_colon();
+    assert_eq!(stripped, "location");
 }

--- a/crates/rustledger-parser/tests/ast.rs
+++ b/crates/rustledger-parser/tests/ast.rs
@@ -792,3 +792,107 @@ fn payee_narration_zero_strings_returns_none() {
     assert!(t.payee().is_none());
     assert!(t.narration().is_none());
 }
+
+// ---- Round-3 review fixes ----------------------------------------
+
+#[test]
+fn transaction_header_tokens_eof_without_newline() {
+    // EOF-terminated transaction with no NEWLINE in the tree.
+    // header_tokens (take_while != NEWLINE) walks ALL direct-child
+    // tokens. Since there's no body, all tokens ARE header — the
+    // accessors must still return the right answers, kind-filtered.
+    let f = parse("2024-01-15 * \"Coffee\"");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    assert_eq!(t.date().unwrap().text(), "2024-01-15");
+    assert!(t.flag().unwrap().is_star());
+    assert_eq!(t.narration().unwrap().text_unquoted().unwrap(), "Coffee");
+    assert!(t.payee().is_none());
+}
+
+#[test]
+fn amount_arithmetic_paren_contents_stay_flat_under_amount() {
+    // Pin the structural invariant Amount::currency depends on:
+    // emit_amount_operand keeps paren contents flat under AMOUNT,
+    // so direct-token paren-depth tracking is sound. If a future
+    // phase wraps parens in a PAREN_EXPR sub-node, currency()'s
+    // depth tracking breaks silently — this test catches the
+    // structural change.
+    use rustledger_parser::cst::SyntaxKind;
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  (10 + 5) USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let amt = t.postings().next().unwrap().amount().unwrap();
+    let has_node_children = amt
+        .syntax()
+        .children()
+        .any(|n| n.kind() != SyntaxKind::AMOUNT);
+    assert!(
+        !has_node_children,
+        "AMOUNT must keep paren contents as direct tokens, no sub-nodes"
+    );
+    // And the L_PAREN/R_PAREN tokens must be direct children:
+    let token_kinds: Vec<SyntaxKind> = amt
+        .syntax()
+        .children_with_tokens()
+        .filter_map(|el| el.into_token().map(|t| t.kind()))
+        .collect();
+    assert!(token_kinds.contains(&SyntaxKind::L_PAREN));
+    assert!(token_kinds.contains(&SyntaxKind::R_PAREN));
+}
+
+#[test]
+fn transaction_strings_excludes_catch_all_body_leak() {
+    // Pin the round-2 body-pollution fix against the exact builder
+    // shape that structured_directives.rs::catch_all_indented_
+    // unknown_content_closes_posting_and_emits_flat exercises:
+    // a stray indented STRING line between postings lands as a
+    // flat direct child of TRANSACTION. strings()/payee()/
+    // narration() must ignore it.
+    let f = parse(
+        "2024-01-15 * \"x\"\n\
+         \x20\x20Assets:Cash 1 USD\n\
+         \x20\x20\"stray string on own line\"\n\
+         \x20\x20Expenses:Food 1 USD\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let all: Vec<String> = t
+        .strings()
+        .map(|s| s.text_unquoted().unwrap().to_string())
+        .collect();
+    assert_eq!(all, vec!["x"], "only the header string");
+    assert_eq!(t.narration().unwrap().text_unquoted().unwrap(), "x");
+    assert!(t.payee().is_none());
+}
+
+#[test]
+fn cost_spec_per_unit_plus_total_positive() {
+    // Positive test for is_per_unit_plus_total. Existing tests
+    // only assert NOT-per-unit-plus-total for normal `{...}`
+    // costs; this pins the `{# ... }` form.
+    let f = parse(
+        "2024-01-15 * \"x\"\n\
+         \x20\x20Assets:Inv  10 HOOL {# 500.00 USD}\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let cost = t.postings().next().unwrap().cost_spec().unwrap();
+    assert!(cost.is_per_unit_plus_total());
+    assert!(!cost.is_total());
+    assert!(!cost.is_merge());
+}
+
+#[test]
+fn syntax_text_is_reexported_from_ast() {
+    // Re-export sanity: ErrorNode::text returns SyntaxText, and
+    // SyntaxText is reachable as rustledger_parser::cst::ast::
+    // SyntaxText so downstream code doesn't need a direct rowan
+    // dep.
+    fn t<T>() {}
+    t::<rustledger_parser::cst::ast::SyntaxText>();
+}

--- a/crates/rustledger-parser/tests/ast.rs
+++ b/crates/rustledger-parser/tests/ast.rs
@@ -379,7 +379,7 @@ fn error_node_surfaces_through_typed_api() {
     assert_eq!(errs[0].text(), "bogus content here\n");
     let ds: Vec<Directive> = f.directives().collect();
     assert_eq!(ds.len(), 1);
-    matches!(ds[0], Directive::Open(_));
+    assert!(matches!(ds[0], Directive::Open(_)));
 }
 
 // ---- AstNode / AstToken trait surface ----------------------------

--- a/crates/rustledger-parser/tests/ast.rs
+++ b/crates/rustledger-parser/tests/ast.rs
@@ -584,3 +584,211 @@ fn ast_token_text_is_borrowed_not_allocated() {
     let stripped: &str = mkey.text_without_colon();
     assert_eq!(stripped, "location");
 }
+
+// ---- Round-2 review fixes ----------------------------------------
+
+#[test]
+fn transaction_strings_excludes_malformed_body_strings() {
+    // emit_transaction_body's catch-all (parser.rs:396-401) emits
+    // malformed indented body lines flat into TRANSACTION; their
+    // STRING tokens would be siblings of the header STRING.
+    // strings() / payee() / narration() must scope to the header
+    // region (tokens before the first NEWLINE) and ignore body
+    // strings.
+    let f = parse(
+        "2024-01-15 * \"header\"\n\
+         \x20\x20\"stray body string\"\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let all: Vec<String> = t
+        .strings()
+        .map(|s| s.text_unquoted().unwrap().to_string())
+        .collect();
+    assert_eq!(all, vec!["header"]);
+    assert!(t.payee().is_none());
+    assert_eq!(t.narration().unwrap().text_unquoted().unwrap(), "header");
+}
+
+#[test]
+fn transaction_flag_scoped_to_pre_string_region() {
+    // A stray trailing single-char CURRENCY after the narration
+    // STRING must NOT be misclassified as a ticker-letter flag.
+    // The header is `DATE WS STRING WS CURRENCY NEWLINE`,
+    // classified as TRANSACTION via the STRING-implied-flag arm.
+    let f = parse("2024-01-15 \"narration\" T\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    assert!(
+        t.flag().is_none(),
+        "trailing stray CURRENCY 'T' must NOT be reported as a flag"
+    );
+    assert_eq!(t.narration().unwrap().text_unquoted().unwrap(), "narration");
+}
+
+#[test]
+fn transaction_tags_links_excluded_from_body() {
+    // Body tags/links (if any leak via catch-all) must not appear
+    // in tags() / links() either.
+    let f = parse(
+        "2024-01-15 * \"x\" #header-tag ^header-link\n\
+         \x20\x20#body-tag-stray\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let tags: Vec<String> = t.tags().map(|t| t.text().to_string()).collect();
+    assert_eq!(tags, vec!["#header-tag"]);
+    let links: Vec<String> = t.links().map(|l| l.text().to_string()).collect();
+    assert_eq!(links, vec!["^header-link"]);
+}
+
+#[test]
+fn amount_currency_unclosed_paren_returns_none() {
+    // emit_amount_operand breaks on NEWLINE without emitting a
+    // synthetic R_PAREN, so AMOUNT for `(1 USD\n` is
+    // [L_PAREN, NUMBER, WS, CURRENCY] with unbalanced parens.
+    // currency() must refuse rather than silently surface the
+    // paren-internal USD.
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  (1 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let amt = t.postings().next().unwrap().amount().unwrap();
+    assert!(
+        amt.currency().is_none(),
+        "unclosed paren must yield None, not the inside-paren USD"
+    );
+}
+
+#[test]
+fn amount_currency_closed_paren_no_outer_currency_returns_none() {
+    // `(10 + 5)` — closed paren with no trailing outer currency.
+    // depth returns to 0 by end, but no CURRENCY was seen at
+    // depth 0, so result is None.
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  (10 + 5)\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let amt = t.postings().next().unwrap().amount().unwrap();
+    assert!(amt.currency().is_none());
+}
+
+#[test]
+fn amount_currency_paren_arithmetic_with_outer_currency() {
+    // `(10 + 5) USD` — closed paren followed by outer USD.
+    // Forward walk picks USD at depth 0.
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  (10 + 5) USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let amt = t.postings().next().unwrap().amount().unwrap();
+    assert_eq!(amt.currency().unwrap().text(), "USD");
+}
+
+#[test]
+fn error_node_text_is_syntaxtext_zero_alloc() {
+    // ErrorNode::text returns a rowan SyntaxText (rope view); the
+    // implementation should not call to_string(). SyntaxText
+    // impls PartialEq<&str>, so direct comparison still works.
+    let f = parse("bogus content here\n2024-01-01 open Assets:Cash\n");
+    let errs: Vec<ErrorNode> = f.errors().collect();
+    assert_eq!(errs.len(), 1);
+    let txt: rowan::SyntaxText = errs[0].text();
+    assert_eq!(txt, "bogus content here\n");
+    // Also verify Display works (LSP diagnostic path).
+    assert_eq!(format!("{txt}"), "bogus content here\n");
+}
+
+#[test]
+fn directive_enum_can_cast_and_cast_agree_for_every_kind() {
+    // Pin lockstep between the macro-derived can_cast and cast.
+    // If a contributor adds a Directive variant but forgets one
+    // half of the match (which the macro now makes impossible),
+    // this test catches the drift.
+    use rustledger_parser::cst::SyntaxKind;
+    let directive_kinds = [
+        ("open", SyntaxKind::OPEN_DIRECTIVE),
+        ("close", SyntaxKind::CLOSE_DIRECTIVE),
+        ("balance", SyntaxKind::BALANCE_DIRECTIVE),
+        ("pad", SyntaxKind::PAD_DIRECTIVE),
+        ("event", SyntaxKind::EVENT_DIRECTIVE),
+        ("query", SyntaxKind::QUERY_DIRECTIVE),
+        ("note", SyntaxKind::NOTE_DIRECTIVE),
+        ("document", SyntaxKind::DOCUMENT_DIRECTIVE),
+        ("price", SyntaxKind::PRICE_DIRECTIVE),
+        ("commodity", SyntaxKind::COMMODITY_DIRECTIVE),
+        ("pushtag", SyntaxKind::PUSHTAG_DIRECTIVE),
+        ("poptag", SyntaxKind::POPTAG_DIRECTIVE),
+        ("pushmeta", SyntaxKind::PUSHMETA_DIRECTIVE),
+        ("popmeta", SyntaxKind::POPMETA_DIRECTIVE),
+        ("option", SyntaxKind::OPTION_DIRECTIVE),
+        ("include", SyntaxKind::INCLUDE_DIRECTIVE),
+        ("plugin", SyntaxKind::PLUGIN_DIRECTIVE),
+        ("custom", SyntaxKind::CUSTOM_DIRECTIVE),
+        ("transaction", SyntaxKind::TRANSACTION),
+    ];
+    for (name, kind) in directive_kinds {
+        assert!(
+            Directive::can_cast(kind),
+            "can_cast must accept {name} ({kind:?})"
+        );
+    }
+    // Negative cases — non-directive kinds must be rejected.
+    for kind in [
+        SyntaxKind::POSTING,
+        SyntaxKind::AMOUNT,
+        SyntaxKind::META_ENTRY,
+        SyntaxKind::ERROR_NODE,
+        SyntaxKind::SOURCE_FILE,
+    ] {
+        assert!(
+            !Directive::can_cast(kind),
+            "can_cast must reject non-directive {kind:?}"
+        );
+    }
+}
+
+#[test]
+fn transaction_flag_classify_is_exhaustive() {
+    use rustledger_parser::cst::ast::TransactionFlagKind;
+    let f = parse("2024-01-15 ! \"x\"\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let flag = t.flag().unwrap();
+    match flag.classify() {
+        TransactionFlagKind::Pending => {} // expected
+        other => panic!("expected Pending, got {other:?}"),
+    }
+}
+
+#[test]
+fn posting_flag_classify_is_exhaustive() {
+    use rustledger_parser::cst::ast::PostingFlagKind;
+    let f = parse("2024-01-15 * \"x\"\n  ! Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        unreachable!()
+    };
+    let p = t.postings().next().unwrap();
+    let flag = p.flag().unwrap();
+    match flag.classify() {
+        PostingFlagKind::Pending => {} // expected
+        other => panic!("expected Pending, got {other:?}"),
+    }
+}
+
+#[test]
+fn payee_narration_zero_strings_returns_none() {
+    // Bareword `txn` keyword with no strings — header strings
+    // count is 0; both accessors must return None.
+    let f = parse("2024-01-15 txn\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    assert_eq!(t.strings().count(), 0);
+    assert!(t.payee().is_none());
+    assert!(t.narration().is_none());
+}

--- a/crates/rustledger-parser/tests/ast.rs
+++ b/crates/rustledger-parser/tests/ast.rs
@@ -1,0 +1,433 @@
+//! Integration tests for the typed-AST surface (`cst::ast`).
+//!
+//! Each test parses a Beancount source via `SourceFile::parse`,
+//! walks the typed accessors, and asserts the read values match
+//! the source text. The round-trip property (`syntax().text() ==
+//! source`) is also asserted by every test so the typed layer
+//! can never accidentally lose bytes.
+
+#![allow(clippy::missing_panics_doc)]
+
+use rustledger_parser::cst::ast::{
+    Account, AstNode, AstToken, BoolFalse, BoolTrue, CostSpec, CurrencyName, Date, Directive,
+    ErrorNode, Link, MetaKey, Number, PriceAnnotation, SourceFile, StringLit, Tag,
+};
+
+fn parse(source: &str) -> SourceFile {
+    let f = SourceFile::parse(source);
+    assert_eq!(f.syntax().text().to_string(), source, "round-trip");
+    f
+}
+
+fn single_directive(f: &SourceFile) -> Directive {
+    let ds: Vec<Directive> = f.directives().collect();
+    assert_eq!(ds.len(), 1);
+    ds.into_iter().next().unwrap()
+}
+
+// ---- 10 dated single-line directives -----------------------------
+
+#[test]
+fn open_directive_accessors() {
+    let f = parse("2024-01-01 open Assets:Cash USD,EUR \"STRICT\"\n");
+    let Directive::Open(d) = single_directive(&f) else {
+        panic!("expected Open");
+    };
+    assert_eq!(d.date().unwrap().text(), "2024-01-01");
+    assert_eq!(d.account().unwrap().text(), "Assets:Cash");
+    let curs: Vec<String> = d.currencies().map(|c| c.text()).collect();
+    assert_eq!(curs, vec!["USD", "EUR"]);
+    assert_eq!(
+        d.booking_method().unwrap().text_unquoted().unwrap(),
+        "STRICT"
+    );
+}
+
+#[test]
+fn close_directive_accessors() {
+    let f = parse("2024-12-31 close Assets:Cash\n");
+    let Directive::Close(d) = single_directive(&f) else {
+        panic!("expected Close");
+    };
+    assert_eq!(d.date().unwrap().text(), "2024-12-31");
+    assert_eq!(d.account().unwrap().text(), "Assets:Cash");
+}
+
+#[test]
+fn balance_directive_accessors() {
+    let f = parse("2024-06-30 balance Assets:Cash 100.00 USD\n");
+    let Directive::Balance(d) = single_directive(&f) else {
+        panic!("expected Balance");
+    };
+    assert_eq!(d.date().unwrap().text(), "2024-06-30");
+    assert_eq!(d.account().unwrap().text(), "Assets:Cash");
+    assert_eq!(d.number().unwrap().text(), "100.00");
+    assert_eq!(d.currency().unwrap().text(), "USD");
+}
+
+#[test]
+fn pad_directive_accessors() {
+    let f = parse("2024-01-01 pad Assets:Cash Equity:Opening\n");
+    let Directive::Pad(d) = single_directive(&f) else {
+        panic!("expected Pad");
+    };
+    assert_eq!(d.target_account().unwrap().text(), "Assets:Cash");
+    assert_eq!(d.source_account().unwrap().text(), "Equity:Opening");
+}
+
+#[test]
+fn event_directive_accessors() {
+    let f = parse("2024-01-15 event \"location\" \"Berlin\"\n");
+    let Directive::Event(d) = single_directive(&f) else {
+        panic!("expected Event");
+    };
+    assert_eq!(d.event_type().unwrap().text_unquoted().unwrap(), "location");
+    assert_eq!(d.value().unwrap().text_unquoted().unwrap(), "Berlin");
+}
+
+#[test]
+fn query_directive_accessors() {
+    let f = parse("2024-01-01 query \"income\" \"SELECT *\"\n");
+    let Directive::Query(d) = single_directive(&f) else {
+        panic!("expected Query");
+    };
+    assert_eq!(d.name().unwrap().text_unquoted().unwrap(), "income");
+    assert_eq!(d.query().unwrap().text_unquoted().unwrap(), "SELECT *");
+}
+
+#[test]
+fn note_directive_accessors() {
+    let f = parse("2024-01-15 note Assets:Cash \"deposit\"\n");
+    let Directive::Note(d) = single_directive(&f) else {
+        panic!("expected Note");
+    };
+    assert_eq!(d.account().unwrap().text(), "Assets:Cash");
+    assert_eq!(d.text().unwrap().text_unquoted().unwrap(), "deposit");
+}
+
+#[test]
+fn document_directive_accessors() {
+    let f = parse("2024-01-15 document Assets:Cash \"/path/file.pdf\"\n");
+    let Directive::Document(d) = single_directive(&f) else {
+        panic!("expected Document");
+    };
+    assert_eq!(d.account().unwrap().text(), "Assets:Cash");
+    assert_eq!(d.path().unwrap().text_unquoted().unwrap(), "/path/file.pdf");
+}
+
+#[test]
+fn price_directive_accessors() {
+    let f = parse("2024-01-15 price USD 1.10 EUR\n");
+    let Directive::Price(d) = single_directive(&f) else {
+        panic!("expected Price");
+    };
+    assert_eq!(d.base_currency().unwrap().text(), "USD");
+    assert_eq!(d.number().unwrap().text(), "1.10");
+    assert_eq!(d.quote_currency().unwrap().text(), "EUR");
+}
+
+#[test]
+fn commodity_directive_accessors() {
+    let f = parse("2024-01-01 commodity HOOL\n");
+    let Directive::Commodity(d) = single_directive(&f) else {
+        panic!("expected Commodity");
+    };
+    assert_eq!(d.currency().unwrap().text(), "HOOL");
+}
+
+// ---- 4 standalone-keyword directives -----------------------------
+
+#[test]
+fn pushtag_directive_accessors() {
+    let f = parse("pushtag #trip\n");
+    let Directive::Pushtag(d) = single_directive(&f) else {
+        panic!("expected Pushtag");
+    };
+    assert_eq!(d.tag().unwrap().text(), "#trip");
+}
+
+#[test]
+fn poptag_directive_accessors() {
+    let f = parse("poptag #trip\n");
+    let Directive::Poptag(d) = single_directive(&f) else {
+        panic!("expected Poptag");
+    };
+    assert_eq!(d.tag().unwrap().text(), "#trip");
+}
+
+#[test]
+fn pushmeta_directive_accessors() {
+    let f = parse("pushmeta location: \"Berlin\"\n");
+    let Directive::Pushmeta(d) = single_directive(&f) else {
+        panic!("expected Pushmeta");
+    };
+    assert_eq!(d.key().unwrap().text_without_colon(), "location");
+}
+
+#[test]
+fn popmeta_directive_accessors() {
+    let f = parse("popmeta location:\n");
+    let Directive::Popmeta(d) = single_directive(&f) else {
+        panic!("expected Popmeta");
+    };
+    assert_eq!(d.key().unwrap().text_without_colon(), "location");
+}
+
+// ---- 4 edge directives -------------------------------------------
+
+#[test]
+fn option_directive_accessors() {
+    let f = parse("option \"title\" \"My Ledger\"\n");
+    let Directive::Option(d) = single_directive(&f) else {
+        panic!("expected Option");
+    };
+    assert_eq!(d.key().unwrap().text_unquoted().unwrap(), "title");
+    assert_eq!(d.value().unwrap().text_unquoted().unwrap(), "My Ledger");
+}
+
+#[test]
+fn include_directive_accessors() {
+    let f = parse("include \"shared.beancount\"\n");
+    let Directive::Include(d) = single_directive(&f) else {
+        panic!("expected Include");
+    };
+    assert_eq!(
+        d.path().unwrap().text_unquoted().unwrap(),
+        "shared.beancount"
+    );
+}
+
+#[test]
+fn plugin_directive_accessors() {
+    let f = parse("plugin \"my.plugin\" \"cfg\"\n");
+    let Directive::Plugin(d) = single_directive(&f) else {
+        panic!("expected Plugin");
+    };
+    assert_eq!(d.module().unwrap().text_unquoted().unwrap(), "my.plugin");
+    assert_eq!(d.config().unwrap().text_unquoted().unwrap(), "cfg");
+}
+
+#[test]
+fn custom_directive_accessors() {
+    let f = parse("2024-01-01 custom \"budget\" \"food\" 500 USD\n");
+    let Directive::Custom(d) = single_directive(&f) else {
+        panic!("expected Custom");
+    };
+    assert_eq!(d.date().unwrap().text(), "2024-01-01");
+    assert_eq!(d.custom_type().unwrap().text_unquoted().unwrap(), "budget");
+}
+
+// ---- TRANSACTION + POSTING + sub-structures ----------------------
+
+#[test]
+fn transaction_with_payee_narration_tags_links() {
+    let f = parse(
+        "2024-01-15 * \"Coffee Shop\" \"Morning coffee\" #daily ^trip1\n\
+         \x20\x20Assets:Cash  -5.00 USD\n\
+         \x20\x20Expenses:Food\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    assert_eq!(t.date().unwrap().text(), "2024-01-15");
+    assert_eq!(t.flag().unwrap().text(), "*");
+    assert_eq!(t.payee().unwrap().text_unquoted().unwrap(), "Coffee Shop");
+    assert_eq!(
+        t.narration().unwrap().text_unquoted().unwrap(),
+        "Morning coffee"
+    );
+    let tags: Vec<String> = t.tags().map(|tg| tg.text()).collect();
+    assert_eq!(tags, vec!["#daily"]);
+    let links: Vec<String> = t.links().map(|l| l.text()).collect();
+    assert_eq!(links, vec!["^trip1"]);
+    assert_eq!(t.postings().count(), 2);
+}
+
+#[test]
+fn transaction_with_narration_only_no_payee() {
+    let f = parse("2024-01-15 * \"Coffee\"\n  Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    assert!(t.payee().is_none());
+    assert_eq!(t.narration().unwrap().text_unquoted().unwrap(), "Coffee");
+}
+
+#[test]
+fn posting_accessors_basic() {
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  -5.00 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let p = t.postings().next().unwrap();
+    assert!(p.flag().is_none());
+    assert_eq!(p.account().unwrap().text(), "Assets:Cash");
+    let amt = p.amount().unwrap();
+    assert_eq!(amt.sign().unwrap().text(), "-");
+    assert_eq!(amt.number().unwrap().text(), "5.00");
+    assert_eq!(amt.currency().unwrap().text(), "USD");
+}
+
+#[test]
+fn posting_with_flag() {
+    let f = parse("2024-01-15 * \"x\"\n  ! Assets:Cash  -5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let p = t.postings().next().unwrap();
+    assert_eq!(p.flag().unwrap().text(), "!");
+}
+
+#[test]
+fn posting_with_cost_and_price() {
+    let f = parse(
+        "2024-01-15 * \"x\"\n\
+         \x20\x20Assets:Inv  10 HOOL {500.00 USD} @ 510 USD\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let p = t.postings().next().unwrap();
+    let cost = p.cost_spec().unwrap();
+    assert!(!cost.is_total());
+    assert!(!cost.is_per_unit_plus_total());
+    assert_eq!(cost.number().unwrap().text(), "500.00");
+    assert_eq!(cost.currency().unwrap().text(), "USD");
+
+    let price = p.price_annotation().unwrap();
+    assert!(!price.is_total());
+    let inner = price.amount().unwrap();
+    assert_eq!(inner.number().unwrap().text(), "510");
+    assert_eq!(inner.currency().unwrap().text(), "USD");
+}
+
+#[test]
+fn cost_spec_total_double_brace() {
+    let f = parse(
+        "2024-01-15 * \"x\"\n\
+         \x20\x20Assets:Inv  10 HOOL {{5000 USD, 2024-01-01, \"lot\"}}\n",
+    );
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let cost = t.postings().next().unwrap().cost_spec().unwrap();
+    assert!(cost.is_total());
+    assert_eq!(cost.number().unwrap().text(), "5000");
+    assert_eq!(cost.date().unwrap().text(), "2024-01-01");
+    assert_eq!(cost.label().unwrap().text_unquoted().unwrap(), "lot");
+}
+
+#[test]
+fn price_annotation_total_at_at() {
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Inv  10 HOOL @@ 5000 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let price = t.postings().next().unwrap().price_annotation().unwrap();
+    assert!(price.is_total());
+}
+
+#[test]
+fn amount_arithmetic_detected_and_currency_picked() {
+    let f = parse("2024-01-15 * \"x\"\n  Assets:Cash  100+5 USD\n");
+    let Directive::Transaction(t) = single_directive(&f) else {
+        panic!("expected Transaction");
+    };
+    let amt = t.postings().next().unwrap().amount().unwrap();
+    assert!(amt.is_arithmetic());
+    // Leading number is the first NUMBER; currency is the trailing
+    // CURRENCY (last one).
+    assert_eq!(amt.number().unwrap().text(), "100");
+    assert_eq!(amt.currency().unwrap().text(), "USD");
+}
+
+#[test]
+fn meta_entry_typed_values() {
+    let f = parse(
+        "2024-01-01 open Assets:Cash\n\
+         \x20\x20description: \"main\"\n\
+         \x20\x20count: 42\n\
+         \x20\x20since: 2024-01-01\n\
+         \x20\x20active: TRUE\n\
+         \x20\x20mirror: Assets:Mirror\n",
+    );
+    let dir = single_directive(&f);
+    assert!(matches!(dir, Directive::Open(_)));
+    let metas: Vec<_> = dir.meta_entries().collect();
+    assert_eq!(metas.len(), 5);
+    assert_eq!(metas[0].key().unwrap().text_without_colon(), "description");
+    assert_eq!(
+        metas[0].value_string().unwrap().text_unquoted().unwrap(),
+        "main"
+    );
+    assert_eq!(metas[1].value_number().unwrap().text(), "42");
+    assert_eq!(metas[2].value_date().unwrap().text(), "2024-01-01");
+    assert!(metas[3].value_bool().unwrap());
+    assert_eq!(metas[4].value_account().unwrap().text(), "Assets:Mirror");
+}
+
+// ---- ERROR_NODE --------------------------------------------------
+
+#[test]
+fn error_node_surfaces_through_typed_api() {
+    let f = parse("bogus content here\n2024-01-01 open Assets:Cash\n");
+    let errs: Vec<ErrorNode> = f.errors().collect();
+    assert_eq!(errs.len(), 1);
+    assert_eq!(errs[0].text(), "bogus content here\n");
+    let ds: Vec<Directive> = f.directives().collect();
+    assert_eq!(ds.len(), 1);
+    matches!(ds[0], Directive::Open(_));
+}
+
+// ---- AstNode / AstToken trait surface ----------------------------
+
+#[test]
+fn ast_node_cast_rejects_wrong_kind() {
+    // Cast OPEN_DIRECTIVE node to CloseDirective — must return None.
+    use rustledger_parser::cst::ast::{CloseDirective, OpenDirective};
+    let f = parse("2024-01-01 open Assets:Cash\n");
+    let Directive::Open(d) = single_directive(&f) else {
+        unreachable!()
+    };
+    let node = d.syntax().clone();
+    assert!(CloseDirective::cast(node.clone()).is_none());
+    assert!(OpenDirective::cast(node).is_some());
+}
+
+#[test]
+fn ast_token_cast_rejects_wrong_kind() {
+    let f = parse("2024-01-01 open Assets:Cash\n");
+    let Directive::Open(d) = single_directive(&f) else {
+        unreachable!()
+    };
+    let acct_tok = d.account().unwrap().syntax().clone();
+    assert!(Date::cast(acct_tok.clone()).is_none());
+    assert!(Account::cast(acct_tok).is_some());
+}
+
+#[test]
+fn string_lit_unquoted_handles_empty() {
+    let f = parse("option \"\" \"\"\n");
+    let Directive::Option(d) = single_directive(&f) else {
+        unreachable!()
+    };
+    assert_eq!(d.key().unwrap().text_unquoted().unwrap(), "");
+}
+
+// Trait-import sanity: pull in everything from the public surface
+// without using each (silences unused_imports without losing the
+// re-export check).
+#[test]
+fn public_re_exports_exist() {
+    fn t<T>() {}
+    t::<BoolTrue>();
+    t::<BoolFalse>();
+    t::<CurrencyName>();
+    t::<StringLit>();
+    t::<Number>();
+    t::<MetaKey>();
+    t::<Tag>();
+    t::<Link>();
+    t::<CostSpec>();
+    t::<PriceAnnotation>();
+}


### PR DESCRIPTION
## Summary

Phase 3 of #1262. Adds a thin typed-AST layer on top of the lossless
CST built in phases 1-2: newtype wrappers around `SyntaxNode` /
`SyntaxToken` with `kind()`-gated `cast` constructors and structural
accessors (rust-analyzer pattern).

- Two traits anchor the surface: `AstNode { can_cast, cast, syntax }`
  and `AstToken { ..., text }`. Zero cost: wrappers store the rowan
  node/token by value and forward.
- 19-variant `Directive` enum dispatches to per-directive structs;
  `Transaction`/`Posting`/`Amount`/`CostSpec`/`PriceAnnotation`/`MetaEntry`/`ErrorNode`
  expose typed accessors covering everything the CST nodes carry.
- All accessors return `Option<_>` because the CST is lossless: a
  malformed input still produces a tree, just one with missing children.
- Module-level `#![allow(missing_docs)]` on `ast.rs` is deliberate:
  accessors are self-documenting via name + return type, so the
  alternative would be ~100 boilerplate doc stubs.

## Notable accessor semantics

- **Transaction payee/narration:** with 2+ STRING children, first is
  payee and last is narration (Beancount convention). With 1, the
  string is narration and payee is `None`.
- **Amount.currency():** returns the LAST CURRENCY token under
  AMOUNT, so arithmetic shapes like `(10+5) USD` and bare-currency
  shapes both resolve correctly.
- **Amount.is_arithmetic():** detects operator tokens (PLUS / MINUS /
  STAR / SLASH) at the top level of AMOUNT, ignoring sign positions.
- **CostSpec markers:** `is_total()` for `{{ ... }}`,
  `is_per_unit_plus_total()` for `{# ... }`, `is_merge()` for `*`.
- **PriceAnnotation.is_total():** distinguishes `@@` from `@`.

## Testing

32 integration tests in `tests/ast.rs` cover every wrapper:

- 10 dated directives + 4 standalone-keyword + 4 edge directives
- Transaction payee/narration/tags/links combinations
- Posting basic + flag + cost + price + meta accessors
- Amount arithmetic detection and currency-picking
- Cost spec `{{` total marker; price annotation `@@` total marker
- Meta entry typed-value extraction (string / number / date / account
  / currency / bool)
- ErrorNode round-trip through typed API
- `AstNode` / `AstToken` cast rejection of wrong kinds
- Public re-exports remain reachable

All gates clean:

- `cargo test -p rustledger-parser`: 143 tests + 2 doctests
- `cargo clippy -p rustledger-parser --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p rustledger-parser --no-deps`

## Test plan

- [x] Local: `cargo test -p rustledger-parser` passes (143 + 2 + 32 = all green)
- [x] Local: clippy, fmt, doc gates clean
- [ ] CI passes
- [ ] Copilot review surfaces no real issues

Refs #1262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)