### PR TITLE
fix(format): preserve author blank lines between directives (#1325)

### DIFF
--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -40,7 +40,10 @@
 //! # Canonical form (locked in the PR-decision comment on #1262)
 //!
 //! - Indent inside a directive body: 2 spaces. Tabs converted.
-//! - Blank lines between directives: exactly 1.
+//! - Blank lines between directives: preserved from the source
+//!   (#1325). Grouped directives (consecutive `open`s, a `price`
+//!   feed) stay grouped; the formatter does not insert or collapse
+//!   blank lines, matching Python `bean-format`.
 //! - Blank lines inside a directive: 0.
 //! - Number lexical form: thousands separators dropped; user
 //!   decimal-place count preserved.
@@ -672,12 +675,20 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
     // directive and surface from `emit_directive`'s leading-trivia
     // pass.
     //
-    // Blank-line policy at the top level: insert exactly one blank
-    // line BEFORE a directive iff the previously emitted item was
-    // also a directive. Adjacent file-level comments stay tight as
-    // a group (so a `; ====\n; HEADER\n; ====` section header keeps
-    // its visual grouping), and a comment group sitting against a
-    // directive on either side stays flush.
+    // Blank-line policy at the top level: PRESERVE the author's blank
+    // lines between directives rather than normalizing to exactly one.
+    // Between two directives, emit as many blank lines as the source
+    // had — including zero, so deliberately grouped runs (consecutive
+    // `open`s, a dense `price` feed) stay grouped instead of being
+    // double-spaced (#1325). This matches Python `bean-format` and the
+    // rest of the beancount formatter lineage (fava,
+    // beancount-language-server, beancount-mode), all of which leave
+    // blank-line structure untouched and only realign amounts.
+    //
+    // Adjacent file-level comments still stay tight as a group (so a
+    // `; ====\n; HEADER\n; ====` section header keeps its visual
+    // grouping), and a comment group sitting against a directive on
+    // either side stays flush.
     let mut prev_was_directive = false;
     for el in node.children_with_tokens() {
         match el {
@@ -686,7 +697,9 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
                     continue;
                 };
                 if prev_was_directive {
-                    out.push('\n');
+                    for _ in 0..leading_blank_lines(directive.syntax()) {
+                        out.push('\n');
+                    }
                 }
                 emit_directive(&directive, alignment, &mut out);
                 prev_was_directive = true;
@@ -932,8 +945,13 @@ pub fn format_node_range_with_alignment(
                 let Some(directive) = ast::Directive::cast(n) else {
                     continue;
                 };
+                // Preserve the author's inter-directive blank lines
+                // (#1325), identically to `format_node_with_alignment`,
+                // so range formatting and whole-file formatting agree.
                 if prev_was_directive {
-                    out.push('\n');
+                    for _ in 0..leading_blank_lines(directive.syntax()) {
+                        out.push('\n');
+                    }
                 }
                 emit_directive(&directive, alignment, &mut out);
                 prev_was_directive = true;
@@ -1149,6 +1167,33 @@ fn emit_directive(d: &ast::Directive, align: PostingAlignment, out: &mut String)
         splice.push_str(&c);
         out.insert_str(insert_at, &splice);
     }
+}
+
+/// Number of blank lines the author left immediately before this
+/// directive's first visible line (its leading comment, if any, else
+/// its content). Each NEWLINE in the leading trivia that precedes the
+/// first comment / content token is exactly one blank line: the
+/// previous directive owns its own terminator NEWLINE (the Directive-
+/// Terminator Rule), so this node's leading NEWLINEs are purely the
+/// blank gap, with no off-by-one. WHITESPACE-only "blank" lines count
+/// too (the NEWLINE that ends them is included). Scanning stops at the
+/// first comment or content token, so a blank line sitting *between* a
+/// leading comment and the directive's content is not counted here
+/// (that gap is collapsed by `emit_leading_comments`, as before).
+fn leading_blank_lines(node: &crate::SyntaxNode) -> usize {
+    let mut blanks = 0;
+    for el in node.children_with_tokens() {
+        let rowan::NodeOrToken::Token(t) = el else {
+            break;
+        };
+        match t.kind() {
+            crate::SyntaxKind::NEWLINE => blanks += 1,
+            crate::SyntaxKind::WHITESPACE => {}
+            // First comment or content token — past the leading gap.
+            _ => break,
+        }
+    }
+    blanks
 }
 
 /// Walk the directive's direct-child tokens until the first
@@ -2152,12 +2197,22 @@ mod tests {
     }
 
     #[test]
-    fn blank_line_between_directives() {
-        let src = "2024-01-01 open Assets:A\n2024-01-02 open Assets:B\n";
-        assert_eq!(
-            format_source(src),
-            "2024-01-01 open Assets:A\n\n2024-01-02 open Assets:B\n"
-        );
+    fn blank_lines_between_directives_preserved() {
+        // #1325: the formatter preserves the author's inter-directive
+        // blank lines rather than normalizing to exactly one (matching
+        // Python bean-format and the rest of the beancount lineage).
+
+        // Grouped (no blank in source) stays grouped — not double-spaced.
+        let grouped = "2024-01-01 open Assets:A\n2024-01-02 open Assets:B\n";
+        assert_eq!(format_source(grouped), grouped);
+
+        // One blank is preserved as one.
+        let one = "2024-01-01 open Assets:A\n\n2024-01-02 open Assets:B\n";
+        assert_eq!(format_source(one), one);
+
+        // Two blanks are preserved as two (not collapsed).
+        let two = "2024-01-01 open Assets:A\n\n\n2024-01-02 open Assets:B\n";
+        assert_eq!(format_source(two), two);
     }
 
     #[test]
@@ -2381,16 +2436,18 @@ mod tests {
 
     #[test]
     fn pushtag_poptag_canonical() {
+        // No blank line in the source — preserved as grouped (#1325).
         let src = "pushtag  #active\npoptag  #active\n";
-        assert_eq!(format_source(src), "pushtag #active\n\npoptag #active\n");
+        assert_eq!(format_source(src), "pushtag #active\npoptag #active\n");
     }
 
     #[test]
     fn pushmeta_popmeta_canonical() {
+        // No blank line in the source — preserved as grouped (#1325).
         let src = "pushmeta location: \"NYC\"\npopmeta location:\n";
         assert_eq!(
             format_source(src),
-            "pushmeta location: \"NYC\"\n\npopmeta location:\n"
+            "pushmeta location: \"NYC\"\npopmeta location:\n"
         );
     }
 
@@ -3768,19 +3825,31 @@ mod tests {
     /// Multi-directive selection: snap covers both, output
     /// includes the canonical inter-directive blank line.
     #[test]
-    fn format_node_range_multi_directive_includes_blank_separator() {
-        let source = "\
+    fn format_node_range_multi_directive_preserves_blank_lines() {
+        // #1325: range formatting preserves the author's inter-directive
+        // blank lines, identically to whole-file formatting. A source
+        // with a blank between the two directives keeps it...
+        let spaced = "\
 2024-01-01 open Assets:Bank USD
+
 2024-01-31 close Assets:Bank
 ";
-        let (node, src) = parse_for_range(source);
+        let (node, src) = parse_for_range(spaced);
         let sel = rowan::TextRange::new(ts(0), ts(src.len()));
         let (snap, formatted) = format_node_range(&node, sel).expect("intersects 2 directives");
         assert_eq!(snap, rowan::TextRange::new(ts(0), ts(src.len())));
-        assert_eq!(
-            formatted, "2024-01-01 open Assets:Bank USD\n\n2024-01-31 close Assets:Bank\n",
-            "the canonical blank-line separator must appear between the two directives",
-        );
+        assert_eq!(formatted, spaced, "the blank separator must be preserved");
+
+        // ...and a grouped source (no blank) stays grouped, rather than
+        // having a separator inserted.
+        let grouped = "\
+2024-01-01 open Assets:Bank USD
+2024-01-31 close Assets:Bank
+";
+        let (node2, src2) = parse_for_range(grouped);
+        let sel2 = rowan::TextRange::new(ts(0), ts(src2.len()));
+        let (_, formatted2) = format_node_range(&node2, sel2).expect("intersects 2 directives");
+        assert_eq!(formatted2, grouped, "grouped directives must stay grouped");
     }
 
     /// Cursor-only (zero-width) selection inside a directive

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -948,7 +948,24 @@ pub fn format_node_range_with_alignment(
                 // Preserve the author's inter-directive blank lines
                 // (#1325), identically to `format_node_with_alignment`,
                 // so range formatting and whole-file formatting agree.
-                if prev_was_directive {
+                //
+                // The FIRST directive emitted from the snap needs care:
+                // its predecessor may sit OUTSIDE the selection, but the
+                // blank lines between them are this directive's leading
+                // trivia (the Directive-Terminator Rule), so they fall
+                // INSIDE the snapped range. Dropping them would delete
+                // the blank line above the selection. Emit them whenever
+                // a directive precedes this one in the file — the same
+                // condition the whole-file path expresses as
+                // `prev_was_directive`. For the file's first directive
+                // (no predecessor) there is nothing to preserve.
+                let preceded_by_directive = prev_was_directive
+                    || directive
+                        .syntax()
+                        .prev_sibling()
+                        .and_then(ast::Directive::cast)
+                        .is_some();
+                if preceded_by_directive {
                     for _ in 0..leading_blank_lines(directive.syntax()) {
                         out.push('\n');
                     }
@@ -2213,6 +2230,14 @@ mod tests {
         // Two blanks are preserved as two (not collapsed).
         let two = "2024-01-01 open Assets:A\n\n\n2024-01-02 open Assets:B\n";
         assert_eq!(format_source(two), two);
+
+        // A whitespace-only "blank" line still counts as one blank line
+        // (its trailing whitespace is stripped, leaving an empty line).
+        let ws_blank = "2024-01-01 open Assets:A\n   \n2024-01-02 open Assets:B\n";
+        assert_eq!(
+            format_source(ws_blank),
+            "2024-01-01 open Assets:A\n\n2024-01-02 open Assets:B\n"
+        );
     }
 
     #[test]
@@ -3822,8 +3847,9 @@ mod tests {
         assert_eq!(formatted, "2024-01-01 open Assets:Bank USD\n");
     }
 
-    /// Multi-directive selection: snap covers both, output
-    /// includes the canonical inter-directive blank line.
+    /// Multi-directive selection: the author's inter-directive
+    /// blank lines are preserved (a blank stays a blank; grouped
+    /// stays grouped), matching whole-file formatting (#1325).
     #[test]
     fn format_node_range_multi_directive_preserves_blank_lines() {
         // #1325: range formatting preserves the author's inter-directive
@@ -3850,6 +3876,34 @@ mod tests {
         let sel2 = rowan::TextRange::new(ts(0), ts(src2.len()));
         let (_, formatted2) = format_node_range(&node2, sel2).expect("intersects 2 directives");
         assert_eq!(formatted2, grouped, "grouped directives must stay grouped");
+    }
+
+    #[test]
+    fn format_node_range_first_directive_in_snap_keeps_leading_blank() {
+        // Regression (Copilot review of #1325): when the selection
+        // covers only the SECOND directive, its predecessor sits outside
+        // the snap, but the blank line between them is the second
+        // directive's leading trivia and therefore inside the snapped
+        // range. Range formatting must re-emit it, not silently delete
+        // the blank line above the selection.
+        let source = "2024-01-01 open Assets:Bank USD\n\n2024-01-31 close Assets:Bank\n";
+        let (node, src) = parse_for_range(source);
+        // Cursor inside the second (close) directive only.
+        let close_byte = src.find("close").expect("fixture has 'close'");
+        let cursor = rowan::TextRange::new(ts(close_byte), ts(close_byte));
+        let (snap, formatted) = format_node_range(&node, cursor).expect("intersects close");
+        // The leading blank is preserved in the replacement text...
+        assert_eq!(formatted, "\n2024-01-31 close Assets:Bank\n");
+        // ...so applying the edit leaves the blank line intact.
+        let mut result = src;
+        result.replace_range(
+            usize::from(snap.start())..usize::from(snap.end()),
+            &formatted,
+        );
+        assert_eq!(
+            result, source,
+            "range-formatting the second directive must not delete the blank above it"
+        );
     }
 
     /// Cursor-only (zero-width) selection inside a directive

--- a/crates/rustledger-parser/tests/format_compat/cases/commas_stripped_per_canonical_form/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/commas_stripped_per_canonical_form/expected.bean
@@ -7,7 +7,6 @@
 ; lexical form would require extending the typed AST to carry a
 ; had-comma flag, which is a #1262 phase-5+ refactor.
 2024-01-01 open Assets:Money
-
 2024-07-20 * "comma-bearing amount"
   Assets:Money  -1024 USD
   Expenses:Thingamabobs

--- a/crates/rustledger-parser/tests/format_compat/cases/comment_with_unbalanced_quote/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/comment_with_unbalanced_quote/expected.bean
@@ -1,4 +1,3 @@
 ; comment with a stray " quote
 2024-01-15 open Assets:A
-
 2024-01-16 open Assets:B

--- a/crates/rustledger-parser/tests/format_compat/cases/crlf_outside_strings_folded/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/crlf_outside_strings_folded/expected.bean
@@ -1,3 +1,2 @@
 2024-01-01 open Assets:A
-
 2024-01-02 open Assets:B

--- a/crates/rustledger-parser/tests/format_compat/cases/options_includes_plugins_block/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/options_includes_plugins_block/expected.bean
@@ -1,11 +1,8 @@
 option "title" "My Ledger"
-
 option "operating_currency" "USD"
 
 include "sub.beancount"
-
 include "another.beancount"
 
 plugin "my.plugin"
-
 plugin "my.other.plugin" "cfg-string"

--- a/crates/rustledger-parser/tests/format_compat/cases/realistic_multi_feature/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/realistic_multi_feature/expected.bean
@@ -1,17 +1,11 @@
 option "title" "Example Ledger"
-
 option "operating_currency" "USD"
 
 2020-01-01 open Assets:Checking USD
-
 2020-01-01 open Assets:Brokerage
-
 2020-01-01 open Expenses:Food
-
 2020-01-01 open Expenses:Coffee
-
 2020-01-01 open Income:Salary USD
-
 2020-01-01 open Equity:Opening-Balances
 
 2020-01-01 commodity AAPL
@@ -40,7 +34,6 @@ option "operating_currency" "USD"
 2020-02-15 balance Assets:Checking 943.20 USD
 
 2020-03-01 document Assets:Checking "/stmt-jan.pdf" #statement
-
 2020-03-02 document Assets:Checking "/stmt-feb.pdf" #statement ^scan-2
 
 2020-03-05 note Assets:Checking "reconciled"

--- a/crates/rustledger-parser/tests/format_compat/cases/section_header_comments_tight/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/section_header_comments_tight/expected.bean
@@ -2,7 +2,6 @@
 ; ACCOUNTS
 ; =================
 2024-01-01 open Assets:Bank
-
 2024-01-01 open Assets:Cash
 
 ; =================

--- a/crates/rustledger-parser/tests/format_compat/cases/unary_plus_stripped_per_canonical_form/expected.bean
+++ b/crates/rustledger-parser/tests/format_compat/cases/unary_plus_stripped_per_canonical_form/expected.bean
@@ -7,7 +7,6 @@
 ; lexical form would require extending the typed AST to carry a
 ; had-plus flag, which is a #1262 phase-5+ refactor.
 2024-01-01 open Assets:Money
-
 2024-07-20 * "leading plus sign on posting amount"
   Assets:Money  0.1 USD
   Expenses:Thingamabobs

--- a/crates/rustledger/src/cmd/doctor/roundtrip.rs
+++ b/crates/rustledger/src/cmd/doctor/roundtrip.rs
@@ -291,11 +291,10 @@ mod tests {
     #[test]
     fn glob_no_match_continues_with_advisory() {
         let dir = TempDir::new().unwrap();
-        // Two-directive file with the canonical inter-directive blank
-        // so the per-file roundtrip is stable. (An earlier version of
-        // this test packed two directives back-to-back; the
-        // opinionated formatter would now reflow that into the
-        // canonical blank-separated form.)
+        // Two-directive file with a blank line between the include and
+        // the open. Since #1325 the formatter preserves the author's
+        // blank lines verbatim (grouped or separated both round-trip
+        // stably); this fixture keeps the blank purely for readability.
         let main = write_file(
             dir.path(),
             "main.beancount",


### PR DESCRIPTION
## What

`rledger format` normalized inter-directive spacing to **exactly one blank line** — inserting a blank where the author grouped directives, and collapsing runs of 2+ down to one. This PR makes the formatter **preserve the author's blank lines** instead: grouped directives stay grouped, separated ones stay separated, and nothing is inserted or collapsed.

Closes #1325.

## Why

Researching the beancount ecosystem (recorded on #1325) was decisive — **every formatter in the lineage preserves blank lines**, and rledger was the outlier:

| Tool | Blank-line behavior |
|------|---------------------|
| Python **`bean-format`** | Preserve — docstring promises *"no other changes than whitespace changes"*; a hard assertion enforces it |
| **Fava** | Preserve — only re-spaces amount lines |
| **beancount-language-server** | Preserve — *"recreates bean-format's behavior exactly"* |
| **Emacs beancount-mode** | Preserve |

The old behavior double-spaced a hand-grouped chart of accounts and, worse, a compact `price` feed (hundreds of consecutive `price` directives), which is the most painful real-world case for `rledger format --in-place`.

## How

In the source CST the previous directive owns its terminator NEWLINE (the Directive-Terminator Rule), so a directive's *leading* NEWLINEs are exactly the blank gap before it — a clean 1:1 count, verified against the tree (0 blanks → `[]`, 1 → `[NEWLINE]`, 2 → `[NEWLINE, NEWLINE]`). The new `leading_blank_lines()` helper returns that count, and both the whole-file (`format_node_with_alignment`) and range-formatting emit loops use it in place of the hardcoded single `\n`, so the two paths stay in agreement.

## Tests

- `blank_lines_between_directives_preserved` (0/1/2-blank cases) and the range-formatting equivalent replace the old "insert exactly one" assertions.
- `pushtag/poptag` and `pushmeta/popmeta` canonical tests now expect grouped output (their sources had no blank).
- **7 `format_compat` goldens regenerated** — every diff is pure blank-line removal, **no content change**. `realistic_multi_feature` now reads idiomatically: `option`s grouped, `open`s grouped, `document`s grouped, transactions still blank-separated.

## Validation

- Parser lib **270/270**, `format_compat` green, full **LSP / CLI / FFI** suites green.
- Over the **714-file compat corpus**, the format-idempotence and bean-format-roundtrip gates stay **676/0** — the new output is *more* faithful to the source than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
