### PR TITLE
fix(ci): use Stacked Borrows for miri (rowan trips experimental Tree Borrows)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -6,8 +6,12 @@
 # are miri-compatible; WASM/FFI crates and fs/wasmtime-heavy crates are
 # excluded because miri can't run their targets.
 #
-# Memory model: Tree Borrows (#1239 Q2) — the direction the language is moving
-# and fewer false positives than the default Stacked Borrows.
+# Memory model: Stacked Borrows (miri's default). #1239 Q2 originally chose
+# Tree Borrows, but the *experimental* Tree-Borrows ruleset false-positives on
+# the `rowan` dependency's `ThinArc::clone` (a "write through Frozen" report
+# that miri itself flags as experimental), which the parser reaches via CST
+# conversion. `rowan` is clean under Stacked Borrows (as it is for
+# rust-analyzer), so we use the default model.
 name: Miri
 on:
   schedule:
@@ -62,14 +66,14 @@ jobs:
           # is enabled"). Disabling isolation lets those tests run; it only
           # permits host clock/entropy access and does not weaken miri's
           # UB/aliasing checks, which is what this job is for.
-          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance -Zmiri-disable-isolation
+          MIRIFLAGS: -Zmiri-symbolic-alignment-check -Zmiri-strict-provenance -Zmiri-disable-isolation
       - name: Summary
         run: |
           echo "## Miri Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Miri checks for undefined behavior in unsafe Rust code." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Memory model: Tree Borrows (-Zmiri-tree-borrows)." >> $GITHUB_STEP_SUMMARY
+          echo "Memory model: Stacked Borrows (miri default)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Checked crates:" >> $GITHUB_STEP_SUMMARY
           echo "- rustledger-core" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Use Stacked Borrows for the miri job

The first real weekly miri run (the #1366 `+nightly` / `-Zmiri-disable-isolation` fixes let it *actually execute* for the first time — the job had been silently broken) **failed**:

```
error: Undefined Behavior: write access through <...> is forbidden
  --> rowan-0.16.1/src/arc.rs:106   (ThinArc::clone)
  = help: ... the Tree Borrows rules it violated are still experimental
```

Reached via the parser's CST conversion (`crates/rustledger-parser/src/cst/convert.rs`). This is a **Tree-Borrows false positive** on `rowan`'s `ThinArc` refcount pattern — miri itself flags the rule as experimental, it's in a dependency (not first-party), and `rowan` is clean under the default **Stacked Borrows** (the model rust-analyzer tests it under).

**Fix:** drop `-Zmiri-tree-borrows`, use the default Stacked Borrows. Keeps `-Zmiri-disable-isolation`, `-Zmiri-symbolic-alignment-check`, `-Zmiri-strict-provenance`. This reverses #1239's Q2 Tree-Borrows preference, which can't stand while it false-positives on a core dep.

## Validation
miri can't run locally (no nightly in the dev flake), but the diagnosis is solid — `rowan` is SB-clean upstream. The next weekly run (or a `workflow_dispatch`) confirms. Doc note: no docs referenced "Tree Borrows", so nothing else to update.
