### PR TITLE
docs: fix rustdoc factual drift across crates (audit wave 4, final)

### DIFF
--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -374,7 +374,8 @@ pub fn is_balanced(transaction: &Transaction, tolerances: &HashMap<Currency, Dec
 
 /// Normalize total prices (`@@`) to per-unit prices (`@`) on a transaction.
 ///
-/// This converts `PriceAnnotation::Total` to `PriceAnnotation::Unit` by dividing
+/// This converts a `PriceAnnotation` with `PriceKind::Total` to one with
+/// `PriceKind::Unit` by dividing
 /// the total price by the number of units. This should be called AFTER validation
 /// (balance checking) to preserve exact total prices for precise residual calculation.
 ///

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1,7 +1,7 @@
 //! Booking method implementations for Inventory.
 //!
 //! This module contains the implementation of all booking methods (STRICT,
-//! STRICT_WITH_SIZE, FIFO, LIFO, HIFO, AVERAGE, NONE) used to reduce positions
+//! `STRICT_WITH_SIZE`, FIFO, LIFO, HIFO, AVERAGE, NONE) used to reduce positions
 //! from an inventory.
 
 use rust_decimal::Decimal;

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1,7 +1,8 @@
 //! Booking method implementations for Inventory.
 //!
-//! This module contains the implementation of all booking methods (STRICT, FIFO,
-//! LIFO, HIFO, AVERAGE, NONE) used to reduce positions from an inventory.
+//! This module contains the implementation of all booking methods (STRICT,
+//! STRICT_WITH_SIZE, FIFO, LIFO, HIFO, AVERAGE, NONE) used to reduce positions
+//! from an inventory.
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/mod.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/mod.rs
@@ -40,7 +40,7 @@
 //!
 //! ## Utility Operations
 //! - `util.version` - Get API and package version
-//! - `util.types` - Get TypeScript type definitions
+//! - `util.types` - Get directive types, booking methods, and account types
 //! - `util.isEncrypted` - Check if file is encrypted
 //! - `util.getAccountType` - Get account type from name
 

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -165,8 +165,8 @@ impl From<EnrichedImportResult> for ImportResult {
 
 impl From<ImportResult> for EnrichedImportResult {
     /// Promote an [`ImportResult`] into an [`EnrichedImportResult`] by
-    /// attaching a default (uncategorized, no-fingerprint) [`Enrichment`]
-    /// to each directive. This is the cheap-default impl used by
+    /// attaching a default (uncategorized) [`Enrichment`] — with a
+    /// computed fingerprint — to each directive. This is the cheap-default impl used by
     /// [`Importer::extract_enriched`] when an importer does not provide
     /// a custom enrichment path; format-specific importers should
     /// override `extract_enriched` to produce real metadata.

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -54,7 +54,7 @@ const READONLY_OPTIONS: &[&str] = &["filename"];
 /// Option validation warning.
 #[derive(Debug, Clone)]
 pub struct OptionWarning {
-    /// Warning code (E7001, E7002, E7003).
+    /// Warning code (E7001 through E7006).
     pub code: &'static str,
     /// Warning message.
     pub message: String,

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -299,9 +299,10 @@ impl MainLoopState {
     }
 
     /// Replace the exit action. Returns `self` for chaining. The
-    /// default action is [`std::process::exit`]; tests pass a no-op
-    /// (or a flag-set closure) to avoid terminating the test process
-    /// when the `exit` notification arrives.
+    /// default action is a no-op (process termination, if any, is the
+    /// caller's responsibility after `io_threads.join()`); tests pass a
+    /// no-op (or a flag-set closure) to avoid terminating the test
+    /// process when the `exit` notification arrives.
     #[must_use]
     pub fn with_exit_action<F>(mut self, action: F) -> Self
     where
@@ -1748,8 +1749,9 @@ pub fn run_main_loop(
 /// Same as [`run_main_loop`] but with a caller-supplied `exit_action`
 /// invoked when the `exit` notification arrives.
 ///
-/// Production calls [`run_main_loop`] which wires the action to
-/// [`std::process::exit`]. The in-process integration test harness
+/// Production calls [`run_main_loop`], which wires the action to a
+/// no-op (process termination, if any, is the caller's responsibility
+/// AFTER `io_threads.join()`). The in-process integration test harness
 /// calls this entry point with a no-op so receipt of `exit` does NOT
 /// terminate the cargo-test process. After the no-op returns, the
 /// main loop continues running until the connection is closed; the

--- a/crates/rustledger-ops/src/merchants.rs
+++ b/crates/rustledger-ops/src/merchants.rs
@@ -1,6 +1,6 @@
 //! Built-in merchant dictionary for transaction categorization.
 //!
-//! Contains ~150 common merchant patterns covering groceries, dining,
+//! Contains ~75 common merchant patterns covering groceries, dining,
 //! transport, shopping, subscriptions, utilities, health, and more.
 //! These are compiled into the binary and serve as a low-priority
 //! fallback when user rules don't match.

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -22,13 +22,14 @@
 //! powers numeric values in BALANCE and PRICE directives.
 //!
 //! Field-level extractors populate `ParseResult.options`,
-//! `.includes`, `.plugins`, `.comments`, `.currency_occurrences`.
+//! `.includes`, `.plugins`, `.comments`, `.currency_occurrences`,
+//! `.account_occurrences`.
 //!
 //! ## Error surfacing
 //!
 //! A single [`walk_descendants_once`] pass collects standalone
-//! comments, currency occurrences, and inline `ERROR_TOKEN` /
-//! mid-file-BOM errors. Specialized extractors run alongside for
+//! comments, currency occurrences, account occurrences, and inline
+//! `ERROR_TOKEN` / mid-file-BOM errors. Specialized extractors run alongside for
 //! `ERROR_NODE` classification, transaction body errors, unclosed
 //! cost braces, indented top-level directives, and bare-currency
 //! values in custom directives.

--- a/crates/rustledger-parser/src/error.rs
+++ b/crates/rustledger-parser/src/error.rs
@@ -198,7 +198,7 @@ impl std::error::Error for ParseError {}
 /// Kinds of parse errors.
 ///
 /// Marked `#[non_exhaustive]` because new variants land routinely
-/// (the most recent was `InvalidBookingMethod` — variant 25). Without
+/// (the most recent was `BomInDirectiveBody` — variant 26). Without
 /// the attribute, every new variant would be a `SemVer`-breaking change
 /// for external consumers that `match err.kind { ... }` exhaustively
 /// without a wildcard arm.

--- a/crates/rustledger-plugin-types/src/guest.rs
+++ b/crates/rustledger-plugin-types/src/guest.rs
@@ -245,12 +245,13 @@ pub fn default_enriched_from(out: ImporterOutput) -> EnrichedImporterOutput {
 ///
 /// # Invocation constraint
 ///
-/// **Invoke at most once per crate.** Each call generates Rust
-/// items named `__wasm_importer_alloc`/`metadata`/`identify`/
-/// `extract`/`extract_enriched`/`abi_version` and (on `wasm32`) wasm
-/// exports named `alloc`/`metadata`/etc. — two invocations in one crate
-/// collide on both. Each WASM importer should be its own
-/// `cdylib` crate.
+/// **Invoke at most once per crate.** Each call generates Rust items
+/// named `__wasm_importer_alloc`, `__wasm_importer_metadata`,
+/// `__wasm_importer_identify`, `__wasm_importer_extract`,
+/// `__wasm_importer_extract_enriched`, and `__wasm_importer_abi_version`
+/// (every name carries the `__wasm_importer_` prefix), plus — on `wasm32` —
+/// wasm exports named `alloc`/`metadata`/etc. Two invocations in one crate
+/// collide on both. Each WASM importer should be its own `cdylib` crate.
 ///
 /// # Native vs `wasm32` symbol names
 ///

--- a/crates/rustledger-plugin-types/src/guest.rs
+++ b/crates/rustledger-plugin-types/src/guest.rs
@@ -104,6 +104,7 @@
 //! | `identify`         | `fn (u32, u32) -> u64`             | Packed `(ptr, len)` of msgpack `IdentifyOutput` |
 //! | `extract`          | `fn (u32, u32) -> u64`             | Packed `(ptr, len)` of msgpack `ImporterOutput` |
 //! | `extract_enriched` | `fn (u32, u32) -> u64`             | Packed `(ptr, len)` of msgpack `EnrichedImporterOutput` |
+//! | `__rustledger_abi_version` | `fn () -> u32`             | ABI version the host checks at load time |
 //!
 //! `(ptr << 32) | len` packs the return so the host can unpack both
 //! halves from a single u64 (wasmtime's typed-func ergonomics don't
@@ -239,15 +240,15 @@ pub fn default_enriched_from(out: ImporterOutput) -> EnrichedImporterOutput {
     }
 }
 
-/// Emit the five `#[no_mangle] pub extern "C"` exports that a
+/// Emit the six `#[no_mangle] pub extern "C"` exports that a
 /// rustledger-host-loaded `.wasm` importer must provide.
 ///
 /// # Invocation constraint
 ///
 /// **Invoke at most once per crate.** Each call generates Rust
 /// items named `__wasm_importer_alloc`/`metadata`/`identify`/
-/// `extract`/`extract_enriched` and (on `wasm32`) wasm exports
-/// named `alloc`/`metadata`/etc. — two invocations in one crate
+/// `extract`/`extract_enriched`/`abi_version` and (on `wasm32`) wasm
+/// exports named `alloc`/`metadata`/etc. — two invocations in one crate
 /// collide on both. Each WASM importer should be its own
 /// `cdylib` crate.
 ///

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -974,7 +974,7 @@ pub struct ImporterInput {
 /// gets file content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdentifyInput {
-    /// Source file path. Same lossy-utf8 caveat as
+    /// Source file path. Informational only, same as
     /// [`ImporterInput::path`].
     pub path: String,
 }

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -14,7 +14,7 @@
 //! - **WASM Plugins**: Sandboxed plugins loaded from `.wasm` files
 //! - **Native Plugins**: Built-in plugins implemented in Rust
 //!
-//! # Built-in Plugins (30)
+//! # Built-in Plugins (31)
 //!
 //! See the [plugin reference](https://rustledger.github.io/docs/reference/plugins) for the full list.
 //!

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -375,7 +375,7 @@ impl LedgerState {
     }
 }
 
-/// Internal trait that lets [`validate_inner`] operate over both plain
+/// Internal trait that lets [`validate_phase_inner`] operate over both plain
 /// `Directive`s and `Spanned<Directive>`s without duplicating the loop
 /// body. The two inputs differ only in whether errors get a span/file
 /// stamp at the end of each iteration — encoded here as the return of

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -259,9 +259,6 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
     to_js(&result)
 }
 
-/// Run a native plugin on the source.
-///
-/// Available plugins can be listed with `listPlugins()`.
 /// Materialize a plugin's `ops` against its input wrapper list,
 /// producing the resulting flat wrapper list. Used by WASM entry
 /// points that need to round-trip a plugin's output back to


### PR DESCRIPTION
## Doc accuracy audit — Wave 4 (final): rustdoc

Each crate's rustdoc (module `//!` + public-item `///`) audited against its own source. **Doc-comment text only — zero code changes** (verified: every changed line is a `//!`/`///`), and **workspace doctests are unchanged: 23 passed / 0 failed** before and after.

14 small, targeted drift fixes:

| Crate | Fix |
|-------|-----|
| core | booking-method list missing `STRICT_WITH_SIZE` |
| parser | stale "most recent variant"; `convert.rs` omitted `account_occurrences` |
| plugin-types | broken cross-ref; "five exports" → six; ABI-version export added |
| plugin | built-in plugin count 30 → **31** |
| validate | `validate_inner` → `validate_phase_inner` (renamed) |
| loader | `OptionWarning::code` doc said E7001–E7003; code emits E7001–**E7006** |
| booking | `normalize_prices` referenced pre-#1167 `PriceAnnotation::Total/Unit` → `PriceKind` |
| importer | a `From` doc claimed "no fingerprint" while code computes one |
| ops | merchant-pattern count ~150 → ~75 |
| lsp | default `exit_action` documented as `process::exit`; it's a no-op |
| wasm | doc described `run_plugin` but annotated `materialize_plugin_ops` |
| ffi-wasi | `util.types` described as returning TS defs; returns metadata |

`query` and `completion` needed no changes — rustdoc already accurate. Representative claims spot-checked against source (StrictWithSize, 31 plugins, E7001–E7006, validate_phase_inner).

**Final wave** of the repo-wide doc audit. Disjoint from #1368/#1369/#1370.
