### PR TITLE
chore: release v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agcli",
  "anyhow",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3250,11 +3250,11 @@ dependencies = [
 
 [[package]]
 name = "rustledger-completion"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "rustledger-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "imbl",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.2",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "glob",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "crossbeam-channel",
  "jiff",
@@ -3363,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-only"
@@ -185,19 +185,19 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.15.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.15.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.15.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.15.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.15.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.15.0", path = "crates/rustledger-query" }
-rustledger-completion = { version = "0.15.0", path = "crates/rustledger-completion" }
-rustledger-plugin = { version = "0.15.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.15.0", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.15.0", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.15.0", path = "crates/rustledger-ops" }
-rustledger-ffi-wasi = { version = "0.15.0", path = "crates/rustledger-ffi-wasi" }
-rustledger-wasm = { version = "0.15.0", path = "crates/rustledger-wasm" }
+rustledger-core = { version = "0.16.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.16.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.16.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.16.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.16.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.16.0", path = "crates/rustledger-query" }
+rustledger-completion = { version = "0.16.0", path = "crates/rustledger-completion" }
+rustledger-plugin = { version = "0.16.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.16.0", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.16.0", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.16.0", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.16.0", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.16.0", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-completion"
 description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Rustledger FFI via WASI - JSON API for embedding in any language"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.15.0"
+    "@rustledger/wasm": "^0.16.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.15.0
+Version:        0.16.0
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.15.0.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.16.0.tar.gz
 
 # Must match `workspace.package.rust-version` in Cargo.toml.
 # Edition 2024 stabilized in 1.85, so older toolchains fail at parse
@@ -24,7 +24,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.15.0
+%setup -q -n rustledger-0.16.0
 
 %build
 cargo build --release


### PR DESCRIPTION
Version bump to **v0.16.0**.

202 commits since v0.15.0 — headline work: the full CST parser migration (#1262), the opinionated CST-backed formatter, WASM importers, the `ag-rledger` agent-native JSON CLI, CST-backed LSP rename/range-formatting, ML category suggestions in `extract`, and the parse-cache reuse across report/query/check. Detailed notes will be auto-generated on the GitHub Release.

## Version surface bumped (per RELEASING.md)
- Workspace `Cargo.toml` (`[workspace.package].version` + 13 sibling dep pins)
- All 15 crate `Cargo.toml`s + 2 `sample_stub` fixture lockfiles
- `Cargo.lock`
- `packages/mcp-server/package.json` (version + `@rustledger/wasm` dep)
- `packaging/rpm/rustledger.spec` (Version, Source0, `%setup -n`)
- **rpm `BuildRequires: rust >= 1.94 → 1.95`** to match `[workspace.package].rust-version` (the v0.14.1 #927 footgun)

## Preflight (all green)
- `cargo check --workspace --all-features --all-targets` ✅
- mcp-server `npm ci && npm run build` (tsc) ✅
- `wasm-pack build --target web --release` ✅

After this merges, the GitHub Release for `v0.16.0` will be created (pinned to the merge SHA) to trigger build + publish.