### PR TITLE
fix(ci): add rustledger-completion to crates.io publish list

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -80,6 +80,9 @@ jobs:
           # crate path-depends on ops, so cargo publish refuses to push
           # a plugin version whose `ops` requirement isn't on crates.io
           # yet.
+          # rustledger-completion MUST come before rustledger-wasm and
+          # rustledger-lsp, which path-depend on it. (Its omission here
+          # broke the v0.16.0 crates.io publish for wasm + lsp.)
           CRATES=(
             rustledger-core
             rustledger-parser
@@ -92,6 +95,7 @@ jobs:
             rustledger-query
             rustledger-importer
             rustledger
+            rustledger-completion
             rustledger-wasm
             rustledger-ffi-wasi
             rustledger-lsp


### PR DESCRIPTION
Recovery for the v0.16.0 release. `rustledger-completion` (#1319) was missing from the `CRATES` publish array, so its 0.16.0 was never pushed and `rustledger-wasm` / `rustledger-lsp` failed crates.io publish (`failed to select a version for rustledger-completion = ^0.16.0`). The crate already exists on crates.io (0.15.0 published manually), so OIDC can push 0.16.0 once it is listed. Placed before its dependents (wasm, lsp).

After this merges, re-running Release Publish for v0.16.0 will publish completion 0.16.0 + wasm + lsp.