### PR TITLE
refactor(cli): unify report/query/check on shared parse-cache helper + --no-cache flags

### DIFF
--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -388,6 +388,7 @@ fn main() -> ExitCode {
                 args.verbose,
                 &format,
                 args.no_pager,
+                args.no_cache,
             ) {
                 Ok(()) => ExitCode::SUCCESS,
                 Err(e) if rustledger::pager::is_broken_pipe(&e) => ExitCode::SUCCESS,

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -5,10 +5,7 @@ use crate::report::{self, SourceCache};
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use rustledger_core::Directive;
-use rustledger_loader::{
-    CacheEntry, CachedOptions, CachedPlugin, LoadError, Loader, cache_disabled_by_env,
-    load_cache_entry, reintern_directives, save_cache_entry,
-};
+use rustledger_loader::LoadError;
 #[cfg(feature = "python-plugin-wasm")]
 use rustledger_plugin::PluginManager;
 #[cfg(feature = "python-plugin-wasm")]
@@ -185,92 +182,17 @@ pub fn run(args: &Args) -> Result<ExitCode> {
     // Determine if colors should be used (TTY detection + NO_COLOR)
     let use_color = !json_mode && report::should_use_color();
 
-    // Cache is disabled by --no-cache or by setting BEANCOUNT_DISABLE_LOAD_CACHE
-    // (the latter mirrors Python beancount's opt-out env var, see issue #939).
-    // The loader honors the env var on its own; this CLI-level check is a
-    // perf optimization that lets us skip building the cache entry entirely.
-    let cache_disabled = args.no_cache || cache_disabled_by_env();
-
-    // Try loading from cache first (unless disabled)
-    let cache_entry = if cache_disabled {
-        None
-    } else {
-        load_cache_entry(file)
-    };
-
-    let (load_result, from_cache) = if let Some(mut entry) = cache_entry {
-        if args.verbose && !args.quiet {
-            eprintln!("Loaded {} directives from cache", entry.directives.len());
-        }
-
-        // Re-intern strings to deduplicate memory
-        let dedup_count = reintern_directives(&mut entry.directives);
-        if args.verbose && !args.quiet {
-            eprintln!("Re-interned strings ({dedup_count} deduplicated)");
-        }
-
-        // Reconstruct an equivalent LoadResult (source map, plugins, and
-        // a rebuilt display context) from the cache entry. Previously
-        // open-coded here with an empty `DisplayContext`; the shared
-        // `CacheEntry::into_load_result` rebuilds the context so a cache
-        // hit is fully equivalent to a fresh parse.
-        (entry.into_load_result(), true)
-    } else {
-        // Load the file normally
-        if args.verbose && !args.quiet {
-            eprintln!("Loading {}...", file.display());
-        }
-
-        let mut loader = Loader::new();
-        let result = loader
-            .load(file)
-            .with_context(|| format!("failed to load {}", file.display()))?;
-
-        // Save to cache (unless disabled, parse errors, or option warnings).
-        // Option warnings (E7001-E7006) are not stored in the cache, so we must
-        // avoid caching files that have them — otherwise the warnings are silently
-        // lost on subsequent loads.
-        if !cache_disabled && result.errors.is_empty() && result.options.warnings.is_empty() {
-            // Collect all loaded file paths for cache (as strings for serialization)
-            let files: Vec<String> = result
-                .source_map
-                .files()
-                .iter()
-                .map(|f| f.path.to_string_lossy().into_owned())
-                .collect();
-            let files = if files.is_empty() {
-                vec![file.to_string_lossy().into_owned()]
-            } else {
-                files
-            };
-
-            // Create full cache entry
-            let entry = CacheEntry {
-                directives: result.directives.clone(),
-                options: CachedOptions::from(&result.options),
-                plugins: result
-                    .plugins
-                    .iter()
-                    .map(|p| CachedPlugin {
-                        name: p.name.clone(),
-                        config: p.config.clone(),
-                        force_python: p.force_python,
-                    })
-                    .collect(),
-                files,
-            };
-
-            if let Err(e) = save_cache_entry(file, &entry) {
-                if args.verbose && !args.quiet {
-                    eprintln!("Warning: failed to save cache: {e}");
-                }
-            } else if args.verbose && !args.quiet {
-                eprintln!("Saved {} directives to cache", result.directives.len());
-            }
-        }
-
-        (result, false)
-    };
+    // Load the parsed file via the shared on-disk parse cache
+    // (`cmd::loadcache::load_result_cached`): a cache hit skips the
+    // expensive parse and reconstructs an equivalent `LoadResult`,
+    // otherwise it parses and saves. `--no-cache` /
+    // `BEANCOUNT_DISABLE_LOAD_CACHE` disable it. `from_cache` drives the
+    // "(from cache)" note below.
+    let (load_result, from_cache) = crate::cmd::loadcache::load_result_cached(
+        file,
+        args.no_cache,
+        args.verbose && !args.quiet,
+    )?;
 
     // Build source cache for error reporting
     let mut cache = SourceCache::new();

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -131,7 +131,7 @@ pub fn run(args: &Args) -> Result<()> {
     // cached `LoadResult` is the parsed (pre-booking) stream with a
     // rebuilt display context (`CacheEntry::into_load_result`), so
     // booking and the display-context-dependent BQL output below are
-    // identical to the uncached path. Disable with
+    // identical to the uncached path. Disable with `--no-cache` or
     // `BEANCOUNT_DISABLE_LOAD_CACHE`.
     let (raw, _from_cache) =
         crate::cmd::loadcache::load_result_cached(file, args.no_cache, args.verbose)?;

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -77,6 +77,10 @@ pub struct Args {
     /// Show verbose output
     #[arg(short, long)]
     verbose: bool,
+
+    /// Disable the on-disk parse cache (always re-parse)
+    #[arg(long = "no-cache")]
+    no_cache: bool,
 }
 
 /// Output format for query results.
@@ -129,7 +133,8 @@ pub fn run(args: &Args) -> Result<()> {
     // booking and the display-context-dependent BQL output below are
     // identical to the uncached path. Disable with
     // `BEANCOUNT_DISABLE_LOAD_CACHE`.
-    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, false, args.verbose)?;
+    let (raw, _from_cache) =
+        crate::cmd::loadcache::load_result_cached(file, args.no_cache, args.verbose)?;
     let ledger = rustledger_loader::process(raw, &options)
         .with_context(|| format!("failed to load {}", file.display()))?;
 

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -187,7 +187,7 @@ pub fn run(
     // repeated `report` (or a `report` after `check`) skips the parse
     // entirely. The cached `LoadResult` is the parsed (pre-booking)
     // stream; `process` books it exactly as the uncached `load` did.
-    // Disable with `BEANCOUNT_DISABLE_LOAD_CACHE`.
+    // Disable with `--no-cache` or `BEANCOUNT_DISABLE_LOAD_CACHE`.
     let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, no_cache, verbose)?;
     let ledger = rustledger_loader::process(raw, &options)
         .with_context(|| format!("failed to load {}", file.display()))?;

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -68,6 +68,10 @@ pub struct Args {
     /// Disable pager for output
     #[arg(long, global = true)]
     pub no_pager: bool,
+
+    /// Disable the on-disk parse cache (always re-parse)
+    #[arg(long = "no-cache", global = true)]
+    pub no_cache: bool,
 }
 
 /// Output format for reports.
@@ -162,6 +166,7 @@ pub fn run(
     verbose: bool,
     format: &OutputFormat,
     no_pager: bool,
+    no_cache: bool,
 ) -> Result<()> {
     // Check if file exists
     if !file.exists() {
@@ -183,7 +188,7 @@ pub fn run(
     // entirely. The cached `LoadResult` is the parsed (pre-booking)
     // stream; `process` books it exactly as the uncached `load` did.
     // Disable with `BEANCOUNT_DISABLE_LOAD_CACHE`.
-    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, false, verbose)?;
+    let (raw, _from_cache) = crate::cmd::loadcache::load_result_cached(file, no_cache, verbose)?;
     let ledger = rustledger_loader::process(raw, &options)
         .with_context(|| format!("failed to load {}", file.display()))?;
 

--- a/crates/rustledger/tests/query_parse_cache.rs
+++ b/crates/rustledger/tests/query_parse_cache.rs
@@ -101,3 +101,37 @@ fn query_uses_parse_cache_with_identical_output() {
         "cache-disabled query output must match the cached run"
     );
 }
+
+/// The `--no-cache` flag must disable the cache entirely: a query run
+/// with it set must not write a cache file (and must still succeed).
+/// `--no-cache` precedes the positionals (QUERY is `trailing_var_arg`).
+#[test]
+fn query_no_cache_flag_skips_cache() {
+    let bin = require_rledger!();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let out = std::process::Command::new(&bin)
+        .arg("query")
+        .arg("--no-cache")
+        .arg(&file)
+        .arg(QUERY)
+        .env_remove("BEANCOUNT_DISABLE_LOAD_CACHE")
+        .env_remove("BEANCOUNT_LOAD_CACHE_FILENAME")
+        .output()
+        .expect("run rledger query --no-cache");
+    assert!(
+        out.status.success(),
+        "query --no-cache failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let cache_file = dir.path().join(".ledger.beancount.cache");
+    assert!(
+        !cache_file.exists(),
+        "--no-cache must not write the parse cache, but {} exists",
+        cache_file.display()
+    );
+}

--- a/crates/rustledger/tests/report_parse_cache.rs
+++ b/crates/rustledger/tests/report_parse_cache.rs
@@ -96,3 +96,37 @@ fn report_uses_parse_cache_with_identical_output() {
         "cache-disabled report output must match the cached run"
     );
 }
+
+/// The `--no-cache` flag must disable the cache entirely: a report run
+/// with it set must not write a cache file (and must still succeed).
+#[test]
+fn report_no_cache_flag_skips_cache() {
+    let bin = require_rledger!();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, SRC).expect("write ledger");
+
+    let out = std::process::Command::new(&bin)
+        .arg("report")
+        .arg(&file)
+        .arg("balances")
+        .arg("--no-pager")
+        .arg("--no-cache")
+        .env_remove("BEANCOUNT_DISABLE_LOAD_CACHE")
+        .env_remove("BEANCOUNT_LOAD_CACHE_FILENAME")
+        .output()
+        .expect("run rledger report --no-cache");
+    assert!(
+        out.status.success(),
+        "report --no-cache failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let cache_file = dir.path().join(".ledger.beancount.cache");
+    assert!(
+        !cache_file.exists(),
+        "--no-cache must not write the parse cache, but {} exists",
+        cache_file.display()
+    );
+}


### PR DESCRIPTION
## What

The two remaining loose ends from the parse-cache work (ADR-0005), bundled:

### 1. De-dup `check` onto the shared helper
`check` open-coded the same cache-or-parse flow that `cmd::loadcache::load_result_cached` now provides (cache lookup → reintern → reconstruct via `into_load_result`, else parse → save). Replaced its ~85-line block with a single call. The helper emits the **identical** verbose progress lines, so `check`'s CLI + snapshot tests are unchanged. `report` / `query` / `check` now share **one** parse-cache code path; the loader owns reconstruction (`CacheEntry::into_load_result`).

### 2. `--no-cache` flag for `report` and `query`
Previously they could only opt out via `BEANCOUNT_DISABLE_LOAD_CACHE`; now they have the `--no-cache` flag for parity with `check`. (For `query` the flag precedes the positionals, since `QUERY` is `trailing_var_arg`.)

## Correctness

- `check` behavior is byte-identical: `cli_commands_test` (48) and `cli_snapshot_test` (7) green - the snapshots would catch any stderr/output drift from the dedup.
- New `--no-cache`-flag tests in `report_parse_cache` / `query_parse_cache` assert no cache file is written.
- Loader `cache_env_var_test` (7) green; clippy/fmt clean.

## Notes

This completes the parse-cache cleanup. The only remaining ADR item is the green-tree rewrite, which stays documented-but-not-recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)