### PR TITLE
fix(ci): make miri run on nightly + adopt Tree Borrows (#1239)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,5 +1,13 @@
 # Miri - detect undefined behavior in unsafe code
-# Runs weekly (too slow for every PR)
+#
+# First-party crates are all #![forbid(unsafe_code)], so this targets UB hit
+# through transitive deps (rayon, parking_lot, rkyv, ...) by our call patterns
+# (#1239). Runs weekly (too slow for every PR) on the pure-logic crates that
+# are miri-compatible; WASM/FFI crates and fs/wasmtime-heavy crates are
+# excluded because miri can't run their targets.
+#
+# Memory model: Tree Borrows (#1239 Q2) — the direction the language is moving
+# and fewer false positives than the default Stacked Borrows.
 name: Miri
 on:
   schedule:
@@ -39,15 +47,22 @@ jobs:
           echo "::group::rustledger-booking"
           cargo miri test --package rustledger-booking --all-features
           echo "::endgroup::"
+
+          echo "::group::rustledger-query"
+          cargo miri test --package rustledger-query --all-features
+          echo "::endgroup::"
         env:
-          MIRIFLAGS: -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance
+          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance
       - name: Summary
         run: |
           echo "## Miri Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Miri checks for undefined behavior in unsafe Rust code." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Memory model: Tree Borrows (-Zmiri-tree-borrows)." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "Checked crates:" >> $GITHUB_STEP_SUMMARY
           echo "- rustledger-core" >> $GITHUB_STEP_SUMMARY
           echo "- rustledger-parser" >> $GITHUB_STEP_SUMMARY
           echo "- rustledger-booking" >> $GITHUB_STEP_SUMMARY
+          echo "- rustledger-query" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -56,7 +56,13 @@ jobs:
           cargo +nightly miri test --package rustledger-query --all-features
           echo "::endgroup::"
         env:
-          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance
+          # -Zmiri-disable-isolation: some tests read the realtime clock
+          # (e.g. "today"-based date helpers), which miri rejects under its
+          # default isolation ("clock_gettime ... not available when isolation
+          # is enabled"). Disabling isolation lets those tests run; it only
+          # permits host clock/entropy access and does not weaken miri's
+          # UB/aliasing checks, which is what this job is for.
+          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance -Zmiri-disable-isolation
       - name: Summary
         run: |
           echo "## Miri Results" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,24 +32,28 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           prefix-key: miri
+      # `+nightly` is required: the repo's rust-toolchain.toml pins `stable`,
+      # which otherwise overrides the nightly installed above, and miri only
+      # exists on nightly (bare `cargo miri` resolves to stable and fails with
+      # "the 'miri' component ... is not available for the 'stable' toolchain").
       - name: Setup Miri
-        run: cargo miri setup
+        run: cargo +nightly miri setup
       - name: Run Miri on core crates
         run: |
           echo "::group::rustledger-core"
-          cargo miri test --package rustledger-core --all-features
+          cargo +nightly miri test --package rustledger-core --all-features
           echo "::endgroup::"
 
           echo "::group::rustledger-parser"
-          cargo miri test --package rustledger-parser --all-features
+          cargo +nightly miri test --package rustledger-parser --all-features
           echo "::endgroup::"
 
           echo "::group::rustledger-booking"
-          cargo miri test --package rustledger-booking --all-features
+          cargo +nightly miri test --package rustledger-booking --all-features
           echo "::endgroup::"
 
           echo "::group::rustledger-query"
-          cargo miri test --package rustledger-query --all-features
+          cargo +nightly miri test --package rustledger-query --all-features
           echo "::endgroup::"
         env:
           MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance


### PR DESCRIPTION
## What

Brings the miri job (transitive-dep UB detection) in line with #1239 — and **fixes a pre-existing bug that made it never actually run miri.**

### The bug
The weekly job used bare `cargo miri`, but the repo's `rust-toolchain.toml` pins `stable`, which overrides the nightly the action installs. So every run failed at `cargo miri setup` with *"the 'miri' component … is not available for the 'stable' toolchain"* — confirmed via a manual `workflow_dispatch` (run 27539711232).

### Fixes / changes
- **`cargo +nightly miri …`** for setup + all test invocations (matches #1239's own spec), with an inline comment explaining why so it can't regress.
- **Tree Borrows** (`-Zmiri-tree-borrows`) — #1239 Q2's recommendation (fewer false positives; the direction the language is moving).
- **Extend coverage to `rustledger-query`** (pure BQL logic, no fs/wasm in tests).
- Document the transitive-UB rationale + exclusion reasoning inline.

### Scope
Stays **weekly** (miri is too slow to gate every PR — the issue's own "honorable mention / low-yield" framing). Broader coverage of fs/wasm-heavy crates (loader/plugin/importer) needs `cfg(miri)` test curation — left as a follow-up.

## Test plan
Validated by `workflow_dispatch` on this branch (re-run after the `+nightly` fix). The first dispatch surfaced the stable-toolchain bug; this run confirms miri actually executes.

Closes #1239.
