### PR TITLE
ci(ratchet): forbid std::sync Mutex/RwLock in library code (#1237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, plugin-test-quality, ci, doctest, regressions, bindings-fresh]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, plugin-test-quality, ci, doctest, regressions, bindings-fresh]
     steps:
       - name: Check results
         run: |
@@ -312,7 +312,7 @@ jobs:
           # part of the gate (ADR-0004 Phase 3 / #1232): wire-format
           # drift in the generated TS / JSON Schema / Python artifacts
           # blocks merge just like any other failure.
-          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }}"
+          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }}"
           echo "Job results: $results"
 
           if echo "$results" | grep -qE '(failure|cancelled)'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,20 @@ jobs:
       - name: Verify forbid-unsafe-code invariant
         run: ./scripts/check-unsafe-invariant.sh
 
+  # Ratchet for the parking_lot adoption (#1076): forbid std::sync Mutex/RwLock
+  # in library code so the perf decision can't silently regress. Same
+  # lightweight named-status pattern as the unsafe invariant; no extra
+  # toolchain required (deliberately a grep ratchet rather than a dylint lint).
+  sync-primitives:
+    name: Sync Primitives
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Forbid std::sync Mutex/RwLock in library code
+        run: ./scripts/check-sync-primitives.sh
+
   # Plugin-test policies (Phase 5 of plugin-testing-quality plan, see #992).
   # Catches weak count assertions and `(partial)` test ports that tend to
   # silently mask plugin bugs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,6 +4093,7 @@ dependencies = [
  "criterion",
  "insta",
  "jiff",
+ "parking_lot",
  "proptest",
  "rayon",
  "regex",

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -26,6 +26,7 @@ thiserror.workspace = true
 regex = "1"
 rustc-hash.workspace = true
 rayon.workspace = true
+parking_lot.workspace = true
 
 [dev-dependencies]
 rust_decimal_macros.workspace = true

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -11,7 +11,7 @@ pub use types::{
     WindowContext,
 };
 
-use std::sync::RwLock;
+use parking_lot::RwLock;
 
 use rustc_hash::FxHashMap;
 
@@ -258,12 +258,10 @@ impl<'a> Executor<'a> {
     fn get_or_compile_regex(&self, pattern: &str) -> Option<Regex> {
         // Fast path: check read lock first
         {
-            // Handle lock poisoning gracefully - if another thread panicked while holding
-            // the lock, we can still recover the cached data via into_inner()
-            let cache = match self.regex_cache.read() {
-                Ok(guard) => guard,
-                Err(poisoned) => poisoned.into_inner(),
-            };
+            // parking_lot's RwLock does not poison, so the read guard is
+            // returned directly (this matches the previous std behavior,
+            // which recovered from poisoning via into_inner()).
+            let cache = self.regex_cache.read();
             if let Some(cached) = cache.get(pattern) {
                 return cached.clone();
             }
@@ -274,10 +272,7 @@ impl<'a> Executor<'a> {
             .case_insensitive(true)
             .build()
             .ok();
-        let mut cache = match self.regex_cache.write() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let mut cache = self.regex_cache.write();
         // Double-check in case another thread inserted while we waited
         if let Some(cached) = cache.get(pattern) {
             return cached.clone();

--- a/scripts/check-sync-primitives.sh
+++ b/scripts/check-sync-primitives.sh
@@ -9,8 +9,10 @@
 # named-CI-status pattern as `check-unsafe-invariant.sh`, deliberately chosen
 # over a `dylint` lint so it needs no extra (nightly) toolchain.
 #
-# Scope: `crates/*/src/` only (library code). Tests, benches, and examples are
-# not checked — std locks there are harmless.
+# Scope: `crates/*/src/` only, and within those files only non-test code —
+# `#[cfg(test)] mod ...` blocks are skipped (std locks in unit tests are
+# harmless, matching #1237's "excluding #[cfg(test)]" intent). Integration
+# tests / benches / examples live outside `src/` and aren't scanned.
 #
 # Escape hatch: append `// ratchet-allow: std-sync <reason>` to the offending
 # line for a legitimate exception (none exist today).
@@ -19,7 +21,6 @@
 # ----------
 #   0  no forbidden std::sync locks found
 #   1  one or more forbidden usages found
-#   2  invocation error
 #
 # Usage
 # -----
@@ -30,28 +31,42 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-# Matches `std::sync::Mutex`, `std::sync::RwLock`, and the brace-import form
-# `std::sync::{... Mutex ...}` / `{... RwLock ...}`.
-pattern='std::sync::(\{[^}]*)?(Mutex|RwLock)'
+# Matches `std::sync::Mutex`/`RwLock` and the brace-import form
+# `std::sync::{... Mutex ...}`. The trailing `\b` excludes the guard types
+# (`MutexGuard`, `RwLockReadGuard`, `RwLockWriteGuard`), which are type
+# references, not lock constructions.
+forbidden='std::sync::(\{[^}]*)?(Mutex|RwLock)\b'
 
-if ! command -v rg >/dev/null 2>&1; then
-    grep_cmd() { grep -rnE "$pattern" crates/*/src --include='*.rs' 2>/dev/null || true; }
-else
-    grep_cmd() { rg -n --no-heading -e "$pattern" -g 'crates/*/src/**/*.rs' 2>/dev/null || true; }
-fi
+# Print a file's non-test code: everything up to the trailing
+# `#[cfg(test)]`-attributed `mod`. A `#[cfg(test)]` that precedes anything
+# other than a module (e.g. a test-only `use`/`fn` near the top) does NOT
+# truncate scanning — only the conventional trailing test module does.
+strip_test_module() {
+    awk '
+        /#\[cfg\(test\)\]/ { pending = 1; print; next }
+        pending && /^[[:space:]]*$/ { print; next }              # blank lines between attr and mod
+        pending && /^[[:space:]]*(pub[[:space:]]+)?mod[[:space:]]/ { exit }
+        { pending = 0; print }
+    ' "$1"
+}
 
-# Collect hits, dropping any line that carries the explicit allow marker.
-hits="$(grep_cmd | grep -v 'ratchet-allow: std-sync' || true)"
+violations=""
+while IFS= read -r f; do
+    hits="$(strip_test_module "$f" | grep -nE "$forbidden" | grep -v 'ratchet-allow: std-sync' || true)"
+    if [ -n "$hits" ]; then
+        violations+="$f:"$'\n'"$(printf '%s\n' "$hits" | sed 's/^/    /')"$'\n'
+    fi
+done < <(grep -rlE "$forbidden" crates/*/src --include='*.rs' 2>/dev/null | sort)
 
-if [ -n "$hits" ]; then
-    echo "error: forbidden std::sync lock(s) found in library code." >&2
+if [ -n "$violations" ]; then
+    echo "error: forbidden std::sync lock(s) found in non-test library code." >&2
     echo "       Use parking_lot::Mutex / parking_lot::RwLock instead (see #1076)." >&2
     echo "       If a std lock is genuinely required, append" >&2
     echo "         // ratchet-allow: std-sync <reason>" >&2
     echo "       to the line." >&2
     echo >&2
-    echo "$hits" >&2
+    printf '%s' "$violations" >&2
     exit 1
 fi
 
-echo "ok: no std::sync::Mutex / RwLock in library source."
+echo "ok: no std::sync::Mutex / RwLock in non-test library source."

--- a/scripts/check-sync-primitives.sh
+++ b/scripts/check-sync-primitives.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Forbid `std::sync::Mutex` / `std::sync::RwLock` in library source.
+#
+# `parking_lot` was adopted as a performance quick win (#1076): its locks are
+# smaller, faster, and do not poison. Nothing at the compiler level prevents a
+# new `std::sync::Mutex`/`RwLock` from creeping back in, which would silently
+# regress that decision. This script is the ratchet — the same lightweight,
+# named-CI-status pattern as `check-unsafe-invariant.sh`, deliberately chosen
+# over a `dylint` lint so it needs no extra (nightly) toolchain.
+#
+# Scope: `crates/*/src/` only (library code). Tests, benches, and examples are
+# not checked — std locks there are harmless.
+#
+# Escape hatch: append `// ratchet-allow: std-sync <reason>` to the offending
+# line for a legitimate exception (none exist today).
+#
+# Exit codes
+# ----------
+#   0  no forbidden std::sync locks found
+#   1  one or more forbidden usages found
+#   2  invocation error
+#
+# Usage
+# -----
+#   ./scripts/check-sync-primitives.sh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Matches `std::sync::Mutex`, `std::sync::RwLock`, and the brace-import form
+# `std::sync::{... Mutex ...}` / `{... RwLock ...}`.
+pattern='std::sync::(\{[^}]*)?(Mutex|RwLock)'
+
+if ! command -v rg >/dev/null 2>&1; then
+    grep_cmd() { grep -rnE "$pattern" crates/*/src --include='*.rs' 2>/dev/null || true; }
+else
+    grep_cmd() { rg -n --no-heading -e "$pattern" -g 'crates/*/src/**/*.rs' 2>/dev/null || true; }
+fi
+
+# Collect hits, dropping any line that carries the explicit allow marker.
+hits="$(grep_cmd | grep -v 'ratchet-allow: std-sync' || true)"
+
+if [ -n "$hits" ]; then
+    echo "error: forbidden std::sync lock(s) found in library code." >&2
+    echo "       Use parking_lot::Mutex / parking_lot::RwLock instead (see #1076)." >&2
+    echo "       If a std lock is genuinely required, append" >&2
+    echo "         // ratchet-allow: std-sync <reason>" >&2
+    echo "       to the line." >&2
+    echo >&2
+    echo "$hits" >&2
+    exit 1
+fi
+
+echo "ok: no std::sync::Mutex / RwLock in library source."


### PR DESCRIPTION
## What

First of the #1237 static-analysis ratchets: forbid `std::sync::Mutex` / `std::sync::RwLock` in library code so the **parking_lot** adoption (#1076) can't silently regress.

Implemented as a **grep ratchet** (the same lightweight, named-CI-status pattern as `check-unsafe-invariant.sh`) rather than a `dylint` lint — deliberately, because dylint requires a separate **nightly** toolchain, which is real friction for this stable-pinned (1.95.0) nix flake. A grep ratchet needs no extra tooling.

## Changes

- **`scripts/check-sync-primitives.sh`** — scans `crates/*/src/` for `std::sync::Mutex`/`RwLock` (including the `std::sync::{...}` brace-import form). Escape hatch: `// ratchet-allow: std-sync <reason>`. Verified it passes clean today and correctly fails on an injected violation.
- **`.github/workflows/ci.yml`** — new `Sync Primitives` job mirroring `Unsafe Invariant`.
- **`rustledger-query` regex cache** — the one pre-existing usage, converted from `std::sync::RwLock` to `parking_lot::RwLock`. The std code already recovered from poisoning via `into_inner()`, which is exactly parking_lot's no-poison semantics, so the change is behavior-preserving and removes the now-dead poison-handling match arms.

## Scope

This intentionally does **only** the cheap, high-ROI slice of #1237. Left as follow-ups (see issue discussion):
- `dylint` lint crate (`no_unwrap_in_lib`, `no_panic_in_lib`, `no_std_collections_in_hot_paths`) — carries a nightly-toolchain cost; the no-unwrap/no-panic lints also face ~136/~29 existing lib-code sites that need a cleanup/allowlist pass first.
- `cargo-public-api` baselines — overlaps the still-open #1233 (cargo-semver-checks); better tracked there.
- `loom` — defer per the issue's own conservative-scope note.

(Several of those dylint lints could likewise be done as grep ratchets to avoid the nightly cost — noted on the issue.)

## Test plan

- `nix develop --command cargo test -p rustledger-query` — passes (537 tests)
- `nix develop --command cargo clippy -p rustledger-query --all-features --all-targets -- -D warnings` — clean
- `./scripts/check-sync-primitives.sh` — passes; injected `std::sync::Mutex` correctly rejected

Part of #1237.
