### PR TITLE
perf(report,booking): skip pad-expansion clone for pad-free ledgers

### DIFF
--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -56,14 +56,16 @@ pub fn is_synthesized_pad(txn: &Transaction) -> bool {
 }
 
 /// Result of processing pad directives.
+///
+/// This holds only what `process_pads` *derives* from the input: the
+/// synthesized padding transactions and any errors. It deliberately
+/// does NOT echo the input directives back — the caller already owns
+/// that slice, so cloning it into the result was pure waste on every
+/// call (a full deep-clone of the directive stream the caller then
+/// discarded). Callers that want the source merged with the synth
+/// transactions for balance math should use [`merge_with_padding`].
 #[derive(Debug, Clone)]
 pub struct PadResult {
-    /// The original input directives, verbatim. Pads are NOT
-    /// removed; the field is the same slice the caller handed in.
-    /// Callers that want the source merged with synthesized pad
-    /// transactions for balance math should use
-    /// [`merge_with_padding`].
-    pub directives: Vec<Directive>,
     /// Synthetic padding transactions generated.
     pub padding_transactions: Vec<Transaction>,
     /// Any errors encountered during pad processing.
@@ -116,7 +118,6 @@ struct PendingPad {
 /// 2. When a pad is encountered, stores it as pending
 /// 3. When a balance assertion is encountered for an account with a pending pad,
 ///    generates a synthetic transaction to make the balance match
-/// 4. Returns the directives with synthetic transactions inserted
 ///
 /// # Arguments
 ///
@@ -125,9 +126,12 @@ struct PendingPad {
 /// # Returns
 ///
 /// A `PadResult` containing:
-/// - The original directives (with pads preserved for reference)
-/// - Synthetic padding transactions
+/// - The synthetic padding transactions derived from the input
 /// - Any errors encountered
+///
+/// The input directives are NOT echoed back in the result; the caller
+/// already owns them. To get the source merged with the synth
+/// transactions, use [`merge_with_padding`].
 pub fn process_pads(directives: &[Directive]) -> PadResult {
     let num_directives = directives.len();
     let mut inventories: HashMap<rustledger_core::Account, Inventory> =
@@ -252,7 +256,6 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
     }
 
     PadResult {
-        directives: directives.to_vec(),
         padding_transactions,
         errors,
     }

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -121,7 +121,9 @@ struct PendingPad {
 ///
 /// # Arguments
 ///
-/// * `directives` - The directives to process (should be sorted by date)
+/// * `directives` - The directives to process. Order does not matter:
+///   `process_pads` sorts a view of them by date internally before
+///   applying pad math.
 ///
 /// # Returns
 ///

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -241,11 +241,10 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
     let pad_result = process_pads(&load.directives);
 
     let result = PadResult {
-        directives: pad_result
-            .directives
-            .iter()
-            .map(directive_to_json)
-            .collect(),
+        // The source stream, verbatim — `process_pads` no longer
+        // echoes its input back, so read it from the directives we
+        // already loaded instead of from the result.
+        directives: load.directives.iter().map(directive_to_json).collect(),
         padding_transactions: pad_result
             .padding_transactions
             .iter()

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -80,11 +80,10 @@ fn execute_expand_pads(directives: &[Directive]) -> Result<JsValue, JsError> {
     let pad_result = process_pads(directives);
 
     let result = PadResult {
-        directives: pad_result
-            .directives
-            .iter()
-            .map(directive_to_json)
-            .collect(),
+        // The source stream, verbatim — `process_pads` no longer
+        // echoes its input back, so read it from the directives we
+        // were handed instead of from the result.
+        directives: directives.iter().map(directive_to_json).collect(),
         padding_transactions: pad_result
             .padding_transactions
             .iter()

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -220,7 +220,7 @@ pub fn run(
         && ledger
             .directives
             .iter()
-            .any(|s| matches!(s.value, rustledger_core::Directive::Pad(_)));
+            .any(|s| matches!(&s.value, rustledger_core::Directive::Pad(_)));
     let balance_view = if has_pads {
         Some(ledger.balance_view())
     } else {
@@ -251,7 +251,9 @@ pub fn run(
     };
 
     // Generate the requested report. Balance-computing reports get
-    // `balance_view.as_ref().expect("balance_view computed above when report needs it")`; source-faithful reports get `&directives`.
+    // `balance_input` (the pad-expanded view when the ledger has pads,
+    // otherwise the borrowed source stream); source-faithful reports
+    // get `&directives`.
     match report {
         Report::Balances { account } => {
             balances::report_balances(balance_input, account.as_deref(), format, &mut writer)?;

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -198,10 +198,16 @@ pub fn run(
     //
     // The split mirrors the architectural rule documented on
     // `rustledger_loader::Ledger.directives`. `balance_view` is
-    // expensive (an O(n) clone + `process_pads` walk), so compute
-    // it only when the chosen report actually needs it. Run the
-    // check BEFORE consuming `ledger.directives` so the borrow
-    // checker is happy.
+    // expensive (an O(n) clone + `process_pads` walk + re-sort), so
+    // compute it only when the chosen report actually needs it AND
+    // the ledger actually has `pad` directives. With no pads there
+    // are no synth transactions to merge, so the pad-expanded view
+    // is byte-for-byte the source stream — building it would clone
+    // and re-sort the whole stream to produce an identical result.
+    // Most ledgers have no pads, so the balance reports fall through
+    // to the borrowed source directly (no clone). Run both checks
+    // BEFORE consuming `ledger.directives` so the borrow checker is
+    // happy.
     let needs_balance_view = matches!(
         report,
         Report::Balances { .. }
@@ -210,12 +216,24 @@ pub fn run(
             | Report::Holdings { .. }
             | Report::Networth { .. }
     );
-    let balance_view = if needs_balance_view {
+    let has_pads = needs_balance_view
+        && ledger
+            .directives
+            .iter()
+            .any(|s| matches!(s.value, rustledger_core::Directive::Pad(_)));
+    let balance_view = if has_pads {
         Some(ledger.balance_view())
     } else {
         None
     };
     let directives: Vec<_> = ledger.directives.into_iter().map(|s| s.value).collect();
+
+    // Balance-computing reports read the pad-expanded view when one
+    // was built (the ledger has pads), otherwise the source stream
+    // directly. `unwrap_or` makes the no-pad fast path explicit: same
+    // directives, no clone.
+    let balance_input: &[rustledger_core::Directive] =
+        balance_view.as_deref().unwrap_or(&directives);
 
     // Create pager AFTER loading (don't spawn pager if load fails)
     let use_pager = !no_pager && matches!(format, OutputFormat::Text);
@@ -236,45 +254,19 @@ pub fn run(
     // `balance_view.as_ref().expect("balance_view computed above when report needs it")`; source-faithful reports get `&directives`.
     match report {
         Report::Balances { account } => {
-            balances::report_balances(
-                balance_view
-                    .as_ref()
-                    .expect("balance_view computed above when report needs it"),
-                account.as_deref(),
-                format,
-                &mut writer,
-            )?;
+            balances::report_balances(balance_input, account.as_deref(), format, &mut writer)?;
         }
         Report::Balsheet => {
-            balsheet::report_balsheet(
-                balance_view
-                    .as_ref()
-                    .expect("balance_view computed above when report needs it"),
-                format,
-                &mut writer,
-            )?;
+            balsheet::report_balsheet(balance_input, format, &mut writer)?;
         }
         Report::Income => {
-            income::report_income(
-                balance_view
-                    .as_ref()
-                    .expect("balance_view computed above when report needs it"),
-                format,
-                &mut writer,
-            )?;
+            income::report_income(balance_input, format, &mut writer)?;
         }
         Report::Journal { account, limit } => {
             journal::report_journal(&directives, account.as_deref(), *limit, format, &mut writer)?;
         }
         Report::Holdings { account } => {
-            holdings::report_holdings(
-                balance_view
-                    .as_ref()
-                    .expect("balance_view computed above when report needs it"),
-                account.as_deref(),
-                format,
-                &mut writer,
-            )?;
+            holdings::report_holdings(balance_input, account.as_deref(), format, &mut writer)?;
         }
         Report::Networth {
             period,
@@ -283,9 +275,7 @@ pub fn run(
             no_zero,
         } => {
             networth::report_networth(
-                balance_view
-                    .as_ref()
-                    .expect("balance_view computed above when report needs it"),
+                balance_input,
                 period,
                 currency.as_deref(),
                 account.as_deref(),


### PR DESCRIPTION
## What

Removes wasted work from the balance-computing report path for the common case of a ledger with **no `pad` directives**.

1. **`report_cmd` skips `balance_view()` when there are no pads.** `balance_view()` does a full clone + re-sort of the directive stream to merge synthesized pad transactions. With no pads there is nothing to merge, so the pad-expanded view is byte-for-byte the source stream. The balance reports now read the borrowed source directly; `balance_view` is built only when pads are actually present.

2. **`process_pads` no longer echoes its input back in `PadResult.directives`.** That field was a full deep-clone of the caller-owned directive stream that every caller either discarded (`balance_view`) or could read from the input it already held (the two wasm consumers). Removed the field; updated `api.rs` / `parsed_ledger.rs` to read the directives they already own.

## Why

`process_pads` was deep-cloning the entire directive stream into a result field nobody used, and `report` built a pad-expanded clone even for ledgers with zero pads.

## Measurement

10K-transaction pad-free ledger, `rledger report ... balances`: **~132ms -> ~116ms**.

## Scope note

This is the pad-path cleanup only. The **bulk** of the nightly balance-benchmark regression (the ~37ms -> ~130ms jump) is a **separate** root cause: the `#1262` CST parser migration (`#1282` made `parse()` unconditionally use `parse_via_cst`, ~2-3x slower than the removed direct parser) combined with `report` having no parse cache, so it re-parses on every invocation. The validation benchmark stayed flat only because `check` caches parses. That is tracked/handled separately.

## Tests

- `rustledger-booking` pad unit tests: 13 pass
- `rustledger-loader` `balance_view_test`: 4 pass
- `rustledger` `report_pad_expansion_test`: 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)