### PR TITLE
feat(booking): one-shot book helper + booking-coupled validation invariant (#1235)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -8,8 +8,8 @@
 
 use rustc_hash::FxHashMap;
 use rustledger_core::{
-    AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, IncompleteAmount, Inventory,
-    Position, Posting, ReductionScope, Transaction,
+    AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, Directive, IncompleteAmount,
+    Inventory, Position, Posting, ReductionScope, Transaction,
 };
 use thiserror::Error;
 
@@ -572,6 +572,82 @@ pub fn book_transactions(
     }
 
     results
+}
+
+/// Outcome of booking an entire ledger in one shot — see [`book`].
+#[derive(Debug, Clone)]
+pub struct LedgerBookResult {
+    /// Successfully booked directives, in the **original input order**.
+    /// Every `Transaction` has its cost specs filled and elided amounts
+    /// interpolated; all other directive kinds pass through unchanged.
+    pub booked: Vec<Directive>,
+    /// Directives whose `Transaction` failed to book, in original input
+    /// order, paired with the error. They are left in their pre-booking
+    /// shape so a caller can still surface the user's original input.
+    pub failed: Vec<(Directive, BookingError)>,
+}
+
+/// Book and interpolate every transaction in a ledger in one shot.
+///
+/// This is the standalone equivalent of the loader's internal booking
+/// pass. Transactions are processed in **booking order** — sorted by
+/// `(date, priority, has_cost_reduction)` — so lot matching and
+/// capital-gains tracking observe inventory in the correct sequence, while
+/// the returned [`LedgerBookResult::booked`] / [`LedgerBookResult::failed`]
+/// vectors preserve the caller's **original input order**. Non-transaction
+/// directives pass through untouched. Per-account booking methods declared
+/// via `Open ... "METHOD"` are honored; `method` is the fallback for
+/// accounts that declare none.
+///
+/// Booking is a pure function of its inputs, so calling it twice on the
+/// same `(directives, method)` yields equal results — this is the booking
+/// half of the #1235 pipeline-boundary invariants.
+#[must_use]
+pub fn book(directives: &[Directive], method: BookingMethod) -> LedgerBookResult {
+    let mut engine = BookingEngine::with_method(method);
+    engine.register_account_methods(directives.iter());
+
+    // Stable sort into booking order. Display order — `(date, priority,
+    // file position)` — is already encoded in the input's positional order,
+    // and a stable sort keeps that as the tiebreak.
+    let mut order: Vec<usize> = (0..directives.len()).collect();
+    order.sort_by_key(|&i| {
+        let d = &directives[i];
+        (d.date(), d.priority(), d.has_cost_reduction())
+    });
+
+    // Book in booking order, recording each transaction's outcome against
+    // its original index so the result can be reassembled in input order.
+    let mut booked_txns: Vec<Option<Transaction>> = directives.iter().map(|_| None).collect();
+    let mut booking_errors: Vec<Option<BookingError>> = directives.iter().map(|_| None).collect();
+    for &i in &order {
+        if let Directive::Transaction(txn) = &directives[i] {
+            match engine.book_and_interpolate(txn) {
+                Ok(result) => {
+                    // Apply the booked transaction (filled-in costs), not
+                    // the original, so subsequent lot matching is correct.
+                    engine.apply(&result.transaction);
+                    booked_txns[i] = Some(result.transaction);
+                }
+                Err(e) => booking_errors[i] = Some(e),
+            }
+        }
+    }
+
+    // Reassemble in original input order, partitioning failures out.
+    let mut booked = Vec::with_capacity(directives.len());
+    let mut failed = Vec::new();
+    for (i, directive) in directives.iter().enumerate() {
+        if let Some(e) = booking_errors[i].take() {
+            failed.push((directive.clone(), e));
+        } else if let Some(txn) = booked_txns[i].take() {
+            booked.push(Directive::Transaction(txn));
+        } else {
+            booked.push(directive.clone());
+        }
+    }
+
+    LedgerBookResult { booked, failed }
 }
 
 #[cfg(test)]
@@ -1300,6 +1376,129 @@ mod tests {
         assert!(
             rendered.contains("15") && rendered.contains("10"),
             "InsufficientUnits Display must include requested and available amounts. Got: {rendered}"
+        );
+    }
+
+    /// Helper: does any posting still have an unfilled (elided) amount?
+    fn has_elided_posting(txn: &Transaction) -> bool {
+        txn.postings.iter().any(|p| p.units.is_none())
+    }
+
+    #[test]
+    fn book_interpolates_elided_posting_and_preserves_order() {
+        use rustledger_core::Open;
+
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Expenses:Food")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "Lunch")
+                    .with_synthesized_posting(Posting::new(
+                        "Expenses:Food",
+                        Amount::new(dec!(50.00), "USD"),
+                    ))
+                    .with_synthesized_posting(Posting::auto("Assets:Cash")),
+            ),
+        ];
+
+        let result = book(&directives, BookingMethod::Strict);
+        assert!(result.failed.is_empty(), "nothing should fail to book");
+        assert_eq!(result.booked.len(), 3, "all directives preserved");
+
+        // Order preserved: the two Opens come first, unchanged.
+        assert_eq!(result.booked[0], directives[0]);
+        assert_eq!(result.booked[1], directives[1]);
+
+        // The transaction's elided posting got filled in.
+        let Directive::Transaction(booked_txn) = &result.booked[2] else {
+            panic!("third directive should still be a transaction");
+        };
+        assert!(
+            !has_elided_posting(booked_txn),
+            "the auto posting should have been interpolated"
+        );
+    }
+
+    #[test]
+    fn book_is_deterministic() {
+        use rustledger_core::Open;
+
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Stock")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "Buy")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))
+                            .with_price(PriceAnnotation::unit(Amount::new(dec!(150.00), "USD"))),
+                    )
+                    .with_synthesized_posting(Posting::auto("Assets:Cash")),
+            ),
+        ];
+
+        let first = book(&directives, BookingMethod::Strict);
+        let second = book(&directives, BookingMethod::Strict);
+        assert_eq!(
+            first.booked, second.booked,
+            "booking the same ledger twice must produce identical output"
+        );
+    }
+
+    #[test]
+    fn book_partitions_failed_transaction() {
+        use rustledger_core::Open;
+
+        // Buy a lot at $150, then sell against a cost basis ($200) that
+        // matches no existing lot. Under Strict this is a no-matching-lot
+        // error, so the sell is partitioned into `failed`.
+        let buy_cost = CostSpec::empty()
+            .with_number(rustledger_core::CostNumber::PerUnit {
+                value: dec!(150.00),
+            })
+            .with_currency("USD");
+        let sell_cost = CostSpec::empty()
+            .with_number(rustledger_core::CostNumber::PerUnit {
+                value: dec!(200.00),
+            })
+            .with_currency("USD");
+
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Stock")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 10), "Buy")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL"))
+                            .with_cost(buy_cost),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-1500.00), "USD"),
+                    )),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 15), "Sell at phantom cost basis")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Stock", Amount::new(dec!(-5), "AAPL"))
+                            .with_cost(sell_cost),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(1000.00), "USD"),
+                    )),
+            ),
+        ];
+
+        let result = book(&directives, BookingMethod::Strict);
+        assert_eq!(result.failed.len(), 1, "the mismatched sell should fail");
+        // The two Opens and the successful buy survive; the sell is dropped.
+        assert_eq!(result.booked.len(), 3, "Opens + buy remain in booked");
+        assert!(
+            !result.booked.iter().any(|d| matches!(
+                d,
+                Directive::Transaction(t) if t.narration.as_ref() == "Sell at phantom cost basis"
+            )),
+            "failed sell must not appear in booked"
         );
     }
 }

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -26,7 +26,10 @@ mod book;
 mod interpolate;
 mod pad;
 
-pub use book::{BookedTransaction, BookingEngine, BookingError, CapitalGain, book_transactions};
+pub use book::{
+    BookedTransaction, BookingEngine, BookingError, CapitalGain, LedgerBookResult, book,
+    book_transactions,
+};
 pub use interpolate::{InterpolationError, InterpolationResult, interpolate};
 pub use pad::{
     PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, is_synthesized_pad, merge_with_padding,

--- a/crates/rustledger-validate/tests/booking_phase_invariants.rs
+++ b/crates/rustledger-validate/tests/booking_phase_invariants.rs
@@ -1,0 +1,138 @@
+//! Booking-coupled validation phase-consistency property test (#1235).
+//!
+//! The real load pipeline is `early-validate(raw) -> book -> late-validate(booked)`:
+//! `run_late`'s own contract requires booking to have filled in elided
+//! amounts and cost specs first. The earlier validation determinism test
+//! (`pipeline_invariants.rs`) used only explicit postings, so booking was a
+//! no-op there — this test closes that gap with the public
+//! [`rustledger_booking::book`] one-shot helper, generating ledgers whose
+//! transactions genuinely need interpolation and lot matching.
+//!
+//! Two invariants:
+//! 1. **Determinism** — the full early->book->late sequence yields the same
+//!    error codes every run.
+//! 2. **Booking idempotence at the pipeline boundary** — re-booking the
+//!    already-booked directives does not change what late validation sees
+//!    (`late(book(book(L))) == late(book(L))`), i.e. booking reaches a
+//!    fixed point that validation agrees on.
+
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rustledger_booking::book;
+use rustledger_core::{
+    Amount, BookingMethod, Directive, NaiveDate, Open, Posting, PriceAnnotation, Transaction,
+};
+use rustledger_validate::{ErrorCode, ValidationOptions, ValidationSession};
+
+fn date(day: u32) -> NaiveDate {
+    rustledger_core::naive_date(2024, 1, day).unwrap()
+}
+
+const ACCOUNTS: &[&str] = &[
+    "Assets:Cash",
+    "Assets:Stock",
+    "Expenses:Food",
+    "Income:Salary",
+];
+
+fn amount(currency: &'static str) -> impl Strategy<Value = Amount> {
+    (1i64..100_000, 0u32..3)
+        .prop_map(move |(n, scale)| Amount::new(Decimal::new(n, scale), currency))
+}
+
+/// Transactions that exercise the booker:
+/// - `Elided`: one explicit posting + one auto posting interpolation fills.
+/// - `Priced`: a priced stock posting + an auto cash posting.
+///
+/// Random accounts mean some postings hit unopened accounts.
+fn txn() -> impl Strategy<Value = Transaction> {
+    prop_oneof![
+        (
+            1u32..28,
+            0usize..ACCOUNTS.len(),
+            0usize..ACCOUNTS.len(),
+            amount("USD")
+        )
+            .prop_map(|(day, a, b, amt)| {
+                Transaction::new(date(day), "elided")
+                    .with_synthesized_posting(Posting::new(ACCOUNTS[a], amt))
+                    .with_synthesized_posting(Posting::auto(ACCOUNTS[b]))
+            }),
+        (1u32..28, amount("HOOL"), amount("USD")).prop_map(|(day, units, price)| {
+            Transaction::new(date(day), "priced")
+                .with_synthesized_posting(
+                    Posting::new("Assets:Stock", units).with_price(PriceAnnotation::unit(price)),
+                )
+                .with_synthesized_posting(Posting::auto("Assets:Cash"))
+        }),
+    ]
+}
+
+fn ledger() -> impl Strategy<Value = Vec<Directive>> {
+    (
+        prop::collection::vec(any::<bool>(), ACCOUNTS.len()),
+        prop::collection::vec(txn(), 1..8),
+    )
+        .prop_map(|(open_mask, txns)| {
+            let mut ds: Vec<Directive> = ACCOUNTS
+                .iter()
+                .zip(open_mask)
+                .filter(|(_, open)| *open)
+                .map(|(a, _)| Directive::Open(Open::new(date(1), *a)))
+                .collect();
+            ds.extend(txns.into_iter().map(Directive::Transaction));
+            ds
+        })
+}
+
+/// Run the real coupled pipeline: early on raw, book, late on booked.
+fn run_pipeline(raw: &[Directive]) -> Vec<ErrorCode> {
+    let today = date(28);
+    let session = ValidationSession::new(ValidationOptions::default());
+    let (session, early) = session.run_early(raw, today);
+    let booked = book(raw, BookingMethod::Strict).booked;
+    let (session, late) = session.run_late(&booked, today);
+    let pad = session.finalize();
+    early
+        .iter()
+        .chain(&late)
+        .chain(&pad)
+        .map(|e| e.code)
+        .collect()
+}
+
+/// Late validation over directives that were booked twice — used to check
+/// the pipeline-level booking fixed point.
+fn run_pipeline_double_booked(raw: &[Directive]) -> Vec<ErrorCode> {
+    let today = date(28);
+    let session = ValidationSession::new(ValidationOptions::default());
+    let (session, early) = session.run_early(raw, today);
+    let once = book(raw, BookingMethod::Strict).booked;
+    let twice = book(&once, BookingMethod::Strict).booked;
+    let (session, late) = session.run_late(&twice, today);
+    let pad = session.finalize();
+    early
+        .iter()
+        .chain(&late)
+        .chain(&pad)
+        .map(|e| e.code)
+        .collect()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    #[test]
+    fn coupled_pipeline_is_deterministic(directives in ledger()) {
+        let first = run_pipeline(&directives);
+        let second = run_pipeline(&directives);
+        prop_assert_eq!(first, second, "early->book->late produced different error codes across runs");
+    }
+
+    #[test]
+    fn booking_is_idempotent_at_pipeline_boundary(directives in ledger()) {
+        let once = run_pipeline(&directives);
+        let twice = run_pipeline_double_booked(&directives);
+        prop_assert_eq!(once, twice, "re-booking changed what late validation saw");
+    }
+}

--- a/crates/rustledger-validate/tests/booking_phase_invariants.rs
+++ b/crates/rustledger-validate/tests/booking_phase_invariants.rs
@@ -6,7 +6,9 @@
 //! (`pipeline_invariants.rs`) used only explicit postings, so booking was a
 //! no-op there — this test closes that gap with the public
 //! [`rustledger_booking::book`] one-shot helper, generating ledgers whose
-//! transactions genuinely need interpolation and lot matching.
+//! transactions need interpolation and cost-spec booking (augmentations
+//! that drive `book` past its no-cost-spec fast path). Lot *reduction*
+//! matching is covered by `rustledger-booking`'s own unit tests, not here.
 //!
 //! Two invariants:
 //! 1. **Determinism** — the full early->book->late sequence yields the same
@@ -20,7 +22,8 @@ use proptest::prelude::*;
 use rust_decimal::Decimal;
 use rustledger_booking::book;
 use rustledger_core::{
-    Amount, BookingMethod, Directive, NaiveDate, Open, Posting, PriceAnnotation, Transaction,
+    Amount, BookingMethod, CostNumber, CostSpec, Directive, NaiveDate, Open, Posting,
+    PriceAnnotation, Transaction,
 };
 use rustledger_validate::{ErrorCode, ValidationOptions, ValidationSession};
 
@@ -43,6 +46,14 @@ fn amount(currency: &'static str) -> impl Strategy<Value = Amount> {
 /// Transactions that exercise the booker:
 /// - `Elided`: one explicit posting + one auto posting interpolation fills.
 /// - `Priced`: a priced stock posting + an auto cash posting.
+/// - `Cost`: a stock buy carrying an explicit `{N USD}` cost spec + an auto
+///   cash posting. This drives `BookingEngine::book` past its no-cost-spec
+///   fast path into the real cost-filling / position-accumulation machinery
+///   (an augmentation — no prior inventory, so it always books). Lot
+///   *reductions* (sells that must match a lot) are covered by the
+///   `book_partitions_failed_transaction` unit test rather than here, since
+///   generating a sell that matches a prior buy under Strict is awkward in
+///   a property strategy.
 ///
 /// Random accounts mean some postings hit unopened accounts.
 fn txn() -> impl Strategy<Value = Transaction> {
@@ -63,6 +74,16 @@ fn txn() -> impl Strategy<Value = Transaction> {
                 .with_synthesized_posting(
                     Posting::new("Assets:Stock", units).with_price(PriceAnnotation::unit(price)),
                 )
+                .with_synthesized_posting(Posting::auto("Assets:Cash"))
+        }),
+        (1u32..28, amount("HOOL"), 1i64..100_000, 0u32..3).prop_map(|(day, units, n, scale)| {
+            let cost = CostSpec::empty()
+                .with_number(CostNumber::PerUnit {
+                    value: Decimal::new(n, scale),
+                })
+                .with_currency("USD");
+            Transaction::new(date(day), "cost")
+                .with_synthesized_posting(Posting::new("Assets:Stock", units).with_cost(cost))
                 .with_synthesized_posting(Posting::auto("Assets:Cash"))
         }),
     ]

--- a/crates/rustledger-validate/tests/booking_phase_invariants.rs
+++ b/crates/rustledger-validate/tests/booking_phase_invariants.rs
@@ -46,14 +46,19 @@ fn amount(currency: &'static str) -> impl Strategy<Value = Amount> {
 /// Transactions that exercise the booker:
 /// - `Elided`: one explicit posting + one auto posting interpolation fills.
 /// - `Priced`: a priced stock posting + an auto cash posting.
-/// - `Cost`: a stock buy carrying an explicit `{N USD}` cost spec + an auto
-///   cash posting. This drives `BookingEngine::book` past its no-cost-spec
+/// - `Cost`: a stock buy carrying an explicit per-unit `{N USD}` cost spec +
+///   an auto cash posting. Drives `BookingEngine::book` past its no-cost-spec
 ///   fast path into the real cost-filling / position-accumulation machinery
-///   (an augmentation — no prior inventory, so it always books). Lot
-///   *reductions* (sells that must match a lot) are covered by the
-///   `book_partitions_failed_transaction` unit test rather than here, since
-///   generating a sell that matches a prior buy under Strict is awkward in
-///   a property strategy.
+///   (an augmentation — no prior inventory, so it always books).
+/// - `TotalCost`: a buy with a `{{ T USD }}` total cost. Booking rewrites
+///   `Total` into `PerUnitFromTotal`, so re-booking exercises a cost
+///   representation that genuinely changes during the first book — this is
+///   where the idempotence assertion has teeth.
+///
+/// Lot *reductions* (sells that must match a lot) are covered by the
+/// `book_partitions_failed_transaction` unit test rather than here, since
+/// generating a sell that matches a prior buy under Strict is awkward in a
+/// property strategy.
 ///
 /// Random accounts mean some postings hit unopened accounts.
 fn txn() -> impl Strategy<Value = Transaction> {
@@ -83,6 +88,22 @@ fn txn() -> impl Strategy<Value = Transaction> {
                 })
                 .with_currency("USD");
             Transaction::new(date(day), "cost")
+                .with_synthesized_posting(Posting::new("Assets:Stock", units).with_cost(cost))
+                .with_synthesized_posting(Posting::auto("Assets:Cash"))
+        }),
+        // Total-cost buy (`{{ T USD }}`). Booking rewrites `Total` into
+        // `PerUnitFromTotal` (per-unit = total / units) — the cost
+        // representation that actually *changes* during booking, so this is
+        // where the `late(book(book(L))) == late(book(L))` fixed-point
+        // assertion has real teeth (the `PerUnit` shape above is stable by
+        // construction and can't exercise that rewrite).
+        (1u32..28, amount("HOOL"), 1i64..1_000_000, 0u32..2).prop_map(|(day, units, n, scale)| {
+            let cost = CostSpec::empty()
+                .with_number(CostNumber::Total {
+                    value: Decimal::new(n, scale),
+                })
+                .with_currency("USD");
+            Transaction::new(date(day), "total_cost")
                 .with_synthesized_posting(Posting::new("Assets:Stock", units).with_cost(cost))
                 .with_synthesized_posting(Posting::auto("Assets:Cash"))
         }),


### PR DESCRIPTION
## What

Adds the public **one-shot `book` ledger helper** and uses it to implement the **booking-coupled** half of the #1235 pipeline-boundary invariants — the piece #1359 had to defer because no such helper was public.

### `rustledger_booking::book`

```rust
pub fn book(directives: &[Directive], method: BookingMethod) -> LedgerBookResult
```

The standalone equivalent of the loader's internal booking pass (`run_booking`):

- books **and** interpolates every transaction in a ledger;
- processes them in **booking order** — `(date, priority, has_cost_reduction)` — so lot matching and capital-gains tracking observe inventory in the right sequence;
- returns `booked` / `failed` directives in the caller's **original input order**;
- passes non-transaction directives through untouched;
- honors per-account booking methods declared via `Open ... "METHOD"`, with `method` as the fallback.

`LedgerBookResult { booked: Vec<Directive>, failed: Vec<(Directive, BookingError)> }` partitions failures so a caller can still surface the user's original input.

## Why

`run_late`'s contract requires booking to have run first (it needs filled-in amounts and cost specs). The #1359 validation determinism test could only use explicit postings, where booking is a no-op. With `book`, the real `early-validate(raw) → book → late-validate(booked)` pipeline is now testable.

## Tests

**Unit (`book.rs`):**
- `book_interpolates_elided_posting_and_preserves_order` — auto postings get filled; input order preserved
- `book_is_deterministic` — booking the same ledger twice is identical
- `book_partitions_failed_transaction` — a sell against a non-matching cost basis (Strict) lands in `failed`, not `booked`

**Property (`rustledger-validate/tests/booking_phase_invariants.rs`):** drives the coupled pipeline on ledgers that genuinely need interpolation and lot matching:
- `coupled_pipeline_is_deterministic` — early→book→late yields the same error codes every run
- `booking_is_idempotent_at_pipeline_boundary` — `late(book(book(L))) == late(book(L))` (booking reaches a fixed point validation agrees on)

## Test plan

- `nix develop --command cargo test -p rustledger-booking -p rustledger-validate` — all pass
- `nix develop --command cargo clippy -p rustledger-booking -p rustledger-validate --all-features --all-targets -- -D warnings` — clean

Part of #1235. Follow-up to #1359.
