### PR TITLE
ci: drop obsolete Homebrew bump job (homebrew-core autobumps)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,6 @@
 # | npm (wasm)   | @rustledger/wasm                       |
 # | npm (mcp)    | @rustledger/mcp-server                 |
 # | Docker       | ghcr.io/rustledger/rustledger          |
-# | Homebrew     | homebrew-core (official)               |
 # | Scoop        | rustledger/scoop-rustledger            |
 # | COPR         | copr.fedorainfracloud.org/rustledger   |
 # | AUR          | aur.archlinux.org (rustledger*)        |
@@ -23,7 +22,6 @@
 # SECRETS REQUIRED
 # ----------------
 # - BOT_CLIENT_ID / BOT_PRIVATE_KEY: GitHub App for cross-repo dispatches (Scoop, website)
-# - HOMEBREW_GITHUB_API_TOKEN: PAT with public_repo scope for homebrew-core PRs
 # - COPR_LOGIN / COPR_TOKEN: COPR build trigger
 # - AUR_SSH_PRIVATE_KEY: SSH key for pushing to AUR (aur.archlinux.org)
 # - (crates.io and npm use OIDC trusted publishing, no tokens needed)
@@ -365,21 +363,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-  # Submit PR to homebrew-core
-  update-homebrew:
-    name: Bump Homebrew formula
-    runs-on: ubuntu-latest
-    steps:
-      - name: Bump rustledger formula in homebrew-core
-        uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
-        with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          formula: rustledger
-          tag: ${{ env.RELEASE_TAG }}
-          # If this fails with "PR already exists" on a re-run, re-run only
-          # the other jobs (`gh run rerun --failed --job <ids>`). We intentionally
-          # do NOT use continue-on-error — silently swallowing this step has
-          # masked credential and network failures in the past.
+  # NOTE: there is no Homebrew bump job. homebrew-core now autobumps
+  # rustledger by default — BrewTestBot detects each GitHub release and
+  # opens the version-bump PR itself (~every 3h). A manual
+  # `brew bump-formula-pr` is rejected for autobump formulae, so the old
+  # job only ever failed red. To opt back out, add `no_autobump!` (or a
+  # `livecheck` `skip`) to the formula in homebrew-core.
   # Update Scoop bucket
   update-scoop:
     name: Update Scoop bucket

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,7 @@ The version surface is:
   - `BuildRequires: rust >= X.Y` must match `[workspace.package].rust-version` in the root `Cargo.toml`. Since Edition 2024 stabilized in 1.85, an out-of-date pin makes COPR fail at parse time on edition2024 syntax — caught in v0.14.1 (#927) where the pin was still `1.75` long after MSRV moved to `1.95`.
 - `Cargo.lock`: refreshed by `cargo check` after the Cargo.toml edits.
 
-`packages/vscode/package.json` is *not* bumped here — the VS Code extension version is synced from the release tag at build time. The AUR `PKGBUILD`s under `packaging/arch/` also don't need manual edits — `release-publish.yml` `sed`-bumps them at release time. The Homebrew formula at `packaging/homebrew/rustledger.rb` is bumped automatically by `dawidd6/action-homebrew-bump-formula` during release-publish.
+`packages/vscode/package.json` is *not* bumped here — the VS Code extension version is synced from the release tag at build time. The AUR `PKGBUILD`s under `packaging/arch/` also don't need manual edits — `release-publish.yml` `sed`-bumps them at release time. The Homebrew formula needs no action either — homebrew-core **autobumps** rustledger: BrewTestBot detects each GitHub release and opens the version-bump PR itself (~every 3 hours).
 
 ### 3. Pre-flight smoke check
 
@@ -90,7 +90,7 @@ gh release create v0.14.0 --target "$(git rev-parse HEAD)" --generate-notes
 This creates the `v0.14.0` tag and triggers two workflows:
 
 - `release-build.yml` — builds binaries for all 8 platforms, the WASM package, the FFI-WASI binary, and the VS Code extension; attaches them to the release.
-- `release-publish.yml` — distributes to crates.io, npm, Docker, Homebrew, Scoop, COPR, AUR.
+- `release-publish.yml` — distributes to crates.io, npm, Docker, Scoop, COPR, AUR (Homebrew autobumps separately).
 
 The full release takes ~30–45 minutes.
 
@@ -154,7 +154,7 @@ Trusted-publish tokens are publish-scoped only — they cannot run `npm dist-tag
 | File | Purpose |
 |------|---------|
 | `release-build.yml` | Builds binaries, WASM, FFI-WASI, VSCode extension; attaches to GitHub Release |
-| `release-publish.yml` | Distributes to crates.io, npm, Docker, Homebrew, Scoop, COPR, AUR |
+| `release-publish.yml` | Distributes to crates.io, npm, Docker, Scoop, COPR, AUR (Homebrew autobumps separately) |
 
 ## Adding a new workspace crate
 
@@ -195,15 +195,15 @@ gh run view <release-publish-run-id> --json jobs --jq '.jobs[] | select(.conclus
 gh run rerun --failed --job=<job-id>
 ```
 
-### `Bump Homebrew formula` exits 1 with "Whoops, the rustledger formula has its version update"
+### Homebrew formula didn't update
 
-Misleading error from `dawidd6/action-homebrew-bump-formula` — it fires when the formula in `homebrew-core` master is **already** at the target version (typically because a prior re-run of release-publish merged the bump PR). Verify with:
+There's nothing to do — homebrew-core **autobumps** rustledger. BrewTestBot detects each GitHub release and opens the `rustledger <version>` PR itself (~every 3 hours); it merges after Homebrew CI passes. Check progress:
 
 ```bash
-curl -s https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/r/rustledger.rb | grep -E '^\s*url\s+"'
+gh search prs --repo Homebrew/homebrew-core "rustledger" --json title,state,url
 ```
 
-If the URL is at the target version, the failure is a no-op and can be ignored.
+(There is no Homebrew job in `release-publish.yml` — a manual `brew bump-formula-pr` is rejected for autobump formulae. To opt out of autobump, add `no_autobump!` or a `livecheck`/`skip` to the formula.)
 
 ### Need to redrive `Release Publish` after a workflow fix
 


### PR DESCRIPTION
The `Bump Homebrew formula` job in `release-publish.yml` is obsolete and fails red on every release for no reason.

**Why:** homebrew-core now **autobumps** rustledger by default — BrewTestBot detects each GitHub release and opens the version-bump PR itself (it already opened the open [`rustledger 0.16.0`](https://github.com/Homebrew/homebrew-core/pulls?q=rustledger) PR). A manual `brew bump-formula-pr` is *rejected* for autobump formulae, so the job errored out with "Whoops, the rustledger formula has its version update pull requests automatically opened by BrewTestBot…" while BrewTestBot did the real work in parallel. This has been redundant since ≥0.15.0.

**Changes:**
- Remove the `update-homebrew` job and the `HOMEBREW_GITHUB_API_TOKEN` secret note from `release-publish.yml` (replaced with an explanatory comment).
- `RELEASING.md`: drop Homebrew from the workflow's distribution list and replace the obsolete troubleshooting entry with an autobump note.

To opt back *out* of autobump (and resume manual bumps), add `no_autobump!` or a `livecheck`/`skip` to the formula in homebrew-core.

Surfaced during the v0.16.0 release. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)