### PR TITLE
docs: correct reference & command docs against current source (audit wave 1)

### DIFF
--- a/docs/commands/check.md
+++ b/docs/commands/check.md
@@ -30,6 +30,8 @@ rledger check [OPTIONS] [FILE]
 | `--plugin <WASM_FILE>` | Load a WASM plugin (can be repeated) |
 | `--native-plugin <PLUGIN>` | Enable a native plugin (can be repeated) |
 | `-f, --format <FORMAT>` | Output format: `text`, `json` |
+| `--lint <NAME>` | Run non-fatal advisory lints alongside validation (can be repeated). Available: `transfers` |
+| `--lint-min-confidence <VALUE>` | Minimum confidence (0.0 - 1.0) for `--lint transfers` matches to be reported (default: 0.8) |
 
 ## Examples
 
@@ -77,16 +79,24 @@ rledger check -f json ledger.beancount
 
 ```json
 {
-  "valid": false,
-  "errors": [
+  "diagnostics": [
     {
-      "code": "E3001",
-      "message": "Transaction does not balance",
       "file": "ledger.beancount",
       "line": 42,
-      "help": "Expenses:Food has 5.00 USD, Assets:Bank has -4.99 USD"
+      "column": 1,
+      "end_line": 42,
+      "end_column": 26,
+      "severity": "error",
+      "phase": "validate",
+      "code": "E3001",
+      "message": "Transaction does not balance",
+      "hint": "Expenses:Food has 5.00 USD, Assets:Bank has -4.99 USD"
     }
-  ]
+  ],
+  "error_count": 1,
+  "warning_count": 0,
+  "parse_error_count": 0,
+  "validate_error_count": 1
 }
 ```
 
@@ -135,11 +145,12 @@ Common validation errors:
 
 | Code | Description |
 |------|-------------|
-| E1001 | Syntax error |
-| E2001 | Account not opened |
-| E2002 | Account already opened |
+| E1001 | Account not opened |
+| E1002 | Account already opened |
+| E2001 | Balance assertion failed |
+| E2002 | Balance exceeds explicit tolerance |
 | E3001 | Transaction does not balance |
-| E3002 | Invalid balance assertion |
+| E3002 | Multiple postings missing amounts for same currency |
 
 See [Error Reference](../reference/errors.md) for all error codes.
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -39,13 +39,13 @@ rledger config show
 Output:
 
 ```toml
+# Merged configuration (highest priority wins)
+# Sources: user > system
+
 [default]
 file = "/home/user/finances/main.beancount"
 
-[check]
-auto = true
-
-[query]
+[output]
 format = "text"
 ```
 
@@ -58,13 +58,17 @@ rledger config path
 Output:
 
 ```
-Searching for config in:
-  1. ./rledger.toml
-  2. ./.rledger.toml
-  3. /home/user/.config/rledger/config.toml
-  4. /home/user/.rledger.toml
+Configuration file search paths:
 
-Found: /home/user/.config/rledger/config.toml
+  project  (not found)  /home/user/finances/.rledger.toml
+  user     (found)      /home/user/.config/rledger/config.toml
+  system   (not found)  /etc/rledger/config.toml
+
+Environment variables:
+  RLEDGER_FILE     Default beancount file
+  RLEDGER_FORMAT   Output format (text, csv, json)
+  RLEDGER_PROFILE  Active profile name
+  NO_COLOR         Disable colored output
 ```
 
 ### Create Default Config
@@ -81,7 +85,7 @@ Creates `~/.config/rledger/config.toml` with default settings.
 rledger config edit
 ```
 
-Opens config file in `$EDITOR` (or `vi` if not set).
+Opens the config file in the editor configured via `default.editor` in the config, or the `$VISUAL`/`$EDITOR` environment variables.
 
 ### List Aliases
 
@@ -93,8 +97,11 @@ Output:
 
 ```
 Configured aliases:
-  bal     -> query "BALANCES"
-  recent  -> query "SELECT date, payee, narration ORDER BY date DESC LIMIT 20"
+
+  bal = "report balances"
+  inc = "report income"
+
+Usage: rledger <alias> [additional args]
 ```
 
 ## Config File Format

--- a/docs/commands/format.md
+++ b/docs/commands/format.md
@@ -27,10 +27,6 @@ rledger format [OPTIONS] [FILE]...
 | `-i, --in-place` | Format file(s) in place |
 | `--check` | Check if file is formatted (exit 1 if not) |
 | `--diff` | Show diff when using --check |
-| `-c, --currency-column <COLUMN>` | Column for aligning currencies [default: 60] |
-| `-w, --prefix-width <WIDTH>` | Force fixed prefix width (account name column) |
-| `-W, --num-width <WIDTH>` | Force fixed numbers width |
-| `--indent <INDENT>` | Number of spaces for posting indentation [default: 2] |
 | `-v, --verbose` | Show verbose output |
 
 ## Examples
@@ -62,16 +58,6 @@ rledger format --check ledger.beancount
 
 # Show diff of what would change
 rledger format --check --diff ledger.beancount
-```
-
-### Custom Alignment
-
-```bash
-# Align currencies at column 80
-rledger format -c 80 ledger.beancount
-
-# Fixed account column width
-rledger format -w 40 ledger.beancount
 ```
 
 ### Pre-commit Hook

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -17,14 +17,20 @@ rustledger provides several commands for working with beancount ledgers.
 | [extract](extract.md) | Import from bank statements |
 | [price](price.md) | Fetch commodity prices |
 | [doctor](doctor.md) | Debugging and diagnostic tools |
+| [config](config.md) | Manage configuration |
+| [add](add.md) | Add transactions to beancount files |
+| compat | Install or uninstall bean-* compatibility wrapper scripts |
+| lint | Non-fatal advisory passes (e.g. detect inter-account transfer pairs) |
+| completions | Generate shell completions |
 
 ## Global Options
 
 These options work with all commands:
 
 ```
--h, --help       Print help information
--V, --version    Print version information
+-P, --profile <PROFILE>  Use a specific profile from config
+-h, --help               Print help information
+-V, --version            Print version information
 ```
 
 ## Specifying the Ledger File
@@ -66,6 +72,7 @@ rledger compat uninstall        # removes them
 | `bean-check` | `rledger check` |
 | `bean-query` | `rledger query` |
 | `bean-format` | `rledger format` |
+| `bean-report` | `rledger report` |
 | `bean-doctor` | `rledger doctor` |
 | `bean-extract` | `rledger extract` |
 | `bean-price` | `rledger price` |

--- a/docs/commands/query.md
+++ b/docs/commands/query.md
@@ -30,6 +30,7 @@ rledger query [OPTIONS] [FILE] [QUERY]
 | `-m, --numberify` | Remove currencies, output raw numbers |
 | `-q, --no-errors` | Suppress ledger validation errors on load |
 | `-v, --verbose` | Show verbose output |
+| `--no-cache` | Disable the on-disk parse cache (always re-parse) |
 
 ## Examples
 

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -12,6 +12,8 @@ Generate standard financial reports from your ledger.
 rledger report [OPTIONS] [FILE] [COMMAND]
 ```
 
+A report subcommand (e.g. `balances`, `journal`) is required — running `rledger report FILE` with no subcommand errors. `FILE` precedes the subcommand.
+
 ## Subcommands
 
 | Command | Alias | Description |

--- a/docs/commands/report.md
+++ b/docs/commands/report.md
@@ -9,7 +9,7 @@ Generate standard financial reports from your ledger.
 ## Usage
 
 ```bash
-rledger report [OPTIONS] [FILE] <SUBCOMMAND>
+rledger report [OPTIONS] [FILE] [COMMAND]
 ```
 
 ## Subcommands
@@ -34,28 +34,30 @@ rledger report [OPTIONS] [FILE] <SUBCOMMAND>
 | `-P, --profile <PROFILE>` | Use a profile from config |
 | `-f, --format <FORMAT>` | Output: `text`, `csv`, `json` |
 | `-v, --verbose` | Show verbose output |
+| `--no-pager` | Disable pager for output |
+| `--no-cache` | Disable the on-disk parse cache (always re-parse) |
 
 ## Examples
 
 ### Account Balances
 
 ```bash
-rledger report balances ledger.beancount
+rledger report ledger.beancount balances
 ```
 
 Filter by account:
 
 ```bash
-rledger report balances -a Expenses ledger.beancount
-rledger report balances -a Assets:Bank ledger.beancount
+rledger report ledger.beancount balances -a Expenses
+rledger report ledger.beancount balances -a Assets:Bank
 ```
 
 ### Balance Sheet
 
 ```bash
-rledger report balsheet ledger.beancount
+rledger report ledger.beancount balsheet
 # or
-rledger report bal ledger.beancount
+rledger report ledger.beancount bal
 ```
 
 Output:
@@ -79,28 +81,28 @@ Net Worth              25,284.00 USD
 ### Income Statement
 
 ```bash
-rledger report income ledger.beancount
+rledger report ledger.beancount income
 # or
-rledger report is ledger.beancount
+rledger report ledger.beancount is
 ```
 
 ### Transaction Journal
 
 ```bash
 # All transactions
-rledger report journal ledger.beancount
+rledger report ledger.beancount journal
 
 # Filter by account
-rledger report journal -a Expenses:Food ledger.beancount
+rledger report ledger.beancount journal -a Expenses:Food
 
 # Limit entries
-rledger report journal -l 20 ledger.beancount
+rledger report ledger.beancount journal -l 20
 ```
 
 ### Holdings
 
 ```bash
-rledger report holdings ledger.beancount
+rledger report ledger.beancount holdings
 ```
 
 Output:
@@ -115,13 +117,13 @@ Assets:Brokerage:GOOGL     5.00     2,000.00 USD   2,100.00 USD   +100.00 USD
 ### Net Worth Over Time
 
 ```bash
-rledger report networth ledger.beancount
+rledger report ledger.beancount networth
 ```
 
 ### Statistics
 
 ```bash
-rledger report stats ledger.beancount
+rledger report ledger.beancount stats
 ```
 
 Output:
@@ -140,10 +142,10 @@ Date range:       2020-01-01 to 2024-03-15
 
 ```bash
 # CSV for spreadsheets
-rledger report balances -f csv ledger.beancount > balances.csv
+rledger report -f csv ledger.beancount balances > balances.csv
 
 # JSON for scripts
-rledger report balances -f json ledger.beancount | jq '.'
+rledger report -f json ledger.beancount balances | jq '.'
 ```
 
 ## See Also

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -48,9 +48,9 @@ This document describes rustledger's crate structure and data flow.
     │ (JS/TS bindings)│   │ (JSON-RPC/WASI)   │   │    (CSV/OFX)      │
     └────────┬────────┘   └────────┬──────────┘   └────────┬──────────┘
               │                     │                       │
-              │                     └──► core, booking, validate, plugin, query
-              └────────────────────────► core, parser, booking, validate, loader, query
-                                                            └──► core, ops
+              │                     └──► core, parser, loader, booking, validate, plugin, query
+              └────────────────────────► core, parser, booking, validate, loader, query, completion
+                                                            └──► core, ops, plugin, plugin-types
 
     ┌─────────────────────┐
     │   rustledger-ops    │
@@ -276,7 +276,7 @@ After the regular pass, **Late validation** runs (balance assertions, commodity 
 
 Parsed ledgers are cached to disk in a binary format (rkyv) so subsequent runs can skip parsing entirely. The cache is stored as a hidden dotfile alongside the source — `ledger.beancount` → `.ledger.beancount.cache` — matching Python beancount's `.{filename}.picklecache` convention.
 
-The cache header stores a SHA-256 hash over every source file's path, modification time, and size (the main ledger and all transitively-`include`d files). On load, the hash is recomputed from the cached file list; any mismatch rejects the cache and the ledger is re-parsed. File contents themselves are not hashed — content-based invalidation is a possible future improvement but isn't currently implemented.
+The cache header stores a BLAKE3 hash over every source file's path, modification time, and size (the main ledger and all transitively-`include`d files). On load, the hash is recomputed from the cached file list; any mismatch rejects the cache and the ledger is re-parsed. File contents themselves are not hashed — content-based invalidation is a possible future improvement but isn't currently implemented.
 
 Two environment variables, both compatible with Python beancount, control the cache: `BEANCOUNT_DISABLE_LOAD_CACHE` to opt out entirely, and `BEANCOUNT_LOAD_CACHE_FILENAME` to redirect to a custom path (with `{filename}` substitution). See [`rledger check`](../commands/check.md#cache-file) for usage details.
 

--- a/docs/reference/bql.md
+++ b/docs/reference/bql.md
@@ -228,6 +228,7 @@ Note: PIVOT BY must reference a SELECT output column, either by name or by its 1
 | `last(x)` | Last value |
 | `min(x)` | Minimum value |
 | `max(x)` | Maximum value |
+| `avg(x)` | Average value |
 
 ### Examples
 
@@ -255,7 +256,7 @@ SELECT min(date), max(date)
 | Function | Description |
 |----------|-------------|
 | `cost(position)` | Convert to cost basis |
-| `units(position)` | Get units (number) |
+| `units(position)` | Get units (number + currency) |
 | `currency(position)` | Get currency |
 | `number(amount)` | Extract number from amount |
 
@@ -339,7 +340,7 @@ BQL distinguishes between:
 -- Get cost in operating currency
 SELECT sum(cost(position))
 
--- Get units (ignoring currency)
+-- Get units (number + currency)
 SELECT sum(units(position))
 
 -- Get currency
@@ -372,7 +373,12 @@ WHERE "trip-2024" IN links
 
 ## Subqueries
 
-Not currently supported. Use multiple queries or shell piping.
+A subquery can be used as the source of a `FROM` clause:
+
+```sql
+SELECT account, total
+FROM (SELECT account, sum(position) AS total GROUP BY account)
+```
 
 ## Examples
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,14 +1,15 @@
 # Beancount Compatibility Report
 
-This document describes the compatibility between rustledger and Python beancount, based on testing 694 real-world beancount files from multiple sources.
+This document describes the compatibility between rustledger and Python beancount, based on testing 792 real-world beancount files from multiple sources.
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Files tested | 694 |
-| Check exit match | **99.86%** (693/694) |
-| BQL query data match | **99%** (544/550) |
+| Files tested | 792 |
+| Check exit match | **100%** |
+| BQL query data match | **100%** |
+| Full-AST match | **100%** |
 
 ## Test Sources
 
@@ -24,7 +25,7 @@ Files were collected from:
 
 ## Compatibility Status
 
-With 99.86% check compatibility on 694 files (1 failure due to decimal precision limits), rustledger matches Python beancount's validation behavior on the tested corpus. The test suite includes files from:
+With 100% check compatibility on 792 files, rustledger matches Python beancount's validation behavior on the tested corpus. The test suite includes files from:
 
 - Official beancount v2/v3 repositories
 - Parser conformance tests
@@ -55,12 +56,12 @@ Rustledger does not execute Python plugins. Files using `plugin "some_python_plu
 
 Rustledger supports 30 native plugins that match Python beancount behavior:
 
-- `auto_accounts`, `auto_tag`, `box_accrual`, `capital_gains_gain_loss`
-- `capital_gains_long_short`, `check_average_cost`, `check_closing`, `check_commodity`
+- `auto_accounts`, `auto_tag`, `box_accrual`, `gain_loss`
+- `long_short`, `check_average_cost`, `check_closing`, `check_commodity`
 - `check_drained`, `close_tree`, `coherent_cost`, `commodity_attr`
 - `currency_accounts`, `effective_date`, `forecast`, `generate_base_ccy_prices`
 - `implicit_prices`, `leafonly`, `noduplicates`, `nounused`
-- `onecommodity`, `pedantic`, `rename_accounts`, `rxtxn`
+- `onecommodity`, `pedantic`, `rename_accounts`, `rx_txn_plugin`
 - `sellgains`, `split_expenses`, `unique_prices`, `unrealized`
 - `valuation`, `zerosum`
 
@@ -106,80 +107,42 @@ BQL (Beancount Query Language) compatibility was tested with 11 standard queries
 | `SELECT account, FIRST(date) GROUP BY account` | First dates |
 | `SELECT MIN(date), MAX(date)` | Date range |
 
-**Results: 99% data match (544/550 queries)**
+**Results: 100% data match**
 
-Breakdown:
-
-- **542 exact matches** - Identical output
-- **2 precision differences** - Display precision only (acceptable)
-- **6 data differences** - Real calculation bugs (see Known Issues below)
-
-Acceptable differences:
+The only remaining differences are display-only:
 
 - Python's bean-query uses a "display context" that truncates decimals (e.g., shows `111 USD` for `111.11 USD`)
 - Rustledger shows the actual precision (e.g., `111.11 USD`)
 
-### Known BQL Issues
-
-The 6 failing queries involve **capital gains calculation** in cost lot sales:
-
-1. **Missing interpolated capital gains**: When selling lots with `Income:Capital-Gains` as an elided posting, rustledger doesn't compute the gain (sale price - cost basis)
-
-1. **Extra zero positions in inventory**: SUM(position) may show `0.000 CURRENCY` entries that Python filters out
-
-These affect files with options trading and HSA investments that have buy/sell transactions with cost tracking.
+These do not affect the underlying values.
 
 ## Running Compatibility Tests
 
 ```bash
 # Inside nix develop shell:
 
-# Quick test with curated files (~100 files, committed)
-./scripts/compat-test.sh tests/compatibility/files
+# Download the full test suite first
+./scripts/fetch-compat-test-files.sh   # Populates tests/compatibility/files
 
-# Full test suite (~800 files, downloaded)
-./scripts/fetch-compat-test-files.sh  # Download first
-./scripts/compat-test.sh               # Runs on tests/compatibility-full/
-
-# Run BQL comparison
-./scripts/compat-bql-test.sh
-
-# Analyze results
-python scripts/analyze-compat-results.py
+# Run BQL comparison (bean-query vs rledger)
+python scripts/compat-bql-test.py
 ```
 
 ## Directory Structure
 
 ```
-tests/compatibility/                    # Curated test suite (committed)
+tests/compatibility/                    # Compatibility test suite
 ├── README.md                    # Test documentation
 ├── sources.toml                 # Source documentation and licenses
-└── files/                       # ~100 curated beancount files
-    ├── parser/                  # Parser edge cases
-    ├── validation/              # Validation scenarios
-    ├── plugins/                 # Plugin configurations
-    ├── real-world/              # Real-world examples
-    └── edge-cases/              # Known compatibility differences
-
-tests/compatibility-full/               # Full test suite (gitignored, downloaded)
-├── beancount-v2/                # Official beancount v2 files
-├── beancount-v3/                # Official beancount v3 files
-├── parser-lima/                 # Parser conformance tests
-├── fava/                        # Fava web interface tests
-├── beangulp/                    # Importer framework examples
-├── ledger2beancount/            # Converter tests
-├── beancount-import/            # Import test data
-└── community/                   # Community project files
-
-tests/compatibility-results/            # Test output (gitignored)
+├── exclusions.toml              # Files excluded from the metric
+├── bql-queries.toml             # BQL queries run by compat-bql-test.py
+└── files/                       # beancount files (mostly gitignored, downloaded)
 ```
 
 ## Scripts
 
 - `scripts/fetch-compat-test-files.sh` - Downloads full test suite from GitHub
-- `scripts/compat-test.sh` - Main test harness (bean-check vs rledger check)
-- `scripts/compat-bql-test.sh` - BQL query comparison
-- `scripts/analyze-compat-results.py` - Results analysis and reporting
+- `scripts/compat-bql-test.py` - BQL query comparison (bean-query vs rledger)
 
 ## Improving Compatibility
 
@@ -192,4 +155,4 @@ If you encounter a file that works with Python beancount but not rustledger:
 ______________________________________________________________________
 
 *Generated: February 2026*
-*Test environment: Beancount 3.2.0, beanquery 0.2.0, rustledger 0.10.0*
+*Test environment: Beancount 3.2.0, beanquery 0.2.0, rustledger 0.15.0*

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -54,7 +54,7 @@ Rustledger does not execute Python plugins. Files using `plugin "some_python_plu
 - Report error E8001 "Plugin not found" for unknown plugins
 - This matches Python beancount's behavior of failing on missing plugins
 
-Rustledger supports 30 native plugins that match Python beancount behavior:
+Rustledger supports 31 native plugins that match Python beancount behavior:
 
 - `auto_accounts`, `auto_tag`, `box_accrual`, `gain_loss`
 - `long_short`, `check_average_cost`, `check_closing`, `check_commodity`

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -75,7 +75,7 @@ Or use `rledger doctor missing-open` to generate them.
 
 **Fix**: Use correct account or adjust close date.
 
-### E1004: Account Close With Non-Zero Balance
+### E1004: Account Close With Non-Zero Balance (Warning)
 
 **Cause**: Closing an account that still has a balance.
 
@@ -230,6 +230,12 @@ Or use `rledger doctor missing-open` to generate them.
 ```
 
 **Fix**: Use allowed currency or update account declaration.
+
+### E5003: Invalid Precision Metadata (Warning)
+
+**Cause**: A `commodity` directive has invalid `precision` metadata.
+
+**Fix**: Correct the `precision` metadata value on the commodity directive.
 
 ## Option Errors (E7xxx)
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -122,10 +122,10 @@ option "inferred_tolerance_default" "*:0.005"
 
 ### inferred_tolerance_multiplier
 
-Multiplier for inferred tolerances.
+Multiplier for inferred tolerances. This name is deprecated (warning `E7004`); use `tolerance_multiplier` instead.
 
 ```beancount
-option "inferred_tolerance_multiplier" "1.1"
+option "tolerance_multiplier" "1.1"
 ```
 
 ## Plugin Options
@@ -175,10 +175,17 @@ option "documents" "/home/user/finances/documents"
 | `account_rounding` | string | - | Rounding errors account |
 | `conversion_currency` | string | - | Currency for conversions |
 | `inferred_tolerance_default` | string | - | Balance tolerance |
-| `inferred_tolerance_multiplier` | decimal | 0.5 | Tolerance multiplier |
+| `inferred_tolerance_multiplier` | decimal | 0.5 | Tolerance multiplier (deprecated; renamed to `tolerance_multiplier`) |
+| `tolerance_multiplier` | decimal | 0.5 | Tolerance multiplier |
 | `infer_tolerance_from_cost` | bool | FALSE | Infer tolerance from cost |
+| `use_legacy_fixed_tolerances` | bool | FALSE | Use legacy fixed tolerances |
+| `experiment_explicit_tolerances` | bool | FALSE | Enable experimental explicit tolerances |
+| `display_precision` | string | - | Per-currency display precision (e.g. `USD:0.01`) |
+| `allow_pipe_separator` | bool | FALSE | Allow pipe separator (deprecated) |
 | `documents` | string | - | Documents root directory |
 | `plugin_processing_mode` | string | default | Plugin mode |
+| `plugin` | string | - | Plugin (deprecated; use the `plugin` directive) |
+| `filename` | string | - | Source filename (read-only, auto-set) |
 | `long_string_maxlines` | int | 64 | Max lines for long strings |
 
 ## Example Configuration

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -29,7 +29,7 @@ rustledger supports three types of plugins:
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐       │
 │  │   Native    │ │    WASM     │ │   Python    │       │
 │  │  Registry   │ │   Runtime   │ │   Runtime   │       │
-│  │  (30 plugins)│ │ (Wasmtime)  │ │(CPython-WASI)│      │
+│  │  (31 plugins)│ │ (Wasmtime)  │ │(CPython-WASI)│      │
 │  └─────────────┘ └─────────────┘ └─────────────┘       │
 └─────────────────────────────────────────────────────────┘
                           │
@@ -126,7 +126,7 @@ plugin "beancount.plugins.implicit_prices"
 
 ## Built-in Plugins
 
-rustledger includes 30 native plugins. Here are the most commonly used:
+rustledger includes 31 native plugins. Here are the most commonly used:
 
 ### Validation Plugins
 
@@ -172,7 +172,7 @@ rustledger includes 30 native plugins. Here are the most commonly used:
 ### All Built-in Plugins
 
 <details>
-<summary>Complete list of 30 native plugins</summary>
+<summary>Complete list of 31 native plugins</summary>
 
 | Plugin | Description |
 |--------|-------------|
@@ -189,6 +189,7 @@ rustledger includes 30 native plugins. Here are the most commonly used:
 | `coherent_cost` | Enforce cost OR price (not both) |
 | `commodity_attr` | Validate commodity attributes |
 | `currency_accounts` | Auto-generate currency trading postings |
+| `document_discovery` | Auto-discover documents from directories |
 | `effective_date` | Override posting date via metadata |
 | `forecast` | Generate recurring transactions |
 | `generate_base_ccy_prices` | Create base currency price entries |

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -50,7 +50,7 @@ Declare an account before using it.
 Syntax: `DATE open ACCOUNT [CURRENCIES] [BOOKING]`
 
 - **CURRENCIES**: Optional comma-separated list of allowed currencies
-- **BOOKING**: Optional booking method (`"STRICT"`, `"FIFO"`, `"LIFO"`, `"AVERAGE"`, `"NONE"`)
+- **BOOKING**: Optional booking method (`"STRICT"`, `"STRICT_WITH_SIZE"`, `"FIFO"`, `"LIFO"`, `"HIFO"`, `"AVERAGE"`, `"NONE"`)
 
 ### Close
 


### PR DESCRIPTION
## Repo-wide doc accuracy audit — Wave 1: reference & command docs

First batch of a full documentation accuracy review. These 13 docs were audited against a pre-extracted **source-of-truth ledger** (actual `rledger --help` for every subcommand, the `Options`/`ErrorCode` enums, the native-plugin registry, crate exports, live compat numbers) and the real source code, then corrected. A lot had drifted.

### High-impact corrections
| Doc | Was wrong | Now |
|-----|-----------|-----|
| `commands/index.md` | listed 7 subcommands | added the 5 missing: `config`, `add`, `compat`, `lint`, `completions` |
| `commands/check.md` | error table mislabeled (E1001="syntax error"); JSON shape fictional | table matches `ErrorCode`; JSON matches `JsonOutput`/`JsonDiagnostic` |
| `commands/report.md` | every example had `report <subcmd> FILE` | clap requires `report FILE <subcmd>` (verified the old form errors) |
| `commands/format.md` | documented `--currency-column`/`--prefix-width`/… | removed — format is now no-knobs |
| `commands/config.md` | fictional `config path` output | matches actual project/user/system search paths |
| `reference/plugins.md` | 30 plugins, missing `document_discovery` | 31 |
| `reference/bql.md` | "subqueries not supported" | `FROM (SELECT …)` **is** supported |
| `reference/compatibility.md` | 694 files / 99.86% | 792 files / 100% Check / 100% BQL / 100% Full-AST |

Plus `options.md`, `errors.md`, `query.md`, `syntax.md`, `architecture.md` reconciled against source.

### Verification
Edits were made by per-doc audit agents citing the source; I independently spot-checked the riskiest ones against the **built binary** (report arg order, error-code table, removed format flags) — all confirmed.

Wave 1 of N. Subsequent waves (prose guides, crate READMEs, rustdoc) will follow as separate PRs.
