### PR TITLE
ci: format idempotence + bean-format roundtrip over the compat corpus (#1323, #1324)

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -128,6 +128,17 @@ jobs:
         # cleanly are skipped. See scripts/format-idempotence.sh (#1323).
         run: |
           RLEDGER=./target/release/rledger ./scripts/format-idempotence.sh tests/compatibility/files
+      - name: bean-format roundtrip over the corpus
+        # External-oracle check: running Python beancount's own bean-format
+        # over rledger's output must change nothing of substance. Pins
+        # agreement with beancount on directive/posting order, tag/link
+        # placement, decimal/currency normalization, costs and metadata -
+        # everything except the deliberate column-alignment difference
+        # (rledger aligns per-transaction, bean-format whole-file), which
+        # the script normalizes away. See
+        # scripts/format-bean-format-roundtrip.sh (#1324).
+        run: |
+          RLEDGER=./target/release/rledger ./scripts/format-bean-format-roundtrip.sh tests/compatibility/files
       - name: Fetch previous results for regression detection
         run: |
           mkdir -p .github/badges

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -120,6 +120,14 @@ jobs:
           bean-query --version
           ./target/release/rledger check --version
           ./target/release/rledger query --version
+      - name: Format idempotence over the corpus
+        # `rledger format` must be a fixed point on every real-world file
+        # it can format: re-formatting its own output must be byte-
+        # identical. Catches formatter bugs the small golden cases miss
+        # (e.g. #1321 / the document variant). Files that don't format
+        # cleanly are skipped. See scripts/format-idempotence.sh (#1323).
+        run: |
+          RLEDGER=./target/release/rledger ./scripts/format-idempotence.sh tests/compatibility/files
       - name: Fetch previous results for regression detection
         run: |
           mkdir -p .github/badges

--- a/scripts/format-bean-format-roundtrip.sh
+++ b/scripts/format-bean-format-roundtrip.sh
@@ -35,6 +35,10 @@
 # Env:     RLEDGER     path to the rledger binary (default ./target/release/rledger)
 #          BEANFORMAT  bean-format command (default: bean-format on PATH)
 #          STRICT      if "0", report divergences but exit 0 (default: strict, exit 1 on any)
+#
+# Note: `-e` is intentionally omitted (see scripts/format-idempotence.sh) -
+# the loop must survive `diff`/per-file tool failures and report rather than
+# abort. Setup commands that must not fail silently (mktemp) are guarded.
 set -uo pipefail
 
 RLEDGER="${RLEDGER:-./target/release/rledger}"
@@ -55,10 +59,10 @@ if [ ! -d "$CORPUS" ]; then
   exit 2
 fi
 
-once=$(mktemp)
-oracle=$(mktemp)
-once_n=$(mktemp)
-oracle_n=$(mktemp)
+once=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
+oracle=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
+once_n=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
+oracle_n=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
 trap 'rm -f "$once" "$oracle" "$once_n" "$oracle_n"' EXIT
 
 # Strip alignment padding: preserve leading indentation, collapse internal

--- a/scripts/format-bean-format-roundtrip.sh
+++ b/scripts/format-bean-format-roundtrip.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# bean-format roundtrip check (#1324).
+#
+# Idempotence (scripts/format-idempotence.sh) proves `rledger format` is a
+# fixed point of *itself*. That is necessary but not sufficient: the
+# formatter could converge on output that is stable yet structurally wrong
+# (wrong directive order, a misplaced tag, a mangled number) and stay
+# green forever. This check adds an *external oracle* - Python beancount's
+# own `bean-format` - and asserts that our output is a fixed point of it
+# too:
+#
+#     normalize(bean-format(rledger format(x))) == normalize(rledger format(x))
+#
+# i.e. once rledger has formatted a file, running Python's canonical
+# formatter over the result changes nothing of substance. That pins
+# agreement with beancount on everything `bean-format` touches: directive
+# and posting order, tag/link placement, decimal and currency
+# normalization, costs, metadata, flags.
+#
+# Why `normalize`. rledger and bean-format deliberately disagree on ONE
+# thing: the column model. bean-format aligns every posting amount to a
+# single whole-file column (the max prefix width in the entire file);
+# rledger aligns per transaction (the max within each transaction). Both
+# are legitimate; per-transaction alignment keeps unrelated transactions
+# from reflowing when one long account name appears elsewhere in the file.
+# So we normalize away horizontal *alignment padding* before comparing:
+# leading indentation is preserved (a real indent regression still fails),
+# but internal runs of two-or-more spaces - which is exactly where the two
+# tools pad differently - collapse to one. Across the ~700-file compat
+# corpus this leaves precisely zero divergences, so the check ships as a
+# strict gate with no allowlist: any future structural disagreement with
+# bean-format is a real regression.
+#
+# Usage:   scripts/format-bean-format-roundtrip.sh [CORPUS_DIR]
+# Env:     RLEDGER     path to the rledger binary (default ./target/release/rledger)
+#          BEANFORMAT  bean-format command (default: bean-format on PATH)
+#          STRICT      if "0", report divergences but exit 0 (default: strict, exit 1 on any)
+set -uo pipefail
+
+RLEDGER="${RLEDGER:-./target/release/rledger}"
+BEANFORMAT="${BEANFORMAT:-bean-format}"
+CORPUS="${1:-tests/compatibility/files}"
+STRICT="${STRICT:-1}"
+
+if ! command -v "$RLEDGER" >/dev/null 2>&1 && [ ! -x "$RLEDGER" ]; then
+  echo "error: rledger binary not found/executable at '$RLEDGER'" >&2
+  exit 2
+fi
+if ! command -v "$BEANFORMAT" >/dev/null 2>&1; then
+  echo "error: bean-format not found (set BEANFORMAT or install beancount)" >&2
+  exit 2
+fi
+if [ ! -d "$CORPUS" ]; then
+  echo "error: corpus directory not found: '$CORPUS'" >&2
+  exit 2
+fi
+
+once=$(mktemp)
+oracle=$(mktemp)
+once_n=$(mktemp)
+oracle_n=$(mktemp)
+trap 'rm -f "$once" "$oracle" "$once_n" "$oracle_n"' EXIT
+
+# Strip alignment padding: preserve leading indentation, collapse internal
+# runs of 2+ spaces to one, drop trailing whitespace. This is the one axis
+# on which rledger (per-transaction) and bean-format (whole-file) are meant
+# to differ; everything else must match exactly.
+normalize() {
+  sed -E 's/([^[:space:]])[[:space:]]{2,}/\1 /g; s/[[:space:]]+$//' "$1"
+}
+
+checked=0
+skipped=0
+fail=0
+failed_files=()
+
+while IFS= read -r -d '' f; do
+  # Format with rledger. Skip files rledger can't format (out of scope).
+  if ! "$RLEDGER" format "$f" >"$once" 2>/dev/null; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  # Run Python's bean-format over our output. Skip files bean-format
+  # chokes on (it is regex-based and not a full parser).
+  if ! "$BEANFORMAT" "$once" >"$oracle" 2>/dev/null; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  checked=$((checked + 1))
+
+  normalize "$once" >"$once_n"
+  normalize "$oracle" >"$oracle_n"
+  if ! cmp -s "$once_n" "$oracle_n"; then
+    echo "FAIL (bean-format disagrees beyond alignment): $f"
+    diff "$once_n" "$oracle_n" | head -20
+    failed_files+=("$f")
+    fail=$((fail + 1))
+  fi
+done < <(find "$CORPUS" -name '*.beancount' -type f -print0)
+
+echo "----"
+echo "bean-format roundtrip: checked=$checked skipped=$skipped divergent=$fail"
+
+if [ "$fail" -gt 0 ]; then
+  {
+    echo "divergent files:"
+    printf '  %s\n' "${failed_files[@]}"
+  } >&2
+  if [ "$STRICT" != "0" ]; then
+    exit 1
+  fi
+fi

--- a/scripts/format-idempotence.sh
+++ b/scripts/format-idempotence.sh
@@ -16,6 +16,12 @@
 # Usage:   scripts/format-idempotence.sh [CORPUS_DIR]
 # Env:     RLEDGER  path to the rledger binary (default ./target/release/rledger)
 #          STRICT   if "0", report non-idempotent files but exit 0 (default: strict, exit 1 on any)
+#
+# Note: `-e` is intentionally omitted. The loop must survive a `diff` (which
+# exits 1 on the very differences we are reporting) and per-file `rledger`
+# failures without aborting; correctness comes from explicit return-code
+# checks and the `fail` accumulator, not from `-e`. Setup commands that
+# must not fail silently (mktemp) are guarded individually below.
 set -uo pipefail
 
 RLEDGER="${RLEDGER:-./target/release/rledger}"
@@ -31,8 +37,8 @@ if [ ! -d "$CORPUS" ]; then
   exit 2
 fi
 
-once=$(mktemp)
-twice=$(mktemp)
+once=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
+twice=$(mktemp) || { echo "error: mktemp failed" >&2; exit 2; }
 trap 'rm -f "$once" "$twice"' EXIT
 
 checked=0

--- a/scripts/format-idempotence.sh
+++ b/scripts/format-idempotence.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Format idempotence check (#1323).
+#
+# `rledger format` must be a fixed point: re-formatting an
+# already-formatted file must produce byte-identical output. This
+# catches whole classes of formatter bugs that the small golden cases in
+# `crates/rustledger-parser/tests/format_compat/cases/` miss - e.g.
+# #1321, where header `#tag` / `^link` migrated to continuation lines for
+# every transaction after the first.
+#
+# Runs over the fetched compatibility corpus (the ~800 real-world
+# `.beancount` files the compat workflow already downloads), exercising
+# far more shapes than the golden cases. Files that do not format cleanly
+# (parse errors, unsupported constructs) are out of scope and skipped.
+#
+# Usage:   scripts/format-idempotence.sh [CORPUS_DIR]
+# Env:     RLEDGER  path to the rledger binary (default ./target/release/rledger)
+#          STRICT   if "0", report non-idempotent files but exit 0 (default: strict, exit 1 on any)
+set -uo pipefail
+
+RLEDGER="${RLEDGER:-./target/release/rledger}"
+CORPUS="${1:-tests/compatibility/files}"
+STRICT="${STRICT:-1}"
+
+if ! command -v "$RLEDGER" >/dev/null 2>&1 && [ ! -x "$RLEDGER" ]; then
+  echo "error: rledger binary not found/executable at '$RLEDGER'" >&2
+  exit 2
+fi
+if [ ! -d "$CORPUS" ]; then
+  echo "error: corpus directory not found: '$CORPUS'" >&2
+  exit 2
+fi
+
+once=$(mktemp)
+twice=$(mktemp)
+trap 'rm -f "$once" "$twice"' EXIT
+
+checked=0
+skipped=0
+fail=0
+failed_files=()
+
+while IFS= read -r -d '' f; do
+  # Format once. Skip files rledger can't format (out of scope here).
+  if ! "$RLEDGER" format "$f" >"$once" 2>/dev/null; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+  checked=$((checked + 1))
+
+  # Re-format the formatted output; it must be byte-identical.
+  if ! "$RLEDGER" format "$once" >"$twice" 2>/dev/null; then
+    echo "FAIL (rledger format errored on its own output): $f"
+    failed_files+=("$f")
+    fail=$((fail + 1))
+    continue
+  fi
+  if ! cmp -s "$once" "$twice"; then
+    echo "FAIL (not idempotent): $f"
+    diff "$once" "$twice" | head -20
+    failed_files+=("$f")
+    fail=$((fail + 1))
+  fi
+done < <(find "$CORPUS" -name '*.beancount' -type f -print0)
+
+echo "----"
+echo "format idempotence: checked=$checked skipped=$skipped non_idempotent=$fail"
+
+if [ "$fail" -gt 0 ]; then
+  {
+    echo "non-idempotent files:"
+    printf '  %s\n' "${failed_files[@]}"
+  } >&2
+  if [ "$STRICT" != "0" ]; then
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## What

Two complementary external-correctness checks for `rledger format`, run over the **~700 real-world `.beancount` files the compat workflow already downloads**:

### 1. Format idempotence (#1323)
`rledger format` must be a **fixed point**: re-formatting an already-formatted file must produce byte-identical output. The small golden cases in `format_compat` exercise too few shapes - **#1321 and its document-directive variant slipped through**. This runs `format -> format` over the corpus and fails on any non-fixed-point.

- `scripts/format-idempotence.sh` - byte-exact double-format over a corpus dir; skips files that don't format cleanly (parse errors); `STRICT=0` to report-only.

### 2. bean-format roundtrip (#1324)
Idempotence proves we are a fixed point of *ourselves* - necessary but not sufficient, since the formatter could converge on stable-but-wrong output and stay green forever. This adds an **external oracle**, Python beancount's own `bean-format`, and asserts our output is a fixed point of it too:

```
normalize(bean-format(rledger format(x))) == normalize(rledger format(x))
```

pinning agreement with beancount on directive/posting order, tag/link placement, decimal & currency normalization, costs, and metadata.

- `scripts/format-bean-format-roundtrip.sh` - `bean-format` is already on PATH in the compat job (`pip install beancount`), so this is a pure addition with no new dependency.

**Why `normalize`.** rledger and bean-format deliberately disagree on exactly one axis: the column model. bean-format aligns every amount to one whole-file column; rledger aligns per transaction, so a long account name elsewhere in the file doesn't reflow every other transaction. The script normalizes away that alignment padding (leading indentation **preserved**, so a real indent regression still fails) before comparing.

Both checks are wired into the **Compatibility** workflow, after the corpus fetch + release build.

## Validation (local, against the fetched corpus)

714 fetched -> **676 checked / 38 skipped** for both checks.

- **Idempotence: 0 non-idempotent** *with the #1321 fixes applied*. Before the document fix the check found exactly the **2 real-world files** with the document-directive bug (`parser-lima/...Document.DocumentTags`, `fava/...example`) - i.e. it immediately surfaced a real bug the golden cases missed.
- **bean-format roundtrip: 0 divergent.** The empirical finding is strong: across all 676 files, rledger and Python's canonical formatter differ on **alignment alone** (176 raw whitespace diffs) and on **nothing else** (0 after normalization). So the gate ships **strict with no allowlist** - any future structural disagreement with bean-format is a real regression.

## Dependency

Depends on the #1321 formatter fixes (#1322, broadened to cover the `document` variant the idempotence check found). **Merge #1322 first** so both strict checks are green over the corpus; this is pure CI infrastructure.

Closes #1323
Refs #1321, #1290, #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)