### PR TITLE
docs(roadmap): deepen rationale, cut grandiosity and false precision

### DIFF
--- a/docs/roadmap/formal-verification.md
+++ b/docs/roadmap/formal-verification.md
@@ -7,6 +7,13 @@ model-checked in CI, Kani proofs over the Rust core, and the tooling that ties
 counterexamples back to executable tests. Items here are not-yet-done; shipped
 work lives in the changelog.
 
+This is part of the [substrate](./index.md#the-substrate-keep-raising-the-floor):
+the value isn't proofs for their own sake, it's that the engine's core invariants
+— balance, conservation, non-negative inventory — stay machine-checked as the code
+evolves, and that every counterexample TLC finds becomes a pinned Rust regression
+test. The bar for adding a spec is therefore practical: it has to catch a class of
+bug that property tests and types don't already rule out.
+
 ## Now / In progress
 
 | Item | Notes |

--- a/docs/roadmap/importing.md
+++ b/docs/roadmap/importing.md
@@ -1,53 +1,57 @@
 # Importing & Ingestion
 
-Forward-looking roadmap for getting transactions into rustledger: parsing, multi-source validation, extraction, API sync, and the source archive.
+> Part of the [rustledger roadmap](./index.md). This is the engine room of
+> [bet #2 — make ingestion painless](./index.md#2-make-ingestion-painless--the-real-adoption-barrier).
 
-> Part of the [rustledger roadmap](./index.md).
+For plain-text accounting the ledger format is the easy part; the friction is
+getting bank data *in* and trusting that it's complete and correct. The shipped
+baseline already covers the mechanics — `rledger extract` with `importers.toml`
+profiles, sandboxed WASM importers, rule-based + Naive-Bayes categorization, and
+balance-assertion generation. What's left is making it **work out of the box**
+for common cases and **earn trust** that nothing was missed.
 
-The shipped baseline is `rledger extract` driven by `importers.toml` profiles, sandboxed WASM importers, rule-based + Naive Bayes categorization, and user-supplied balance-assertion generation. Everything below is **not yet built**.
+Guiding principles: **local-first** (no data leaves the machine unless the user
+opts in), **declarative** (banks described by data, not code), and
+**trust-building** (surface uncertainty rather than silently importing).
 
 ## Now / In progress
 
-Work that is partially done or is the clear next thing to pick up.
+The clear next steps, building directly on the shipped pipeline.
 
-| Item | Notes |
-|------|-------|
-| Automatic balance extraction | `--balance` exists but the amount is user-supplied; extract opening/closing balance from the statement and compare against the computed ledger balance, flagging mismatches with diagnostics. |
-| Institution profile loader | Load declarative bank profiles (CSV/PDF/API source definitions + categorization rules) so common banks work without per-user column mapping. |
-| Top-20 US bank profiles | Ship built-in profiles for the most common institutions on top of the loader. |
-| Online-learning categorization | The Naive Bayes model trains on the existing ledger; feed user corrections back in to improve over time. |
+| Item | Why it matters | Approach |
+|------|----------------|----------|
+| **Declarative institution profiles** | Per-user CSV column-mapping is the #1 setup friction. | A profile loader: a bank described by its source format (CSV/OFX layout), date/amount conventions, and default categorization rules — so a known bank "just works". Ships with built-in profiles for the most common US institutions on top of the loader. |
+| **Automatic balance extraction** | `--balance` exists but the amount is hand-typed, so the assertion only catches *your* typos, not import gaps. | Pull the statement's opening/closing balance during extraction and compare it against the computed ledger balance; emit a diagnostic on mismatch. This is what turns importing from "hope it's complete" into "proven complete". |
+| **Online-learning categorization** | The model trains once on the existing ledger and never improves from use. | Feed accept/correct decisions back into the Naive-Bayes model so suggestions get better the more you import. |
 
 ## Next
 
-Committed, well-scoped future items.
+Well-scoped, but sequenced behind the items above.
 
-| Item | Notes |
-|------|-------|
-| Multi-source matching engine | Probabilistic (Fellegi-Sunter-style) matching: blocking on amount + date window, field scoring, confidence output, and match groups instead of binary yes/no. |
-| Confidence scoring & trust ladder | Score transactions by source agreement (single source → corroborated → reconciled); route low-confidence items to a review queue. |
-| SimpleFIN API integration | Open-protocol bank sync; candidate default given low cost. |
-| Plaid API integration (issue ref) | Optional, user-supplied key; transaction enrichment + merchant normalization. |
-| Teller API integration | Optional direct bank API. |
-| IBKR importer (#923) | Interactive Brokers activity/statement importer. |
-| Recurring / expected-transaction detection | Declare expected recurring transactions (rent, salary) and alert on missing bills or anomalies. |
-| Reconciliation / review UX | Per-account period view showing opening/closing balances, per-source agreement, and a queue to resolve mismatches. |
-| PDF statement extraction | Local-first pipeline (text/OCR → layout → table detection → parse), with a declarative parser registry per statement format. |
-| Cloud/LLM extraction fallback | Optional cloud Document AI or vision-LLM extraction for low-confidence pages; privacy/accuracy is a user-chosen tradeoff (local-only vs. local+cloud). |
-| Source archive (audit trail) | Append-only SQLite store of original source documents keyed by content hash, with extraction history and integrity verification. Compliance design (SEC 17a-4 / GoBD / GDPR audit trail) is captured separately. |
+| Item | Why it matters | Approach |
+|------|----------------|----------|
+| **Reconciliation / review UX** | Imports need a confirmation step, not blind trust. | A per-account, per-period view: opening/closing balances, what each source agrees on, and a queue to resolve mismatches before they hit the ledger. Pairs with balance extraction. |
+| **Bank-API sync (SimpleFIN first)** | CSV/PDF is manual and lossy; an API is the difference between weekly chores and continuous. | Start with **SimpleFIN** (open protocol, low cost, no per-bank engineering). Plaid/Teller as optional, user-keyed backends behind the same interface later. Strictly opt-in. |
+| **Recurring / expected-transaction detection** | Plain-text accounting silently *omits* what's missing; nobody notices a skipped paycheck import. | Let users declare expected recurring entries (rent, salary) and alert when an expected transaction doesn't show up — catches gaps the balance check can't. |
+| **Multi-source matching** | Once there are two sources (CSV + API, or statement + export), naive dedup produces doubles or drops. | Match on amount + a date window with field-level scoring and a confidence output, producing match *groups* rather than binary yes/no. Feeds the review queue rather than auto-resolving. |
+| **Community importer registry** | Every user re-deriving the same bank profile is wasted effort. | A shareable registry of `importers.toml` profiles, with automated tests against sample data so a contributed profile is verifiably correct before others rely on it. |
+| **PDF statement extraction** | Many institutions only provide PDFs. | A local-first pipeline (text or OCR → layout/table detection → parse) with a declarative parser registry keyed by statement format. Local OCR by default; see below for the cloud escape hatch. |
 
 ## Exploring / Later
 
-Aspirational / brainstorm — not committed.
+Genuinely uncertain — pursued only if the simpler items above prove insufficient
+and there's real demand.
 
-| Item | Notes |
-|------|-------|
-| Community importer registry (NEW) | A shareable, community-maintained `importers.toml` / institution-profile registry so users can pull and contribute bank importers with automated testing against sample data. |
-| OCR ensemble | Multi-engine OCR (Tesseract / PaddleOCR / ONNX-exported models) with consensus voting to cut extraction errors; ONNX (`ort`) as the pure-Rust escape hatch. |
-| LLM/MCP-assisted categorization | LLM-assisted account suggestion via MCP for transactions rules + ML leave uncategorized. |
-| Compliance / audit attestation | Multi-jurisdiction compliance modes, transparency-log (Sigstore-style) attestation, and a path to third-party SEC 17a-4 assessment for regulated users. |
-| Background sync daemon | Scheduled API sync with push notifications and anomaly detection for new transactions. |
-| Statement-from-photo import | Import statements captured from a phone photo (mobile/HITL workflow). |
+| Item | Open question |
+|------|---------------|
+| **Opt-in cloud / LLM extraction fallback** | For PDF pages local extraction can't parse confidently, a user-chosen cloud Document-AI or vision-LLM pass. The whole point is local-first, so this stays strictly opt-in and per-document — is the accuracy gain worth introducing a network dependency at all? |
+| **LLM-assisted categorization** | An MCP-driven account suggestion for what rules + ML leave uncategorized. Useful, but only if it beats the (free, local, private) statistical model often enough to justify the dependency. |
+| **Long-term source archive** | An append-only, content-hash-keyed store of original statements with extraction history — valuable for audit and re-extraction. The detailed design (storage, integrity, any regulatory framing) lives in [import-architecture.md](../development/import-architecture.md); it's deliberately *not* committed roadmap until there's a concrete user need. |
 
 ---
 
-Shipped import features (trait system, CSV/OFX importers, auto-inference, ops crate, rules engine + merchant dictionary, fingerprinting/dedup, ML categorization, WASM plugins, user-supplied balance generation): see CHANGELOG.
+Shipped import features (trait system, CSV/OFX importers, auto-inference, the
+`rustledger-ops` crate, rules engine + merchant dictionary, fingerprinting/dedup,
+ML categorization, WASM plugins, balance-directive generation): see the
+[CHANGELOG](https://github.com/rustledger/rustledger/blob/main/CHANGELOG.md).
+Detailed design notes: [import-architecture.md](../development/import-architecture.md).

--- a/docs/roadmap/importing.md
+++ b/docs/roadmap/importing.md
@@ -3,11 +3,11 @@
 > Part of the [rustledger roadmap](./index.md). This is the engine room of
 > [bet #2 — make ingestion painless](./index.md#2-make-ingestion-painless--the-real-adoption-barrier).
 
-For plain-text accounting the ledger format is the easy part; the friction is
+For plain-text accounting, the ledger format is the easy part; the friction is
 getting bank data *in* and trusting that it's complete and correct. The shipped
 baseline already covers the mechanics — `rledger extract` with `importers.toml`
 profiles, sandboxed WASM importers, rule-based + Naive-Bayes categorization, and
-balance-assertion generation. What's left is making it **work out of the box**
+balance-directive generation. What's left is making it **work out of the box**
 for common cases and **earn trust** that nothing was missed.
 
 Guiding principles: **local-first** (no data leaves the machine unless the user

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -8,7 +8,7 @@ work lives in the [CHANGELOG](https://github.com/rustledger/rustledger/blob/main
 
 Rustledger is a fast, Rust-native, Beancount-compatible plain-text accounting
 engine: 100% check / BQL / full-AST parity on the compatibility corpus, ~10–30×
-faster than Python beancount, with a property-tested pipeline, formal specs in
+faster than Python Beancount, with a property-tested pipeline, formal specs in
 CI, and a stable plugin ABI. The foundation is solid. That changes what the
 roadmap is *for*: the leverage now is less in raw speed and more in **removing
 the reasons someone wouldn't switch** and **making the engine a platform**.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,66 +1,68 @@
 # Rustledger Roadmap
 
-Where rustledger is headed. This is a **forward-looking** document — it lists
-what's planned and what we're exploring, not what's already done. For shipped
-work, see the [CHANGELOG](https://github.com/rustledger/rustledger/blob/main/CHANGELOG.md).
+This is a **forward-looking** document: where rustledger is going and why. It
+lists what's planned and what we're weighing, not what's already done — shipped
+work lives in the [CHANGELOG](https://github.com/rustledger/rustledger/blob/main/CHANGELOG.md).
+
+## Where we are
+
+Rustledger is a fast, Rust-native, Beancount-compatible plain-text accounting
+engine: 100% check / BQL / full-AST parity on the compatibility corpus, ~10–30×
+faster than Python beancount, with a property-tested pipeline, formal specs in
+CI, and a stable plugin ABI. The foundation is solid. That changes what the
+roadmap is *for*: the leverage now is less in raw speed and more in **removing
+the reasons someone wouldn't switch** and **making the engine a platform**.
+
+## Strategy
+
+Three bets, in priority order. Everything in the per-area files ladders up to
+one of these.
+
+### 1. Finish compatibility — make "drop-in" literally true
+"99% compatible" is not a migration story; the last 1% is where trust is won or
+lost. The remaining gaps are narrow and worth closing completely:
+
+- **Arbitrary-precision decimal** ([#1240](https://github.com/rustledger/rustledger/issues/1240)) — the only known numeric divergence. `rust_decimal` caps at 28–29 digits; beancount uses Python's unbounded `Decimal`. This is the single most-cited reason a ledger could produce different numbers.
+- **Tooling parity** — a deliberate audit of `bean-price` / `bean-query` / `bean-report` against rustledger's equivalents at the flag and output level, so scripts and muscle memory port over unchanged.
+- **Plugin commutativity** — the one pipeline-invariant family not yet pinned (does plugin order matter where it shouldn't?). Needs a `COMMUTATIVE` marker on the plugin trait. See [Testing & Quality](./testing-and-quality.md).
+
+### 2. Make ingestion painless — the real adoption barrier
+For plain-text accounting, the hard part isn't the ledger format; it's getting
+bank data *into* it. This is where most product leverage sits, and where the
+existing ML/WASM building blocks pay off — kept **local-first**, with cloud/LLM
+strictly opt-in:
+
+- **Declarative institution profiles** so common banks work without per-user CSV column-mapping, plus built-in profiles for the most common institutions.
+- **Reconciliation that builds trust** — extract statement balances, compare against the computed ledger, and surface mismatches instead of silently importing.
+- **Categorization that improves** — feed user corrections back into the existing Naive-Bayes model; offer an opt-in LLM suggestion path for what rules + ML leave uncategorized.
+
+See [Importing & Ingestion](./importing.md). Statement OCR and bank-API sync
+are further out and gated on real demand.
+
+### 3. Be a platform, not just a CLI
+Lower the on-ramp and meet people where they work:
+
+- A **browser playground** — `rustledger-wasm` already compiles the engine to WASM, so a "try it in the browser" surface is mostly packaging, and it doubles as live, runnable docs.
+- **Incremental, low-latency LSP** so editor responsiveness stays flat as ledgers grow (range-based reparse over the lossless CST), plus the missing refactors (rename, code actions).
+- A **stable, documented plugin surface** (the SemVer gate is the first step) so third-party native and WASM plugins are safe to depend on.
+
+## The substrate: keep raising the floor
+
+These don't ship features, but they're why the above can move fast without
+regressions — and they're the cheapest insurance the project has:
+
+- **[Performance](./performance.md)** — protect the speed lead; only chase bottlenecks profiling actually shows.
+- **[Testing & Engineering Quality](./testing-and-quality.md)** — extend the property tests, fuzzing, and API-stability gates.
+- **[Formal Verification](./formal-verification.md)** — keep the core's invariants machine-checked, and turn counterexamples into regression tests.
 
 ## How this is organized
 
-The roadmap is split by area, and each area file is forward-only:
-
-| Area | What it covers |
-|------|----------------|
-| [Performance](./performance.md) | Parser/loader/query speed, memory, caching |
-| [Importing & Ingestion](./importing.md) | Bank/broker imports, categorization, source archive |
-| [Testing & Engineering Quality](./testing-and-quality.md) | Test depth, fuzzing, formal bridges, API stability, lint ratchets |
-| [Formal Verification](./formal-verification.md) | TLA+ specs, Kani proofs |
-
-Each area groups work into **Now** (in progress / next up), **Next**
-(committed, well-scoped), and **Exploring / Later** (aspirational). Completed
-items move out of the roadmap into the [CHANGELOG](https://github.com/rustledger/rustledger/blob/main/CHANGELOG.md), which
-keeps these files from accumulating stale "done" entries.
+Each area file is **forward-only** and groups work into **Now** (in progress /
+next up), **Next** (committed, well-scoped), and **Exploring / Later**
+(genuinely uncertain — may be reshaped or dropped). When something ships it
+moves to the [CHANGELOG](https://github.com/rustledger/rustledger/blob/main/CHANGELOG.md),
+so these files never accumulate stale "done" entries.
 
 > Lifecycle: **idea** (Exploring) → **tracked issue** (Next) → **in progress**
-> (Now) → **shipped** (CHANGELOG). The roadmap captures intent; GitHub issues
-> track committed work.
-
-## Cross-cutting themes
-
-A few directions span multiple areas and set the medium-term agenda:
-
-### 1. Close the last beancount gaps
-Rustledger is at 100% check / BQL / full-AST compatibility on the corpus. The
-remaining divergences are narrow:
-- **Arbitrary-precision decimal** ([#1240](https://github.com/rustledger/rustledger/issues/1240)) — the last numeric divergence from Python beancount.
-- A **bean-price / bean-query / bean-report parity audit** to confirm flag- and output-level parity.
-- **Plugin commutativity** — the one pipeline-invariant family not yet pinned (needs a `COMMUTATIVE` plugin marker). See [Testing & Quality](./testing-and-quality.md).
-
-### 2. AI-assisted bookkeeping
-The pieces already exist (a Naive-Bayes categorizer in `rustledger-ops`, WASM
-plugins, a clean query/extract API). Natural next steps:
-- An **MCP server** exposing query / extract / categorize so AI agents can
-  drive rustledger directly.
-- **LLM / MCP categorization** as an alternative to the statistical model, and
-  **online learning** that improves the existing model from user corrections.
-- **Anomaly / duplicate detection** on import.
-
-### 3. Editor, web & developer experience
-- A **browser playground** — the `rustledger-wasm` crate already compiles the
-  engine to WASM; a web "try it" surface is mostly packaging.
-- **LSP feature completeness** (rename, more code actions/refactors) and a
-  possible **TUI report viewer**.
-- Continued **diagnostics / `doctor`** improvements.
-
-### 4. Extensibility & ecosystem
-- A **shareable importer registry** (community `importers.toml` profiles).
-- A **plugin registry / marketplace** for native and WASM plugins.
-
-## Tracked work
-
-Items with a GitHub issue are the committed near-term work:
-
-- [#1240](https://github.com/rustledger/rustledger/issues/1240) — arbitrary-precision decimal
-- [#923](https://github.com/rustledger/rustledger/issues/923) — IBKR importer
-
-Everything else lives in the per-area files above until it's promoted to an
-issue.
+> (Now) → **shipped** (CHANGELOG). The roadmap captures intent and rationale;
+> GitHub issues track the committed work.

--- a/docs/roadmap/performance.md
+++ b/docs/roadmap/performance.md
@@ -10,7 +10,7 @@ Items that are partially done or the most valuable next steps.
 
 | Item | Notes |
 |------|-------|
-| Bumpalo arena for AST nodes | Phase 6 (lexer + arena) is partial: the Logos lexer and structured CST parser shipped, but AST allocation still uses the global allocator. Move AST nodes into a [bumpalo](https://github.com/fitzgen/bumpalo) arena (~11 instructions/alloc, mass-reset on discard) for phase-oriented parse → use → discard. Projected ~+20% parsing. |
+| Bumpalo arena for AST nodes | Phase 6 (lexer + arena) is partial: the Logos lexer and structured CST parser shipped, but AST allocation still uses the global allocator. Move AST nodes into a [bumpalo](https://github.com/fitzgen/bumpalo) arena (~11 instructions/alloc, mass-reset on discard), which fits the parse → use → discard lifecycle exactly. The win depends on how alloc-bound parsing actually is — measure with `pipeline_bench` before and after rather than committing to a number up front. |
 | Pre-allocate hot HashMaps | Add `.with_capacity()` in validation and query execution to avoid rehashing on known-size maps (`rustledger-validate`, `rustledger-query/src/executor.rs`). |
 
 ## Next
@@ -19,7 +19,7 @@ Committed, well-scoped future work.
 
 | Item | Notes |
 |------|-------|
-| Memory-mapped files for large ledgers | Optional `mmap` (via `memmap2`) above a size threshold (e.g. 50MB), with fallback to standard read for smaller files. Zero-copy load; projected 10-20% for files >100MB. Cross-platform. |
+| Memory-mapped files for large ledgers | Optional `mmap` (via `memmap2`) above a size threshold (e.g. 50MB), with fallback to standard read for smaller files. Zero-copy load avoids one full read into a buffer; the payoff is concentrated in the largest files, where I/O dominates parse time. Gate on a benchmark with a representative large ledger before shipping. |
 | Incremental LSP reparse | Re-parse only the edited region instead of the whole document on each keystroke. The Logos lexer + lossless rowan CST already give us the structure to support range-based reparsing in `rustledger-lsp`; this keeps editor latency flat as ledgers grow. |
 | Remaining parser/validation micro-optimizations | Continue the fast-path approach (zero-alloc collections, SIMD escape/scan, hand-rolled numeric parsing) for any hot spots profiling still surfaces. |
 

--- a/docs/roadmap/performance.md
+++ b/docs/roadmap/performance.md
@@ -2,7 +2,7 @@
 
 > Part of the [rustledger roadmap](./index.md).
 
-Forward-looking performance work. rustledger is already 10-30x faster than Python beancount on typical ledgers; this tracks the remaining optimizations and ideas, not what has already shipped.
+Forward-looking performance work. rustledger is already 10-30x faster than Python Beancount on typical ledgers; this tracks the remaining optimizations and ideas, not what has already shipped.
 
 ## Now / In progress
 

--- a/docs/roadmap/testing-and-quality.md
+++ b/docs/roadmap/testing-and-quality.md
@@ -20,37 +20,39 @@ already in place.
 
 Committed, well-scoped future items.
 
-| Item | Notes | Rough effort |
-|------|-------|--------------|
-| **OSS-Fuzz integration** | Google's continuous 24/7 fuzzing, auto-files bugs on crashes. Needs `Dockerfile` + `build.sh` + `project.yaml` and a PR to google/oss-fuzz. Builds on the existing `fuzz.yml` targets. | ~1 day |
-| **Incremental test running** | Only run tests affected by changed files using `cargo-nextest` file-to-test mapping. Significant CI-time savings on partial changes. | ~2-3 days |
-| **dylint custom lints** | Project-specific lints via `dylint` to enforce conventions the standard clippy set can't (e.g. backing the unwrap/panic-in-lib rule, hot-path and sync-primitive conventions). Deferred from #1237. | — |
-| **SemVer gate Tier-2 (core / parser)** | Extend `cargo-semver-checks` beyond the plugin DTOs to `rustledger-core` and `rustledger-parser`. Follow-up to #1233. | — |
-| **`cargo-public-api` visibility** | Track the full public API surface with `cargo-public-api` so API changes are visible in diffs, complementing the SemVer gate. Follow-up to #1233. | — |
-| **Plugin-commutativity property** | The one deferred member of the #1235 pipeline-property family: assert that plugins marked commutative produce the same result regardless of application order. Needs a `COMMUTATIVE` trait marker before the property can be written. | — |
-| **BQL file-sampling lift** | `compat-bql-test.py` currently caps execution at `MAX_FILES = 30`. Lift the limit via parallel execution and/or nightly-vs-PR sampling tiers. | ~4 hours |
+| Item | Notes |
+|------|-------|
+| **Plugin-commutativity property** | The one deferred member of the #1235 pipeline-property family, and the test-side of [compatibility bet #1](./index.md#1-finish-compatibility--make-drop-in-literally-true): assert that plugins marked commutative produce the same result regardless of application order. Needs a `COMMUTATIVE` trait marker before the property can be written. |
+| **SemVer gate Tier-2 (core / parser)** | Extend `cargo-semver-checks` beyond the plugin DTOs to `rustledger-core` and `rustledger-parser` — the next crates third parties build against. Follow-up to #1233. |
+| **`cargo-public-api` visibility** | Track the full public API surface with `cargo-public-api` so API changes show up in diffs, complementing the SemVer gate. Follow-up to #1233. |
+| **OSS-Fuzz integration** | Google's continuous 24/7 fuzzing, auto-filing bugs on crashes. Needs `Dockerfile` + `build.sh` + `project.yaml` and a PR to google/oss-fuzz; builds on the existing `fuzz.yml` targets. |
+| **dylint custom lints** | Project-specific lints via `dylint` for conventions clippy can't express (backing the unwrap/panic-in-lib rule, hot-path and sync-primitive conventions). Deferred from #1237. |
+| **Incremental test running** | Only run tests affected by changed files via `cargo-nextest` file-to-test mapping — meaningful CI savings on partial changes. |
+| **BQL file-sampling lift** | `compat-bql-test.py` caps execution at `MAX_FILES = 30`. Lift the limit via parallel execution and/or nightly-vs-PR sampling tiers so the headline compat number reflects the full corpus. |
 
 ## Exploring / Later
 
-Aspirational / brainstorm — not committed, may be reshaped or dropped.
+Genuinely uncertain — pursued only if it earns its keep against the gates already
+in place. Each of these has a concrete reason it might *not* be worth it.
 
-- **loom for concurrency** — model-check concurrent code paths with `loom` to surface
-  interleaving bugs the grep ratchets and Miri don't catch. (Deferred from #1237.)
 - **Differential testing against Beancount** — run `rledger` and `bean-check` on the same
-  inputs and auto-detect behavior divergence, reusing the compatibility corpus.
-- **Chaos testing** — inject random failures (disk, network, memory pressure) and test
-  graceful degradation; most useful for cache and file-loading code.
-- **Contract testing for plugins** — property-test plugin API contracts, ensure plugins
-  can't crash the host, and test WASM sandbox isolation.
-- **Benchmark regression detection** — benchmarks run today but don't fail on regression;
-  add statistical-significance testing (criterion `--baseline`) and block PRs above a
-  threshold (e.g. >5%).
-- **Visual regression testing** — snapshot CLI output formatting and error-message
-  rendering; ensure colored output doesn't break.
-- **Cross-platform testing matrix** — extend beyond Linux x86_64 to macOS ARM64, Windows,
-  and Linux ARM64 for critical paths.
-- **Load testing** — exercise very large ledgers (1M+ transactions), profile memory under
-  load, and detect leaks in long-running processes.
+  inputs and auto-detect divergence, reusing the compatibility corpus. The strongest
+  candidate here: it directly serves the compatibility bet, and the corpus already exists.
+  Open question is mostly how to triage *intended* deviations (the "fixable Python bugs"
+  policy) from real ones without drowning in noise.
+- **Contract testing for plugins** — property-test the plugin API contract: that a plugin
+  can't crash or corrupt the host and that WASM sandbox isolation holds. Pairs with the
+  stable-plugin-surface platform bet; worth it once the plugin ABI is the thing third
+  parties depend on.
+- **loom for concurrency** — model-check concurrent code paths with `loom` for interleaving
+  bugs Miri and the grep ratchets miss. (Deferred from #1237.) Gated on there being enough
+  hand-written concurrency to justify it — most parallelism today is structured rayon.
+- **Benchmark regression detection** — benchmarks run but don't fail on regression. Adding
+  criterion `--baseline` comparison with a significance threshold would make the
+  performance bet's "protect the lead" claim enforceable rather than aspirational. The
+  hard part is a stable enough CI baseline to avoid false alarms.
+- **Cross-platform CI matrix** — extend beyond Linux x86_64 to macOS ARM64 and Windows for
+  the parser/booking core. Justified by where users actually run, not for its own sake.
 
 ---
 


### PR DESCRIPTION
Re-review pass on the `docs/roadmap/` files that landed in #1373 — making them read as a coherent, deliberately-reasoned strategy rather than a grab-bag of buzzwordy items.

## What changed

- **`index.md`** — removed the "Tracked work" issue list (per request). Now leads with where the project actually stands (fast, 100% compat, solid engineering) and three **prioritized strategic bets** every area file ladders up to: (1) finish compatibility, (2) make ingestion painless, (3) be a platform.
- **`importing.md`** — reframed around the real adoption barrier: getting bank data *in* and trusting it's complete. Principles: local-first, declarative, trust-building. Cut the grandiose statement-from-photo / OCR-consensus / compliance-transparency-log headline items; consolidated bank-API work behind SimpleFIN with Plaid/Teller as opt-in backends later.
- **`performance.md`** — replaced fabricated speedup percentages ("~+20% parsing", "10–20% for files >100MB") with "measure before committing to a number".
- **`testing-and-quality.md`** — dropped false-precision effort estimates ("~1 day", "~4 hours"), reordered by strategic value, and trimmed filler exploring items (chaos testing, visual regression, generic load testing). Each remaining item now states why it might *not* be worth it.
- **`formal-verification.md`** — added a thesis tying it to the substrate and a clear bar for when a new spec earns its place.

Doc-only. No code or new GitHub issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)