### PR TITLE
fix(cli): surface config-load errors instead of silently using defaults (#1306)

### DIFF
--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -266,34 +266,49 @@ fn parse_alias_expansion(expansion: &str) -> Vec<String> {
 fn main() -> ExitCode {
     // Load config early (before parsing) for alias expansion.
     //
-    // Surface a config-load failure instead of silently falling back to
-    // defaults. `Config::load()` only errors when a config file is
-    // present but cannot be read or parsed; a missing config is `Ok`.
-    // Swallowing the error here meant a malformed config (e.g. a
-    // wrong-shaped `[price.mapping.X]` table) was discarded and the user
-    // got a misleading downstream message — `rledger price hy` reported
-    // "no price source configured" while `rledger config show` reported
-    // the real TOML parse error (issue #1306). Fail fast with the same
-    // error either path would show.
-    let config = match Config::load() {
-        Ok(loaded) => loaded.config,
-        Err(e) => {
-            eprintln!("error: {e:#}");
-            return ExitCode::from(2);
-        }
-    };
+    // A config file that exists but fails to parse must NOT be silently
+    // discarded: that swallowed a malformed `[price.mapping.X]` and left
+    // `rledger price hy` reporting "no price source configured" instead
+    // of the real TOML parse error (issue #1306). But it must also NOT
+    // block commands that don't read it — `--help`/`--version` and the
+    // `config` subcommands a user runs to *fix* the broken file (else a
+    // bootstrap deadlock: the command that repairs the config is blocked
+    // by the config it would repair).
+    //
+    // So: keep the load result, expand aliases with whatever loaded
+    // (defaults if it failed — a broken config just yields no aliases),
+    // let clap handle `--help`/`--version`, then surface the error only
+    // for a command that actually consumes config.
+    let config_result = Config::load();
+    let config = config_result
+        .as_ref()
+        .map(|loaded| loaded.config.clone())
+        .unwrap_or_default();
 
     // Expand aliases in command line arguments
     let args: Vec<String> = std::env::args().collect();
     let expanded_args = expand_aliases(args, &config);
 
-    // Parse the (possibly expanded) arguments
+    // Parse the (possibly expanded) arguments. clap intercepts
+    // `--help`/`--version` here via `e.exit()`, so those never reach the
+    // config-error gate below.
     let cli = match Cli::try_parse_from(&expanded_args) {
         Ok(cli) => cli,
         Err(e) => {
             e.exit();
         }
     };
+
+    // A config that failed to load is fatal for commands that consume
+    // it, but the `config` subcommands operate on the file directly
+    // (`init` creates one, `edit` opens it, `show` surfaces this very
+    // error), so they must still run when the existing config is broken.
+    if let Err(e) = &config_result
+        && !matches!(cli.command, Commands::Config { .. })
+    {
+        eprintln!("error: {e:#}");
+        return ExitCode::from(2);
+    }
 
     // Get effective profile: CLI flag takes precedence, then env var
     let profile = cli

--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -264,8 +264,24 @@ fn parse_alias_expansion(expansion: &str) -> Vec<String> {
 }
 
 fn main() -> ExitCode {
-    // Load config early (before parsing) for alias expansion
-    let config = Config::load().map(|l| l.config).unwrap_or_default();
+    // Load config early (before parsing) for alias expansion.
+    //
+    // Surface a config-load failure instead of silently falling back to
+    // defaults. `Config::load()` only errors when a config file is
+    // present but cannot be read or parsed; a missing config is `Ok`.
+    // Swallowing the error here meant a malformed config (e.g. a
+    // wrong-shaped `[price.mapping.X]` table) was discarded and the user
+    // got a misleading downstream message — `rledger price hy` reported
+    // "no price source configured" while `rledger config show` reported
+    // the real TOML parse error (issue #1306). Fail fast with the same
+    // error either path would show.
+    let config = match Config::load() {
+        Ok(loaded) => loaded.config,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            return ExitCode::from(2);
+        }
+    };
 
     // Expand aliases in command line arguments
     let args: Vec<String> = std::env::args().collect();

--- a/crates/rustledger/tests/config_load_error_surfaced.rs
+++ b/crates/rustledger/tests/config_load_error_surfaced.rs
@@ -29,11 +29,17 @@ fn malformed_config_surfaces_parse_error_instead_of_silent_default() {
     let output = Command::new(bin)
         .args(["price", "hy"])
         // Run inside the tempdir so its `.rledger.toml` is the project
-        // config, and point HOME/XDG at the (empty) tempdir so no real
-        // user/system config is loaded first.
+        // config, and point every config-dir source at the (empty)
+        // tempdir so no real user/system config is loaded first. HOME +
+        // XDG_CONFIG_HOME cover Unix; APPDATA / PROGRAMDATA / USERPROFILE
+        // cover the Windows paths `dirs::config_dir()` consults, keeping
+        // the test hermetic across platforms.
         .current_dir(dir.path())
         .env("HOME", dir.path())
         .env("XDG_CONFIG_HOME", dir.path())
+        .env("APPDATA", dir.path())
+        .env("PROGRAMDATA", dir.path())
+        .env("USERPROFILE", dir.path())
         .output()
         .expect("run rledger price");
 

--- a/crates/rustledger/tests/config_load_error_surfaced.rs
+++ b/crates/rustledger/tests/config_load_error_surfaced.rs
@@ -1,0 +1,58 @@
+//! Regression for issue #1306.
+//!
+//! A config file that exists but fails to parse must surface a clear
+//! error, not be silently discarded so the user gets a misleading
+//! downstream message. The reporter put a *source* definition
+//! (`type` / `command`) under `[price.mapping.hy]`, which can't
+//! deserialize as a `CommodityMapping`; `rledger price hy` then reported
+//! "no price source configured" while `rledger config show` reported the
+//! real TOML parse error. `main` now fails fast on a config-load error.
+
+mod common;
+
+use std::process::Command;
+
+#[test]
+fn malformed_config_surfaces_parse_error_instead_of_silent_default() {
+    let bin = require_rledger!();
+
+    // The exact mistake from #1306: a `[price.mapping.X]` table shaped
+    // like a source definition. A valid mapping is a ticker string or a
+    // `{ source = "..." }` table, so this can't deserialize.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".rledger.toml"),
+        "[price.mapping.hy]\ntype = \"command\"\ncommand = [\"uv\", \"run\", \"pricedl\"]\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(bin)
+        .args(["price", "hy"])
+        // Run inside the tempdir so its `.rledger.toml` is the project
+        // config, and point HOME/XDG at the (empty) tempdir so no real
+        // user/system config is loaded first.
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .output()
+        .expect("run rledger price");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "a malformed config must fail, not exit 0 with defaults.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Failed to parse config file"),
+        "stderr should name the config parse failure.\nstderr: {stderr}"
+    );
+    // The whole bug was that the misleading message masked the real
+    // parse error — it must no longer appear.
+    assert!(
+        !stdout.contains("no price source configured")
+            && !stderr.contains("no price source configured"),
+        "the real parse error must replace the misleading 'no price source configured' message.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}

--- a/crates/rustledger/tests/config_load_error_surfaced.rs
+++ b/crates/rustledger/tests/config_load_error_surfaced.rs
@@ -62,3 +62,43 @@ fn malformed_config_surfaces_parse_error_instead_of_silent_default() {
         "the real parse error must replace the misleading 'no price source configured' message.\nstdout: {stdout}\nstderr: {stderr}"
     );
 }
+
+/// A broken config must NOT block commands that don't read it. `main`
+/// loads config before clap parses (for alias expansion), so a naive
+/// fail-fast there would break `--help`/`--version` and the `config`
+/// subcommands a user runs to *fix* the file — a bootstrap deadlock.
+/// `--help` must still succeed with a malformed config present.
+#[test]
+fn malformed_config_does_not_block_help() {
+    let bin = require_rledger!();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".rledger.toml"),
+        "[price.mapping.hy]\ntype = \"command\"\ncommand = [\"uv\", \"run\", \"pricedl\"]\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(bin)
+        .arg("--help")
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .env("XDG_CONFIG_HOME", dir.path())
+        .env("APPDATA", dir.path())
+        .env("PROGRAMDATA", dir.path())
+        .env("USERPROFILE", dir.path())
+        .output()
+        .expect("run rledger --help");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "--help must succeed despite a broken config (no bootstrap deadlock); \
+         stdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("Usage") || stdout.contains("usage"),
+        "--help should print usage; stdout: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

`rledger price hy` reported `no price source configured for hy` even though the user had a `[price.mapping.hy]` block in `.rledger.toml`. The root cause isn't in the price code — it's that **`main` silently discards a malformed config**.

## Root cause

`crates/rustledger/src/bin/rledger.rs`:

```rust
let config = Config::load().map(|l| l.config).unwrap_or_default();
```

`Config::load()` returns `Err` when a config file exists but can't be read or parsed (a *missing* config is `Ok` with defaults). `unwrap_or_default()` swallowed that error and fell back to an empty config, so the user's whole `.rledger.toml` was dropped and they got a misleading downstream message.

The reporter's config put a *source definition* under a *mapping* key:

```toml
[price.mapping.hy]
type = "command"
command = ["uv", "run", "pricedl", "vanguard", "hy"]
```

A `[price.mapping.X]` value must be a ticker string or a `{ source = "..." }` table (`CommodityMapping`), so this fails to deserialize. The proof that the error existed all along: `rledger config show` reported it correctly, while `rledger price hy` (and every other command) silently ignored it.

```
# before
$ rledger price hy
; Failed to fetch hy: no price source configured for hy. Pick one: ...   (exit 0)

# after
$ rledger price hy
error: Failed to parse config file: /.../.rledger.toml: TOML parse error at line 1, column 1
  |
1 | [price.mapping.hy]
  | ^^^^^^^^^^^^^^^^^^
data did not match any variant of untagged enum CommodityMapping        (exit 2)
```

## Fix

Match on `Config::load()` and fail fast on `Err`, using the same `error: {e:#}` + `ExitCode::from(2)` pattern the rest of `main` uses. A valid config (or no config) is unaffected.

For reference, the shape the reporter wanted is a source plus a mapping that references it:

```toml
[price.sources.pricedl]
type = "command"
command = ["uv", "run", "pricedl", "vanguard", "hy"]

[price.mapping.hy]
source = "pricedl"
```

(verified working with `config show`).

## Tests

New integration test `config_load_error_surfaced.rs` runs the binary against the issue's exact malformed config (isolating HOME/XDG and using a tempdir as the project root) and asserts: non-zero exit, stderr names the parse failure, and the old "no price source configured" message is gone. Existing CLI + price integration suites (`cli_commands_test`, `bean_price_compat`, `price_clobber_post_fetch`) pass unchanged.

## Note / possible follow-up

The surfaced serde message (`data did not match any variant of untagged enum CommodityMapping`) names the file and line but is a little terse. A friendlier message ("expected a ticker string or a `{ source = ... }` table") would need a custom `Deserialize` for `CommodityMapping`; left out to keep this fix focused on the silent-swallow bug. Verified with `nix develop`: clippy `-D warnings` (exit 0) and `cargo fmt --check` clean.

Closes #1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)