### PR TITLE
fix(format): preserve unparsable content (org headers) verbatim (#1335)

### DIFF
--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -693,16 +693,25 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
     for el in node.children_with_tokens() {
         match el {
             rowan::NodeOrToken::Node(n) => {
-                let Some(directive) = ast::Directive::cast(n) else {
-                    continue;
-                };
-                if prev_was_directive {
-                    for _ in 0..leading_blank_lines(directive.syntax()) {
-                        out.push('\n');
+                if let Some(directive) = ast::Directive::cast(n.clone()) {
+                    if prev_was_directive {
+                        for _ in 0..leading_blank_lines(directive.syntax()) {
+                            out.push('\n');
+                        }
                     }
+                    emit_directive(&directive, alignment, &mut out);
+                    prev_was_directive = true;
+                } else if n.kind() == crate::SyntaxKind::ERROR_NODE {
+                    // Preserve unparsable content verbatim (#1335): `format`
+                    // must never delete the author's text. Org-mode `*`
+                    // section headers (and any comments grouped with them)
+                    // parse into ERROR_NODEs; emit them as-is rather than
+                    // dropping them. Treated like a file-level comment group
+                    // for spacing — it stays flush against its neighbors.
+                    emit_error_node(&n, &mut out);
+                    prev_was_directive = false;
                 }
-                emit_directive(&directive, alignment, &mut out);
-                prev_was_directive = true;
+                // Any other non-directive node: nothing to emit.
             }
             rowan::NodeOrToken::Token(t) => {
                 if matches!(
@@ -942,6 +951,10 @@ pub fn format_node_range_with_alignment(
         }
         match el {
             rowan::NodeOrToken::Node(n) => {
+                // ERROR_NODEs never reach here: the range path bails out
+                // above (returns None) when the snap covers one, so it
+                // refuses to format rather than risk touching unparsable
+                // content. Only the whole-file path preserves them verbatim.
                 let Some(directive) = ast::Directive::cast(n) else {
                     continue;
                 };
@@ -1183,6 +1196,20 @@ fn emit_directive(d: &ast::Directive, align: PostingAlignment, out: &mut String)
         splice.push(' ');
         splice.push_str(&c);
         out.insert_str(insert_at, &splice);
+    }
+}
+
+/// Emit an `ERROR_NODE`'s text verbatim, so `format` never deletes content it
+/// could not parse (#1335) — chiefly org-mode `*` section headers and the
+/// comments grouped with them. Only trailing whitespace per line is stripped
+/// (the formatter's no-trailing-space policy) and the node's trailing newlines
+/// are collapsed to one; everything else — including blank lines, comments and
+/// the unparsable lines themselves — is preserved exactly as written.
+fn emit_error_node(node: &crate::SyntaxNode, out: &mut String) {
+    let text = node.text().to_string();
+    for line in text.trim_end_matches(['\n', '\r']).split('\n') {
+        out.push_str(line.trim_end());
+        out.push('\n');
     }
 }
 
@@ -2463,6 +2490,49 @@ mod tests {
             "comment must stay between postings:\n{out}"
         );
         assert_eq!(format_source(&out), out, "format must be idempotent");
+    }
+
+    #[test]
+    fn issue_1335_org_headers_and_grouped_comments_preserved() {
+        // The formatter must not delete unparsable content (#1335).
+        // Org-mode `*` section headers parse into ERROR_NODEs, and comments
+        // grouped with them get swallowed into the same node — previously all
+        // dropped. They must survive, and the result must be idempotent.
+        let src = "\
+* Section A
+;; comment between headers
+;; second line
+* Section B
+2013-01-01 open Assets:X
+";
+        let out = format_source(src);
+        for needle in [
+            "* Section A",
+            "; comment between headers",
+            "; second line",
+            "* Section B",
+            "2013-01-01 open Assets:X",
+        ] {
+            assert!(
+                out.contains(needle),
+                "lost {needle:?} on format; got:\n{out}"
+            );
+        }
+        assert_eq!(format_source(&out), out, "format must be idempotent");
+    }
+
+    #[test]
+    fn issue_1335_org_header_then_directive_keeps_header() {
+        // A lone org header before a directive: the header is an ERROR_NODE
+        // and must be kept (the comment here attaches to the directive and
+        // was already preserved).
+        let src = "* Accounts\n2013-01-01 open Assets:X\n";
+        let out = format_source(src);
+        assert!(
+            out.contains("* Accounts"),
+            "org header dropped; got:\n{out}"
+        );
+        assert_eq!(format_source(&out), out);
     }
 
     #[test]

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -706,10 +706,17 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
                     // must never delete the author's text. Org-mode `*`
                     // section headers (and any comments grouped with them)
                     // parse into ERROR_NODEs; emit them as-is rather than
-                    // dropping them. Treated like a file-level comment group
-                    // for spacing — it stays flush against its neighbors.
+                    // dropping them. Treated like a directive for spacing — an
+                    // ERROR_NODE is a top-level content block, so the author's
+                    // blank lines around it (before it, and before the next
+                    // directive) are preserved, not flushed.
+                    if prev_was_directive {
+                        for _ in 0..leading_blank_lines(&n) {
+                            out.push('\n');
+                        }
+                    }
                     emit_error_node(&n, &mut out);
-                    prev_was_directive = false;
+                    prev_was_directive = true;
                 }
                 // Any other non-directive node: nothing to emit.
             }
@@ -1207,7 +1214,11 @@ fn emit_directive(d: &ast::Directive, align: PostingAlignment, out: &mut String)
 /// the unparsable lines themselves — is preserved exactly as written.
 fn emit_error_node(node: &crate::SyntaxNode, out: &mut String) {
     let text = node.text().to_string();
-    for line in text.trim_end_matches(['\n', '\r']).split('\n') {
+    // Trim leading AND trailing blank lines: the caller emits the leading
+    // blank lines (via `leading_blank_lines`) so emitting them here too would
+    // double-count them and break idempotence. Internal blank lines and the
+    // content (org headers, grouped comments) are preserved.
+    for line in text.trim_matches(['\n', '\r']).split('\n') {
         out.push_str(line.trim_end());
         out.push('\n');
     }
@@ -2506,10 +2517,12 @@ mod tests {
 2013-01-01 open Assets:X
 ";
         let out = format_source(src);
+        // Use the exact `;;` needles: a single-`;` substring would still match
+        // `;; ...` even if one `;` were dropped, weakening the regression.
         for needle in [
             "* Section A",
-            "; comment between headers",
-            "; second line",
+            ";; comment between headers",
+            ";; second line",
             "* Section B",
             "2013-01-01 open Assets:X",
         ] {
@@ -2533,6 +2546,20 @@ mod tests {
             "org header dropped; got:\n{out}"
         );
         assert_eq!(format_source(&out), out);
+    }
+
+    #[test]
+    fn issue_1335_blank_lines_around_org_header_preserved() {
+        // An ERROR_NODE is a top-level content block: the author's blank line
+        // between an org header and the following directive is preserved (it
+        // is not flushed), and the result is idempotent.
+        let src = "* Accounts\n\n2013-01-01 open Assets:X\n";
+        assert_eq!(
+            format_source(src),
+            src,
+            "blank around org header must be kept"
+        );
+        assert_eq!(format_source(&format_source(src)), format_source(src));
     }
 
     #[test]


### PR DESCRIPTION
## What

`rledger format` deleted content it couldn't parse — **org-mode `*` section headers** and the comments grouped with them. Closes #1335.

```beancount
* Section A
;; comment between headers
;; second line
* Section B
2013-01-01 open Assets:X
```
Before: only `2013-01-01 open Assets:X` survived. One corpus file (an Emacs/org-style ledger) lost **223 → 120** comment lines.

## Root cause

Org headers aren't valid rledger directives, so the parser emits them as `ERROR_NODE`s, and comments grouped with such a header are swallowed into the same `ERROR_NODE`. The top-level emit loop skipped every child that didn't `cast` to a `Directive`, dropping the headers and the grouped comments.

## Fix

Emit `ERROR_NODE` text **verbatim** (new `emit_error_node` helper): strip only trailing whitespace per line and collapse the node's trailing newlines to one; preserve the unparseable lines, blank lines and grouped comments exactly. The range-formatting path is unchanged — it already *refuses* (returns `None`) when a selection covers an `ERROR_NODE`, which is the right conservative behavior there.

## Test plan

- Unit tests: org headers + grouped comments preserved (idempotent), and a lone header before a directive.
- Full `rustledger-parser` suite green; `format_compat` unchanged; clippy clean.
- Over the ~700-file corpus, **format-idempotence** and **bean-format-roundtrip** stay **676/0**; the org-style file now preserves all 223 comment lines.

## Stacking & follow-up

- **Stacked on #1334** (directive-body comments). The two together take the corpus comment-deletion count from many → a small tail. Merge #1334 first; this retargets to `main` automatically.
- A residual comment-loss tail remains (posting-internal comments and exact-duplicate comment lines in a few conversion-test files) — distinct from org headers, tracked in #1337. The corpus comment-preservation guard that found both #1332 and #1335 will ship as a strict CI gate once that tail is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
