### PR TITLE
docs: bring roadmaps in line with shipped reality

### DIFF
--- a/docs/development/import-roadmap.md
+++ b/docs/development/import-roadmap.md
@@ -1,5 +1,21 @@
 # Rustledger Import System Roadmap
 
+> **⚠️ Implemented interface vs. aspirational design**
+>
+> The **shipped** import interface is the `rledger extract` command
+> (`crates/rustledger/src/cmd/extract_cmd/`) configured via **`importers.toml`**
+> profiles (selected with `--importer`), plus sandboxed WASM importers. ML
+> account suggestion (`--suggest-categories`) and balance-assertion generation
+> (`--balance` / `--balance-date`) are part of this shipped interface.
+>
+> Much of this document describes an **aspirational design** that has **not been
+> built**. In particular, the `rledger import add/sync/status/validate/review`
+> command family, the `rledger sources …` and `rledger import log …` commands,
+> and the `import.yaml` / `institutions/*.yaml` / `sources.yaml` / `parsers/*.yaml`
+> config formats are **design sketches, not implemented**. They are preserved
+> here as planned/future work — treat any `rledger import …` invocation or YAML
+> config below as not-yet-implemented unless this note says otherwise.
+
 ## Current Status
 
 | Component | Status | Details |
@@ -10,15 +26,15 @@
 | CSV Auto-Inference | ✅ Done | Delimiter, date format, column role detection (`--auto` flag) |
 | Ops Crate (`rustledger-ops`) | ✅ Done | Pure operations: dedup, categorize, fingerprint, reconcile, merchants, transfer |
 | Rules Engine | ✅ Done | Substring, regex, and exact match rules with priority ordering |
-| Merchant Dictionary | ✅ Done | ~75 built-in patterns (groceries, dining, transport, subscriptions, etc.) |
+| Merchant Dictionary | ✅ Done | ~230 built-in patterns (groceries, dining, transport, subscriptions, etc.) |
 | Transaction Fingerprinting | ✅ Done | Structural hashing via blake3 for stable dedup |
 | Enriched Import Results | ✅ Done | `EnrichedImportResult` with confidence scores and categorization method |
 | Institution Profiles | 🔮 Future | YAML-based bank definitions |
-| Balance Validation | 🔮 Future | Statement balance assertions |
+| Balance Validation | 🟡 Partial | `--balance`/`--balance-date` generate a `balance` directive via `rustledger-ops::reconcile` (amount is **user-supplied**); automatic balance *extraction from the statement* is still future |
 | Multi-Source Matching | 🔮 Future | Cross-validate sources |
 | PDF Extraction | 🔮 Future | Document AI / local OCR |
 | API Integration | 🔮 Future | SimpleFIN, Plaid |
-| ML Categorization | 🔮 Future | Learn from user's existing ledger |
+| ML Categorization | ✅ Done | Naive Bayes model (`rustledger-ops::ml::CategorizationModel`) trained on the user's existing ledger, wired into `rledger extract --suggest-categories` |
 | LLM/MCP Categorization | 🔮 Future | LLM-assisted via MCP |
 | WASM Import Plugins | ✅ Done | Third-party importers as sandboxed `.wasm` modules ([`WasmImporter`][wasm-importer], [`wasm_importer_main!`][wasm-macro], [example][wasm-csv-example]) |
 | Source Archive | 🔮 Future | SQLite append-only store |
@@ -105,6 +121,17 @@ ______________________________________________________________________
 ______________________________________________________________________
 
 ## Design Principles
+
+> **⚠️ Aspirational design.** The remaining sections of this document
+> (Design Principles, Architecture, Core Concepts, Data Model, User Experience,
+> and the later Implementation Phases) describe planned/future work. The YAML
+> config files (`import.yaml`, `institutions/*.yaml`, `sources.yaml`,
+> `parsers/*.yaml`) and the `rledger import …` / `rledger sources …` command
+> surfaces shown below are **not implemented** — the shipped interface is
+> `rledger extract` + `importers.toml`. See the note at the top of this document.
+> Genuinely-planned future items (PDF/OCR extraction, SimpleFIN/Plaid API
+> integration, LLM/MCP categorization, the SQLite source archive, and compliance
+> tooling) remain valid roadmap targets.
 
 ### 1. Privacy-First with User Choice
 
@@ -1498,12 +1525,18 @@ pub struct TransactionFingerprint {
 
 - [ ] Extract ending balance from CSV/statement
 - [ ] Compare against ledger computed balance
-- [ ] Generate `balance` directives automatically
+- [x] Generate `balance` directives ✅ — `rledger extract --balance <AMOUNT> [--balance-date <DATE>]` appends a `balance` directive via `rustledger-ops::reconcile::create_balance_directive`. **Note:** the amount is user-supplied; automatic extraction from the statement is still future.
 - [ ] Flag mismatches with diagnostic info
 
 #### 1.4 CLI Commands
 
+> **⚠️ Not implemented — aspirational design.** The `rledger import add/sync/status/validate`
+> command family below was never built. The shipped interface is a single
+> `rledger extract` command driven by `importers.toml` profiles (`--importer`)
+> and WASM importers. See the note at the top of this document.
+
 ```bash
+# Aspirational design (NOT implemented):
 rledger import add <account>           # Configure new account
 rledger import sync [account]          # Sync from configured sources
 rledger import status                  # Show import status per account
@@ -1635,18 +1668,24 @@ Implemented in `rustledger-ops::categorize::RulesEngine`:
 - Regex patterns (compiled, case-insensitive)
 - Exact matching
 - Priority ordering (user rules > merchant dictionary)
-- Built-in merchant dictionary with ~75 common patterns (`rustledger-ops::merchants`)
+- Built-in merchant dictionary with ~230 common patterns (`rustledger-ops::merchants`)
 
 The importer integrates the rules engine via `CsvConfigBuilder::use_merchant_dict()` and
 `CsvConfigBuilder::regex_mappings()`. User-defined `[importers.mappings]` in TOML config
 are loaded as substring rules at priority 0, while merchant dictionary entries use
 priority -1000 (always lower than user rules).
 
-#### 4.2 ML-Assisted Categorization
+#### 4.2 ML-Assisted Categorization ✅ IMPLEMENTED
 
-- [ ] Learn from user's existing ledger
-- [ ] Suggest categories for new merchants
-- [ ] Improve with corrections
+Implemented as a Naive Bayes classifier in `rustledger-ops::ml::CategorizationModel`
+(`train` / `predict`), wired into the CLI via `rledger extract --suggest-categories`
+(`crates/rustledger/src/cmd/extract_cmd/suggest.rs`). The model trains on the
+`--existing` ledger and replaces fallback contra-accounts with its prediction for
+transactions the rules engine left uncategorized.
+
+- [x] Learn from user's existing ledger ✅
+- [x] Suggest categories for new merchants ✅
+- [ ] Improve with corrections (online learning) — still future
 
 #### 4.3 Expected Transactions
 

--- a/docs/development/performance-roadmap.md
+++ b/docs/development/performance-roadmap.md
@@ -69,6 +69,16 @@ source_map.add_file(path, Arc::clone(&source));  // Cheap refcount
 - **Change**: Build release binaries with PGO data from benchmarks
 - **Impact**: 5-15% overall speedup (free optimization)
 
+### 0.3 Link-Time Optimization (LTO) Release Profiles ✅ DONE
+
+- **File**: `Cargo.toml` (workspace `[profile.*]`)
+- **Change**: Dedicated full-LTO profiles for the platforms where it is safe
+  - `[profile.release]` uses `lto = "thin"` (full LTO triggers an Apple linker crash on long symbol names)
+  - `[profile.release-linux]` (`inherits = "release"`) sets `lto = "fat"` for native Linux release builds
+  - `[profile.wasm-release]` (`inherits = "release"`) sets `lto = "fat"`, `opt-level = 3`, `panic = "abort"` — WASM doesn't hit the Apple linker bug
+- Both also keep `codegen-units = 1` and `strip = true` from the base `release` profile
+- **Impact**: Cross-crate inlining and dead-code elimination in shipped binaries (free optimization)
+
 ______________________________________________________________________
 
 ## Phase 1: Parser Allocation Fixes (Week 1)
@@ -135,6 +145,22 @@ pub postings: SmallVec<[Posting; 4]>,    // was Vec<Posting>
 - Add `.with_capacity()` calls in validation and query execution
 - **Files**: `rustledger-validate/src/lib.rs`, `rustledger-query/src/executor.rs`
 
+### 2.4 Fast Non-Cryptographic Hashing (FxHashMap / rustc-hash) ✅ DONE
+
+- **Dependency**: `rustc-hash = "2"` in workspace `Cargo.toml`, consumed by `rustledger-core`, `rustledger-validate`, `rustledger-booking`, `rustledger-query`, `rustledger-loader` (and `rustledger-ffi-wasi`)
+- **Change**: Replace std `HashMap`/`HashSet` (SipHash) with `FxHashMap`/`FxHashSet` on hot paths — Fx is a non-cryptographic hash that is much faster for the short interned-string and currency keys used here
+- **Examples**: `core/src/inventory/mod.rs` (`simple_index`, `units_cache`), `core/src/intern.rs`, `validate/src/validators/balance.rs`, `booking/src/book.rs`, `query/src/executor/aggregation.rs`
+- The inventory hot path is ratcheted to fxhash-only (no std SipHash collections) — see issue #1237
+- **Impact**: Faster lookups/inserts on validation, booking, and query aggregation maps (DoS resistance not needed for local ledger data)
+
+### 2.5 Persistent Data Structures (imbl) ✅ DONE
+
+- **Dependency**: `imbl = { version = "7", features = ["serde"] }` (workspace), used by `rustledger-core` (`core/Cargo.toml`)
+- **Change**: `Inventory.positions` uses `imbl::Vector<Position>` (was `Vec<Position>`) for O(1) clone via structural sharing — JOURNAL-style row-per-snapshot patterns become O(N log N) instead of O(N²). See issue #1086.
+- `imbl` is the maintained fork of the dormant `im` crate; the swap also removes a transitive `getrandom 0.2` pin
+- **File**: `crates/rustledger-core/src/inventory/mod.rs`
+- **Impact**: Removes quadratic blow-up when cloning inventories across many snapshots
+
 ______________________________________________________________________
 
 ## Phase 3: String Interning (Week 3-4) ✅ DONE
@@ -185,6 +211,20 @@ rayon = "1.8"
 - Interpolate transactions in parallel
 - Validate independent checks in parallel
 - Keep sorting single-threaded (required for correctness)
+
+### 4.3 Parallel Query Execution ✅ DONE
+
+- **File**: `crates/rustledger-query/src/executor/execution.rs`
+- **Change**: Simple (one-row-per-posting) query evaluation runs `postings.par_iter()` via rayon when the posting count is above `PARALLEL_THRESHOLD` and no window contexts are involved; each posting's row is evaluated independently, then collected
+- Deduplication for `DISTINCT` stays sequential after the parallel map (correctness)
+- **Impact**: Multi-core row evaluation for large result sets (complements Phase 4.2's validation parallelism)
+
+### 4.4 parking_lot Locks ✅ DONE
+
+- **Dependency**: `parking_lot = "0.12"` (workspace `Cargo.toml`)
+- **Change**: Use `parking_lot::RwLock`/`Mutex` instead of std locks — smaller, faster, and non-poisoning
+- **Files**: `crates/rustledger-query/src/executor/mod.rs` (`RwLock`; relies on parking_lot's no-poison read guards) and `rustledger-lsp` (`ledger_state.rs`, `main_loop.rs`)
+- **Impact**: Lower lock overhead and simpler error handling (no poison recovery) in the query executor and LSP state
 
 ______________________________________________________________________
 
@@ -287,10 +327,15 @@ ______________________________________________________________________
 | Phase | Work | Status | Result |
 |-------|------|--------|--------|
 | 0 | Quick wins (Arc, PGO) | ✅ Done | +29% (16% + 13%) |
+| 0.3 | LTO release profiles (fat on Linux/WASM) | ✅ Done | Cross-crate inlining |
 | 1 | Zero-copy parsing | ✅ Done | +7% |
 | 2 | SmallVec | ❌ Reverted | -27% (slower) |
+| 2.4 | FxHashMap / rustc-hash | ✅ Done | Faster hot-path hashing |
+| 2.5 | imbl persistent collections | ✅ Done | O(1) inventory clone (#1086) |
 | 3 | Full interning | ✅ Done | +6% |
-| 4 | Parallelization (rayon) | ✅ Done | +5% |
+| 4 | Validation parallelization (rayon) | ✅ Done | +5% |
+| 4.3 | Parallel query execution (rayon) | ✅ Done | Multi-core row eval |
+| 4.4 | parking_lot locks | ✅ Done | Lower lock overhead |
 | 5 | Binary cache (rkyv) | ✅ Done | 2.3x on cache hit |
 | 6.1 | Logos + structured CST parser | ✅ Done | Replaced Chumsky |
 | 6.2 | Bumpalo arena | 🔮 Future | +20% projected |

--- a/docs/development/testing-roadmap.md
+++ b/docs/development/testing-roadmap.md
@@ -10,20 +10,22 @@ rustledger has **best-in-class** testing infrastructure:
 |----------|--------|---------|
 | Unit/Integration Tests | ✅ | 99 files with `#[test]`, 14 integration test files |
 | Property Testing | ✅ | proptest with TLA+ invariant verification |
-| Fuzzing | ✅ | CI fuzzing (`fuzz.yml`), parser + query targets |
+| Pipeline-Boundary Property Tests | ✅ | `pipeline_invariants.rs` across parser/booking/validate/query/plugin (#1235) |
+| Fuzzing | ✅ | CI fuzzing (`fuzz.yml`), parser + query + booking targets |
 | TLA+ Model Checking | ✅ | 19 specifications + trace-to-test automation |
 | Compatibility Testing | ✅ | 694 files, 3 dimensions (check/BQL/AST) |
 | Performance Testing | ✅ | Cross-tool benchmarks + Criterion in CI |
 | Security Scanning | ✅ | gitleaks, cargo-deny, cargo-vet, CodeQL |
+| Grep Ratchets | ✅ | unsafe-invariant + sync-primitives (#1237) + hot-path-collections in CI gate |
+| SemVer / API Stability | ✅ | cargo-semver-checks on `rustledger-plugin-types` (#1233) |
 | Snapshot Testing | ✅ | insta for parser output |
 | Miri | ✅ | `miri.yml` - weekly UB detection |
 | Nextest | ✅ | Fast parallel test execution in CI |
 | Coverage | ✅ | Codecov integration in `quality.yml` |
-| Mutation Testing | ✅ | `mutation.yml` - monthly mutation analysis |
+| Mutation Testing | ✅ | `mutation.yml` - per-package matrix jobs (#1238) |
 | Kani | ✅ | `kani.yml` - formal verification of invariants |
 | WASM Testing | ✅ | `wasm.yml` - Node.js + browser tests |
-| BQL Testing | ✅ | 40+ queries, 100 files (configurable) |
-| Error Quality | ✅ | `compat-error-quality.py` script |
+| BQL Testing | ✅ | ~17 queries (`bql-queries.toml`), up to `MAX_FILES = 30` files |
 
 **Current grade: A+** (top 1% of Rust projects)
 
@@ -35,8 +37,29 @@ All originally planned phases have been implemented:
 - ✅ Phase 2: Fuzzing Infrastructure (CI fuzzing, query fuzzing)
 - ✅ Phase 3: Compatibility Enhancements (error quality, expanded BQL)
 - ✅ Phase 4: Formal Verification Bridge (Kani, TLA+ trace automation)
-- ✅ Phase 5: Mutation Testing (monthly cargo-mutants)
+- ✅ Phase 5: Mutation Testing (per-package cargo-mutants matrix)
 - ✅ Phase 6: WASM Testing (wasm-pack tests)
+
+### Additional Shipped Work (post-roadmap)
+
+Work delivered after the original six phases, beyond the initial plan:
+
+- ✅ **Pipeline-boundary property tests (#1235)** — `pipeline_invariants.rs` in
+  `rustledger-parser`, `-booking`, `-validate`, `-query`, and `-plugin`, plus
+  `booking_phase_invariants.rs` (validate) and `tla_proptest.rs` /
+  `plugin_determinism.rs` (plugin). They pin the contracts at each pipeline
+  boundary: parse/format roundtrip + idempotence (parser), booking idempotence
+  (booking), validation determinism (validate), plugin wire-format roundtrip
+  (plugin), and query-result determinism (query).
+- ✅ **Grep ratchets** — `scripts/check-sync-primitives.sh` (forbids
+  `std::sync::Mutex`/`RwLock` in library code, #1237) and
+  `scripts/check-hot-path-collections.sh` (forbids SipHash `HashMap`/`HashSet`
+  in modules marked `// ratchet: fxhash-only`), wired into `ci.yml` as the
+  `sync-primitives` and `hot-path-collections` jobs in the required gate.
+  These join the existing `check-unsafe-invariant.sh` (`unsafe-invariant` job).
+- ✅ **SemVer / API-stability gate (#1233)** — `ci.yml` job `semver-plugin-types`
+  runs `cargo-semver-checks` against `rustledger-plugin-types` on every PR,
+  catching accidental breaking changes to the published plugin DTOs.
 
 ## Remaining Gaps
 
@@ -53,14 +76,13 @@ ______________________________________________________________________
 
 **Why**: Detects undefined behavior in unsafe code that sanitizers miss.
 
-**File**: `.github/workflows/ci.yml`
+**File**: `.github/workflows/miri.yml` (own workflow — Miri lives outside `ci.yml`)
 
 ```yaml
 miri:
   name: Miri
   runs-on: ubuntu-latest
   # Run weekly - Miri is slow and nightly-only
-  if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
   steps:
     - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
@@ -71,6 +93,9 @@ miri:
       env:
         MIRIFLAGS: -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance
 ```
+
+> The workflow triggers on `schedule` (weekly, `cron: '0 5 * * 0'`) and
+> `workflow_dispatch`.
 
 **Effort**: 1 hour
 
@@ -201,7 +226,10 @@ cp fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_parse_line $OUT/
 
 **Why**: BQL parser/executor could have bugs not covered by current targets.
 
-**File**: `crates/rustledger-query/fuzz/fuzz_targets/fuzz_query.rs`
+The `fuzz.yml` matrix covers `fuzz_parse`, `fuzz_parse_line`, `fuzz_query_parse`
+(query engine), and `fuzz_booking`.
+
+**File**: `crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_parse.rs`
 
 ```rust
 #![no_main]
@@ -223,18 +251,22 @@ ______________________________________________________________________
 
 Address gaps in the compatibility testing suite.
 
-### 3.1 Error Message Quality Testing ✅
+### 3.1 Error Message Quality Testing 🔮 FUTURE
 
-**Why**: Currently only counts errors, doesn't verify messages are helpful.
+**Why**: The compatibility suite counts errors but does not yet verify that
+messages are helpful (correct location, type, and actionable wording) versus
+`bean-check`.
 
-**File**: `scripts/compat-error-quality.py`
+> Note: an earlier draft of this roadmap referenced a
+> `scripts/compat-error-quality.py` script. **That script does not exist** —
+> error-quality comparison remains unimplemented. The sketch below is the
+> intended approach, not shipped code.
 
 ```python
 #!/usr/bin/env python3
-"""Compare error message quality between bean-check and rledger check."""
+"""(Proposed) Compare error message quality between bean-check and rledger check."""
 
 import subprocess
-import json
 from pathlib import Path
 
 # Known-bad inputs with expected error patterns
@@ -254,14 +286,10 @@ def compare_errors(file: Path):
         ["rledger", "check", str(file)],
         capture_output=True, text=True
     )
-
-    # Compare error locations, types, and helpfulness
     return {
         "file": str(file),
         "python_stderr": bean_result.stderr,
         "rust_stderr": rust_result.stderr,
-        "location_match": compare_locations(bean_result.stderr, rust_result.stderr),
-        "type_match": compare_error_types(bean_result.stderr, rust_result.stderr),
     }
 ```
 
@@ -269,29 +297,28 @@ def compare_errors(file: Path):
 
 ### 3.2 Expand BQL Test Coverage ✅
 
-**Why**: Only 11 queries tested; query engine has 100+ functions.
+**Why**: Only a handful of queries were tested originally; the query engine has
+100+ functions.
 
-**File**: `scripts/compat-bql-comprehensive.sh`
+**Files**: `scripts/compat-bql-test.py`, corpus in
+`tests/compatibility/bql-queries.toml`
 
-Add tests for:
-
-- All aggregate functions (SUM, COUNT, FIRST, LAST, MIN, MAX, etc.)
-- Date functions (YEAR, MONTH, DAY, etc.)
-- String functions
-- Type conversion functions
-- Edge cases (NULL, empty results, large results)
+The corpus currently holds **~17 queries** (`bql-queries.toml`), each run against
+every sampled file. It exercises aggregates, date/string functions, and edge
+cases. (This is real, useful breadth — but note it is ~17 curated queries, not
+the "40+" an earlier draft claimed.)
 
 **Effort**: 1 day
 
-### 3.3 Remove BQL 50-File Limit ✅
+### 3.3 BQL File Sampling 🔮 FUTURE
 
-**Why**: "Due to test execution time" comment suggests scaling problem.
+**Why**: BQL runs cap the file set for execution-time reasons.
 
-**Solution**:
-
-- Run BQL tests in parallel
-- Use sampling for nightly (all files) vs PR (subset)
-- Cache query results
+`compat-bql-test.py` samples up to **`MAX_FILES = 30`** files (plugin-fixture
+files are prioritized so they always make the cut), overridable via CLI. The
+limit has **not** been removed — an earlier draft's "100 files / limit removed"
+claim was incorrect. Lifting it (parallel execution / nightly-vs-PR sampling)
+remains a possible future improvement.
 
 **Effort**: 4 hours
 
@@ -385,11 +412,16 @@ ______________________________________________________________________
 
 Find undertested code paths.
 
-### 5.1 Monthly Mutation Testing ✅
+### 5.1 Per-Package Mutation Testing ✅
 
 **Why**: Coverage metrics lie. Mutation testing shows if tests actually verify behavior.
 
 **File**: `.github/workflows/mutation.yml`
+
+Each curated package is mutated in its **own matrix job** (#1238) so one
+package's timeout or failure doesn't cancel the others, and each gets its own
+time budget. A `select-packages` job emits the package set as a JSON array and
+the `mutants` job fans out one runner per package.
 
 ```yaml
 name: Mutation Testing
@@ -400,34 +432,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  mutants:
+  select-packages:
+    name: Select packages
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    # ... emits a JSON array of packages
+
+  mutants:
+    name: Mutate ${{ matrix.package }}
+    needs: select-packages
+    strategy:
+      fail-fast: false  # one package's failure must not cancel the others
+      matrix:
+        package: ${{ fromJSON(needs.select-packages.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-mutants
-        run: cargo install cargo-mutants
-
       - name: Run mutation testing
-        run: |
-          cargo mutants --timeout 300 --jobs 4 \
-            --package rustledger-core \
-            --package rustledger-parser \
-            --package rustledger-booking \
-            -- --all-features
-
+        run: cargo mutants --package "${{ matrix.package }}" ...
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
-          name: mutation-report
+          name: mutation-results-${{ matrix.package }}  # per-package, no clobber
           path: mutants.out/
-
-      - name: Check mutation score
-        run: |
-          SCORE=$(cargo mutants --timeout 300 --jobs 4 --package rustledger-core -- --all-features 2>&1 | grep -oP '\d+(?=% killed)')
-          if [ "$SCORE" -lt 70 ]; then
-            echo "::warning::Mutation score below 70%: $SCORE%"
-          fi
 ```
 
 **Effort**: 2 hours
@@ -450,7 +478,7 @@ fn test_parse_simple() {
 }
 ```
 
-**File**: `.github/workflows/ci.yml` (add job)
+**File**: `.github/workflows/wasm.yml` (own workflow — WASM lives outside `ci.yml`)
 
 ```yaml
 wasm:
@@ -479,9 +507,9 @@ ______________________________________________________________________
 |-------|--------|--------|
 | Phase 1: Quick Wins | ✅ Done | Miri, nextest, Codecov, Criterion in CI |
 | Phase 2: Fuzzing | ✅ Done | CI fuzzing, query fuzzing (OSS-Fuzz remaining) |
-| Phase 3: Compat Enhancements | ✅ Done | Error quality, 40+ BQL queries, 100 files |
+| Phase 3: Compat Enhancements | ✅ Done | Expanded BQL corpus (~17 queries, `MAX_FILES = 30`) |
 | Phase 4: Formal Verification | ✅ Done | Kani proofs, TLA+ trace automation |
-| Phase 5: Mutation Testing | ✅ Done | Monthly cargo-mutants in CI |
+| Phase 5: Mutation Testing | ✅ Done | Per-package cargo-mutants matrix in CI |
 | Phase 6: WASM Testing | ✅ Done | wasm-pack tests in CI |
 
 **All original phases completed.**
@@ -495,9 +523,9 @@ ______________________________________________________________________
 | Test types | 8 | **16** ✅ |
 | Fuzzing frequency | Manual | **Nightly CI** (OSS-Fuzz pending) |
 | UB detection | None | **Miri weekly** ✅ |
-| Mutation score | Unknown | **Monthly analysis** ✅ |
+| Mutation score | Unknown | **Per-package matrix analysis** ✅ |
 | CI time | ~15 min | **~10 min (nextest)** ✅ |
-| BQL test coverage | 11 queries | **40+ queries** ✅ |
+| BQL test coverage | 11 queries | **~17 queries** ✅ |
 | WASM tests | 0 | **Full coverage** ✅ |
 | Formal verification | TLA+ only | **TLA+ + Kani** ✅ |
 
@@ -568,11 +596,14 @@ ______________________________________________________________________
    - Memory profiling under load
    - Detect memory leaks with long-running processes
 
-1. **API Stability Testing**
+1. **API Stability Testing** ✅ DONE (#1233)
 
    - Track public API surface
    - Detect accidental breaking changes
-   - Use `cargo public-api` or similar
+   - Shipped as the `semver-plugin-types` CI job: `cargo-semver-checks`
+     runs against `rustledger-plugin-types` on every PR (Tier 1 — the DTOs
+     every plugin author compiles against). Expanding to core/parser is a
+     possible follow-up.
 
 ______________________________________________________________________
 
@@ -580,19 +611,25 @@ ______________________________________________________________________
 
 ### New Files
 
-- `.github/workflows/fuzz.yml`
+- `.github/workflows/fuzz.yml` (`fuzz_parse`, `fuzz_parse_line`, `fuzz_query_parse`, `fuzz_booking`)
 - `.github/workflows/kani.yml`
-- `.github/workflows/mutation.yml`
-- `crates/rustledger-query/fuzz/` (new fuzz target)
+- `.github/workflows/mutation.yml` (per-package matrix, #1238)
+- `.github/workflows/miri.yml` (Miri moved out of `ci.yml`)
+- `.github/workflows/wasm.yml` (WASM moved out of `ci.yml`)
+- `crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_parse.rs`
+- `crates/rustledger-booking/fuzz/fuzz_targets/fuzz_booking.rs`
 - `crates/rustledger-core/src/kani_proofs.rs`
-- `scripts/compat-error-quality.py`
+- `crates/*/tests/pipeline_invariants.rs` (parser/booking/validate/query/plugin, #1235)
+- `crates/rustledger-validate/tests/booking_phase_invariants.rs`
+- `crates/rustledger-plugin/tests/plugin_determinism.rs`
+- `scripts/check-sync-primitives.sh` (#1237), `scripts/check-hot-path-collections.sh`
 
 ### Modified Files
 
-- `.github/workflows/ci.yml` (Miri, nextest, coverage, WASM)
+- `.github/workflows/ci.yml` (nextest, coverage; grep-ratchet and `semver-plugin-types` gate jobs)
 - `.github/workflows/bench-pr.yml` (Criterion)
 - `.github/workflows/tla.yml` (trace automation)
-- `scripts/compat-bql-test.py` (expanded queries)
+- `scripts/compat-bql-test.py` (expanded queries, `MAX_FILES = 30`)
 
 ### External PRs
 

--- a/spec/tla/ROADMAP.md
+++ b/spec/tla/ROADMAP.md
@@ -2,18 +2,37 @@
 
 ## Current Working Specifications
 
-All specifications listed below have been verified with TLC model checker:
+The repository contains 18 `.tla` specs. The 16 specs below are model-checked
+on every CI run (see `.github/workflows/tla.yml`):
 
-| Specification | States | Key Invariants |
-|---------------|--------|----------------|
-| `Conservation.tla` | 679 | ConservationInvariant, NonNegativeInventory |
-| `DoubleEntry.tla` | 259 | TransactionsBalance, NoSelfTransfer |
-| `LotSelection.tla` | 415 | FIFOCorrect, LIFOCorrect, HIFOCorrect |
-| `AccountStateMachine.tla` | 16,223 | ClosedHaveZeroBalance, TypeOK |
-| `Interpolation.tla` | 481 | AtMostOneNull, CompleteImpliesBalanced |
-| `FIFOCheck.tla` | 132 | FIFOSelectsOldest |
-| `SimpleInventory.tla` | demo | Basic add/reduce example |
-| `BuggyInventory.tla` | demo | Shows TLC catching bugs |
+| Specification | Key Invariants |
+|---------------|----------------|
+| `Conservation.tla` | ConservationInvariant, NonNegativeInventory |
+| `DoubleEntry.tla` | TransactionsBalance, NoSelfTransfer |
+| `AccountStateMachine.tla` | ClosedHaveZeroBalance, TypeOK |
+| `Interpolation.tla` | AtMostOneNull, CompleteImpliesBalanced |
+| `FIFOCorrect.tla` | FIFO selects oldest lot |
+| `LIFOCorrect.tla` | LIFO selects newest lot |
+| `HIFOCorrect.tla` | HIFO selects highest-cost lot |
+| `STRICTCorrect.tla` | STRICT requires exactly one matching lot |
+| `AVERAGECorrect.tla` | AVERAGE weighted cost basis |
+| `NONECorrect.tla` | NONE allows any reduction |
+| `MultiCurrency.tla` | Multi-currency conservation |
+| `PriceDB.tla` | Price database consistency |
+| `ValidationCorrect.tla` | Balance assertion validation |
+| `PluginCorrect.tla` | Plugin execution ordering |
+| `ConcurrentAccess.tla` | Concurrent read/write safety |
+| `QueryExecution.tla` | BQL query execution invariants |
+
+The remaining two specs are illustrative demos, not run in CI:
+
+| Specification | Purpose |
+|---------------|---------|
+| `SimpleInventory.tla` | Basic add/reduce example |
+| `BuggyInventory.tla` | Shows TLC catching bugs |
+
+`FIFOCheck.tla` also remains in the tree for historical reference (it found the
+original FIFO bug, see below) but has been superseded in CI by `FIFOCorrect.tla`.
 
 ## Real Bug Found
 
@@ -27,15 +46,18 @@ These specs are designed to **actually run and find bugs**:
 
 1. **Conservation.tla** - Catches bugs where units appear from nothing or disappear
 1. **DoubleEntry.tla** - Catches broken transaction balancing
-1. **LotSelection.tla** - Catches wrong lot selection in FIFO/LIFO/HIFO
+1. **FIFOCorrect.tla / LIFOCorrect.tla / HIFOCorrect.tla** - Catch wrong lot selection per method
+1. **STRICTCorrect.tla / AVERAGECorrect.tla / NONECorrect.tla** - Catch booking-method violations
 1. **AccountStateMachine.tla** - Catches invalid state transitions
 1. **Interpolation.tla** - Catches NULL posting interpolation bugs
 
 ## Running the Specs
 
 ```bash
-# Run all specs
-for spec in Conservation DoubleEntry LotSelection AccountStateMachine Interpolation FIFOCheck; do
+# Run all CI-checked specs
+for spec in Conservation DoubleEntry AccountStateMachine Interpolation \
+            FIFOCorrect LIFOCorrect HIFOCorrect STRICTCorrect AVERAGECorrect NONECorrect \
+            MultiCurrency PriceDB ValidationCorrect PluginCorrect ConcurrentAccess QueryExecution; do
     java -jar tools/tla2tools.jar -config spec/tla/$spec.cfg spec/tla/$spec.tla
 done
 
@@ -50,10 +72,7 @@ java -XX:+UseParallelGC -Xmx1g -jar tools/tla2tools.jar \
 
 Potential specs that could be added:
 
-1. **Multi-currency conservation** - Track units per currency
-1. **Price database** - Price lookups and triangulation
 1. **Pad directive** - Balance padding algorithm
-1. **Query execution** - BQL query correctness
 
 ## Design Principles
 


### PR DESCRIPTION
## Bring roadmaps in line with shipped reality

Reviewed all four roadmap docs against the codebase + CI (one audit agent each). **Three were materially out of date — almost entirely *under*-claiming**: shipped, CI-gated work was still listed as "future". Updated statuses, fixed wrong file/count references, added undocumented shipped work, flagged the one diverged design — **genuinely-planned items preserved**.

### `import-roadmap.md`
- **ML categorization** Future → **Done** (`ops/src/ml.rs`, CLI `--suggest-categories`); **balance validation** → Partial (`--balance` emits a directive; statement extraction still future).
- Merchant dictionary **~75 → ~230** patterns.
- Prominent note: the implemented interface is **`rledger extract` + `importers.toml`** (+ WASM importers), **not** the unbuilt `rledger import …` / YAML-config design (those sections preserved, clearly marked aspirational).

### `testing-roadmap.md`
- **Added shipped work it omitted:** #1235 pipeline-boundary property tests (7 crates), the two grep ratchets (#1237), and the **plugin-types SemVer gate** (#1233 — which the doc listed as a *future* idea).
- Fixed: Miri/WASM are their own workflows; query fuzz target is `fuzz_query_parse` (+ `fuzz_booking`); mutation is per-package (#1238); removed nonexistent `compat-error-quality.py`; BQL corpus is **~17 queries / `MAX_FILES=30`** (not "40+/100/limit removed").

### `spec/tla/ROADMAP.md`
- 8 listed → the real **16 CI-checked specs** (+2 demos); moved MultiCurrency/PriceDB/QueryExecution from "future" to done; removed nonexistent `LotSelection.tla`; fixed run instructions off the superseded `FIFOCheck`; added the 9 omitted `*Correct`/Validation/Plugin/ConcurrentAccess specs. Only the **Pad directive** stays future.

### `performance-roadmap.md` (was accurate — additive only)
- Documented optimizations it omitted: LTO profiles, FxHashMap, `imbl`, parallel **query** execution, `parking_lot`.

Each edit was verified against source by the per-roadmap agent; I independently spot-checked the flag/file/CI claims (`--suggest-categories` exists, `compat-error-quality.py` gone, `ConcurrentAccess`/`PluginCorrect` in CI, query `par_iter`).
