### PR TITLE
perf(query): reuse on-disk parse cache so repeated queries skip parsing

### DIFF
--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -19,7 +19,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rustledger_booking::merge_with_padding;
 use rustledger_core::DisplayContext;
-use rustledger_loader::{LoadOptions, load};
+use rustledger_loader::LoadOptions;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
@@ -115,15 +115,23 @@ pub fn run(args: &Args) -> Result<()> {
         anyhow::bail!("file not found: {}", file.display());
     }
 
-    // Load and fully process the file (parse → book → plugins)
-    // This uses the new loader API which matches Python's loader.load_file()
+    // Load and fully process the file (parse → book → plugins).
     let options = LoadOptions {
         validate: false, // Query doesn't need validation
         ..Default::default()
     };
 
-    let ledger =
-        load(file, &options).with_context(|| format!("failed to load {}", file.display()))?;
+    // Parse via the shared on-disk cache: `parse()` dominates load cost
+    // and is identical run-to-run for an unchanged file, so a repeated
+    // `query` (or a `query` after `check`/`report`) skips the parse. The
+    // cached `LoadResult` is the parsed (pre-booking) stream with a
+    // rebuilt display context (`CacheEntry::into_load_result`), so
+    // booking and the display-context-dependent BQL output below are
+    // identical to the uncached path. Disable with
+    // `BEANCOUNT_DISABLE_LOAD_CACHE`.
+    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, false, args.verbose)?;
+    let ledger = rustledger_loader::process(raw, &options)
+        .with_context(|| format!("failed to load {}", file.display()))?;
 
     // Report errors to stderr (matching bean-query behavior)
     // Continue with successfully parsed directives rather than bailing

--- a/crates/rustledger/tests/query_parse_cache.rs
+++ b/crates/rustledger/tests/query_parse_cache.rs
@@ -1,0 +1,103 @@
+//! `rledger query` reuses the on-disk parse cache (shared with `check`
+//! / `report`) so a repeated query on an unchanged file skips the
+//! expensive parse. These tests pin two guarantees:
+//!
+//! 1. A query writes the cache and a subsequent query hits it.
+//! 2. Cached, uncached, and cache-disabled runs produce byte-identical
+//!    output. The query outputs summed amounts, which depend on the
+//!    `DisplayContext` (per-currency precision); a cache hit rebuilds
+//!    that context, so this would catch an empty-context regression.
+
+mod common;
+
+use std::process::Command;
+
+const SRC: &str = r#"option "operating_currency" "USD"
+
+2024-01-01 open Assets:Bank USD
+2024-01-01 open Expenses:Food USD
+
+2024-01-15 * "Coffee"
+  Expenses:Food  5.00 USD
+  Assets:Bank
+
+2024-01-20 * "Lunch"
+  Expenses:Food  12.50 USD
+  Assets:Bank
+"#;
+
+const QUERY: &str = "SELECT account, sum(position) GROUP BY account ORDER BY account";
+
+#[test]
+fn query_uses_parse_cache_with_identical_output() {
+    let bin = require_rledger!();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let run = |verbose: bool, disable_cache: bool| {
+        let mut cmd = Command::new(&bin);
+        cmd.arg("query");
+        // `--verbose` must precede the positionals: the QUERY arg is
+        // `trailing_var_arg`, so anything after the file is captured as
+        // query text.
+        if verbose {
+            cmd.arg("--verbose");
+        }
+        cmd.arg(&file).arg(QUERY);
+        // Hermetic: ignore any cache env the developer/CI may have set,
+        // so the cache lands at the default path next to the source and
+        // is actually written.
+        cmd.env_remove("BEANCOUNT_DISABLE_LOAD_CACHE")
+            .env_remove("BEANCOUNT_LOAD_CACHE_FILENAME");
+        if disable_cache {
+            cmd.env("BEANCOUNT_DISABLE_LOAD_CACHE", "1");
+        }
+        cmd.output().expect("run rledger query")
+    };
+
+    // Cold run: parses and writes the cache.
+    let cold = run(false, false);
+    assert!(
+        cold.status.success(),
+        "cold query failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    let cold_out = String::from_utf8_lossy(&cold.stdout).into_owned();
+
+    // The cache is written alongside the source as `.<name>.cache`.
+    let cache_file = dir.path().join(".ledger.beancount.cache");
+    assert!(
+        cache_file.exists(),
+        "a cold query should have written the parse cache at {}",
+        cache_file.display()
+    );
+
+    // Warm run (verbose): must hit the cache and print identical output.
+    let warm = run(true, false);
+    assert!(
+        warm.status.success(),
+        "warm query failed: {}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&warm.stdout),
+        cold_out,
+        "cached query output must match the cold run (incl. amount precision)"
+    );
+    let warm_err = String::from_utf8_lossy(&warm.stderr);
+    assert!(
+        warm_err.contains("from cache"),
+        "a verbose warm run should report a cache hit; stderr was:\n{warm_err}"
+    );
+
+    // Cache-disabled run: must still produce the same output.
+    let nocache = run(false, true);
+    assert!(nocache.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&nocache.stdout),
+        cold_out,
+        "cache-disabled query output must match the cached run"
+    );
+}


### PR DESCRIPTION
## What

Follow-up to #1314. `query` is the other CLI command ADR-0005 named that re-parsed on **every** invocation. It now routes through the same shared `cmd::loadcache::load_result_cached` helper and `process()`es the result, exactly like `report` and `check`.

- Cache keyed by the main file and **shared across commands** - a repeated `query` (or a `query` after `check`/`report`) is a cache hit. Verified manually: a `query` writes the cache and a subsequent `report` reads it.
- Disable with `BEANCOUNT_DISABLE_LOAD_CACHE`.

## Why this exercises the #1314 hardening

Unlike `report`, **`query` reads `ledger.display_context`** to format BQL output. That's exactly the consumer the display-context rebuild in #1314's `CacheEntry::into_load_result` was added for. The regression test queries summed amounts and asserts **byte-identical output including per-currency precision** across cold / warm / cache-disabled runs - so an empty-context-on-hit regression would fail it.

## Tests

- New `query_parse_cache`: cache written on cold, hit on warm (verified via verbose "from cache"), identical output across cold/warm/cache-disabled. (`--verbose` is placed before the positionals since `query`'s `QUERY` arg is `trailing_var_arg`.)
- `rustledger-query` engine suite (139+377+13+3) unaffected; `cli_commands_test` (48) green; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)