### PR TITLE
perf(report): reuse on-disk parse cache so repeated reports skip parsing

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -186,6 +186,60 @@ impl CacheEntry {
     pub fn file_paths(&self) -> Vec<PathBuf> {
         self.files.iter().map(PathBuf::from).collect()
     }
+
+    /// Reconstruct a [`LoadResult`](crate::LoadResult) equivalent to a
+    /// fresh parse of the cached source.
+    ///
+    /// Re-reads each cached source file for the source map (so error
+    /// reporting still has text), converts the cached plugin
+    /// declarations back (their span / `file_id` are not meaningful
+    /// from cache), and — crucially — rebuilds the display context from
+    /// the cached directives + options via the same inference a fresh
+    /// load uses, so a cache-hit `LoadResult` formats numbers
+    /// identically to an uncached one. Reconstructing it as an empty
+    /// `DisplayContext` (as the per-command CLI code used to) would
+    /// silently change per-currency display precision for any consumer
+    /// that reads it.
+    ///
+    /// `errors` is empty by construction: the cache is only written for
+    /// error-free, warning-free loads.
+    ///
+    /// Strings are NOT re-interned here; a caller that wants the memory
+    /// dedup should call [`crate::reintern_directives`] on
+    /// `self.directives` first (it needs `&mut`).
+    #[must_use]
+    pub fn into_load_result(self) -> crate::LoadResult {
+        let mut source_map = crate::SourceMap::new();
+        for path in self.file_paths() {
+            if let Ok(content) = fs::read_to_string(&path) {
+                source_map.add_file(path, content.into());
+            }
+        }
+
+        let plugins: Vec<crate::Plugin> = self
+            .plugins
+            .iter()
+            .map(|p| crate::Plugin {
+                name: p.name.clone(),
+                config: p.config.clone(),
+                span: rustledger_parser::Span::ZERO,
+                file_id: 0,
+                force_python: p.force_python,
+            })
+            .collect();
+
+        let options: Options = self.options.into();
+        let display_context = crate::build_display_context(&self.directives, &options);
+
+        crate::LoadResult {
+            directives: self.directives,
+            options,
+            plugins,
+            source_map,
+            errors: Vec::new(),
+            display_context,
+        }
+    }
 }
 
 /// Magic bytes to identify cache files.

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -211,7 +211,13 @@ impl CacheEntry {
     pub fn into_load_result(self) -> crate::LoadResult {
         let mut source_map = crate::SourceMap::new();
         for path in self.file_paths() {
-            if let Ok(content) = fs::read_to_string(&path) {
+            // Read bytes + lossy UTF-8 to match `DiskFileSystem::read`
+            // (the uncached loader path). `read_to_string` would error
+            // and silently skip a non-UTF8 source file, leaving the
+            // cache-hit source map missing text the uncached run has -
+            // an error-reporting parity gap.
+            if let Ok(bytes) = fs::read(&path) {
+                let content = String::from_utf8_lossy(&bytes).into_owned();
                 source_map.add_file(path, content.into());
             }
         }

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -209,37 +209,12 @@ pub fn run(args: &Args) -> Result<ExitCode> {
             eprintln!("Re-interned strings ({dedup_count} deduplicated)");
         }
 
-        // Rebuild source map from cached file list
-        let mut source_map = rustledger_loader::SourceMap::new();
-        for path in entry.file_paths() {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                source_map.add_file(path, content.into());
-            }
-        }
-
-        // Convert CachedPlugin -> Plugin (span/file_id are not meaningful from cache)
-        let plugins: Vec<rustledger_loader::Plugin> = entry
-            .plugins
-            .iter()
-            .map(|p| rustledger_loader::Plugin {
-                name: p.name.clone(),
-                config: p.config.clone(),
-                span: rustledger_parser::Span::ZERO,
-                file_id: 0,
-                force_python: p.force_python,
-            })
-            .collect();
-
-        let result = rustledger_loader::LoadResult {
-            directives: entry.directives,
-            options: entry.options.into(),
-            plugins,
-            source_map,
-            errors: Vec::new(),
-            // Build display context from cached directives
-            display_context: rustledger_core::DisplayContext::new(),
-        };
-        (result, true)
+        // Reconstruct an equivalent LoadResult (source map, plugins, and
+        // a rebuilt display context) from the cache entry. Previously
+        // open-coded here with an empty `DisplayContext`; the shared
+        // `CacheEntry::into_load_result` rebuilds the context so a cache
+        // hit is fully equivalent to a fresh parse.
+        (entry.into_load_result(), true)
     } else {
         // Load the file normally
         if args.verbose && !args.quiet {

--- a/crates/rustledger/src/cmd/loadcache.rs
+++ b/crates/rustledger/src/cmd/loadcache.rs
@@ -1,0 +1,145 @@
+//! Shared parse-cache load path for CLI commands.
+//!
+//! `parse()` (the CST parser) is the dominant cost of loading a large
+//! ledger, and it is identical run-to-run for an unchanged file. The
+//! loader already persists a parsed [`LoadResult`] to an on-disk cache
+//! ([`load_cache_entry`] / [`save_cache_entry`]); `check` has used it
+//! for a while. This helper factors that "load from cache, else parse
+//! and save" step out so other commands (notably `report`, which had
+//! no cache and re-parsed on every invocation) can reuse it.
+//!
+//! The returned [`LoadResult`] is the *parsed* stream (pre-booking);
+//! callers feed it to [`rustledger_loader::process`] to book/validate,
+//! exactly as the uncached path does. The cache is keyed by the main
+//! file and shared across commands, so a `check` followed by a
+//! `report` on the same file is a cache hit.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use rustledger_loader::{
+    CacheEntry, CachedOptions, CachedPlugin, LoadResult, Loader, cache_disabled_by_env,
+    load_cache_entry, reintern_directives, save_cache_entry,
+};
+
+/// Load a file's parsed [`LoadResult`], using the on-disk parse cache
+/// when one is present and valid. Returns `(result, from_cache)`.
+///
+/// `no_cache` (a CLI `--no-cache`-style flag) or the
+/// `BEANCOUNT_DISABLE_LOAD_CACHE` env var disables both reading and
+/// writing the cache. `verbose` gates the same progress lines `check`
+/// emits.
+///
+/// # Errors
+///
+/// Propagates loader errors from a fresh parse (cache misses fall
+/// through to `Loader::load`). A cache *save* failure is non-fatal and
+/// only surfaced as a `verbose` warning.
+pub fn load_result_cached(
+    file: &Path,
+    no_cache: bool,
+    verbose: bool,
+) -> Result<(LoadResult, bool)> {
+    let cache_disabled = no_cache || cache_disabled_by_env();
+
+    let cache_entry = if cache_disabled {
+        None
+    } else {
+        load_cache_entry(file)
+    };
+
+    if let Some(mut entry) = cache_entry {
+        if verbose {
+            eprintln!("Loaded {} directives from cache", entry.directives.len());
+        }
+
+        // Re-intern strings to deduplicate memory (mirrors `check`).
+        let dedup_count = reintern_directives(&mut entry.directives);
+        if verbose {
+            eprintln!("Re-interned strings ({dedup_count} deduplicated)");
+        }
+
+        // Rebuild the source map from the cached file list so error
+        // reporting still has source text.
+        let mut source_map = rustledger_loader::SourceMap::new();
+        for path in entry.file_paths() {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                source_map.add_file(path, content.into());
+            }
+        }
+
+        // Cached plugins carry no meaningful span/file_id.
+        let plugins: Vec<rustledger_loader::Plugin> = entry
+            .plugins
+            .iter()
+            .map(|p| rustledger_loader::Plugin {
+                name: p.name.clone(),
+                config: p.config.clone(),
+                span: rustledger_parser::Span::ZERO,
+                file_id: 0,
+                force_python: p.force_python,
+            })
+            .collect();
+
+        let result = LoadResult {
+            directives: entry.directives,
+            options: entry.options.into(),
+            plugins,
+            source_map,
+            errors: Vec::new(),
+            display_context: rustledger_core::DisplayContext::new(),
+        };
+        return Ok((result, true));
+    }
+
+    // Cache miss (or disabled): parse fresh.
+    if verbose {
+        eprintln!("Loading {}...", file.display());
+    }
+    let mut loader = Loader::new();
+    let result = loader
+        .load(file)
+        .with_context(|| format!("failed to load {}", file.display()))?;
+
+    // Save to cache unless disabled, or the load had errors / option
+    // warnings (E7001-E7006 are not stored, so caching would silently
+    // drop them on a later hit). Mirrors `check`.
+    if !cache_disabled && result.errors.is_empty() && result.options.warnings.is_empty() {
+        let files: Vec<String> = result
+            .source_map
+            .files()
+            .iter()
+            .map(|f| f.path.to_string_lossy().into_owned())
+            .collect();
+        let files = if files.is_empty() {
+            vec![file.to_string_lossy().into_owned()]
+        } else {
+            files
+        };
+
+        let entry = CacheEntry {
+            directives: result.directives.clone(),
+            options: CachedOptions::from(&result.options),
+            plugins: result
+                .plugins
+                .iter()
+                .map(|p| CachedPlugin {
+                    name: p.name.clone(),
+                    config: p.config.clone(),
+                    force_python: p.force_python,
+                })
+                .collect(),
+            files,
+        };
+
+        if let Err(e) = save_cache_entry(file, &entry) {
+            if verbose {
+                eprintln!("Warning: failed to save cache: {e}");
+            }
+        } else if verbose {
+            eprintln!("Saved {} directives to cache", result.directives.len());
+        }
+    }
+
+    Ok((result, false))
+}

--- a/crates/rustledger/src/cmd/loadcache.rs
+++ b/crates/rustledger/src/cmd/loadcache.rs
@@ -53,43 +53,15 @@ pub fn load_result_cached(
             eprintln!("Loaded {} directives from cache", entry.directives.len());
         }
 
-        // Re-intern strings to deduplicate memory (mirrors `check`).
+        // Re-intern strings to deduplicate memory before reconstruction.
         let dedup_count = reintern_directives(&mut entry.directives);
         if verbose {
             eprintln!("Re-interned strings ({dedup_count} deduplicated)");
         }
 
-        // Rebuild the source map from the cached file list so error
-        // reporting still has source text.
-        let mut source_map = rustledger_loader::SourceMap::new();
-        for path in entry.file_paths() {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                source_map.add_file(path, content.into());
-            }
-        }
-
-        // Cached plugins carry no meaningful span/file_id.
-        let plugins: Vec<rustledger_loader::Plugin> = entry
-            .plugins
-            .iter()
-            .map(|p| rustledger_loader::Plugin {
-                name: p.name.clone(),
-                config: p.config.clone(),
-                span: rustledger_parser::Span::ZERO,
-                file_id: 0,
-                force_python: p.force_python,
-            })
-            .collect();
-
-        let result = LoadResult {
-            directives: entry.directives,
-            options: entry.options.into(),
-            plugins,
-            source_map,
-            errors: Vec::new(),
-            display_context: rustledger_core::DisplayContext::new(),
-        };
-        return Ok((result, true));
+        // Reconstruct an equivalent `LoadResult` (source map, plugins,
+        // and a rebuilt display context) - see `CacheEntry::into_load_result`.
+        return Ok((entry.into_load_result(), true));
     }
 
     // Cache miss (or disabled): parse fresh.

--- a/crates/rustledger/src/cmd/mod.rs
+++ b/crates/rustledger/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub mod doctor;
 pub mod extract_cmd;
 pub mod format;
 pub mod lint;
+pub mod loadcache;
 pub mod price;
 pub mod price_cmd;
 pub mod query;

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -168,11 +168,10 @@ pub fn run(
         anyhow::bail!("file not found: {}", file.display());
     }
 
-    // Load and fully process the file (parse → book → plugins)
-    if verbose {
-        eprintln!("Loading {}...", file.display());
-    }
-
+    // Load and fully process the file (parse → book → plugins).
+    // Verbose progress (incl. the "Loading ..." / cache-hit lines) is
+    // emitted by `load_result_cached`, so don't pre-log here - that
+    // would double up on a miss and mislead on a cache hit.
     let options = LoadOptions {
         validate: false, // Reports don't need validation
         ..Default::default()

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -37,7 +37,7 @@ use crate::cmd::completions::ShellType;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use rustledger_core::NaiveDate;
-use rustledger_loader::{LoadOptions, load};
+use rustledger_loader::LoadOptions;
 use std::io;
 use std::path::PathBuf;
 /// Generate reports from beancount files.
@@ -178,8 +178,15 @@ pub fn run(
         ..Default::default()
     };
 
-    let ledger =
-        load(file, &options).with_context(|| format!("failed to load {}", file.display()))?;
+    // Parse via the shared on-disk cache: `parse()` dominates load
+    // cost and is identical run-to-run for an unchanged file, so a
+    // repeated `report` (or a `report` after `check`) skips the parse
+    // entirely. The cached `LoadResult` is the parsed (pre-booking)
+    // stream; `process` books it exactly as the uncached `load` did.
+    // Disable with `BEANCOUNT_DISABLE_LOAD_CACHE`.
+    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, false, verbose)?;
+    let ledger = rustledger_loader::process(raw, &options)
+        .with_context(|| format!("failed to load {}", file.display()))?;
 
     // Report any errors
     for err in &ledger.errors {

--- a/crates/rustledger/tests/report_parse_cache.rs
+++ b/crates/rustledger/tests/report_parse_cache.rs
@@ -1,0 +1,93 @@
+//! `rledger report` reuses the on-disk parse cache (shared with
+//! `check`) so a repeated report on an unchanged file skips the
+//! expensive parse. These tests pin two guarantees:
+//!
+//! 1. A report writes the cache and a subsequent report hits it.
+//! 2. Cached, uncached, and cache-disabled runs produce byte-identical
+//!    output (the cache must never change what a report prints).
+
+mod common;
+
+use std::process::Command;
+
+const SRC: &str = r#"option "operating_currency" "USD"
+
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Expenses:Food USD
+
+2024-01-15 * "Coffee"
+  Expenses:Food  5.00 USD
+  Assets:Bank
+
+2024-01-20 * "Lunch"
+  Expenses:Food  12.00 USD
+  Assets:Bank
+"#;
+
+#[test]
+fn report_uses_parse_cache_with_identical_output() {
+    let bin = require_rledger!();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let run = |verbose: bool, disable_cache: bool| {
+        let mut cmd = Command::new(&bin);
+        cmd.arg("report")
+            .arg(&file)
+            .arg("balances")
+            .arg("--no-pager");
+        if verbose {
+            cmd.arg("--verbose");
+        }
+        if disable_cache {
+            cmd.env("BEANCOUNT_DISABLE_LOAD_CACHE", "1");
+        }
+        cmd.output().expect("run rledger report")
+    };
+
+    // Cold run: parses and writes the cache.
+    let cold = run(false, false);
+    assert!(
+        cold.status.success(),
+        "cold report failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    let cold_out = String::from_utf8_lossy(&cold.stdout).into_owned();
+
+    // The cache is written alongside the source as `.<name>.cache`.
+    let cache_file = dir.path().join(".ledger.beancount.cache");
+    assert!(
+        cache_file.exists(),
+        "a cold report should have written the parse cache at {}",
+        cache_file.display()
+    );
+
+    // Warm run (verbose): must hit the cache and print identical output.
+    let warm = run(true, false);
+    assert!(
+        warm.status.success(),
+        "warm report failed: {}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&warm.stdout),
+        cold_out,
+        "cached report output must match the cold run"
+    );
+    let warm_err = String::from_utf8_lossy(&warm.stderr);
+    assert!(
+        warm_err.contains("from cache"),
+        "a verbose warm run should report a cache hit; stderr was:\n{warm_err}"
+    );
+
+    // Cache-disabled run: must still produce the same output.
+    let nocache = run(false, true);
+    assert!(nocache.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&nocache.stdout),
+        cold_out,
+        "cache-disabled report output must match the cached run"
+    );
+}

--- a/crates/rustledger/tests/report_parse_cache.rs
+++ b/crates/rustledger/tests/report_parse_cache.rs
@@ -37,7 +37,12 @@ fn report_uses_parse_cache_with_identical_output() {
         cmd.arg("report")
             .arg(&file)
             .arg("balances")
-            .arg("--no-pager");
+            .arg("--no-pager")
+            // Hermetic: ignore any cache env the developer/CI may have
+            // set, so the cache lands at the default path next to the
+            // source (`.ledger.beancount.cache`) and is actually written.
+            .env_remove("BEANCOUNT_DISABLE_LOAD_CACHE")
+            .env_remove("BEANCOUNT_LOAD_CACHE_FILENAME");
         if verbose {
             cmd.arg("--verbose");
         }


### PR DESCRIPTION
## What

`parse()` (the CST parser) dominates ledger load time and is identical run-to-run for an unchanged file. `check` already persists a parsed `LoadResult` to an on-disk cache and reuses it; **`report` did not** - it re-parsed on every invocation. This was identified as the highest value/risk lever for the balance-report regression (see ADR-0005, #1313).

This factors `check`'s "load from cache, else parse + save" step into a shared `cmd::loadcache::load_result_cached` helper and routes `report` through it, then `process()`es the result exactly as the uncached `load` did.

- Cache is keyed by the main file and **shared across commands**, so a `report` after a `check` (or a repeated `report`) is a cache hit.
- The cached `LoadResult` is the parsed (pre-booking) stream; booking/plugins still run each time, identical to the uncached path and to how `check` uses the cache.
- Disable with `BEANCOUNT_DISABLE_LOAD_CACHE` (the same opt-out `check` honors).

## Measurement

10k-transaction ledger, `rledger report ... balances`:

| | Time |
|--|------|
| cache disabled (parse every run) | ~124 ms |
| **cache hit (warm)** | **~46 ms (~2.7x)** |

Output is **byte-identical** across cold / warm / cache-disabled runs.

## Correctness

- New regression test `report_parse_cache`: a report writes the cache, a second report hits it (verified via the verbose "from cache" line), and cached / uncached / cache-disabled output is identical.
- Existing `report_pad_expansion_test` (8) still green.
- clippy + fmt clean.

## Scope notes

- Cold first runs (e.g. the nightly benchmark, which always starts cold) are unchanged - this recovers the cost users feel on *repeated* invocations. The cold-parse cost is the CST tradeoff documented in ADR-0005.
- `check` still has its own inline copy of this logic; de-duplicating `check` onto the shared helper is a safe follow-up left out here to keep this PR's blast radius on the new `report` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)