### PR TITLE
ci(semver): advisory cargo-semver-checks gate for plugin-types (#1233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,40 @@ jobs:
       - name: Forbid std SipHash collections in fxhash-only modules
         run: ./scripts/check-hot-path-collections.sh
 
+  # Public-API SemVer ratchet for the plugin DTOs (#1233, Tier 1).
+  # `rustledger-plugin-types` is what every plugin author compiles against —
+  # an accidental breaking change (a renamed pub field, a changed trait
+  # signature, a pub enum variant added without `#[non_exhaustive]`) would
+  # ship in the published crate and break every plugin. cargo-semver-checks
+  # compares the current public API against the last crates.io release (the
+  # crate is published by release-publish.yml) and fails on an unmarked
+  # SemVer-major break. The action manages the nightly toolchain rustdoc
+  # JSON needs, so no nightly is added to the flake.
+  #
+  # ADVISORY for now: this job is deliberately NOT part of the `build` merge
+  # gate, so it surfaces breaks without blocking. Promote it to required
+  # (add to the `build` aggregator or branch protection) once it has proven
+  # stable on real PRs. Tier 1 = plugin-types only; expand to core/parser
+  # later.
+  #
+  # RUSTC_WRAPPER is cleared for this job because the workflow sets it to
+  # sccache globally (line ~21) and this job does not install the
+  # sccache-action, so cargo would otherwise fail with "could not execute
+  # process sccache" when the action builds rustdoc.
+  semver-plugin-types:
+    name: SemVer (plugin-types)
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ''
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Check rustledger-plugin-types public API for SemVer breaks
+        uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+        with:
+          package: rustledger-plugin-types
+
   # Main CI matrix - check, clippy, test, doc (only on code changes)
   ci:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,17 +216,21 @@ jobs:
   # stable on real PRs. Tier 1 = plugin-types only; expand to core/parser
   # later.
   #
-  # RUSTC_WRAPPER is cleared for this job because the workflow sets it to
+  # Runs on EVERY PR (no `should_build` gate): the semver check must always
+  # report so it (a) self-validates on workflow-only PRs and (b) can be
+  # promoted to a required check later without a skipped run blocking
+  # config-only PRs forever (a skipped required check never goes green).
+  #
+  # Env overrides: RUSTC_WRAPPER is cleared because the workflow sets it to
   # sccache globally (line ~21) and this job does not install the
-  # sccache-action, so cargo would otherwise fail with "could not execute
-  # process sccache" when the action builds rustdoc.
+  # sccache-action; RUSTFLAGS is cleared so nightly-rustdoc warning churn
+  # can't red the ratchet for reasons unrelated to a SemVer break.
   semver-plugin-types:
     name: SemVer (plugin-types)
-    needs: [changes]
-    if: needs.changes.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: ''
+      RUSTFLAGS: ''
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check rustledger-plugin-types public API for SemVer breaks


### PR DESCRIPTION
## What

Implements the **Tier-1** half of #1233: an advisory `cargo-semver-checks` CI gate on `rustledger-plugin-types`, the crate every plugin author compiles against.

It compares the current public API against the **last crates.io release** and fails on an unmarked SemVer-major break (renamed/removed pub item, changed trait signature, pub enum variant added without `#[non_exhaustive]`, etc.) — the *accidental* breaks that the conventional-commit `!:` discipline relies on humans to catch.

## Decisions (resolving the issue's open questions)

- **Q1 (semver-checks vs public-api):** went with `cargo-semver-checks` — it's the actual gate. `cargo-public-api`'s checked-in `public-api.txt` would need a baseline file generated with a nightly toolchain that isn't in the dev flake, so it's deferred as a visibility follow-up.
- **Q2 (scope):** Tier 1 = `rustledger-plugin-types` only, via the action's `package:` input. Core/parser later.
- **Q3 (baseline / publish):** `plugin-types` is already published to crates.io by `release-publish.yml`, so the action's default crates.io baseline works — **no need to publish anything new or maintain a git-tag baseline.**

## Rollout: advisory first

The job is deliberately **not** wired into the required `build` aggregator, so it surfaces breaks without blocking merges. Promote it to required (add to `build` / branch protection) once it's proven stable on real PRs.

## Notes

- Uses `obi1kenobi/cargo-semver-checks-action@v2.8` (pinned by SHA per repo convention). The action manages the nightly rustdoc toolchain itself — **no nightly added to the flake**.
- Clears `RUSTC_WRAPPER` for the job (the workflow sets it to `sccache` globally and this job doesn't install the sccache-action).

## Test plan

⚠️ `cargo-semver-checks` requires nightly rustdoc JSON, which isn't in the dev flake, so this **could not be run locally** — this PR's own CI run is the first real execution. The workflow YAML is validated and the job is confirmed to be outside the required `build` gate (advisory).

Part of #1233.
