### PR TITLE
feat(mcp): add file_path + include resolution to editor_* tools (#1328)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -71,6 +71,19 @@ Add to your Claude Code settings:
 | `editor_document_symbols` | Get document outline/structure |
 | `editor_references` | Find all references to accounts/currencies/payees |
 
+Each editor tool accepts either inline `source` **or** a `file_path` (one is
+required). With `file_path` the server reads the file from disk, so you can ask
+for hover/completions at a cursor position without inlining the whole ledger.
+If both are given, `source` is the unsaved-buffer contents and wins, while
+`file_path` still anchors include resolution.
+
+`editor_hover` and `editor_completions` additionally **resolve `include`
+directives** when `file_path` is set — so an account's balance/usage count and
+the completion candidates reflect the whole ledger, not just the edited file.
+`editor_definition`, `editor_references` and `editor_document_symbols` operate
+on the edited document only (their results are file-local locations, so
+cross-file resolution is intentionally not performed).
+
 ### Analysis Tools
 
 | Tool | Description |

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import { initSync } from '@rustledger/wasm';
 import * as rustledger from '@rustledger/wasm';
 import { handleToolCall } from '../handlers.js';
-import { validateArgs, formatErrors, formatQueryResult, textResponse, errorResponse, jsonResponse, loadWithIncludes } from '../helpers.js';
+import { validateArgs, formatErrors, formatQueryResult, textResponse, errorResponse, jsonResponse, loadWithIncludes, withIncludedContext } from '../helpers.js';
 import { TOOLS } from '../tools.js';
 import { RESOURCES, getResourceContents } from '../resources.js';
 import { PROMPTS, getPrompt } from '../prompts.js';
@@ -954,5 +954,206 @@ include "transactions.beancount"
       // Should report the missing account error
       expect(result.content[0].text).toContain('error');
     });
+  });
+});
+
+// ============================================================================
+// Editor tools: file_path + include resolution (#1328)
+// ============================================================================
+
+describe('withIncludedContext', () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-ctx-'));
+  });
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns the source unchanged when it includes nothing', () => {
+    const src = '2024-01-01 open Assets:Bank USD\n';
+    expect(withIncludedContext(src, tempDir)).toBe(src);
+  });
+
+  it('appends included contents AFTER the edited source (line numbers preserved)', () => {
+    fs.writeFileSync(path.join(tempDir, 'journal.beancount'), '2024-01-01 open Assets:Cash USD');
+    const edited = 'include "journal.beancount"\n2024-01-01 open Assets:Bank USD\n';
+    const full = withIncludedContext(edited, tempDir);
+    // The edited document is a verbatim prefix — so a (line, character)
+    // cursor into it still resolves correctly.
+    expect(full.startsWith(edited)).toBe(true);
+    // The included account is present for aggregate lookups.
+    expect(full).toContain('Assets:Cash');
+  });
+
+  it('de-duplicates a diamond include graph', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-diamond-'));
+    fs.writeFileSync(path.join(d, 'shared.beancount'), '2024-01-01 open Assets:Shared USD');
+    fs.writeFileSync(path.join(d, 'b.beancount'), 'include "shared.beancount"');
+    fs.writeFileSync(path.join(d, 'c.beancount'), 'include "shared.beancount"');
+    const edited = 'include "b.beancount"\ninclude "c.beancount"\n';
+    const full = withIncludedContext(edited, d);
+    const occurrences = full.split('Assets:Shared').length - 1;
+    expect(occurrences).toBe(1);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('throws a contextual error for a missing include', () => {
+    const edited = 'include "does-not-exist.beancount"\n';
+    expect(() => withIncludedContext(edited, tempDir)).toThrow(/Failed to include "does-not-exist\.beancount"/);
+  });
+});
+
+describe('editor tools with file_path', () => {
+  let tempDir: string;
+  let mainPath: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-editor-'));
+    // journal.beancount defines Assets:Checking and uses it in one posting.
+    fs.writeFileSync(
+      path.join(tempDir, 'journal.beancount'),
+      `2024-01-01 open Assets:Checking USD
+2024-01-01 open Income:Salary USD
+2024-01-10 * "Salary"
+  Assets:Checking  100.00 USD
+  Income:Salary   -100.00 USD
+`
+    );
+    // main.beancount includes the journal and uses Assets:Checking once more.
+    mainPath = path.join(tempDir, 'main.beancount');
+    fs.writeFileSync(
+      mainPath,
+      `include "journal.beancount"
+2024-01-01 open Expenses:Food USD
+2024-02-01 * "Coffee"
+  Assets:Checking  -5.00 USD
+  Expenses:Food     5.00 USD
+`
+    );
+  });
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // The hover cursor sits on `Assets:Checking` in main.beancount
+  // (line 3 = the Coffee posting, column 5 is inside the account name).
+  const HOVER_LINE = 3;
+  const HOVER_CHAR = 5;
+
+  function hoverContents(result: { content: Array<{ text: string }> }): string {
+    return result.content[0].text;
+  }
+
+  it('editor_hover resolves includes: open is found and the posting count is whole-ledger', () => {
+    const result = handleToolCall('editor_hover', {
+      file_path: mainPath,
+      line: HOVER_LINE,
+      character: HOVER_CHAR,
+    });
+    const text = hoverContents(result);
+    // The Open lives in the included journal — found only with include resolution.
+    expect(text).toContain('Opened:');
+    // Used in 2 postings: the Coffee posting (main) + the Salary posting (journal).
+    expect(text).toContain('Used in:** 2 postings');
+  });
+
+  it('editor_hover without file_path sees only the edited file (no open, fewer postings)', () => {
+    const source = fs.readFileSync(mainPath, 'utf-8');
+    const result = handleToolCall('editor_hover', {
+      source,
+      line: HOVER_LINE,
+      character: HOVER_CHAR,
+    });
+    const text = hoverContents(result);
+    // Open is in the (unresolved) include, so it's reported as missing...
+    expect(text).toContain('No `open` directive found');
+    // ...and only the single in-file posting is counted.
+    expect(text).toContain('Used in:** 1 postings');
+  });
+
+  it('source overrides file_path contents while file_path still anchors includes', () => {
+    // Unsaved buffer adds a SECOND in-file posting of Assets:Checking.
+    const buffer = `include "journal.beancount"
+2024-01-01 open Expenses:Food USD
+2024-02-01 * "Coffee"
+  Assets:Checking  -5.00 USD
+  Expenses:Food     5.00 USD
+2024-02-02 * "Tea"
+  Assets:Checking  -3.00 USD
+  Expenses:Food     3.00 USD
+`;
+    const result = handleToolCall('editor_hover', {
+      source: buffer,
+      file_path: mainPath,
+      line: HOVER_LINE,
+      character: HOVER_CHAR,
+    });
+    const text = hoverContents(result);
+    // 2 in-buffer postings + 1 from the resolved journal = 3.
+    expect(text).toContain('Used in:** 3 postings');
+  });
+
+  it('editor_hover errors when neither source nor file_path is given', () => {
+    const result = handleToolCall('editor_hover', { line: 0, character: 0 });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Provide either 'source'.*'file_path'/);
+  });
+
+  it('editor_hover errors for a nonexistent file_path', () => {
+    const result = handleToolCall('editor_hover', {
+      file_path: path.join(tempDir, 'nope.beancount'),
+      line: 0,
+      character: 0,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error reading file');
+  });
+
+  it('editor_completions offers accounts defined in included files', () => {
+    // Cursor at the start of an empty posting line in a fresh buffer that
+    // includes the journal; completions should surface Assets:Checking.
+    const buffer = `include "journal.beancount"
+2024-03-01 * "x"
+  Assets`;
+    const result = handleToolCall('editor_completions', {
+      source: buffer,
+      file_path: mainPath,
+      line: 2,
+      character: 8,
+    });
+    expect(result.content[0].text).toContain('Assets:Checking');
+  });
+
+  it('editor_document_symbols stays document-local (does not inline includes)', () => {
+    const result = handleToolCall('editor_document_symbols', { file_path: mainPath });
+    const symbols = JSON.parse(result.content[0].text);
+    // main.beancount has its own directives; the journal's Income:Salary open
+    // must NOT appear (includes are not inlined for the outline).
+    const text = JSON.stringify(symbols);
+    expect(text).toContain('Expenses:Food');
+    expect(text).not.toContain('Income:Salary');
+  });
+
+  it('editor_definition reads file_path from disk (document-local)', () => {
+    // Define + use an account in a single self-contained file.
+    const selfContained = path.join(tempDir, 'solo.beancount');
+    fs.writeFileSync(
+      selfContained,
+      `2024-01-01 open Assets:Solo USD
+2024-01-02 * "x"
+  Assets:Solo  1.00 USD
+  Expenses:Misc
+`
+    );
+    const result = handleToolCall('editor_definition', {
+      file_path: selfContained,
+      line: 2,
+      character: 5,
+    });
+    // Either a definition object or the "no definition" text — but never an
+    // input error, proving the file was loaded.
+    expect(result.isError).toBeFalsy();
   });
 });

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -1003,6 +1003,18 @@ describe('withIncludedContext', () => {
     const edited = 'include "does-not-exist.beancount"\n';
     expect(() => withIncludedContext(edited, tempDir)).toThrow(/Failed to include "does-not-exist\.beancount"/);
   });
+
+  it('is cycle-safe: a circular include graph terminates and appends each file once', () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-cycle-'));
+    fs.writeFileSync(path.join(d, 'a.beancount'), 'include "b.beancount"\n2024-01-01 open Assets:A USD');
+    fs.writeFileSync(path.join(d, 'b.beancount'), 'include "a.beancount"\n2024-01-01 open Assets:B USD');
+    // The global `visited` set is added to BEFORE recursing, so A -> B -> A
+    // terminates (no infinite loop) and each file is appended exactly once.
+    const full = withIncludedContext('include "a.beancount"\n', d);
+    expect(full.split('Assets:A').length - 1).toBe(1);
+    expect(full.split('Assets:B').length - 1).toBe(1);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
 });
 
 describe('editor tools with file_path', () => {

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -1004,6 +1004,39 @@ describe('withIncludedContext', () => {
     expect(() => withIncludedContext(edited, tempDir)).toThrow(/Failed to include "does-not-exist\.beancount"/);
   });
 
+  it('resolves an include that has a trailing comment', () => {
+    fs.writeFileSync(path.join(tempDir, 'commented.beancount'), '2024-01-01 open Assets:Commented USD');
+    const edited = 'include "commented.beancount" ; monthly journal\n';
+    const full = withIncludedContext(edited, tempDir);
+    expect(full).toContain('Assets:Commented');
+  });
+
+  it('resolves an include on a BOM-prefixed first line', () => {
+    fs.writeFileSync(path.join(tempDir, 'bom-target.beancount'), '2024-01-01 open Assets:Bom USD');
+    const edited = '﻿include "bom-target.beancount"\n';
+    const full = withIncludedContext(edited, tempDir);
+    expect(full).toContain('Assets:Bom');
+  });
+
+  it('preserves the edited document verbatim when it lacks a trailing newline', () => {
+    fs.writeFileSync(path.join(tempDir, 'nl-target.beancount'), '2024-01-01 open Assets:NlInc USD');
+    // No trailing newline on the edited source.
+    const edited = 'include "nl-target.beancount"\n2024-01-01 open Assets:NoNl USD';
+    const full = withIncludedContext(edited, tempDir);
+    // The join inserts a separator, so the edited doc's last line stays intact
+    // (cursor coordinates into it remain valid) and both accounts are present.
+    expect(full.startsWith(edited)).toBe(true);
+    expect(full).toContain('Assets:NoNl');
+    expect(full).toContain('Assets:NlInc');
+  });
+
+  it('resolves a CRLF include line', () => {
+    fs.writeFileSync(path.join(tempDir, 'crlf-target.beancount'), '2024-01-01 open Assets:Crlf USD');
+    const edited = 'include "crlf-target.beancount"\r\n2024-01-01 open Assets:Main USD\r\n';
+    const full = withIncludedContext(edited, tempDir);
+    expect(full).toContain('Assets:Crlf');
+  });
+
   it('is cycle-safe: a circular include graph terminates and appends each file once', () => {
     const d = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-cycle-'));
     fs.writeFileSync(path.join(d, 'a.beancount'), 'include "b.beancount"\n2024-01-01 open Assets:A USD');

--- a/packages/mcp-server/src/handlers.ts
+++ b/packages/mcp-server/src/handlers.ts
@@ -17,6 +17,7 @@ import {
   formatErrors,
   formatQueryResult,
   loadWithIncludes,
+  withIncludedContext,
 } from "./helpers.js";
 import { getBqlTablesDocs } from "./resources.js";
 
@@ -327,21 +328,91 @@ function handleRunPlugin(args: ToolArguments | undefined): ToolResponse {
 
 // === Editor Tools ===
 
+/**
+ * Resolve the source an editor tool should operate on.
+ *
+ * Accepts inline `source`, a `file_path` to read from disk, or both (then
+ * `source` is the unsaved-buffer content and wins, while `file_path` still
+ * anchors include resolution). Returns either the resolved source string or a
+ * ToolResponse describing the error (neither input given, or a read failure).
+ *
+ * When `withContext` is true and a `file_path` is given, the edited document
+ * is augmented with the contents of every file it `include`s (appended after
+ * it, so cursor coordinates are preserved) — giving hover/completions
+ * whole-ledger balances and account names. Location-returning tools
+ * (definition/references) and the document outline pass `withContext: false`
+ * and operate on the edited document alone.
+ */
+type ResolvedEditorSource =
+  | { ok: true; source: string }
+  | { ok: false; response: ToolResponse };
+
+function resolveEditorSource(
+  args: ToolArguments | undefined,
+  withContext: boolean
+): ResolvedEditorSource {
+  const inlineSource = args?.source;
+  const filePath = args?.file_path;
+
+  if (inlineSource == null && filePath == null) {
+    return {
+      ok: false,
+      response: errorResponse(
+        "Provide either 'source' (inline ledger text) or 'file_path' (a ledger file to read)."
+      ),
+    };
+  }
+  if (filePath == null) {
+    return { ok: true, source: inlineSource! };
+  }
+
+  try {
+    const absolutePath = path.resolve(filePath);
+    const baseDir = path.dirname(absolutePath);
+    // `source` (an unsaved buffer) overrides the on-disk contents; `file_path`
+    // still anchors include resolution.
+    const editedSource = inlineSource ?? fs.readFileSync(absolutePath, "utf-8");
+    return {
+      ok: true,
+      source: withContext
+        ? withIncludedContext(editedSource, baseDir)
+        : editedSource,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      response: errorResponse(
+        `Error reading file: ${error instanceof Error ? error.message : String(error)}`
+      ),
+    };
+  }
+}
+
 function handleEditorCompletions(args: ToolArguments | undefined): ToolResponse {
-  const validation = validateArgs(args, ["source", "line", "character"]);
+  const validation = validateArgs(args, ["line", "character"]);
   if (validation) return validation;
 
-  const ledger = new rustledger.ParsedLedger(args!.source!);
+  // Whole-ledger context so completions can offer accounts/commodities
+  // defined in included files (#1328, #1297).
+  const resolved = resolveEditorSource(args, true);
+  if (!resolved.ok) return resolved.response;
+
+  const ledger = new rustledger.ParsedLedger(resolved.source);
   const result = ledger.getCompletions(args!.line!, args!.character!);
   ledger.free();
   return jsonResponse(result);
 }
 
 function handleEditorHover(args: ToolArguments | undefined): ToolResponse {
-  const validation = validateArgs(args, ["source", "line", "character"]);
+  const validation = validateArgs(args, ["line", "character"]);
   if (validation) return validation;
 
-  const ledger = new rustledger.ParsedLedger(args!.source!);
+  // Whole-ledger context so the hovered account's balance and transaction
+  // count reflect the full ledger, not just the edited file (#1328).
+  const resolved = resolveEditorSource(args, true);
+  if (!resolved.ok) return resolved.response;
+
+  const ledger = new rustledger.ParsedLedger(resolved.source);
   const result = ledger.getHoverInfo(args!.line!, args!.character!);
   ledger.free();
 
@@ -352,10 +423,16 @@ function handleEditorHover(args: ToolArguments | undefined): ToolResponse {
 }
 
 function handleEditorDefinition(args: ToolArguments | undefined): ToolResponse {
-  const validation = validateArgs(args, ["source", "line", "character"]);
+  const validation = validateArgs(args, ["line", "character"]);
   if (validation) return validation;
 
-  const ledger = new rustledger.ParsedLedger(args!.source!);
+  // Document-local: a definition returns a (line, character) location, which
+  // would be meaningless in the synthetic whole-ledger concatenation. Cross-
+  // file go-to-definition is a known limitation (see helpers.withIncludedContext).
+  const resolved = resolveEditorSource(args, false);
+  if (!resolved.ok) return resolved.response;
+
+  const ledger = new rustledger.ParsedLedger(resolved.source);
   const result = ledger.getDefinition(args!.line!, args!.character!);
   ledger.free();
 
@@ -366,20 +443,27 @@ function handleEditorDefinition(args: ToolArguments | undefined): ToolResponse {
 }
 
 function handleEditorDocumentSymbols(args: ToolArguments | undefined): ToolResponse {
-  const validation = validateArgs(args, ["source"]);
-  if (validation) return validation;
+  // Document outline of the edited file only — including other files' symbols
+  // would pollute the outline.
+  const resolved = resolveEditorSource(args, false);
+  if (!resolved.ok) return resolved.response;
 
-  const ledger = new rustledger.ParsedLedger(args!.source!);
+  const ledger = new rustledger.ParsedLedger(resolved.source);
   const result = ledger.getDocumentSymbols();
   ledger.free();
   return jsonResponse(result);
 }
 
 function handleEditorReferences(args: ToolArguments | undefined): ToolResponse {
-  const validation = validateArgs(args, ["source", "line", "character"]);
+  const validation = validateArgs(args, ["line", "character"]);
   if (validation) return validation;
 
-  const ledger = new rustledger.ParsedLedger(args!.source!);
+  // Document-local, same rationale as editor_definition: references return
+  // locations that only make sense within the edited file's coordinate space.
+  const resolved = resolveEditorSource(args, false);
+  if (!resolved.ok) return resolved.response;
+
+  const ledger = new rustledger.ParsedLedger(resolved.source);
   const result = ledger.getReferences(args!.line!, args!.character!);
   ledger.free();
 

--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -100,6 +100,12 @@ function appendIncludes(
   const includeRe = /^include\s+"([^"]+)"\s*$/gm;
   for (const match of source.matchAll(includeRe)) {
     const includeAbsPath = path.resolve(baseDir, match[1]);
+    // A single global `visited` set, added to BEFORE recursing, both
+    // de-duplicates a diamond graph (a shared file is appended once, which is
+    // what aggregate counts want) and makes a cycle (A -> B -> A) terminate
+    // without re-appending. Unlike `loadWithIncludes`, this does NOT throw on a
+    // cycle: an aggregate lookup for hover/completions stays useful even if the
+    // ledger has an include cycle elsewhere, rather than failing the whole tool.
     if (visited.has(includeAbsPath)) continue;
     visited.add(includeAbsPath);
     let content: string;

--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -9,8 +9,14 @@ import type {
   ToolArguments,
 } from "./types.js";
 
-// Regex to match include directives: include "path/to/file.beancount"
-const INCLUDE_REGEX = /^include\s+"([^"]+)"\s*$/gm;
+// Source for the include-directive matcher, e.g. `include "path/file.beancount"`.
+// Tolerates an optional leading BOM on the first line, and an optional trailing
+// `;` comment (`include "x" ; note`) which is valid beancount the parser treats
+// as trivia. `[ \t]*` before/after avoids crossing line boundaries. Callers
+// that need a fresh `lastIndex` (recursion) build a new RegExp from this; the
+// module-level constant is used by `.replace()`, which manages `lastIndex`.
+const INCLUDE_PATTERN = '^\\uFEFF?include\\s+"([^"]+)"[ \\t]*(?:;[^\\r\\n]*)?[ \\t\\r]*$';
+const INCLUDE_REGEX = new RegExp(INCLUDE_PATTERN, 'gm');
 
 /**
  * Load a beancount file with all its includes resolved.
@@ -97,7 +103,7 @@ function appendIncludes(
 ): void {
   // Fresh regex per call: a shared global regex would carry `lastIndex`
   // state across recursive invocations.
-  const includeRe = /^include\s+"([^"]+)"\s*$/gm;
+  const includeRe = new RegExp(INCLUDE_PATTERN, 'gm');
   for (const match of source.matchAll(includeRe)) {
     const includeAbsPath = path.resolve(baseDir, match[1]);
     // A single global `visited` set, added to BEFORE recursing, both

--- a/packages/mcp-server/src/helpers.ts
+++ b/packages/mcp-server/src/helpers.ts
@@ -59,6 +59,63 @@ function loadFileRecursive(filePath: string, visited: Set<string>): string {
 }
 
 /**
+ * Build a whole-ledger source for the *aggregate* editor tools (hover,
+ * completions) WITHOUT shifting the edited document's line numbers.
+ *
+ * The edited document is kept verbatim and FIRST, so a `(line, character)`
+ * cursor still resolves against it. The recursively-resolved contents of
+ * every file it `include`s are appended AFTER it, so balances, transaction
+ * counts and candidate accounts reflect the whole ledger. Each included file
+ * is appended at most once (de-duplicated across the include graph), and the
+ * `include` lines in the edited document — which the parser treats as inert
+ * directives — keep it from being double-counted.
+ *
+ * This append strategy is why these tools resolve includes while
+ * `editor_definition` / `editor_references` do not: appended directives have
+ * synthetic line numbers that don't map back to any real file, which is fine
+ * for "what is this account's balance" but wrong for "where is it defined".
+ *
+ * @param editedSource - The source of the file under the cursor.
+ * @param baseDir - Directory the edited document's includes resolve against
+ *   (normally the directory of its `file_path`).
+ * @returns `editedSource` followed by the appended include contents (or
+ *   `editedSource` unchanged when it includes nothing).
+ * @throws Error if an included file cannot be read.
+ */
+export function withIncludedContext(editedSource: string, baseDir: string): string {
+  const visited = new Set<string>();
+  const appended: string[] = [];
+  appendIncludes(editedSource, baseDir, visited, appended);
+  return appended.length === 0 ? editedSource : [editedSource, ...appended].join("\n");
+}
+
+function appendIncludes(
+  source: string,
+  baseDir: string,
+  visited: Set<string>,
+  out: string[]
+): void {
+  // Fresh regex per call: a shared global regex would carry `lastIndex`
+  // state across recursive invocations.
+  const includeRe = /^include\s+"([^"]+)"\s*$/gm;
+  for (const match of source.matchAll(includeRe)) {
+    const includeAbsPath = path.resolve(baseDir, match[1]);
+    if (visited.has(includeAbsPath)) continue;
+    visited.add(includeAbsPath);
+    let content: string;
+    try {
+      content = fs.readFileSync(includeAbsPath, "utf-8");
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to include "${match[1]}": ${msg}`);
+    }
+    out.push(content);
+    // Nested includes resolve relative to the included file's directory.
+    appendIncludes(content, path.dirname(includeAbsPath), visited, out);
+  }
+}
+
+/**
  * Validate that required arguments are present.
  * Returns a ToolResponse with error if validation fails, null otherwise.
  */

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -149,115 +149,117 @@ export const runPluginTool: ToolDefinition = {
 
 // === Editor Tools (LSP-like) ===
 
+// Shared property fragments for the editor tools. Every editor tool accepts
+// `source` OR `file_path` (validated in the handler, since JSON Schema can't
+// express "exactly one of"). `file_path` lets a client pass a path instead of
+// inlining the whole ledger, and lets the server resolve `include` directives.
+const editorSourceProp = {
+  type: "string",
+  description:
+    "The Beancount ledger source text. Optional when `file_path` is given; if both are provided, `source` is the (unsaved) buffer contents and wins, while `file_path` still anchors include resolution.",
+} as const;
+
+const editorLineProp = {
+  type: "number",
+  description: "Line number (0-indexed)",
+} as const;
+
+const editorCharacterProp = {
+  type: "number",
+  description: "Character position in the line (0-indexed)",
+} as const;
+
+// For hover/completions: file_path additionally resolves includes for
+// whole-ledger context.
+const editorFilePathContextProp = {
+  type: "string",
+  description:
+    "Path to the ledger file under the cursor. Read from disk when `source` is omitted, and used to resolve `include` directives (relative to its directory) so the result reflects the whole ledger, not just the edited file.",
+} as const;
+
+// For definition/references/document_symbols: file_path loads the file but the
+// tool stays document-local (its result is a location/outline).
+const editorFilePathLocalProp = {
+  type: "string",
+  description:
+    "Path to the ledger file to read when `source` is omitted. This tool operates on the edited document only; `include` directives are not followed (its result is a location within this file).",
+} as const;
+
 export const editorCompletionsTool: ToolDefinition = {
   name: "editor_completions",
   description:
-    "Get context-aware completions for Beancount source at a given position. Returns account names, currencies, directives, etc.",
+    "Get context-aware completions for Beancount source at a given position. Returns account names, currencies, directives, etc. When `file_path` is given, `include` directives are resolved so completions also offer accounts/commodities defined in included files.",
   inputSchema: {
     type: "object",
     properties: {
-      source: {
-        type: "string",
-        description: "The Beancount ledger source text",
-      },
-      line: {
-        type: "number",
-        description: "Line number (0-indexed)",
-      },
-      character: {
-        type: "number",
-        description: "Character position in the line (0-indexed)",
-      },
+      source: editorSourceProp,
+      file_path: editorFilePathContextProp,
+      line: editorLineProp,
+      character: editorCharacterProp,
     },
-    required: ["source", "line", "character"],
+    required: ["line", "character"],
   },
 };
 
 export const editorHoverTool: ToolDefinition = {
   name: "editor_hover",
   description:
-    "Get hover information for a symbol at the given position. Returns documentation for accounts, currencies, and directives.",
+    "Get hover information for a symbol at the given position. Returns documentation for accounts, currencies, and directives. When `file_path` is given, `include` directives are resolved so an account's balance and transaction count reflect the whole ledger, not just the edited file.",
   inputSchema: {
     type: "object",
     properties: {
-      source: {
-        type: "string",
-        description: "The Beancount ledger source text",
-      },
-      line: {
-        type: "number",
-        description: "Line number (0-indexed)",
-      },
-      character: {
-        type: "number",
-        description: "Character position in the line (0-indexed)",
-      },
+      source: editorSourceProp,
+      file_path: editorFilePathContextProp,
+      line: editorLineProp,
+      character: editorCharacterProp,
     },
-    required: ["source", "line", "character"],
+    required: ["line", "character"],
   },
 };
 
 export const editorDefinitionTool: ToolDefinition = {
   name: "editor_definition",
   description:
-    "Get the definition location for a symbol (account or currency). Returns the location of the Open or Commodity directive.",
+    "Get the definition location for a symbol (account or currency). Returns the location of the Open or Commodity directive. Operates on the edited document only (cross-file definitions are not resolved).",
   inputSchema: {
     type: "object",
     properties: {
-      source: {
-        type: "string",
-        description: "The Beancount ledger source text",
-      },
-      line: {
-        type: "number",
-        description: "Line number (0-indexed)",
-      },
-      character: {
-        type: "number",
-        description: "Character position in the line (0-indexed)",
-      },
+      source: editorSourceProp,
+      file_path: editorFilePathLocalProp,
+      line: editorLineProp,
+      character: editorCharacterProp,
     },
-    required: ["source", "line", "character"],
+    required: ["line", "character"],
   },
 };
 
 export const editorDocumentSymbolsTool: ToolDefinition = {
   name: "editor_document_symbols",
   description:
-    "Get all symbols in the document for an outline/structure view. Returns all directives with their positions.",
+    "Get all symbols in the document for an outline/structure view. Returns all directives with their positions. Operates on the edited document only (included files are not inlined).",
   inputSchema: {
     type: "object",
     properties: {
-      source: {
-        type: "string",
-        description: "The Beancount ledger source text",
-      },
+      source: editorSourceProp,
+      file_path: editorFilePathLocalProp,
     },
-    required: ["source"],
+    required: [],
   },
 };
 
 export const editorReferencesTool: ToolDefinition = {
   name: "editor_references",
   description:
-    "Find all references to a symbol (account, currency, or payee) at the given position. Returns all locations where the symbol is used.",
+    "Find all references to a symbol (account, currency, or payee) at the given position. Returns all locations where the symbol is used. Operates on the edited document only (cross-file references are not resolved).",
   inputSchema: {
     type: "object",
     properties: {
-      source: {
-        type: "string",
-        description: "The Beancount ledger source text",
-      },
-      line: {
-        type: "number",
-        description: "Line number (0-indexed)",
-      },
-      character: {
-        type: "number",
-        description: "Character position in the line (0-indexed)",
-      },
+      source: editorSourceProp,
+      file_path: editorFilePathLocalProp,
+      line: editorLineProp,
+      character: editorCharacterProp,
     },
-    required: ["source", "line", "character"],
+    required: ["line", "character"],
   },
 };
 


### PR DESCRIPTION
## What

Adds an optional **`file_path`** to all five `editor_*` MCP tools (`editor_hover`, `editor_completions`, `editor_definition`, `editor_document_symbols`, `editor_references`) and resolves `include` directives where it makes sense. `source` becomes optional — exactly one of `source` / `file_path` is required (validated in the handler, since JSON Schema can't express "one of"). If both are given, `source` is the unsaved-buffer content and wins, while `file_path` still anchors include resolution.

Closes #1328 (refs #1297).

## The fix, by tool

**`editor_hover` / `editor_completions` resolve includes** — so an account's usage count and the completion candidates reflect the **whole ledger**, not just the edited file. Before: hovering an account whose `open` lives in an included file returned *"No hover information"*.

**`editor_definition` / `editor_references` / `editor_document_symbols` stay document-local.** Their results are file-local *locations* / an outline, which would be meaningless in a synthetic multi-file concatenation, so cross-file resolution is intentionally **not** performed (documented in code, schema descriptions, and README). This is the main design call I'd like a sanity check on — see below.

## Why "append", not "inline"

The existing `loadWithIncludes` inlines includes in place, which shifts line numbers — fatal for position-based tools. Instead, `withIncludedContext` keeps the edited document as a **verbatim prefix** and appends the resolved include contents after it. The cursor `(line, character)` still maps to the edited document; aggregates (posting counts, available accounts) see everything; the edited document's own `include` lines stay inert so nothing is double-counted; the include graph is de-duplicated.

## Demonstration (from the tests)

Hover on `Assets:Checking` in `main.beancount` (account defined + used in an included `journal.beancount`):

| Input | Result |
|---|---|
| `file_path` (includes resolved) | `**Opened:** 2024-01-01` · `**Used in:** 2 postings` (whole ledger) |
| `source` only (no resolution) | ``No `open` directive found`` · `**Used in:** 1 postings` |

## Design decision for review

I scoped include-resolution to the two tools whose output is *data about a symbol* (hover/completions). For `definition`/`references`, returning a location inside the appended region would point at a line that doesn't exist in any real file — worse than today. Fully cross-file go-to-definition would need real multi-file coordinate mapping (WASM-side), which is a larger change. Flagging in case you'd prefer a different split.

## Test plan
- 12 new tests (`withIncludedContext` append/dedup/missing-include; hover full-ledger vs edited-only; `source` overriding `file_path`; missing-input and missing-file errors; completions surfacing included accounts; `document_symbols` staying local; `definition` reading `file_path`).
- `npm test` → **101/101** green. `npm run build` (tsc) → typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
