### PR TITLE
ci(fuzz): don't fail the crash gate on benign slow-units

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -109,13 +109,26 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         run: |
           cd crates/rustledger-parser
-          if [ -d "fuzz/artifacts/${{ matrix.target }}" ] && [ "$(ls -A fuzz/artifacts/${{ matrix.target }})" ]; then
-            echo "::error::Fuzzer found crashes!"
-            ls -la fuzz/artifacts/${{ matrix.target }}/
-            exit 1
-          else
-            echo "No crashes found"
+          dir="fuzz/artifacts/${{ matrix.target }}"
+          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+            echo "No crash artifacts found"
+            exit 0
           fi
+          # Real failures are crash-/oom-/timeout-/leak- artifacts.
+          # `slow-unit-*` means an input was slow but completed — surface
+          # it as a non-fatal warning instead of failing the build (#1342).
+          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*')
+          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*')
+          if [ -n "$slow" ]; then
+            echo "::warning::Fuzzer found slow units (non-fatal); investigate for super-linear behavior:"
+            echo "$slow"
+          fi
+          if [ -n "$crashes" ]; then
+            echo "::error::Fuzzer found crashes!"
+            ls -la "$dir"/
+            exit 1
+          fi
+          echo "No crashes found (slow units, if present, are non-fatal)"
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -197,13 +210,26 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         run: |
           cd crates/rustledger-query
-          if [ -d "fuzz/artifacts/fuzz_query_parse" ] && [ "$(ls -A fuzz/artifacts/fuzz_query_parse)" ]; then
-            echo "::error::Fuzzer found crashes!"
-            ls -la fuzz/artifacts/fuzz_query_parse/
-            exit 1
-          else
-            echo "No crashes found"
+          dir="fuzz/artifacts/fuzz_query_parse"
+          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+            echo "No crash artifacts found"
+            exit 0
           fi
+          # Real failures are crash-/oom-/timeout-/leak- artifacts.
+          # `slow-unit-*` means an input was slow but completed — surface
+          # it as a non-fatal warning instead of failing the build (#1342).
+          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*')
+          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*')
+          if [ -n "$slow" ]; then
+            echo "::warning::Fuzzer found slow units (non-fatal); investigate for super-linear behavior:"
+            echo "$slow"
+          fi
+          if [ -n "$crashes" ]; then
+            echo "::error::Fuzzer found crashes!"
+            ls -la "$dir"/
+            exit 1
+          fi
+          echo "No crashes found (slow units, if present, are non-fatal)"
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -285,13 +311,26 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         run: |
           cd crates/rustledger-booking
-          if [ -d "fuzz/artifacts/fuzz_booking" ] && [ "$(ls -A fuzz/artifacts/fuzz_booking)" ]; then
-            echo "::error::Fuzzer found crashes!"
-            ls -la fuzz/artifacts/fuzz_booking/
-            exit 1
-          else
-            echo "No crashes found"
+          dir="fuzz/artifacts/fuzz_booking"
+          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+            echo "No crash artifacts found"
+            exit 0
           fi
+          # Real failures are crash-/oom-/timeout-/leak- artifacts.
+          # `slow-unit-*` means an input was slow but completed — surface
+          # it as a non-fatal warning instead of failing the build (#1342).
+          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*')
+          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*')
+          if [ -n "$slow" ]; then
+            echo "::warning::Fuzzer found slow units (non-fatal); investigate for super-linear behavior:"
+            echo "$slow"
+          fi
+          if [ -n "$crashes" ]; then
+            echo "::error::Fuzzer found crashes!"
+            ls -la "$dir"/
+            exit 1
+          fi
+          echo "No crashes found (slow units, if present, are non-fatal)"
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -110,25 +110,29 @@ jobs:
         run: |
           cd crates/rustledger-parser
           dir="fuzz/artifacts/${{ matrix.target }}"
-          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
-            echo "No crash artifacts found"
-            exit 0
-          fi
-          # Real failures are crash-/oom-/timeout-/leak- artifacts.
-          # `slow-unit-*` means an input was slow but completed — surface
-          # it as a non-fatal warning instead of failing the build (#1342).
-          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*')
-          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*')
+          # Fail on ANY artifact that is not a benign `slow-unit-*`. This is
+          # the safe superset of libFuzzer's real-failure prefixes
+          # (crash-/oom-/timeout-/leak-/mismatch-), so an unknown or future
+          # failure type cannot slip through. `slow-unit-*` means an input was
+          # slow but completed — surface it as a non-fatal warning rather than
+          # failing the build (#1342). `find` on a missing dir is empty under
+          # 2>/dev/null, so no separate existence/`ls` guard is needed.
+          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*' 2>/dev/null)
+          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*' 2>/dev/null)
           if [ -n "$slow" ]; then
             echo "::warning::Fuzzer found slow units (non-fatal); investigate for super-linear behavior:"
             echo "$slow"
           fi
           if [ -n "$crashes" ]; then
-            echo "::error::Fuzzer found crashes!"
+            echo "::error::Fuzzer found crash artifacts!"
             ls -la "$dir"/
             exit 1
           fi
-          echo "No crashes found (slow units, if present, are non-fatal)"
+          if [ -z "$slow" ]; then
+            echo "No crash artifacts found"
+          else
+            echo "No crashes found (slow units are non-fatal)"
+          fi
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -211,25 +215,29 @@ jobs:
         run: |
           cd crates/rustledger-query
           dir="fuzz/artifacts/fuzz_query_parse"
-          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
-            echo "No crash artifacts found"
-            exit 0
-          fi
-          # Real failures are crash-/oom-/timeout-/leak- artifacts.
-          # `slow-unit-*` means an input was slow but completed — surface
-          # it as a non-fatal warning instead of failing the build (#1342).
-          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*')
-          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*')
+          # Fail on ANY artifact that is not a benign `slow-unit-*`. This is
+          # the safe superset of libFuzzer's real-failure prefixes
+          # (crash-/oom-/timeout-/leak-/mismatch-), so an unknown or future
+          # failure type cannot slip through. `slow-unit-*` means an input was
+          # slow but completed — surface it as a non-fatal warning rather than
+          # failing the build (#1342). `find` on a missing dir is empty under
+          # 2>/dev/null, so no separate existence/`ls` guard is needed.
+          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*' 2>/dev/null)
+          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*' 2>/dev/null)
           if [ -n "$slow" ]; then
             echo "::warning::Fuzzer found slow units (non-fatal); investigate for super-linear behavior:"
             echo "$slow"
           fi
           if [ -n "$crashes" ]; then
-            echo "::error::Fuzzer found crashes!"
+            echo "::error::Fuzzer found crash artifacts!"
             ls -la "$dir"/
             exit 1
           fi
-          echo "No crashes found (slow units, if present, are non-fatal)"
+          if [ -z "$slow" ]; then
+            echo "No crash artifacts found"
+          else
+            echo "No crashes found (slow units are non-fatal)"
+          fi
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -312,25 +320,29 @@ jobs:
         run: |
           cd crates/rustledger-booking
           dir="fuzz/artifacts/fuzz_booking"
-          if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
-            echo "No crash artifacts found"
-            exit 0
-          fi
-          # Real failures are crash-/oom-/timeout-/leak- artifacts.
-          # `slow-unit-*` means an input was slow but completed — surface
-          # it as a non-fatal warning instead of failing the build (#1342).
-          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*')
-          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*')
+          # Fail on ANY artifact that is not a benign `slow-unit-*`. This is
+          # the safe superset of libFuzzer's real-failure prefixes
+          # (crash-/oom-/timeout-/leak-/mismatch-), so an unknown or future
+          # failure type cannot slip through. `slow-unit-*` means an input was
+          # slow but completed — surface it as a non-fatal warning rather than
+          # failing the build (#1342). `find` on a missing dir is empty under
+          # 2>/dev/null, so no separate existence/`ls` guard is needed.
+          crashes=$(find "$dir" -maxdepth 1 -type f ! -name 'slow-unit-*' 2>/dev/null)
+          slow=$(find "$dir" -maxdepth 1 -type f -name 'slow-unit-*' 2>/dev/null)
           if [ -n "$slow" ]; then
             echo "::warning::Fuzzer found slow units (non-fatal); investigate for super-linear behavior:"
             echo "$slow"
           fi
           if [ -n "$crashes" ]; then
-            echo "::error::Fuzzer found crashes!"
+            echo "::error::Fuzzer found crash artifacts!"
             ls -la "$dir"/
             exit 1
           fi
-          echo "No crashes found (slow units, if present, are non-fatal)"
+          if [ -z "$slow" ]; then
+            echo "No crash artifacts found"
+          else
+            echo "No crashes found (slow units are non-fatal)"
+          fi
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Follow-up to #1342.

## Problem

Each of the three fuzz jobs (`parser` matrix, `query`, `booking`) gates on:

```bash
if [ -d "fuzz/artifacts/<target>" ] && [ "$(ls -A fuzz/artifacts/<target>)" ]; then
  echo "::error::Fuzzer found crashes!"; exit 1
fi
```

This fails on **any** artifact. But libFuzzer writes `slow-unit-*` files for inputs that exceed its slow-execution threshold yet **still complete** — these are not crashes, and because slowness is timing-dependent on the runner, the gate went **intermittently red** (e.g. `fuzz_query_parse` on #1338, which touches no query code).

## Fix

Distinguish genuine failure artifacts (`crash-*` / `oom-*` / `timeout-*` / `leak-*`) from `slow-unit-*`:

- **Real crash artifact** → `::error::` + `exit 1` (unchanged, still uploaded via the `failure()` step).
- **Only slow-units** → `::warning::` listing them, build **passes**.
- **Nothing** → passes.

Applied to all three "Check for crashes" steps.

## Verification

YAML validated; the gate shell logic unit-tested across cases:

| artifacts | result |
|---|---|
| empty | PASS |
| `slow-unit-*` only | **PASS + warning** (was FAIL) |
| `crash-*` | FAIL |
| `slow-unit-*` + `crash-*`/`oom-*` | warn + FAIL |

## Scope

`fuzz.yml` only. Independent of #1343 (which removes the *specific* slow-units by fixing the parser DoS) — this hardens the gate so the whole **class** of slow-unit false-positives can’t recur, while still surfacing slow inputs as warnings for investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)