### PR TITLE
fix(loader): persist set_options across the cache round-trip (#1340)

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -51,7 +51,13 @@ pub struct CachedPlugin {
 
 /// Cached options - a serializable subset of Options.
 ///
-/// Excludes parsing-time fields like `set_options` and `warnings`.
+/// Excludes transient parsing-time fields like `warnings`, but DOES
+/// persist `set_options`: it is load-bearing downstream, because
+/// `resolve_effective_booking_method` gates on
+/// `set_options.contains("booking_method")` to decide whether the
+/// file-level `option "booking_method"` wins over the API default.
+/// Dropping it across the cache round-trip silently re-books FIFO/LIFO
+/// ledgers as STRICT on a cache hit (#1340).
 /// These fields mirror the Options struct and inherit their meaning.
 #[derive(Debug, Clone, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 #[allow(missing_docs)]
@@ -84,6 +90,11 @@ pub struct CachedOptions {
     pub long_string_maxlines: u32,
     pub documents: Vec<String>,
     pub custom: Vec<(String, String)>,
+    /// Names of options the source explicitly set (e.g.
+    /// `"booking_method"`). Restored so downstream resolution that
+    /// distinguishes "file set this" from "inherited default" behaves
+    /// identically on a cache hit. See the struct-level note (#1340).
+    pub set_options: Vec<String>,
 }
 
 impl From<&Options> for CachedOptions {
@@ -124,6 +135,7 @@ impl From<&Options> for CachedOptions {
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
+            set_options: opts.set_options.iter().cloned().collect(),
         }
     }
 }
@@ -164,6 +176,7 @@ impl From<CachedOptions> for Options {
         opts.long_string_maxlines = cached.long_string_maxlines;
         opts.documents = cached.documents;
         opts.custom = cached.custom.into_iter().collect();
+        opts.set_options = cached.set_options.into_iter().collect();
         opts
     }
 }
@@ -295,7 +308,13 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     does NOT require a separate version bump. If a future rkyv
 ///     version changes that encoding, OR if `CostNumber` gains
 ///     additional fields, bump to v9.
-const CACHE_VERSION: u32 = 8;
+/// v9: `CachedOptions` gained a `set_options: Vec<String>` field
+///     (#1340). It was previously dropped, so a cache hit lost the
+///     record of which options the file explicitly set — making
+///     `resolve_effective_booking_method` re-book FIFO/LIFO ledgers as
+///     STRICT. The new trailing field changes the archived layout, so
+///     old bytes must be regenerated.
+const CACHE_VERSION: u32 = 9;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -990,13 +1009,17 @@ mod tests {
         // the developer to also update the fixtures (or remove this
         // tripwire if v9's contract is identical to v8 for CostNumber
         // — which is unusual but possible).
-        const FIXTURE_VERSION: u32 = 8;
+        // v9 (#1340) bumped CACHE_VERSION only to add a `set_options`
+        // field to `CachedOptions` — the `CostNumber` archived layout
+        // these fixtures pin is unchanged, so the byte arrays below are
+        // still valid and only FIXTURE_VERSION moves.
+        const FIXTURE_VERSION: u32 = 9;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \
              the byte fixtures in this test and update FIXTURE_VERSION, \
              or remove the tripwire if v{CACHE_VERSION}'s CostNumber \
-             encoding is byte-identical to v8.",
+             encoding is byte-identical to the fixtures.",
         );
 
         let cases: &[(&str, CostNumber, &[u8])] = &[
@@ -1080,6 +1103,29 @@ mod tests {
         assert_eq!(restored.title, Some("Test Ledger".to_string()));
         assert_eq!(restored.operating_currency, vec!["USD", "EUR"]);
         assert!(restored.render_commas);
+    }
+
+    /// Regression for #1340: `set_options` must survive the cache
+    /// round-trip. It gates `resolve_effective_booking_method`, so
+    /// dropping it makes a cache hit re-book FIFO/LIFO ledgers as
+    /// STRICT (the file-level `option "booking_method"` is ignored).
+    #[test]
+    fn test_cached_options_preserves_set_options_for_booking_method() {
+        let mut opts = Options::new();
+        // `set()` is what a parsed `option "booking_method" "FIFO"`
+        // calls — it records both the value AND the set-membership.
+        opts.set("booking_method", "FIFO");
+        assert!(opts.set_options.contains("booking_method"));
+
+        let cached = CachedOptions::from(&opts);
+        let restored: Options = cached.into();
+
+        assert_eq!(restored.booking_method, "FIFO");
+        assert!(
+            restored.set_options.contains("booking_method"),
+            "set_options dropped across cache round-trip — booking method \
+             resolution would fall back to the STRICT default on a cache hit"
+        );
     }
 
     #[test]

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -307,7 +307,7 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     positionally) — verified against rkyv 0.8.16 — so this change
 ///     does NOT require a separate version bump. If a future rkyv
 ///     version changes that encoding, OR if `CostNumber` gains
-///     additional fields, bump to v9.
+///     additional fields, bump to v10.
 /// v9: `CachedOptions` gained a `set_options: Vec<String>` field
 ///     (#1340). It was previously dropped, so a cache hit lost the
 ///     record of which options the file explicitly set — making

--- a/crates/rustledger/tests/query_parse_cache.rs
+++ b/crates/rustledger/tests/query_parse_cache.rs
@@ -181,8 +181,17 @@ fn query_cache_preserves_file_booking_method() {
          lost across the cache round-trip (#1340)"
     );
     assert_eq!(warm_out, nocache_out, "cached output must match --no-cache");
-    assert!(
-        warm_out.contains('2'),
+
+    // Parse the COUNT(*) value rather than substring-matching: FIFO
+    // expands the multi-lot `-15 STK {}` reduction into 2 per-lot rows,
+    // so the count of negative Assets:Stock postings must be exactly 2.
+    // (STRICT — the buggy cache path — fails to book it, yielding 1.)
+    let count: i64 = warm_out
+        .lines()
+        .find_map(|l| l.trim().parse::<i64>().ok())
+        .expect("query output should contain a numeric COUNT value");
+    assert_eq!(
+        count, 2,
         "FIFO should expand the multi-lot reduction into 2 rows; got:\n{warm_out}"
     );
 }

--- a/crates/rustledger/tests/query_parse_cache.rs
+++ b/crates/rustledger/tests/query_parse_cache.rs
@@ -102,6 +102,91 @@ fn query_uses_parse_cache_with_identical_output() {
     );
 }
 
+/// Regression for #1340: a file-level `option "booking_method"` must
+/// survive the cache round-trip. The `set_options` membership that
+/// `resolve_effective_booking_method` consults was previously dropped
+/// when reconstructing options from cache, so a warm run silently fell
+/// back to the STRICT default — turning a FIFO multi-lot reduction into
+/// an "ambiguous lot match" booking failure and producing different
+/// (wrong) output than the cold/uncached run.
+const FIFO_SRC: &str = r#"option "operating_currency" "USD"
+option "booking_method" "FIFO"
+
+2024-01-01 open Assets:Stock
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:PnL
+
+2024-02-01 * "Buy lot A"
+  Assets:Stock   10 STK {1 USD}
+  Assets:Cash   -10 USD
+
+2024-03-01 * "Buy lot B"
+  Assets:Stock   10 STK {2 USD}
+  Assets:Cash   -20 USD
+
+2024-04-01 * "Sell across both lots"
+  Assets:Stock  -15 STK {}
+  Assets:Cash    30 USD
+  Income:PnL
+"#;
+
+#[test]
+fn query_cache_preserves_file_booking_method() {
+    let bin = require_rledger!();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("ledger.beancount");
+    std::fs::write(&file, FIFO_SRC).expect("write ledger");
+
+    // FIFO booking expands the -15 STK {} reduction into one posting
+    // per matched lot (-10 {1 USD} + -5 {2 USD}) → 2 Assets:Stock
+    // reduction rows. Under the bug, a cache hit booked STRICT, the
+    // reduction failed as ambiguous, and the posting stayed a single
+    // un-booked row — so the count differs.
+    let query = "SELECT count(*) WHERE account = 'Assets:Stock' AND number < 0";
+
+    let run = |disable_cache: bool| {
+        let mut cmd = Command::new(&bin);
+        cmd.arg("query").arg(&file).arg(query);
+        cmd.env_remove("BEANCOUNT_DISABLE_LOAD_CACHE")
+            .env_remove("BEANCOUNT_LOAD_CACHE_FILENAME");
+        if disable_cache {
+            cmd.env("BEANCOUNT_DISABLE_LOAD_CACHE", "1");
+        }
+        cmd.output().expect("run rledger query")
+    };
+
+    // Cold run writes the cache; uncached run is the ground truth.
+    let cold = run(false);
+    assert!(
+        cold.status.success(),
+        "cold query failed: {}",
+        String::from_utf8_lossy(&cold.stderr)
+    );
+    let cold_out = String::from_utf8_lossy(&cold.stdout).into_owned();
+    let nocache_out = {
+        let o = run(true);
+        assert!(o.status.success());
+        String::from_utf8_lossy(&o.stdout).into_owned()
+    };
+
+    // Warm run must hit the cache and match the cold/uncached output.
+    let warm = run(false);
+    assert!(warm.status.success());
+    let warm_out = String::from_utf8_lossy(&warm.stdout).into_owned();
+
+    assert_eq!(
+        warm_out, cold_out,
+        "cached FIFO query diverged from the cold run — booking method \
+         lost across the cache round-trip (#1340)"
+    );
+    assert_eq!(warm_out, nocache_out, "cached output must match --no-cache");
+    assert!(
+        warm_out.contains('2'),
+        "FIFO should expand the multi-lot reduction into 2 rows; got:\n{warm_out}"
+    );
+}
+
 /// The `--no-cache` flag must disable the cache entirely: a query run
 /// with it set must not write a cache file (and must still succeed).
 /// `--no-cache` precedes the positionals (QUERY is `trailing_var_arg`).


### PR DESCRIPTION
Closes #1340.

## Problem

A file-level `option "booking_method" "FIFO"` (or `LIFO`/`HIFO`/`AVERAGE`/`NONE`) is **silently lost on a parse-cache hit**, so cached `query`/`report` runs re-book the ledger under the **STRICT** default. A multi-lot `{}` reduction then fails as `ambiguous lot match`, the transaction is partitioned out as a failed booking, and its postings stay un-booked — yielding **wrong balances and wrong query results** vs. the cold / `--no-cache` run.

This was surfaced while investigating the AST full-match compat gap (one of the two non-matching files, `example_stock.beancount`, reported 22 postings via the cached compat query instead of Python’s 24).

## Root cause

`resolve_effective_booking_method` (process.rs) decides whether the file-level option wins via:

```rust
let file_set = raw.options.set_options.contains("booking_method");
if file_set { raw.options.booking_method.parse()... } else { options.booking_method /* API default = STRICT */ }
```

But `CachedOptions` never persisted `set_options`. `From<CachedOptions> for Options` starts from `Options::new()` (empty set), so on a cache hit `file_set` is **always false** and resolution falls back to the STRICT default — even though the restored `booking_method` string is correctly `"FIFO"`.

## Fix

- Persist `set_options` in `CachedOptions` and restore it on the way out.
- Bump `CACHE_VERSION` 8 → 9 (new trailing field changes the rkyv archived layout, so stale caches must regenerate).
- Advance the `CostNumber` byte-fixture tripwire `FIXTURE_VERSION` to 9 — the `CostNumber` encoding it guards is unchanged, so the byte arrays stay valid.

## Verification (local, via `nix develop`)

```
# minimal FIFO ledger, multi-lot `-15 STK {}` reduction:
cold  →  -10 STK {1 USD} + -5 STK {2 USD}   (FIFO-expanded)
warm  →  -10 STK {1 USD} + -5 STK {2 USD}   (now identical; was un-booked -15 STK before)

# example_stock.beancount: SELECT COUNT(*)  →  24 cold AND warm (was 22 warm)
```

Tests:
- **unit** (`cache.rs`): `CachedOptions` round-trip preserves `set_options` for `booking_method`.
- **integration** (`query_parse_cache.rs`): a FIFO ledger with a multi-lot reduction produces identical, correctly-expanded output across cold / warm / `--no-cache`.
- `cargo test -p rustledger-loader -p rustledger-booking -p rustledger-query` green; `clippy -p rustledger-loader` clean.

This closes one of the two AST full-match gaps from the compat investigation; the other (`effective_date_examples.beancount`) is addressed separately by #1339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)