### PR TITLE
feat(validate): hint at name_* options in E1005 account-type error (#1361)

### DIFF
--- a/crates/rustledger-validate/src/validators/helpers.rs
+++ b/crates/rustledger-validate/src/validators/helpers.rs
@@ -21,7 +21,8 @@ pub fn validate_account_name(account: &str, account_types: &[String]) -> Option<
     }
     if !account_types.iter().any(|t| t == root) {
         return Some(format!(
-            "account must start with one of: {}",
+            "account must start with one of: {}. To use a different root name, \
+             rename a type via an option, e.g. `option \"name_income\" \"Revenue\"`",
             account_types.join(", ")
         ));
     }


### PR DESCRIPTION
## What

Closes #1361. Custom top-level account types (e.g. `Revenue`) are **already supported** the beancount way — rename a root via `option "name_income" "Revenue"` (or `name_assets`/`name_liabilities`/`name_equity`/`name_expenses`), which flows `Options.account_types()` → `ValidationOptions.account_types` → the validator. Verified end-to-end:

- `Revenue:*` with no option → `E1005` (matches beancount)
- `Revenue:*` + `option "name_income" "Revenue"` → `✓ No errors found`

The gap was **discoverability**: the E1005 message listed the five roots but never mentioned the rename options. This extends the message to point at them:

> account must start with one of: Assets, Liabilities, Equity, Income, Expenses. To use a different root name, rename a type via an option, e.g. `option "name_income" "Revenue"`

## Notes

Arbitrary *additional* roots (e.g. `Income` **and** `Revenue` at once) remain unsupported — Python beancount doesn't support that either; it renames the five roots, it doesn't add a sixth.

## Test plan
- `cargo test -p rustledger-validate` — green; no fixtures/snapshots assert the old message
- clippy `-D warnings` clean
- Manually confirmed the new hint renders in `rledger check` output
