### PR TITLE
docs: fix crate READMEs, dev docs, ADRs against source (audit wave 3)

### DIFF
--- a/crates/rustledger-booking/README.md
+++ b/crates/rustledger-booking/README.md
@@ -24,7 +24,8 @@ Beancount booking engine with 7 lot matching methods and amount interpolation.
 ## Example
 
 ```rust
-use rustledger_booking::{BookingEngine, BookingMethod};
+use rustledger_booking::BookingEngine;
+use rustledger_core::BookingMethod;
 
 // Using the booking engine for a single transaction
 let mut engine = BookingEngine::with_method(BookingMethod::Fifo);

--- a/crates/rustledger-ffi-wasi/README.md
+++ b/crates/rustledger-ffi-wasi/README.md
@@ -174,4 +174,4 @@ cargo build -p rustledger-ffi-wasi --target wasm32-wasip1 --release
 
 ## License
 
-GPL-3.0
+GPL-3.0-only

--- a/crates/rustledger-loader/README.md
+++ b/crates/rustledger-loader/README.md
@@ -29,6 +29,8 @@ println!("Processed {} directives", ledger.directives.len());
 ## Cargo Features
 
 - `cache` (default) - Enable rkyv-based binary caching for faster loads
+- `full` (default) - Full processing pipeline (booking + plugins + validation); required for the `load` / `process` API used in the example above
+- `booking` / `plugins` / `validation` - Individual processing features (enabled together by `full`)
 
 ## License
 

--- a/crates/rustledger-ops/README.md
+++ b/crates/rustledger-ops/README.md
@@ -17,6 +17,7 @@ Analogous to Python beancount's `ops/` module.
 | `categorize` | Rule-based and pattern-based account categorization |
 | `merchants` | Merchant name normalization and lookup dictionary |
 | `enrichment` | Shared types for operation results (confidence, method, alternatives) |
+| `ml` | ML-based categorization (TF-IDF + Naive Bayes); host-only, absent on wasm targets |
 | `transfer` | Transfer detection between own accounts |
 | `reconcile` | Reconciliation of imported vs. existing directives |
 
@@ -35,7 +36,7 @@ let hash = structural_hash("2024-01-15", &transaction_data);
 
 ## Design
 
-Operations in this crate depend only on `rustledger-plugin-types` (for `DirectiveWrapper` and related types) and `rust_decimal`. They know nothing about the plugin runtime, CLI, LSP, or import system.
+Operations in this crate depend on `rustledger-plugin-types` (for `DirectiveWrapper` and related types) plus utility crates (`rust_decimal`, `jiff`, `blake3`, `regex`, and a host-only ML stack for the `ml` module). They know nothing about the plugin runtime, CLI, LSP, or import system.
 
 This separation allows the same operations to be used by:
 - The plugin system (via thin `NativePlugin` wrappers)

--- a/crates/rustledger-parser/README.md
+++ b/crates/rustledger-parser/README.md
@@ -1,6 +1,6 @@
 # rustledger-parser
 
-Fast Beancount parser using Logos lexer and Chumsky parser combinators.
+Fast Beancount parser built on a Logos lexer and a lossless Rowan CST.
 
 ## Features
 
@@ -12,7 +12,7 @@ Fast Beancount parser using Logos lexer and Chumsky parser combinators.
 ## Architecture
 
 ```
-Source (&str) → Logos tokenize() → Vec<SpannedToken> → Chumsky parser → Directives
+Source (&str) → Logos lexer → lossless CST (Rowan) → CST converter → Directives
 ```
 
 ## Example

--- a/crates/rustledger-plugin/README.md
+++ b/crates/rustledger-plugin/README.md
@@ -9,8 +9,8 @@ Beancount plugin system with 30 native plugins and WASM support.
 | `auto_accounts` | Auto-generate Open directives |
 | `auto_tag` | Automatically tag transactions |
 | `box_accrual` | Accrual accounting for boxed periods |
-| `capital_gains_gain_loss` | Split capital gains into gain/loss accounts |
-| `capital_gains_long_short` | Split capital gains by holding period |
+| `gain_loss` | Split capital gains into gain/loss accounts |
+| `long_short` | Split capital gains by holding period |
 | `check_average_cost` | Validate average cost bookings |
 | `check_closing` | Zero balance on account close |
 | `check_commodity` | Validate commodity declarations |
@@ -29,7 +29,7 @@ Beancount plugin system with 30 native plugins and WASM support.
 | `onecommodity` | Single commodity per account |
 | `pedantic` | Enable all strict validations |
 | `rename_accounts` | Rename accounts via metadata |
-| `rxtxn` | Link related transactions |
+| `rx_txn_plugin` | Link related transactions |
 | `sellgains` | Cross-check capital gains |
 | `split_expenses` | Split expenses across accounts |
 | `unique_prices` | One price per day per pair |
@@ -42,11 +42,11 @@ Additionally, `document_discovery` is available for auto-discovering document fi
 ## Example
 
 ```rust
-use rustledger_plugin::{NativePluginRegistry, run_plugin};
+use rustledger_plugin::{NativePluginRegistry, PluginInput};
 
-let registry = NativePluginRegistry::new();
-let plugin = registry.get("auto_accounts")?;
-let result = run_plugin(plugin, &directives)?;
+let registry = NativePluginRegistry::global();
+let plugin = registry.find_synth("auto_accounts").unwrap();
+let output = plugin.process(input);
 ```
 
 ## Cargo Features

--- a/crates/rustledger-plugin/README.md
+++ b/crates/rustledger-plugin/README.md
@@ -42,10 +42,16 @@ Additionally, `document_discovery` is available for auto-discovering document fi
 ## Example
 
 ```rust
-use rustledger_plugin::{NativePluginRegistry, PluginInput};
+use rustledger_plugin::{NativePluginRegistry, PluginInput, PluginOptions};
 
 let registry = NativePluginRegistry::global();
 let plugin = registry.find_synth("auto_accounts").unwrap();
+
+let input = PluginInput {
+    directives: vec![],
+    options: PluginOptions { operating_currencies: vec![], title: None },
+    config: None,
+};
 let output = plugin.process(input);
 ```
 

--- a/crates/rustledger-validate/README.md
+++ b/crates/rustledger-validate/README.md
@@ -10,8 +10,7 @@ Beancount validation with 26 error codes for ledger correctness.
 | E2xxx | Balance/pad errors |
 | E3xxx | Transaction errors (unbalanced, no postings) |
 | E4xxx | Inventory/lot errors |
-| E5xxx | Currency errors |
-| E6xxx | Metadata errors |
+| E5xxx | Currency/commodity-metadata errors |
 | E7xxx | Option errors |
 | E8xxx | Document errors |
 | E10xxx | Date warnings |
@@ -24,19 +23,20 @@ Validation is run through a `ValidationSession`. Standalone callers
 phases.
 
 ```rust
-use rustledger_validate::{Phase, ValidationOptions, ValidationSession};
+use rustledger_validate::{ValidationOptions, ValidationSession};
 use rustledger_core::{Directive, naive_date};
 
 let directives: Vec<Directive> = vec![/* parsed + booked input */];
 let today = naive_date(2030, 1, 1).unwrap();
 
-let mut session = ValidationSession::new(ValidationOptions::default());
-let mut errors = session.run_phase(&directives, Phase::Early, today);
-errors.extend(session.run_phase(&directives, Phase::Late, today));
+let session = ValidationSession::new(ValidationOptions::default());
+let (session, mut errors) = session.run_early(&directives, today);
+let (session, late_errors) = session.run_late(&directives, today);
+errors.extend(late_errors);
 errors.extend(session.finalize());
 
 for error in errors {
-    eprintln!("{}: {}", error.code(), error.message());
+    eprintln!("{}: {}", error.code, error.message);
 }
 ```
 

--- a/crates/rustledger-wasm/README.md
+++ b/crates/rustledger-wasm/README.md
@@ -102,4 +102,4 @@ wasm-pack build --target web crates/rustledger-wasm
 
 ## License
 
-GPL-3.0
+GPL-3.0-only

--- a/crates/rustledger/README.md
+++ b/crates/rustledger/README.md
@@ -13,6 +13,11 @@ Drop-in replacement for Beancount CLI tools. Pure Rust, 10-30x faster.
 | `rledger doctor` | Debug ledger issues |
 | `rledger extract` | Import from CSV/OFX |
 | `rledger price` | Fetch commodity prices |
+| `rledger add` | Add transactions to beancount files |
+| `rledger lint` | Non-fatal advisory passes (e.g. detect transfer pairs) |
+| `rledger config` | Manage configuration |
+| `rledger compat` | Install/uninstall bean-* wrapper scripts |
+| `rledger completions` | Generate shell completions |
 
 ## Compatibility
 

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -135,7 +135,7 @@ Located in `crates/*/benches/`. Each crate has focused benchmarks:
 **Commands used:**
 
 - Validation: `rledger check` (rustledger), `bean-check` (beancount), `ledger accounts` (ledger), `hledger check` (hledger)
-- Balance: `rledger report balances` (rustledger), `bean-query BALANCES` (beancount), `ledger balance` (ledger), `hledger balance` (hledger)
+- Balance: `rledger report <file> balances` (rustledger), `bean-query BALANCES` (beancount), `ledger balance` (ledger), `hledger balance` (hledger)
 
 ### 3. PR Benchmarks
 
@@ -150,7 +150,7 @@ Located in `crates/*/benches/`. Each crate has focused benchmarks:
 
 **What it measures:**
 
-- Quick validation benchmark (1K transactions for speed)
+- Quick validation benchmark (10K transactions, 5 runs / 2 warmup for speed)
 - Memory usage (Peak RSS)
 - Comparison against baseline from main branch
 
@@ -162,11 +162,9 @@ Located in `crates/*/benches/`. Each crate has focused benchmarks:
 
 - Posts/updates a PR comment with results
 - Shows speedup factor and memory comparison
-- Indicates change vs main branch baseline (with emoji: 🚀 faster, ✅ stable, ⚠️ slower)
+- Indicates change vs main branch baseline (with emoji: 🟢 faster, ✅ unchanged, 🟡 slower, 🔴 regression)
 
-**Also runs:**
-
-- Criterion benchmarks for `rustledger-core` and `rustledger-parser`
+(Criterion benchmarks are not run here; they are tracked separately on main branch pushes.)
 
 ### 4. Scaling Benchmarks
 
@@ -227,13 +225,8 @@ nix develop .#bench
 The script:
 
 1. Generates test ledgers (`.beancount` and `.ledger` formats)
-1. Runs hyperfine with 10 iterations, 3 warmups
-1. Outputs JSON and formatted summary
-
-**Additional scripts:**
-
-- `scripts/bench-compare.py` - Compare benchmark results and detect regressions
-- `scripts/generate-bench-charts.py` - Generate Vega chart specs from history
+1. Runs hyperfine with 10 runs, 3 warmups (validation and balance benchmarks)
+1. Outputs JSON and a formatted summary
 
 ## Input Size Guidelines
 
@@ -341,18 +334,9 @@ View the benchmark charts on the `benchmarks` branch:
 - `validation-chart.vega.json` - Vega spec (editable)
 - `balance-chart.vega.json` - Vega spec (editable)
 
-**Local chart generation:**
-
-```bash
-# Generate Vega specs from history
-./scripts/generate-bench-charts.py
-
-# Generate with custom values
-./scripts/generate-bench-charts.py --rustledger 32 --ledger 65 --hledger 540 --beancount 880
-
-# Render to SVG (requires: npm install -g vega vega-cli)
-./scripts/generate-bench-charts.py --render
-```
+The Vega specs and SVGs are generated and committed automatically by the
+`bench.yml` workflow (which renders them with `vg2svg` from the `vega`/`vega-lite`/`vega-cli`
+npm packages); there is no standalone local chart-generation script.
 
 ## Performance Regression Detection
 
@@ -366,7 +350,7 @@ To investigate a regression:
 
 1. Check the benchmark history charts
 1. Run local Criterion benchmarks to isolate the component
-1. Use `cargo flamegraph` for profiling (requires nightly shell)
+1. Use `cargo flamegraph` for profiling (install separately via `cargo install flamegraph`)
 
 ## Nix Development Shells
 
@@ -380,8 +364,8 @@ Includes:
 
 - All comparison tools (beancount, ledger, hledger)
 - hyperfine for timing
-- Python with matplotlib for charts
-- Build dependencies for ledger
+- Python with beancount/beanquery (for bean-check and bean-query)
+- Build dependencies for ledger (cmake, boost, gmp)
 
 ### Nightly Shell (`nix develop .#nightly`)
 

--- a/docs/development/contributing-plugins.md
+++ b/docs/development/contributing-plugins.md
@@ -426,8 +426,8 @@ fn process(&self, input: PluginInput) -> PluginOutput {
 // Good: Filter first, then process
 let transactions: Vec<_> = input.directives
     .iter()
-    .filter_map(|d| match d {
-        Directive::Transaction(t) => Some(t),
+    .filter_map(|d| match &d.data {
+        DirectiveData::Transaction(t) => Some(t),
         _ => None,
     })
     .collect();

--- a/docs/development/import-roadmap.md
+++ b/docs/development/import-roadmap.md
@@ -10,7 +10,7 @@
 | CSV Auto-Inference | ✅ Done | Delimiter, date format, column role detection (`--auto` flag) |
 | Ops Crate (`rustledger-ops`) | ✅ Done | Pure operations: dedup, categorize, fingerprint, reconcile, merchants, transfer |
 | Rules Engine | ✅ Done | Substring, regex, and exact match rules with priority ordering |
-| Merchant Dictionary | ✅ Done | ~150 built-in patterns (groceries, dining, transport, subscriptions, etc.) |
+| Merchant Dictionary | ✅ Done | ~75 built-in patterns (groceries, dining, transport, subscriptions, etc.) |
 | Transaction Fingerprinting | ✅ Done | Structural hashing via blake3 for stable dedup |
 | Enriched Import Results | ✅ Done | `EnrichedImportResult` with confidence scores and categorization method |
 | Institution Profiles | 🔮 Future | YAML-based bank definitions |
@@ -1635,7 +1635,7 @@ Implemented in `rustledger-ops::categorize::RulesEngine`:
 - Regex patterns (compiled, case-insensitive)
 - Exact matching
 - Priority ordering (user rules > merchant dictionary)
-- Built-in merchant dictionary with ~60 common patterns (`rustledger-ops::merchants`)
+- Built-in merchant dictionary with ~75 common patterns (`rustledger-ops::merchants`)
 
 The importer integrates the rules engine via `CsvConfigBuilder::use_merchant_dict()` and
 `CsvConfigBuilder::regex_mappings()`. User-defined `[importers.mappings]` in TOML config

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -58,18 +58,21 @@ cargo deny check
 ```
 rustledger/
 ├── crates/
-│   ├── rustledger-core/      # Core types
-│   ├── rustledger-parser/    # Lexer and parser
-│   ├── rustledger-loader/    # File loading
-│   ├── rustledger-booking/   # Booking engine
-│   ├── rustledger-validate/  # Validation
-│   ├── rustledger-query/     # BQL engine
-│   ├── rustledger-plugin/    # Plugin system
-│   ├── rustledger-importer/  # Import framework
-│   ├── rustledger-lsp/       # LSP server
-│   ├── rustledger-wasm/      # WASM target
-│   ├── rustledger-ffi-wasi/  # WASI FFI
-│   └── rustledger/           # CLI binary
+│   ├── rustledger-core/         # Core types
+│   ├── rustledger-parser/       # Lexer and parser
+│   ├── rustledger-loader/       # File loading
+│   ├── rustledger-booking/      # Booking engine
+│   ├── rustledger-validate/     # Validation
+│   ├── rustledger-query/        # BQL engine
+│   ├── rustledger-completion/   # Shared completion logic
+│   ├── rustledger-plugin/       # Plugin system
+│   ├── rustledger-plugin-types/ # Shared plugin types
+│   ├── rustledger-importer/     # Import framework
+│   ├── rustledger-ops/          # Pure directive operations
+│   ├── rustledger-lsp/          # LSP server
+│   ├── rustledger-wasm/         # WASM target
+│   ├── rustledger-ffi-wasi/     # WASI FFI
+│   └── rustledger/              # CLI binary
 ├── spec/                     # Specifications
 └── tests/                    # Integration tests
 ```

--- a/docs/development/performance-roadmap.md
+++ b/docs/development/performance-roadmap.md
@@ -197,7 +197,7 @@ ______________________________________________________________________
 
 - **File**: `crates/rustledger-loader/src/cache.rs`
 - **Format**: [rkyv](https://github.com/rkyv/rkyv) for zero-copy deserialization
-- **Cache key**: SHA256 hash of file mtime + size
+- **Cache key**: BLAKE3 hash of file path + mtime + size
 - **Location**: `ledger.beancount` → `.ledger.beancount.cache` (hidden dotfile, matches Python beancount; see issue #939). Override via `BEANCOUNT_LOAD_CACHE_FILENAME`.
 
 Custom rkyv wrappers for non-rkyv types:
@@ -227,13 +227,13 @@ ______________________________________________________________________
 **Goal**: Replace parser combinators with fast lexer, use arena for AST
 **Expected Impact**: 30-50% faster parsing
 
-### 6.1 Logos Lexer + Winnow Parser ✅ DONE
+### 6.1 Logos Lexer + Structured CST ✅ DONE
 
 - Using [Logos](https://github.com/maciejhirsz/logos) for SIMD-accelerated tokenization
-- Using [Winnow](https://github.com/winnow-rs/winnow) for manual recursive descent parsing
+- Using a [rowan](https://github.com/rust-analyzer/rowan)-based lossless CST built by hand-written structured parsing (`parse_structured`)
 - Replaced Chumsky parser combinators (legacy parser removed)
 - Zero-copy token stream - no allocations during lexing
-- Implemented in `logos_lexer.rs` and `winnow_parser.rs`
+- Implemented in `logos_lexer.rs` and the `cst/` module (`cst/parser.rs`)
 
 ### 6.2 Bumpalo Arena for AST Nodes 🔮 FUTURE
 
@@ -253,14 +253,14 @@ ______________________________________________________________________
 - **Cow strings** — `parse_string` returns `Cow<str>`, zero-alloc for no-escape strings
 - **Result**: Parser 1K txns: 1,204μs → 700μs (**-42%**)
 
-### 6.4 Validation Fast Paths (April 2026, PR #814)
+### 6.4 Validation Fast Paths ✅ DONE (April 2026, PR #814)
 
 - **Compute tolerances once** — pass pre-computed tolerances to balance checker
 - **Fast-path BigDecimal bypass** — skip expensive arbitrary-precision when Decimal residual is zero
 - **Remove Vec allocation** in `validate_account_name` — iterate without collecting
 - **Result**: Validation 1K txns: 210μs → 90μs (**-57%**)
 
-### 6.5 Parallel File Loading (April 2026, PR #813)
+### 6.5 Parallel File Loading ✅ DONE (April 2026, PR #813)
 
 - When multiple sibling includes are found, read + parse files in parallel via rayon
 - Sequential merge preserves include order and handles nested includes
@@ -292,11 +292,11 @@ ______________________________________________________________________
 | 3 | Full interning | ✅ Done | +6% |
 | 4 | Parallelization (rayon) | ✅ Done | +5% |
 | 5 | Binary cache (rkyv) | ✅ Done | 2.3x on cache hit |
-| 6.1 | Logos + Winnow parser | ✅ Done | Replaced Chumsky |
+| 6.1 | Logos + structured CST parser | ✅ Done | Replaced Chumsky |
 | 6.2 | Bumpalo arena | 🔮 Future | +20% projected |
 | 6.3 | Parser fast paths | ✅ Done | +42% parser (Apr 2026, PR #812) |
-| 6.4 | Validation fast paths | 🔄 PR #814 | +57% validation (Apr 2026) |
-| 6.5 | Parallel file loading | 🔄 PR #813 | Multi-file I/O parallelized |
+| 6.4 | Validation fast paths | ✅ Done | +57% validation (Apr 2026, PR #814) |
+| 6.5 | Parallel file loading | ✅ Done | Multi-file I/O parallelized (PR #813) |
 | 7 | Memory-mapped files | 🔮 Future | Large files only |
 
 ## Actual Performance
@@ -421,8 +421,8 @@ ______________________________________________________________________
 ### Parser Performance
 
 - [Logos](https://github.com/maciejhirsz/logos) - current lexer, SIMD-accelerated DFA
-- [Winnow](https://github.com/winnow-rs/winnow) - current parser, manual recursive descent
-- [Chumsky](https://github.com/zesterer/chumsky) - former parser, replaced by Winnow (removed)
+- [rowan](https://github.com/rust-analyzer/rowan) - current lossless CST library, hand-written structured parsing
+- [Chumsky](https://github.com/zesterer/chumsky) - former parser, replaced by the structured CST parser (removed)
 
 ### Serialization
 

--- a/docs/development/testing-roadmap.md
+++ b/docs/development/testing-roadmap.md
@@ -305,7 +305,7 @@ Connect TLA+ specs to Rust implementation.
 
 **Why**: Verify Rust code satisfies TLA+ invariants directly.
 
-**File**: `crates/rustledger-core/src/inventory_proofs.rs`
+**File**: `crates/rustledger-core/src/kani_proofs.rs`
 
 ```rust
 #[cfg(kani)]
@@ -584,7 +584,7 @@ ______________________________________________________________________
 - `.github/workflows/kani.yml`
 - `.github/workflows/mutation.yml`
 - `crates/rustledger-query/fuzz/` (new fuzz target)
-- `crates/rustledger-core/src/inventory_proofs.rs`
+- `crates/rustledger-core/src/kani_proofs.rs`
 - `scripts/compat-error-quality.py`
 
 ### Modified Files
@@ -592,7 +592,7 @@ ______________________________________________________________________
 - `.github/workflows/ci.yml` (Miri, nextest, coverage, WASM)
 - `.github/workflows/bench-pr.yml` (Criterion)
 - `.github/workflows/tla.yml` (trace automation)
-- `scripts/compat-bql-test.sh` (expanded queries)
+- `scripts/compat-bql-test.py` (expanded queries)
 
 ### External PRs
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -84,25 +84,29 @@ rustledger/
 │           ├── integration_test.rs
 │           └── fixture_tests.rs
 ├── tests/
-│   ├── compat/
-│   │   ├── files/                  # 93 curated compatibility files
-│   │   ├── README.md
-│   │   └── sources.toml
-│   ├── compat-full/                # ~800 files (gitignored, fetched on demand)
-│   └── compat-results/             # Test results (gitignored)
-├── spec/
 │   ├── fixtures/                   # Parser and example fixtures
 │   │   ├── booking-scenarios.beancount
 │   │   ├── validation-errors.beancount
+│   │   ├── syntax-edge-cases.beancount
 │   │   ├── examples/
-│   │   └── lima-tests/
+│   │   ├── lima-tests/
+│   │   └── python-plugins/
+│   ├── compatibility/
+│   │   ├── files/                  # ~800 files (gitignored, fetched on demand;
+│   │   │                           #   only files/plugins/ is committed)
+│   │   ├── README.md
+│   │   ├── sources.toml
+│   │   ├── bql-queries.toml
+│   │   └── exclusions.toml
+│   ├── baselines/
+│   └── regressions/
+├── spec/
 │   └── tla/                        # TLA+ specifications (19 specs)
 │       ├── FIFOCorrect.tla
 │       ├── Conservation.tla
 │       └── ...
 └── scripts/
-    ├── compat-test.sh              # Run compatibility tests
-    ├── compat-bql-test.sh          # BQL compatibility tests
+    ├── compat-bql-test.py          # BQL compatibility tests
     └── fetch-compat-test-files.sh  # Download full test suite
 ```
 
@@ -111,12 +115,12 @@ rustledger/
 | Crate | Unit | Integration | Property | TLA+ |
 |-------|:----:|:-----------:|:--------:|:----:|
 | rustledger-core | Yes | - | Yes | Yes |
-| rustledger-parser | Yes | Yes | - | - |
-| rustledger-query | Yes | Yes | - | - |
+| rustledger-parser | Yes | Yes | Yes | - |
+| rustledger-query | Yes | Yes | Yes | Yes |
 | rustledger-validate | Yes | Yes | Yes | Yes |
 | rustledger-loader | Yes | Yes | - | - |
-| rustledger-plugin | Yes | Yes | - | - |
-| rustledger-booking | Yes | - | - | - |
+| rustledger-plugin | Yes | Yes | Yes | Yes |
+| rustledger-booking | Yes | Yes | Yes | Yes |
 | rustledger | Yes | Yes | - | - |
 
 ## Test Systems in Detail
@@ -174,6 +178,9 @@ Located in:
 - `crates/rustledger-core/tests/property_tests.rs`
 - `crates/rustledger-core/tests/tla_proptest.rs`
 - `crates/rustledger-validate/tests/tla_proptest.rs`
+- `crates/*/tests/pipeline_invariants.rs` — pipeline invariant property suites
+  (parser, query, validate, booking, plugin)
+- `crates/{rustledger-query,rustledger-plugin,rustledger-booking}/tests/tla_proptest.rs`
 
 **Example:**
 
@@ -235,24 +242,24 @@ cargo test -p rustledger-core tla_proptest
 
 Compare rustledger against Python beancount to ensure identical behavior.
 
-**Curated files (93 files):** Committed to `tests/compatibility/files/`
+**Test corpus (~800 files):** Most files are downloaded on demand; only
+`tests/compatibility/files/plugins/` is committed in-tree.
 
 ```bash
-./scripts/compat-test.sh tests/compatibility/files
-```
-
-**Full suite (~800 files):** Downloaded on demand
-
-```bash
-# Inside nix develop
+# Inside nix develop — download the corpus first
 ./scripts/fetch-compat-test-files.sh
-./scripts/compat-test.sh
 ```
+
+The compat suite itself is driven by the `compat.yml` workflow, which builds
+`rledger` and compares its output against Python beancount over the fetched
+corpus.
 
 **BQL compatibility:**
 
 ```bash
-./scripts/compat-bql-test.sh
+python3 scripts/compat-bql-test.py \
+  --corpus tests/compatibility/bql-queries.toml \
+  --rledger ./target/release/rledger
 ```
 
 **CI:** Runs nightly at 3 AM UTC via `.github/workflows/compat.yml`
@@ -268,6 +275,7 @@ Compare rustledger against Python beancount to ensure identical behavior.
 | `syntax-edge-cases.beancount` | Parser edge cases |
 | `examples/` | Complete example ledgers |
 | `lima-tests/` | beancount-parser-lima test cases |
+| `python-plugins/` | Python plugin compatibility fixtures |
 
 ### Crate Fixtures (`crates/*/tests/fixtures/`)
 
@@ -278,21 +286,25 @@ Per-crate test data:
 
 ### Compatibility Fixtures (`tests/compatibility/files/`)
 
-Organized by category:
+Most of the corpus is downloaded on demand and gitignored. The only category
+committed in-tree is:
 
-- `parser/` - Parser edge cases (~25 files)
-- `validation/` - Validation scenarios (~20 files)
-- `plugins/` - Plugin configurations (~5 files)
-- `real-world/` - Community examples (~35 files)
-- `edge-cases/` - Known differences (~10 files)
+- `plugins/` - Plugin configuration fixtures
+
+The downloaded corpus (~800 files) is organized by upstream source under
+`files/` (e.g. `beancount-v2/`, `beancount-v3/`, `fava/`).
 
 ## CI Workflows
 
 | Workflow | Trigger | Tests Run |
 |----------|---------|-----------|
-| `ci.yml` | Push, PR | `cargo test --all-features` |
-| `compat.yml` | Nightly | Full compatibility suite |
-| `tla.yml` | Changes to TLA+/inventory/booking | TLA+ model checking |
+| `ci.yml` | Push, PR | `cargo nextest run --all-features` (plus `cargo test --doc`) |
+| `compat.yml` | Nightly (3 AM UTC) | Full compatibility suite |
+| `tla.yml` | Changes to TLA+/`inventory.rs`/booking | TLA+ model checking |
+| `mutation.yml` | Monthly / PR to verified modules | Mutation testing (`cargo-mutants`) |
+| `fuzz.yml` | Nightly / PR to parser, query, booking | Fuzzing |
+| `miri.yml` | Weekly | Miri (undefined-behavior checks) |
+| `kani.yml` | Weekly / PR to core, booking | Kani model checking |
 
 ## Adding New Tests
 
@@ -345,7 +357,7 @@ proptest! {
 1. Determine the appropriate location:
 
    - Parser/syntax: `tests/fixtures/`
-   - Compatibility: `tests/compatibility/files/<category>/`
+   - Committed compatibility plugin fixtures: `tests/compatibility/files/plugins/`
    - Crate-specific: `crates/<crate>/tests/fixtures/`
 
 1. Create a minimal `.beancount` file that reproduces the case

--- a/docs/reference/adr/0001-crate-organization.md
+++ b/docs/reference/adr/0001-crate-organization.md
@@ -28,6 +28,8 @@ Organize the codebase as a workspace with multiple focused crates:
 - **rustledger-plugin**: Native + WASM + Python plugin system (30+ plugins), depends on core
 - **rustledger-plugin-types**: Shared WASM plugin interface types (minimal, no internal deps)
 - **rustledger-importer**: Bank statement import framework (CSV, OFX)
+- **rustledger-ops**: Pure operations on directives (dedup, categorize, reconcile), depends on core
+- **rustledger-completion**: Editor-agnostic completion logic, shared by LSP and WASM
 - **rustledger**: CLI binary (`rledger`, `bean-*` commands)
 - **rustledger-wasm**: WebAssembly bindings for JS/TS
 - **rustledger-lsp**: Language Server Protocol for editor integration

--- a/docs/reference/adr/0003-parser-design.md
+++ b/docs/reference/adr/0003-parser-design.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (Updated February 2026)
+Accepted (Updated June 2026)
 
 ## Context
 
@@ -30,7 +30,7 @@ The lexer (`logos_lexer.rs`) uses Logos, a SIMD-accelerated lexer generator:
 
 - Declarative token definitions via derive macros
 - ~54x faster than hand-written character iteration
-- Produces `Vec<SpannedToken>` with byte offset spans
+- Produces `Vec<(Token, Span)>` with byte offset spans
 
 Tokens include:
 
@@ -40,7 +40,7 @@ Tokens include:
 
 ### Parser (Winnow)
 
-The parser (`winnow_parser.rs`) uses a manual token stream with winnow-style parsing:
+The parser (`cst/parser.rs`) uses a manual token stream with winnow-style parsing:
 
 - Composable parsers for each directive type
 - Manual token stream for simplicity and performance
@@ -50,7 +50,7 @@ The parser (`winnow_parser.rs`) uses a manual token stream with winnow-style par
 Architecture:
 
 ```text
-Source (&str) → Logos tokenize() → Vec<SpannedToken> → Winnow parser → Directives
+Source (&str) → Logos tokenize() → Vec<(Token, Span)> → CST parser → Directives
 ```
 
 ## Consequences
@@ -90,3 +90,4 @@ The parser is organized into sections:
 - **Original decision**: Hand-written recursive descent parser
 - **January 2026**: Migrated to Logos + Chumsky for better performance
 - **February 2026**: Migrated from Chumsky to Winnow for faster compile times and simpler code
+- **June 2026**: Replaced Winnow with a hand-written Rowan-based lossless CST parser (`cst/parser.rs`); Logos is retained for lexing

--- a/docs/reference/adr/0003-parser-design.md
+++ b/docs/reference/adr/0003-parser-design.md
@@ -4,6 +4,11 @@
 
 Accepted (Updated June 2026)
 
+> **Note (June 2026):** The Winnow-based parser described below was subsequently
+> replaced by a hand-written Rowan-based lossless CST parser (`cst/parser.rs`);
+> Logos is retained for lexing. The Winnow design is preserved here as the
+> historical record — see the Changelog at the end.
+
 ## Context
 
 The Beancount language has a relatively simple grammar but with some complexities:

--- a/docs/reference/adr/0004-ts-types-from-rust-dtos.md
+++ b/docs/reference/adr/0004-ts-types-from-rust-dtos.md
@@ -5,7 +5,7 @@
 Accepted — Phase 1, Phase 2, and Phase 3 (May 2026). Spike landed in
 #1220; Phase 1 (#1223) shipped the per-DTO ts-rs derives, the
 `scripts/regen-bindings.sh` post-process, the generated
-`bindings/index.d.ts`, and the CI freshness gate. Phase 2 (#1225)
+`bindings/index.d.ts`, and the CI freshness gate. Phase 2 (#1224)
 replaced the inline `typescript_custom_section` DTO block in
 `src/lib.rs` with `include_str!("../bindings/index.d.ts")` so the
 wasm-bindgen-generated `pkg/*.d.ts` and the importable

--- a/docs/reference/adr/index.md
+++ b/docs/reference/adr/index.md
@@ -13,7 +13,7 @@ ADRs document significant architectural decisions made during rustledger develop
 | [ADR-0001](0001-crate-organization.md) | Crate Organization | Accepted |
 | [ADR-0002](0002-error-handling.md) | Error Handling | Accepted |
 | [ADR-0003](0003-parser-design.md) | Parser Design | Accepted |
-| [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate TypeScript types from Rust DTOs | Accepted (Phase 1 + 2) |
+| [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate wire-format bindings from Rust DTOs | Accepted (Phase 1 + 2 + 3) |
 | [ADR-0005](0005-cst-conversion-performance.md) | CST Conversion Performance (parse cache; green-tree declined) | Accepted |
 
 ## About ADRs


### PR DESCRIPTION
## Doc accuracy audit — Wave 3: crate READMEs, dev docs, ADRs

20 files fixed. Crate READMEs audited against each crate's real public API (`lib.rs` exports), dev docs against the actual repo/CI, ADRs for factual drift only (rationale untouched; roadmap docs keep their planned items).

### Notable — README code examples were compile-breaking
| README | Was | Now |
|--------|-----|-----|
| booking | `use rustledger_booking::{BookingEngine, BookingMethod}` | `BookingMethod` is in `rustledger-core`, not re-exported here — split import |
| parser | "Chumsky parser", `SpannedToken` | Logos lexer → lossless Rowan CST → converter (no chumsky dep) |
| plugin | `run_plugin`, `NativePluginRegistry::new()/.get()` | real API: `global()` / `find_synth()` / `plugin.process(input)` |
| validate | `session.run_phase(...)`, `error.code()/message()` | typestate `run_early`/`run_late`; `code`/`message` are fields |

### Dev docs
- `benchmarking.md`: PR bench is **10K** txns (not 1K); removed references to nonexistent scripts (`bench-compare.py`, `generate-bench-charts.py`) and the dropped in-PR Criterion step.
- `testing.md`: corrected script names (`compat-test.sh` → `fetch-compat-test-files.sh` / `compat-bql-test.py`) and the corpus-fetch description.

### Verification
The README API corrections were independently checked against `lib.rs` exports (BookingMethod not re-exported, no chumsky, the plugin/validate APIs). ADR/roadmap edits limited to factual drift.

Wave 3 of N (rustdoc next). Disjoint from #1368/#1369.
