### PR TITLE
refactor(lsp): drop dead kind-dispatch in completion resolve

### DIFF
--- a/crates/rustledger-lsp/src/handlers/completion_resolve.rs
+++ b/crates/rustledger-lsp/src/handlers/completion_resolve.rs
@@ -36,11 +36,17 @@ pub fn handle_completion_resolve(
     // (payees, tags, links) have no detail popup — resolving those
     // would require the producer to tag items with a kind, which it
     // does not currently do.
-    let label = &item.label;
-    if is_account_like(label) {
-        resolved.documentation = Some(resolve_account_documentation(label, directives));
-    } else if is_currency_like_simple(label) {
-        resolved.documentation = Some(resolve_currency_documentation(label, directives));
+    //
+    // Only fill documentation the item doesn't already carry: a resolve
+    // handler adds missing detail, it doesn't clobber what a producer
+    // (or a client round-trip) may have set eagerly.
+    if resolved.documentation.is_none() {
+        let label = &item.label;
+        if is_account_like(label) {
+            resolved.documentation = Some(resolve_account_documentation(label, directives));
+        } else if is_currency_like_simple(label) {
+            resolved.documentation = Some(resolve_currency_documentation(label, directives));
+        }
     }
 
     resolved

--- a/crates/rustledger-lsp/src/handlers/completion_resolve.rs
+++ b/crates/rustledger-lsp/src/handlers/completion_resolve.rs
@@ -3,7 +3,6 @@
 //! Provides additional information when a completion item is selected:
 //! - Account completions: show current balance and transaction count
 //! - Currency completions: show price history
-//! - Payee completions: show recent transactions
 
 use lsp_types::{CompletionItem, Documentation, MarkupContent, MarkupKind};
 use rustledger_core::Decimal;
@@ -29,44 +28,19 @@ pub fn handle_completion_resolve(
 ) -> CompletionItem {
     let mut resolved = item.clone();
 
-    // Check what kind of completion this is based on data field
-    if let Some(data) = &item.data
-        && let Some(kind) = data.get("kind").and_then(|v| v.as_str())
-    {
-        match kind {
-            "account" => {
-                if let Some(account) = data.get("account").and_then(|v| v.as_str()) {
-                    resolved.documentation =
-                        Some(resolve_account_documentation(account, directives));
-                }
-            }
-            "currency" => {
-                if let Some(currency) = data.get("currency").and_then(|v| v.as_str()) {
-                    resolved.documentation =
-                        Some(resolve_currency_documentation(currency, directives));
-                }
-            }
-            "payee" => {
-                if let Some(payee) = data.get("payee").and_then(|v| v.as_str()) {
-                    resolved.documentation = Some(resolve_payee_documentation(payee, directives));
-                }
-            }
-            _ => {}
-        }
-    }
-
-    // If no data, try to infer from the label
-    if resolved.documentation.is_none() {
-        let label = &item.label;
-
-        // Check if it looks like an account
-        if is_account_like(label) {
-            resolved.documentation = Some(resolve_account_documentation(label, directives));
-        }
-        // Check if it looks like a currency (all caps, 3-4 chars)
-        else if is_currency_like_simple(label) {
-            resolved.documentation = Some(resolve_currency_documentation(label, directives));
-        }
+    // The detail is inferred from the label shape. `handle_completion`
+    // attaches only `{uri}` to each item's `data` (never a structured
+    // "kind"), so there is nothing else to dispatch on here: an
+    // account-like label gets balance/transaction detail, a
+    // currency-like label gets price history. Labels that match neither
+    // (payees, tags, links) have no detail popup — resolving those
+    // would require the producer to tag items with a kind, which it
+    // does not currently do.
+    let label = &item.label;
+    if is_account_like(label) {
+        resolved.documentation = Some(resolve_account_documentation(label, directives));
+    } else if is_currency_like_simple(label) {
+        resolved.documentation = Some(resolve_currency_documentation(label, directives));
     }
 
     resolved
@@ -178,65 +152,6 @@ fn resolve_currency_documentation(
 
         if prices.len() > 5 {
             doc.push_str(&format!("- _...and {} more_\n", prices.len() - 5));
-        }
-    }
-
-    Documentation::MarkupContent(MarkupContent {
-        kind: MarkupKind::Markdown,
-        value: doc,
-    })
-}
-
-/// Resolve documentation for a payee completion.
-fn resolve_payee_documentation(payee: &str, directives: &[Spanned<Directive>]) -> Documentation {
-    let mut transactions: Vec<(rustledger_core::NaiveDate, String)> = Vec::new();
-    let mut accounts_used: HashMap<String, usize> = HashMap::new();
-
-    for spanned in directives {
-        if let Directive::Transaction(txn) = &spanned.value
-            && txn.payee.as_ref().map(|p| p.as_ref()) == Some(payee)
-        {
-            let narration = txn.narration.to_string();
-            transactions.push((txn.date, narration));
-
-            for posting in &txn.postings {
-                *accounts_used
-                    .entry(posting.account.to_string())
-                    .or_default() += 1;
-            }
-        }
-    }
-
-    let mut doc = format!("**{}**\n\n", payee);
-
-    doc.push_str(&format!("📊 **{} transactions**\n\n", transactions.len()));
-
-    if !transactions.is_empty() {
-        // Sort by date descending
-        transactions.sort_by_key(|b| std::cmp::Reverse(b.0));
-
-        doc.push_str("**Recent:**\n");
-        for (date, narration) in transactions.iter().take(3) {
-            let short_narration = if narration.len() > 30 {
-                format!("{}...", &narration[..27])
-            } else {
-                narration.clone()
-            };
-            doc.push_str(&format!("- {} \"{}\"\n", date, short_narration));
-        }
-
-        if transactions.len() > 3 {
-            doc.push_str(&format!("- _...and {} more_\n", transactions.len() - 3));
-        }
-    }
-
-    if !accounts_used.is_empty() {
-        doc.push_str("\n**Common accounts:**\n");
-        let mut sorted: Vec<_> = accounts_used.into_iter().collect();
-        sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
-
-        for (account, count) in sorted.iter().take(3) {
-            doc.push_str(&format!("- {} ({}x)\n", account, count));
         }
     }
 


### PR DESCRIPTION
## Summary

Pure dead-code removal in `handle_completion_resolve`, surfaced by a deep review of #1304. **Stacked on #1304** (base is that branch) because it touches the same function; it will retarget to `main` automatically once #1304 merges.

`handle_completion_resolve` dispatched on `data["kind"]` with arms for `account` / `currency` / `payee`. But `handle_completion` only ever attaches `{uri}` to each item's `data` — it never sets a `kind` — so that entire block was unreachable. Resolution always fell through to the label-heuristic path (`is_account_like` / `is_currency_like_simple`).

This removes:
- the dead `match kind` block, and
- `resolve_payee_documentation`, whose only caller was the dead `payee` arm (payees can't be classified from the label shape, so the heuristic path never resolved them anyway).

## No behavior change

- Account and currency completion details still resolve via the label heuristic, exactly as before.
- Payees, tags, and links had no detail popup before this change and still don't.

Wiring up structured detail for payees/tags/links would require the producer (`handle_completion`) to tag each item with a `kind` — deliberately left as a follow-up rather than smuggled into a cleanup.

## Verification

`nix develop` then, for `rustledger-lsp`: `cargo clippy --all-features --all-targets -- -D warnings` (clean — confirms no orphaned dead code), `cargo test --all-features` (236 lib + integration pass), `cargo fmt -- --check` (clean).

Net: +13 / −98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)