### PR TITLE
refactor(booking): delete redundant expand_pads + add multi-pad CLI regression test

### DIFF
--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -29,8 +29,8 @@ mod pad;
 pub use book::{BookedTransaction, BookingEngine, BookingError, CapitalGain, book_transactions};
 pub use interpolate::{InterpolationError, InterpolationResult, interpolate};
 pub use pad::{
-    PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, expand_pads, is_synthesized_pad,
-    merge_with_padding, process_pads,
+    PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, is_synthesized_pad, merge_with_padding,
+    process_pads,
 };
 
 use bigdecimal::BigDecimal;

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -60,7 +60,8 @@ pub fn is_synthesized_pad(txn: &Transaction) -> bool {
 pub struct PadResult {
     /// The original input directives, verbatim. Pads are NOT
     /// removed; the field is the same slice the caller handed in.
-    /// Callers that want a Pads-removed-or-merged view should use
+    /// Callers that want the source merged with synthesized pad
+    /// transactions for balance math should use
     /// [`merge_with_padding`].
     pub directives: Vec<Directive>,
     /// Synthetic padding transactions generated.

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -61,7 +61,7 @@ pub struct PadResult {
     /// The original input directives, verbatim. Pads are NOT
     /// removed; the field is the same slice the caller handed in.
     /// Callers that want a Pads-removed-or-merged view should use
-    /// [`expand_pads`] (replace) or [`merge_with_padding`] (merge).
+    /// [`merge_with_padding`].
     pub directives: Vec<Directive>,
     /// Synthetic padding transactions generated.
     pub padding_transactions: Vec<Transaction>,
@@ -282,60 +282,10 @@ fn create_padding_transaction(
         .with_synthesized_posting(Posting::new(source_account, difference.neg()))
 }
 
-/// Expand a ledger by replacing pad directives with synthetic transactions.
-///
-/// This is useful for reports that need to show explicit padding transactions.
-///
-/// # Arguments
-///
-/// * `directives` - The original directives
-///
-/// # Returns
-///
-/// A new list of directives with pad directives replaced by synthetic transactions.
-pub fn expand_pads(directives: &[Directive]) -> Vec<Directive> {
-    let result = process_pads(directives);
-
-    let mut expanded: Vec<Directive> = Vec::new();
-
-    // Sort original directives by date
-    let mut sorted_originals: Vec<&Directive> = directives.iter().collect();
-    sorted_originals.sort_by_key(|d| d.date());
-
-    // Create a map of pad dates to padding transactions
-    let mut pad_txns_by_date: HashMap<NaiveDate, Vec<&Transaction>> = HashMap::new();
-    for txn in &result.padding_transactions {
-        pad_txns_by_date.entry(txn.date).or_default().push(txn);
-    }
-
-    for directive in sorted_originals {
-        match directive {
-            Directive::Pad(pad) => {
-                // Replace pad with synthetic transactions if any were generated
-                // A single pad can generate multiple transactions (one per currency)
-                if let Some(txns) = pad_txns_by_date.get(&pad.date) {
-                    // Find ALL matching transactions for this pad (multiple currencies)
-                    for txn in txns {
-                        if txn.postings.iter().any(|p| p.account == pad.account) {
-                            expanded.push(Directive::Transaction((*txn).clone()));
-                        }
-                    }
-                }
-                // If no transaction was generated (difference was zero), omit the pad
-            }
-            other => {
-                expanded.push(other.clone());
-            }
-        }
-    }
-
-    expanded
-}
-
 /// Merge original directives with padding transactions, maintaining date order.
 ///
-/// Unlike [`expand_pads`], this keeps the original pad directives and adds
-/// the synthesized transactions alongside them. Use this when downstream
+/// Keeps the original pad directives and adds the synthesized
+/// transactions alongside them. Use this when downstream
 /// consumers want both views: `Pad` directives for source-faithful queries
 /// (e.g., BQL `WHERE type = 'pad'`) and the synth transactions for inventory
 /// math.
@@ -562,36 +512,6 @@ mod tests {
                 .message
                 .contains("no corresponding balance")
         );
-    }
-
-    #[test]
-    fn test_expand_pads() {
-        let directives = vec![
-            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
-            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
-            Directive::Pad(Pad::new(date(2024, 1, 1), "Assets:Bank", "Equity:Opening")),
-            Directive::Balance(Balance::new(
-                date(2024, 1, 2),
-                "Assets:Bank",
-                Amount::new(dec!(1000.00), "USD"),
-            )),
-        ];
-
-        let expanded = expand_pads(&directives);
-
-        // Should have: 2 opens + 1 synthetic transaction + 1 balance = 4
-        assert_eq!(expanded.len(), 4);
-
-        // The pad should be replaced with a transaction
-        let has_pad = expanded.iter().any(|d| matches!(d, Directive::Pad(_)));
-        assert!(!has_pad, "Pad should be replaced");
-
-        // Should have the synthetic transaction
-        let txn_count = expanded
-            .iter()
-            .filter(|d| matches!(d, Directive::Transaction(_)))
-            .count();
-        assert_eq!(txn_count, 1);
     }
 
     #[test]

--- a/crates/rustledger-ffi-wasi/tests/query_pad_expansion.rs
+++ b/crates/rustledger-ffi-wasi/tests/query_pad_expansion.rs
@@ -110,10 +110,11 @@ fn query_execute_applies_pad_expansion() {
 }
 
 /// `query.batch` runs N queries against one load. The single
-/// `expand_pads` call is hoisted above the per-query loop so every
-/// query in the batch sees the expanded view. Pre-fix, the per-query
-/// `execute_query` saw raw Pads → Equity:Void showed exactly -1000
-/// (the opening transfer only, no pad-source adjustment).
+/// `merge_with_padding` call is hoisted above the per-query loop so
+/// every query in the batch sees the merged view. Pre-fix, the
+/// per-query `execute_query` saw raw Pads → Equity:Void showed
+/// exactly -1000 (the opening transfer only, no pad-source
+/// adjustment).
 #[test]
 fn query_batch_applies_pad_expansion_to_every_query() {
     let req = serde_json::json!({

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -145,8 +145,8 @@ pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
     // Merge pad-synthesized transactions: query is a balance-
     // computing consumer (#1288). `merge_with_padding` preserves
     // Pad directives so `FROM #entries WHERE type = 'pad'` audits
-    // continue to enumerate them, and avoids the multi-pad bug
-    // `expand_pads` had (#1300).
+    // continue to enumerate them, AND handles multi-pad shadowing
+    // (#1300) correctly by construction via `process_pads`.
     let directives = merge_with_padding(&load.directives);
     let mut executor = Executor::new(&directives);
     match executor.execute(&query) {
@@ -699,8 +699,8 @@ pub fn query_multi_file(
     }
 
     // Merge pad-synthesized transactions into the directive stream
-    // (matching CLI query pipeline). See `wasm::query` above for
-    // why `merge_with_padding` over `expand_pads`.
+    // (matching CLI query pipeline). See `wasm::query` above for the
+    // architectural rule.
     let booked_directives: Vec<_> = ledger.directives.into_iter().map(|s| s.value).collect();
     let directives = merge_with_padding(&booked_directives);
 

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -769,10 +769,11 @@ include "accounts.beancount"
         );
     }
 
-    /// Parity: pad directives produce correct padding transactions.
+    /// Parity: pad directives produce equivalent merged views on CLI
+    /// and WASM processing paths.
     #[test]
     fn test_parity_pad_expansion() {
-        use rustledger_booking::expand_pads;
+        use rustledger_booking::merge_with_padding;
 
         let source = r"
 2024-01-01 open Assets:Bank USD
@@ -784,13 +785,13 @@ include "accounts.beancount"
         let cli = cli_process(source);
         let wasm = wasm_process(source);
 
-        let cli_expanded = expand_pads(&cli);
-        let wasm_expanded = expand_pads(&wasm);
+        let cli_merged = merge_with_padding(&cli);
+        let wasm_merged = merge_with_padding(&wasm);
 
         assert_eq!(
-            cli_expanded.len(),
-            wasm_expanded.len(),
-            "expanded directive count differs"
+            cli_merged.len(),
+            wasm_merged.len(),
+            "merged directive count differs"
         );
     }
 

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -769,8 +769,12 @@ include "accounts.beancount"
         );
     }
 
-    /// Parity: pad directives produce equivalent merged views on CLI
-    /// and WASM processing paths.
+    /// Parity: CLI and WASM processing paths produce identical
+    /// merged views for a single pad+balance source. Asserts the
+    /// full directive vectors match, not just length — a length-
+    /// only check would silently accept a divergence that swapped
+    /// directive shapes (e.g. WASM emitting a Pad where CLI emits
+    /// a Transaction) for the same total count.
     #[test]
     fn test_parity_pad_expansion() {
         use rustledger_booking::merge_with_padding;
@@ -789,9 +793,8 @@ include "accounts.beancount"
         let wasm_merged = merge_with_padding(&wasm);
 
         assert_eq!(
-            cli_merged.len(),
-            wasm_merged.len(),
-            "merged directive count differs"
+            cli_merged, wasm_merged,
+            "merged directive vectors differ between CLI and WASM paths",
         );
     }
 

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -141,8 +141,8 @@ pub fn run(args: &Args) -> Result<()> {
     // (BQL is a balance-computing consumer). `merge_with_padding`
     // preserves the original Pad directives in the output so
     // `FROM #entries WHERE type = 'pad'` audits still enumerate them,
-    // AND avoids the multi-pad double-application bug `expand_pads`
-    // had (#1300).
+    // AND handles multi-pad shadowing (#1300) correctly by
+    // construction via `process_pads`.
     let directives = merge_with_padding(&booked_directives);
 
     // Use display context from the loaded ledger

--- a/crates/rustledger/tests/report_pad_expansion_test.rs
+++ b/crates/rustledger/tests/report_pad_expansion_test.rs
@@ -221,3 +221,68 @@ fn report_journal_does_not_include_synth_pad_transactions() {
         "journal must NOT include synth pad transaction rows; output: {stdout}",
     );
 }
+
+/// CI-enforced regression test for issue #1300 (multi-pad
+/// shadowing).
+///
+/// Two `pad` directives target the same account before a single
+/// `balance`. Per beancount semantics only the most recent
+/// effective pad applies; earlier same-target pads are shadowed.
+/// A buggy implementation that applies BOTH pads' synth
+/// adjustments produces 800 USD instead of the correct 900 USD
+/// (1000 opening, then a single -100 adjustment to land at 900).
+///
+/// Until this PR, multi-pad correctness was only pinned by
+/// `process_pads` unit tests and a manual end-to-end fixture
+/// sweep. Both could miss a regression in the CLI query path
+/// (e.g. someone switching `merge_with_padding` for a different
+/// helper). This test catches that class of regression by
+/// running the user-facing command end-to-end.
+const MULTI_PAD_SOURCE: &str = r#"option "operating_currency" "USD"
+
+2026-01-01 open Assets:Wallet USD
+2026-01-01 open Equity:Void USD
+
+2026-01-01 * "opening"
+  Assets:Wallet  1000 USD
+  Equity:Void
+
+2026-06-01 pad Assets:Wallet Equity:Void
+2026-06-01 pad Assets:Wallet Equity:Void
+
+2026-06-02 balance Assets:Wallet 900 USD
+"#;
+
+#[test]
+fn query_multi_pad_does_not_double_apply() {
+    let bin = require_rledger!();
+
+    let mut fixture = tempfile::Builder::new()
+        .prefix("multi-pad-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("create tempfile");
+    fixture
+        .write_all(MULTI_PAD_SOURCE.as_bytes())
+        .expect("write fixture");
+
+    let query_out = Command::new(&bin)
+        .args([
+            "query",
+            fixture.path().to_str().unwrap(),
+            "SELECT account, sum(position) WHERE account = 'Assets:Wallet'",
+        ])
+        .output()
+        .expect("run rledger query");
+    let stdout = String::from_utf8_lossy(&query_out.stdout);
+    assert!(query_out.status.success(), "query should succeed: {stdout}",);
+
+    let units = first_number_for_account(&stdout, "Assets:Wallet")
+        .unwrap_or_else(|| panic!("no Assets:Wallet token: {stdout}"));
+    assert_eq!(
+        units, "900",
+        "multi-pad shadowing: only the most recent pad applies → \
+         expected 900 USD (= 1000 - 100), got {units}. A buggy \
+         double-application would emit 800 (= 1000 - 100 - 100).",
+    );
+}

--- a/crates/rustledger/tests/report_pad_expansion_test.rs
+++ b/crates/rustledger/tests/report_pad_expansion_test.rs
@@ -275,14 +275,19 @@ fn query_multi_pad_does_not_double_apply() {
         .output()
         .expect("run rledger query");
     let stdout = String::from_utf8_lossy(&query_out.stdout);
-    assert!(query_out.status.success(), "query should succeed: {stdout}",);
+    let stderr = String::from_utf8_lossy(&query_out.stderr);
+    assert!(
+        query_out.status.success(),
+        "query should succeed:\nstdout: {stdout}\nstderr: {stderr}",
+    );
 
     let units = first_number_for_account(&stdout, "Assets:Wallet")
-        .unwrap_or_else(|| panic!("no Assets:Wallet token: {stdout}"));
+        .unwrap_or_else(|| panic!("no Assets:Wallet token:\nstdout: {stdout}\nstderr: {stderr}"));
     assert_eq!(
         units, "900",
         "multi-pad shadowing: only the most recent pad applies → \
          expected 900 USD (= 1000 - 100), got {units}. A buggy \
-         double-application would emit 800 (= 1000 - 100 - 100).",
+         double-application would emit 800 (= 1000 - 100 - 100).\n\
+         stderr: {stderr}",
     );
 }


### PR DESCRIPTION
## Summary

Two cleanups identified during the close-out of PR #1301 (which was the original attempt at fixing #1288 + #1300 via loader-side pad expansion; superseded by the merged #1302).

1. **Delete \`rustledger_booking::expand_pads\`**: redundant with \`merge_with_padding\` in the source-faithful architecture; carried a latent multi-pad double-push bug that has been around since #1300 surfaced. Migrated the single internal caller (a WASM CLI/parity test) to \`merge_with_padding\`.
2. **Add CI-enforced multi-pad CLI regression test**: \`query_multi_pad_does_not_double_apply\` runs \`rledger query\` end-to-end against a two-pad fixture, asserting Assets:Wallet = 900 USD. Pins the #1300 fix at the user-facing level.

Pre-existing manual end-to-end fixture sweep already validated this case during PR #1302 review, but CI did not enforce it. A regression in the CLI query path would have slipped through.

## What's removed

- \`pub fn expand_pads\` (rustledger-booking)
- \`pub use ... expand_pads\` re-export
- The \`test_expand_pads\` unit test
- 4 stale doc-comment references in api.rs, query/mod.rs, tests/query_pad_expansion.rs

## What's added

- \`query_multi_pad_does_not_double_apply\` integration test in \`report_pad_expansion_test.rs\`

## Verified

- \`cargo test --workspace --all-features\` (all green; 8/8 report tests pass, including the new one)
- \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` clean
- \`RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features\` clean

## Test plan

- [x] Workspace tests pass
- [x] New test runs against a multi-pad fixture and asserts 900 USD
- [x] Removing \`expand_pads\` does not break any other call site (compiles workspace-clean, no \`#[allow(deprecated)]\` shims)

Refs #1288, #1300, closes out #1301 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)