### PR TITLE
fix(parser): keep header tags/links on the line for non-first transactions (#1321)

### DIFF
--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -1377,7 +1377,13 @@ fn emit_document(d: &ast::DocumentDirective, out: &mut String) {
                 seen_content = true;
             }
             crate::SyntaxKind::NEWLINE if seen_content => break,
-            crate::SyntaxKind::WHITESPACE | crate::SyntaxKind::NEWLINE => {}
+            // Leading trivia before the date: whitespace, blank-line
+            // NEWLINEs, AND comment lines. A comment before a non-first
+            // directive attaches inside this node (Directive-Terminator
+            // Rule); skipping only WHITESPACE/NEWLINE would let it flip
+            // `seen_content`, break at the comment's NEWLINE, and drop
+            // the real header tags/links.
+            k if k.is_trivia() => {}
             _ => seen_content = true,
         }
     }
@@ -1620,8 +1626,13 @@ fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut Str
                 seen_content = true;
             }
             crate::SyntaxKind::NEWLINE if seen_content => break,
-            // Leading WHITESPACE / NEWLINE before the date is trivia.
-            crate::SyntaxKind::WHITESPACE | crate::SyntaxKind::NEWLINE => {}
+            // Leading trivia before the date: whitespace, blank-line
+            // NEWLINEs, AND comment lines (a comment before a non-first
+            // directive attaches inside this node per the Directive-
+            // Terminator Rule). Skipping only WHITESPACE/NEWLINE would
+            // let a leading comment flip `seen_content`, break at the
+            // comment's NEWLINE, and drop the real header tags/links.
+            k if k.is_trivia() => {}
             // DATE / flag / STRING etc. — header content has begun.
             _ => seen_content = true,
         }
@@ -1659,7 +1670,12 @@ fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut Str
         if !past_header {
             match t.kind() {
                 crate::SyntaxKind::NEWLINE if seen_content => past_header = true,
-                crate::SyntaxKind::WHITESPACE | crate::SyntaxKind::NEWLINE => {}
+                // Leading trivia before the date, comments included (see
+                // the header loop above): a leading comment must not flip
+                // `seen_content` and push `past_header` early, which would
+                // misclassify the real header tags/links as trailing
+                // continuation tags.
+                k if k.is_trivia() => {}
                 // DATE / flag / STRING / header TAG / LINK: still header,
                 // never emitted as trailing continuation tags.
                 _ => seen_content = true,
@@ -2243,6 +2259,48 @@ mod tests {
             format_source(src),
             src,
             "format must be a no-op (idempotent)"
+        );
+    }
+
+    #[test]
+    fn issue_1321_comment_before_transaction_keeps_header_tags() {
+        // A comment line before a transaction is leading trivia attached
+        // inside the transaction node (Directive-Terminator Rule), exactly
+        // like a blank line. Skipping only WHITESPACE/NEWLINE let the
+        // comment flip `seen_content`, break at the comment's NEWLINE, and
+        // migrate the real header tags/links to continuation lines. The
+        // header tags/links must stay on the header line. (Found by the
+        // Copilot review of the #1321 fix.)
+        let src = "\
+2024-01-15 * \"first\" #h1 ^l1
+  Assets:Cash    -1.00 USD
+  Expenses:Misc   1.00 USD
+
+; a comment before the second transaction
+2024-01-16 * \"second\" #tag1 ^link1
+  Assets:Cash    -2.00 USD
+  Expenses:Misc   2.00 USD
+";
+        assert_eq!(
+            format_source(src),
+            src,
+            "a leading comment must not migrate header tags/links to continuation lines"
+        );
+    }
+
+    #[test]
+    fn issue_1321_comment_before_document_keeps_tags() {
+        // Document-directive variant of the comment-trivia case above.
+        let src = "\
+2013-05-18 document Assets:Bank \"/a.pdf\" #tag1 ^link1
+; a comment before the second document
+2013-05-19 document Assets:Bank \"/b.pdf\" #tag2 ^link2
+";
+        let once = format_source(src);
+        assert_eq!(format_source(&once), once, "format must be idempotent");
+        assert!(
+            once.contains("\"/b.pdf\" #tag2 ^link2"),
+            "the second document's tags/links must stay on its header line; got:\n{once}"
         );
     }
 

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -1359,18 +1359,26 @@ fn emit_document(d: &ast::DocumentDirective, out: &mut String) {
     out.push(' ');
     out.push_str(&path);
     // Trailing TAG / LINK tokens — typed AST has no accessor, so
-    // walk direct-child tokens until the first NEWLINE.
+    // walk direct-child tokens. Skip LEADING trivia (a blank line
+    // before a non-first directive attaches its NEWLINE inside the
+    // node) and stop at the first NEWLINE *after* the header content
+    // begins; otherwise the tags/links are dropped when reformatting
+    // any document past the first — the same bug as #1321 in the
+    // transaction path.
+    let mut seen_content = false;
     for el in d.syntax().children_with_tokens() {
         let rowan::NodeOrToken::Token(t) = el else {
-            continue;
+            break;
         };
         match t.kind() {
-            crate::SyntaxKind::NEWLINE => break,
             crate::SyntaxKind::TAG | crate::SyntaxKind::LINK => {
                 out.push(' ');
                 out.push_str(t.text());
+                seen_content = true;
             }
-            _ => {}
+            crate::SyntaxKind::NEWLINE if seen_content => break,
+            crate::SyntaxKind::WHITESPACE | crate::SyntaxKind::NEWLINE => {}
+            _ => seen_content = true,
         }
     }
     out.push('\n');
@@ -2194,6 +2202,25 @@ mod tests {
         assert_eq!(
             format_source(src),
             "2024-06-01 document Assets:Bank \"stmt.pdf\" #q1 ^scan42 #urgent\n"
+        );
+    }
+
+    #[test]
+    fn issue_1321_document_tags_links_idempotent_across_directives() {
+        // Same class as the transaction case, in `document` directives:
+        // the 2nd+ document's trailing tags/links were dropped on a
+        // reformat (found by the #1323 corpus idempotence check). Assert
+        // the fixed-point property: re-formatting must not change (and
+        // must not drop the tags/links of the second document).
+        let src = "\
+2013-05-18 document Assets:Bank \"/a.pdf\" #tag1 ^link1
+2013-05-19 document Assets:Bank \"/b.pdf\" #tag2 ^link2
+";
+        let once = format_source(src);
+        assert_eq!(format_source(&once), once, "format must be idempotent");
+        assert!(
+            once.contains("#tag2") && once.contains("^link2"),
+            "the second document's tags/links must survive formatting; got:\n{once}"
         );
     }
 

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -1593,17 +1593,29 @@ fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut Str
     // grouped, which loses interleaving like `#a ^l #b`). Walk
     // direct-child tokens, stopping at the header-terminating
     // NEWLINE.
+    //
+    // `seen_content` guards against LEADING trivia: for any directive
+    // after the first, the preceding blank line's NEWLINE attaches
+    // inside this node before the date (the Directive-Terminator Rule).
+    // The header terminator is the first NEWLINE *after* the date, not
+    // a leading one — otherwise this loop would break immediately and
+    // emit no header tags (#1321).
+    let mut seen_content = false;
     for el in d.syntax().children_with_tokens() {
         let rowan::NodeOrToken::Token(t) = el else {
-            continue;
+            break;
         };
         match t.kind() {
             crate::SyntaxKind::TAG | crate::SyntaxKind::LINK => {
                 out.push(' ');
                 out.push_str(t.text());
+                seen_content = true;
             }
-            crate::SyntaxKind::NEWLINE => break,
-            _ => {}
+            crate::SyntaxKind::NEWLINE if seen_content => break,
+            // Leading WHITESPACE / NEWLINE before the date is trivia.
+            crate::SyntaxKind::WHITESPACE | crate::SyntaxKind::NEWLINE => {}
+            // DATE / flag / STRING etc. — header content has begun.
+            _ => seen_content = true,
         }
     }
     out.push('\n');
@@ -1623,15 +1635,26 @@ fn emit_transaction(d: &ast::Transaction, align: PostingAlignment, out: &mut Str
     // already inside a POSTING / META_ENTRY child). Emit each on
     // its own indented line — that's the canonical form for the
     // "continuation tags" syntax.
+    // `seen_content` mirrors the header loop above: the header ends at
+    // the first NEWLINE *after* the date, so a leading blank-line
+    // NEWLINE (trivia for any directive past the first) does not flip
+    // `past_header` early and misclassify the header tags/links as
+    // trailing continuation tags (#1321).
     let mut past_header = false;
+    let mut seen_content = false;
     for el in d.syntax().children_with_tokens() {
         let rowan::NodeOrToken::Token(t) = el else {
+            // POSTING / META_ENTRY node — definitively past the header.
             past_header = true;
             continue;
         };
         if !past_header {
-            if t.kind() == crate::SyntaxKind::NEWLINE {
-                past_header = true;
+            match t.kind() {
+                crate::SyntaxKind::NEWLINE if seen_content => past_header = true,
+                crate::SyntaxKind::WHITESPACE | crate::SyntaxKind::NEWLINE => {}
+                // DATE / flag / STRING / header TAG / LINK: still header,
+                // never emitted as trailing continuation tags.
+                _ => seen_content = true,
             }
             continue;
         }
@@ -2171,6 +2194,28 @@ mod tests {
         assert_eq!(
             format_source(src),
             "2024-06-01 document Assets:Bank \"stmt.pdf\" #q1 ^scan42 #urgent\n"
+        );
+    }
+
+    #[test]
+    fn issue_1321_header_tags_links_idempotent_across_transactions() {
+        // Header tags/links must stay on the header line for EVERY
+        // transaction, not just the first. Regression for #1321 where
+        // the 2nd+ transaction's header tags/links got migrated to
+        // continuation lines.
+        let src = "\
+2024-01-15 * \"x\" #tag1 ^link1 #tag2 ^link2
+  Assets:Cash    -1.00 USD
+  Expenses:Misc   1.00 USD
+
+2024-01-16 * \"x\" #tag1 ^link1 #tag2 ^link2
+  Assets:Cash    -1.00 USD
+  Expenses:Misc   1.00 USD
+";
+        assert_eq!(
+            format_source(src),
+            src,
+            "format must be a no-op (idempotent)"
         );
     }
 

--- a/crates/rustledger-parser/tests/format_compat/cases/realistic_multi_feature/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/realistic_multi_feature/expected.bean
@@ -1,0 +1,50 @@
+option "title" "Example Ledger"
+
+option "operating_currency" "USD"
+
+2020-01-01 open Assets:Checking USD
+
+2020-01-01 open Assets:Brokerage
+
+2020-01-01 open Expenses:Food
+
+2020-01-01 open Expenses:Coffee
+
+2020-01-01 open Income:Salary USD
+
+2020-01-01 open Equity:Opening-Balances
+
+2020-01-01 commodity AAPL
+  name: "Apple Inc."
+
+2020-01-02 * "Opening" #setup
+  Assets:Checking   1000.00 USD
+  Equity:Opening-Balances
+
+2020-01-15 * "Cafe" "Latte" #coffee ^receipt-15
+  Expenses:Coffee      4.50 USD
+  Assets:Checking
+
+2020-01-16 * "Grocer" "Weekly" #food ^receipt-16 #urgent
+  key: "value"
+  Expenses:Food       52.30 USD
+    note: "on sale"
+  Assets:Checking
+
+2020-02-01 * "Buy AAPL" #invest ^trade-1
+  Assets:Brokerage       10 AAPL {150.00 USD}
+  Assets:Checking
+
+2020-02-10 price AAPL 155.00 USD
+
+2020-02-15 balance Assets:Checking 943.20 USD
+
+2020-03-01 document Assets:Checking "/stmt-jan.pdf" #statement
+
+2020-03-02 document Assets:Checking "/stmt-feb.pdf" #statement ^scan-2
+
+2020-03-05 note Assets:Checking "reconciled"
+
+2020-03-10 event "location" "Office"
+
+2020-12-31 close Expenses:Coffee

--- a/crates/rustledger-parser/tests/format_compat/cases/realistic_multi_feature/input.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/realistic_multi_feature/input.bean
@@ -1,0 +1,43 @@
+option "title" "Example Ledger"
+option "operating_currency" "USD"
+
+2020-01-01 open Assets:Checking USD
+2020-01-01 open Assets:Brokerage
+2020-01-01 open Expenses:Food
+2020-01-01 open Expenses:Coffee
+2020-01-01 open Income:Salary USD
+2020-01-01 open Equity:Opening-Balances
+
+2020-01-01 commodity AAPL
+  name: "Apple Inc."
+
+2020-01-02 * "Opening" #setup
+  Assets:Checking   1000.00 USD
+  Equity:Opening-Balances
+
+2020-01-15 * "Cafe" "Latte" #coffee ^receipt-15
+  Expenses:Coffee  4.50 USD
+  Assets:Checking
+
+2020-01-16 * "Grocer" "Weekly" #food ^receipt-16 #urgent
+  key: "value"
+  Expenses:Food    52.30 USD
+    note: "on sale"
+  Assets:Checking
+
+2020-02-01 * "Buy AAPL" #invest ^trade-1
+  Assets:Brokerage   10 AAPL {150.00 USD}
+  Assets:Checking
+
+2020-02-10 price AAPL   155.00 USD
+
+2020-02-15 balance Assets:Checking   943.20 USD
+
+2020-03-01 document Assets:Checking "/stmt-jan.pdf" #statement
+2020-03-02 document Assets:Checking "/stmt-feb.pdf" #statement ^scan-2
+
+2020-03-05 note Assets:Checking "reconciled"
+
+2020-03-10 event "location" "Office"
+
+2020-12-31 close Expenses:Coffee


### PR DESCRIPTION
## Root cause

The CST formatter (`cst::format::emit_transaction`) split a transaction's header from its body by **the first `NEWLINE` token in the directive node**. That's wrong for any directive after the first: the preceding blank line attaches its `NEWLINE` *inside* the node as **leading trivia** (the Directive-Terminator Rule), so the split fired on that leading newline. The header tag/link loop broke immediately (emitting no header tags), and the trailing-tag loop's `past_header` flipped early, so the real header `#tag`/`^link` were treated as body continuation tags and migrated to their own indented lines.

That's exactly the reporter's symptom: only the **first** transaction (which has no leading trivia inside its node) formatted correctly; every later one had its header tags/links migrated.

```
2024-01-16 * "x"
  Assets:Cash    -1.00 USD
  Expenses:Misc   1.00 USD
  #tag1
  ^link1
  ...
```

## Fix

Both loops now skip leading `WHITESPACE`/`NEWLINE` trivia and key off the first `NEWLINE` **after the header content begins** (`seen_content`). Header tags/links stay on the header line for every transaction, while genuine body-line continuation tags (after the postings) still emit as continuation lines.

## Tests

- New `issue_1321_header_tags_links_idempotent_across_transactions`: the reporter's two-transaction file is a no-op under `format` (it was failing before).
- Full `rustledger-parser` suite green (267 incl. the new test, plus the 143 format/compat golden cases that pin both header-tag and continuation-tag formatting) - **0 failures**. clippy/fmt clean.

## Follow-ups from the reporter
Both of @lutzky's suggestions are now implemented:

- **Large multi-feature golden fixture** (here, this PR): `realistic_multi_feature` in `format_compat` - one file exercising option/open/close/commodity, transactions with header tags+links on **non-first** transactions (`#food ^receipt-16 #urgent`, the regression surface), txn- and posting-level metadata, costs, price/balance/note/event, and two `document` directives (the second with `#statement ^scan-2`, the emit_document variant). Idempotence catches `format(format(x)) != format(x)`; this golden additionally pins the exact **canonical** output, so a silent degradation to a worse-but-stable form is caught too.
- **`bean-format(rledger format(x)) == rledger format(x)` roundtrip** (separate PR, #1324): external-oracle check over the full compat corpus. Empirically rledger and Python's bean-format diverge on **alignment alone** and nothing else (0 structural divergences across 676 files).

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update: leading-comment edge case (Copilot review)
Copilot caught that the first fix skipped leading *whitespace/newline* trivia but not leading *comments* — a comment line before a directive attaches inside that node (Directive-Terminator Rule) just like a blank line, so the header scan broke at the comment's NEWLINE and dropped the real header tags/links. Confirmed real (it's the stable-but-wrong class idempotence can't see). Fixed in `8f82c7c` by keying the leading-trivia skip off `SyntaxKind::is_trivia()` (the single source of truth, covering `COMMENT`/`PERCENT_COMMENT`/`SHEBANG`/`EMACS_DIRECTIVE`) across all three header-scan loops, plus transaction- and document-directive regression tests.
