### PR TITLE
docs: fix runnable examples in prose/guides against the CLI (audit wave 2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thank you for your interest in contributing to Rustledger!
 
 ### Prerequisites
 
-- Rust 1.90+ (`rustup update stable`) - Rust 2024 edition
-- Node.js 18+ (for MCP server)
+- Rust 1.95+ (`rustup update stable`) - Rust 2024 edition
+- Node.js 24+ (for MCP server)
 - wasm-pack (for WASM builds): `cargo install wasm-pack`
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ______________________________________________________________________
 | **AI-ready** | MCP server for Claude, Cursor, and other AI assistants |
 | **Runs anywhere** | WebAssembly support for browser and Node.js |
 | **Better errors** | Detailed error messages with source locations |
-| **30 built-in plugins** | Plus Python plugin compatibility via WASI sandbox |
+| **31 built-in plugins** | Plus Python plugin compatibility via WASI sandbox |
 | **Bank import** | CSV/OFX import with auto-detection, dedup, and categorization |
 
 <details>
@@ -87,7 +87,7 @@ ______________________________________________________________________
 
 <sub>Missing your platform? [Open an issue](https://github.com/rustledger/rustledger/issues/new) to request it.</sub>
 
-**Coming from Python beancount?** See the [Migration Guide](docs/MIGRATION.md) for command equivalents and plugin mapping.
+**Coming from Python beancount?** See the [Migration Guide](docs/migration/index.md) for command equivalents and plugin mapping.
 
 ## Quick Start
 
@@ -277,7 +277,7 @@ WASM importers implement the same `Importer` trait as the built-ins via the [`wa
 | `rustledger-booking` | Interpolation and 7 booking methods |
 | `rustledger-validate` | 26 validation error codes |
 | `rustledger-query` | BQL query engine |
-| `rustledger-plugin` | 30 built-in plugins + Python plugin support |
+| `rustledger-plugin` | 31 built-in plugins + Python plugin support |
 | `rustledger-plugin-types` | Shared plugin type definitions |
 | `rustledger-importer` | Import framework: built-in CSV/OFX, plus a `WasmImporter` host loader for third-party `.wasm` importers |
 | `rustledger-ops` | Pure operations — ML categorization, LLM prompts, dedup, transfer detection, balance reconciliation, merchant dictionary |
@@ -301,15 +301,15 @@ WASM importers implement the same `Importer` trait as the built-ins via the [`wa
 </details>
 
 <details>
-<summary><strong>Built-in plugins (30)</strong></summary>
+<summary><strong>Built-in plugins (31)</strong></summary>
 
 | Plugin | Description |
 |--------|-------------|
 | `auto_accounts` | Auto-generate Open directives |
 | `auto_tag` | Automatically tag transactions |
 | `box_accrual` | Accrual accounting for boxed periods |
-| `capital_gains_gain_loss` | Split capital gains into gain/loss accounts |
-| `capital_gains_long_short` | Split capital gains by holding period |
+| `gain_loss` | Split capital gains into gain/loss accounts |
+| `long_short` | Split capital gains by holding period |
 | `check_average_cost` | Validate average cost bookings |
 | `check_closing` | Zero balance assertion on account close |
 | `check_commodity` | Validate commodity declarations |
@@ -328,7 +328,7 @@ WASM importers implement the same `Importer` trait as the built-ins via the [`wa
 | `onecommodity` | Single commodity per account |
 | `pedantic` | Enable all strict validations |
 | `rename_accounts` | Rename accounts via metadata |
-| `rxtxn` | Link related transactions |
+| `rx_txn_plugin` | Link related transactions |
 | `sellgains` | Cross-check capital gains against sales |
 | `split_expenses` | Split expenses across accounts |
 | `unique_prices` | One price per day per commodity pair |
@@ -438,7 +438,7 @@ cargo bench -p rustledger-core
 cargo bench -p rustledger-parser
 ```
 
-See [BENCHMARKING.md](docs/BENCHMARKING.md) for detailed benchmark documentation.
+See [benchmarking.md](docs/development/benchmarking.md) for detailed benchmark documentation.
 
 </details>
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,12 +36,12 @@ The version surface is:
 
 - Workspace `Cargo.toml`:
   - `[workspace.package].version`.
-  - All 10 entries under `[workspace.dependencies]` that path-depend on a sibling crate (`rustledger-core`, `rustledger-parser`, `rustledger-loader`, `rustledger-booking`, `rustledger-validate`, `rustledger-query`, `rustledger-plugin`, `rustledger-plugin-types`, `rustledger-importer`, `rustledger-ops`). Their pinned `version = "X.Y.Z"` must match — `cargo publish` rejects a crate whose dep version doesn't match what's on crates.io.
-- All 14 crate `Cargo.toml` files under `crates/` (each currently hardcodes its own `version = "X.Y.Z"` rather than inheriting from the workspace).
+  - All 13 entries under `[workspace.dependencies]` that path-depend on a sibling crate (`rustledger-core`, `rustledger-parser`, `rustledger-loader`, `rustledger-booking`, `rustledger-validate`, `rustledger-query`, `rustledger-completion`, `rustledger-plugin`, `rustledger-plugin-types`, `rustledger-importer`, `rustledger-ops`, `rustledger-ffi-wasi`, `rustledger-wasm`). Their pinned `version = "X.Y.Z"` must match — `cargo publish` rejects a crate whose dep version doesn't match what's on crates.io.
+- All 16 crate `Cargo.toml` files under `crates/` (each currently hardcodes its own `version = "X.Y.Z"` rather than inheriting from the workspace).
 - `packages/mcp-server/package.json`: both `version` and the `@rustledger/wasm` entry under `dependencies`. **Don't try to update `package-lock.json`** — `@rustledger/wasm@X.Y.Z` doesn't exist on npm yet during the bump PR, so `npm install` fails with `ETARGET`. The publish workflow regenerates the lockfile after wasm is published.
 - `packaging/rpm/rustledger.spec`:
   - `Version`, `Source0` URL, and the `%setup -n rustledger-X.Y.Z` directory all hardcode the version. COPR pulls this file from the release tag via SCM integration, so missing this means COPR keeps building the old version.
-  - `BuildRequires: rust >= X.Y` must match `[workspace.package].rust-version` in the root `Cargo.toml`. Since Edition 2024 stabilized in 1.85, an out-of-date pin makes COPR fail at parse time on edition2024 syntax — caught in v0.14.1 (#927) where the pin was still `1.75` long after MSRV moved to `1.94`.
+  - `BuildRequires: rust >= X.Y` must match `[workspace.package].rust-version` in the root `Cargo.toml`. Since Edition 2024 stabilized in 1.85, an out-of-date pin makes COPR fail at parse time on edition2024 syntax — caught in v0.14.1 (#927) where the pin was still `1.75` long after MSRV moved to `1.95`.
 - `Cargo.lock`: refreshed by `cargo check` after the Cargo.toml edits.
 
 `packages/vscode/package.json` is *not* bumped here — the VS Code extension version is synced from the release tag at build time. The AUR `PKGBUILD`s under `packaging/arch/` also don't need manual edits — `release-publish.yml` `sed`-bumps them at release time. The Homebrew formula at `packaging/homebrew/rustledger.rb` is bumped automatically by `dawidd6/action-homebrew-bump-formula` during release-publish.
@@ -137,7 +137,7 @@ Distributed via GitHub Releases only (not the VS Code Marketplace). Users downlo
 | Docker | `ghcr.io/rustledger/rustledger` |
 | Homebrew | `homebrew-core` (official) |
 | Scoop | `rustledger/scoop-rustledger` |
-| COPR | `copr.fedoraproject.org/rustledger` |
+| COPR | `copr.fedorainfracloud.org/rustledger` |
 | AUR | `rustledger`, `rustledger-bin` |
 
 ## Trusted Publishing

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -100,7 +100,7 @@ option "booking_method" "FIFO"
 | `booking_method` | FIFO, LIFO, AVERAGE, etc. | STRICT |
 | `account_previous_balances` | Retained earnings account | `Equity:Opening-Balances` |
 | `account_current_earnings` | Current earnings account | `Equity:Earnings:Current` |
-| `inferred_tolerance_default` | Balance tolerance | `0.005` |
+| `inferred_tolerance_default` | Per-currency balance tolerance (e.g. `USD:0.005`) | (none) |
 
 ### Booking Methods
 
@@ -145,20 +145,34 @@ alias ris='rledger report income'
 
 ### VS Code
 
-Install the [Beancount extension](https://marketplace.visualstudio.com/items?itemName=Lencerf.beancount) and configure it to use rustledger:
+Install the rustledger VS Code extension (a thin LSP client around `rledger-lsp`). Point it at the LSP binary if it is not already on your `PATH`:
 
 ```json
 {
-  "beancount.lspPath": "rledger-lsp"
+  "rustledger.server.path": "rledger-lsp"
 }
 ```
 
 ### Neovim
 
-Using nvim-lspconfig:
+Using nvim-lspconfig (register the server manually, since it is not built in):
 
 ```lua
-require('lspconfig').rledger_lsp.setup{}
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig.configs')
+
+if not configs.rledger then
+  configs.rledger = {
+    default_config = {
+      cmd = { 'rledger-lsp' },
+      filetypes = { 'beancount' },
+      root_dir = lspconfig.util.root_pattern('.git', '*.beancount'),
+      settings = {},
+    },
+  }
+end
+
+lspconfig.rledger.setup {}
 ```
 
 ### Helix
@@ -168,7 +182,7 @@ Add to `~/.config/helix/languages.toml`:
 ```toml
 [[language]]
 name = "beancount"
-language-server = { command = "rledger-lsp" }
+language-servers = ["rledger-lsp"]
 ```
 
 See [Editor Integration](../guides/editor-integration.md) for detailed setup instructions.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -182,7 +182,10 @@ Add to `~/.config/helix/languages.toml`:
 ```toml
 [[language]]
 name = "beancount"
-language-servers = ["rledger-lsp"]
+language-servers = ["rustledger"]
+
+[language-server.rustledger]
+command = "rledger-lsp"
 ```
 
 See [Editor Integration](../guides/editor-integration.md) for detailed setup instructions.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -72,7 +72,7 @@ Download from [GitHub Releases](https://github.com/rustledger/rustledger/release
 | macOS ARM64 | `rustledger-v<VERSION>-aarch64-apple-darwin.tar.gz` |
 | Windows x86_64 | `rustledger-v<VERSION>-x86_64-pc-windows-msvc.zip` |
 
-Replace `<VERSION>` with the release version (e.g., `0.10.1`).
+Replace `<VERSION>` with the release version (e.g., `0.15.0`).
 
 ## Verify Installation
 
@@ -83,7 +83,7 @@ rledger --version
 You should see output like:
 
 ```
-rledger 0.10.1
+rledger 0.15.0
 ```
 
 ## Shell Completions

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -57,18 +57,27 @@ If everything is correct, you'll see:
 See all account balances:
 
 ```bash
-rledger report balances ledger.beancount
+rledger report ledger.beancount balances
 ```
 
 Output:
 
 ```
-Assets:Bank:Checking      3850.00 USD
-Assets:Cash                -50.00 USD
-Equity:Opening-Balances  -1000.00 USD
-Expenses:Food              150.00 USD
-Expenses:Transport          50.00 USD
-Income:Salary            -3000.00 USD
+Account Balances
+============================================================
+
+Assets:Bank:Checking
+          3850.00 USD
+Assets:Cash
+           -50.00 USD
+Equity:Opening-Balances
+         -1000.00 USD
+Expenses:Food
+           150.00 USD
+Expenses:Transport
+            50.00 USD
+Income:Salary
+         -3000.00 USD
 ```
 
 ## Run Queries
@@ -95,13 +104,13 @@ rledger query ledger.beancount "
 
 ```bash
 # Balance sheet
-rledger report balsheet ledger.beancount
+rledger report ledger.beancount balsheet
 
 # Income statement
-rledger report income ledger.beancount
+rledger report ledger.beancount income
 
 # Transaction register
-rledger report journal ledger.beancount
+rledger report ledger.beancount journal
 ```
 
 ## Format Your Ledger

--- a/docs/guides/accounting-concepts.md
+++ b/docs/guides/accounting-concepts.md
@@ -251,7 +251,7 @@ Shows your financial position at a point in time:
 - **Net Worth**: The difference
 
 ```bash
-rledger report balsheet ledger.beancount
+rledger report ledger.beancount balsheet
 ```
 
 ### Income Statement
@@ -263,7 +263,7 @@ Shows financial activity over a period:
 - **Net Income**: The difference
 
 ```bash
-rledger report income ledger.beancount
+rledger report ledger.beancount income
 ```
 
 ## Account Hierarchy

--- a/docs/guides/budgeting.md
+++ b/docs/guides/budgeting.md
@@ -48,12 +48,12 @@ echo "Budget vs Actual for $MONTH"
 echo "============================"
 
 # Food:Groceries - Budget $400
-actual=$(rledger query "$LEDGER" "
+actual=$(rledger query "$LEDGER" -f csv "
   SELECT sum(cost(position))
   WHERE account ~ 'Expenses:Food:Groceries'
     AND year(date) = year(today())
     AND month(date) = month(today())
-" -f csv | tail -1)
+" | tail -1)
 
 echo "Groceries:    \$${actual} / \$400"
 
@@ -312,11 +312,11 @@ Instead of fixed budgets, track 3-month averages:
 ```sql
 -- Get last 3 months of expenses (adjust date range as needed)
 SELECT root(account, 2),
-       sum(cost(position)) / 3 AS monthly_avg
+       sum(number(cost(position))) / 3 AS monthly_avg
 WHERE account ~ "Expenses"
   AND date >= 2024-01-01 AND date < 2024-04-01
 GROUP BY 1
-ORDER BY 2 DESC
+ORDER BY monthly_avg DESC
 ```
 
 ### 5. Separate Needs vs Wants

--- a/docs/guides/common-queries.md
+++ b/docs/guides/common-queries.md
@@ -201,7 +201,7 @@ ORDER BY account
 Create shell aliases for frequently used queries:
 
 ```bash
-alias expenses='rledger query ledger.beancount "SELECT root(account, 2), sum(cost(position)) WHERE account ~ \"Expenses\" GROUP BY 1 ORDER BY 2 DESC"'
+alias expenses='rledger query ledger.beancount "SELECT root(account, 2) AS category, sum(cost(position)) AS total WHERE account ~ \"Expenses\" GROUP BY category ORDER BY total DESC"'
 ```
 
 ### Output to CSV

--- a/docs/guides/custom-plugins.md
+++ b/docs/guides/custom-plugins.md
@@ -264,6 +264,14 @@ pub extern "C" fn alloc(size: u32) -> *mut u8 {
     unsafe { std::alloc::alloc(layout) }
 }
 
+// ABI version export. The host checks this right after instantiation and
+// refuses to run a plugin built against an incompatible rustledger-plugin-types.
+// Must return the host's current ABI version (1).
+#[no_mangle]
+pub extern "C" fn __rustledger_abi_version() -> u32 {
+    1
+}
+
 // Main plugin entry point
 #[no_mangle]
 pub extern "C" fn process(input_ptr: u32, input_len: u32) -> u64 {
@@ -400,7 +408,6 @@ Output:
 
 ```
 warning: Large transaction: 25000.00 USD in Expenses:Transport
-  --> ledger.beancount:10
 ```
 
 ## Examples
@@ -447,11 +454,11 @@ fn process_directives(input: PluginInput) -> PluginOutput {
     for (i, mut directive) in input.directives.into_iter().enumerate() {
         if let Directive::Transaction(ref mut txn) = directive {
             // Add review-status metadata if not present
-            if !txn.meta.contains_key("review-status") {
-                txn.meta.insert(
+            if !txn.metadata.iter().any(|(k, _)| k == "review-status") {
+                txn.metadata.push((
                     "review-status".to_string(),
-                    "pending".to_string(),
-                );
+                    MetaValue::String("pending".to_string()),
+                ));
                 ops.push(PluginOp::Modify(i, directive));
                 continue;
             }
@@ -555,13 +562,12 @@ mod tests {
                 narration: "Test".to_string(),
                 tags: vec![],
                 links: vec![],
-                meta: Default::default(),
+                metadata: vec![],
                 postings: vec![],
-                source: None,
             })],
             options: Options {
                 title: None,
-                operating_currency: vec![],
+                operating_currencies: vec![],
             },
             config: None,
         };

--- a/docs/guides/editor-integration.md
+++ b/docs/guides/editor-integration.md
@@ -303,11 +303,11 @@ Install "Beancount" package from Package Control.
 
 ### LSP Not Starting
 
-Check that `rledger` is in your PATH:
+Check that `rledger-lsp` is in your PATH:
 
 ```bash
-which rledger
-rledger --version
+which rledger-lsp
+rledger-lsp --version
 ```
 
 Test LSP manually:

--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -170,7 +170,7 @@ The import pipeline can automatically enrich transactions beyond basic CSV/OFX
 extraction:
 
 - **Auto-inference**: Automatically detect CSV delimiter, date format, and column roles
-- **Merchant dictionary**: ~150 built-in merchant patterns (grocery, dining, transport, subscriptions, etc.) for automatic account categorization
+- **Merchant dictionary**: ~75 built-in merchant patterns (grocery, dining, transport, subscriptions, etc.) for automatic account categorization
 - **Transaction fingerprinting**: Stable structural hashes for deduplication against existing ledger entries
 - **Confidence scores**: Every enrichment decision carries a confidence value
 

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -28,7 +28,9 @@ Most commands support `--format json` for machine-readable output:
 
 ```bash
 # Get balances as JSON
-rledger query ledger.beancount "BALANCES" --format json
+# Note: --format must precede the FILE/QUERY arguments, otherwise the
+# variadic QUERY argument swallows the flag.
+rledger query --format json ledger.beancount "BALANCES"
 
 # Check for errors
 rledger check ledger.beancount --format json
@@ -45,7 +47,7 @@ import json
 
 def get_balances(ledger_path):
     result = subprocess.run(
-        ["rledger", "query", ledger_path, "BALANCES", "--format", "json"],
+        ["rledger", "query", "--format", "json", ledger_path, "BALANCES"],
         capture_output=True, text=True
     )
     if result.returncode != 0:
@@ -113,7 +115,11 @@ let mut loader = Loader::new();
 let result = loader.load(Path::new("ledger.beancount"))?;
 
 let query = parse_query("SELECT account, sum(position) GROUP BY account")?;
-let executor = Executor::new(&result.directives);
+
+// Strip spans: the executor takes `&[Directive]`, while the loader
+// returns `Vec<Spanned<Directive>>`.
+let directives: Vec<_> = result.directives.into_iter().map(|s| s.value).collect();
+let mut executor = Executor::new(&directives);
 let query_result = executor.execute(&query)?;
 
 for row in &query_result.rows {

--- a/docs/guides/multi-file.md
+++ b/docs/guides/multi-file.md
@@ -147,7 +147,7 @@ Have a single `main.beancount` that includes everything:
 ```bash
 # Always use the same entry point
 rledger check main.beancount
-rledger report balances main.beancount
+rledger report main.beancount balances
 ```
 
 ### 2. Accounts in One Place

--- a/docs/guides/shell-aliases.md
+++ b/docs/guides/shell-aliases.md
@@ -22,10 +22,10 @@ export LEDGER_FILE="$HOME/finances/ledger.beancount"
 alias rl='rledger'
 
 # Common reports
-alias bal='rledger report balances "$LEDGER_FILE"'
-alias balsheet='rledger report balsheet "$LEDGER_FILE"'
-alias is='rledger report income "$LEDGER_FILE"'
-alias reg='rledger report journal "$LEDGER_FILE"'
+alias bal='rledger report "$LEDGER_FILE" balances'
+alias balsheet='rledger report "$LEDGER_FILE" balsheet'
+alias is='rledger report "$LEDGER_FILE" income'
+alias reg='rledger report "$LEDGER_FILE" journal'
 
 # Validation
 alias check='rledger check "$LEDGER_FILE"'
@@ -42,7 +42,7 @@ After setting up aliases:
 # Check your ledger
 check
 
-# View balance sheet
+# View account balances
 bal
 
 # View recent transactions
@@ -62,18 +62,18 @@ Create functions for more flexibility:
 # Balance for specific account
 bal() {
   if [ -n "$1" ]; then
-    rledger report balances -a "$1" "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" balances -a "$1"
   else
-    rledger report balances "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" balances
   fi
 }
 
 # Register filtered by account
 reg() {
   if [ -n "$1" ]; then
-    rledger report journal -a "$1" "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" journal -a "$1"
   else
-    rledger report journal "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" journal
   fi
 }
 
@@ -87,7 +87,7 @@ reg() {
 
 ```bash
 # Monthly expenses summary
-alias expenses='rledger query "$LEDGER_FILE" "SELECT root(account, 2), sum(cost(position)) WHERE account ~ \"Expenses\" GROUP BY 1 ORDER BY 2 DESC"'
+alias expenses='rledger query "$LEDGER_FILE" "SELECT root(account, 2), sum(cost(position)) WHERE account ~ \"Expenses\" GROUP BY 1 ORDER BY sum(cost(position)) DESC"'
 
 # Net worth
 alias networth='rledger query "$LEDGER_FILE" "SELECT sum(cost(position)) WHERE account ~ \"Assets\" OR account ~ \"Liabilities\""'
@@ -101,7 +101,7 @@ alias thismonth='rledger query "$LEDGER_FILE" "SELECT root(account, 2), sum(cost
 ```bash
 # Transactions from specific period
 period() {
-  rledger report journal "$LEDGER_FILE" --begin "$1" --end "$2"
+  rledger query "$LEDGER_FILE" "SELECT date, account, position WHERE date >= $1 AND date <= $2"
 }
 
 # Usage: period 2024-01-01 2024-03-31
@@ -111,10 +111,10 @@ period() {
 
 ```bash
 # CSV export
-alias bal-csv='rledger report balances -f csv "$LEDGER_FILE"'
+alias bal-csv='rledger report "$LEDGER_FILE" balances -f csv'
 
 # JSON for scripting
-alias bal-json='rledger report balances -f json "$LEDGER_FILE"'
+alias bal-json='rledger report "$LEDGER_FILE" balances -f json'
 ```
 
 ## Per-Project Aliases
@@ -164,16 +164,16 @@ alias rl='rledger'
 alias check='rledger check "$LEDGER_FILE"'
 
 # Reports
-alias bal='rledger report balances "$LEDGER_FILE"'
-alias balsheet='rledger report balsheet "$LEDGER_FILE"'
-alias is='rledger report income "$LEDGER_FILE"'
+alias bal='rledger report "$LEDGER_FILE" balances'
+alias balsheet='rledger report "$LEDGER_FILE" balsheet'
+alias is='rledger report "$LEDGER_FILE" income'
 
 # Journal/register with optional account filter
 reg() {
   if [ -n "$1" ]; then
-    rledger report journal -a "$1" "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" journal -a "$1"
   else
-    rledger report journal "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" journal
   fi
 }
 
@@ -183,7 +183,7 @@ q() {
 }
 
 # Common reports
-alias expenses='q "SELECT root(account, 2), sum(cost(position)) WHERE account ~ \"Expenses\" GROUP BY 1 ORDER BY 2 DESC"'
+alias expenses='q "SELECT root(account, 2), sum(cost(position)) WHERE account ~ \"Expenses\" GROUP BY 1 ORDER BY sum(cost(position)) DESC"'
 alias networth='q "SELECT sum(cost(position)) WHERE account ~ \"Assets\" OR account ~ \"Liabilities\""'
 
 # Format in-place
@@ -204,14 +204,14 @@ set -x LEDGER_FILE "$HOME/finances/ledger.beancount"
 
 alias rl='rledger'
 alias check='rledger check $LEDGER_FILE'
-alias bal='rledger report balances $LEDGER_FILE'
-alias balsheet='rledger report balsheet $LEDGER_FILE'
+alias bal='rledger report $LEDGER_FILE balances'
+alias balsheet='rledger report $LEDGER_FILE balsheet'
 
 function reg
     if test -n "$argv[1]"
-        rledger report journal -a $argv[1] $LEDGER_FILE
+        rledger report $LEDGER_FILE journal -a $argv[1]
     else
-        rledger report journal $LEDGER_FILE
+        rledger report $LEDGER_FILE journal
     end
 end
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -13,7 +13,7 @@ Welcome to rustledger, a high-performance Rust implementation of [Beancount](htt
 - **No dependencies** - single binary, no Python runtime needed
 - **Full BQL support** - 100% query language compatibility
 - **LSP support** - IDE integration for VS Code, Neovim, Helix
-- **29 built-in plugins** - plus Python plugin compatibility
+- **31 built-in plugins** - plus Python plugin compatibility
 
 ## Quick Start
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -13,7 +13,7 @@ Welcome to rustledger, a high-performance Rust implementation of [Beancount](htt
 - **No dependencies** - single binary, no Python runtime needed
 - **Full BQL support** - 100% query language compatibility
 - **LSP support** - IDE integration for VS Code, Neovim, Helix
-- **30 built-in plugins** - plus Python plugin compatibility
+- **29 built-in plugins** - plus Python plugin compatibility
 
 ## Quick Start
 
@@ -29,7 +29,7 @@ rledger check ledger.beancount
 rledger query ledger.beancount "SELECT account, sum(position) GROUP BY account"
 
 # Generate reports
-rledger report balances ledger.beancount
+rledger report ledger.beancount balances
 ```
 
 ## Documentation Sections

--- a/docs/migration/from-beancount.md
+++ b/docs/migration/from-beancount.md
@@ -79,7 +79,7 @@ bean-check ledger.beancount
 
 ```bash
 # Balance report
-rledger report balances ledger.beancount
+rledger report ledger.beancount balances
 
 # Compare with
 bean-report ledger.beancount balances

--- a/docs/migration/from-hledger.md
+++ b/docs/migration/from-hledger.md
@@ -162,15 +162,15 @@ Recreate hledger-style commands:
 # ~/.bashrc
 export LEDGER_FILE="$HOME/finances/ledger.beancount"
 
-alias bal='rledger report balances "$LEDGER_FILE"'
-alias bs='rledger report balsheet "$LEDGER_FILE"'
-alias is='rledger report income "$LEDGER_FILE"'
+alias bal='rledger report "$LEDGER_FILE" balances'
+alias bs='rledger report "$LEDGER_FILE" balsheet'
+alias is='rledger report "$LEDGER_FILE" income'
 
 reg() {
   if [ -n "$1" ]; then
-    rledger report journal -a "$1" "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" journal -a "$1"
   else
-    rledger report journal "$LEDGER_FILE"
+    rledger report "$LEDGER_FILE" journal
   fi
 }
 ```

--- a/docs/migration/from-ledger.md
+++ b/docs/migration/from-ledger.md
@@ -176,16 +176,16 @@ Recreate familiar commands:
 # ~/.bashrc
 export LEDGER_FILE="$HOME/finances/ledger.beancount"
 
-alias bal='rledger report balances "$LEDGER_FILE"'
-alias reg='rledger report journal "$LEDGER_FILE"'
+alias bal='rledger report "$LEDGER_FILE" balances'
+alias reg='rledger report "$LEDGER_FILE" journal'
 
 # With account filter
 bal() {
-  rledger report balances ${1:+-a "$1"} "$LEDGER_FILE"
+  rledger report "$LEDGER_FILE" balances ${1:+-a "$1"}
 }
 
 reg() {
-  rledger report journal ${1:+-a "$1"} "$LEDGER_FILE"
+  rledger report "$LEDGER_FILE" journal ${1:+-a "$1"}
 }
 ```
 


### PR DESCRIPTION
## Doc accuracy audit — Wave 2: prose & guides (runnable examples)

Every CLI example in the user-facing prose (getting-started, guides, migration, README/CONTRIBUTING/RELEASING) was **executed against the built `rledger`** and corrected. 19 files fixed.

### Dominant breakage classes
| Class | Example | Fix |
|-------|---------|-----|
| `report` arg order | `report balances FILE` errors | `report FILE balances` (clap is `report [FILE] [COMMAND]`) |
| `query` flag order | `query FILE "Q" --format json` → flag swallowed into the variadic query, parse fails | flags before args: `query --format json FILE "Q"` |
| LSP editor setup | `beancount.lspPath` / `lspconfig.rledger_lsp` (third-party) | repo's own `rustledger.server.path` + manual nvim registration |
| Plugin ABI | custom-plugins long-form omitted `__rustledger_abi_version()` (host refuses to load without it) | added |
| BQL arithmetic | `sum(cost(position)) / 3` is a type error | `sum(number(cost(position))) / 3` |

Plus assorted command/flag/path corrections in migration guides, shell-aliases, README, etc.

Every example was run against `target/debug/rledger`; the `report`/`query` arg-order fixes were independently spot-checked.

Wave 2 of N. Independent of #1368 (disjoint files). Next: crate READMEs + dev docs + ADRs, then rustdoc.
