### PR TITLE
feat(ops): replace ferrolearn with an in-house Multinomial Naive Bayes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,16 +205,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-wait"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
-dependencies = [
- "libc",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,26 +424,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1027,19 +997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,15 +1020,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1145,12 +1093,6 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
 ]
-
-[[package]]
-name = "defer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
 
 [[package]]
 name = "deflate64"
@@ -1256,22 +1198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "dyn-stack"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
-dependencies = [
- "bytemuck",
- "dyn-stack-macros",
-]
-
-[[package]]
-name = "dyn-stack-macros"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
-
-[[package]]
 name = "edit"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,73 +1247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "equator"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
-dependencies = [
- "equator-macro 0.2.1",
-]
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro 0.4.2",
-]
-
-[[package]]
-name = "equator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02da895aab06bbebefb6b2595f6d637b18c9ff629b4cd840965bb3164e4194b0"
-dependencies = [
- "equator-macro 0.6.0",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,76 +1269,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
-name = "faer"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2ecfb80b6f8b0c569e36988a052e64b14d8def9d372390b014e8bf79f299a"
-dependencies = [
- "bytemuck",
- "dyn-stack",
- "equator 0.6.0",
- "faer-traits",
- "gemm",
- "generativity",
- "libm",
- "nano-gemm",
- "npyz",
- "num-complex",
- "num-traits",
- "private-gemm-x86",
- "pulp",
- "rand 0.9.4",
- "rand_distr",
- "rayon",
- "reborrow",
- "spindle",
-]
-
-[[package]]
-name = "faer-traits"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87d23ed7ab1f26c0cba0e5b9e061a796fbb7dc170fa8bee6970055a1308bb0f"
-dependencies = [
- "bytemuck",
- "dyn-stack",
- "generativity",
- "libm",
- "num-complex",
- "num-traits",
- "pulp",
- "qd",
- "reborrow",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "ferrolearn-bayes"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd68e8885dc40175b3f1de2b72680a646c45909fde2654b77139005a53f4b6a"
-dependencies = [
- "ferrolearn-core",
- "ndarray",
- "num-traits",
-]
-
-[[package]]
-name = "ferrolearn-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6c506ed793fbda2abf60125cbfae95f6af104613915f01234a0ac8a3d2c8a"
-dependencies = [
- "faer",
- "ndarray",
- "num-traits",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1649,146 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gemm"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
-dependencies = [
- "dyn-stack",
- "gemm-c32",
- "gemm-c64",
- "gemm-common",
- "gemm-f16",
- "gemm-f32",
- "gemm-f64",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-c32"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-c64"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-common"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
-dependencies = [
- "bytemuck",
- "dyn-stack",
- "half",
- "libm",
- "num-complex",
- "num-traits",
- "once_cell",
- "paste",
- "pulp",
- "raw-cpuid",
- "rayon",
- "seq-macro",
- "sysctl",
-]
-
-[[package]]
-name = "gemm-f16"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "gemm-f32",
- "half",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "rayon",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-f32"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-f64"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "generativity"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
-
-[[package]]
-name = "generator"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows-link",
- "windows-result",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,10 +1524,8 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "bytemuck",
  "cfg-if",
  "crunchy",
- "num-traits",
  "zerocopy",
 ]
 
@@ -1926,12 +1577,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -2166,17 +1811,6 @@ dependencies = [
  "serde",
  "similar 2.7.0",
  "tempfile",
-]
-
-[[package]]
-name = "interpol"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2448,19 +2082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lsp-server"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,16 +2132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata 0.4.14",
-]
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
 ]
 
 [[package]]
@@ -2632,91 +2243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nano-gemm"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e04345dc84b498ff89fe0d38543d1f170da9e43a2c2bcee73a0f9069f72d081"
-dependencies = [
- "equator 0.2.2",
- "nano-gemm-c32",
- "nano-gemm-c64",
- "nano-gemm-codegen",
- "nano-gemm-core",
- "nano-gemm-f32",
- "nano-gemm-f64",
- "num-complex",
-]
-
-[[package]]
-name = "nano-gemm-c32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0775b1e2520e64deee8fc78b7732e3091fb7585017c0b0f9f4b451757bbbc562"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
- "num-complex",
-]
-
-[[package]]
-name = "nano-gemm-c64"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af49a20d58816e6b5ee65f64142e50edb5eba152678d4bb7377fcbf63f8437a"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
- "num-complex",
-]
-
-[[package]]
-name = "nano-gemm-codegen"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc8d495c791627779477a2cf5df60049f5b165342610eb0d76bee5ff5c5d74c"
-
-[[package]]
-name = "nano-gemm-core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d998dfa644de87a0f8660e5ea511d7cb5c33b5a2d9847b7af57a2565105089f0"
-
-[[package]]
-name = "nano-gemm-f32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d962e79bc8952e4ad21ca4845a21132540ed3f5e01184b2ff7f720e666523"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
-]
-
-[[package]]
-name = "nano-gemm-f64"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a513473dce7dc00c7e7c318481ca4494034e76997218d8dad51bd9f007a815"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,17 +2274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "npyz"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0e759e014e630f90af745101b614f761306ddc541681e546649068e25ec1b9"
-dependencies = [
- "byteorder",
- "num-bigint",
- "py_literal",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,17 +2290,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "bytemuck",
- "num-traits",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -2811,16 +2315,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2945,12 +2439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,49 +2453,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "petgraph"
@@ -3145,22 +2590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "private-gemm-x86"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
-dependencies = [
- "crossbeam",
- "defer",
- "interpol",
- "num_cpus",
- "raw-cpuid",
- "rayon",
- "spindle",
- "sysctl",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,58 +2700,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulp"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "libm",
- "num-complex",
- "paste",
- "pulp-wasm-simd-flag",
- "raw-cpuid",
- "reborrow",
- "version_check",
-]
-
-[[package]]
-name = "pulp-wasm-simd-flag"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
-
-[[package]]
 name = "pure-rust-locales"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
-
-[[package]]
-name = "py_literal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-traits",
- "pest",
- "pest_derive",
-]
-
-[[package]]
-name = "qd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1304a5aecdcfe9ee72fbba90aa37b3aa067a69d14cb7f3d9deada0be7c07c"
-dependencies = [
- "bytemuck",
- "libm",
- "num-traits",
- "pulp",
-]
 
 [[package]]
 name = "quick-error"
@@ -3453,16 +2834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand 0.9.4",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,21 +2850,6 @@ checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3514,12 +2870,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "reborrow"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -4016,10 +3366,7 @@ name = "rustledger-ops"
 version = "0.15.0"
 dependencies = [
  "blake3",
- "ferrolearn-bayes",
- "ferrolearn-core",
  "jiff",
- "ndarray",
  "proptest",
  "regex",
  "rust_decimal",
@@ -4297,12 +3644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,12 +3664,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -4550,19 +3885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spindle"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
-dependencies = [
- "atomic-wait",
- "crossbeam",
- "equator 0.4.2",
- "loom",
- "rayon",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,20 +3973,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sysctl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
-dependencies = [
- "bitflags 2.13.0",
- "byteorder",
- "enum-as-inner",
- "libc",
- "thiserror 1.0.69",
- "walkdir",
 ]
 
 [[package]]
@@ -5039,12 +4347,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -5945,21 +5247,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5991,21 +5278,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6015,21 +5296,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6045,21 +5314,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6069,21 +5326,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -22,18 +22,13 @@ jiff.workspace = true
 blake3.workspace = true
 regex.workspace = true
 
-# ML stack — host-only. `ferrolearn-bayes` pulls `faer` → `spindle` →
-# `atomic-wait`, which doesn't compile on `wasm32-unknown-unknown`
-# (no `platform::wake_*` impl for the wasm target). The ML
-# categorizer doesn't run in browsers/WASI today — gate the deps off
-# wasm targets and gate the `ml` module body the same way. Same
-# MultinomialNB classifier as the linfa-bayes predecessor it replaced
-# (#1194), with a real `predict_proba`. `ferrolearn-core` brings the
-# `Fit` trait into scope for `MultinomialNB::fit`.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ferrolearn-bayes = "0.4"
-ferrolearn-core = "0.4"
-ndarray = "0.17"
+# Note: the ML categorizer (`ml` module) implements its own Multinomial
+# Naive Bayes in pure Rust (std only) — no external ML/array crates. It
+# previously used `ferrolearn-bayes` + `ndarray` (and `linfa-bayes`
+# before that), which dragged in native deps (`atomic-wait`, then
+# OpenBLAS via `ferray` in ferrolearn 0.5) that broke `wasm32` and
+# ballooned the tree for a textbook classifier. The in-house version
+# works on every target.
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/rustledger-ops/src/lib.rs
+++ b/crates/rustledger-ops/src/lib.rs
@@ -14,10 +14,8 @@
 //! - [`merchants`] — built-in merchant dictionary of common patterns
 //! - [`enrichment`] — shared types for operation results (confidence, method, alternatives)
 //! - [`reconcile`] — balance reconciliation against statement ending balances
-//! - `ml` — ML-based categorization (TF-IDF + Naive Bayes via
-//!   ferrolearn-bayes). Host-only: `ferrolearn-bayes` pulls
-//!   `atomic-wait`, which does not compile on
-//!   `wasm32-unknown-unknown`. The module is absent on wasm targets.
+//! - [`ml`] — ML-based categorization (TF-IDF + an in-house Multinomial
+//!   Naive Bayes classifier, pure `std`, available on every target)
 //! - [`transfer`] — inter-account transfer detection and linking
 
 #![forbid(unsafe_code)]
@@ -28,7 +26,6 @@ pub mod dedup;
 pub mod enrichment;
 pub mod fingerprint;
 pub mod merchants;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod ml;
 pub mod reconcile;
 pub mod transfer;

--- a/crates/rustledger-ops/src/ml.rs
+++ b/crates/rustledger-ops/src/ml.rs
@@ -523,4 +523,26 @@ mod tests {
         assert!(tokens.contains(&"market".to_string()));
         assert!(tokens.contains(&"1234".to_string()));
     }
+
+    #[test]
+    fn naive_bayes_known_values() {
+        // Two classes, two features: class 0 sees feature 0, class 1 sees
+        // feature 1. With Laplace alpha = 1.0 and equal priors:
+        //   feature_log_prob[0] = ln([3/4, 1/4]),  [1] = ln([1/4, 3/4])
+        //   class_log_prior      = ln([1/2, 1/2])
+        // For x = [1, 0]: jll = ln(3/8) vs ln(1/8) → softmax = [0.75, 0.25].
+        let nb = MultinomialNB::fit(&[vec![2.0, 0.0], vec![0.0, 2.0]], &[0, 1], 2);
+
+        let p = nb.predict_proba(&[1.0, 0.0]);
+        assert!((p[0] - 0.75).abs() < 1e-9, "p[0] = {}", p[0]);
+        assert!((p[1] - 0.25).abs() < 1e-9, "p[1] = {}", p[1]);
+        assert!(
+            (p.iter().sum::<f64>() - 1.0).abs() < 1e-12,
+            "posteriors must sum to 1.0"
+        );
+
+        // The symmetric input flips the posteriors.
+        let q = nb.predict_proba(&[0.0, 1.0]);
+        assert!((q[0] - 0.25).abs() < 1e-9 && (q[1] - 0.75).abs() < 1e-9);
+    }
 }

--- a/crates/rustledger-ops/src/ml.rs
+++ b/crates/rustledger-ops/src/ml.rs
@@ -5,7 +5,7 @@
 //! payee and narration text.
 //!
 //! Uses TF-IDF vectorization plus a small, self-contained Multinomial
-//! Naive Bayes classifier (see [`MultinomialNB`]) implemented in pure
+//! Naive Bayes classifier (see `MultinomialNB`) implemented in pure
 //! `std` — no external ML or linear-algebra crates. Earlier versions
 //! delegated to `linfa-bayes` and then `ferrolearn-bayes`, but both
 //! dragged heavy, occasionally wasm-incompatible dependencies in for an
@@ -187,8 +187,8 @@ impl CategorizationModel {
     ///
     /// Returns predictions sorted by confidence (highest first). Each
     /// prediction is an `(account, probability)` pair. The probabilities
-    /// are the class-conditional posteriors from
-    /// [`MultinomialNB::predict_proba`] (they sum to 1.0 across all
+    /// are the class-conditional posteriors from the underlying
+    /// Multinomial Naive Bayes model (they sum to 1.0 across all
     /// classes), so callers can treat them as honest scores.
     #[must_use]
     pub fn predict(&self, narration: &str, payee: Option<&str>) -> Vec<(String, f64)> {

--- a/crates/rustledger-ops/src/ml.rs
+++ b/crates/rustledger-ops/src/ml.rs
@@ -4,11 +4,12 @@
 //! to predict the expense/income account for new transactions based on their
 //! payee and narration text.
 //!
-//! Uses TF-IDF vectorization with `ferrolearn-bayes` for classification.
-//! (Previously `linfa-bayes`, but that crate pinned ndarray 0.16 and was
-//! blocking the workspace's ndarray + getrandom upgrades; `ferrolearn-bayes`
-//! gives us the same `MultinomialNB` plus a real `predict_proba` for
-//! honest confidence scores.)
+//! Uses TF-IDF vectorization plus a small, self-contained Multinomial
+//! Naive Bayes classifier (see [`MultinomialNB`]) implemented in pure
+//! `std` — no external ML or linear-algebra crates. Earlier versions
+//! delegated to `linfa-bayes` and then `ferrolearn-bayes`, but both
+//! dragged heavy, occasionally wasm-incompatible dependencies in for an
+//! algorithm that is ~80 lines of textbook arithmetic.
 //!
 //! # Example
 //!
@@ -18,9 +19,6 @@
 //! // → [("Expenses:Groceries", 0.92), ("Expenses:Dining", 0.05), ...]
 //! ```
 
-use ferrolearn_bayes::multinomial::{FittedMultinomialNB, MultinomialNB};
-use ferrolearn_core::traits::Fit;
-use ndarray::{Array1, Array2};
 use rustledger_plugin_types::{DirectiveData, DirectiveWrapper};
 use std::collections::HashMap;
 
@@ -30,7 +28,7 @@ use std::collections::HashMap;
 /// extracted from transaction payee/narration text.
 pub struct CategorizationModel {
     /// The trained classifier.
-    model: FittedMultinomialNB<f64>,
+    model: MultinomialNB,
     /// Vocabulary: word → column index in the feature matrix.
     vocabulary: HashMap<String, usize>,
     /// IDF weights for each word in the vocabulary.
@@ -157,13 +155,13 @@ impl CategorizationModel {
             .map(|&df| (n_docs / (1.0 + f64::from(df))).ln() + 1.0)
             .collect();
 
-        // Build TF-IDF feature matrix
-        let n_samples = samples.len();
+        // Build the dense TF-IDF feature matrix (one row per sample) and
+        // the parallel class-index targets.
         let n_features = vocab.len();
-        let mut features = Array2::<f64>::zeros((n_samples, n_features));
-        let mut targets = Array1::<usize>::zeros(n_samples);
+        let mut features: Vec<Vec<f64>> = Vec::with_capacity(samples.len());
+        let mut targets: Vec<usize> = Vec::with_capacity(samples.len());
 
-        for (i, (tokens, (_, account))) in tokenized.iter().zip(samples.iter()).enumerate() {
+        for (tokens, (_, account)) in tokenized.iter().zip(samples.iter()) {
             // Term frequency
             let mut tf = vec![0u32; n_features];
             for token in tokens {
@@ -171,21 +169,19 @@ impl CategorizationModel {
                     tf[idx] += 1;
                 }
             }
-            // TF-IDF
-            for (j, &count) in tf.iter().enumerate() {
-                features[[i, j]] = f64::from(count) * idf[j];
-            }
-            targets[i] = label_to_idx[account.as_str()];
+            // TF-IDF row
+            features.push(
+                tf.iter()
+                    .enumerate()
+                    .map(|(j, &count)| f64::from(count) * idf[j])
+                    .collect(),
+            );
+            targets.push(label_to_idx[account.as_str()]);
         }
 
-        // Train Multinomial Naive Bayes. ferrolearn-bayes takes
-        // features + targets directly (no Dataset wrapper) — the
-        // unfitted MultinomialNB::new() carries hyperparameters
-        // (alpha defaults to 1.0 = Laplace smoothing, matching the
-        // previous linfa-bayes default).
-        let model = MultinomialNB::new()
-            .fit(&features, &targets)
-            .map_err(|e| MlError::TrainingFailed(format!("{e}")))?;
+        // Train the classifier. Laplace smoothing (alpha = 1.0) matches
+        // the linfa-bayes / ferrolearn defaults this replaced.
+        let model = MultinomialNB::fit(&features, &targets, label_set.len());
 
         Ok(Self {
             model,
@@ -198,15 +194,10 @@ impl CategorizationModel {
     /// Predict the account for a transaction.
     ///
     /// Returns predictions sorted by confidence (highest first). Each
-    /// prediction is an `(account, probability)` pair. Probabilities
-    /// come from `predict_proba` (calibrated class-conditional
-    /// posteriors that sum to 1.0 across all classes), so callers can
-    /// use them as honest scores — pre-ferrolearn-bayes this was
-    /// faked (0.8 for predicted class, 0.0 otherwise).
-    ///
-    /// Predict failures (which only happen on shape mismatches inside
-    /// the classifier — impossible here, since we built `features` to
-    /// match the trained vocabulary) collapse to an empty result.
+    /// prediction is an `(account, probability)` pair. The probabilities
+    /// are the class-conditional posteriors from
+    /// [`MultinomialNB::predict_proba`] (they sum to 1.0 across all
+    /// classes), so callers can treat them as honest scores.
     #[must_use]
     pub fn predict(&self, narration: &str, payee: Option<&str>) -> Vec<(String, f64)> {
         let mut text = String::new();
@@ -217,32 +208,25 @@ impl CategorizationModel {
         text.push_str(narration);
 
         let features = self.vectorize(&text.to_lowercase());
-        let features_2d = features.insert_axis(ndarray::Axis(0));
 
-        // `predict_proba` returns shape (n_samples=1, n_classes); take
-        // row 0 and pair each probability with its label. Sort
-        // descending; drop zero-probability entries to keep the output
-        // compact for callers that only care about top-k.
-        let Ok(probas) = self.model.predict_proba(&features_2d) else {
-            return Vec::new();
-        };
+        // Pair each class posterior with its label, then sort descending;
+        // callers take the top-k. Softmax posteriors are all > 0, so
+        // every known category is returned.
         let mut results: Vec<(String, f64)> = self
             .labels
             .iter()
-            .enumerate()
-            .map(|(i, label)| (label.clone(), probas[[0, i]]))
-            .filter(|(_, p)| *p > 0.0)
+            .cloned()
+            .zip(self.model.predict_proba(&features))
             .collect();
 
         results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         results
     }
 
-    /// Vectorize text into a TF-IDF feature array.
-    fn vectorize(&self, text: &str) -> Array1<f64> {
+    /// Vectorize text into a dense TF-IDF feature vector.
+    fn vectorize(&self, text: &str) -> Vec<f64> {
         let tokens = tokenize(text);
-        let n_features = self.vocabulary.len();
-        let mut tf = vec![0u32; n_features];
+        let mut tf = vec![0u32; self.vocabulary.len()];
 
         for token in &tokens {
             if let Some(&idx) = self.vocabulary.get(token) {
@@ -250,11 +234,10 @@ impl CategorizationModel {
             }
         }
 
-        let mut features = Array1::<f64>::zeros(n_features);
-        for (j, &count) in tf.iter().enumerate() {
-            features[j] = f64::from(count) * self.idf[j];
-        }
-        features
+        tf.iter()
+            .enumerate()
+            .map(|(j, &count)| f64::from(count) * self.idf[j])
+            .collect()
     }
 
     /// Number of distinct categories the model was trained on.
@@ -267,6 +250,98 @@ impl CategorizationModel {
     #[must_use]
     pub fn vocab_size(&self) -> usize {
         self.vocabulary.len()
+    }
+}
+
+/// A Multinomial Naive Bayes classifier with Laplace (add-α) smoothing.
+///
+/// This is the standard multinomial NB used for text classification —
+/// equivalent to scikit-learn's `MultinomialNB` with `alpha = 1.0`, and
+/// to the `linfa-bayes` / `ferrolearn-bayes` implementations this
+/// replaced. Feature values are treated as fractional counts, so the
+/// TF-IDF weights produced above are valid inputs directly.
+///
+/// `fit` computes, per class `c`: a log prior `ln(n_c / n)` and smoothed
+/// feature log-probabilities `ln((Σᵢ xᵢⱼ + α) / (Σⱼ Σᵢ xᵢⱼ + α·n_features))`.
+/// `predict_proba` forms the joint log-likelihood
+/// `log_prior[c] + Σⱼ xⱼ · feature_log_prob[c][j]` per class and
+/// normalizes it with a numerically-stable softmax (log-sum-exp).
+struct MultinomialNB {
+    /// `ln P(class)` for each class — indexed `[class]`.
+    class_log_prior: Vec<f64>,
+    /// `ln P(feature | class)` — indexed `[class][feature]`.
+    feature_log_prob: Vec<Vec<f64>>,
+}
+
+impl MultinomialNB {
+    /// Laplace / additive smoothing parameter (the sklearn / linfa /
+    /// ferrolearn default).
+    const ALPHA: f64 = 1.0;
+
+    /// Fit on dense feature rows and their class-index targets.
+    ///
+    /// `features[i]` is the feature vector for sample `i` and `targets[i]`
+    /// its class in `0..n_classes`. Every class is assumed to occur at
+    /// least once (the caller derives the label set from the samples), so
+    /// no class prior is `-inf`.
+    fn fit(features: &[Vec<f64>], targets: &[usize], n_classes: usize) -> Self {
+        let n_features = features.first().map_or(0, Vec::len);
+        let n_samples = features.len() as f64;
+
+        // Per-class sample counts and summed feature weights.
+        let mut class_count = vec![0.0_f64; n_classes];
+        let mut feature_count = vec![vec![0.0_f64; n_features]; n_classes];
+        for (row, &class) in features.iter().zip(targets) {
+            class_count[class] += 1.0;
+            let counts = &mut feature_count[class];
+            for (j, &value) in row.iter().enumerate() {
+                counts[j] += value;
+            }
+        }
+
+        let class_log_prior = class_count.iter().map(|&n| (n / n_samples).ln()).collect();
+
+        let feature_log_prob = feature_count
+            .iter()
+            .map(|counts| {
+                let denom: f64 = Self::ALPHA.mul_add(n_features as f64, counts.iter().sum::<f64>());
+                counts
+                    .iter()
+                    .map(|&count| ((count + Self::ALPHA) / denom).ln())
+                    .collect()
+            })
+            .collect();
+
+        Self {
+            class_log_prior,
+            feature_log_prob,
+        }
+    }
+
+    /// Posterior class probabilities for one sample, summing to 1.0.
+    ///
+    /// The returned vector is indexed by class, in the order the model
+    /// was trained with.
+    fn predict_proba(&self, x: &[f64]) -> Vec<f64> {
+        // Joint log-likelihood per class.
+        let jll: Vec<f64> = self
+            .class_log_prior
+            .iter()
+            .zip(&self.feature_log_prob)
+            .map(|(&prior, log_prob)| {
+                prior
+                    + x.iter()
+                        .zip(log_prob)
+                        .map(|(&xj, &lp)| xj * lp)
+                        .sum::<f64>()
+            })
+            .collect();
+
+        // Stable softmax: subtract the max before exponentiating.
+        let max = jll.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let exps: Vec<f64> = jll.iter().map(|&v| (v - max).exp()).collect();
+        let total: f64 = exps.iter().sum();
+        exps.iter().map(|&e| e / total).collect()
     }
 }
 

--- a/crates/rustledger-ops/src/ml.rs
+++ b/crates/rustledger-ops/src/ml.rs
@@ -38,20 +38,23 @@ pub struct CategorizationModel {
 }
 
 /// Error type for ML operations.
+///
+/// Training is the only fallible step, and it fails only when there's too
+/// little data to build a useful model — fitting itself is infallible.
+///
+/// Marked `#[non_exhaustive]` so future failure modes can be added without
+/// breaking downstream matches.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum MlError {
-    /// Not enough training data.
+    /// Not enough training data (too few transactions or categories).
     InsufficientData(String),
-    /// Model training failed.
-    TrainingFailed(String),
 }
 
 impl std::fmt::Display for MlError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InsufficientData(msg) => write!(f, "insufficient training data: {msg}"),
-            Self::TrainingFailed(msg) => write!(f, "training failed: {msg}"),
-        }
+        let Self::InsufficientData(msg) = self;
+        write!(f, "insufficient training data: {msg}")
     }
 }
 
@@ -155,33 +158,22 @@ impl CategorizationModel {
             .map(|&df| (n_docs / (1.0 + f64::from(df))).ln() + 1.0)
             .collect();
 
-        // Build the dense TF-IDF feature matrix (one row per sample) and
-        // the parallel class-index targets.
+        // Build sparse TF-IDF rows — only the non-zero `(vocab index,
+        // weight)` entries, sorted by index for deterministic summation.
+        // TF-IDF vectors are mostly zero, so a dense matrix would cost
+        // O(n_samples × vocab); sparse rows cost O(total tokens).
         let n_features = vocab.len();
-        let mut features: Vec<Vec<f64>> = Vec::with_capacity(samples.len());
+        let mut features: Vec<Vec<(usize, f64)>> = Vec::with_capacity(samples.len());
         let mut targets: Vec<usize> = Vec::with_capacity(samples.len());
 
         for (tokens, (_, account)) in tokenized.iter().zip(samples.iter()) {
-            // Term frequency
-            let mut tf = vec![0u32; n_features];
-            for token in tokens {
-                if let Some(&idx) = vocab.get(token) {
-                    tf[idx] += 1;
-                }
-            }
-            // TF-IDF row
-            features.push(
-                tf.iter()
-                    .enumerate()
-                    .map(|(j, &count)| f64::from(count) * idf[j])
-                    .collect(),
-            );
+            features.push(tfidf_row(tokens, &vocab, &idf));
             targets.push(label_to_idx[account.as_str()]);
         }
 
         // Train the classifier. Laplace smoothing (alpha = 1.0) matches
         // the linfa-bayes / ferrolearn defaults this replaced.
-        let model = MultinomialNB::fit(&features, &targets, label_set.len());
+        let model = MultinomialNB::fit(&features, &targets, label_set.len(), n_features);
 
         Ok(Self {
             model,
@@ -223,21 +215,10 @@ impl CategorizationModel {
         results
     }
 
-    /// Vectorize text into a dense TF-IDF feature vector.
-    fn vectorize(&self, text: &str) -> Vec<f64> {
-        let tokens = tokenize(text);
-        let mut tf = vec![0u32; self.vocabulary.len()];
-
-        for token in &tokens {
-            if let Some(&idx) = self.vocabulary.get(token) {
-                tf[idx] += 1;
-            }
-        }
-
-        tf.iter()
-            .enumerate()
-            .map(|(j, &count)| f64::from(count) * self.idf[j])
-            .collect()
+    /// Vectorize text into a sparse TF-IDF feature vector (the non-zero
+    /// `(vocab index, weight)` entries).
+    fn vectorize(&self, text: &str) -> Vec<(usize, f64)> {
+        tfidf_row(&tokenize(text), &self.vocabulary, &self.idf)
     }
 
     /// Number of distinct categories the model was trained on.
@@ -258,8 +239,9 @@ impl CategorizationModel {
 /// This is the standard multinomial NB used for text classification —
 /// equivalent to scikit-learn's `MultinomialNB` with `alpha = 1.0`, and
 /// to the `linfa-bayes` / `ferrolearn-bayes` implementations this
-/// replaced. Feature values are treated as fractional counts, so the
-/// TF-IDF weights produced above are valid inputs directly.
+/// replaced. Samples are passed as **sparse** `(feature index, value)`
+/// rows; values are treated as fractional counts, so TF-IDF weights are
+/// valid inputs directly.
 ///
 /// `fit` computes, per class `c`: a log prior `ln(n_c / n)` and smoothed
 /// feature log-probabilities `ln((Σᵢ xᵢⱼ + α) / (Σⱼ Σᵢ xᵢⱼ + α·n_features))`.
@@ -278,14 +260,25 @@ impl MultinomialNB {
     /// ferrolearn default).
     const ALPHA: f64 = 1.0;
 
-    /// Fit on dense feature rows and their class-index targets.
+    /// Fit on sparse feature rows and their class-index targets.
     ///
-    /// `features[i]` is the feature vector for sample `i` and `targets[i]`
-    /// its class in `0..n_classes`. Every class is assumed to occur at
-    /// least once (the caller derives the label set from the samples), so
-    /// no class prior is `-inf`.
-    fn fit(features: &[Vec<f64>], targets: &[usize], n_classes: usize) -> Self {
-        let n_features = features.first().map_or(0, Vec::len);
+    /// `features[i]` is sample `i` as `(feature index, value)` pairs and
+    /// `targets[i]` is its class. Preconditions, all guaranteed by the
+    /// caller (which builds both from the same sample set):
+    /// `features.len() == targets.len()`; every feature index is
+    /// `< n_features`; every class index is `< n_classes`; and every
+    /// class occurs at least once, so no class prior is `-inf`.
+    fn fit(
+        features: &[Vec<(usize, f64)>],
+        targets: &[usize],
+        n_classes: usize,
+        n_features: usize,
+    ) -> Self {
+        debug_assert_eq!(
+            features.len(),
+            targets.len(),
+            "features and targets must be parallel"
+        );
         let n_samples = features.len() as f64;
 
         // Per-class sample counts and summed feature weights.
@@ -294,7 +287,7 @@ impl MultinomialNB {
         for (row, &class) in features.iter().zip(targets) {
             class_count[class] += 1.0;
             let counts = &mut feature_count[class];
-            for (j, &value) in row.iter().enumerate() {
+            for &(j, value) in row {
                 counts[j] += value;
             }
         }
@@ -318,23 +311,17 @@ impl MultinomialNB {
         }
     }
 
-    /// Posterior class probabilities for one sample, summing to 1.0.
+    /// Posterior class probabilities for one sparse sample, summing to 1.0.
     ///
-    /// The returned vector is indexed by class, in the order the model
-    /// was trained with.
-    fn predict_proba(&self, x: &[f64]) -> Vec<f64> {
+    /// `x` is the sample as `(feature index, value)` pairs. The returned
+    /// vector is indexed by class, in the order the model was trained with.
+    fn predict_proba(&self, x: &[(usize, f64)]) -> Vec<f64> {
         // Joint log-likelihood per class.
         let jll: Vec<f64> = self
             .class_log_prior
             .iter()
             .zip(&self.feature_log_prob)
-            .map(|(&prior, log_prob)| {
-                prior
-                    + x.iter()
-                        .zip(log_prob)
-                        .map(|(&xj, &lp)| xj * lp)
-                        .sum::<f64>()
-            })
+            .map(|(&prior, log_prob)| prior + x.iter().map(|&(j, v)| v * log_prob[j]).sum::<f64>())
             .collect();
 
         // Stable softmax: subtract the max before exponentiating.
@@ -351,6 +338,25 @@ fn tokenize(text: &str) -> Vec<String> {
         .filter(|s| s.len() >= 2)
         .map(str::to_lowercase)
         .collect()
+}
+
+/// Build a sparse TF-IDF row: the non-zero `(vocab index, weight)` entries
+/// for `tokens`, sorted by index. Tokens absent from `vocab` are ignored.
+/// Sorting makes the row order (and thus the downstream summation)
+/// deterministic, independent of `HashMap` iteration order.
+fn tfidf_row(tokens: &[String], vocab: &HashMap<String, usize>, idf: &[f64]) -> Vec<(usize, f64)> {
+    let mut tf: HashMap<usize, u32> = HashMap::new();
+    for token in tokens {
+        if let Some(&idx) = vocab.get(token) {
+            *tf.entry(idx).or_insert(0) += 1;
+        }
+    }
+    let mut row: Vec<(usize, f64)> = tf
+        .into_iter()
+        .map(|(idx, count)| (idx, f64::from(count) * idf[idx]))
+        .collect();
+    row.sort_unstable_by_key(|&(idx, _)| idx);
+    row
 }
 
 #[cfg(test)]
@@ -531,9 +537,11 @@ mod tests {
         //   feature_log_prob[0] = ln([3/4, 1/4]),  [1] = ln([1/4, 3/4])
         //   class_log_prior      = ln([1/2, 1/2])
         // For x = [1, 0]: jll = ln(3/8) vs ln(1/8) → softmax = [0.75, 0.25].
-        let nb = MultinomialNB::fit(&[vec![2.0, 0.0], vec![0.0, 2.0]], &[0, 1], 2);
+        // Sparse rows: class 0's sample is feature 0 = 2.0, class 1's is
+        // feature 1 = 2.0; two features total.
+        let nb = MultinomialNB::fit(&[vec![(0, 2.0)], vec![(1, 2.0)]], &[0, 1], 2, 2);
 
-        let p = nb.predict_proba(&[1.0, 0.0]);
+        let p = nb.predict_proba(&[(0, 1.0)]);
         assert!((p[0] - 0.75).abs() < 1e-9, "p[0] = {}", p[0]);
         assert!((p[1] - 0.25).abs() < 1e-9, "p[1] = {}", p[1]);
         assert!(
@@ -542,7 +550,7 @@ mod tests {
         );
 
         // The symmetric input flips the posteriors.
-        let q = nb.predict_proba(&[0.0, 1.0]);
+        let q = nb.predict_proba(&[(1, 1.0)]);
         assert!((q[0] - 0.25).abs() < 1e-9 && (q[1] - 0.75).abs() < 1e-9);
     }
 }

--- a/crates/rustledger/src/cmd/extract_cmd/suggest.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/suggest.rs
@@ -89,9 +89,9 @@ pub(super) fn apply_ml_suggestions(
         let predictions = model.predict(narration, payee);
 
         if let Some((predicted, _conf)) = predictions.into_iter().next() {
-            // `predict` returns at most one prediction with non-zero
-            // confidence; if the predicted account differs from the
-            // fallback, rewrite it.
+            // `predict` returns every category ranked by posterior
+            // (highest first); take the top one. If it differs from the
+            // fallback, rewrite the account.
             if predicted != contra.account.as_str() {
                 txn.postings[1].account = rustledger_core::Account::from(predicted);
                 stats.modified += 1;

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -95,10 +95,6 @@ criteria = "safe-to-deploy"
 version = "1.2.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.atomic-wait]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.autocfg]]
 version = "1.5.1"
 criteria = "safe-to-deploy"
@@ -161,10 +157,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bytemuck]]
 version = "1.25.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bytemuck_derive]]
-version = "1.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
@@ -251,10 +243,6 @@ criteria = "safe-to-deploy"
 version = "0.8.2"
 criteria = "safe-to-run"
 
-[[exemptions.crossbeam]]
-version = "0.8.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.crossbeam-channel]]
 version = "0.5.15"
 criteria = "safe-to-deploy"
@@ -265,10 +253,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-epoch]]
 version = "0.9.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.crossbeam-queue]]
-version = "0.3.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-utils]]
@@ -285,10 +269,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ctutils]]
 version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.defer]]
-version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.deflate64]]
@@ -327,14 +307,6 @@ criteria = "safe-to-deploy"
 version = "1.0.19"
 criteria = "safe-to-deploy"
 
-[[exemptions.dyn-stack]]
-version = "0.13.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.dyn-stack-macros]]
-version = "0.1.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.edit]]
 version = "0.1.5"
 criteria = "safe-to-deploy"
@@ -347,56 +319,12 @@ criteria = "safe-to-run"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.enum-as-inner]]
-version = "0.6.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.equator]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.equator]]
-version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.equator]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.equator-macro]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.equator-macro]]
-version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.equator-macro]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.error-code]]
 version = "3.3.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.faer]]
-version = "0.24.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.faer-traits]]
-version = "0.24.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.fastrand]]
 version = "2.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ferrolearn-bayes]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ferrolearn-core]]
-version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.find-msvc-tools]]
@@ -419,42 +347,6 @@ criteria = "safe-to-deploy"
 version = "2.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.gemm]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gemm-c32]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gemm-c64]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gemm-common]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gemm-f16]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gemm-f32]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.gemm-f64]]
-version = "0.19.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.generativity]]
-version = "1.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.generator]]
-version = "0.8.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.generic-array]]
 version = "0.14.7"
 criteria = "safe-to-deploy"
@@ -473,14 +365,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.half]]
 version = "2.7.1"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.hashbrown]]
 version = "0.14.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.hermit-abi]]
-version = "0.3.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.hmac]]
@@ -555,10 +443,6 @@ criteria = "safe-to-deploy"
 version = "1.48.0"
 criteria = "safe-to-run"
 
-[[exemptions.interpol]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.ipnet]]
 version = "2.12.0"
 criteria = "safe-to-deploy"
@@ -623,10 +507,6 @@ criteria = "safe-to-deploy"
 version = "0.16.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.loom]]
-version = "0.7.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.lsp-server]]
 version = "0.7.9"
 criteria = "safe-to-deploy"
@@ -641,10 +521,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.mach2]]
 version = "0.4.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.matrixmultiply]]
-version = "0.3.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.maybe-owned]]
@@ -679,38 +555,6 @@ criteria = "safe-to-deploy"
 version = "0.4.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.nano-gemm]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.nano-gemm-c32]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.nano-gemm-c64]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.nano-gemm-codegen]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.nano-gemm-core]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.nano-gemm-f32]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.nano-gemm-f64]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ndarray]]
-version = "0.17.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.nibble_vec]]
 version = "0.1.0"
 criteria = "safe-to-deploy"
@@ -719,20 +563,8 @@ criteria = "safe-to-deploy"
 version = "0.31.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.npyz]]
-version = "0.8.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.num-complex]]
-version = "0.4.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.num-conv]]
 version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.num_cpus]]
-version = "1.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.num_enum]]
@@ -763,28 +595,8 @@ criteria = "safe-to-deploy"
 version = "0.9.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.paste]]
-version = "1.0.10"
-criteria = "safe-to-deploy"
-
 [[exemptions.pbkdf2]]
 version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.pest]]
-version = "2.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.pest_derive]]
-version = "2.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.pest_generator]]
-version = "2.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.pest_meta]]
-version = "2.8.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.petgraph]]
@@ -831,10 +643,6 @@ criteria = "safe-to-deploy"
 version = "0.2.21"
 criteria = "safe-to-deploy"
 
-[[exemptions.private-gemm-x86]]
-version = "0.1.20"
-criteria = "safe-to-deploy"
-
 [[exemptions.proc-macro-crate]]
 version = "3.5.0"
 criteria = "safe-to-deploy"
@@ -863,24 +671,8 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.pulp]]
-version = "0.22.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.pulp-wasm-simd-flag]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.pure-rust-locales]]
 version = "0.8.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.py_literal]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.qd]]
-version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.r-efi]]
@@ -909,18 +701,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand_xoshiro]]
 version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.raw-cpuid]]
-version = "11.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rawpointer]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.reborrow]]
-version = "0.5.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
@@ -1023,10 +803,6 @@ criteria = "safe-to-deploy"
 version = "0.7.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.same-file]]
-version = "1.0.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.schemars]]
 version = "1.2.1"
 criteria = "safe-to-deploy"
@@ -1035,16 +811,8 @@ criteria = "safe-to-deploy"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.scoped-tls]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.scopeguard]]
 version = "1.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.seq-macro]]
-version = "0.3.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde-wasm-bindgen]]
@@ -1091,10 +859,6 @@ criteria = "safe-to-deploy"
 version = "1.0.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.spindle]]
-version = "0.2.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.stable_deref_trait]]
 version = "1.2.1"
 criteria = "safe-to-deploy"
@@ -1117,10 +881,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.supports-unicode]]
 version = "3.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sysctl]]
-version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
@@ -1185,10 +945,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.typenum]]
 version = "1.20.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ucd-trie]]
-version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.untrusted]]
@@ -1288,10 +1044,6 @@ version = "0.60.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
-version = "0.42.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
 version = "0.52.0"
 criteria = "safe-to-deploy"
 
@@ -1304,15 +1056,7 @@ version = "0.61.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_aarch64_msvc]]
-version = "0.42.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_aarch64_msvc]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_gnu]]
-version = "0.42.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_i686_gnu]]
@@ -1320,23 +1064,11 @@ version = "0.52.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_i686_msvc]]
-version = "0.42.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_i686_msvc]]
 version = "0.52.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_gnu]]
-version = "0.42.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_gnu]]
 version = "0.52.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows_x86_64_msvc]]
-version = "0.42.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows_x86_64_msvc]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -949,13 +949,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_aarch64_gnullvm]]
-version = "0.42.2"
-when = "2023-03-13"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_gnullvm]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -965,13 +958,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_i686_gnullvm]]
 version = "0.52.6"
 when = "2024-07-03"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnullvm]]
-version = "0.42.2"
-when = "2023-03-13"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1670,12 +1656,6 @@ criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.5.0"
 notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
 
-[[audits.bytecode-alliance.audits.hermit-abi]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.3.9 -> 0.5.2"
-notes = "API updates and looks like libc, nothing new here."
-
 [[audits.bytecode-alliance.audits.iana-time-zone-haiku]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
@@ -1839,12 +1819,6 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 version = "0.2.19"
 notes = "As advertised: a numeric library. The only `unsafe` is from some float-to-int conversions, which seems expected."
-
-[[audits.bytecode-alliance.audits.num_cpus]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "1.15.0 -> 1.16.0"
-notes = "Some minor platform updates but no major change to any code."
 
 [[audits.bytecode-alliance.audits.percent-encoding]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2070,13 +2044,6 @@ think this justifies marking this crate as `ub-risk-1`.
 
 Additional review comments can be found at https://crrev.com/c/4723145/31
 """
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.byteorder]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.5.0"
-notes = "Unsafe review in https://crrev.com/c/5838022"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.cast]]
@@ -2314,6 +2281,12 @@ criteria = "safe-to-deploy"
 delta = "1.0.19 -> 1.0.20"
 notes = "Only minor updates to documentation and the mock today used for testing."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.same-file]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "1.0.6"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.serde]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -2699,11 +2672,6 @@ delta = "0.6.4 -> 0.9.3"
 who = "J.C. Jones <jc@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.3 -> 0.9.5"
-
-[[audits.isrg.audits.rand_distr]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.3 -> 0.5.1"
 
 [[audits.isrg.audits.rayon-core]]
 who = "Ameer Ghani <inahga@divviup.org>"
@@ -3171,18 +3139,6 @@ criteria = "safe-to-deploy"
 delta = "1.0.3 -> 1.1.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.num_cpus]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.13.1 -> 1.14.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.num_cpus]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.14.0 -> 1.15.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.oorandom]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-run"
@@ -3195,12 +3151,6 @@ who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
 version = "0.2.0"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.paste]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.10 -> 1.0.15"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.percent-encoding]]
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
@@ -3237,16 +3187,6 @@ delta = "0.8.5 -> 0.8.6"
 notes = """
 Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
 feature. No new dependencies or unsafe code.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.rand_distr]]
-who = "Ben Dean-Kawamura <bdk@mozilla.com>"
-criteria = "safe-to-deploy"
-version = "0.4.3"
-notes = """
-Simple crate that extends `rand`.  It has little unsafe code and uses Miri to test it.
-As far as I can tell, it does not have any file IO or network access.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -3560,23 +3500,11 @@ delta = "0.14.2 -> 0.14.5"
 notes = "I did not thoroughly check the safety argument for fold_impl, but it at least seems to be well documented."
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
-[[audits.zcash.audits.hermit-abi]]
-who = "Daira-Emma Hopwood <daira@jacaranda.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.3 -> 0.3.9"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
 [[audits.zcash.audits.inout]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.1.3 -> 0.1.4"
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.num_cpus]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.16.0 -> 1.17.0"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.rand_xorshift]]
 who = "Sean Bowe <ewillbefull@gmail.com>"


### PR DESCRIPTION
Removes the `ferrolearn-bayes` / `ferrolearn-core` dependency (and `ndarray`) from `rustledger-ops` by vendoring the ~80-line Multinomial Naive Bayes classifier the categorizer actually needs.

### Why
The `ml` categorizer used ferrolearn for exactly two calls — `fit` and `predict_proba` — while all the real work (TF-IDF, vocabulary, IDF, tokenization, label mapping) was already hand-written here. The trigger was **ferrolearn 0.5**, which (with no changelog or release notes) swapped its math backend to the author's own NumPy clone `ferray`, pulling in **OpenBLAS + bindgen/libclang + ~22 transitive crates** — a heavyweight native dependency change in a *minor* release, to power Naive Bayes. Rather than chase that or pin 0.4 forever, drop the dependency.

### What changed
- **New `MultinomialNB` in `ml.rs`** — pure `std`, Laplace smoothing (α=1.0), numerically-stable softmax (log-sum-exp). Same semantics as the sklearn / linfa / ferrolearn implementations it replaces; existing prediction tests pass unchanged.
- **Removed `ferrolearn-bayes`, `ferrolearn-core`, `ndarray`** → `Cargo.lock` drops ~700 lines.
- **Lifted the `wasm32` gate** on the `ml` module (the native deps were its only reason), so categorization now works on every target.
- Public API (`CategorizationModel`) unchanged — `rledger extract --suggest-categories` unaffected.

### Verified on 1.96
- `rustledger-ops` tests pass (predictions still correct) · full-workspace `clippy -D warnings` clean
- `cargo check -p rustledger-ops --target wasm32-unknown-unknown` ✅ (gate lift confirmed)

Closes #1382, closes #1383 (the ferrolearn 0.5 Dependabot bumps — now moot, the dependency is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)