### PR TITLE
fix(license): use GPL-3.0-only SPDX everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ By submitting a pull request, you agree to the [Contributor License Agreement](C
 
 ## License
 
-[GPL-3.0](LICENSE)
+[GPL-3.0-only](LICENSE)
 
 **Commercial licensing available** - [contact us](https://rustledger.github.io/#contact) for proprietary license options.
 

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@rustledger/mcp-server",
       "version": "0.15.0",
-      "license": "GPL-3.0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@rustledger/wasm": "^0.15.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,7 +24,7 @@
     "rustledger"
   ],
   "author": "Rustledger Contributors",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "repository": {
     "type": "git",
     "url": "https://github.com/rustledger/rustledger"


### PR DESCRIPTION
Aligns the one stray license declaration with the rest of the repo.

`packages/mcp-server/package.json` (and its lockfile) declared the **deprecated, ambiguous** bare `GPL-3.0` SPDX identifier. Everything else — `LICENSE` (full GPLv3 text), the workspace + all 17 crates (`GPL-3.0-only`), `packaging/rpm/rustledger.spec`, both AUR PKGBUILDs, and the vscode extension — uses `GPL-3.0-only`.

- `packages/mcp-server/package.json`: `GPL-3.0` → `GPL-3.0-only`
- `packages/mcp-server/package-lock.json`: same
- `README.md`: tighten the license link label `[GPL-3.0]` → `[GPL-3.0-only]`

No license change — just the unambiguous SPDX id. (Bare `GPL-3.0` was deprecated by SPDX precisely because it doesn't disambiguate `-only` vs `-or-later`.) Surfaced while auditing the repo in response to #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)