### PR TITLE
feat(plugin): WASM ABI version handshake for plugins + importers (#1234)

### DIFF
--- a/crates/rustledger-importer/src/test_fixtures.rs
+++ b/crates/rustledger-importer/src/test_fixtures.rs
@@ -4,9 +4,11 @@
 //!
 //! Tests in both this crate and `rustledger` (the CLI) need tiny WASM
 //! modules that satisfy the importer ABI: `memory`, `alloc`,
-//! `metadata`, `identify`, `extract`, `extract_enriched`. Both
-//! previously hand-rolled identical WAT strings; this module is the
-//! single source of truth so an ABI change updates one place.
+//! `metadata`, `identify`, `extract`, `extract_enriched`, plus the
+//! `__rustledger_abi_version` handshake export the host now checks at
+//! load (issue #1234). Both previously hand-rolled identical WAT
+//! strings; this module is the single source of truth so an ABI change
+//! updates one place.
 //!
 //! Marked `#[doc(hidden)]` so the helpers don't show up in published
 //! docs — they're a crate-internal convenience for tests, not a
@@ -45,6 +47,9 @@ pub fn metadata_wat(name: &str) -> String {
             (func (export "identify") (param i32 i32) (result i64) i64.const 0)
             (func (export "extract") (param i32 i32) (result i64) i64.const 0)
             (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+            ;; ABI handshake (issue #1234): must equal the host's
+            ;; rustledger_plugin_types::ABI_VERSION (currently 1).
+            (func (export "__rustledger_abi_version") (result i32) i32.const 1)
         )
         "#
     )
@@ -78,6 +83,9 @@ pub fn identifying_wat(name: &str) -> String {
             (func (export "identify") (param i32 i32) (result i64) i64.const 0x10_0000_0002)
             (func (export "extract") (param i32 i32) (result i64) i64.const 0)
             (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+            ;; ABI handshake (issue #1234): must equal the host's
+            ;; rustledger_plugin_types::ABI_VERSION (currently 1).
+            (func (export "__rustledger_abi_version") (result i32) i32.const 1)
         )
         "#
     )

--- a/crates/rustledger-importer/src/test_fixtures.rs
+++ b/crates/rustledger-importer/src/test_fixtures.rs
@@ -35,6 +35,10 @@
 #[must_use]
 pub fn metadata_wat(name: &str) -> String {
     assert_eq!(name.len(), 3, "test fixture only supports 3-char names");
+    // Interpolate the host ABI version so the fixture tracks
+    // `rustledger_plugin_types::ABI_VERSION` automatically when it's
+    // bumped (issue #1234).
+    let abi = rustledger_plugin_types::ABI_VERSION;
     format!(
         r#"
         (module
@@ -47,9 +51,7 @@ pub fn metadata_wat(name: &str) -> String {
             (func (export "identify") (param i32 i32) (result i64) i64.const 0)
             (func (export "extract") (param i32 i32) (result i64) i64.const 0)
             (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
-            ;; ABI handshake (issue #1234): must equal the host's
-            ;; rustledger_plugin_types::ABI_VERSION (currently 1).
-            (func (export "__rustledger_abi_version") (result i32) i32.const 1)
+            (func (export "__rustledger_abi_version") (result i32) i32.const {abi})
         )
         "#
     )
@@ -68,6 +70,8 @@ pub fn metadata_wat(name: &str) -> String {
 #[must_use]
 pub fn identifying_wat(name: &str) -> String {
     assert_eq!(name.len(), 3, "test fixture only supports 3-char names");
+    // Interpolate the host ABI version (see `metadata_wat`).
+    let abi = rustledger_plugin_types::ABI_VERSION;
     format!(
         r#"
         (module
@@ -83,9 +87,7 @@ pub fn identifying_wat(name: &str) -> String {
             (func (export "identify") (param i32 i32) (result i64) i64.const 0x10_0000_0002)
             (func (export "extract") (param i32 i32) (result i64) i64.const 0)
             (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
-            ;; ABI handshake (issue #1234): must equal the host's
-            ;; rustledger_plugin_types::ABI_VERSION (currently 1).
-            (func (export "__rustledger_abi_version") (result i32) i32.const 1)
+            (func (export "__rustledger_abi_version") (result i32) i32.const {abi})
         )
         "#
     )

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -181,6 +181,34 @@ pub enum WasmImporterError {
         /// Underlying wasmtime type-mismatch error.
         source: anyhow::Error,
     },
+    /// The importer does not advertise an ABI version (no
+    /// `__rustledger_abi_version` export). It was built without the
+    /// `wasm_importer_main!` macro or against a `plugin-types` from
+    /// before the ABI handshake existed; the host can't confirm wire
+    /// compatibility and refuses to run it (issue #1234).
+    #[error(
+        "WASM importer does not declare an ABI version (missing `{export}` export); \
+         host requires ABI v{expected}. Rebuild against a matching rustledger-plugin-types."
+    )]
+    AbiVersionMissing {
+        /// The export symbol the host looked up.
+        export: &'static str,
+        /// ABI version the host speaks.
+        expected: u32,
+    },
+    /// The importer advertises a different ABI version than the host.
+    /// Running it would risk an opaque trap from a misread wire
+    /// message, so the host rejects it at load (issue #1234).
+    #[error(
+        "WASM importer ABI version mismatch: importer declares v{found}, host requires \
+         v{expected}. Rebuild against a matching rustledger-plugin-types."
+    )]
+    AbiVersionMismatch {
+        /// Version the importer reported.
+        found: u32,
+        /// Version the host requires.
+        expected: u32,
+    },
 }
 
 // `MemoryLimiter`, `StoreState`, `MAX_TABLE_ELEMENTS`, and the
@@ -489,6 +517,29 @@ fn call_metadata(
     let instance = linker
         .instantiate(&mut store, module)
         .map_err(runtime_err)?;
+
+    // ABI handshake. `metadata` is the first thing the host calls on a
+    // freshly loaded importer, so this is the natural load-time gate:
+    // an importer built against an incompatible plugin-types is
+    // rejected here with a clear error instead of trapping opaquely
+    // inside a later `extract` (issue #1234). Subsequent identify /
+    // extract calls re-instantiate the same already-verified module,
+    // so they don't repeat the check.
+    match sandbox::check_guest_abi(&instance, &mut store) {
+        sandbox::AbiCheck::Match => {}
+        sandbox::AbiCheck::Missing => {
+            return Err(WasmImporterError::AbiVersionMissing {
+                export: rustledger_plugin_types::ABI_VERSION_EXPORT,
+                expected: sandbox::HOST_ABI_VERSION,
+            });
+        }
+        sandbox::AbiCheck::Mismatch { found } => {
+            return Err(WasmImporterError::AbiVersionMismatch {
+                found,
+                expected: sandbox::HOST_ABI_VERSION,
+            });
+        }
+    }
 
     // Invariant: `validate_module` verified `memory` at load time.
     let memory = instance
@@ -1007,6 +1058,14 @@ mod tests {
             ;; extract_enriched: ptr=32, len=4 → (32<<32) | 4
             (func (export "extract_enriched") (param i32 i32) (result i64)
                 i64.const 0x20_0000_0004)
+
+            ;; ABI handshake export. Must equal sandbox::HOST_ABI_VERSION
+            ;; (rustledger_plugin_types::ABI_VERSION = 1). If the ABI
+            ;; version is ever bumped, this literal moves in lockstep —
+            ;; the deliberate test update that proves a real guest would
+            ;; need rebuilding too.
+            (func (export "__rustledger_abi_version") (result i32)
+                i32.const 1)
         )
         "#
     }
@@ -1016,6 +1075,71 @@ mod tests {
             account: "Assets:Bank:Checking".to_string(),
             currency: Some("USD".to_string()),
             importer_type: ImporterType::Csv(CsvConfig::default()),
+        }
+    }
+
+    /// A WAT importer with every required export present (so
+    /// `validate_module` passes) but a configurable
+    /// `__rustledger_abi_version`. `abi_section` is spliced in verbatim,
+    /// so a caller can omit it entirely to model a pre-handshake guest.
+    /// `metadata` returns junk on purpose — the ABI check runs before
+    /// the host ever reads it, so these fixtures never need real
+    /// `MessagePack`.
+    fn importer_wat_with_abi(abi_section: &str) -> String {
+        format!(
+            r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "metadata") (result i64) i64.const 0)
+                (func (export "identify") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract") (param i32 i32) (result i64) i64.const 0)
+                (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+                {abi_section}
+            )
+            "#
+        )
+    }
+
+    /// Issue #1234: an importer that doesn't advertise an ABI version
+    /// is rejected at load with a clear error, not an opaque trap on
+    /// the first `extract`.
+    #[test]
+    fn load_rejects_importer_missing_abi_version() {
+        let bytes = wat::parse_str(importer_wat_with_abi("")).expect("WAT parses");
+        let err = WasmImporter::load_from_bytes(
+            PathBuf::from("noabi.wasm"),
+            &bytes,
+            WasmRuntimeConfig::default(),
+        )
+        .expect_err("load must reject an importer with no ABI export");
+        assert!(
+            matches!(err, WasmImporterError::AbiVersionMissing { .. }),
+            "expected AbiVersionMissing, got: {err:?}"
+        );
+    }
+
+    /// Issue #1234: an importer built against a different ABI version
+    /// is rejected at load, naming both versions.
+    #[test]
+    fn load_rejects_importer_with_mismatched_abi_version() {
+        // 999 is deliberately not the host ABI version.
+        let wat = importer_wat_with_abi(
+            r#"(func (export "__rustledger_abi_version") (result i32) i32.const 999)"#,
+        );
+        let bytes = wat::parse_str(wat).expect("WAT parses");
+        let err = WasmImporter::load_from_bytes(
+            PathBuf::from("badabi.wasm"),
+            &bytes,
+            WasmRuntimeConfig::default(),
+        )
+        .expect_err("load must reject an ABI-mismatched importer");
+        match err {
+            WasmImporterError::AbiVersionMismatch { found, expected } => {
+                assert_eq!(found, 999);
+                assert_eq!(expected, sandbox::HOST_ABI_VERSION);
+            }
+            other => panic!("expected AbiVersionMismatch, got: {other:?}"),
         }
     }
 
@@ -1070,6 +1194,9 @@ mod tests {
                 (func (export "identify") (param i32 i32) (result i64) i64.const 0)
                 (func (export "extract") (param i32 i32) (result i64) i64.const 0)
                 (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+                ;; ABI handshake passes so the oversized-metadata check
+                ;; downstream is what rejects this module (issue #1234).
+                (func (export "__rustledger_abi_version") (result i32) i32.const 1)
             )
         "#;
         let bytes = wat::parse_str(wat).expect("WAT parses");
@@ -1172,6 +1299,9 @@ mod tests {
                 (func (export "identify") (param i32 i32) (result i64) i64.const 0)
                 (func (export "extract") (param i32 i32) (result i64) i64.const 0)
                 (func (export "extract_enriched") (param i32 i32) (result i64) i64.const 0)
+                ;; Correct ABI so the check passes and the metadata
+                ;; signature mismatch is what surfaces (issue #1234).
+                (func (export "__rustledger_abi_version") (result i32) i32.const 1)
             )
         "#;
         let bytes = wat::parse_str(wat).expect("WAT parses");

--- a/crates/rustledger-importer/src/wasm.rs
+++ b/crates/rustledger-importer/src/wasm.rs
@@ -187,8 +187,10 @@ pub enum WasmImporterError {
     /// before the ABI handshake existed; the host can't confirm wire
     /// compatibility and refuses to run it (issue #1234).
     #[error(
-        "WASM importer does not declare an ABI version (missing `{export}` export); \
-         host requires ABI v{expected}. Rebuild against a matching rustledger-plugin-types."
+        "WASM importer has a missing or invalid `{export}` export (expected signature \
+         `() -> u32`): it was built against an incompatible rustledger-plugin-types, or the \
+         export is absent, mistyped, or traps. Host requires ABI v{expected}. Rebuild against \
+         a matching rustledger-plugin-types."
     )]
     AbiVersionMissing {
         /// The export symbol the host looked up.

--- a/crates/rustledger-plugin-types/README.md
+++ b/crates/rustledger-plugin-types/README.md
@@ -169,6 +169,15 @@ fn error_response(message: &str) -> u64 {
     }
     ((ptr as u64) << 32) | (bytes.len() as u64)
 }
+
+// Required: advertise the ABI version so the host can confirm wire
+// compatibility right after instantiation. Without this export the
+// host refuses to run the plugin with a clear error rather than
+// trapping opaquely once `process` misreads its input.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rustledger_abi_version() -> u32 {
+    ABI_VERSION
+}
 ```
 
 </details>
@@ -238,6 +247,7 @@ let warning = PluginError::warning("Duplicate entry")
 Plugins must export:
 
 - `alloc(size: u32) -> *mut u8` - **Required**. The host calls this to allocate memory for input data.
+- `__rustledger_abi_version() -> u32` - **Required**. Returns `ABI_VERSION`; the host checks it right after instantiation and refuses to run a guest built against an incompatible `plugin-types`. The `wasm_plugin_main!` / `wasm_importer_main!` macros emit it for you.
 
 Plugins may optionally export:
 

--- a/crates/rustledger-plugin-types/src/guest.rs
+++ b/crates/rustledger-plugin-types/src/guest.rs
@@ -451,6 +451,20 @@ macro_rules! wasm_importer_main {
             let bytes = $crate::guest::to_vec(&output).expect("extract_enriched output encode");
             $crate::guest::pack_output(bytes)
         }
+
+        /// Advertises the `plugin-types` ABI version this importer was
+        /// built against. The host checks it right after instantiation
+        /// (see `rustledger_plugin::sandbox::check_guest_abi`) and
+        /// refuses to run a version it doesn't speak, so an ABI skew
+        /// surfaces as a clear error instead of an opaque trap inside a
+        /// later `extract` call (issue #1234).
+        #[cfg_attr(
+            target_arch = "wasm32",
+            unsafe(export_name = "__rustledger_abi_version")
+        )]
+        pub extern "C" fn __wasm_importer_abi_version() -> u32 {
+            $crate::ABI_VERSION
+        }
     };
 }
 
@@ -563,6 +577,20 @@ macro_rules! wasm_plugin_main {
             let output: $crate::PluginOutput = process_fn(input);
             let bytes = $crate::guest::to_vec(&output).expect("process output encode");
             $crate::guest::pack_output(bytes)
+        }
+
+        /// Advertises the `plugin-types` ABI version this plugin was
+        /// built against. The host checks it right after instantiation
+        /// (see `rustledger_plugin::sandbox::check_guest_abi`) and
+        /// refuses to run a version it doesn't speak, so an ABI skew
+        /// surfaces as a clear error instead of an opaque trap inside
+        /// the `process` call (issue #1234).
+        #[cfg_attr(
+            target_arch = "wasm32",
+            unsafe(export_name = "__rustledger_abi_version")
+        )]
+        pub extern "C" fn __wasm_plugin_abi_version() -> u32 {
+            $crate::ABI_VERSION
         }
     };
 }

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -141,6 +141,31 @@ pub mod guest;
 
 use serde::{Deserialize, Serialize};
 
+/// Version of the host/guest WASM ABI defined by this crate.
+///
+/// A WASM plugin or importer built with the `wasm_plugin_main!` /
+/// `wasm_importer_main!` macros exports this value as
+/// `__rustledger_abi_version() -> u32`. The host reads that export right
+/// after instantiating the module and refuses to run a guest whose
+/// version differs from its own — turning what used to be an opaque
+/// trap deep inside a later call (a guest built against an
+/// incompatible `plugin-types`) into a clear, actionable load-time
+/// error (issue #1234).
+///
+/// Bump this whenever a *breaking* change is made to the wire format or
+/// the export/call convention shared between host and guest (a changed
+/// `PluginInput`/`ImporterInput` shape, a renamed required export, a
+/// different packing scheme, …). It is intentionally a small standalone
+/// counter rather than the crate's `SemVer`: most `plugin-types` releases
+/// do not touch the ABI, and a guest only needs to agree with the host
+/// on the ABI, not on the exact crate version.
+pub const ABI_VERSION: u32 = 1;
+
+/// The WASM export symbol a guest uses to advertise [`ABI_VERSION`].
+/// The `wasm_*_main!` macros emit it; the host looks it up by this
+/// name. Kept here as the single source of truth shared by both sides.
+pub const ABI_VERSION_EXPORT: &str = "__rustledger_abi_version";
+
 // ============================================================================
 // Top-Level Plugin Interface
 // ============================================================================

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -230,6 +230,31 @@ impl Plugin {
         // Instantiate the module
         let instance = linker.instantiate(&mut store, &self.module)?;
 
+        // ABI handshake: confirm the guest was built against a
+        // compatible plugin-types before we hand it any data. A
+        // version skew otherwise manifests as an opaque trap once the
+        // guest misreads `PluginInput`; the check turns that into a
+        // clear error naming both versions (issue #1234). Plugins
+        // instantiate per-execute, so this runs here rather than at
+        // load; the cost is one extra typed-func call.
+        match sandbox::check_guest_abi(&instance, &mut store) {
+            sandbox::AbiCheck::Match => {}
+            sandbox::AbiCheck::Missing => anyhow::bail!(
+                "plugin `{name}` does not export `{export}` (built against an incompatible \
+                 rustledger-plugin-types; host requires ABI v{ver}). Rebuild it against a \
+                 matching rustledger-plugin-types.",
+                name = self.name,
+                export = rustledger_plugin_types::ABI_VERSION_EXPORT,
+                ver = sandbox::HOST_ABI_VERSION,
+            ),
+            sandbox::AbiCheck::Mismatch { found } => anyhow::bail!(
+                "plugin `{name}` ABI version mismatch: plugin declares v{found}, host requires \
+                 v{ver}. Rebuild it against a matching rustledger-plugin-types.",
+                name = self.name,
+                ver = sandbox::HOST_ABI_VERSION,
+            ),
+        }
+
         // Serialize input. The serializer choice (default-mode
         // `to_vec`, not `to_vec_named`) is pinned by the
         // cross-boundary wire-format tests in
@@ -1179,6 +1204,72 @@ mod tests {
         );
     }
 
+    /// A plugin WAT with the required memory/alloc/process exports plus
+    /// a configurable `__rustledger_abi_version`. Pass `""` to model a
+    /// pre-handshake guest. `process` returns junk because the ABI
+    /// check runs right after instantiation, before it is ever called.
+    fn plugin_wat_with_abi(abi_section: &str) -> String {
+        format!(
+            r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "alloc") (param i32) (result i32) i32.const 0)
+                (func (export "process") (param i32 i32) (result i64) i64.const 0)
+                {abi_section}
+            )
+            "#
+        )
+    }
+
+    fn abi_test_plugin_input() -> PluginInput {
+        PluginInput {
+            directives: vec![],
+            options: PluginOptions {
+                operating_currencies: vec![],
+                title: None,
+            },
+            config: None,
+        }
+    }
+
+    /// Issue #1234: a plugin that doesn't advertise an ABI version is
+    /// rejected with a clear error instead of an opaque trap when the
+    /// guest misreads `PluginInput`.
+    #[test]
+    fn execute_rejects_plugin_missing_abi_version() {
+        let wasm = wat::parse_str(plugin_wat_with_abi("")).expect("WAT parses");
+        let plugin =
+            Plugin::load_bytes("noabi", &wasm, &RuntimeConfig::default()).expect("module loads");
+        let err = plugin
+            .execute(&abi_test_plugin_input(), &RuntimeConfig::default())
+            .expect_err("execute must reject a plugin with no ABI export");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("__rustledger_abi_version") && msg.contains("does not export"),
+            "expected a missing-ABI error, got: {msg}"
+        );
+    }
+
+    /// Issue #1234: a plugin built against a different ABI version is
+    /// rejected, naming both versions.
+    #[test]
+    fn execute_rejects_plugin_with_mismatched_abi_version() {
+        let wasm = wat::parse_str(plugin_wat_with_abi(
+            r#"(func (export "__rustledger_abi_version") (result i32) i32.const 999)"#,
+        ))
+        .expect("WAT parses");
+        let plugin =
+            Plugin::load_bytes("badabi", &wasm, &RuntimeConfig::default()).expect("module loads");
+        let err = plugin
+            .execute(&abi_test_plugin_input(), &RuntimeConfig::default())
+            .expect_err("execute must reject an ABI-mismatched plugin");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("ABI version mismatch") && msg.contains("999"),
+            "expected an ABI-mismatch error naming v999, got: {msg}"
+        );
+    }
+
     #[test]
     fn execute_surfaces_wrong_signature_on_alloc() {
         // Plugin has `alloc(i64) -> i64` instead of the required
@@ -1193,6 +1284,9 @@ mod tests {
                 (memory (export "memory") 1)
                 (func (export "alloc") (param i64) (result i64) i64.const 0)
                 (func (export "process") (param i32 i32) (result i64) i64.const 0)
+                ;; Correct ABI so the check passes and the alloc
+                ;; signature mismatch is what surfaces (issue #1234).
+                (func (export "__rustledger_abi_version") (result i32) i32.const 1)
             )
             "#,
         )
@@ -1229,6 +1323,9 @@ mod tests {
                 (memory (export "memory") 1)
                 (func (export "alloc") (param i32) (result i32) i32.const 0)
                 (func (export "process") (param i32 i32) (result i32) i32.const 0)
+                ;; Correct ABI so the check passes and the process
+                ;; signature mismatch is what surfaces (issue #1234).
+                (func (export "__rustledger_abi_version") (result i32) i32.const 1)
             )
             "#,
         )
@@ -1262,6 +1359,9 @@ mod tests {
             (memory (export "memory") 1)
             (func (export "alloc") (param i32) (result i32) i32.const 0)
             (func (export "process") (param i32 i32) (result i64) i64.const 0)
+            ;; ABI handshake (issue #1234): matches the host so execute
+            ;; reaches the process/decode path the fuel tests exercise.
+            (func (export "__rustledger_abi_version") (result i32) i32.const 1)
         )
         "#
     }
@@ -1347,6 +1447,8 @@ mod tests {
                 (memory (export "memory") 1)
                 (func (export "alloc") (param i32) (result i32) i32.const 0)
                 (func (export "process") (param i32 i32) (result i64) i64.const 0)
+                ;; A valid plugin advertises the ABI version (issue #1234).
+                (func (export "__rustledger_abi_version") (result i32) i32.const 1)
             )
             "#,
         )

--- a/crates/rustledger-plugin/src/runtime.rs
+++ b/crates/rustledger-plugin/src/runtime.rs
@@ -240,9 +240,11 @@ impl Plugin {
         match sandbox::check_guest_abi(&instance, &mut store) {
             sandbox::AbiCheck::Match => {}
             sandbox::AbiCheck::Missing => anyhow::bail!(
-                "plugin `{name}` does not export `{export}` (built against an incompatible \
-                 rustledger-plugin-types; host requires ABI v{ver}). Rebuild it against a \
-                 matching rustledger-plugin-types.",
+                "plugin `{name}` has a missing or invalid `{export}` export (expected \
+                 signature `() -> u32`): it was built against an incompatible \
+                 rustledger-plugin-types, or the export is absent, mistyped, or traps. \
+                 Host requires ABI v{ver}. Rebuild it against a matching \
+                 rustledger-plugin-types.",
                 name = self.name,
                 export = rustledger_plugin_types::ABI_VERSION_EXPORT,
                 ver = sandbox::HOST_ABI_VERSION,
@@ -1245,7 +1247,7 @@ mod tests {
             .expect_err("execute must reject a plugin with no ABI export");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("__rustledger_abi_version") && msg.contains("does not export"),
+            msg.contains("__rustledger_abi_version") && msg.contains("missing or invalid"),
             "expected a missing-ABI error, got: {msg}"
         );
     }

--- a/crates/rustledger-plugin/src/sandbox.rs
+++ b/crates/rustledger-plugin/src/sandbox.rs
@@ -43,7 +43,7 @@
 
 use std::sync::{Arc, OnceLock};
 
-use wasmtime::{Config, Engine, ResourceLimiter, Store};
+use wasmtime::{Config, Engine, Instance, ResourceLimiter, Store};
 
 /// Default per-instance linear-memory cap (in bytes) for any
 /// sandboxed wasmtime [`Store`] in rustledger.
@@ -232,6 +232,60 @@ pub fn make_sandboxed_store(
     let fuel = max_time_secs.max(1).saturating_mul(1_000_000);
     store.set_fuel(fuel)?;
     Ok(store)
+}
+
+/// The `plugin-types` ABI version this host build speaks.
+///
+/// A loaded guest must advertise a matching version via its
+/// `__rustledger_abi_version` export. Re-exported from
+/// [`rustledger_plugin_types::ABI_VERSION`] so host and guest share one
+/// source of truth.
+pub const HOST_ABI_VERSION: u32 = rustledger_plugin_types::ABI_VERSION;
+
+/// Outcome of reading a freshly instantiated guest's ABI version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiCheck {
+    /// The guest advertises [`HOST_ABI_VERSION`]; it is safe to call.
+    Match,
+    /// The guest does not export `__rustledger_abi_version` (built
+    /// without the `wasm_*_main!` macros, or against a `plugin-types`
+    /// from before the handshake existed), or the export trapped /
+    /// has the wrong signature. Either way the host can't confirm
+    /// compatibility, so the guest is rejected.
+    Missing,
+    /// The guest advertises a different ABI version than the host.
+    Mismatch {
+        /// Version the guest reported.
+        found: u32,
+    },
+}
+
+/// Read a freshly instantiated guest's ABI version and compare it to
+/// [`HOST_ABI_VERSION`].
+///
+/// Call this immediately after [`wasmtime::Linker::instantiate`] and
+/// before invoking any guest entry point. A guest compiled against an
+/// incompatible `plugin-types` otherwise fails far from the load site
+/// with an opaque trap (a misread `PluginInput`, a bad pointer); the
+/// handshake converts that into a clear, actionable error up front
+/// (issue #1234).
+///
+/// The check is intentionally total — a missing export, a wrong
+/// signature, or a trap while calling it all collapse to
+/// [`AbiCheck::Missing`] rather than propagating a `wasmtime::Error`,
+/// because from the host's perspective they are the same condition:
+/// "this guest can't prove it speaks our ABI."
+pub fn check_guest_abi(instance: &Instance, store: &mut Store<StoreState>) -> AbiCheck {
+    let Ok(func) = instance
+        .get_typed_func::<(), u32>(&mut *store, rustledger_plugin_types::ABI_VERSION_EXPORT)
+    else {
+        return AbiCheck::Missing;
+    };
+    match func.call(&mut *store, ()) {
+        Ok(v) if v == HOST_ABI_VERSION => AbiCheck::Match,
+        Ok(found) => AbiCheck::Mismatch { found },
+        Err(_) => AbiCheck::Missing,
+    }
 }
 
 /// Build a wasmtime [`Config`] with rustledger's locked-down security


### PR DESCRIPTION
## Summary

Adds the ABI version handshake from #1234. The other half of that issue — fuel/memory resource limits — is **already implemented** for both the plugin and importer hosts via the shared `rustledger_plugin::sandbox` (`consume_fuel` + `set_fuel` + a `ResourceLimiter`), so this PR focuses on the missing piece.

### The problem

A WASM plugin or importer compiled against an incompatible `plugin-types` (a changed `PluginInput`/`ImporterInput` shape, a different packing convention) loads fine, then misreads its input and **traps opaquely deep inside a later call** — a bad pointer, a fuel exhaustion, a decode failure far from the real cause. There was no way to tell "this guest speaks a different ABI" from "this guest has a bug."

### The handshake

- `rustledger_plugin_types::ABI_VERSION` (currently `1`) and `ABI_VERSION_EXPORT` (`"__rustledger_abi_version"`) are the shared source of truth.
- `wasm_plugin_main!` and `wasm_importer_main!` now emit `__rustledger_abi_version() -> u32` returning `ABI_VERSION` (alongside the existing `alloc`/`process`/… exports, same `#[cfg_attr(wasm32, export_name=…)]` pattern).
- A shared `sandbox::check_guest_abi(&Instance, &mut Store)` reads that export immediately after `Linker::instantiate` and compares it to the host. A missing export, wrong signature, or version mismatch all collapse to a clear error naming both versions.

### Where each host checks

| Host | Check point | Why |
|------|-------------|-----|
| Plugins | `execute()`, right after instantiate | Plugins instantiate per-call by design (lazy, stateless sandbox); there is no persistent load-time instance to check. Cost is one extra typed-func call. |
| Importers | load (`call_metadata`) | `metadata` is the first call on a freshly loaded importer, so this is a true load-time gate. Later identify/extract re-instantiate the same already-verified module. |

This separation keeps the existing static `validate_module`/`validate_loaded_module` (structural sandbox safety: no imports, has `memory`/`alloc`/…) untouched — the ABI check is a distinct runtime concern at instantiate time.

## Compatibility note

Guests built with the macros gain the export automatically and need no changes. **Manual (non-macro) guests must add the export** or the host will refuse to run them (with a clear "rebuild against a matching plugin-types" error). The plugin-types README's "without the macro" section and required-exports list are updated.

## Tests

- Plugin: `execute_rejects_plugin_missing_abi_version`, `execute_rejects_plugin_with_mismatched_abi_version`.
- Importer: `load_rejects_importer_missing_abi_version`, `load_rejects_importer_with_mismatched_abi_version`.
- Positive path: the existing macro-built e2e fixtures (`wasm_plugin_e2e`, `wasm_importer_e2e`) — the macros now emit the export, so these exercise a real guest passing the handshake.
- Synthetic WAT modules and shared test fixtures that are loaded/executed gained the export (a guest without it is now correctly rejected).

## Verification

In `nix develop`: `cargo clippy -p rustledger-plugin-types -p rustledger-plugin -p rustledger-importer --all-features --all-targets -- -D warnings` (exit 0), `cargo fmt -- --check` (clean), and the full test suites for all three crates plus the CLI wasm-dispatch tests pass.

Closes #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)