### PR TITLE
chore: bump Rust toolchain + MSRV to 1.96

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -13,13 +13,13 @@ env:
 jobs:
   # MSRV check - verify minimum supported Rust version
   msrv:
-    name: MSRV (1.94)
+    name: MSRV (1.96)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
-          toolchain: "1.94"
+          toolchain: "1.96"
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Check MSRV compatibility
         run: cargo check --workspace --all-features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Rustledger!
 
 ### Prerequisites
 
-- Rust 1.95+ (`rustup update stable`) - Rust 2024 edition
+- Rust 1.96+ (`rustup update stable`) - Rust 2024 edition
 - Node.js 24+ (for MCP server)
 - wasm-pack (for WASM builds): `cargo install wasm-pack`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default-members = [
 [workspace.package]
 version = "0.15.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 license = "GPL-3.0-only"
 repository = "https://github.com/rustledger/rustledger"
 homepage = "https://rustledger.github.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Produces a minimal image with static musl binaries
 
 # Build stage
-FROM rust:1.95-alpine AS builder
+FROM rust:1.96-alpine AS builder
 
 RUN apk add --no-cache musl-dev
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 # https://doc.rust-lang.org/clippy/configuration.html
 
 # MSRV - Minimum Supported Rust Version
-msrv = "1.95"
+msrv = "1.96"
 
 # Cognitive complexity threshold
 cognitive-complexity-threshold = 25

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1779099656,
-        "narHash": "sha256-x+PMKsZHKbgNbWrkyNP58xb4LrQfzzFd0QJVnPc+VnY=",
+        "lastModified": 1781527054,
+        "narHash": "sha256-1fX9ev2Fh5QoKQ41G9dYutjo5j/jywu6tZse5Eb1Ck4=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f553608656def48a8aa2984b85f27fbee7c83dd8",
+        "rev": "8c2e51dffefc040a21975da7abf6f252c8c9b783",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779074864,
-        "narHash": "sha256-0M3WqsWmtXmv9Ev/vnFfCHosWvISDwiuuhQ104UO3CI=",
+        "lastModified": 1781453968,
+        "narHash": "sha256-+V3nK4pCngbmgyVGXY6Kkrlevp4ocPkJJLf2aqwkDNA=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "cdfe408d4b436e806ff525cb3e67588a6a009ed1",
+        "rev": "cc272809a173c2c11d0e479d639c811c1eacf049",
         "type": "github"
       },
       "original": {

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -12,7 +12,7 @@ Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.15
 # Must match `workspace.package.rust-version` in Cargo.toml.
 # Edition 2024 stabilized in 1.85, so older toolchains fail at parse
 # time regardless of MSRV.
-BuildRequires:  rust >= 1.94
+BuildRequires:  rust >= 1.96
 BuildRequires:  cargo
 BuildRequires:  gcc
 


### PR DESCRIPTION
Moves the whole toolchain surface to the current stable **Rust 1.96.0** (2026-05-25) and makes the declared MSRV self-consistent.

### Why
The repo disagreed with itself about the floor: `rust-version`/`clippy.toml`/`Dockerfile` said **1.95**, the CI `MSRV` job tested **1.94**, and the rpm spec said **1.94**. This pins everything to **1.96**.

### Changes
- `flake.lock`: fenix `stable` → rustc 1.96.0 (dev shell + Nix CI builds)
- `Cargo.toml`: `rust-version` 1.95 → 1.96
- `clippy.toml`: `msrv` 1.95 → 1.96
- `Dockerfile`: `rust:1.95-alpine` → `rust:1.96-alpine`
- `packaging/rpm/rustledger.spec`: `BuildRequires: rust >= 1.94 → 1.96`
- `.github/workflows/quality.yml`: MSRV job `1.94 → 1.96` (name + toolchain)

`rust-toolchain.toml` stays `channel = "stable"` so non-Nix contributors track latest stable automatically.

### Verified locally on 1.96.0
- `cargo check --workspace --all-features --all-targets` ✅
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✅ (0 new lints)

Split out of the v0.16.0 release PR (#1376) per request — that PR is now a pure version bump and touches no MSRV state, so the two land in any order without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)