### PR TITLE
refactor(completion): unify LSP and WASM completion in a shared crate (#1319)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustledger-completion"
+version = "0.15.0"
+
+[[package]]
 name = "rustledger-core"
 version = "0.15.0"
 dependencies = [
@@ -3984,6 +3988,7 @@ dependencies = [
  "ropey",
  "rust_decimal",
  "rustledger-booking",
+ "rustledger-completion",
  "rustledger-core",
  "rustledger-loader",
  "rustledger-parser",
@@ -4117,6 +4122,7 @@ dependencies = [
  "js-sys",
  "rkyv 0.8.16",
  "rustledger-booking",
+ "rustledger-completion",
  "rustledger-core",
  "rustledger-loader",
  "rustledger-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/rustledger-booking",
   "crates/rustledger-validate",
   "crates/rustledger-query",
+  "crates/rustledger-completion",
   "crates/rustledger-plugin",
   "crates/rustledger-plugin-types",
   "crates/rustledger-importer",
@@ -25,6 +26,7 @@ default-members = [
   "crates/rustledger-booking",
   "crates/rustledger-validate",
   "crates/rustledger-query",
+  "crates/rustledger-completion",
   "crates/rustledger-plugin",
   "crates/rustledger-plugin-types",
   "crates/rustledger-importer",
@@ -187,6 +189,7 @@ rustledger-loader = { version = "0.15.0", path = "crates/rustledger-loader" }
 rustledger-booking = { version = "0.15.0", path = "crates/rustledger-booking" }
 rustledger-validate = { version = "0.15.0", path = "crates/rustledger-validate" }
 rustledger-query = { version = "0.15.0", path = "crates/rustledger-query" }
+rustledger-completion = { version = "0.15.0", path = "crates/rustledger-completion" }
 rustledger-plugin = { version = "0.15.0", path = "crates/rustledger-plugin", default-features = false }
 rustledger-plugin-types = { version = "0.15.0", path = "crates/rustledger-plugin-types" }
 rustledger-importer = { version = "0.15.0", path = "crates/rustledger-importer" }

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rustledger-completion"
+description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
+version = "0.15.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+authors.workspace = true
+readme = "README.md"
+
+[lib]
+bench = false
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/rustledger-completion/README.md
+++ b/crates/rustledger-completion/README.md
@@ -1,0 +1,20 @@
+# rustledger-completion
+
+Editor-agnostic completion logic for Beancount sources.
+
+This crate is the single source of truth for the completion logic shared
+between the rustledger LSP server (`rustledger-lsp`) and the WASM editor
+(`rustledger-wasm`). It is deliberately pure: no clock access, no
+`lsp-types`, no `wasm-bindgen`. Callers supply the live data (account /
+currency / payee / tag / link string lists and "today's" date) and map the
+neutral `CompletionCandidate` results into their own editor-specific item
+types.
+
+It provides:
+
+- `offset_to_byte` — map a position (UTF-8, UTF-16, or character offset)
+  to a char-boundary-safe byte offset.
+- `classify_context` — classify the text before the cursor into a
+  `CompletionContext`.
+- `*_candidates` functions — produce neutral `CompletionCandidate` lists
+  for each context.

--- a/crates/rustledger-completion/src/lib.rs
+++ b/crates/rustledger-completion/src/lib.rs
@@ -1,0 +1,836 @@
+//! Editor-agnostic completion logic for Beancount sources.
+//!
+//! This crate is the single source of truth for the completion logic
+//! shared between the LSP (`rustledger-lsp`) and the WASM editor
+//! (`rustledger-wasm`). It is deliberately pure: no clock access, no
+//! `lsp-types`, no `wasm-bindgen`. Callers supply the live data
+//! (account/currency/payee/tag/link string lists and "today's" date)
+//! and map the neutral [`CompletionCandidate`] results into their own
+//! editor-specific item types.
+//!
+//! The two responsibilities are:
+//! 1. **Context detection** — [`offset_to_byte`] maps a position
+//!    (under a [`PositionEncoding`]) to a byte offset, then
+//!    [`classify_context`] classifies the text before the cursor into a
+//!    [`CompletionContext`].
+//! 2. **Candidate generation** — the `*_candidates` functions produce
+//!    neutral [`CompletionCandidate`] lists for each context.
+
+/// Standard Beancount account types.
+pub const ACCOUNT_TYPES: &[&str] = &["Assets", "Liabilities", "Equity", "Income", "Expenses"];
+
+/// Standard Beancount directives.
+pub const DIRECTIVES: &[&str] = &[
+    "open",
+    "close",
+    "commodity",
+    "balance",
+    "pad",
+    "event",
+    "query",
+    "note",
+    "document",
+    "custom",
+    "price",
+    "txn",
+    "*",
+    "!",
+];
+
+/// Completion context detected from cursor position.
+///
+/// This is the LSP superset (the WASM editor previously lacked the
+/// `Tag`/`Link` variants; it now gains them through this crate).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompletionContext {
+    /// At the start of a line (expecting date or directive).
+    LineStart,
+    /// After a date (expecting directive keyword or flag).
+    AfterDate,
+    /// After directive keyword (expecting account).
+    ExpectingAccount,
+    /// Inside an account name (after colon).
+    AccountSegment {
+        /// The prefix typed so far (e.g., "Assets:").
+        prefix: String,
+    },
+    /// After an amount (expecting currency).
+    ExpectingCurrency,
+    /// Inside a string (payee/narration).
+    InsideString,
+    /// Typing a tag (after `#`) on a transaction header or in
+    /// `pushtag`/`poptag`.
+    Tag,
+    /// Typing a link (after `^`) on a transaction header.
+    Link,
+    /// Unknown context.
+    Unknown,
+}
+
+/// How a position offset is encoded by the caller.
+///
+/// The LSP negotiates UTF-8 byte offsets or UTF-16 code units; the WASM
+/// editor passes character (Unicode scalar value) offsets. All three map
+/// to a byte offset via [`offset_to_byte`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PositionEncoding {
+    /// UTF-8 byte offsets.
+    Utf8,
+    /// UTF-16 code units (the LSP 3.17 default).
+    Utf16,
+    /// Unicode scalar value (character) offsets — the WASM editor's
+    /// convention (see issue #1289).
+    Char,
+}
+
+/// The kind of a completion candidate.
+///
+/// One variant per distinct item kind emitted by either adapter, so the
+/// neutral candidate can be mapped back to the exact LSP
+/// `CompletionItemKind` / WASM `CompletionKind` it replaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionKind {
+    /// Today's date template (line start).
+    Date,
+    /// A directive keyword (after a date).
+    Directive,
+    /// A standard account type (`Assets:`, `Expenses:`, …).
+    AccountType,
+    /// A fully-qualified known account name.
+    Account,
+    /// An intermediate account segment that has further sub-segments
+    /// (rendered as a folder).
+    AccountSegmentFolder,
+    /// A currency/commodity.
+    Currency,
+    /// A known payee name.
+    Payee,
+    /// A tag (after `#`).
+    Tag,
+    /// A link (after `^`).
+    Link,
+}
+
+/// A neutral, editor-agnostic completion candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionCandidate {
+    /// The label shown in the completion popup.
+    pub label: String,
+    /// The text to insert. Distinguished from `label` (e.g. tags keep
+    /// the `#` in `label` but drop it in `insert_text`). When equal to
+    /// `label` (no special insert behavior) adapters may treat it as
+    /// "no explicit insert text".
+    pub insert_text: String,
+    /// The kind of candidate.
+    pub kind: CompletionKind,
+    /// Human-readable detail string, if any.
+    pub detail: Option<String>,
+}
+
+/// Map a position `offset` (in the given `encoding`) into a byte offset
+/// into `line`, clamped to a char boundary.
+///
+/// - [`PositionEncoding::Utf8`] / [`PositionEncoding::Utf16`] walk the
+///   line's chars once accumulating the encoded length, bailing at the
+///   start of the char a mid-char offset would land in (the LSP
+///   behavior).
+/// - [`PositionEncoding::Char`] treats `offset` as a character index and
+///   maps to the byte offset of that char, clamping past end-of-line to
+///   the line length (the #1289 WASM behavior).
+///
+/// The result is always a valid char boundary in `line`, so slicing
+/// `&line[..offset_to_byte(...)]` never panics.
+#[must_use]
+pub fn offset_to_byte(line: &str, offset: usize, encoding: PositionEncoding) -> usize {
+    match encoding {
+        PositionEncoding::Char => line
+            .char_indices()
+            .nth(offset)
+            .map_or(line.len(), |(b, _)| b),
+        PositionEncoding::Utf8 | PositionEncoding::Utf16 => {
+            let mut acc = 0usize;
+            let mut byte_col = 0usize;
+            for ch in line.chars() {
+                if acc >= offset {
+                    break;
+                }
+                let u = match encoding {
+                    PositionEncoding::Utf8 => ch.len_utf8(),
+                    PositionEncoding::Utf16 => ch.len_utf16(),
+                    PositionEncoding::Char => unreachable!(),
+                };
+                if acc + u > offset {
+                    // Position lands mid-char — bail at the start of this char.
+                    break;
+                }
+                acc += u;
+                byte_col += ch.len_utf8();
+            }
+            byte_col
+        }
+    }
+}
+
+/// Classify the completion context from the text before the cursor.
+///
+/// `before_cursor` is the slice of the current line up to (and not
+/// including) the cursor, already mapped to a byte boundary via
+/// [`offset_to_byte`].
+///
+/// This is the LSP classification body, ported verbatim, including the
+/// `in_code_position`-gated Tag/Link detection.
+#[must_use]
+pub fn classify_context(before_cursor: &str) -> CompletionContext {
+    let trimmed = before_cursor.trim_start();
+
+    // Check if we're at the start of a posting (indented line)
+    // This must come before the empty check since an indented line
+    // with just spaces should be expecting an account.
+    if before_cursor.starts_with("  ") || before_cursor.starts_with('\t') {
+        // Empty indented line means expecting an account
+        if trimmed.is_empty() {
+            return CompletionContext::ExpectingAccount;
+        }
+        // Inside a posting - could be account or amount
+        let posting_content = trimmed;
+
+        // Check if there's already an account (contains colon and space after)
+        if posting_content.contains(':') && posting_content.contains(' ') {
+            // After account, might be expecting amount or currency
+            let parts: Vec<&str> = posting_content.split_whitespace().collect();
+            if parts.len() >= 2 {
+                // Check if last part looks like a number
+                if let Some(last) = parts.last()
+                    && (last.parse::<f64>().is_ok() || last.ends_with('.'))
+                {
+                    return CompletionContext::ExpectingCurrency;
+                }
+            }
+            return CompletionContext::Unknown;
+        }
+
+        // Check if typing an account segment
+        if let Some(colon_pos) = posting_content.rfind(':') {
+            let prefix = &posting_content[..=colon_pos];
+            return CompletionContext::AccountSegment {
+                prefix: prefix.to_string(),
+            };
+        }
+
+        // Starting an account name
+        return CompletionContext::ExpectingAccount;
+    }
+
+    // Tag (`#tag`) / link (`^link`) completion. Tags and links appear
+    // on transaction header lines (after the date/flag/strings) and in
+    // `pushtag`/`poptag` directives. We trigger when the token directly
+    // under the cursor begins with the sigil, but only when the cursor
+    // is in *code* position: not inside a string literal (a `#` in a
+    // narration is just text) and not after a comment marker. The
+    // cursor must also sit at the end of the token (no trailing
+    // whitespace), i.e. the user is still typing it.
+    if in_code_position(before_cursor)
+        && !before_cursor.ends_with(char::is_whitespace)
+        && let Some(token) = before_cursor.split_whitespace().next_back()
+    {
+        if token.starts_with('#') {
+            return CompletionContext::Tag;
+        }
+        if token.starts_with('^') {
+            return CompletionContext::Link;
+        }
+    }
+
+    // Empty or whitespace only at line start (not indented)
+    if trimmed.is_empty() {
+        return CompletionContext::LineStart;
+    }
+
+    // Check for date at line start (YYYY-MM-DD pattern). Guard the
+    // 10-byte split on a char boundary: a `YYYY-MM-DD` prefix is all
+    // ASCII, so if byte 10 lands mid-character the line can't be a
+    // date, and slicing there would panic on multi-byte input.
+    if trimmed.len() >= 10 && trimmed.is_char_boundary(10) && is_date_like(&trimmed[..10]) {
+        let after_date = trimmed[10..].trim_start();
+        if after_date.is_empty() {
+            return CompletionContext::AfterDate;
+        }
+
+        // Check for directive keywords
+        for directive in DIRECTIVES {
+            if let Some(rest) = after_date.strip_prefix(directive) {
+                let after_directive = rest.trim_start();
+                if after_directive.is_empty() || !after_directive.contains(' ') {
+                    // After directive, expecting account for most directives
+                    match *directive {
+                        "open" | "close" | "balance" | "pad" | "note" | "document" => {
+                            if let Some(colon_pos) = after_directive.rfind(':') {
+                                return CompletionContext::AccountSegment {
+                                    prefix: after_directive[..=colon_pos].to_string(),
+                                };
+                            }
+                            return CompletionContext::ExpectingAccount;
+                        }
+                        _ => return CompletionContext::Unknown,
+                    }
+                }
+            }
+        }
+
+        // After date but no recognized directive yet
+        return CompletionContext::AfterDate;
+    }
+
+    // Check if inside a quoted string
+    let quote_count = before_cursor.chars().filter(|&c| c == '"').count();
+    if quote_count % 2 == 1 {
+        return CompletionContext::InsideString;
+    }
+
+    CompletionContext::Unknown
+}
+
+/// Whether the end of `before` is in "code" position: not inside a
+/// string literal and not past a comment marker. A single forward scan
+/// tracks string state with backslash-escape handling, matching the
+/// lexer's string rule (`"([^"\\]|\\.)*"`), so a `"` or `;` that lives
+/// *inside* a narration does not flip the classification. An unescaped,
+/// unquoted `;` starts a comment, after which nothing is code.
+fn in_code_position(before: &str) -> bool {
+    let mut in_string = false;
+    let mut escaped = false;
+    for ch in before.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+        } else if ch == '"' {
+            in_string = true;
+        } else if ch == ';' {
+            // Comment marker outside any string: rest of line is comment.
+            return false;
+        }
+    }
+    !in_string
+}
+
+/// Check if a string looks like a date (YYYY-MM-DD).
+fn is_date_like(s: &str) -> bool {
+    if s.len() != 10 {
+        return false;
+    }
+    let chars: Vec<char> = s.chars().collect();
+    chars[4] == '-'
+        && chars[7] == '-'
+        && chars.iter().enumerate().all(|(i, c)| {
+            if i == 4 || i == 7 {
+                *c == '-'
+            } else {
+                c.is_ascii_digit()
+            }
+        })
+}
+
+/// The detail string shown for a directive keyword.
+#[must_use]
+fn directive_detail(directive: &str) -> &'static str {
+    match directive {
+        "open" => "Open an account",
+        "close" => "Close an account",
+        "commodity" => "Define a commodity/currency",
+        "balance" => "Assert account balance",
+        "pad" => "Pad account to target",
+        "event" => "Record an event",
+        "query" => "Define a named query",
+        "note" => "Add a note to an account",
+        "document" => "Link a document",
+        "custom" => "Custom directive",
+        "price" => "Record a price",
+        "txn" | "*" => "Transaction (complete)",
+        "!" => "Transaction (incomplete)",
+        _ => "",
+    }
+}
+
+/// Candidates at line start: a single date template using the supplied
+/// `today` string (the crate is clock-free; each adapter passes its own
+/// date).
+#[must_use]
+pub fn line_start_candidates(today: &str) -> Vec<CompletionCandidate> {
+    vec![CompletionCandidate {
+        label: today.to_string(),
+        insert_text: format!("{today} "),
+        kind: CompletionKind::Date,
+        detail: Some("Today's date".to_string()),
+    }]
+}
+
+/// Candidates after a date: the directive keywords.
+#[must_use]
+pub fn after_date_candidates() -> Vec<CompletionCandidate> {
+    DIRECTIVES
+        .iter()
+        .map(|&d| CompletionCandidate {
+            label: d.to_string(),
+            insert_text: format!("{d} "),
+            kind: CompletionKind::Directive,
+            detail: Some(directive_detail(d).to_string()),
+        })
+        .collect()
+}
+
+/// Candidates when starting an account name: the standard account types
+/// followed by every known account.
+///
+/// `accounts` must be the full, sorted, deduplicated list of known
+/// accounts — the adapters gather it the same way (file + ledger state).
+/// We return every known account: the client filters by the typed
+/// prefix, and capping server-side defeats that filtering (issue #1183).
+#[must_use]
+pub fn account_start_candidates(accounts: &[String]) -> Vec<CompletionCandidate> {
+    let mut items: Vec<CompletionCandidate> = ACCOUNT_TYPES
+        .iter()
+        .map(|&t| CompletionCandidate {
+            label: format!("{t}:"),
+            insert_text: format!("{t}:"),
+            kind: CompletionKind::AccountType,
+            detail: Some(format!("{t} account type")),
+        })
+        .collect();
+
+    for account in accounts {
+        items.push(CompletionCandidate {
+            label: account.clone(),
+            insert_text: account.clone(),
+            kind: CompletionKind::Account,
+            detail: Some("Known account".to_string()),
+        });
+    }
+
+    items
+}
+
+/// Candidates for the next account segment after a `prefix`.
+///
+/// For a `prefix` like `Assets:`, emits the unique next segments of
+/// every account that starts with `prefix`; a segment that has further
+/// sub-segments is a folder (inserts `segment:`), otherwise a leaf
+/// account (inserts `segment`).
+#[must_use]
+pub fn account_segment_candidates(prefix: &str, accounts: &[String]) -> Vec<CompletionCandidate> {
+    // Find accounts that start with this prefix
+    let matching: Vec<_> = accounts.iter().filter(|a| a.starts_with(prefix)).collect();
+
+    // Extract unique next segments
+    let mut segments: Vec<String> = matching
+        .iter()
+        .filter_map(|a| {
+            let after_prefix = &a[prefix.len()..];
+            let next_segment = after_prefix.split(':').next()?;
+            if next_segment.is_empty() {
+                None
+            } else {
+                Some(next_segment.to_string())
+            }
+        })
+        .collect();
+
+    segments.sort();
+    segments.dedup();
+
+    segments
+        .into_iter()
+        .map(|seg| {
+            let full = format!("{prefix}{seg}");
+            // Check if this is a complete account or has more segments
+            let has_more = matching.iter().any(|a| a.starts_with(&format!("{full}:")));
+            let insert_text = if has_more {
+                format!("{seg}:")
+            } else {
+                seg.clone()
+            };
+            CompletionCandidate {
+                label: seg,
+                insert_text,
+                kind: if has_more {
+                    CompletionKind::AccountSegmentFolder
+                } else {
+                    CompletionKind::Account
+                },
+                detail: Some(if has_more {
+                    "Account segment".to_string()
+                } else {
+                    "Account".to_string()
+                }),
+            }
+        })
+        .collect()
+}
+
+/// Candidates for a currency after an amount.
+#[must_use]
+pub fn currency_candidates(currencies: &[String]) -> Vec<CompletionCandidate> {
+    currencies
+        .iter()
+        .map(|c| CompletionCandidate {
+            label: c.clone(),
+            insert_text: c.clone(),
+            kind: CompletionKind::Currency,
+            detail: Some("Currency".to_string()),
+        })
+        .collect()
+}
+
+/// Candidates for a payee/narration inside a string. Returns all known
+/// payees — the client filters (issue #1183, the `.take(20)` trap).
+#[must_use]
+pub fn payee_candidates(payees: &[String]) -> Vec<CompletionCandidate> {
+    payees
+        .iter()
+        .map(|p| CompletionCandidate {
+            label: p.clone(),
+            insert_text: p.clone(),
+            kind: CompletionKind::Payee,
+            detail: Some("Known payee".to_string()),
+        })
+        .collect()
+}
+
+/// Candidates for a tag after `#` (issue #1268).
+///
+/// The `#` is a trigger character the user has already typed, so
+/// `insert_text` carries the tag name *without* the `#`; `label` keeps
+/// the `#` for a readable popup. `tags` come back without the leading
+/// `#` from the core extractor.
+#[must_use]
+pub fn tag_candidates(tags: &[String]) -> Vec<CompletionCandidate> {
+    tags.iter()
+        .map(|tag| CompletionCandidate {
+            label: format!("#{tag}"),
+            insert_text: tag.clone(),
+            kind: CompletionKind::Tag,
+            detail: Some("Tag".to_string()),
+        })
+        .collect()
+}
+
+/// Candidates for a link after `^` (issue #1268). Mirrors
+/// [`tag_candidates`]; the sigil is kept in `label` and dropped in
+/// `insert_text`.
+#[must_use]
+pub fn link_candidates(links: &[String]) -> Vec<CompletionCandidate> {
+    links
+        .iter()
+        .map(|link| CompletionCandidate {
+            label: format!("^{link}"),
+            insert_text: link.clone(),
+            kind: CompletionKind::Link,
+            detail: Some("Link".to_string()),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Classify the context at the end of `before` (the whole string is
+    /// treated as the text before the cursor).
+    fn ctx(before: &str) -> CompletionContext {
+        classify_context(before)
+    }
+
+    #[test]
+    fn test_is_date_like() {
+        assert!(is_date_like("2024-01-15"));
+        assert!(is_date_like("2000-12-31"));
+        assert!(!is_date_like("2024/01/15"));
+        assert!(!is_date_like("24-01-15"));
+        assert!(!is_date_like("not-a-date"));
+    }
+
+    #[test]
+    fn classify_line_start() {
+        assert_eq!(ctx(""), CompletionContext::LineStart);
+        // A single leading space is not the 2-space posting indent.
+        assert_eq!(ctx(" "), CompletionContext::LineStart);
+    }
+
+    #[test]
+    fn classify_after_date() {
+        assert_eq!(ctx("2024-01-15 "), CompletionContext::AfterDate);
+    }
+
+    #[test]
+    fn classify_expecting_account() {
+        assert_eq!(ctx("  "), CompletionContext::ExpectingAccount);
+        assert_eq!(ctx("2024-01-15 open "), CompletionContext::ExpectingAccount);
+    }
+
+    #[test]
+    fn classify_account_segment() {
+        assert_eq!(
+            ctx("  Assets:"),
+            CompletionContext::AccountSegment {
+                prefix: "Assets:".to_string()
+            }
+        );
+        assert_eq!(
+            ctx("2024-01-15 open Assets:"),
+            CompletionContext::AccountSegment {
+                prefix: "Assets:".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_expecting_currency() {
+        assert_eq!(
+            ctx("  Assets:Bank  100.00 "),
+            CompletionContext::ExpectingCurrency
+        );
+    }
+
+    #[test]
+    fn classify_inside_string() {
+        assert_eq!(ctx("text \"inside"), CompletionContext::InsideString);
+    }
+
+    #[test]
+    fn classify_unknown() {
+        assert_eq!(ctx("some random text"), CompletionContext::Unknown);
+    }
+
+    #[test]
+    fn classify_tag_on_transaction_header() {
+        assert_eq!(
+            ctx("2024-01-15 * \"Central Perk\" #cof"),
+            CompletionContext::Tag
+        );
+        assert_eq!(
+            ctx("2024-01-15 * \"Central Perk\" #"),
+            CompletionContext::Tag
+        );
+    }
+
+    #[test]
+    fn classify_link_on_transaction_header() {
+        assert_eq!(
+            ctx("2024-01-15 * \"Central Perk\" ^trip"),
+            CompletionContext::Link
+        );
+    }
+
+    #[test]
+    fn classify_tag_on_pushtag() {
+        assert_eq!(ctx("pushtag #tr"), CompletionContext::Tag);
+        assert_eq!(ctx("poptag #tr"), CompletionContext::Tag);
+    }
+
+    #[test]
+    fn classify_hash_inside_string_is_not_tag() {
+        let c = ctx("2024-01-15 * \"paid #5 invoice");
+        assert_ne!(c, CompletionContext::Tag);
+        assert_ne!(c, CompletionContext::Link);
+    }
+
+    #[test]
+    fn classify_hash_in_comment_is_not_tag() {
+        let c = ctx("2024-01-15 * \"Lunch\" ; see #123");
+        assert_ne!(c, CompletionContext::Tag);
+        assert_ne!(c, CompletionContext::Link);
+    }
+
+    #[test]
+    fn classify_after_completed_tag_is_not_tag() {
+        assert_eq!(
+            ctx("2024-01-15 * \"Central Perk\" #coffee "),
+            CompletionContext::AfterDate
+        );
+    }
+
+    #[test]
+    fn classify_tag_after_semicolon_inside_string() {
+        assert_eq!(ctx("2024-01-15 * \"a;b\" #tr"), CompletionContext::Tag);
+    }
+
+    #[test]
+    fn classify_escaped_quote_keeps_string_open() {
+        let c = ctx("2024-01-15 * \"a\\\"b #tag");
+        assert_ne!(c, CompletionContext::Tag);
+        assert_ne!(c, CompletionContext::Link);
+    }
+
+    #[test]
+    fn test_in_code_position() {
+        assert!(in_code_position("2024-01-15 * \"x\" #"));
+        assert!(in_code_position("pushtag #"));
+        assert!(!in_code_position("2024-01-15 * \"x\" ; "));
+        assert!(!in_code_position("2024-01-15 * \"open"));
+        assert!(in_code_position("2024-01-15 * \"a;b\" "));
+        assert!(!in_code_position("2024-01-15 * \"a\\\"b"));
+    }
+
+    // ---- offset_to_byte ----
+
+    #[test]
+    fn offset_to_byte_char_korean_partial_segment() {
+        // #1289: "  Liabilities:Card:롯", char offset 20 is after "롯".
+        let line = "  Liabilities:Card:롯";
+        let byte = offset_to_byte(line, 20, PositionEncoding::Char);
+        // The slice must not panic and must contain the colon prefix.
+        let before = &line[..byte];
+        assert_eq!(
+            classify_context(before),
+            CompletionContext::AccountSegment {
+                prefix: "Liabilities:Card:".to_string()
+            }
+        );
+        // Offset 19 (at the colon, before "롯") is the other boundary.
+        let byte19 = offset_to_byte(line, 19, PositionEncoding::Char);
+        assert_eq!(
+            classify_context(&line[..byte19]),
+            CompletionContext::AccountSegment {
+                prefix: "Liabilities:Card:".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn offset_to_byte_char_past_end_clamps() {
+        let line = "abc";
+        assert_eq!(offset_to_byte(line, 100, PositionEncoding::Char), 3);
+    }
+
+    #[test]
+    fn offset_to_byte_utf16_surrogate_pair() {
+        // "🍣" is 2 UTF-16 units, 4 UTF-8 bytes.
+        let line = "a🍣b";
+        // After 'a' (1 unit) + "🍣" (2 units) = 3 units -> byte 5.
+        assert_eq!(offset_to_byte(line, 3, PositionEncoding::Utf16), 5);
+        // Mid-surrogate (offset 2) bails at the start of "🍣" -> byte 1.
+        assert_eq!(offset_to_byte(line, 2, PositionEncoding::Utf16), 1);
+    }
+
+    #[test]
+    fn offset_to_byte_utf8_multibyte() {
+        // "소" is 3 UTF-8 bytes.
+        let line = "x소y";
+        // After 'x' (1 byte) + "소" (3 bytes) = byte 4.
+        assert_eq!(offset_to_byte(line, 4, PositionEncoding::Utf8), 4);
+        // Mid-char (offset 2) bails at the start of "소" -> byte 1.
+        assert_eq!(offset_to_byte(line, 2, PositionEncoding::Utf8), 1);
+    }
+
+    // ---- candidate algorithms ----
+
+    #[test]
+    fn line_start_candidate_uses_supplied_date() {
+        let items = line_start_candidates("2026-06-12");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, "2026-06-12");
+        assert_eq!(items[0].insert_text, "2026-06-12 ");
+        assert_eq!(items[0].kind, CompletionKind::Date);
+    }
+
+    #[test]
+    fn after_date_candidates_returns_all_directives() {
+        let items = after_date_candidates();
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"open"));
+        assert!(labels.contains(&"close"));
+        assert!(labels.contains(&"balance"));
+        assert!(labels.contains(&"*"));
+        assert!(labels.contains(&"!"));
+        // insert_text appends a space.
+        let open = items.iter().find(|i| i.label == "open").unwrap();
+        assert_eq!(open.insert_text, "open ");
+        assert_eq!(open.detail.as_deref(), Some("Open an account"));
+    }
+
+    #[test]
+    fn account_start_candidates_includes_types_and_all_accounts() {
+        let accounts: Vec<String> = (1..=30)
+            .map(|n| format!("Expenses:ExpenseType{n:02}"))
+            .collect();
+        let items = account_start_candidates(&accounts);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"Assets:"));
+        // No cap (#1183): all 30 accounts present.
+        assert!(labels.contains(&"Expenses:ExpenseType19"));
+        assert!(labels.contains(&"Expenses:ExpenseType20"));
+        assert!(labels.contains(&"Expenses:ExpenseType30"));
+        // Account-type entry is a folder kind.
+        let assets = items.iter().find(|i| i.label == "Assets:").unwrap();
+        assert_eq!(assets.kind, CompletionKind::AccountType);
+    }
+
+    #[test]
+    fn account_segment_candidates_filters_and_marks_folders() {
+        let accounts = vec![
+            "Assets:Bank:Checking".to_string(),
+            "Assets:Bank:Savings".to_string(),
+            "Assets:Crypto".to_string(),
+            "Expenses:Food".to_string(),
+        ];
+        let items = account_segment_candidates("Assets:Bank:", &accounts);
+        assert_eq!(items.len(), 2);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"Checking"));
+        assert!(labels.contains(&"Savings"));
+        // Leaf segments insert without a trailing colon.
+        let checking = items.iter().find(|i| i.label == "Checking").unwrap();
+        assert_eq!(checking.insert_text, "Checking");
+        assert_eq!(checking.kind, CompletionKind::Account);
+
+        // Top-level prefix: "Bank" has more, "Crypto" does not.
+        let top = account_segment_candidates("Assets:", &accounts);
+        let bank = top.iter().find(|i| i.label == "Bank").unwrap();
+        assert_eq!(bank.kind, CompletionKind::AccountSegmentFolder);
+        assert_eq!(bank.insert_text, "Bank:");
+        let crypto = top.iter().find(|i| i.label == "Crypto").unwrap();
+        assert_eq!(crypto.kind, CompletionKind::Account);
+        assert_eq!(crypto.insert_text, "Crypto");
+    }
+
+    #[test]
+    fn currency_candidates_basic() {
+        let items = currency_candidates(&["USD".to_string(), "EUR".to_string()]);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].kind, CompletionKind::Currency);
+        assert_eq!(items[0].detail.as_deref(), Some("Currency"));
+    }
+
+    #[test]
+    fn payee_candidates_returns_all() {
+        let payees: Vec<String> = (1..=30).map(|n| format!("Buy{n:02}")).collect();
+        let items = payee_candidates(&payees);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"Buy19"));
+        assert!(labels.contains(&"Buy20"));
+        assert!(labels.contains(&"Buy30"));
+        assert_eq!(items[0].kind, CompletionKind::Payee);
+    }
+
+    #[test]
+    fn tag_candidates_keep_sigil_in_label_only() {
+        let items = tag_candidates(&["coffee".to_string(), "morning".to_string()]);
+        let coffee = items.iter().find(|i| i.label == "#coffee").unwrap();
+        assert_eq!(coffee.insert_text, "coffee");
+        assert_eq!(coffee.kind, CompletionKind::Tag);
+        assert_eq!(coffee.detail.as_deref(), Some("Tag"));
+    }
+
+    #[test]
+    fn link_candidates_keep_sigil_in_label_only() {
+        let items = link_candidates(&["trip-2024".to_string()]);
+        let trip = items.iter().find(|i| i.label == "^trip-2024").unwrap();
+        assert_eq!(trip.insert_text, "trip-2024");
+        assert_eq!(trip.kind, CompletionKind::Link);
+        assert_eq!(trip.detail.as_deref(), Some("Link"));
+    }
+}

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -28,6 +28,7 @@ parking_lot.workspace = true
 # Our crates
 rustledger-parser.workspace = true
 rustledger-core.workspace = true
+rustledger-completion.workspace = true
 rustledger-loader = { workspace = true, features = ["plugins"] }
 rustledger-booking.workspace = true
 rustledger-validate.workspace = true

--- a/crates/rustledger-lsp/src/handlers/completion.rs
+++ b/crates/rustledger-lsp/src/handlers/completion.rs
@@ -5,60 +5,25 @@
 //! - Currencies (after amounts)
 //! - Directives (after dates)
 //! - Payees and narrations (in transaction headers)
+//! - Tags (`#`) and links (`^`) on transaction headers
+//!
+//! The detection and candidate logic lives in the editor-agnostic
+//! `rustledger-completion` crate (issue #1319). This module is a thin
+//! adapter: it gathers the live account/currency/payee/tag/link strings
+//! from the parse result and ledger state, calls the shared candidate
+//! algorithms, and maps the neutral [`CompletionCandidate`] results into
+//! `lsp_types::CompletionItem` (kind mapping + resolve `uri` data).
 
 use crate::ledger_state::LedgerState;
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, Position,
 };
+use rustledger_completion::{CompletionCandidate, CompletionKind};
 use rustledger_parser::ParseResult;
 
-/// Standard Beancount account types.
-const ACCOUNT_TYPES: &[&str] = &["Assets", "Liabilities", "Equity", "Income", "Expenses"];
-
-/// Standard Beancount directives.
-const DIRECTIVES: &[&str] = &[
-    "open",
-    "close",
-    "commodity",
-    "balance",
-    "pad",
-    "event",
-    "query",
-    "note",
-    "document",
-    "custom",
-    "price",
-    "txn",
-    "*",
-    "!",
-];
-
-/// Completion context detected from cursor position.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CompletionContext {
-    /// At the start of a line (expecting date or directive)
-    LineStart,
-    /// After a date (expecting directive keyword or flag)
-    AfterDate,
-    /// After directive keyword (expecting account)
-    ExpectingAccount,
-    /// Inside an account name (after colon)
-    AccountSegment {
-        /// The prefix typed so far (e.g., "Assets:")
-        prefix: String,
-    },
-    /// After an amount (expecting currency)
-    ExpectingCurrency,
-    /// Inside a string (payee/narration)
-    InsideString,
-    /// Typing a tag (after `#`) on a transaction header or in
-    /// `pushtag`/`poptag`.
-    Tag,
-    /// Typing a link (after `^`) on a transaction header.
-    Link,
-    /// Unknown context
-    Unknown,
-}
+/// Re-export of the shared completion context so existing call sites and
+/// tests keep working against `handlers::completion::CompletionContext`.
+pub use rustledger_completion::CompletionContext;
 
 /// Handle a completion request.
 ///
@@ -106,8 +71,8 @@ pub fn handle_completion(
         // ledger", this log line tells you the response size without
         // needing to instrument from scratch. Cheap because completion
         // requests are user-driven, not hot-loop. The context is
-        // already logged above (line ~72) so the size alone here is
-        // enough to correlate.
+        // already logged above so the size alone here is enough to
+        // correlate.
         tracing::debug!("Completion response: {} items", items.len());
         Some(CompletionResponse::Array(items))
     }
@@ -116,143 +81,31 @@ pub fn handle_completion(
 /// Detect the completion context from cursor position.
 ///
 /// `position.character` is interpreted in the negotiated `encoding`
-/// — UTF-8 byte offset or UTF-16 code-unit count. Walking `chars()`
-/// once accumulates the encoded length so the conversion is correct
-/// under either negotiation.
+/// — UTF-8 byte offset or UTF-16 code-unit count. The shared
+/// `offset_to_byte` maps it to a char-boundary byte offset; the shared
+/// `classify_context` then classifies the text before the cursor.
 fn detect_context(
     source: &str,
     position: Position,
     encoding: super::utils::PositionEncoding,
 ) -> CompletionContext {
-    use super::utils::PositionEncoding;
     let line = get_line(source, position.line as usize);
+    let byte_col = rustledger_completion::offset_to_byte(
+        line,
+        position.character as usize,
+        shared_encoding(encoding),
+    );
+    rustledger_completion::classify_context(&line[..byte_col])
+}
 
-    // Map `position.character` (in the negotiated encoding) to a byte
-    // offset into `line`. Walks chars once.
-    let col = position.character as usize;
-    let mut acc = 0usize;
-    let mut byte_col = 0usize;
-    for ch in line.chars() {
-        if acc >= col {
-            break;
-        }
-        let u = match encoding {
-            PositionEncoding::Utf8 => ch.len_utf8(),
-            PositionEncoding::Utf16 => ch.len_utf16(),
-        };
-        if acc + u > col {
-            // Position lands mid-char — bail at the start of this char.
-            break;
-        }
-        acc += u;
-        byte_col += ch.len_utf8();
+/// Map the LSP's `PositionEncoding` to the shared crate's.
+fn shared_encoding(
+    encoding: super::utils::PositionEncoding,
+) -> rustledger_completion::PositionEncoding {
+    match encoding {
+        super::utils::PositionEncoding::Utf8 => rustledger_completion::PositionEncoding::Utf8,
+        super::utils::PositionEncoding::Utf16 => rustledger_completion::PositionEncoding::Utf16,
     }
-    let before_cursor = &line[..byte_col];
-
-    let trimmed = before_cursor.trim_start();
-
-    // Check if we're at the start of a posting (indented line)
-    // This must come before the empty check since an indented line
-    // with just spaces should be expecting an account.
-    if before_cursor.starts_with("  ") || before_cursor.starts_with('\t') {
-        // Empty indented line means expecting an account
-        if trimmed.is_empty() {
-            return CompletionContext::ExpectingAccount;
-        }
-        // Inside a posting - could be account or amount
-        let posting_content = trimmed;
-
-        // Check if there's already an account (contains colon and space after)
-        if posting_content.contains(':') && posting_content.contains(' ') {
-            // After account, might be expecting amount or currency
-            let parts: Vec<&str> = posting_content.split_whitespace().collect();
-            if parts.len() >= 2 {
-                // Check if last part looks like a number
-                if let Some(last) = parts.last()
-                    && (last.parse::<f64>().is_ok() || last.ends_with('.'))
-                {
-                    return CompletionContext::ExpectingCurrency;
-                }
-            }
-            return CompletionContext::Unknown;
-        }
-
-        // Check if typing an account segment
-        if let Some(colon_pos) = posting_content.rfind(':') {
-            let prefix = &posting_content[..colon_pos + 1];
-            return CompletionContext::AccountSegment {
-                prefix: prefix.to_string(),
-            };
-        }
-
-        // Starting an account name
-        return CompletionContext::ExpectingAccount;
-    }
-
-    // Tag (`#tag`) / link (`^link`) completion. Tags and links appear
-    // on transaction header lines (after the date/flag/strings) and in
-    // `pushtag`/`poptag` directives. We trigger when the token directly
-    // under the cursor begins with the sigil, but only when the cursor
-    // is in *code* position: not inside a string literal (a `#` in a
-    // narration is just text) and not after a comment marker. The
-    // cursor must also sit at the end of the token (no trailing
-    // whitespace), i.e. the user is still typing it.
-    if in_code_position(before_cursor)
-        && !before_cursor.ends_with(char::is_whitespace)
-        && let Some(token) = before_cursor.split_whitespace().next_back()
-    {
-        if token.starts_with('#') {
-            return CompletionContext::Tag;
-        }
-        if token.starts_with('^') {
-            return CompletionContext::Link;
-        }
-    }
-
-    // Empty or whitespace only at line start (not indented)
-    if trimmed.is_empty() {
-        return CompletionContext::LineStart;
-    }
-
-    // Check for date at line start (YYYY-MM-DD pattern)
-    if trimmed.len() >= 10 && is_date_like(&trimmed[..10]) {
-        let after_date = trimmed[10..].trim_start();
-        if after_date.is_empty() {
-            return CompletionContext::AfterDate;
-        }
-
-        // Check for directive keywords
-        for directive in DIRECTIVES {
-            if let Some(rest) = after_date.strip_prefix(directive) {
-                let after_directive = rest.trim_start();
-                if after_directive.is_empty() || !after_directive.contains(' ') {
-                    // After directive, expecting account for most directives
-                    match *directive {
-                        "open" | "close" | "balance" | "pad" | "note" | "document" => {
-                            if let Some(colon_pos) = after_directive.rfind(':') {
-                                return CompletionContext::AccountSegment {
-                                    prefix: after_directive[..colon_pos + 1].to_string(),
-                                };
-                            }
-                            return CompletionContext::ExpectingAccount;
-                        }
-                        _ => return CompletionContext::Unknown,
-                    }
-                }
-            }
-        }
-
-        // After date but no recognized directive yet
-        return CompletionContext::AfterDate;
-    }
-
-    // Check if inside a quoted string
-    let quote_count = before_cursor.chars().filter(|&c| c == '"').count();
-    if quote_count % 2 == 1 {
-        return CompletionContext::InsideString;
-    }
-
-    CompletionContext::Unknown
 }
 
 /// Get a specific line from source.
@@ -260,138 +113,92 @@ fn get_line(source: &str, line_num: usize) -> &str {
     source.lines().nth(line_num).unwrap_or("")
 }
 
-/// Whether the end of `before` is in "code" position: not inside a
-/// string literal and not past a comment marker. A single forward scan
-/// tracks string state with backslash-escape handling, matching the
-/// lexer's string rule (`"([^"\\]|\\.)*"`), so a `"` or `;` that lives
-/// *inside* a narration does not flip the classification. An unescaped,
-/// unquoted `;` starts a comment, after which nothing is code.
-///
-/// This is what lets tag/link detection fire on `"a;b" #tag` (the `;`
-/// is in the string) while staying silent on `"x" ; #note` (real
-/// comment) and `"open #not-a-tag` (unterminated string).
-fn in_code_position(before: &str) -> bool {
-    let mut in_string = false;
-    let mut escaped = false;
-    for ch in before.chars() {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == '"' {
-                in_string = false;
-            }
-        } else if ch == '"' {
-            in_string = true;
-        } else if ch == ';' {
-            // Comment marker outside any string: rest of line is comment.
-            return false;
+/// Map a shared `CompletionKind` to the LSP `CompletionItemKind`,
+/// reproducing the kinds the previous hand-written builders emitted.
+fn lsp_kind(kind: CompletionKind) -> CompletionItemKind {
+    match kind {
+        CompletionKind::Date => CompletionItemKind::VALUE,
+        CompletionKind::Directive => CompletionItemKind::KEYWORD,
+        CompletionKind::AccountType | CompletionKind::AccountSegmentFolder => {
+            CompletionItemKind::FOLDER
         }
+        CompletionKind::Account => CompletionItemKind::VARIABLE,
+        CompletionKind::Currency => CompletionItemKind::UNIT,
+        CompletionKind::Payee => CompletionItemKind::TEXT,
+        CompletionKind::Tag => CompletionItemKind::CONSTANT,
+        CompletionKind::Link => CompletionItemKind::REFERENCE,
     }
-    !in_string
 }
 
-/// Check if a string looks like a date (YYYY-MM-DD).
-fn is_date_like(s: &str) -> bool {
-    if s.len() != 10 {
-        return false;
+/// Map a neutral [`CompletionCandidate`] into an `lsp_types::CompletionItem`,
+/// reproducing the exact item shapes the previous builders produced.
+fn to_item(candidate: CompletionCandidate) -> CompletionItem {
+    let CompletionCandidate {
+        label,
+        insert_text,
+        kind,
+        detail,
+    } = candidate;
+
+    let mut item = CompletionItem {
+        label,
+        kind: Some(lsp_kind(kind)),
+        detail,
+        ..Default::default()
+    };
+
+    match kind {
+        // The account-type / known-account / currency / payee items
+        // carried no explicit `insert_text` — the label is inserted
+        // verbatim. The shared candidate sets `insert_text == label`
+        // for these, so suppress it to match the original output.
+        CompletionKind::AccountType
+        | CompletionKind::Account
+        | CompletionKind::Currency
+        | CompletionKind::Payee => {}
+        // Date / directive / account-segment carried an `insert_text`
+        // distinct from (or appended to) the label.
+        CompletionKind::Date | CompletionKind::Directive | CompletionKind::AccountSegmentFolder => {
+            item.insert_text = Some(insert_text);
+        }
+        // Tags and links: the sigil is already typed, so insert/filter
+        // text drops it.
+        CompletionKind::Tag | CompletionKind::Link => {
+            item.filter_text = Some(insert_text.clone());
+            item.insert_text = Some(insert_text);
+        }
     }
-    let chars: Vec<char> = s.chars().collect();
-    chars[4] == '-'
-        && chars[7] == '-'
-        && chars.iter().enumerate().all(|(i, c)| {
-            if i == 4 || i == 7 {
-                *c == '-'
-            } else {
-                c.is_ascii_digit()
-            }
-        })
+
+    item
 }
 
 /// Complete at line start (date template).
 fn complete_line_start() -> Vec<CompletionItem> {
     let today = jiff::Zoned::now().date().to_string();
-    vec![CompletionItem {
-        label: today.clone(),
-        kind: Some(CompletionItemKind::VALUE),
-        detail: Some("Today's date".to_string()),
-        insert_text: Some(format!("{} ", today)),
-        ..Default::default()
-    }]
+    rustledger_completion::line_start_candidates(&today)
+        .into_iter()
+        .map(to_item)
+        .collect()
 }
 
 /// Complete after a date (directive keywords).
 fn complete_after_date() -> Vec<CompletionItem> {
-    DIRECTIVES
-        .iter()
-        .map(|&d| {
-            let detail = match d {
-                "open" => "Open an account",
-                "close" => "Close an account",
-                "commodity" => "Define a commodity/currency",
-                "balance" => "Assert account balance",
-                "pad" => "Pad account to target",
-                "event" => "Record an event",
-                "query" => "Define a named query",
-                "note" => "Add a note to an account",
-                "document" => "Link a document",
-                "custom" => "Custom directive",
-                "price" => "Record a price",
-                "txn" | "*" => "Transaction (complete)",
-                "!" => "Transaction (incomplete)",
-                _ => "",
-            };
-            CompletionItem {
-                label: d.to_string(),
-                kind: Some(CompletionItemKind::KEYWORD),
-                detail: Some(detail.to_string()),
-                insert_text: Some(format!("{} ", d)),
-                ..Default::default()
-            }
-        })
+    rustledger_completion::after_date_candidates()
+        .into_iter()
+        .map(to_item)
         .collect()
 }
 
-/// Complete account name start (account types).
+/// Complete account name start (account types + known accounts).
 fn complete_account_start(
     parse_result: &ParseResult,
     ledger_state: Option<&LedgerState>,
 ) -> Vec<CompletionItem> {
-    // First, offer standard account types
-    let mut items: Vec<CompletionItem> = ACCOUNT_TYPES
-        .iter()
-        .map(|&t| CompletionItem {
-            label: format!("{}:", t),
-            kind: Some(CompletionItemKind::FOLDER),
-            detail: Some(format!("{} account type", t)),
-            ..Default::default()
-        })
-        .collect();
-
-    // Collect known accounts from the current file and ledger state.
-    //
-    // Return every known account: the LSP client filters by the
-    // user's typed prefix, and capping server-side here defeats that
-    // filtering (the client never sees accounts past the cap, so any
-    // prefix that matches a later-sorted account silently fails to
-    // complete). The pre-fix `.take(20)` produced exactly issue
-    // #1183, where `Expenses:ExpenseType20` and later accounts
-    // wouldn't autocomplete because the alphabetical cut-off landed
-    // at `ExpenseType19`. If completion latency on enormous ledgers
-    // ever becomes a concern, switch to `isIncomplete: true` with
-    // server-side prefix filtering rather than a blind cap.
     let known_accounts = get_all_accounts(parse_result, ledger_state);
-    for account in &known_accounts {
-        items.push(CompletionItem {
-            label: account.clone(),
-            kind: Some(CompletionItemKind::VARIABLE),
-            detail: Some("Known account".to_string()),
-            ..Default::default()
-        });
-    }
-
-    items
+    rustledger_completion::account_start_candidates(&known_accounts)
+        .into_iter()
+        .map(to_item)
+        .collect()
 }
 
 /// Complete account segment after colon.
@@ -401,54 +208,9 @@ fn complete_account_segment(
     ledger_state: Option<&LedgerState>,
 ) -> Vec<CompletionItem> {
     let known_accounts = get_all_accounts(parse_result, ledger_state);
-
-    // Find accounts that start with this prefix
-    let matching: Vec<_> = known_accounts
-        .iter()
-        .filter(|a| a.starts_with(prefix))
-        .collect();
-
-    // Extract unique next segments
-    let mut segments: Vec<String> = matching
-        .iter()
-        .filter_map(|a| {
-            let after_prefix = &a[prefix.len()..];
-            let next_segment = after_prefix.split(':').next()?;
-            if next_segment.is_empty() {
-                None
-            } else {
-                Some(next_segment.to_string())
-            }
-        })
-        .collect();
-
-    segments.sort();
-    segments.dedup();
-
-    segments
+    rustledger_completion::account_segment_candidates(prefix, &known_accounts)
         .into_iter()
-        .map(|seg| {
-            let full = format!("{}{}", prefix, seg);
-            // Check if this is a complete account or has more segments
-            let has_more = matching
-                .iter()
-                .any(|a| a.starts_with(&format!("{}:", full)));
-            CompletionItem {
-                label: seg.clone(),
-                kind: Some(if has_more {
-                    CompletionItemKind::FOLDER
-                } else {
-                    CompletionItemKind::VARIABLE
-                }),
-                detail: Some(if has_more {
-                    "Account segment".to_string()
-                } else {
-                    "Account".to_string()
-                }),
-                insert_text: Some(if has_more { format!("{}:", seg) } else { seg }),
-                ..Default::default()
-            }
-        })
+        .map(to_item)
         .collect()
 }
 
@@ -458,15 +220,9 @@ fn complete_currency(
     ledger_state: Option<&LedgerState>,
 ) -> Vec<CompletionItem> {
     let currencies = get_all_currencies(parse_result, ledger_state);
-
-    currencies
+    rustledger_completion::currency_candidates(&currencies)
         .into_iter()
-        .map(|c| CompletionItem {
-            label: c.clone(),
-            kind: Some(CompletionItemKind::UNIT),
-            detail: Some("Currency".to_string()),
-            ..Default::default()
-        })
+        .map(to_item)
         .collect()
 }
 
@@ -476,65 +232,33 @@ fn complete_payee(
     ledger_state: Option<&LedgerState>,
 ) -> Vec<CompletionItem> {
     let payees = get_all_payees(parse_result, ledger_state);
-
-    // Same `.take(20)` trap as account completion (issue #1183):
-    // the LSP client filters by the user's typed prefix, so capping
-    // server-side silently drops payees that sort after the cap.
-    // Return all; the client handles the volume.
-    payees
+    rustledger_completion::payee_candidates(&payees)
         .into_iter()
-        .map(|p| CompletionItem {
-            label: p.clone(),
-            kind: Some(CompletionItemKind::TEXT),
-            detail: Some("Known payee".to_string()),
-            ..Default::default()
-        })
+        .map(to_item)
         .collect()
 }
 
 /// Complete a tag after `#` (issue #1268).
-///
-/// The `#` is a trigger character that the user has already typed, so
-/// `insert_text`/`filter_text` carry the tag name *without* the `#` —
-/// the client replaces the word it is completing (the text after the
-/// sigil) and leaves the `#` in place. `label` keeps the `#` for a
-/// readable popup. We return every known tag and let the client filter
-/// as the user types (the same approach as `complete_account_start`),
-/// rather than filtering server-side and risking a stale list under
-/// `isIncomplete: false`.
 fn complete_tag(
     parse_result: &ParseResult,
     ledger_state: Option<&LedgerState>,
 ) -> Vec<CompletionItem> {
-    get_all_tags(parse_result, ledger_state)
+    let tags = get_all_tags(parse_result, ledger_state);
+    rustledger_completion::tag_candidates(&tags)
         .into_iter()
-        .map(|tag| CompletionItem {
-            label: format!("#{tag}"),
-            kind: Some(CompletionItemKind::CONSTANT),
-            detail: Some("Tag".to_string()),
-            filter_text: Some(tag.clone()),
-            insert_text: Some(tag),
-            ..Default::default()
-        })
+        .map(to_item)
         .collect()
 }
 
-/// Complete a link after `^` (issue #1268). Mirrors [`complete_tag`];
-/// see its docs for the sigil/insert-text rationale.
+/// Complete a link after `^` (issue #1268).
 fn complete_link(
     parse_result: &ParseResult,
     ledger_state: Option<&LedgerState>,
 ) -> Vec<CompletionItem> {
-    get_all_links(parse_result, ledger_state)
+    let links = get_all_links(parse_result, ledger_state);
+    rustledger_completion::link_candidates(&links)
         .into_iter()
-        .map(|link| CompletionItem {
-            label: format!("^{link}"),
-            kind: Some(CompletionItemKind::REFERENCE),
-            detail: Some("Link".to_string()),
-            filter_text: Some(link.clone()),
-            insert_text: Some(link),
-            ..Default::default()
-        })
+        .map(to_item)
         .collect()
 }
 
@@ -628,8 +352,7 @@ fn extract_payees(parse_result: &ParseResult) -> Vec<String> {
 
 /// Extract tags from parse result. Tag text comes back without the
 /// leading `#`, which is exactly the form completion inserts after the
-/// already-typed sigil. Delegates to the core visitor for exhaustive
-/// position coverage (transaction/document tags, metadata, Custom).
+/// already-typed sigil.
 fn extract_tags(parse_result: &ParseResult) -> Vec<String> {
     rustledger_core::extract_tags_iter(parse_result.directives.iter().map(|s| &s.value))
 }
@@ -643,15 +366,6 @@ fn extract_links(parse_result: &ParseResult) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_is_date_like() {
-        assert!(is_date_like("2024-01-15"));
-        assert!(is_date_like("2000-12-31"));
-        assert!(!is_date_like("2024/01/15"));
-        assert!(!is_date_like("24-01-15"));
-        assert!(!is_date_like("not-a-date"));
-    }
 
     #[test]
     fn test_detect_context_line_start() {
@@ -725,7 +439,7 @@ mod tests {
     #[test]
     fn test_detect_context_emoji_narration_utf16_offset() {
         // Non-BMP emoji uses two UTF-16 code units in LSP positions.
-        // Validates surrogate-pair handling in char_offset_to_byte.
+        // Validates surrogate-pair handling in offset_to_byte.
         let source = "2024-01-15 * \"🍣\"\n";
         // UTF-16 offsets: "2024-01-15 * \"" = 14 units, "🍣" = 2 units, "\"" = 1 unit
         // Position 17 is after the closing quote
@@ -984,16 +698,6 @@ mod tests {
         let ctx = ctx_at_end("2024-01-15 * \"a\\\"b #tag");
         assert_ne!(ctx, CompletionContext::Tag);
         assert_ne!(ctx, CompletionContext::Link);
-    }
-
-    #[test]
-    fn test_in_code_position() {
-        assert!(in_code_position("2024-01-15 * \"x\" #")); // after closed string
-        assert!(in_code_position("pushtag #")); // plain directive
-        assert!(!in_code_position("2024-01-15 * \"x\" ; ")); // in comment
-        assert!(!in_code_position("2024-01-15 * \"open")); // in string
-        assert!(in_code_position("2024-01-15 * \"a;b\" ")); // ; was in string
-        assert!(!in_code_position("2024-01-15 * \"a\\\"b")); // escaped quote, still open
     }
 
     #[test]

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -49,6 +49,7 @@ rustledger-booking.workspace = true
 rustledger-validate.workspace = true
 rustledger-query.workspace = true
 rustledger-loader.workspace = true
+rustledger-completion.workspace = true
 rustledger-plugin = { workspace = true, default-features = false, optional = true }
 wasm-bindgen.workspace = true
 serde-wasm-bindgen.workspace = true

--- a/crates/rustledger-wasm/bindings/index.d.ts
+++ b/crates/rustledger-wasm/bindings/index.d.ts
@@ -98,7 +98,9 @@ export type CompletionKind =
   | "currency"
   | "payee"
   | "date"
-  | "text";
+  | "text"
+  | "tag"
+  | "link";
 
 /**
  * Result of BQL completion request.

--- a/crates/rustledger-wasm/bindings/index.schema.json
+++ b/crates/rustledger-wasm/bindings/index.schema.json
@@ -187,6 +187,16 @@
           "const": "text",
           "description": "A text/string value.",
           "type": "string"
+        },
+        {
+          "const": "tag",
+          "description": "A tag (after `#`).",
+          "type": "string"
+        },
+        {
+          "const": "link",
+          "description": "A link (after `^`).",
+          "type": "string"
         }
       ]
     },

--- a/crates/rustledger-wasm/src/editor/completions.rs
+++ b/crates/rustledger-wasm/src/editor/completions.rs
@@ -1,14 +1,31 @@
 //! Completion support for the editor.
+//!
+//! Detection and candidate logic live in the editor-agnostic
+//! `rustledger-completion` crate (issue #1319). This module is a thin
+//! adapter: it maps the WASM character offset to a byte offset and
+//! classifies the context via the shared crate, then maps the neutral
+//! [`rustledger_completion::CompletionCandidate`] results into
+//! [`EditorCompletion`] items (preserving the existing WASM item shapes
+//! and gaining tag/link completion).
 
 #[cfg(test)]
 use rustledger_parser::ParseResult;
 
+use rustledger_completion::{
+    CompletionCandidate, CompletionKind as SharedKind, PositionEncoding, classify_context,
+    offset_to_byte,
+};
+
 use crate::types::{CompletionKind, EditorCompletion, EditorCompletionResult};
 
-use super::helpers::{ACCOUNT_TYPES, DIRECTIVES, get_line, is_date_like};
+use super::helpers::get_line;
 use super::line_index::EditorCache;
 
 /// Completion context detected from cursor position.
+///
+/// This mirrors [`rustledger_completion::CompletionContext`] (the shared
+/// superset) but is a local type so it can carry the editor's `Display`
+/// representation used in [`EditorCompletionResult::context`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompletionContext {
     /// At the start of a line (expecting date or directive).
@@ -26,8 +43,29 @@ pub enum CompletionContext {
     ExpectingCurrency,
     /// Inside a string (payee/narration).
     InsideString,
+    /// Typing a tag (after `#`).
+    Tag,
+    /// Typing a link (after `^`).
+    Link,
     /// Unknown context.
     Unknown,
+}
+
+impl From<rustledger_completion::CompletionContext> for CompletionContext {
+    fn from(ctx: rustledger_completion::CompletionContext) -> Self {
+        use rustledger_completion::CompletionContext as S;
+        match ctx {
+            S::LineStart => Self::LineStart,
+            S::AfterDate => Self::AfterDate,
+            S::ExpectingAccount => Self::ExpectingAccount,
+            S::AccountSegment { prefix } => Self::AccountSegment { prefix },
+            S::ExpectingCurrency => Self::ExpectingCurrency,
+            S::InsideString => Self::InsideString,
+            S::Tag => Self::Tag,
+            S::Link => Self::Link,
+            S::Unknown => Self::Unknown,
+        }
+    }
 }
 
 impl std::fmt::Display for CompletionContext {
@@ -39,8 +77,62 @@ impl std::fmt::Display for CompletionContext {
             Self::AccountSegment { prefix } => write!(f, "account_segment:{prefix}"),
             Self::ExpectingCurrency => write!(f, "expecting_currency"),
             Self::InsideString => write!(f, "inside_string"),
+            Self::Tag => write!(f, "tag"),
+            Self::Link => write!(f, "link"),
             Self::Unknown => write!(f, "unknown"),
         }
+    }
+}
+
+/// Map a shared [`SharedKind`] to the WASM [`CompletionKind`],
+/// reproducing the kinds the previous hand-written builders emitted.
+fn editor_kind(kind: SharedKind) -> CompletionKind {
+    match kind {
+        SharedKind::Date => CompletionKind::Date,
+        SharedKind::Directive => CompletionKind::Keyword,
+        // Account types and folder segments were both `AccountSegment`.
+        SharedKind::AccountType | SharedKind::AccountSegmentFolder => {
+            CompletionKind::AccountSegment
+        }
+        SharedKind::Account => CompletionKind::Account,
+        SharedKind::Currency => CompletionKind::Currency,
+        SharedKind::Payee => CompletionKind::Payee,
+        SharedKind::Tag => CompletionKind::Tag,
+        SharedKind::Link => CompletionKind::Link,
+    }
+}
+
+/// Map a neutral [`CompletionCandidate`] into an [`EditorCompletion`],
+/// reproducing the existing WASM item shapes for the prior kinds.
+fn to_completion(candidate: CompletionCandidate) -> EditorCompletion {
+    let CompletionCandidate {
+        label,
+        insert_text,
+        kind,
+        detail,
+    } = candidate;
+
+    // The previous WASM builders left `insert_text` as `None` for the
+    // account-type / known-account / currency / payee items (the label
+    // is inserted verbatim). The shared candidate sets
+    // `insert_text == label` for those, so suppress it to match.
+    let insert_text = match kind {
+        SharedKind::AccountType
+        | SharedKind::Account
+        | SharedKind::Currency
+        | SharedKind::Payee => None,
+        SharedKind::Date
+        | SharedKind::Directive
+        | SharedKind::AccountSegmentFolder
+        | SharedKind::Tag
+        | SharedKind::Link => Some(insert_text),
+    };
+
+    EditorCompletion {
+        label,
+        kind: editor_kind(kind),
+        detail,
+        insert_text,
     }
 }
 
@@ -52,17 +144,28 @@ pub fn get_completions_cached(
     cache: &EditorCache,
 ) -> EditorCompletionResult {
     let context = detect_context(source, line, character);
-    let completions = match &context {
-        CompletionContext::LineStart => complete_line_start(),
-        CompletionContext::AfterDate => complete_after_date(),
-        CompletionContext::ExpectingAccount => complete_account_start_cached(&cache.accounts),
-        CompletionContext::AccountSegment { prefix } => {
-            complete_account_segment_cached(prefix, &cache.accounts)
+    let candidates = match &context {
+        CompletionContext::LineStart => {
+            let today = jiff::Zoned::now().date().to_string();
+            rustledger_completion::line_start_candidates(&today)
         }
-        CompletionContext::ExpectingCurrency => complete_currency_cached(&cache.currencies),
-        CompletionContext::InsideString => complete_payee_cached(&cache.payees),
+        CompletionContext::AfterDate => rustledger_completion::after_date_candidates(),
+        CompletionContext::ExpectingAccount => {
+            rustledger_completion::account_start_candidates(&cache.accounts)
+        }
+        CompletionContext::AccountSegment { prefix } => {
+            rustledger_completion::account_segment_candidates(prefix, &cache.accounts)
+        }
+        CompletionContext::ExpectingCurrency => {
+            rustledger_completion::currency_candidates(&cache.currencies)
+        }
+        CompletionContext::InsideString => rustledger_completion::payee_candidates(&cache.payees),
+        CompletionContext::Tag => rustledger_completion::tag_candidates(&cache.tags),
+        CompletionContext::Link => rustledger_completion::link_candidates(&cache.links),
         CompletionContext::Unknown => Vec::new(),
     };
+
+    let completions = candidates.into_iter().map(to_completion).collect();
 
     EditorCompletionResult {
         completions,
@@ -83,219 +186,15 @@ pub fn get_completions(
 }
 
 /// Detect the completion context from cursor position.
+///
+/// `character` is a character offset (not a byte offset); the shared
+/// `offset_to_byte` maps it to a char-boundary byte offset (preserving
+/// the #1289 fix), then `classify_context` classifies the text before
+/// the cursor.
 pub fn detect_context(source: &str, line: u32, character: u32) -> CompletionContext {
     let line_text = get_line(source, line as usize);
-    // `character` is a character offset, not a byte offset. Slicing
-    // `line_text` by it directly panics when a multi-byte character
-    // (e.g. a Korean Hangul syllable) sits before the cursor, because
-    // the byte index lands mid-character — in the WASM build that
-    // surfaces as an `unreachable` trap and kills completion (#1289).
-    // Map the character offset to a char-boundary byte offset; clamp
-    // past end-of-line to the line length.
-    let col = character as usize;
-    let byte_col = line_text
-        .char_indices()
-        .nth(col)
-        .map_or(line_text.len(), |(b, _)| b);
-    let before_cursor = &line_text[..byte_col];
-
-    let trimmed = before_cursor.trim_start();
-
-    // Check if we're at the start of a posting (indented line)
-    if before_cursor.starts_with("  ") || before_cursor.starts_with('\t') {
-        if trimmed.is_empty() {
-            return CompletionContext::ExpectingAccount;
-        }
-
-        let posting_content = trimmed;
-
-        // Check if there's already an account (contains colon and space after)
-        if posting_content.contains(':') && posting_content.contains(' ') {
-            let parts: Vec<&str> = posting_content.split_whitespace().collect();
-            if parts.len() >= 2
-                && let Some(last) = parts.last()
-                && (last.parse::<f64>().is_ok() || last.ends_with('.'))
-            {
-                return CompletionContext::ExpectingCurrency;
-            }
-            return CompletionContext::Unknown;
-        }
-
-        // Check if typing an account segment
-        if let Some(colon_pos) = posting_content.rfind(':') {
-            let prefix = &posting_content[..=colon_pos];
-            return CompletionContext::AccountSegment {
-                prefix: prefix.to_string(),
-            };
-        }
-
-        return CompletionContext::ExpectingAccount;
-    }
-
-    // Empty or whitespace only at line start (not indented)
-    if trimmed.is_empty() {
-        return CompletionContext::LineStart;
-    }
-
-    // Check for date at line start (YYYY-MM-DD pattern). Guard the
-    // 10-byte split on a char boundary: a `YYYY-MM-DD` prefix is all
-    // ASCII, so if byte 10 lands mid-character the line can't be a
-    // date, and slicing there would panic on multi-byte input.
-    if trimmed.len() >= 10 && trimmed.is_char_boundary(10) && is_date_like(&trimmed[..10]) {
-        let after_date = trimmed[10..].trim_start();
-        if after_date.is_empty() {
-            return CompletionContext::AfterDate;
-        }
-
-        // Check for directive keywords
-        for (directive, _) in DIRECTIVES {
-            if let Some(rest) = after_date.strip_prefix(directive) {
-                let after_directive = rest.trim_start();
-                if after_directive.is_empty() || !after_directive.contains(' ') {
-                    match *directive {
-                        "open" | "close" | "balance" | "pad" | "note" | "document" => {
-                            if let Some(colon_pos) = after_directive.rfind(':') {
-                                return CompletionContext::AccountSegment {
-                                    prefix: after_directive[..=colon_pos].to_string(),
-                                };
-                            }
-                            return CompletionContext::ExpectingAccount;
-                        }
-                        _ => return CompletionContext::Unknown,
-                    }
-                }
-            }
-        }
-
-        return CompletionContext::AfterDate;
-    }
-
-    // Check if inside a quoted string
-    let quote_count = before_cursor.chars().filter(|&c| c == '"').count();
-    if quote_count % 2 == 1 {
-        return CompletionContext::InsideString;
-    }
-
-    CompletionContext::Unknown
-}
-
-/// Complete at line start (date template).
-pub fn complete_line_start() -> Vec<EditorCompletion> {
-    let today = jiff::Zoned::now().date().to_string();
-    vec![EditorCompletion {
-        label: today.clone(),
-        kind: CompletionKind::Date,
-        detail: Some("Today's date".to_string()),
-        insert_text: Some(format!("{today} ")),
-    }]
-}
-
-/// Complete after a date (directive keywords).
-pub fn complete_after_date() -> Vec<EditorCompletion> {
-    DIRECTIVES
-        .iter()
-        .map(|(name, description)| EditorCompletion {
-            label: (*name).to_string(),
-            kind: CompletionKind::Keyword,
-            detail: Some((*description).to_string()),
-            insert_text: Some(format!("{name} ")),
-        })
-        .collect()
-}
-
-/// Complete account name start (account types) - cached version.
-pub fn complete_account_start_cached(accounts: &[String]) -> Vec<EditorCompletion> {
-    let mut items: Vec<EditorCompletion> = ACCOUNT_TYPES
-        .iter()
-        .map(|&t| EditorCompletion {
-            label: format!("{t}:"),
-            kind: CompletionKind::AccountSegment,
-            detail: Some(format!("{t} account type")),
-            insert_text: None,
-        })
-        .collect();
-
-    // Also offer known accounts from the file
-    for account in accounts.iter().take(20) {
-        items.push(EditorCompletion {
-            label: account.clone(),
-            kind: CompletionKind::Account,
-            detail: Some("Known account".to_string()),
-            insert_text: None,
-        });
-    }
-
-    items
-}
-
-/// Complete account segment after colon - cached version.
-pub fn complete_account_segment_cached(prefix: &str, accounts: &[String]) -> Vec<EditorCompletion> {
-    let matching: Vec<_> = accounts.iter().filter(|a| a.starts_with(prefix)).collect();
-
-    let mut segments: Vec<String> = matching
-        .iter()
-        .filter_map(|a| {
-            let after_prefix = &a[prefix.len()..];
-            let next_segment = after_prefix.split(':').next()?;
-            if next_segment.is_empty() {
-                None
-            } else {
-                Some(next_segment.to_string())
-            }
-        })
-        .collect();
-
-    segments.sort();
-    segments.dedup();
-
-    segments
-        .into_iter()
-        .map(|seg| {
-            let full = format!("{prefix}{seg}");
-            let has_more = matching.iter().any(|a| a.starts_with(&format!("{full}:")));
-            EditorCompletion {
-                label: seg.clone(),
-                kind: if has_more {
-                    CompletionKind::AccountSegment
-                } else {
-                    CompletionKind::Account
-                },
-                detail: Some(if has_more {
-                    "Account segment".to_string()
-                } else {
-                    "Account".to_string()
-                }),
-                insert_text: Some(if has_more { format!("{seg}:") } else { seg }),
-            }
-        })
-        .collect()
-}
-
-/// Complete currency after amount - cached version.
-pub fn complete_currency_cached(currencies: &[String]) -> Vec<EditorCompletion> {
-    currencies
-        .iter()
-        .map(|c| EditorCompletion {
-            label: c.clone(),
-            kind: CompletionKind::Currency,
-            detail: Some("Currency".to_string()),
-            insert_text: None,
-        })
-        .collect()
-}
-
-/// Complete payee/narration inside string - cached version.
-pub fn complete_payee_cached(payees: &[String]) -> Vec<EditorCompletion> {
-    payees
-        .iter()
-        .take(20)
-        .map(|p| EditorCompletion {
-            label: p.clone(),
-            kind: CompletionKind::Payee,
-            detail: Some("Known payee".to_string()),
-            insert_text: None,
-        })
-        .collect()
+    let byte_col = offset_to_byte(line_text, character as usize, PositionEncoding::Char);
+    classify_context(&line_text[..byte_col]).into()
 }
 
 #[cfg(test)]
@@ -442,7 +341,7 @@ mod tests {
 
     #[test]
     fn test_complete_after_date_returns_all_directives() {
-        let completions = complete_after_date();
+        let completions = rustledger_completion::after_date_candidates();
         assert!(!completions.is_empty());
 
         let labels: Vec<_> = completions.iter().map(|c| c.label.as_str()).collect();
@@ -462,10 +361,80 @@ mod tests {
             "Expenses:Food".to_string(),
         ];
 
-        let completions = complete_account_segment_cached("Assets:Bank:", &accounts);
+        let completions =
+            rustledger_completion::account_segment_candidates("Assets:Bank:", &accounts);
         assert_eq!(completions.len(), 2);
         let labels: Vec<_> = completions.iter().map(|c| c.label.as_str()).collect();
         assert!(labels.contains(&"Checking"));
         assert!(labels.contains(&"Savings"));
+    }
+
+    /// WASM now offers tag completion (issue #1319): typing `#` on a
+    /// transaction header yields the known tags, with the sigil kept in
+    /// the label but dropped from the inserted text.
+    #[test]
+    fn test_tag_completion_offered() {
+        let source = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Expenses:Stuff USD
+
+2024-01-15 * \"Central Perk\" #coffee #morning
+  Assets:Bank:Checking  -5 USD
+  Expenses:Stuff
+";
+        let result = parse(source);
+        // Cursor right after a fresh `#` on a new transaction header.
+        let header = "2024-02-01 * \"x\" #";
+        let mut doc = String::from(source);
+        doc.push_str(header);
+        let line = doc.lines().count() as u32 - 1;
+        let character = header.chars().count() as u32;
+        let completions = get_completions(&doc, line, character, &result);
+
+        assert_eq!(completions.context, "tag");
+        let labels: Vec<_> = completions
+            .completions
+            .iter()
+            .map(|c| c.label.as_str())
+            .collect();
+        assert!(labels.contains(&"#coffee"), "labels = {labels:?}");
+        assert!(labels.contains(&"#morning"), "labels = {labels:?}");
+
+        let coffee = completions
+            .completions
+            .iter()
+            .find(|c| c.label == "#coffee")
+            .unwrap();
+        assert_eq!(coffee.kind, CompletionKind::Tag);
+        assert_eq!(coffee.insert_text.as_deref(), Some("coffee"));
+    }
+
+    /// WASM now offers link completion (issue #1319).
+    #[test]
+    fn test_link_completion_offered() {
+        let source = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Expenses:Stuff USD
+
+2024-01-15 * \"Flight\" ^trip-2024
+  Assets:Bank:Checking  -5 USD
+  Expenses:Stuff
+";
+        let result = parse(source);
+        let header = "2024-02-01 * \"x\" ^";
+        let mut doc = String::from(source);
+        doc.push_str(header);
+        let line = doc.lines().count() as u32 - 1;
+        let character = header.chars().count() as u32;
+        let completions = get_completions(&doc, line, character, &result);
+
+        assert_eq!(completions.context, "link");
+        let trip = completions
+            .completions
+            .iter()
+            .find(|c| c.label == "^trip-2024")
+            .expect("trip-2024 link should be offered");
+        assert_eq!(trip.kind, CompletionKind::Link);
+        assert_eq!(trip.insert_text.as_deref(), Some("trip-2024"));
     }
 }

--- a/crates/rustledger-wasm/src/editor/helpers.rs
+++ b/crates/rustledger-wasm/src/editor/helpers.rs
@@ -5,47 +5,9 @@ use rustledger_parser::ParseResult;
 
 use crate::types::EditorRange;
 
-/// Standard Beancount account types.
-pub const ACCOUNT_TYPES: &[&str] = &["Assets", "Liabilities", "Equity", "Income", "Expenses"];
-
-/// Standard Beancount directives.
-pub const DIRECTIVES: &[(&str, &str)] = &[
-    ("open", "Open an account"),
-    ("close", "Close an account"),
-    ("commodity", "Define a commodity/currency"),
-    ("balance", "Assert account balance"),
-    ("pad", "Pad account to target"),
-    ("event", "Record an event"),
-    ("query", "Define a named query"),
-    ("note", "Add a note to an account"),
-    ("document", "Link a document"),
-    ("custom", "Custom directive"),
-    ("price", "Record a price"),
-    ("txn", "Transaction (complete)"),
-    ("*", "Transaction (complete)"),
-    ("!", "Transaction (incomplete)"),
-];
-
 /// Get a specific line from source.
 pub fn get_line(source: &str, line_num: usize) -> &str {
     source.lines().nth(line_num).unwrap_or("")
-}
-
-/// Check if a string looks like a date (YYYY-MM-DD).
-pub fn is_date_like(s: &str) -> bool {
-    if s.len() != 10 {
-        return false;
-    }
-    let chars: Vec<char> = s.chars().collect();
-    chars[4] == '-'
-        && chars[7] == '-'
-        && chars.iter().enumerate().all(|(i, c)| {
-            if i == 4 || i == 7 {
-                *c == '-'
-            } else {
-                c.is_ascii_digit()
-            }
-        })
 }
 
 /// Get the word at a given position in the source.
@@ -112,6 +74,19 @@ pub fn extract_currencies(parse_result: &ParseResult) -> Vec<String> {
 /// Extract payees from parse result.
 pub fn extract_payees(parse_result: &ParseResult) -> Vec<String> {
     rustledger_core::extract_payees_iter(parse_result.directives.iter().map(|s| &s.value))
+}
+
+/// Extract tags from parse result. Tag text comes back without the
+/// leading `#`, the form completion inserts after the already-typed
+/// sigil.
+pub fn extract_tags(parse_result: &ParseResult) -> Vec<String> {
+    rustledger_core::extract_tags_iter(parse_result.directives.iter().map(|s| &s.value))
+}
+
+/// Extract links from parse result. Like tags, link text comes back
+/// without the leading `^`.
+pub fn extract_links(parse_result: &ParseResult) -> Vec<String> {
+    rustledger_core::extract_links_iter(parse_result.directives.iter().map(|s| &s.value))
 }
 
 /// Count how many times an account is used in postings.
@@ -239,16 +214,6 @@ mod tests {
         let word = get_word_at_position(source, 0, 5);
         // Position 5 is 'o' in "hello", still part of word
         assert_eq!(word, Some("hello".to_string()));
-    }
-
-    #[test]
-    fn test_is_date_like() {
-        assert!(is_date_like("2024-01-15"));
-        assert!(is_date_like("1999-12-31"));
-        assert!(!is_date_like("2024-1-15")); // Wrong format (too short)
-        assert!(!is_date_like("not-a-date"));
-        // Note: is_date_like only checks format, not validity
-        assert!(is_date_like("2024-13-99")); // Pattern matches
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/editor/helpers.rs
+++ b/crates/rustledger-wasm/src/editor/helpers.rs
@@ -13,13 +13,16 @@ pub fn get_line(source: &str, line_num: usize) -> &str {
 /// Get the word at a given position in the source.
 pub fn get_word_at_position(source: &str, line: u32, character: u32) -> Option<String> {
     let line_text = source.lines().nth(line as usize)?;
+    let chars: Vec<char> = line_text.chars().collect();
     let col = character as usize;
 
-    if col > line_text.len() {
+    // `character` is a character offset and is used to index `chars`, so
+    // bound it by the character count, not the byte length (they differ
+    // on multi-byte lines). Bounding by `line_text.len()` (bytes) would
+    // accept an out-of-range char offset and then index incorrectly.
+    if col > chars.len() {
         return None;
     }
-
-    let chars: Vec<char> = line_text.chars().collect();
 
     // Find start of word
     let mut start = col;
@@ -214,6 +217,17 @@ mod tests {
         let word = get_word_at_position(source, 0, 5);
         // Position 5 is 'o' in "hello", still part of word
         assert_eq!(word, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_get_word_at_position_multibyte() {
+        // `character` is a CHARACTER offset. "롯" is 3 bytes / 1 char.
+        // Account "Assets:롯데" is 9 characters; the cursor at char 8 is
+        // inside the word. Bounding by char count (not byte length) must
+        // accept this and return the full word.
+        let source = "  Assets:롯데  100 KRW";
+        let word = get_word_at_position(source, 0, 8);
+        assert_eq!(word, Some("Assets:롯데".to_string()));
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/editor/line_index.rs
+++ b/crates/rustledger-wasm/src/editor/line_index.rs
@@ -3,7 +3,9 @@
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 
-use super::helpers::{extract_accounts, extract_currencies, extract_payees};
+use super::helpers::{
+    extract_accounts, extract_currencies, extract_links, extract_payees, extract_tags,
+};
 
 /// Cached data for editor features to avoid repeated extraction.
 ///
@@ -17,6 +19,10 @@ pub struct EditorCache {
     pub currencies: Vec<String>,
     /// All unique payees in the document.
     pub payees: Vec<String>,
+    /// All unique tags in the document (without the leading `#`).
+    pub tags: Vec<String>,
+    /// All unique links in the document (without the leading `^`).
+    pub links: Vec<String>,
     /// Line index for efficient offset-to-position conversion.
     pub line_index: LineIndex,
 }
@@ -28,6 +34,8 @@ impl EditorCache {
             accounts: extract_accounts(parse_result),
             currencies: extract_currencies(parse_result),
             payees: extract_payees(parse_result),
+            tags: extract_tags(parse_result),
+            links: extract_links(parse_result),
             line_index: LineIndex::new(source),
         }
     }
@@ -42,6 +50,8 @@ impl EditorCache {
             accounts: rustledger_core::extract_accounts(directives),
             currencies: rustledger_core::extract_currencies(directives),
             payees: rustledger_core::extract_payees(directives),
+            tags: rustledger_core::extract_tags(directives),
+            links: rustledger_core::extract_links(directives),
             line_index: LineIndex::empty(),
         }
     }

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -879,6 +879,10 @@ pub enum CompletionKind {
     Date,
     /// A text/string value.
     Text,
+    /// A tag (after `#`).
+    Tag,
+    /// A link (after `^`).
+    Link,
 }
 
 /// Result of a completion request.

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -31,6 +31,9 @@ audit-as-crates-io = false
 [policy.rustledger-booking]
 audit-as-crates-io = false
 
+[policy.rustledger-completion]
+audit-as-crates-io = false
+
 [policy.rustledger-core]
 audit-as-crates-io = false
 


### PR DESCRIPTION
## What

The LSP (`rustledger-lsp/.../completion.rs`) and the WASM editor (`rustledger-wasm/src/editor/completions.rs`) carried two parallel, **drifted** copies of completion logic. That duplication is exactly what let #1289 (the non-ASCII offset crash) live in the WASM path after the LSP path was already correct, and the WASM path lacked the tag/link completion the LSP had.

This introduces a new **dependency-free** crate `rustledger-completion` as the single source of truth, and makes both paths thin adapters.

### `rustledger-completion` (new, no deps)
- `CompletionContext` (LSP superset, incl. `Tag`/`Link`).
- `offset_to_byte(line, offset, encoding)` - one char-boundary-safe mapping for all three conventions (`Char` = the #1289 WASM behavior, `Utf8`/`Utf16` = the LSP behavior).
- `classify_context(before_cursor)` - the LSP classification body, incl. the `in_code_position`-gated tag/link detection and the #1289 char-boundary date guard.
- Neutral `CompletionCandidate` / `CompletionKind` + pure candidate algorithms over `&[String]` (line-start, after-date, account-start, account-segment, currency, payee, tag, link). 29 unit tests.

### Adapters
- **LSP**: `detect_context` → `offset_to_byte` (negotiated encoding) → `classify_context`; dispatch gathers live `ParseResult`/`LedgerState` strings, calls the shared algorithms, maps `CompletionCandidate` → `lsp_types::CompletionItem` (kind mapping + resolve `data`). Output unchanged - existing item-shape tests pass as-is.
- **WASM**: `detect_context` → `offset_to_byte(Char)` (preserves #1289) → `classify_context`; `EditorCache` gained `tags`/`links`; dispatch now handles all contexts. **WASM gains tag/link completion** (additive `tag`/`link` variants on the `CompletionKind` wire enum; bindings regenerated).

## Verification

- `rustledger-completion` 29, `rustledger-lsp` 234 (+integration suites), `rustledger-wasm` 83 - all green, **0 failures** (independently re-run, not just trusted from the build agent).
- clippy + fmt clean; wasm32 target builds; bindings change is purely additive (non-breaking).
- Net ~325 fewer lines in the adapters.

## Notes
- This is the structural follow-up to #1289 - the duplication that caused it is now gone.
- WASM gaining tag/link is the only behavior change; LSP behavior is identical.

Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)