### PR TITLE
ci(ratchet): forbid std SipHash collections in hot-path modules (#1237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, plugin-test-quality, ci, doctest, regressions, bindings-fresh]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bindings-fresh]
     steps:
       - name: Check results
         run: |
@@ -326,7 +326,7 @@ jobs:
           # part of the gate (ADR-0004 Phase 3 / #1232): wire-format
           # drift in the generated TS / JSON Schema / Python artifacts
           # blocks merge just like any other failure.
-          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }}"
+          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.hot-path-collections.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }}"
           echo "Job results: $results"
 
           if echo "$results" | grep -qE '(failure|cancelled)'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,20 @@ jobs:
       - name: Self-test the per-plugin mutation report script
         run: ./scripts/test-per-plugin-mutation-report.sh
 
+  # Ratchet for the FxHasher adoption on hot paths (#1076): modules marked
+  # `// ratchet: fxhash-only` must not use std SipHash HashMap/HashSet, which
+  # would silently regress the perf decision. Grep ratchet, no extra toolchain
+  # (#1237). Same lightweight named-status pattern as the unsafe invariant.
+  hot-path-collections:
+    name: Hot-path Collections
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Forbid std SipHash collections in fxhash-only modules
+        run: ./scripts/check-hot-path-collections.sh
+
   # Main CI matrix - check, clippy, test, doc (only on code changes)
   ci:
     name: ${{ matrix.name }}

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -6,7 +6,8 @@
 //! - Calculating capital gains/losses
 //! - Filling in cost specs for lot reductions
 
-use rustc_hash::FxHashMap;
+// ratchet: fxhash-only — hot path; use FxHashMap/FxHashSet, not std SipHash collections (#1237).
+use rustc_hash::{FxHashMap, FxHashSet};
 use rustledger_core::{
     AccountedBookingError, Amount, BookingMethod, Cost, CostSpec, Directive, IncompleteAmount,
     Inventory, Position, Posting, ReductionScope, Transaction,
@@ -176,7 +177,7 @@ impl BookingEngine {
 
         let mut result = txn.clone();
         let mut gains = Vec::new();
-        let mut booked_indices = std::collections::HashSet::with_capacity(txn.postings.len());
+        let mut booked_indices: FxHashSet<usize> = FxHashSet::default();
         // Track posting expansions: (original_idx, expanded_postings)
         let mut expansions: Vec<(usize, Vec<rustledger_core::Spanned<Posting>>)> =
             Vec::with_capacity(txn.postings.len());

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -177,7 +177,8 @@ impl BookingEngine {
 
         let mut result = txn.clone();
         let mut gains = Vec::new();
-        let mut booked_indices: FxHashSet<usize> = FxHashSet::default();
+        let mut booked_indices: FxHashSet<usize> =
+            FxHashSet::with_capacity_and_hasher(txn.postings.len(), Default::default());
         // Track posting expansions: (original_idx, expanded_postings)
         let mut expansions: Vec<(usize, Vec<rustledger_core::Spanned<Posting>>)> =
             Vec::with_capacity(txn.postings.len());

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -4,6 +4,7 @@
 //! [`Position`]s. It provides methods for adding and reducing positions
 //! using different booking methods (FIFO, LIFO, STRICT, NONE).
 
+// ratchet: fxhash-only — hot path; use FxHashMap/FxHashSet, not std SipHash collections (#1237).
 use imbl::Vector;
 use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -3,6 +3,7 @@
 //! This module orchestrates the full processing pipeline for a beancount ledger,
 //! equivalent to Python's `loader.load_file()` function.
 
+// ratchet: fxhash-only — hot path; use FxHashMap/FxHashSet, not std SipHash collections (#1237).
 use crate::{LoadError, LoadResult, Options, Plugin, SourceMap};
 use rustledger_core::{BookingMethod, Directive, DisplayContext};
 use rustledger_parser::Spanned;

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -1,5 +1,6 @@
 //! Types used by the BQL query executor.
 
+// ratchet: fxhash-only — hot path; use FxHashMap/FxHashSet, not std SipHash collections (#1237).
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -1,5 +1,6 @@
 //! Balance and pad validation.
 
+// ratchet: fxhash-only — hot path; use FxHashMap/FxHashSet, not std SipHash collections (#1237).
 use rust_decimal::{Decimal, MathematicalOps};
 use rustledger_core::{Amount, Balance, Pad, Position, is_subaccount_or_equal};
 

--- a/scripts/check-hot-path-collections.sh
+++ b/scripts/check-hot-path-collections.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Forbid std SipHash collections in hot-path modules.
+#
+# `rustc_hash::FxHashMap`/`FxHashSet` were adopted on hot paths as a perf win
+# (#1076): the std `HashMap`/`HashSet` default to `SipHash`, which is much
+# slower for the small integer/short-string keys these paths use. Nothing at
+# the compiler level stops a new `std::collections::HashMap` from creeping
+# into a hot path and silently regressing that. This is the ratchet.
+#
+# Opt-in, not blanket: a module marks itself a hot path with
+#
+#     // ratchet: fxhash-only
+#
+# near the top. This script finds every marked file and fails if its
+# non-test code uses `std::collections::HashMap`/`HashSet`. `BTreeMap` and
+# other collections are unaffected — only the SipHash maps are forbidden.
+#
+# Same lightweight, named-CI-status pattern as `check-unsafe-invariant.sh`,
+# and deliberately a grep ratchet rather than a `dylint` lint so it needs no
+# extra (nightly) toolchain.
+#
+# Escape hatch: append `// ratchet-allow: std-collections <reason>` to a line
+# that genuinely needs a std map (e.g. one relied on for a specific property).
+#
+# Exit codes
+# ----------
+#   0  all marked files are clean
+#   1  a marked file uses a forbidden std collection
+#   2  invocation error (no marked files found)
+#
+# Usage
+# -----
+#   ./scripts/check-hot-path-collections.sh
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+marker='ratchet: fxhash-only'
+forbidden='std::collections::(\{[^}]*)?(HashMap|HashSet)'
+
+# Files that opt in to the ratchet.
+mapfile -t marked < <(grep -rlE "$marker" crates/*/src --include='*.rs' 2>/dev/null | sort)
+
+if [ "${#marked[@]}" -eq 0 ]; then
+    echo "error: no files carry the '$marker' marker — the ratchet would be vacuous." >&2
+    echo "       Did a marked module lose its marker?" >&2
+    exit 2
+fi
+
+violations=""
+for f in "${marked[@]}"; do
+    # Drop everything from the first top-level `#[cfg(test)]` onward: std maps
+    # in unit-test modules are harmless. (Test modules sit at file end by
+    # convention here.)
+    code="$(awk '/#\[cfg\(test\)\]/{exit} {print}' "$f")"
+    hits="$(printf '%s\n' "$code" | grep -nE "$forbidden" | grep -v 'ratchet-allow: std-collections' || true)"
+    if [ -n "$hits" ]; then
+        violations+="$f:"$'\n'"$(printf '%s\n' "$hits" | sed 's/^/    /')"$'\n'
+    fi
+done
+
+if [ -n "$violations" ]; then
+    echo "error: std SipHash collection(s) in hot-path (fxhash-only) modules." >&2
+    echo "       Use rustc_hash::FxHashMap / FxHashSet instead (see #1076)." >&2
+    echo "       If a std map is genuinely required, append" >&2
+    echo "         // ratchet-allow: std-collections <reason>" >&2
+    echo "       to the line." >&2
+    echo >&2
+    printf '%s' "$violations" >&2
+    exit 1
+fi
+
+echo "ok: ${#marked[@]} hot-path module(s) are free of std SipHash collections."

--- a/scripts/check-hot-path-collections.sh
+++ b/scripts/check-hot-path-collections.sh
@@ -52,10 +52,16 @@ fi
 
 violations=""
 for f in "${marked[@]}"; do
-    # Drop everything from the first top-level `#[cfg(test)]` onward: std maps
-    # in unit-test modules are harmless. (Test modules sit at file end by
-    # convention here.)
-    code="$(awk '/#\[cfg\(test\)\]/{exit} {print}' "$f")"
+    # Drop the trailing `#[cfg(test)] mod ...` block: std maps in unit-test
+    # modules are harmless. Only a `#[cfg(test)]` that precedes a `mod`
+    # truncates scanning — a test-only `use`/`fn` near the top must NOT
+    # disable the rest of the file (that would silently defeat the ratchet).
+    code="$(awk '
+        /#\[cfg\(test\)\]/ { pending = 1; print; next }
+        pending && /^[[:space:]]*$/ { print; next }
+        pending && /^[[:space:]]*(pub[[:space:]]+)?mod[[:space:]]/ { exit }
+        { pending = 0; print }
+    ' "$f")"
     hits="$(printf '%s\n' "$code" | grep -nE "$forbidden" | grep -v 'ratchet-allow: std-collections' || true)"
     if [ -n "$hits" ]; then
         violations+="$f:"$'\n'"$(printf '%s\n' "$hits" | sed 's/^/    /')"$'\n'


### PR DESCRIPTION
## What

Second of the #1237 static-analysis ratchets: forbid std SipHash `HashMap`/`HashSet` in **hot-path modules**, so the FxHasher adoption (#1076) can't silently regress.

Like #1363, this is a **grep ratchet** (no nightly toolchain), using the marker-based opt-in pattern of `check-unsafe-invariant.sh`.

## How it works

A module opts in with a marker near the top:

```rust
// ratchet: fxhash-only
```

`scripts/check-hot-path-collections.sh` finds every marked file and fails if its **non-test** code uses `std::collections::HashMap`/`HashSet`. It excludes `#[cfg(test)]` modules and leaves `BTreeMap` (deterministic/sorted) alone. Escape hatch: `// ratchet-allow: std-collections <reason>`.

Verified: passes clean, **catches a real (non-test) violation** injected into a marked file, and correctly **ignores** both test modules and unmarked files.

## Changes

- `scripts/check-hot-path-collections.sh` + a `Hot-path Collections` CI job (anchored after `plugin-test-quality` to avoid colliding with #1363's `sync-primitives` insertion).
- Marked five genuinely-hot, already-clean modules: booking `book.rs`, core `inventory/mod.rs`, loader `process.rs` (the booking pass), validate `balance.rs`, query `executor/types.rs`.
- Converted the one std collection sitting in a hot path — `book.rs`'s local `booked_indices` dedup set — from `std::collections::HashSet` to `FxHashSet` (drop-in: only `insert`/`contains`/`into_iter`).

Modules that use std maps **deliberately** are left unmarked: query `aggregation.rs` (GROUP BY map with an explicit `key_order` for determinism) and the `ShiftSpans` trait impl for `HashMap<_, _, S>`. The ratchet is opt-in and extensible.

## Test plan

- `nix develop --command cargo test -p rustledger-booking` — passes
- `nix develop --command cargo clippy -p rustledger-booking -p rustledger-core -p rustledger-query -p rustledger-validate -p rustledger-loader --all-features --all-targets -- -D warnings` — clean
- `./scripts/check-hot-path-collections.sh` — passes; injected violation rejected; unmarked/test usages ignored

Part of #1237. Independent of #1363 (different script + CI anchor; only `book.rs` overlaps, in disjoint regions).
