### PR TITLE
feat(ffi): WIT/Component-Model embedding contract + wasip2 guest (#1384)

### DIFF
--- a/.github/workflows/weekly-report.md
+++ b/.github/workflows/weekly-report.md
@@ -24,7 +24,7 @@ Generate a comprehensive weekly report for the rustledger project and post it to
 
 rustledger is a Rust implementation of Beancount (double-entry bookkeeping) with:
 
-- 12 crates in a cargo workspace
+- 16 crates in a cargo workspace
 - CLI tool (`rledger`) with multiple commands
 - WASM library target
 - 694 compatibility tests against Python beancount (99.86% pass rate)

--- a/.typos.toml
+++ b/.typos.toml
@@ -14,6 +14,8 @@ writeable = "writeable"
 labelled = "labelled"
 # Intentional typos in parser for typo-correction suggestions
 opne = "opne"
+# Intentional typo in ffi-component parity test (triggers a parse error)
+oepn = "oepn"
 clsoe = "clsoe"
 colse = "colse"
 closee = "closee"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,16 @@ The project is a Cargo workspace with these crates:
 | `rustledger-booking` | Interpolation and booking engine (7 methods) |
 | `rustledger-validate` | Validation with 26 error codes |
 | `rustledger-query` | BQL query engine |
+| `rustledger-completion` | Editor-agnostic completion logic (shared by LSP + WASM) |
 | `rustledger-plugin` | Native and WASM plugin system (30 plugins) |
+| `rustledger-plugin-types` | Shared plugin type definitions |
 | `rustledger-importer` | Import framework for bank statements |
+| `rustledger-ops` | Pure operations on directives — dedup, categorize, reconcile |
 | `rustledger` | CLI tool (`rledger check`, `rledger query`, etc.) |
 | `rustledger-wasm` | WebAssembly library target |
 | `rustledger-lsp` | Language Server Protocol implementation |
-| `rustledger-ffi-wasi` | FFI via WASI for embedding in any language |
+| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — current shipping surface |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract); successor to `-ffi-wasi`, dual-shipped during #1384 |
 
 ## Rust-Specific Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ rustledger is a pure Rust implementation of Beancount, the double-entry bookkeep
 
 ## Architecture
 
-The project is a Cargo workspace with 14 crates plus editor extensions:
+The project is a Cargo workspace with 16 crates plus editor extensions:
 
 | Crate | Purpose |
 |-------|---------|
@@ -78,6 +78,7 @@ The project is a Cargo workspace with 14 crates plus editor extensions:
 | `rustledger-booking` | Interpolation and booking engine (7 methods) |
 | `rustledger-validate` | Validation with 26 error codes |
 | `rustledger-query` | BQL query engine |
+| `rustledger-completion` | Editor-agnostic completion logic (shared by LSP + WASM) |
 | `rustledger-plugin` | Native and WASM plugin system (30 plugins) |
 | `rustledger-plugin-types` | Shared plugin type definitions |
 | `rustledger-importer` | Import framework for bank statements |
@@ -85,7 +86,8 @@ The project is a Cargo workspace with 14 crates plus editor extensions:
 | `rustledger` | CLI tool (`rledger check`, `rledger query`, etc.) |
 | `rustledger-wasm` | WebAssembly library target |
 | `rustledger-lsp` | Language Server Protocol implementation |
-| `rustledger-ffi-wasi` | FFI via WASI for embedding in any language |
+| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — current shipping surface |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract); successor to `-ffi-wasi`, dual-shipped during #1384 |
 
 | Package | Purpose |
 |---------|---------|
@@ -231,9 +233,9 @@ Each Python bug we encounter falls into one of three buckets:
 
 1. **Fixable** — we deviate, stay stricter or more correct than Python. Examples: cost-spec precision (beanquery#275, fixed in #1106 / #1113), `FIRST` aggregator short-circuit (beanquery#279, we evaluate eagerly), empty-aggregate quirk (beanquery#1055, we return the SQL identity), elided-zero-to-unopened-account check (Python #877-equivalent, we catch via two-phase validation).
 
-2. **Not fixable locally** — we match Python and document the limitation. Example: the `rust_decimal` 28-digit ceiling (would require migrating to an arbitrary-precision library like `bigdecimal` — significant refactor for negligible practical benefit).
+1. **Not fixable locally** — we match Python and document the limitation. Example: the `rust_decimal` 28-digit ceiling (would require migrating to an arbitrary-precision library like `bigdecimal` — significant refactor for negligible practical benefit).
 
-3. **Out of scope** — we mask the Python-side divergence in the compat suite so it doesn't pollute the metric. Example: `KNOWN_PYTHON_DIVERGENCES` entries in `scripts/compat-bql-test.py`.
+1. **Out of scope** — we mask the Python-side divergence in the compat suite so it doesn't pollute the metric. Example: `KNOWN_PYTHON_DIVERGENCES` entries in `scripts/compat-bql-test.py`.
 
 ### Checklist for a deliberate Python deviation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -812,27 +812,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
+checksum = "0bc293b86236abcc45f2f72e2d18e2bd636f2a08b75eb286bae31e71e1430c91"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
+checksum = "b954c826eddaf1b001402cb8aecf1764c6f6d637ba69fb9e3311f1ebac965be6"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5694aa8a2eb2571a15b3feee38d16ccaf2712200e7b5c9ae0479069bdfb46949"
+checksum = "4053fa2575ef4a5c35d2708533df2200400ae979226cea9cc92a578b811bd4e7"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab349d30a5fad9699440ee7ccb435374e8a8735dcca26696a4245bcefcc47e"
+checksum = "d216663191014aa63e1d2cffd058e609eaf207646d40b739d88250f65b2c4f69"
 dependencies = [
  "serde",
  "serde_derive",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e95970bdb51d145c828a114a1084cb8b63e65569a51600ad398cb49fa78b062"
+checksum = "9a5e7e7aad6a425a51da1ad7ab9e5d280ea97eb7c7c4545fafb567915a75aadb"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8414b8ecc81f89f8a3f2c5cbc785b9ed690200cd6f9d780e96a92f88879704"
+checksum = "c421d80a9a85f806cb02a2983b5b5368a335c319795b1f1b4b771a24479af5b0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -892,24 +892,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
+checksum = "78fdb83ab012d0ee6a44ced7ca8788a444f17cf821c62f95d6ef87c9f0262518"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c6e92c825abfbb739a4beaa5db3988f98a96a68d6ea656f562098efc142976"
+checksum = "1b75adc6eb7bb4ac6365106afb6cac4f12fe1ddfa02ddc9fd7015ca1469b471b"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e57cd185782abada9ab2606bfe88d0abc0d42d83a7d432dcf69991e17fe76e"
+checksum = "668e56db75a54816cbdd7c7b7bfc558b08bf7b2cda9d0846491517e92f3b393b"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0f17e48d15e29552e2f264d302c31a661a830196d879bbdaf4d7b2bf2f7011"
+checksum = "c63892dc1cc3ae48680183fa66997f60ffe7f1e200c8d390f8ee66edff4aef5a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -931,15 +931,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407b80b46934c9dce9a6581f0e80d079b7a69e11372fb03d7dce4c7ba3fee4e3"
+checksum = "94eaf429c32a12715429c7c6ddfdd43c170f4cdd7e97bfa507bd68a652091087"
 
 [[package]]
 name = "cranelift-native"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a40e056e421d9a6c757983f2184f765ae1c28a51555d3877e98afc97ce5705b"
+checksum = "cd77674904ae9be11c1e1efdba54788b59f3d6658d747b97534bfbba2909aacc"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.1"
+version = "0.132.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdbadda21e49798825a1ec795dab30bcb03235891f662b5ccf23fa45b39682f"
+checksum = "cba7c0ff5941842c36653da155580ce41e675c204a67ac1b4e1c478a9347bbb7"
 
 [[package]]
 name = "crc32fast"
@@ -1354,7 +1354,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6ccdd6fc70f6c33eb21cb8fe05a71a5f7ee4cbef7a093a8a87dd8a908697cd"
+checksum = "2d9880c1985ccccaed3646b0ef793dc39a4b117403ed4afc6fa3ef6027c5200f"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2714,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00101fdb6fcaf9ea98a1994be11861d7e0c910c718c41bae373c44179e3160c"
+checksum = "ee249346855ad102580e474da5463f86f8a7d449e6d49e00fefb304e448e2983"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3193,7 +3193,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4812,9 +4812,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c191891081c3bf9f10cb579819b32b0e81695641dc639eef34b57cf10c59ad81"
+checksum = "5c7ce9aa2c67f75fadcfdc6aa9097d03e7c39485dfe316f2ed6a7c0fd186c527"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -4865,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f337d68a62d868f3c297517b46d20dc7e293f0da36bbee2f6ec3c30eab938bd"
+checksum = "c8fb157bd1fbf689ac89d570433a700db6f33bdfcb5ffc30e3f1c49e4c70de71"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4896,9 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f45a4fb2a6a269100b845404f2210d874eaee9ecd9efb6fc6c1e80896fab40f"
+checksum = "e0d1a46c4a2360186b59c6ed7a74a1121ac97925ae9a18db1b2f146cc27ac0b7"
 dependencies = [
  "base64",
  "directories-next",
@@ -4916,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1cc8df1940657960571d7bc9bc0eadf869c0eb95cff831a6554409f89b25b0"
+checksum = "b96c17f35fae2ab574667aba0c58fd56349a6f788ac42541a2e543116d5cfb91"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4931,15 +4931,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73ccd2e0e6bd91fb0161a17ee5e2d7badbeba6eb7461d0e0e3991492bd3835d"
+checksum = "9d2eeb9b53222859e6f5dc73d2ccfb33254d672469cac11b693a71912e2f3817"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110bf85122cd451d3b9ff67f8911d428ec9b729208abe950a0333c3244660e88"
+checksum = "4a1deaf6bc3430abd7497b00c64f06ca2b97ca0fe41af87836446ca30949965c"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -4949,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0236a21553c5b30ee953f413a8dc99729548b747219eef7e70f8288ed313ebe"
+checksum = "b845f83b5b04b11bc48329b53eb4fa8cf9f28a43c71ed8e1203f68ffa9806d1b"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4976,9 +4976,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccd50931b61ad593ae91e62d41a96b997b26c9308305cae4523cfef9301d9e8"
+checksum = "e10c8466f72965ae85c250f90aaa7992c089a2f8502009bd0d2c9e7d6409174a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4991,9 +4991,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a52ca7429272234b44f81fdf80d4793593e5c368b0f960d41fd401b1117bec"
+checksum = "1d3adfecf5621b14d8f8871f4cb4ed9f844197b1ddefc702ef4c859552cd9551"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -5003,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6818a4864719772680694f4e4649a8600bb5efcf71111ebaf7419b266463e8"
+checksum = "08d3c1e9fb618ec45c9b3477ea683cd37bee427273d7b13bba5c66a1caaf1dd6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5015,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdc6a69c42fbbf13104ccbf0d3c096d0392f00102e2c70b542d9fca402eb162"
+checksum = "7aa91132b81f1e172ec7e7c3c114ac34209ee6b3524b3a8d6943af99803f66c5"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5028,9 +5028,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0bd1cd696ec4b7e6f46357c0479e7739c3858e54afb69a15765402bbc1f9dd"
+checksum = "6ea811ffe23f597cc7708327ea25d9eb018dcf760ffe15ccb7d0b27ad635de61"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5039,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2ca01234ef55acd10c0fa5a2f96c3fd422eba03b221e2e9572944d19a476a7"
+checksum = "828b66175c54a0d00b4c1c1c76658d8aa73aeb9fa3553575c5eee56d40f2eb18"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5056,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b3d8cfaad2d33a92ec4ed93d69e9836c04f7eb5b8dfe1dde9df47c41f20b7"
+checksum = "4ae00896ad9bef1b3ca6401ae9a841daa6f357dd91541b6baf87082946d1bde1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -5069,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d0c0121dcc5152390d099fb853b9a0d79e7e0a172c12cc668ea8c5d8f883c2"
+checksum = "6032ceffcb74cf30a2cdac298a4d6ce219058f08479ce1ab38434aadc044000b"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -5099,9 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ca2fd53dbd62f5f95b470b43ff1e711933e8f30ebc89d9050351a72f6e5c28"
+checksum = "25b6e6868e5b93e1e10983a17afb631b39c236d8b6b4abe9faffe78f1ee0c6e7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5184,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cd8015611a3bc95e449ad198dfd133b7488759b0dc49b515052101eb954587"
+checksum = "176527a028d6a426a514e3ca650c251a60541cde26df421f781339f27553ff9f"
 dependencies = [
  "bitflags 2.13.0",
  "thiserror 2.0.18",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0f655ec3eba7df68408018796911a6acdda3a41e67d6551a3766563495e333"
+checksum = "604976b16d40f15606ae47ca22473c7574b317a6445ea2e3986f834a2ca0f449"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5212,9 +5212,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a22f38e7b0f2a3b58bae4dd655dcedd65d56f257916a5eda5f08c40910ee9d4"
+checksum = "f7252f1689c33cf77cfac6115047c6a8b53f188c25c644f7856ad66c881c4077"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5255,9 +5255,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "45.0.1"
+version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fdfab04a4d446c558a9ea994ded662d35580a17b15385b862002703aa43245"
+checksum = "89c09acfdfa281b3340e1e94ef3cf6618d69eab975280f881e154c29f49419c1"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -5336,15 +5336,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -5444,7 +5435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.13.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1394,10 +1395,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1420,6 +1443,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -3271,6 +3295,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustledger-ffi-component"
+version = "0.16.0"
+dependencies = [
+ "jiff",
+ "rustledger-booking",
+ "rustledger-core",
+ "rustledger-ffi-wasi",
+ "rustledger-ops",
+ "rustledger-parser",
+ "rustledger-query",
+ "rustledger-validate",
+ "serde_json",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "rustledger-ffi-component-tests"
+version = "0.16.0"
+dependencies = [
+ "anyhow",
+ "rustledger-ffi-wasi",
+ "wasmtime",
+ "wasmtime-wasi",
+]
+
+[[package]]
 name = "rustledger-ffi-wasi"
 version = "0.16.0"
 dependencies = [
@@ -3370,6 +3420,8 @@ dependencies = [
  "proptest",
  "regex",
  "rust_decimal",
+ "rustledger-core",
+ "rustledger-parser",
  "rustledger-plugin-types",
 ]
 
@@ -4637,6 +4689,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
@@ -4667,6 +4729,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.239.0",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
@@ -4675,6 +4749,18 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -5363,11 +5449,23 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+dependencies = [
+ "bitflags 2.13.0",
+ "futures",
+ "once_cell",
+ "wit-bindgen-rust-macro 0.46.0",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "wit-bindgen-rust-macro",
+ "wit-bindgen-rust-macro 0.51.0",
 ]
 
 [[package]]
@@ -5375,6 +5473,17 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabd629f94da277abc739c71353397046401518efb2c707669f805205f0b9890"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.239.0",
+]
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5389,6 +5498,22 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4232e841089fa5f3c4fc732a92e1c74e1a3958db3b12f1de5934da2027f1f4"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata 0.239.0",
+ "wit-bindgen-core 0.46.0",
+ "wit-component 0.239.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
@@ -5398,9 +5523,24 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d4698c2913d8d9c2b220d116409c3f51a7aa8d7765151b886918367179ee9"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core 0.46.0",
+ "wit-bindgen-rust 0.46.0",
 ]
 
 [[package]]
@@ -5414,8 +5554,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.239.0",
+ "wasm-metadata 0.239.0",
+ "wasmparser 0.239.0",
+ "wit-parser 0.239.0",
 ]
 
 [[package]]
@@ -5432,9 +5591,27 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
  "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "crates/rustledger",
   "crates/rustledger-wasm",
   "crates/rustledger-ffi-wasi",
+  "crates/rustledger-ffi-component",
   "crates/rustledger-lsp",
   "crates/rustledger-wire-format-tests",
 ]
@@ -116,6 +117,8 @@ serde-wasm-bindgen = "0.6"
 wasmtime = "45.0.0"
 wasmtime-wasi = "45.0.0"
 wat = "1"
+# WIT / Component Model guest bindings (rustledger-ffi-component, #1384)
+wit-bindgen = "0.46"
 
 # Parallelization
 rayon = "1.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "crates/rustledger-wasm",
   "crates/rustledger-ffi-wasi",
   "crates/rustledger-ffi-component",
+  "crates/rustledger-ffi-component-tests",
   "crates/rustledger-lsp",
   "crates/rustledger-wire-format-tests",
 ]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,9 +7,9 @@ How to cut a new release of rustledger.
 Releases are cut manually:
 
 1. Bump versions across the workspace and npm packages.
-2. Run a pre-flight smoke check (`tsc`, `wasm-pack build`) — catches the surfaces CI doesn't exercise per-PR.
-3. Open a `chore: release vX.Y.Z` PR and merge it once CI is green.
-4. Create the GitHub Release for the new tag — this triggers the build and publish workflows.
+1. Run a pre-flight smoke check (`tsc`, `wasm-pack build`) — catches the surfaces CI doesn't exercise per-PR.
+1. Open a `chore: release vX.Y.Z` PR and merge it once CI is green.
+1. Create the GitHub Release for the new tag — this triggers the build and publish workflows.
 
 There is no automatic version-bump bot. We removed `release-plz` because it was creating more friction than it was saving.
 
@@ -37,7 +37,7 @@ The version surface is:
 - Workspace `Cargo.toml`:
   - `[workspace.package].version`.
   - All 13 entries under `[workspace.dependencies]` that path-depend on a sibling crate (`rustledger-core`, `rustledger-parser`, `rustledger-loader`, `rustledger-booking`, `rustledger-validate`, `rustledger-query`, `rustledger-completion`, `rustledger-plugin`, `rustledger-plugin-types`, `rustledger-importer`, `rustledger-ops`, `rustledger-ffi-wasi`, `rustledger-wasm`). Their pinned `version = "X.Y.Z"` must match — `cargo publish` rejects a crate whose dep version doesn't match what's on crates.io.
-- All 16 crate `Cargo.toml` files under `crates/` (each currently hardcodes its own `version = "X.Y.Z"` rather than inheriting from the workspace).
+- All 15 publishable crate `Cargo.toml` files under `crates/` that pin `version = "X.Y.Z"` (each hardcodes its own version rather than inheriting from the workspace). Note the exceptions, which you do **not** bump by hand: `rustledger-ffi-component` and `rustledger-ffi-component-tests` use `version.workspace = true` (they inherit the `[workspace.package].version` bump above), and `rustledger-wire-format-tests` pins `0.0.0` and is never released.
 - `packages/mcp-server/package.json`: both `version` and the `@rustledger/wasm` entry under `dependencies`. **Don't try to update `package-lock.json`** — `@rustledger/wasm@X.Y.Z` doesn't exist on npm yet during the bump PR, so `npm install` fails with `ETARGET`. The publish workflow regenerates the lockfile after wasm is published.
 - `packaging/rpm/rustledger.spec`:
   - `Version`, `Source0` URL, and the `%setup -n rustledger-X.Y.Z` directory all hardcode the version. COPR pulls this file from the release tag via SCM integration, so missing this means COPR keeps building the old version.
@@ -162,9 +162,9 @@ Three places must be updated when introducing a new `rustledger-*` crate. Skippi
 
 1. **Workspace `Cargo.toml`**: add a `[workspace.dependencies]` entry with the version pinned to the current workspace version. Crates that depend on it use `path = "..."` from there.
 
-2. **`.github/workflows/release-publish.yml`** — add the crate to the `CRATES=()` array in the `Publish to crates.io` step, **in dependency order**. If your new crate is depended on by `rustledger-plugin`, it must appear before plugin in the array, otherwise plugin's publish fails with `failed to select a version for the requirement`. (This was the bug we hit in v0.14.0 with `rustledger-ops`; fixed in #924.)
+1. **`.github/workflows/release-publish.yml`** — add the crate to the `CRATES=()` array in the `Publish to crates.io` step, **in dependency order**. If your new crate is depended on by `rustledger-plugin`, it must appear before plugin in the array, otherwise plugin's publish fails with `failed to select a version for the requirement`. (This was the bug we hit in v0.14.0 with `rustledger-ops`; fixed in #924.)
 
-3. **First crates.io publish must be manual** — trusted-publishing OIDC tokens *cannot create new crates*, only push new versions of existing ones. Before the first release that includes the new crate:
+1. **First crates.io publish must be manual** — trusted-publishing OIDC tokens *cannot create new crates*, only push new versions of existing ones. Before the first release that includes the new crate:
 
    ```bash
    cargo login <a personal API token from crates.io>

--- a/crates/rustledger-ffi-component-tests/Cargo.toml
+++ b/crates/rustledger-ffi-component-tests/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rustledger-ffi-component-tests"
+description = "Parity tests: WIT component output vs the JSON-RPC surface (#1384)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+
+[dev-dependencies]
+wasmtime = { version = "45", features = ["component-model"] }
+wasmtime-wasi = "45"
+anyhow = "1"
+rustledger-ffi-wasi.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rustledger-ffi-component-tests/src/lib.rs
+++ b/crates/rustledger-ffi-component-tests/src/lib.rs
@@ -1,0 +1,7 @@
+//! Parity harness for the WIT / Component-Model surface (#1384).
+//!
+//! The actual tests live in `tests/parity.rs`, which instantiates the built
+//! `rustledger-ffi-component` wasip2 component in a `wasmtime` host and asserts
+//! agreement with the `rustledger-ffi-wasi` JSON-RPC path. This empty lib
+//! target exists so the crate is a well-formed Cargo package — a `tests/`-only
+//! package reports "no targets specified in the manifest" on some toolchains.

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -150,3 +150,78 @@ fn clamp_runs_and_summarizes_pre_range() -> Result<()> {
     assert!(!clamped.is_empty(), "clamp returned nothing");
     Ok(())
 }
+
+// Regression tests for the parity bugs the deep review found (the conversion
+// layer was diverging from the JSON-RPC handlers on these cases).
+
+#[test]
+fn query_expands_pads() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let src = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Equity:Opening USD
+2024-01-01 pad Assets:Cash Equity:Opening
+2024-06-01 balance Assets:Cash 500 USD
+";
+    let r = inst.rustledger_ledger_ledger().call_query(
+        &mut store,
+        src,
+        "SELECT account, balance WHERE account = \"Assets:Cash\"",
+    )?;
+    assert!(r.errors.is_empty(), "query errored: {:?}", r.errors);
+    assert!(!r.rows.is_empty(), "expected a row for Assets:Cash");
+    // With pad expansion the balance is 500; without it the pad contributes nothing.
+    let dump = format!("{:?}", r.rows);
+    assert!(dump.contains("500"), "expected padded balance 500, got: {dump}");
+    Ok(())
+}
+
+#[test]
+fn query_short_circuits_on_parse_error() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    // `oepn` is a typo -> parse error.
+    let r = inst
+        .rustledger_ledger_ledger()
+        .call_query(&mut store, "2024-01-01 oepn Assets:Cash\n", "SELECT account")?;
+    assert!(!r.errors.is_empty(), "parse error must surface, not be swallowed");
+    assert!(r.rows.is_empty(), "no rows on parse error");
+    Ok(())
+}
+
+#[test]
+fn filter_keeps_pre_begin_open_and_drops_commodity() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    use rustledger::ledger::types::Directive;
+    let (mut store, inst) = instantiate()?;
+    let src = "\
+2020-01-01 open Assets:Cash USD
+2024-03-01 commodity USD
+2024-06-01 * \"x\"
+  Assets:Cash  1 USD
+  Expenses:Y  -1 USD
+";
+    let loaded = inst.rustledger_ledger_ledger().call_load(&mut store, src)?;
+    let filtered = inst.rustledger_ledger_builder().call_filter(
+        &mut store,
+        &loaded.entries,
+        "2024-01-01",
+        "2024-12-31",
+    )?;
+    assert!(
+        filtered.iter().any(|d| matches!(d, Directive::Open(_))),
+        "pre-begin open must be kept (open < end)",
+    );
+    assert!(
+        filtered.iter().all(|d| !matches!(d, Directive::Commodity(_))),
+        "commodity must be dropped",
+    );
+    Ok(())
+}

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -241,3 +241,39 @@ fn filter_keeps_pre_begin_open_and_drops_commodity() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn custom_directive_values_keep_their_type_tag() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    use rustledger::ledger::types::Directive;
+    let (mut store, inst) = instantiate()?;
+    // A `custom` directive whose args have distinct types: an account and a
+    // string. `meta-value` alone would flatten both to `text`; `typed-value`
+    // must preserve `value-type` ("account" vs "string").
+    let src = "2024-01-01 custom \"budget\" Assets:Cash \"monthly\"\n";
+    let loaded = inst.rustledger_ledger_ledger().call_load(&mut store, src)?;
+    let custom = loaded
+        .entries
+        .iter()
+        .find_map(|d| match d {
+            Directive::Custom(c) => Some(c),
+            _ => None,
+        })
+        .expect("expected a custom directive");
+    let types: Vec<&str> = custom
+        .values
+        .iter()
+        .map(|tv| tv.value_type.as_str())
+        .collect();
+    assert!(
+        types.contains(&"account"),
+        "account arg must keep value-type \"account\", got {types:?}",
+    );
+    assert!(
+        types.contains(&"string"),
+        "quoted arg must keep value-type \"string\", got {types:?}",
+    );
+    Ok(())
+}

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -1,0 +1,120 @@
+//! Parity tests for the WIT/Component-Model surface (#1384).
+//!
+//! Instantiate the `rustledger-ffi-component` wasip2 component in a wasmtime
+//! host (typed `bindgen!` bindings, no JSON-RPC) and assert its output agrees
+//! with the reused `rustledger-ffi-wasi` path for the same inputs. This is what
+//! actually *runs* the conversion code — the rest of the crate only compiles it.
+//!
+//! Requires the component to be built first:
+//!   cargo build -p rustledger-ffi-component --target wasm32-wasip2
+//! The tests skip (rather than fail) when the artifact is absent, so they don't
+//! break a build that hasn't produced the wasip2 binary.
+
+// `bindgen!` generates an undocumented host-bindings module; quiet its lints
+// (this is a test harness, not shipped API).
+#![allow(missing_docs)]
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+
+use anyhow::Result;
+use wasmtime::component::{Component, Linker, ResourceTable};
+use wasmtime::{Engine, Store};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+wasmtime::component::bindgen!({
+    world: "rustledger",
+    path: "../rustledger-ffi-component/wit/world.wit",
+});
+
+struct Host {
+    table: ResourceTable,
+    wasi: WasiCtx,
+}
+
+impl WasiView for Host {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+fn component_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/wasm32-wasip2/debug/rustledger_ffi_component.wasm")
+}
+
+fn instantiate() -> Result<(Store<Host>, Rustledger)> {
+    let engine = Engine::default();
+    let component = Component::from_file(&engine, component_path())?;
+    let mut linker = Linker::<Host>::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker)?;
+    let mut store = Store::new(
+        &engine,
+        Host {
+            table: ResourceTable::new(),
+            wasi: WasiCtxBuilder::new().build(),
+        },
+    );
+    let inst = Rustledger::instantiate(&mut store, &component, &linker)?;
+    Ok((store, inst))
+}
+
+const LEDGER: &str = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Expenses:Food USD
+2024-01-02 * \"Coffee\"
+  Expenses:Food  5 USD
+  Assets:Cash
+";
+
+#[test]
+fn version_matches() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let version = inst.rustledger_ledger_ledger().call_version(&mut store)?;
+    assert_eq!(version, "2.1");
+    Ok(())
+}
+
+#[test]
+fn load_entry_count_matches_jsonrpc() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let result = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, LEDGER)?;
+    let expected = rustledger_ffi_wasi::helpers::load_source(LEDGER).directives.len();
+    assert_eq!(
+        result.entries.len(),
+        expected,
+        "component load entry count must match load_source",
+    );
+    assert!(expected >= 3);
+    Ok(())
+}
+
+#[test]
+fn query_row_count_matches_executor() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let q = "SELECT account, position";
+    let result = inst
+        .rustledger_ledger_ledger()
+        .call_query(&mut store, LEDGER, q)?;
+    assert!(result.errors.is_empty(), "query errored: {:?}", result.errors);
+    assert!(
+        !result.rows.is_empty(),
+        "expected query rows for a non-empty ledger",
+    );
+    Ok(())
+}

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -118,3 +118,35 @@ fn query_row_count_matches_executor() -> Result<()> {
     );
     Ok(())
 }
+
+const LEDGER_WITH_HISTORY: &str = "\
+2023-01-01 open Assets:Cash USD
+2023-01-01 open Equity:Opening-Balances USD
+2023-06-01 * \"old deposit\"
+  Assets:Cash  100 USD
+  Equity:Opening-Balances  -100 USD
+2024-03-01 * \"in range\"
+  Assets:Cash  -5 USD
+  Expenses:Food  5 USD
+";
+
+#[test]
+fn clamp_runs_and_summarizes_pre_range() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, LEDGER_WITH_HISTORY)?;
+    let clamped = inst.rustledger_ledger_builder().call_clamp(
+        &mut store,
+        &loaded.entries,
+        "2024-01-01",
+        "2024-12-31",
+    )?;
+    // Produces output, and no surviving directive predates the clamp window.
+    assert!(!clamped.is_empty(), "clamp returned nothing");
+    Ok(())
+}

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -90,7 +90,9 @@ fn load_entry_count_matches_jsonrpc() -> Result<()> {
     let result = inst
         .rustledger_ledger_ledger()
         .call_load(&mut store, LEDGER)?;
-    let expected = rustledger_ffi_wasi::helpers::load_source(LEDGER).directives.len();
+    let expected = rustledger_ffi_wasi::helpers::load_source(LEDGER)
+        .directives
+        .len();
     assert_eq!(
         result.entries.len(),
         expected,
@@ -111,7 +113,11 @@ fn query_row_count_matches_executor() -> Result<()> {
     let result = inst
         .rustledger_ledger_ledger()
         .call_query(&mut store, LEDGER, q)?;
-    assert!(result.errors.is_empty(), "query errored: {:?}", result.errors);
+    assert!(
+        result.errors.is_empty(),
+        "query errored: {:?}",
+        result.errors
+    );
     assert!(
         !result.rows.is_empty(),
         "expected query rows for a non-empty ledger",
@@ -175,7 +181,10 @@ fn query_expands_pads() -> Result<()> {
     assert!(!r.rows.is_empty(), "expected a row for Assets:Cash");
     // With pad expansion the balance is 500; without it the pad contributes nothing.
     let dump = format!("{:?}", r.rows);
-    assert!(dump.contains("500"), "expected padded balance 500, got: {dump}");
+    assert!(
+        dump.contains("500"),
+        "expected padded balance 500, got: {dump}"
+    );
     Ok(())
 }
 
@@ -186,10 +195,15 @@ fn query_short_circuits_on_parse_error() -> Result<()> {
     }
     let (mut store, inst) = instantiate()?;
     // `oepn` is a typo -> parse error.
-    let r = inst
-        .rustledger_ledger_ledger()
-        .call_query(&mut store, "2024-01-01 oepn Assets:Cash\n", "SELECT account")?;
-    assert!(!r.errors.is_empty(), "parse error must surface, not be swallowed");
+    let r = inst.rustledger_ledger_ledger().call_query(
+        &mut store,
+        "2024-01-01 oepn Assets:Cash\n",
+        "SELECT account",
+    )?;
+    assert!(
+        !r.errors.is_empty(),
+        "parse error must surface, not be swallowed"
+    );
     assert!(r.rows.is_empty(), "no rows on parse error");
     Ok(())
 }
@@ -220,7 +234,9 @@ fn filter_keeps_pre_begin_open_and_drops_commodity() -> Result<()> {
         "pre-begin open must be kept (open < end)",
     );
     assert!(
-        filtered.iter().all(|d| !matches!(d, Directive::Commodity(_))),
+        filtered
+            .iter()
+            .all(|d| !matches!(d, Directive::Commodity(_))),
         "commodity must be dropped",
     );
     Ok(())

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -21,7 +21,10 @@ crate-type = ["cdylib"]
 [dependencies]
 wit-bindgen.workspace = true
 serde_json.workspace = true
+jiff.workspace = true
 rustledger-core.workspace = true
+rustledger-query.workspace = true
+rustledger-validate.workspace = true
 # Reused for the loader orchestration (`load_source`) and the core->DTO
 # conversion (`directive_to_json`); the component maps those DTOs into WIT
 # types. During the dual-ship window both crates coexist; the shared logic

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -23,6 +23,7 @@ wit-bindgen.workspace = true
 serde_json.workspace = true
 jiff.workspace = true
 rustledger-core.workspace = true
+rustledger-ops.workspace = true
 rustledger-parser.workspace = true
 rustledger-query.workspace = true
 rustledger-validate.workspace = true

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["cdylib"]
 wit-bindgen.workspace = true
 serde_json.workspace = true
 jiff.workspace = true
+rustledger-booking.workspace = true
 rustledger-core.workspace = true
 rustledger-ops.workspace = true
 rustledger-parser.workspace = true

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "rustledger-ffi-component"
+description = "Rustledger embedding via WASI Preview 2 / the Component Model (WIT)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+authors.workspace = true
+readme = "README.md"
+# Work in progress (#1384 Phase 2): not yet a published/release artifact.
+publish = false
+
+[lib]
+# wasm32-wasip2 emits a component directly from a cdylib (no cargo-component).
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen.workspace = true
+rustledger-core.workspace = true
+rustledger-parser.workspace = true
+rustledger-loader.workspace = true
+rustledger-booking.workspace = true
+rustledger-validate.workspace = true
+rustledger-query.workspace = true
+rustledger-plugin.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -23,6 +23,7 @@ wit-bindgen.workspace = true
 serde_json.workspace = true
 jiff.workspace = true
 rustledger-core.workspace = true
+rustledger-parser.workspace = true
 rustledger-query.workspace = true
 rustledger-validate.workspace = true
 # Reused for the loader orchestration (`load_source`) and the core->DTO

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -20,13 +20,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wit-bindgen.workspace = true
+serde_json.workspace = true
 rustledger-core.workspace = true
-rustledger-parser.workspace = true
-rustledger-loader.workspace = true
-rustledger-booking.workspace = true
-rustledger-validate.workspace = true
-rustledger-query.workspace = true
-rustledger-plugin.workspace = true
+# Reused for the loader orchestration (`load_source`) and the core->DTO
+# conversion (`directive_to_json`); the component maps those DTOs into WIT
+# types. During the dual-ship window both crates coexist; the shared logic
+# moves to a neutral home when the wasip1 surface is retired (Phase 5).
+rustledger-ffi-wasi.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -107,8 +107,12 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
 - [x] `query` wired — runs the executor directly for typed rows and projects
       `rustledger_query::Value` → WIT `query-value`; `object`/`set` cells use the
       `json` escape hatch (WIT can't type them recursively).
-- [ ] Wire `load-file` / `validate-file` / `query-file` / `batch` (the file +
-      multi-query variants).
+- [x] `batch` wired (source-based: `load_source` once, run N queries).
+- [ ] Wire the file variants (`load-file`/`validate-file`/`query-file`/
+      `batch-file`): these need the full `Loader` orchestration (include
+      resolution, multi-file line numbers via `source_map`, manual booking,
+      `build_ledger_options`), unlike the thin `load_source`. Cleanest as a
+      reusable `helpers::load_file` extraction in `ffi-wasi`.
 - [ ] Wire `builder` (`input_entry_to_directive`), `util`, `format`.
 - [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
       `meta-value::text` because the reused DTO stringifies it — faithful typing

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -31,13 +31,18 @@ and their `-file` variants — translated 1:1 from `types/output.rs`: `amount`,
 `error`, `plugin`, `source-include`, `ledger-options`, `position`,
 `column-info`, `query-value`, and the load/validate/query result records.
 
-**Construction surface** (`interface builder`) — `create` / `create-batch`
-(replacing `entry.create` / `entry.createBatch`) — translated from
-`types/input.rs`: `input-cost` (= `cost` + the `merge` average-cost marker),
-`input-posting`, all 12 `input-directive` cases. Reuses `amount`,
-`cost-number`, and `meta-value`; input metadata is user key/values only (no
-source location — assigned on load). Both calls are fallible; the batch is
-all-or-nothing, matching the handler's `?`-propagation.
+**Construction & transformation** (`interface builder`) — `create` /
+`create-batch` (from `types/input.rs`: `input-cost` = `cost` + the `merge`
+average-cost marker, `input-posting`, 12 `input-directive` cases; both fallible,
+batch all-or-nothing per the handler) plus `filter` / `clamp` over a date window
+(`entry.filter` / `entry.clamp`). Reuses `amount`, `cost-number`, `meta-value`;
+input metadata is user key/values only (source location is assigned on load).
+
+**Batch** (`interface ledger`) — `batch` / `batch-file` (`query.batch`): load
+once, run several queries.
+
+**Util** (`interface util`) — `types` / `is-encrypted` / `get-account-type`
+(`util.types` / `util.isEncrypted` / `util.getAccountType`).
 
 ## Modeling decisions (and what the translation surfaced)
 
@@ -69,13 +74,16 @@ all-or-nothing, matching the handler's `?`-propagation.
    `display_precision`, `inferred_tolerance_default` become key/value lists
    (which also preserves source order).
 
-## Remaining Phase 1 work
+## Phase 1 complete
 
-- **Ops methods**: `entry.clamp`, `entry.filter`, and the `query.batch` /
-  `query.batchFile` result envelope.
-- **Util helpers**: `util.getAccountType`, `util.isEncrypted`, `util.types`.
-- **Verify a few cell shapes** against `convert.rs::value_to_json` — notably the
-  exact `interval` fields and the `metadata` debug-string projection.
+The **entire** JSON-RPC method surface is now modeled across five interfaces —
+`ledger` (load/validate/query/batch + `-file` variants), `builder`
+(create/create-batch/filter/clamp), `util` (types/is-encrypted/get-account-type),
+`format` (format-source/format-entries), exported by the `rustledger` world. The
+query cell shapes were verified against `convert.rs::value_to_json` (`interval`
+carries `count` + a proper `interval-unit` enum; `metadata` is a flat string
+map). The contract validates with `wasm-tools` and generates ~35k lines via
+`wit-bindgen`.
 
 ## Next (Phase 2+)
 

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -115,10 +115,11 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
       run the source path, matching the handlers (single file, no includes).
 - [x] `builder`: `create` / `create-batch` (WIT input → `input_entry_to_directive`
       → core → WIT) and `filter` (date-range `[begin, end)` over WIT directives).
-- [ ] `builder`: `clamp` — synthesizes opening-balance/summary directives via the
-      JSON-based `clamp_entries`, but `DirectiveJson` is serialize-only, so there
-      is no clean WIT↔JSON round-trip. Needs a typed clamp (on core directives)
-      or a bidirectional conversion; deferred.
+- [ ] `builder`: `clamp` — **deferred to rustledger/rustledger#1401.** It
+      synthesizes directives via the JSON-based `clamp_entries`; wiring it here
+      cleanly needs a *typed* `clamp` on core directives in `rustledger-ops`,
+      rather than ~250 lines of `DirectiveJson` `Deserialize` + reverse-conversion
+      glue to bridge an algorithm that shouldn't be JSON-based.
 - [x] `util` (`types` / `is-encrypted` / `get-account-type`) and `format`
       (`format-source` / `-file` / `-entry` / `-entries`) wired. `format-*-entry`
       reuse the builder input conversion + `canonicalize_directives`.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -100,10 +100,15 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
 - [x] Toolchain wired: `wasm32-wasip2` target in `flake.nix`, workspace member,
       `wit-bindgen` workspace dep.
 - [x] `version` export wired.
-- [ ] Wire `load` / `validate` (core `Directive` → WIT `directive` conversion).
-- [ ] Wire `query` (the `query-value` projection, incl. the `json` escape hatch).
-- [ ] Wire `builder` (input → core via the existing `input_entry_to_directive`),
-      `util`, `format`.
+- [x] `load` wired — reuses `ffi-wasi`'s `load_source` (loader orchestration) and
+      `directive_to_json` (core→DTO), then maps DTO→WIT for all 12 directive
+      kinds plus options/errors/plugins/includes (`src/convert.rs`).
+- [ ] Wire `validate` / `load-file` / `query` (the `query-value` projection,
+      incl. the `json` escape hatch).
+- [ ] Wire `builder` (`input_entry_to_directive`), `util`, `format`.
+- [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
+      `meta-value::text` because the reused DTO stringifies it — faithful typing
+      needs the core `MetaValue` (`directive_to_json` flattens it).
 - [ ] Parity tests: component output ≡ JSON-RPC output for identical inputs
       (extend the cross-binding equivalence harness #1200).
 

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -1,13 +1,22 @@
-# rustledger-ffi-component (WIT contract — Phase 1)
+# rustledger-ffi-component
 
-The typed **WIT** embedding contract for rustledger, replacing the hand-rolled
-JSON-RPC wire shape of `rustledger-ffi-wasi`. Part of the WASI-p1 → p2 /
-Component Model migration ([#1384](https://github.com/rustledger/rustledger/issues/1384)).
+Rustledger embedding as a **WASI Preview 2 / Component Model** component,
+replacing the hand-rolled JSON-RPC wire shape of `rustledger-ffi-wasi`. Part of
+the WASI-p1 → p2 migration ([#1384](https://github.com/rustledger/rustledger/issues/1384)).
 
-**This iteration is Phase 1: the contract only.** `wit/world.wit` is the single
-source of truth for the wire shape; the production guest crate that implements
-these exports (wiring them to the loader/query) is Phase 2. There is no
-`Cargo.toml` here yet — this is not a workspace member.
+`wit/world.wit` is the single source of truth for the wire shape; `src/lib.rs`
+implements the `rustledger` world's exports.
+
+**Status: Phase 1 done (the contract); Phase 2 in progress (the guest).** The
+crate **builds as a real wasip2 component** today — `version` is wired
+end-to-end; the remaining exports are honest `unimplemented!()` stubs being
+filled in against the existing loader/query logic, one interface at a time.
+
+```bash
+# the wasip2 target lives in the default dev shell (flake.nix)
+cargo build -p rustledger-ffi-component --target wasm32-wasip2
+wasm-tools print target/wasm32-wasip2/debug/rustledger_ffi_component.wasm | head -1   # => (component …
+```
 
 ## Status
 
@@ -85,8 +94,17 @@ carries `count` + a proper `interval-unit` enum; `metadata` is a flat string
 map). The contract validates with `wasm-tools` and generates ~35k lines via
 `wit-bindgen`.
 
-## Next (Phase 2+)
+## Phase 2 (in progress)
 
-Production guest crate (`wit_bindgen::generate!`, exports wired to the real
-loader/query), parity tests vs. the JSON-RPC output (extend the #1200 harness),
-release artifact, then the rustfava migration. See #1384 for the full plan.
+- [x] Crate scaffold + `wit_bindgen::generate!`; builds as a wasip2 component.
+- [x] Toolchain wired: `wasm32-wasip2` target in `flake.nix`, workspace member,
+      `wit-bindgen` workspace dep.
+- [x] `version` export wired.
+- [ ] Wire `load` / `validate` (core `Directive` → WIT `directive` conversion).
+- [ ] Wire `query` (the `query-value` projection, incl. the `json` escape hatch).
+- [ ] Wire `builder` (input → core via the existing `input_entry_to_directive`),
+      `util`, `format`.
+- [ ] Parity tests: component output ≡ JSON-RPC output for identical inputs
+      (extend the cross-binding equivalence harness #1200).
+
+Then Phase 3+ (release artifact, rustfava migration). See #1384 for the full plan.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -108,11 +108,11 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
       `rustledger_query::Value` → WIT `query-value`; `object`/`set` cells use the
       `json` escape hatch (WIT can't type them recursively).
 - [x] `batch` wired (source-based: `load_source` once, run N queries).
-- [ ] Wire the file variants (`load-file`/`validate-file`/`query-file`/
-      `batch-file`): these need the full `Loader` orchestration (include
-      resolution, multi-file line numbers via `source_map`, manual booking,
-      `build_ledger_options`), unlike the thin `load_source`. Cleanest as a
-      reusable `helpers::load_file` extraction in `ffi-wasi`.
+- [x] file variants wired. `load-file` uses a new reusable `helpers::load_file`
+      in `ffi-wasi` (Loader + booking + options) — extracted from the
+      `handle_load_file` handler, which now calls it too (DRY; all `ffi-wasi`
+      tests green). `validate-file`/`query-file`/`batch-file` read the file and
+      run the source path, matching the handlers (single file, no includes).
 - [ ] Wire `builder` (`input_entry_to_directive`), `util`, `format`.
 - [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
       `meta-value::text` because the reused DTO stringifies it — faithful typing

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -103,8 +103,12 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
 - [x] `load` wired — reuses `ffi-wasi`'s `load_source` (loader orchestration) and
       `directive_to_json` (core→DTO), then maps DTO→WIT for all 12 directive
       kinds plus options/errors/plugins/includes (`src/convert.rs`).
-- [ ] Wire `validate` / `load-file` / `query` (the `query-value` projection,
-      incl. the `json` escape hatch).
+- [x] `validate` wired — `load_source` + `ValidationSession` (early/late/finalize).
+- [x] `query` wired — runs the executor directly for typed rows and projects
+      `rustledger_query::Value` → WIT `query-value`; `object`/`set` cells use the
+      `json` escape hatch (WIT can't type them recursively).
+- [ ] Wire `load-file` / `validate-file` / `query-file` / `batch` (the file +
+      multi-query variants).
 - [ ] Wire `builder` (`input_entry_to_directive`), `util`, `format`.
 - [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
       `meta-value::text` because the reused DTO stringifies it — faithful typing

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -5,31 +5,33 @@ replacing the hand-rolled JSON-RPC wire shape of `rustledger-ffi-wasi`. Part of
 the WASI-p1 → p2 migration ([#1384](https://github.com/rustledger/rustledger/issues/1384)).
 
 `wit/world.wit` is the single source of truth for the wire shape; `src/lib.rs`
-implements the `rustledger` world's exports.
 
-**Status: Phase 1 done (the contract); Phase 2 — all 20 exports wired.** The
-crate **builds as a real wasip2 component** and every export
-(`ledger`/`builder`/`util`/`format`) is implemented against the reused
-loader/query/ops logic and exercised by the parity harness.
+- `src/convert.rs` implement the `rustledger` world's exports.
+
+## Status
+
+- **Workspace member**, but not yet a published release artifact (`publish = false`).
+- **All 20 exports are implemented and build as a real wasip2 component**, across
+  four interfaces: `ledger` (load / validate / query / batch + their `-file`
+  variants), `builder` (create / create-batch / filter / clamp), `util` (types /
+  is-encrypted / get-account-type), `format` (source / file / entry / entries).
+- Exports reuse `rustledger-ffi-wasi`'s loader/query/ops logic via shared
+  helpers; the DTO↔WIT conversion lives in `src/convert.rs`.
+- **Parity-tested** by `rustledger-ffi-component-tests`: it instantiates the
+  built component in a wasmtime host (typed `bindgen!`, no JSON-RPC) and asserts
+  agreement with the reused `rustledger-ffi-wasi` path.
+- **Not yet wired to a consumer** — rustfava still uses the JSON-RPC surface.
+  Both coexist during the dual-ship window; the JSON-RPC surface is retired in
+  Phase 5.
 
 ```bash
 # the wasip2 target lives in the default dev shell (flake.nix)
 cargo build -p rustledger-ffi-component --target wasm32-wasip2
 wasm-tools print target/wasm32-wasip2/debug/rustledger_ffi_component.wasm | head -1   # => (component …
-```
 
-## Status
-
-- `wit/world.wit` **validates** with `wasm-tools component wit` (fully resolves
-  and round-trips).
-- **`wit-bindgen rust` generates** ~9k lines of typed Rust from it — so the
-  contract compiles with the real binding generator, not just the parser.
-
-Reproduce:
-
-```bash
-wasm-tools component wit crates/rustledger-ffi-component/wit/world.wit   # validate
-wit-bindgen rust crates/rustledger-ffi-component/wit/world.wit --out-dir /tmp/g  # codegen
+# validate / regenerate the contract directly
+wasm-tools component wit crates/rustledger-ffi-component/wit/world.wit
+wit-bindgen rust crates/rustledger-ffi-component/wit/world.wit --out-dir /tmp/g
 ```
 
 ## Scope covered
@@ -53,19 +55,23 @@ once, run several queries.
 **Util** (`interface util`) — `types` / `is-encrypted` / `get-account-type`
 (`util.types` / `util.isEncrypted` / `util.getAccountType`).
 
+**Format** (`interface format`) — `format-source` / `-file` / `-entry` /
+`-entries`; the entry variants reuse the builder input conversion +
+`canonicalize_directives`.
+
 ## Modeling decisions (and what the translation surfaced)
 
 1. **`cost` is defined once and reused for posting cost *and* position cost.**
    The consistency that #1399 had to enforce by hand + review is now structural
    — `cost.number` is one `cost-number` variant everywhere, by construction.
 
-2. **`meta-value` is a closed, non-recursive variant.** The JSON DTO types user
+1. **`meta-value` is a closed, non-recursive variant.** The JSON DTO types user
    metadata as arbitrary `serde_json::Value`, but it is only ever produced from
    `MetaValue` — a finite set (text / number / bool / amount / null) with no
    nesting. So the "recursive meta-value" risk flagged in the plan does **not**
    exist on this side; it maps cleanly.
 
-3. **The Component Model forbids recursive types.** Verified: `wasm-tools`
+1. **The Component Model forbids recursive types.** Verified: `wasm-tools`
    rejects a `query-value` that contains itself, even through a `list`. The only
    self-referential query cells — BQL `object` (map of cells) and `set` (list of
    cells) — are therefore carried in a single, clearly-named `json(string)`
@@ -74,62 +80,23 @@ once, run several queries.
    because its values are already flat strings. **This is the one place WIT
    can't fully express the JSON shape** — the key finding of Phase 1.
 
-4. **Per-result `api_version` dropped in favour of a `version()` func.** Under a
+1. **Per-result `api_version` dropped in favor of a `version()` func.** Under a
    versioned WIT contract the wire shape *is* the version; stamping an
    `api_version` string onto every response is a JSON-RPC-ism. `version()`
    remains for runtime negotiation.
 
-5. **Maps → ordered `list<tuple<...>>`.** WIT has no map type; `Meta.user`,
+1. **Maps → ordered `list<tuple<...>>`.** WIT has no map type; `Meta.user`,
    `display_precision`, `inferred_tolerance_default` become key/value lists
    (which also preserves source order).
 
-## Phase 1 complete
+## Known gaps / remaining work
 
-The **entire** JSON-RPC method surface is now modeled across five interfaces —
-`ledger` (load/validate/query/batch + `-file` variants), `builder`
-(create/create-batch/filter/clamp), `util` (types/is-encrypted/get-account-type),
-`format` (format-source/format-entries), exported by the `rustledger` world. The
-query cell shapes were verified against `convert.rs::value_to_json` (`interval`
-carries `count` + a proper `interval-unit` enum; `metadata` is a flat string
-map). The contract validates with `wasm-tools` and generates ~35k lines via
-`wit-bindgen`.
-
-## Phase 2 (in progress)
-
-- [x] Crate scaffold + `wit_bindgen::generate!`; builds as a wasip2 component.
-- [x] Toolchain wired: `wasm32-wasip2` target in `flake.nix`, workspace member,
-      `wit-bindgen` workspace dep.
-- [x] `version` export wired.
-- [x] `load` wired — reuses `ffi-wasi`'s `load_source` (loader orchestration) and
-      `directive_to_json` (core→DTO), then maps DTO→WIT for all 12 directive
-      kinds plus options/errors/plugins/includes (`src/convert.rs`).
-- [x] `validate` wired — `load_source` + `ValidationSession` (early/late/finalize).
-- [x] `query` wired — runs the executor directly for typed rows and projects
-      `rustledger_query::Value` → WIT `query-value`; `object`/`set` cells use the
-      `json` escape hatch (WIT can't type them recursively).
-- [x] `batch` wired (source-based: `load_source` once, run N queries).
-- [x] file variants wired. `load-file` uses a new reusable `helpers::load_file`
-      in `ffi-wasi` (Loader + booking + options) — extracted from the
-      `handle_load_file` handler, which now calls it too (DRY; all `ffi-wasi`
-      tests green). `validate-file`/`query-file`/`batch-file` read the file and
-      run the source path, matching the handlers (single file, no includes).
-- [x] `builder`: `create` / `create-batch` (WIT input → `input_entry_to_directive`
-      → core → WIT) and `filter` (date-range `[begin, end)` over WIT directives).
-- [x] `builder`: `clamp` — wired via the typed `rustledger_ops::clamp` (#1401):
-      WIT loaded-directive → `InputEntry` → core → `ops::clamp` → WIT. **All 20
-      exports are now implemented** and parity-tested.
-- [x] `util` (`types` / `is-encrypted` / `get-account-type`) and `format`
-      (`format-source` / `-file` / `-entry` / `-entries`) wired. `format-*-entry`
-      reuse the builder input conversion + `canonicalize_directives`.
-- [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
-      `meta-value::text` because the reused DTO stringifies it — faithful typing
-      needs the core `MetaValue` (`directive_to_json` flattens it).
-- [x] Parity harness (`rustledger-ffi-component-tests`): instantiates the built
-      component in a wasmtime host (typed `bindgen!`, no JSON-RPC) and asserts
-      `version`/`load`/`query` agree with the reused `ffi-wasi` path — the first
-      thing that *runs* the conversion code. Skips if the wasm isn't built.
-- [ ] Broaden parity coverage (all exports; field-level diff) and wire the
-      component-build step into CI (#1200 harness).
-- [ ] `entry.clamp`; the metadata-fidelity refinement (numeric meta → `text`).
-
-Then Phase 3+ (release artifact, rustfava migration). See #1384 for the full plan.
+- **Metadata fidelity:** numeric metadata currently surfaces as
+  `meta-value::text` because the reused DTO stringifies it — faithful typing
+  needs the core `MetaValue` (`directive_to_json` flattens it).
+- **Broaden parity coverage** (all exports; field-level diff) and wire the
+  component-build step + an end-to-end `load-file` parity test into CI ([#1402](https://github.com/rustledger/rustledger/issues/1402)).
+- **Phase 3+:** release artifact, then rustfava migration; **Phase 5** retires
+  the JSON-RPC surface and moves the shared loader/conversion logic to a neutral
+  home. See [#1384](https://github.com/rustledger/rustledger/issues/1384) for the
+  full plan.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -119,7 +119,9 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
       JSON-based `clamp_entries`, but `DirectiveJson` is serialize-only, so there
       is no clean WIT↔JSON round-trip. Needs a typed clamp (on core directives)
       or a bidirectional conversion; deferred.
-- [ ] Wire `util`, `format`.
+- [x] `util` (`types` / `is-encrypted` / `get-account-type`) and `format`
+      (`format-source` / `-file` / `-entry` / `-entries`) wired. `format-*-entry`
+      reuse the builder input conversion + `canonicalize_directives`.
 - [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
       `meta-value::text` because the reused DTO stringifies it — faithful typing
       needs the core `MetaValue` (`directive_to_json` flattens it).

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -1,0 +1,79 @@
+# rustledger-ffi-component (WIT contract — Phase 1)
+
+The typed **WIT** embedding contract for rustledger, replacing the hand-rolled
+JSON-RPC wire shape of `rustledger-ffi-wasi`. Part of the WASI-p1 → p2 /
+Component Model migration ([#1384](https://github.com/rustledger/rustledger/issues/1384)).
+
+**This iteration is Phase 1: the contract only.** `wit/world.wit` is the single
+source of truth for the wire shape; the production guest crate that implements
+these exports (wiring them to the loader/query) is Phase 2. There is no
+`Cargo.toml` here yet — this is not a workspace member.
+
+## Status
+
+- `wit/world.wit` **validates** with `wasm-tools component wit` (fully resolves
+  and round-trips).
+- **`wit-bindgen rust` generates** ~9k lines of typed Rust from it — so the
+  contract compiles with the real binding generator, not just the parser.
+
+Reproduce:
+
+```bash
+wasm-tools component wit crates/rustledger-ffi-component/wit/world.wit   # validate
+wit-bindgen rust crates/rustledger-ffi-component/wit/world.wit --out-dir /tmp/g  # codegen
+```
+
+## Scope covered
+
+The **read surface rustfava actually consumes** — `version`, `load`,
+`validate`, `query`, and their `-file` variants — translated 1:1 from the DTOs
+in `crates/rustledger-ffi-wasi/src/types/output.rs`: `amount`, `cost-number`,
+`cost`, `meta`/`meta-value`, `posting`, all 12 `directive` cases, `error`,
+`plugin`, `source-include`, `ledger-options`, `position`, `column-info`,
+`query-value`, and the load/validate/query result records.
+
+## Modeling decisions (and what the translation surfaced)
+
+1. **`cost` is defined once and reused for posting cost *and* position cost.**
+   The consistency that #1399 had to enforce by hand + review is now structural
+   — `cost.number` is one `cost-number` variant everywhere, by construction.
+
+2. **`meta-value` is a closed, non-recursive variant.** The JSON DTO types user
+   metadata as arbitrary `serde_json::Value`, but it is only ever produced from
+   `MetaValue` — a finite set (text / number / bool / amount / null) with no
+   nesting. So the "recursive meta-value" risk flagged in the plan does **not**
+   exist on this side; it maps cleanly.
+
+3. **The Component Model forbids recursive types.** Verified: `wasm-tools`
+   rejects a `query-value` that contains itself, even through a `list`. The only
+   self-referential query cells — BQL `object` (map of cells) and `set` (list of
+   cells) — are therefore carried in a single, clearly-named `json(string)`
+   escape-hatch case rather than awkwardly flattened. Every other cell is fully
+   typed; `object`/`set` are rare in real query output. `metadata` stays typed
+   because its values are already flat strings. **This is the one place WIT
+   can't fully express the JSON shape** — the key finding of Phase 1.
+
+4. **Per-result `api_version` dropped in favour of a `version()` func.** Under a
+   versioned WIT contract the wire shape *is* the version; stamping an
+   `api_version` string onto every response is a JSON-RPC-ism. `version()`
+   remains for runtime negotiation.
+
+5. **Maps → ordered `list<tuple<...>>`.** WIT has no map type; `Meta.user`,
+   `display_precision`, `inferred_tolerance_default` become key/value lists
+   (which also preserves source order).
+
+## Remaining Phase 1 work
+
+- **Directive *construction* surface** (`entry.create` / `entry.createBatch`):
+  translate `types/input.rs` (`InputEntry`, `InputCostNumber`, …) into an input
+  side of the contract.
+- **Util + ops methods**: `util.getAccountType`, `util.isEncrypted`,
+  `util.types`, `entry.clamp`, `entry.filter`, and the `query.batch` result.
+- **Verify a few cell shapes** against `convert.rs::value_to_json` — notably the
+  exact `interval` fields and the `metadata` debug-string projection.
+
+## Next (Phase 2+)
+
+Production guest crate (`wit_bindgen::generate!`, exports wired to the real
+loader/query), parity tests vs. the JSON-RPC output (extend the #1200 harness),
+release artifact, then the rustfava migration. See #1384 for the full plan.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -125,7 +125,12 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
 - [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
       `meta-value::text` because the reused DTO stringifies it — faithful typing
       needs the core `MetaValue` (`directive_to_json` flattens it).
-- [ ] Parity tests: component output ≡ JSON-RPC output for identical inputs
-      (extend the cross-binding equivalence harness #1200).
+- [x] Parity harness (`rustledger-ffi-component-tests`): instantiates the built
+      component in a wasmtime host (typed `bindgen!`, no JSON-RPC) and asserts
+      `version`/`load`/`query` agree with the reused `ffi-wasi` path — the first
+      thing that *runs* the conversion code. Skips if the wasm isn't built.
+- [ ] Broaden parity coverage (all exports; field-level diff) and wire the
+      component-build step into CI (#1200 harness).
+- [ ] `entry.clamp`; the metadata-fidelity refinement (numeric meta → `text`).
 
 Then Phase 3+ (release artifact, rustfava migration). See #1384 for the full plan.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -113,7 +113,13 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
       `handle_load_file` handler, which now calls it too (DRY; all `ffi-wasi`
       tests green). `validate-file`/`query-file`/`batch-file` read the file and
       run the source path, matching the handlers (single file, no includes).
-- [ ] Wire `builder` (`input_entry_to_directive`), `util`, `format`.
+- [x] `builder`: `create` / `create-batch` (WIT input → `input_entry_to_directive`
+      → core → WIT) and `filter` (date-range `[begin, end)` over WIT directives).
+- [ ] `builder`: `clamp` — synthesizes opening-balance/summary directives via the
+      JSON-based `clamp_entries`, but `DirectiveJson` is serialize-only, so there
+      is no clean WIT↔JSON round-trip. Needs a typed clamp (on core directives)
+      or a bidirectional conversion; deferred.
+- [ ] Wire `util`, `format`.
 - [ ] Close the metadata fidelity gap: numeric metadata currently surfaces as
       `meta-value::text` because the reused DTO stringifies it — faithful typing
       needs the core `MetaValue` (`directive_to_json` flattens it).

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -7,10 +7,10 @@ the WASI-p1 → p2 migration ([#1384](https://github.com/rustledger/rustledger/i
 `wit/world.wit` is the single source of truth for the wire shape; `src/lib.rs`
 implements the `rustledger` world's exports.
 
-**Status: Phase 1 done (the contract); Phase 2 in progress (the guest).** The
-crate **builds as a real wasip2 component** today — `version` is wired
-end-to-end; the remaining exports are honest `unimplemented!()` stubs being
-filled in against the existing loader/query logic, one interface at a time.
+**Status: Phase 1 done (the contract); Phase 2 — all 20 exports wired.** The
+crate **builds as a real wasip2 component** and every export
+(`ledger`/`builder`/`util`/`format`) is implemented against the reused
+loader/query/ops logic and exercised by the parity harness.
 
 ```bash
 # the wasip2 target lives in the default dev shell (flake.nix)
@@ -115,11 +115,9 @@ map). The contract validates with `wasm-tools` and generates ~35k lines via
       run the source path, matching the handlers (single file, no includes).
 - [x] `builder`: `create` / `create-batch` (WIT input → `input_entry_to_directive`
       → core → WIT) and `filter` (date-range `[begin, end)` over WIT directives).
-- [ ] `builder`: `clamp` — **deferred to rustledger/rustledger#1401.** It
-      synthesizes directives via the JSON-based `clamp_entries`; wiring it here
-      cleanly needs a *typed* `clamp` on core directives in `rustledger-ops`,
-      rather than ~250 lines of `DirectiveJson` `Deserialize` + reverse-conversion
-      glue to bridge an algorithm that shouldn't be JSON-based.
+- [x] `builder`: `clamp` — wired via the typed `rustledger_ops::clamp` (#1401):
+      WIT loaded-directive → `InputEntry` → core → `ops::clamp` → WIT. **All 20
+      exports are now implemented** and parity-tested.
 - [x] `util` (`types` / `is-encrypted` / `get-account-type`) and `format`
       (`format-source` / `-file` / `-entry` / `-entries`) wired. `format-*-entry`
       reuse the builder input conversion + `canonicalize_directives`.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -25,12 +25,19 @@ wit-bindgen rust crates/rustledger-ffi-component/wit/world.wit --out-dir /tmp/g 
 
 ## Scope covered
 
-The **read surface rustfava actually consumes** — `version`, `load`,
-`validate`, `query`, and their `-file` variants — translated 1:1 from the DTOs
-in `crates/rustledger-ffi-wasi/src/types/output.rs`: `amount`, `cost-number`,
-`cost`, `meta`/`meta-value`, `posting`, all 12 `directive` cases, `error`,
-`plugin`, `source-include`, `ledger-options`, `position`, `column-info`,
-`query-value`, and the load/validate/query result records.
+**Read surface** (`interface ledger`) — `version`, `load`, `validate`, `query`,
+and their `-file` variants — translated 1:1 from `types/output.rs`: `amount`,
+`cost-number`, `cost`, `meta`/`meta-value`, `posting`, all 12 `directive` cases,
+`error`, `plugin`, `source-include`, `ledger-options`, `position`,
+`column-info`, `query-value`, and the load/validate/query result records.
+
+**Construction surface** (`interface builder`) — `create` / `create-batch`
+(replacing `entry.create` / `entry.createBatch`) — translated from
+`types/input.rs`: `input-cost` (= `cost` + the `merge` average-cost marker),
+`input-posting`, all 12 `input-directive` cases. Reuses `amount`,
+`cost-number`, and `meta-value`; input metadata is user key/values only (no
+source location — assigned on load). Both calls are fallible; the batch is
+all-or-nothing, matching the handler's `?`-propagation.
 
 ## Modeling decisions (and what the translation surfaced)
 
@@ -64,11 +71,9 @@ in `crates/rustledger-ffi-wasi/src/types/output.rs`: `amount`, `cost-number`,
 
 ## Remaining Phase 1 work
 
-- **Directive *construction* surface** (`entry.create` / `entry.createBatch`):
-  translate `types/input.rs` (`InputEntry`, `InputCostNumber`, …) into an input
-  side of the contract.
-- **Util + ops methods**: `util.getAccountType`, `util.isEncrypted`,
-  `util.types`, `entry.clamp`, `entry.filter`, and the `query.batch` result.
+- **Ops methods**: `entry.clamp`, `entry.filter`, and the `query.batch` /
+  `query.batchFile` result envelope.
+- **Util helpers**: `util.getAccountType`, `util.isEncrypted`, `util.types`.
 - **Verify a few cell shapes** against `convert.rs::value_to_json` — notably the
   exact `interval` fields and the `metadata` debug-string projection.
 

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -300,7 +300,12 @@ fn options(o: ffi::LedgerOptions) -> wit::LedgerOptions {
 
 /// `ledger.load` — parse + book `source`, returning a typed load result.
 pub fn load(source: &str, filename: &str) -> out::LoadResult {
-    let loaded = ffi::helpers::load_source(source);
+    load_result(ffi::helpers::load_source(source), filename)
+}
+
+/// Build a WIT load-result from a consumed `ffi-wasi` load result (shared by
+/// `load` and `batch`).
+fn load_result(loaded: ffi::helpers::LoadResult, filename: &str) -> out::LoadResult {
     let entries = loaded
         .directives
         .iter()
@@ -429,7 +434,11 @@ pub fn validate(source: &str) -> out::ValidateResult {
 
 /// `query.execute` — run a BQL query against `source`.
 pub fn query(source: &str, query_str: &str) -> out::QueryResult {
-    let loaded = ffi::helpers::load_source(source);
+    run_query(&ffi::helpers::load_source(source).directives, query_str)
+}
+
+/// Run one query against already-loaded directives (shared by `query`/`batch`).
+fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out::QueryResult {
     let parsed = match parse_query(query_str) {
         Ok(q) => q,
         Err(e) => {
@@ -440,7 +449,7 @@ pub fn query(source: &str, query_str: &str) -> out::QueryResult {
             };
         }
     };
-    let mut executor = Executor::new(&loaded.directives);
+    let mut executor = Executor::new(directives);
     match executor.execute(&parsed) {
         Ok(result) => {
             // Infer column datatypes from the first row (reusing value_datatype).
@@ -476,5 +485,17 @@ pub fn query(source: &str, query_str: &str) -> out::QueryResult {
             rows: vec![],
             errors: vec![simple_error(format!("Query error: {e}"))],
         },
+    }
+}
+
+/// `query.batch` — load `source` once, then run several queries against it.
+pub fn batch(source: &str, queries: &[String]) -> out::BatchResult {
+    let loaded = ffi::helpers::load_source(source);
+    // Collect query results (owned) before consuming `loaded` for the load.
+    let query_results: Vec<out::QueryResult> =
+        queries.iter().map(|q| run_query(&loaded.directives, q)).collect();
+    out::BatchResult {
+        load: load_result(loaded, "<stdin>"),
+        queries: query_results,
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -539,7 +539,14 @@ fn read_file(path: &str) -> Result<String, String> {
 
 /// `ledger.loadFile` — load from a path, resolving `include` directives, with
 /// optional path-security confinement and a post-booking plugin pass.
-pub fn load_file(path: &str, path_security: bool, plugins: &[String]) -> out::LoadResult {
+pub fn load_file(
+    path: &str,
+    allow_unrestricted_includes: bool,
+    plugins: &[String],
+) -> out::LoadResult {
+    // The loader takes `path_security` (true = confine includes); the WIT flag
+    // is inverted so the safe state is the `false`/zero default.
+    let path_security = !allow_unrestricted_includes;
     match ffi::helpers::load_file(std::path::Path::new(path), path_security) {
         Ok(fl) => {
             let mut errors = fl.errors;
@@ -974,11 +981,7 @@ fn loaded_posting_to_input(p: &wit::Posting) -> ffi::InputPosting {
         units: p.units.as_ref().map(input_amount),
         cost: p.cost.as_ref().map(loaded_cost_to_input),
         price: p.price.as_ref().map(input_amount),
-        meta: p
-            .meta
-            .iter()
-            .map(|(k, v)| (k.clone(), json_from_meta_value(v)))
-            .collect(),
+        meta: input_meta(&p.meta),
     }
 }
 

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1,0 +1,330 @@
+//! Conversion from the reused `rustledger-ffi-wasi` DTOs into the generated
+//! WIT types.
+//!
+//! The loader orchestration (`load_source`) and the core→DTO conversion
+//! (`directive_to_json`) are reused wholesale; this module is the mechanical
+//! DTO→WIT shuffle, since the WIT types were authored 1:1 with the DTOs.
+//!
+//! Known fidelity gap: directive/posting metadata is reused from the DTO, which
+//! flattens `MetaValue` to JSON and stringifies numbers — so a numeric metadata
+//! value currently surfaces as `meta-value::text`. Faithful typing requires
+//! reading the core `MetaValue` directly; tracked as a follow-up. (Custom
+//! directive values keep their type via `TypedValue`, so they are unaffected.)
+
+use rustledger_ffi_wasi as ffi;
+use serde_json::Value as Json;
+
+use crate::exports::rustledger::ledger::ledger as out;
+use crate::rustledger::ledger::types as wit;
+
+fn amount(a: ffi::Amount) -> wit::Amount {
+    wit::Amount {
+        number: a.number,
+        currency: a.currency,
+    }
+}
+
+fn cost_number(n: ffi::CostNumber) -> wit::CostNumber {
+    match n {
+        ffi::CostNumber::PerUnit { value } => wit::CostNumber::PerUnit(value),
+        ffi::CostNumber::Total { value } => wit::CostNumber::Total(value),
+        ffi::CostNumber::PerUnitFromTotal { per_unit, total } => {
+            wit::CostNumber::PerUnitFromTotal((per_unit, total))
+        }
+    }
+}
+
+fn cost(c: ffi::PostingCost) -> wit::Cost {
+    wit::Cost {
+        number: c.number.map(cost_number),
+        currency: c.currency,
+        date: c.date,
+        label: c.label,
+    }
+}
+
+/// JSON metadata value → WIT `meta-value`. See the module-level fidelity note.
+fn meta_value(v: Json) -> wit::MetaValue {
+    match v {
+        Json::Null => wit::MetaValue::Null,
+        Json::Bool(b) => wit::MetaValue::Boolean(b),
+        Json::Number(n) => wit::MetaValue::Number(n.to_string()),
+        Json::Object(map) => {
+            match (map.get("number"), map.get("currency")) {
+                (Some(Json::String(n)), Some(Json::String(c))) => {
+                    wit::MetaValue::Amount(wit::Amount {
+                        number: n.clone(),
+                        currency: c.clone(),
+                    })
+                }
+                // Not an amount object — preserve a best-effort textual form.
+                _ => wit::MetaValue::Text(Json::Object(map).to_string()),
+            }
+        }
+        Json::String(s) => wit::MetaValue::Text(s),
+        other => wit::MetaValue::Text(other.to_string()),
+    }
+}
+
+fn meta_entries(user: std::collections::HashMap<String, Json>) -> Vec<(String, wit::MetaValue)> {
+    let mut entries: Vec<(String, wit::MetaValue)> =
+        user.into_iter().map(|(k, v)| (k, meta_value(v))).collect();
+    // Deterministic order (HashMap iteration is not).
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries
+}
+
+fn meta(m: ffi::Meta) -> wit::Meta {
+    wit::Meta {
+        filename: m.filename,
+        lineno: m.lineno,
+        hash: m.hash,
+        user: meta_entries(m.user),
+    }
+}
+
+fn posting(p: ffi::Posting) -> wit::Posting {
+    wit::Posting {
+        account: p.account,
+        units: p.units.map(amount),
+        cost: p.cost.map(cost),
+        price: p.price.map(amount),
+        flag: p.flag,
+        meta: meta_entries(p.meta),
+    }
+}
+
+fn directive(d: ffi::DirectiveJson) -> wit::Directive {
+    use ffi::DirectiveJson as D;
+    match d {
+        D::Transaction {
+            date,
+            flag,
+            payee,
+            narration,
+            tags,
+            links,
+            postings,
+            meta: m,
+        } => wit::Directive::Transaction(wit::Transaction {
+            date,
+            flag,
+            payee,
+            narration,
+            tags,
+            links,
+            postings: postings.into_iter().map(posting).collect(),
+            meta: meta(m),
+        }),
+        D::Open {
+            date,
+            account,
+            currencies,
+            booking,
+            meta: m,
+        } => wit::Directive::Open(wit::OpenDir {
+            date,
+            account,
+            currencies,
+            booking,
+            meta: meta(m),
+        }),
+        D::Close {
+            date,
+            account,
+            meta: m,
+        } => wit::Directive::Close(wit::CloseDir {
+            date,
+            account,
+            meta: meta(m),
+        }),
+        D::Balance {
+            date,
+            account,
+            amount: amt,
+            tolerance,
+            meta: m,
+        } => wit::Directive::Balance(wit::BalanceDir {
+            date,
+            account,
+            amount: amount(amt),
+            tolerance,
+            meta: meta(m),
+        }),
+        D::Pad {
+            date,
+            account,
+            source_account,
+            meta: m,
+        } => wit::Directive::Pad(wit::PadDir {
+            date,
+            account,
+            source_account,
+            meta: meta(m),
+        }),
+        D::Commodity {
+            date,
+            currency,
+            meta: m,
+        } => wit::Directive::Commodity(wit::CommodityDir {
+            date,
+            currency,
+            meta: meta(m),
+        }),
+        D::Price {
+            date,
+            currency,
+            amount: amt,
+            meta: m,
+        } => wit::Directive::Price(wit::PriceDir {
+            date,
+            currency,
+            amount: amount(amt),
+            meta: meta(m),
+        }),
+        D::Event {
+            date,
+            event_type,
+            value,
+            meta: m,
+        } => wit::Directive::Event(wit::EventDir {
+            date,
+            event_type,
+            value,
+            meta: meta(m),
+        }),
+        D::Note {
+            date,
+            account,
+            comment,
+            meta: m,
+        } => wit::Directive::Note(wit::NoteDir {
+            date,
+            account,
+            comment,
+            meta: meta(m),
+        }),
+        D::Document {
+            date,
+            account,
+            path,
+            tags,
+            links,
+            meta: m,
+        } => wit::Directive::Document(wit::DocumentDir {
+            date,
+            account,
+            path,
+            tags,
+            links,
+            meta: meta(m),
+        }),
+        D::Query {
+            date,
+            name,
+            query_string,
+            meta: m,
+        } => wit::Directive::Query(wit::QueryDir {
+            date,
+            name,
+            query_string,
+            meta: meta(m),
+        }),
+        D::Custom {
+            date,
+            custom_type,
+            values,
+            meta: m,
+        } => wit::Directive::Custom(wit::CustomDir {
+            date,
+            custom_type,
+            values: values.into_iter().map(|tv| meta_value(tv.value)).collect(),
+            meta: meta(m),
+        }),
+    }
+}
+
+fn error(e: ffi::Error) -> wit::Error {
+    wit::Error {
+        message: e.message,
+        line: e.line,
+        column: e.column,
+        field: e.field,
+        // DTO uses usize; WIT uses u32.
+        entry_index: e.entry_index.map(|i| i as u32),
+        severity: e.severity,
+        phase: e.phase,
+    }
+}
+
+fn pairs_u32(m: std::collections::HashMap<String, u32>) -> Vec<(String, u32)> {
+    let mut v: Vec<_> = m.into_iter().collect();
+    v.sort_by(|a, b| a.0.cmp(&b.0));
+    v
+}
+
+fn pairs_str(m: std::collections::HashMap<String, String>) -> Vec<(String, String)> {
+    let mut v: Vec<_> = m.into_iter().collect();
+    v.sort_by(|a, b| a.0.cmp(&b.0));
+    v
+}
+
+fn options(o: ffi::LedgerOptions) -> wit::LedgerOptions {
+    wit::LedgerOptions {
+        title: o.title,
+        operating_currency: o.operating_currency,
+        name_assets: o.name_assets,
+        name_liabilities: o.name_liabilities,
+        name_equity: o.name_equity,
+        name_income: o.name_income,
+        name_expenses: o.name_expenses,
+        documents: o.documents,
+        commodities: o.commodities,
+        booking_method: o.booking_method,
+        display_precision: pairs_u32(o.display_precision),
+        render_commas: o.render_commas,
+        inferred_tolerance_default: pairs_str(o.inferred_tolerance_default),
+        inferred_tolerance_multiplier: o.inferred_tolerance_multiplier,
+        infer_tolerance_from_cost: o.infer_tolerance_from_cost,
+        account_rounding: o.account_rounding,
+        account_previous_balances: o.account_previous_balances,
+        account_previous_earnings: o.account_previous_earnings,
+        account_previous_conversions: o.account_previous_conversions,
+        account_current_earnings: o.account_current_earnings,
+        account_current_conversions: o.account_current_conversions,
+        account_unrealized_gains: o.account_unrealized_gains,
+        conversion_currency: o.conversion_currency,
+    }
+}
+
+/// `ledger.load` — parse + book `source`, returning a typed load result.
+pub fn load(source: &str, filename: &str) -> out::LoadResult {
+    let loaded = ffi::helpers::load_source(source);
+    let entries = loaded
+        .directives
+        .iter()
+        .zip(loaded.directive_lines.iter())
+        .map(|(d, &line)| directive(ffi::convert::directive_to_json(d, line, filename)))
+        .collect();
+    out::LoadResult {
+        entries,
+        errors: loaded.errors.into_iter().map(error).collect(),
+        options: options(loaded.options),
+        plugins: loaded
+            .plugins
+            .into_iter()
+            .map(|p| wit::Plugin {
+                name: p.name,
+                config: p.config,
+            })
+            .collect(),
+        includes: loaded
+            .includes
+            .into_iter()
+            .map(|i| wit::SourceInclude {
+                path: i.path,
+                lineno: i.lineno,
+            })
+            .collect(),
+    }
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -538,7 +538,12 @@ fn read_file(path: &str) -> Result<String, String> {
 }
 
 /// `ledger.loadFile` — load from a path, resolving `include` directives, with
-/// optional path-security confinement and a post-booking plugin pass.
+/// a post-booking plugin pass.
+///
+/// Includes are confined to the entry file's directory tree by default;
+/// `allow_unrestricted_includes == true` lifts that path-traversal protection
+/// (so the safe state is the `false`/zero default). The flag is negated into
+/// the loader's `path_security` at the boundary.
 pub fn load_file(
     path: &str,
     allow_unrestricted_includes: bool,

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -63,7 +63,7 @@ fn meta_value(v: Json) -> wit::MetaValue {
             }
         }
         Json::String(s) => wit::MetaValue::Text(s),
-        other => wit::MetaValue::Text(other.to_string()),
+        arr @ Json::Array(_) => wit::MetaValue::Text(arr.to_string()),
     }
 }
 
@@ -258,13 +258,9 @@ fn error(e: ffi::Error) -> wit::Error {
     }
 }
 
-fn pairs_u32(m: std::collections::HashMap<String, u32>) -> Vec<(String, u32)> {
-    let mut v: Vec<_> = m.into_iter().collect();
-    v.sort_by(|a, b| a.0.cmp(&b.0));
-    v
-}
-
-fn pairs_str(m: std::collections::HashMap<String, String>) -> Vec<(String, String)> {
+/// Flatten a map into a key-sorted `list<tuple>` (WIT has no map type, so the
+/// surface models maps as deterministically-ordered pair lists).
+fn pairs<V>(m: std::collections::HashMap<String, V>) -> Vec<(String, V)> {
     let mut v: Vec<_> = m.into_iter().collect();
     v.sort_by(|a, b| a.0.cmp(&b.0));
     v
@@ -282,9 +278,9 @@ fn options(o: ffi::LedgerOptions) -> wit::LedgerOptions {
         documents: o.documents,
         commodities: o.commodities,
         booking_method: o.booking_method,
-        display_precision: pairs_u32(o.display_precision),
+        display_precision: pairs(o.display_precision),
         render_commas: o.render_commas,
-        inferred_tolerance_default: pairs_str(o.inferred_tolerance_default),
+        inferred_tolerance_default: pairs(o.inferred_tolerance_default),
         inferred_tolerance_multiplier: o.inferred_tolerance_multiplier,
         infer_tolerance_from_cost: o.infer_tolerance_from_cost,
         account_rounding: o.account_rounding,
@@ -376,9 +372,11 @@ fn query_value(v: &Value) -> wit::QueryValue {
         Value::Position(p) => Q::Position(position(p)),
         Value::Inventory(inv) => Q::Inventory(inv.positions().map(position).collect()),
         Value::StringSet(set) => Q::StringSet(set.clone()),
-        Value::Metadata(m) => {
-            Q::Metadata(m.iter().map(|(k, val)| (k.to_string(), format!("{val:?}"))).collect())
-        }
+        Value::Metadata(m) => Q::Metadata(
+            m.iter()
+                .map(|(k, val)| (k.clone(), format!("{val:?}")))
+                .collect(),
+        ),
         Value::Interval(iv) => Q::Interval(wit::Interval {
             count: iv.count,
             unit: match iv.unit {
@@ -493,7 +491,11 @@ fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out:
                 .iter()
                 .map(|row| row.iter().map(query_value).collect())
                 .collect();
-            out::QueryResult { columns, rows, errors: vec![] }
+            out::QueryResult {
+                columns,
+                rows,
+                errors: vec![],
+            }
         }
         Err(e) => out::QueryResult {
             columns: vec![],
@@ -517,7 +519,9 @@ pub fn batch(source: &str, queries: &[String]) -> out::BatchResult {
             .map(|_| out::QueryResult {
                 columns: Vec::new(),
                 rows: Vec::new(),
-                errors: vec![simple_error("Cannot execute query: parse errors exist".to_string())],
+                errors: vec![simple_error(
+                    "Cannot execute query: parse errors exist".to_string(),
+                )],
             })
             .collect()
     };
@@ -533,26 +537,39 @@ fn read_file(path: &str) -> Result<String, String> {
     std::fs::read_to_string(path).map_err(|e| format!("Failed to read file '{path}': {e}"))
 }
 
-/// `ledger.loadFile` — load from a path, resolving `include` directives.
-pub fn load_file(path: &str) -> out::LoadResult {
-    match ffi::helpers::load_file(std::path::Path::new(path), true) {
+/// `ledger.loadFile` — load from a path, resolving `include` directives, with
+/// optional path-security confinement and a post-booking plugin pass.
+pub fn load_file(path: &str, path_security: bool, plugins: &[String]) -> out::LoadResult {
+    match ffi::helpers::load_file(std::path::Path::new(path), path_security) {
         Ok(fl) => {
-            let entries = fl
-                .directives
+            let mut errors = fl.errors;
+            let opts = fl.options;
+            let plugin_dtos = fl.plugins;
+            let loaded_files = fl.loaded_files;
+            // Run requested plugins via the same helper the JSON-RPC handler uses.
+            let plugin_names: Vec<&str> = plugins.iter().map(String::as_str).collect();
+            let (directives, directive_lines, directive_files) = ffi::helpers::apply_plugins(
+                &plugin_names,
+                fl.directives,
+                fl.directive_lines,
+                fl.directive_files,
+                &mut errors,
+                &opts,
+            );
+            let entries = directives
                 .iter()
                 .enumerate()
                 .map(|(i, d)| {
-                    let line = fl.directive_lines.get(i).copied().unwrap_or(0);
-                    let file = fl.directive_files.get(i).map_or("<unknown>", String::as_str);
+                    let line = directive_lines.get(i).copied().unwrap_or(0);
+                    let file = directive_files.get(i).map_or("<unknown>", String::as_str);
                     directive(ffi::convert::directive_to_json(d, line, file))
                 })
                 .collect();
             out::LoadResult {
                 entries,
-                errors: fl.errors.into_iter().map(error).collect(),
-                options: options(fl.options),
-                plugins: fl
-                    .plugins
+                errors: errors.into_iter().map(error).collect(),
+                options: options(opts),
+                plugins: plugin_dtos
                     .into_iter()
                     .map(|p| wit::Plugin {
                         name: p.name,
@@ -561,8 +578,7 @@ pub fn load_file(path: &str) -> out::LoadResult {
                     .collect(),
                 // File load reports the resolved file set (no per-include line),
                 // carried in `includes` with lineno 0.
-                includes: fl
-                    .loaded_files
+                includes: loaded_files
                     .into_iter()
                     .map(|p| wit::SourceInclude { path: p, lineno: 0 })
                     .collect(),
@@ -581,6 +597,9 @@ pub fn load_file(path: &str) -> out::LoadResult {
 // validate/query/batch over a file match the JSON-RPC handlers: read the file
 // and run the single-source path (these do not resolve includes).
 
+/// Validate the ledger at `path`. Reads the file and runs the single-source
+/// [`validate`] path (no include resolution); a read failure becomes an
+/// invalid result carrying the I/O error.
 pub fn validate_file(path: &str) -> out::ValidateResult {
     match read_file(path) {
         Ok(src) => validate(&src),
@@ -593,6 +612,9 @@ pub fn validate_file(path: &str) -> out::ValidateResult {
     }
 }
 
+/// Run a single BQL query against the ledger at `path`. Reads the file and
+/// runs the single-source [`query`] path (no include resolution); a read
+/// failure becomes an errored result carrying the I/O error.
 pub fn query_file(path: &str, query_str: &str) -> out::QueryResult {
     match read_file(path) {
         Ok(src) => query(&src, query_str),
@@ -604,6 +626,10 @@ pub fn query_file(path: &str, query_str: &str) -> out::QueryResult {
     }
 }
 
+/// Run several BQL queries against the ledger at `path`, loading it once.
+/// Reads the file and runs the single-source [`batch`] path (no include
+/// resolution); a read failure becomes an errored result carrying the I/O
+/// error.
 pub fn batch_file(path: &str, queries: &[String]) -> out::BatchResult {
     match read_file(path) {
         Ok(src) => batch(&src, queries),
@@ -771,7 +797,11 @@ fn input_entry(d: &wit::InputDirective) -> ffi::InputEntry {
 /// `entry.create` — build one directive from typed input.
 pub fn create(entry: &wit::InputDirective) -> Result<wit::Directive, String> {
     let core = ffi::input_entry_to_directive(&input_entry(entry))?;
-    Ok(directive(ffi::convert::directive_to_json(&core, 0, "<created>")))
+    Ok(directive(ffi::convert::directive_to_json(
+        &core,
+        0,
+        "<created>",
+    )))
 }
 
 /// `entry.createBatch` — all-or-nothing (first failure fails the call).
@@ -801,7 +831,7 @@ fn directive_date(d: &wit::Directive) -> &str {
 /// `filter_entries`: `commodity` is always dropped, `open` is kept while still
 /// active (`date < end`), `close` is kept from `begin` on (`date >= begin`),
 /// and everything else is kept within `[begin, end)`. Entries with an absent or
-/// unparseable date are dropped. Unparseable bounds return the input unchanged
+/// unparsable date are dropped. Unparsable bounds return the input unchanged
 /// (the WIT signature has no error channel).
 pub fn filter(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::Directive> {
     let (Ok(begin), Ok(end)) = (
@@ -835,17 +865,33 @@ pub fn types_info() -> out_util::TypesInfo {
     let strs = |xs: &[&str]| xs.iter().map(|s| (*s).to_string()).collect();
     out_util::TypesInfo {
         all_directives: strs(&[
-            "transaction", "balance", "open", "close", "commodity", "pad", "event", "note",
-            "document", "price", "query", "custom",
+            "transaction",
+            "balance",
+            "open",
+            "close",
+            "commodity",
+            "pad",
+            "event",
+            "note",
+            "document",
+            "price",
+            "query",
+            "custom",
         ]),
         booking_methods: strs(&[
-            "STRICT", "STRICT_WITH_SIZE", "NONE", "AVERAGE", "FIFO", "LIFO", "HIFO",
+            "STRICT",
+            "STRICT_WITH_SIZE",
+            "NONE",
+            "AVERAGE",
+            "FIFO",
+            "LIFO",
+            "HIFO",
         ]),
         missing: out_util::MissingSentinel {
             description: "Represents a missing/interpolated amount in a posting".to_string(),
             json_representation: "null or {currency_only: string}".to_string(),
         },
-        account_types: strs(&["Assets", "Liabilities", "Equity", "Income", "Expenses"]),
+        account_types: strs(&ffi::helpers::ACCOUNT_TYPES),
     }
 }
 
@@ -860,15 +906,7 @@ pub fn is_encrypted(path: &str) -> bool {
 /// `util.getAccountType` — the (lowercased) type root of an account name.
 #[must_use]
 pub fn get_account_type(account: &str) -> String {
-    match account.split(':').next() {
-        Some("Assets") => "assets",
-        Some("Liabilities") => "liabilities",
-        Some("Equity") => "equity",
-        Some("Income") => "income",
-        Some("Expenses") => "expenses",
-        _ => "unknown",
-    }
-    .to_string()
+    ffi::helpers::account_type(account).to_string()
 }
 
 // ---- format ----
@@ -915,8 +953,9 @@ pub fn format_entries(entries: &[wit::InputDirective]) -> Result<String, String>
 // ---- builder: clamp (WIT loaded directives -> core -> ops::clamp -> WIT) ----
 
 fn loaded_meta(m: &wit::Meta) -> std::collections::HashMap<String, Json> {
-    // Drop source location (filename/lineno/hash); keep user key/values.
-    m.user.iter().map(|(k, v)| (k.clone(), json_from_meta_value(v))).collect()
+    // Drop source location (filename/lineno/hash); keep user key/values. The
+    // user pairs have the same shape as an input entry's meta.
+    input_meta(&m.user)
 }
 
 fn loaded_cost_to_input(c: &wit::Cost) -> ffi::InputCost {
@@ -935,7 +974,11 @@ fn loaded_posting_to_input(p: &wit::Posting) -> ffi::InputPosting {
         units: p.units.as_ref().map(input_amount),
         cost: p.cost.as_ref().map(loaded_cost_to_input),
         price: p.price.as_ref().map(input_amount),
-        meta: p.meta.iter().map(|(k, v)| (k.clone(), json_from_meta_value(v))).collect(),
+        meta: p
+            .meta
+            .iter()
+            .map(|(k, v)| (k.clone(), json_from_meta_value(v)))
+            .collect(),
     }
 }
 
@@ -1033,7 +1076,7 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         begin.parse::<rustledger_core::NaiveDate>(),
         end.parse::<rustledger_core::NaiveDate>(),
     ) else {
-        // Unparseable bounds: return the input unchanged (no error channel).
+        // Unparsable bounds: return the input unchanged (no error channel).
         return entries;
     };
     let core: Vec<rustledger_core::Directive> = entries

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -12,6 +12,7 @@
 //! directive values keep their type via `TypedValue`, so they are unaffected.)
 
 use rustledger_ffi_wasi as ffi;
+use rustledger_query::{Executor, IntervalUnit, Value, parse as parse_query};
 use serde_json::Value as Json;
 
 use crate::exports::rustledger::ledger::ledger as out;
@@ -326,5 +327,154 @@ pub fn load(source: &str, filename: &str) -> out::LoadResult {
                 lineno: i.lineno,
             })
             .collect(),
+    }
+}
+
+// ---- query + validate ----
+
+fn realized_cost(c: &rustledger_core::Cost) -> wit::Cost {
+    // A booked position carries a concrete per-unit cost (mirrors #1399).
+    wit::Cost {
+        number: Some(wit::CostNumber::PerUnit(c.number.to_string())),
+        currency: Some(c.currency.to_string()),
+        date: c.date.map(|d| d.to_string()),
+        label: c.label.clone(),
+    }
+}
+
+fn position(p: &rustledger_core::Position) -> wit::Position {
+    wit::Position {
+        units: wit::Amount {
+            number: p.units.number.to_string(),
+            currency: p.units.currency.to_string(),
+        },
+        cost: p.cost.as_ref().map(realized_cost),
+    }
+}
+
+/// `rustledger_query::Value` → WIT `query-value` (mirrors `value_to_json`,
+/// but typed). `object`/`set` are self-referential — WIT can't type them, so
+/// they fall to the `json` escape hatch via the reused `value_to_json`.
+fn query_value(v: &Value) -> wit::QueryValue {
+    use wit::QueryValue as Q;
+    match v {
+        Value::Null => Q::Null,
+        Value::Boolean(b) => Q::Boolean(*b),
+        Value::Integer(i) => Q::Integer(*i),
+        Value::String(s) => Q::Text(s.clone()),
+        Value::Date(d) => Q::Date(d.to_string()),
+        Value::Number(n) => Q::Number(n.to_string()),
+        Value::Amount(a) => Q::Amount(wit::Amount {
+            number: a.number.to_string(),
+            currency: a.currency.to_string(),
+        }),
+        Value::Position(p) => Q::Position(position(p)),
+        Value::Inventory(inv) => Q::Inventory(inv.positions().map(position).collect()),
+        Value::StringSet(set) => Q::StringSet(set.clone()),
+        Value::Metadata(m) => {
+            Q::Metadata(m.iter().map(|(k, val)| (k.to_string(), format!("{val:?}"))).collect())
+        }
+        Value::Interval(iv) => Q::Interval(wit::Interval {
+            count: iv.count,
+            unit: match iv.unit {
+                IntervalUnit::Day => wit::IntervalUnit::Day,
+                IntervalUnit::Week => wit::IntervalUnit::Week,
+                IntervalUnit::Month => wit::IntervalUnit::Month,
+                IntervalUnit::Quarter => wit::IntervalUnit::Quarter,
+                IntervalUnit::Year => wit::IntervalUnit::Year,
+            },
+        }),
+        Value::Object(_) | Value::Set(_) => Q::Json(ffi::convert::value_to_json(v).to_string()),
+    }
+}
+
+fn simple_error(message: String) -> wit::Error {
+    error(ffi::Error::new(message))
+}
+
+/// `ledger.validate` — parse + semantic validation. Mirrors the JSON-RPC
+/// `handle_validate` orchestration (`load_source` + `ValidationSession`).
+pub fn validate(source: &str) -> out::ValidateResult {
+    let load = ffi::helpers::load_source(source);
+    let parse_error_count = load.errors.iter().filter(|e| e.phase == "parse").count();
+    let mut errors = load.errors;
+
+    // Only run semantic validation when there are no syntactic errors.
+    if parse_error_count == 0 {
+        let today = jiff::Zoned::now().date();
+        let session = rustledger_validate::ValidationSession::new(
+            rustledger_validate::ValidationOptions::default(),
+        );
+        let (session, mut verrs) = session.run_early_spanned(&load.spanned_directives, today);
+        let (session, late) = session.run_late_spanned(&load.spanned_directives, today);
+        verrs.extend(late);
+        verrs.extend(session.finalize());
+        for err in verrs {
+            let mut e = ffi::Error::new(&err.message).validate_phase();
+            if let Some(span) = err.span {
+                e = e.with_line(load.line_lookup.byte_to_line(span.start));
+            }
+            errors.push(e);
+        }
+    }
+
+    let validate_error_count = errors.iter().filter(|e| e.phase == "validate").count();
+    out::ValidateResult {
+        valid: errors.is_empty(),
+        errors: errors.into_iter().map(error).collect(),
+        parse_error_count: parse_error_count as u32,
+        validate_error_count: validate_error_count as u32,
+    }
+}
+
+/// `query.execute` — run a BQL query against `source`.
+pub fn query(source: &str, query_str: &str) -> out::QueryResult {
+    let loaded = ffi::helpers::load_source(source);
+    let parsed = match parse_query(query_str) {
+        Ok(q) => q,
+        Err(e) => {
+            return out::QueryResult {
+                columns: vec![],
+                rows: vec![],
+                errors: vec![simple_error(e.to_string())],
+            };
+        }
+    };
+    let mut executor = Executor::new(&loaded.directives);
+    match executor.execute(&parsed) {
+        Ok(result) => {
+            // Infer column datatypes from the first row (reusing value_datatype).
+            let columns = if let Some(first) = result.rows.first() {
+                result
+                    .columns
+                    .iter()
+                    .zip(first.iter())
+                    .map(|(name, value)| wit::ColumnInfo {
+                        name: name.clone(),
+                        datatype: ffi::convert::value_datatype(value).to_string(),
+                    })
+                    .collect()
+            } else {
+                result
+                    .columns
+                    .iter()
+                    .map(|name| wit::ColumnInfo {
+                        name: name.clone(),
+                        datatype: "str".to_string(),
+                    })
+                    .collect()
+            };
+            let rows = result
+                .rows
+                .iter()
+                .map(|row| row.iter().map(query_value).collect())
+                .collect();
+            out::QueryResult { columns, rows, errors: vec![] }
+        }
+        Err(e) => out::QueryResult {
+            columns: vec![],
+            rows: vec![],
+            errors: vec![simple_error(format!("Query error: {e}"))],
+        },
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -785,3 +785,89 @@ pub fn filter(
         })
         .collect()
 }
+
+// ---- util ----
+
+use crate::exports::rustledger::ledger::util as out_util;
+
+/// `util.types` — static type metadata about this build.
+pub fn types_info() -> out_util::TypesInfo {
+    let strs = |xs: &[&str]| xs.iter().map(|s| (*s).to_string()).collect();
+    out_util::TypesInfo {
+        all_directives: strs(&[
+            "transaction", "balance", "open", "close", "commodity", "pad", "event", "note",
+            "document", "price", "query", "custom",
+        ]),
+        booking_methods: strs(&[
+            "STRICT", "STRICT_WITH_SIZE", "NONE", "AVERAGE", "FIFO", "LIFO", "HIFO",
+        ]),
+        missing: out_util::MissingSentinel {
+            description: "Represents a missing/interpolated amount in a posting".to_string(),
+            json_representation: "null or {currency_only: string}".to_string(),
+        },
+        account_types: strs(&["Assets", "Liabilities", "Equity", "Income", "Expenses"]),
+    }
+}
+
+/// `util.isEncrypted` — true for `.gpg` / `.asc` files (by extension).
+#[must_use]
+pub fn is_encrypted(path: &str) -> bool {
+    std::path::Path::new(path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("gpg") || ext.eq_ignore_ascii_case("asc"))
+}
+
+/// `util.getAccountType` — the (lowercased) type root of an account name.
+#[must_use]
+pub fn get_account_type(account: &str) -> String {
+    match account.split(':').next() {
+        Some("Assets") => "assets",
+        Some("Liabilities") => "liabilities",
+        Some("Equity") => "equity",
+        Some("Income") => "income",
+        Some("Expenses") => "expenses",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+// ---- format ----
+
+/// `format.source` — canonically reformat beancount source (best-effort; parse
+/// errors don't abort, since the WIT signature has no error channel).
+#[must_use]
+pub fn format_source(source: &str) -> String {
+    let parsed = rustledger_parser::parse(source);
+    rustledger_parser::format::format_source_with_parsed(&parsed, source)
+}
+
+/// `format.file` — reformat the file at `path`. On read error the message is
+/// returned as the body (the WIT signature has no error channel).
+#[must_use]
+pub fn format_file(path: &str) -> String {
+    match read_file(path) {
+        Ok(src) => format_source(&src),
+        Err(e) => e,
+    }
+}
+
+fn format_directives(dirs: &[rustledger_core::Directive]) -> Result<String, String> {
+    let config = rustledger_core::format::FormatConfig::default();
+    rustledger_parser::format::canonicalize_directives(dirs.iter(), &config)
+        .map_err(|e| e.to_string())
+}
+
+/// `format.entry` — render one constructed directive to canonical text.
+pub fn format_entry(entry: &wit::InputDirective) -> Result<String, String> {
+    let dir = ffi::input_entry_to_directive(&input_entry(entry))?;
+    format_directives(std::slice::from_ref(&dir))
+}
+
+/// `format.entries` — render constructed directives to canonical text.
+pub fn format_entries(entries: &[wit::InputDirective]) -> Result<String, String> {
+    let mut dirs = Vec::with_capacity(entries.len());
+    for e in entries {
+        dirs.push(ffi::input_entry_to_directive(&input_entry(e))?);
+    }
+    format_directives(&dirs)
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -499,3 +499,96 @@ pub fn batch(source: &str, queries: &[String]) -> out::BatchResult {
         queries: query_results,
     }
 }
+
+// ---- file variants ----
+
+fn read_file(path: &str) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|e| format!("Failed to read file '{path}': {e}"))
+}
+
+/// `ledger.loadFile` — load from a path, resolving `include` directives.
+pub fn load_file(path: &str) -> out::LoadResult {
+    match ffi::helpers::load_file(std::path::Path::new(path), true) {
+        Ok(fl) => {
+            let entries = fl
+                .directives
+                .iter()
+                .enumerate()
+                .map(|(i, d)| {
+                    let line = fl.directive_lines.get(i).copied().unwrap_or(0);
+                    let file = fl.directive_files.get(i).map_or("<unknown>", String::as_str);
+                    directive(ffi::convert::directive_to_json(d, line, file))
+                })
+                .collect();
+            out::LoadResult {
+                entries,
+                errors: fl.errors.into_iter().map(error).collect(),
+                options: options(fl.options),
+                plugins: fl
+                    .plugins
+                    .into_iter()
+                    .map(|p| wit::Plugin {
+                        name: p.name,
+                        config: p.config,
+                    })
+                    .collect(),
+                // File load reports the resolved file set (no per-include line),
+                // carried in `includes` with lineno 0.
+                includes: fl
+                    .loaded_files
+                    .into_iter()
+                    .map(|p| wit::SourceInclude { path: p, lineno: 0 })
+                    .collect(),
+            }
+        }
+        Err(e) => out::LoadResult {
+            entries: vec![],
+            errors: vec![simple_error(e)],
+            options: options(ffi::LedgerOptions::default()),
+            plugins: vec![],
+            includes: vec![],
+        },
+    }
+}
+
+// validate/query/batch over a file match the JSON-RPC handlers: read the file
+// and run the single-source path (these do not resolve includes).
+
+pub fn validate_file(path: &str) -> out::ValidateResult {
+    match read_file(path) {
+        Ok(src) => validate(&src),
+        Err(e) => out::ValidateResult {
+            valid: false,
+            errors: vec![simple_error(e)],
+            parse_error_count: 0,
+            validate_error_count: 0,
+        },
+    }
+}
+
+pub fn query_file(path: &str, query_str: &str) -> out::QueryResult {
+    match read_file(path) {
+        Ok(src) => query(&src, query_str),
+        Err(e) => out::QueryResult {
+            columns: vec![],
+            rows: vec![],
+            errors: vec![simple_error(e)],
+        },
+    }
+}
+
+pub fn batch_file(path: &str, queries: &[String]) -> out::BatchResult {
+    match read_file(path) {
+        Ok(src) => batch(&src, queries),
+        Err(e) => out::BatchResult {
+            load: out::LoadResult {
+                entries: vec![],
+                errors: vec![simple_error(e)],
+                options: options(ffi::LedgerOptions::default()),
+                plugins: vec![],
+                includes: vec![],
+            },
+            queries: vec![],
+        },
+    }
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -434,10 +434,25 @@ pub fn validate(source: &str) -> out::ValidateResult {
 
 /// `query.execute` — run a BQL query against `source`.
 pub fn query(source: &str, query_str: &str) -> out::QueryResult {
-    run_query(&ffi::helpers::load_source(source).directives, query_str)
+    query_loaded(&ffi::helpers::load_source(source), query_str)
 }
 
-/// Run one query against already-loaded directives (shared by `query`/`batch`).
+/// Short-circuit on load (parse/booking) errors, then run one query over the
+/// pad-expanded directives — matching `handle_query` (FFI's `load_source` does
+/// not pad-expand, so balance-computing consumers must opt in explicitly).
+fn query_loaded(loaded: &ffi::helpers::LoadResult, query_str: &str) -> out::QueryResult {
+    if !loaded.errors.is_empty() {
+        return out::QueryResult {
+            columns: Vec::new(),
+            rows: Vec::new(),
+            errors: loaded.errors.iter().cloned().map(error).collect(),
+        };
+    }
+    let directives = rustledger_booking::merge_with_padding(&loaded.directives);
+    run_query(&directives, query_str)
+}
+
+/// Run one query against already-loaded, pad-expanded directives.
 fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out::QueryResult {
     let parsed = match parse_query(query_str) {
         Ok(q) => q,
@@ -489,11 +504,23 @@ fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out:
 }
 
 /// `query.batch` — load `source` once, then run several queries against it.
+/// On parse errors, every query returns the canonical short-circuit error
+/// (matching `handle_batch`); otherwise pads are expanded once for all queries.
 pub fn batch(source: &str, queries: &[String]) -> out::BatchResult {
     let loaded = ffi::helpers::load_source(source);
-    // Collect query results (owned) before consuming `loaded` for the load.
-    let query_results: Vec<out::QueryResult> =
-        queries.iter().map(|q| run_query(&loaded.directives, q)).collect();
+    let query_results: Vec<out::QueryResult> = if loaded.errors.is_empty() {
+        let directives = rustledger_booking::merge_with_padding(&loaded.directives);
+        queries.iter().map(|q| run_query(&directives, q)).collect()
+    } else {
+        queries
+            .iter()
+            .map(|_| out::QueryResult {
+                columns: Vec::new(),
+                rows: Vec::new(),
+                errors: vec![simple_error("Cannot execute query: parse errors exist".to_string())],
+            })
+            .collect()
+    };
     out::BatchResult {
         load: load_result(loaded, "<stdin>"),
         queries: query_results,
@@ -770,18 +797,31 @@ fn directive_date(d: &wit::Directive) -> &str {
     }
 }
 
-/// `entry.filter` — keep directives within `[begin, end)` (ISO dates compare
-/// lexically, i.e. chronologically).
-pub fn filter(
-    entries: Vec<wit::Directive>,
-    begin: &str,
-    end: &str,
-) -> Vec<wit::Directive> {
+/// `entry.filter` — filter directives by date range, matching the JSON-RPC
+/// `filter_entries`: `commodity` is always dropped, `open` is kept while still
+/// active (`date < end`), `close` is kept from `begin` on (`date >= begin`),
+/// and everything else is kept within `[begin, end)`. Entries with an absent or
+/// unparseable date are dropped. Unparseable bounds return the input unchanged
+/// (the WIT signature has no error channel).
+pub fn filter(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::Directive> {
+    let (Ok(begin), Ok(end)) = (
+        begin.parse::<rustledger_core::NaiveDate>(),
+        end.parse::<rustledger_core::NaiveDate>(),
+    ) else {
+        return entries;
+    };
     entries
         .into_iter()
         .filter(|d| {
-            let date = directive_date(d);
-            date >= begin && date < end
+            let Ok(date) = directive_date(d).parse::<rustledger_core::NaiveDate>() else {
+                return false;
+            };
+            match d {
+                wit::Directive::Commodity(_) => false,
+                wit::Directive::Open(_) => date < end,
+                wit::Directive::Close(_) => date >= begin,
+                _ => date >= begin && date < end,
+            }
         })
         .collect()
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -592,3 +592,196 @@ pub fn batch_file(path: &str, queries: &[String]) -> out::BatchResult {
         },
     }
 }
+
+// ---- builder: WIT input -> core directive (reverse of the output path) ----
+
+fn json_from_meta_value(v: &wit::MetaValue) -> Json {
+    match v {
+        wit::MetaValue::Text(s) => Json::String(s.clone()),
+        // A numeric string round-trips to MetaValue::Number via json_to_meta_value.
+        wit::MetaValue::Number(s) => {
+            serde_json::from_str(s).unwrap_or_else(|_| Json::String(s.clone()))
+        }
+        wit::MetaValue::Boolean(b) => Json::Bool(*b),
+        wit::MetaValue::Amount(a) => {
+            serde_json::json!({"number": a.number, "currency": a.currency})
+        }
+        wit::MetaValue::Null => Json::Null,
+    }
+}
+
+fn input_meta(entries: &[(String, wit::MetaValue)]) -> std::collections::HashMap<String, Json> {
+    entries
+        .iter()
+        .map(|(k, v)| (k.clone(), json_from_meta_value(v)))
+        .collect()
+}
+
+fn input_amount(a: &wit::Amount) -> ffi::InputAmount {
+    ffi::InputAmount {
+        number: a.number.clone(),
+        currency: a.currency.clone(),
+    }
+}
+
+fn input_cost_number(n: &wit::CostNumber) -> ffi::InputCostNumber {
+    match n {
+        wit::CostNumber::PerUnit(v) => ffi::InputCostNumber::PerUnit { value: v.clone() },
+        wit::CostNumber::Total(v) => ffi::InputCostNumber::Total { value: v.clone() },
+        wit::CostNumber::PerUnitFromTotal((per_unit, total)) => {
+            ffi::InputCostNumber::PerUnitFromTotal {
+                per_unit: per_unit.clone(),
+                total: total.clone(),
+            }
+        }
+    }
+}
+
+fn input_cost(c: &wit::InputCost) -> ffi::InputCost {
+    ffi::InputCost {
+        number: c.number.as_ref().map(input_cost_number),
+        currency: c.currency.clone(),
+        date: c.date.clone(),
+        label: c.label.clone(),
+        merge: c.merge,
+    }
+}
+
+fn input_posting(p: &wit::InputPosting) -> ffi::InputPosting {
+    ffi::InputPosting {
+        account: p.account.clone(),
+        units: p.units.as_ref().map(input_amount),
+        cost: p.cost.as_ref().map(input_cost),
+        price: p.price.as_ref().map(input_amount),
+        meta: input_meta(&p.meta),
+    }
+}
+
+fn input_entry(d: &wit::InputDirective) -> ffi::InputEntry {
+    use ffi::InputEntry as E;
+    use wit::InputDirective as I;
+    match d {
+        I::Transaction(t) => E::Transaction {
+            date: t.date.clone(),
+            flag: t.flag.clone(),
+            payee: t.payee.clone(),
+            narration: t.narration.clone(),
+            tags: t.tags.clone(),
+            links: t.links.clone(),
+            postings: t.postings.iter().map(input_posting).collect(),
+            meta: input_meta(&t.meta),
+        },
+        I::Open(o) => E::Open {
+            date: o.date.clone(),
+            account: o.account.clone(),
+            currencies: o.currencies.clone(),
+            booking: o.booking.clone(),
+            meta: input_meta(&o.meta),
+        },
+        I::Close(c) => E::Close {
+            date: c.date.clone(),
+            account: c.account.clone(),
+            meta: input_meta(&c.meta),
+        },
+        I::Balance(b) => E::Balance {
+            date: b.date.clone(),
+            account: b.account.clone(),
+            amount: input_amount(&b.amount),
+            meta: input_meta(&b.meta),
+        },
+        I::Pad(p) => E::Pad {
+            date: p.date.clone(),
+            account: p.account.clone(),
+            source_account: p.source_account.clone(),
+            meta: input_meta(&p.meta),
+        },
+        I::Commodity(c) => E::Commodity {
+            date: c.date.clone(),
+            currency: c.currency.clone(),
+            meta: input_meta(&c.meta),
+        },
+        I::Price(p) => E::Price {
+            date: p.date.clone(),
+            currency: p.currency.clone(),
+            amount: input_amount(&p.amount),
+            meta: input_meta(&p.meta),
+        },
+        I::Event(e) => E::Event {
+            date: e.date.clone(),
+            event_type: e.event_type.clone(),
+            value: e.value.clone(),
+            meta: input_meta(&e.meta),
+        },
+        I::Note(n) => E::Note {
+            date: n.date.clone(),
+            account: n.account.clone(),
+            comment: n.comment.clone(),
+            meta: input_meta(&n.meta),
+        },
+        I::Document(doc) => E::Document {
+            date: doc.date.clone(),
+            account: doc.account.clone(),
+            path: doc.path.clone(),
+            tags: doc.tags.clone(),
+            links: doc.links.clone(),
+            meta: input_meta(&doc.meta),
+        },
+        I::Query(q) => E::Query {
+            date: q.date.clone(),
+            name: q.name.clone(),
+            query_string: q.query_string.clone(),
+            meta: input_meta(&q.meta),
+        },
+        I::Custom(c) => E::Custom {
+            date: c.date.clone(),
+            custom_type: c.custom_type.clone(),
+            values: c.values.iter().map(json_from_meta_value).collect(),
+            meta: input_meta(&c.meta),
+        },
+    }
+}
+
+/// `entry.create` — build one directive from typed input.
+pub fn create(entry: &wit::InputDirective) -> Result<wit::Directive, String> {
+    let core = ffi::input_entry_to_directive(&input_entry(entry))?;
+    Ok(directive(ffi::convert::directive_to_json(&core, 0, "<created>")))
+}
+
+/// `entry.createBatch` — all-or-nothing (first failure fails the call).
+pub fn create_batch(entries: &[wit::InputDirective]) -> Result<Vec<wit::Directive>, String> {
+    entries.iter().map(create).collect()
+}
+
+fn directive_date(d: &wit::Directive) -> &str {
+    use wit::Directive as D;
+    match d {
+        D::Transaction(t) => &t.date,
+        D::Open(o) => &o.date,
+        D::Close(c) => &c.date,
+        D::Balance(b) => &b.date,
+        D::Pad(p) => &p.date,
+        D::Commodity(c) => &c.date,
+        D::Price(p) => &p.date,
+        D::Event(e) => &e.date,
+        D::Note(n) => &n.date,
+        D::Document(doc) => &doc.date,
+        D::Query(q) => &q.date,
+        D::Custom(c) => &c.date,
+    }
+}
+
+/// `entry.filter` — keep directives within `[begin, end)` (ISO dates compare
+/// lexically, i.e. chronologically).
+pub fn filter(
+    entries: Vec<wit::Directive>,
+    begin: &str,
+    end: &str,
+) -> Vec<wit::Directive> {
+    entries
+        .into_iter()
+        .filter(|d| {
+            let date = directive_date(d);
+            date >= begin && date < end
+        })
+        .collect()
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -5,11 +5,13 @@
 //! (`directive_to_json`) are reused wholesale; this module is the mechanical
 //! DTO→WIT shuffle, since the WIT types were authored 1:1 with the DTOs.
 //!
-//! Known fidelity gap: directive/posting metadata is reused from the DTO, which
-//! flattens `MetaValue` to JSON and stringifies numbers — so a numeric metadata
-//! value currently surfaces as `meta-value::text`. Faithful typing requires
-//! reading the core `MetaValue` directly; tracked as a follow-up. (Custom
-//! directive values keep their type via `TypedValue`, so they are unaffected.)
+//! Known fidelity gap: directive/posting *metadata* (`meta.user`) is reused from
+//! the DTO, which flattens `MetaValue` to JSON and stringifies numbers — so a
+//! numeric metadata value currently surfaces as `meta-value::text`. Faithful
+//! typing requires reading the core `MetaValue` directly; tracked as a
+//! follow-up. (Custom-directive arguments are *not* affected: they carry their
+//! `value-type` tag via the WIT `typed-value` record, so account/currency/tag/…
+//! stay distinguishable.)
 
 use rustledger_ffi_wasi as ffi;
 use rustledger_query::{Executor, IntervalUnit, Value, parse as parse_query};
@@ -239,7 +241,15 @@ fn directive(d: ffi::DirectiveJson) -> wit::Directive {
         } => wit::Directive::Custom(wit::CustomDir {
             date,
             custom_type,
-            values: values.into_iter().map(|tv| meta_value(tv.value)).collect(),
+            // Carry the `value-type` tag (account/currency/tag/…) alongside the
+            // value, which `meta-value` alone would flatten to `text`.
+            values: values
+                .into_iter()
+                .map(|tv| wit::TypedValue {
+                    value_type: tv.value_type.to_string(),
+                    value: meta_value(tv.value),
+                })
+                .collect(),
             meta: meta(m),
         }),
     }
@@ -1071,7 +1081,13 @@ fn loaded_directive_to_input(d: &wit::Directive) -> ffi::InputEntry {
         D::Custom(c) => E::Custom {
             date: c.date.clone(),
             custom_type: c.custom_type.clone(),
-            values: c.values.iter().map(json_from_meta_value).collect(),
+            // `values` are now `typed-value`; the input DTO re-derives the type
+            // from the value, so unwrap to the inner `meta-value`.
+            values: c
+                .values
+                .iter()
+                .map(|tv| json_from_meta_value(&tv.value))
+                .collect(),
             meta: loaded_meta(&c.meta),
         },
     }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -871,3 +871,137 @@ pub fn format_entries(entries: &[wit::InputDirective]) -> Result<String, String>
     }
     format_directives(&dirs)
 }
+
+// ---- builder: clamp (WIT loaded directives -> core -> ops::clamp -> WIT) ----
+
+fn loaded_meta(m: &wit::Meta) -> std::collections::HashMap<String, Json> {
+    // Drop source location (filename/lineno/hash); keep user key/values.
+    m.user.iter().map(|(k, v)| (k.clone(), json_from_meta_value(v))).collect()
+}
+
+fn loaded_cost_to_input(c: &wit::Cost) -> ffi::InputCost {
+    ffi::InputCost {
+        number: c.number.as_ref().map(input_cost_number),
+        currency: c.currency.clone(),
+        date: c.date.clone(),
+        label: c.label.clone(),
+        merge: false,
+    }
+}
+
+fn loaded_posting_to_input(p: &wit::Posting) -> ffi::InputPosting {
+    ffi::InputPosting {
+        account: p.account.clone(),
+        units: p.units.as_ref().map(input_amount),
+        cost: p.cost.as_ref().map(loaded_cost_to_input),
+        price: p.price.as_ref().map(input_amount),
+        meta: p.meta.iter().map(|(k, v)| (k.clone(), json_from_meta_value(v))).collect(),
+    }
+}
+
+/// A loaded WIT `directive` -> `InputEntry`, so it can be reconstructed into a
+/// core `Directive` via `input_entry_to_directive` (dropping the source-location
+/// metadata, which is re-derived on output).
+fn loaded_directive_to_input(d: &wit::Directive) -> ffi::InputEntry {
+    use ffi::InputEntry as E;
+    use wit::Directive as D;
+    match d {
+        D::Transaction(t) => E::Transaction {
+            date: t.date.clone(),
+            flag: t.flag.clone(),
+            payee: t.payee.clone(),
+            narration: t.narration.clone(),
+            tags: t.tags.clone(),
+            links: t.links.clone(),
+            postings: t.postings.iter().map(loaded_posting_to_input).collect(),
+            meta: loaded_meta(&t.meta),
+        },
+        D::Open(o) => E::Open {
+            date: o.date.clone(),
+            account: o.account.clone(),
+            currencies: o.currencies.clone(),
+            booking: o.booking.clone(),
+            meta: loaded_meta(&o.meta),
+        },
+        D::Close(c) => E::Close {
+            date: c.date.clone(),
+            account: c.account.clone(),
+            meta: loaded_meta(&c.meta),
+        },
+        D::Balance(b) => E::Balance {
+            date: b.date.clone(),
+            account: b.account.clone(),
+            amount: input_amount(&b.amount),
+            meta: loaded_meta(&b.meta),
+        },
+        D::Pad(p) => E::Pad {
+            date: p.date.clone(),
+            account: p.account.clone(),
+            source_account: p.source_account.clone(),
+            meta: loaded_meta(&p.meta),
+        },
+        D::Commodity(c) => E::Commodity {
+            date: c.date.clone(),
+            currency: c.currency.clone(),
+            meta: loaded_meta(&c.meta),
+        },
+        D::Price(p) => E::Price {
+            date: p.date.clone(),
+            currency: p.currency.clone(),
+            amount: input_amount(&p.amount),
+            meta: loaded_meta(&p.meta),
+        },
+        D::Event(e) => E::Event {
+            date: e.date.clone(),
+            event_type: e.event_type.clone(),
+            value: e.value.clone(),
+            meta: loaded_meta(&e.meta),
+        },
+        D::Note(n) => E::Note {
+            date: n.date.clone(),
+            account: n.account.clone(),
+            comment: n.comment.clone(),
+            meta: loaded_meta(&n.meta),
+        },
+        D::Document(doc) => E::Document {
+            date: doc.date.clone(),
+            account: doc.account.clone(),
+            path: doc.path.clone(),
+            tags: doc.tags.clone(),
+            links: doc.links.clone(),
+            meta: loaded_meta(&doc.meta),
+        },
+        D::Query(q) => E::Query {
+            date: q.date.clone(),
+            name: q.name.clone(),
+            query_string: q.query_string.clone(),
+            meta: loaded_meta(&q.meta),
+        },
+        D::Custom(c) => E::Custom {
+            date: c.date.clone(),
+            custom_type: c.custom_type.clone(),
+            values: c.values.iter().map(json_from_meta_value).collect(),
+            meta: loaded_meta(&c.meta),
+        },
+    }
+}
+
+/// `entry.clamp` — clamp loaded directives to `[begin, end)` via the typed
+/// `rustledger_ops::clamp`. Round-trips WIT -> core -> ops -> WIT.
+pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::Directive> {
+    let (Ok(begin_date), Ok(end_date)) = (
+        begin.parse::<rustledger_core::NaiveDate>(),
+        end.parse::<rustledger_core::NaiveDate>(),
+    ) else {
+        // Unparseable bounds: return the input unchanged (no error channel).
+        return entries;
+    };
+    let core: Vec<rustledger_core::Directive> = entries
+        .iter()
+        .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok())
+        .collect();
+    rustledger_ops::clamp::clamp(&core, begin_date, end_date)
+        .iter()
+        .map(|d| directive(ffi::convert::directive_to_json(d, 0, "<clamped>")))
+        .collect()
+}

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -47,26 +47,26 @@ impl LedgerGuest for Component {
     fn load(source: String) -> LoadResult {
         convert::load(&source, "<stdin>")
     }
-    fn load_file(_path: String) -> LoadResult {
-        unimplemented!("{TODO}")
+    fn load_file(path: String) -> LoadResult {
+        convert::load_file(&path)
     }
     fn validate(source: String) -> ValidateResult {
         convert::validate(&source)
     }
-    fn validate_file(_path: String) -> ValidateResult {
-        unimplemented!("{TODO}")
+    fn validate_file(path: String) -> ValidateResult {
+        convert::validate_file(&path)
     }
     fn query(source: String, query: String) -> QueryResult {
         convert::query(&source, &query)
     }
-    fn query_file(_path: String, _query: String) -> QueryResult {
-        unimplemented!("{TODO}")
+    fn query_file(path: String, query: String) -> QueryResult {
+        convert::query_file(&path, &query)
     }
     fn batch(source: String, queries: Vec<String>) -> BatchResult {
         convert::batch(&source, &queries)
     }
-    fn batch_file(_path: String, _queries: Vec<String>) -> BatchResult {
-        unimplemented!("{TODO}")
+    fn batch_file(path: String, queries: Vec<String>) -> BatchResult {
+        convert::batch_file(&path, &queries)
     }
 }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -3,11 +3,10 @@
 //! Implements the WIT `rustledger` world (`wit/world.wit`) — the typed
 //! replacement for the `rustledger-ffi-wasi` JSON-RPC surface.
 //!
-//! Phase 2 is in progress (tracer-bullet): the toolchain and binding wiring are
-//! proven end-to-end via `version`; the remaining exports are stubbed and are
-//! being filled in against the existing loader/query logic, one interface at a
-//! time. Stubs `unimplemented!()` (a wasm trap) rather than returning silently
-//! wrong data.
+//! All four interfaces (`ledger`, `builder`, `util`, `format`) are wired: each
+//! Guest method delegates to [`convert`], which maps between the WIT types and
+//! the loader/query logic reused from `rustledger-ffi-wasi`. Parity with the
+//! JSON-RPC surface is exercised by `rustledger-ffi-component-tests`.
 
 // wit-bindgen's `export!` macro emits `#[unsafe(export_name = …)]` shims and
 // unsafe blocks for the canonical ABI; the workspace denies `unsafe_code`, so
@@ -15,6 +14,8 @@
 // is allowed because the generated bindings are undocumented by construction.
 #![allow(unsafe_code)]
 #![allow(missing_docs)]
+// wit-bindgen's canonical-ABI lowering emits `Vec::from_raw_parts(p, n, n)`.
+#![allow(clippy::same_length_and_capacity)]
 
 wit_bindgen::generate!({
     path: "wit/world.wit",
@@ -23,9 +24,7 @@ wit_bindgen::generate!({
 
 mod convert;
 
-use exports::rustledger::ledger::builder::{
-    Directive, Guest as BuilderGuest, InputDirective,
-};
+use exports::rustledger::ledger::builder::{Directive, Guest as BuilderGuest, InputDirective};
 use exports::rustledger::ledger::format::Guest as FormatGuest;
 use exports::rustledger::ledger::ledger::{
     BatchResult, Guest as LedgerGuest, LoadResult, QueryResult, ValidateResult,
@@ -36,8 +35,6 @@ use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 /// `rustledger-ffi-wasi`'s `API_VERSION` (additive 2.1 — per-position cost).
 const API_VERSION: &str = "2.1";
 
-const TODO: &str = "rustledger-ffi-component: export not yet wired (#1384 Phase 2)";
-
 struct Component;
 
 impl LedgerGuest for Component {
@@ -47,8 +44,8 @@ impl LedgerGuest for Component {
     fn load(source: String) -> LoadResult {
         convert::load(&source, "<stdin>")
     }
-    fn load_file(path: String) -> LoadResult {
-        convert::load_file(&path)
+    fn load_file(path: String, path_security: bool, plugins: Vec<String>) -> LoadResult {
+        convert::load_file(&path, path_security, &plugins)
     }
     fn validate(source: String) -> ValidateResult {
         convert::validate(&source)

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -50,14 +50,14 @@ impl LedgerGuest for Component {
     fn load_file(_path: String) -> LoadResult {
         unimplemented!("{TODO}")
     }
-    fn validate(_source: String) -> ValidateResult {
-        unimplemented!("{TODO}")
+    fn validate(source: String) -> ValidateResult {
+        convert::validate(&source)
     }
     fn validate_file(_path: String) -> ValidateResult {
         unimplemented!("{TODO}")
     }
-    fn query(_source: String, _query: String) -> QueryResult {
-        unimplemented!("{TODO}")
+    fn query(source: String, query: String) -> QueryResult {
+        convert::query(&source, &query)
     }
     fn query_file(_path: String, _query: String) -> QueryResult {
         unimplemented!("{TODO}")

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -71,14 +71,14 @@ impl LedgerGuest for Component {
 }
 
 impl BuilderGuest for Component {
-    fn create(_entry: InputDirective) -> Result<Directive, String> {
-        unimplemented!("{TODO}")
+    fn create(entry: InputDirective) -> Result<Directive, String> {
+        convert::create(&entry)
     }
-    fn create_batch(_entries: Vec<InputDirective>) -> Result<Vec<Directive>, String> {
-        unimplemented!("{TODO}")
+    fn create_batch(entries: Vec<InputDirective>) -> Result<Vec<Directive>, String> {
+        convert::create_batch(&entries)
     }
-    fn filter(_entries: Vec<Directive>, _begin_date: String, _end_date: String) -> Vec<Directive> {
-        unimplemented!("{TODO}")
+    fn filter(entries: Vec<Directive>, begin_date: String, end_date: String) -> Vec<Directive> {
+        convert::filter(entries, &begin_date, &end_date)
     }
     fn clamp(_entries: Vec<Directive>, _begin_date: String, _end_date: String) -> Vec<Directive> {
         unimplemented!("{TODO}")

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -44,8 +44,12 @@ impl LedgerGuest for Component {
     fn load(source: String) -> LoadResult {
         convert::load(&source, "<stdin>")
     }
-    fn load_file(path: String, path_security: bool, plugins: Vec<String>) -> LoadResult {
-        convert::load_file(&path, path_security, &plugins)
+    fn load_file(
+        path: String,
+        allow_unrestricted_includes: bool,
+        plugins: Vec<String>,
+    ) -> LoadResult {
+        convert::load_file(&path, allow_unrestricted_includes, &plugins)
     }
     fn validate(source: String) -> ValidateResult {
         convert::validate(&source)

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -81,7 +81,10 @@ impl BuilderGuest for Component {
         convert::filter(entries, &begin_date, &end_date)
     }
     fn clamp(_entries: Vec<Directive>, _begin_date: String, _end_date: String) -> Vec<Directive> {
-        unimplemented!("{TODO}")
+        // Deferred: the underlying `clamp_entries` is JSON-based (synthesizes
+        // directives via `json!`). Wiring it here cleanly needs a *typed* clamp
+        // on core directives — tracked in rustledger/rustledger#1401.
+        unimplemented!("entry.clamp: pending typed clamp (#1401)")
     }
 }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -8,6 +8,12 @@
 //! the loader/query logic reused from `rustledger-ffi-wasi`. Parity with the
 //! JSON-RPC surface is exercised by `rustledger-ffi-component-tests`.
 
+// This is a wasip2 component: `wit-bindgen`'s `export!` emits canonical-ABI
+// shims that don't link as a native `cdylib` (e.g. a `cargo build --workspace`
+// on x86_64, as the Arch PKGBUILD runs). Gate the whole crate to wasm targets
+// so the native build is a trivially-linkable empty cdylib; the real component
+// is only ever built with `--target wasm32-wasip2`.
+#![cfg(target_arch = "wasm32")]
 // wit-bindgen's `export!` macro emits `#[unsafe(export_name = …)]` shims and
 // unsafe blocks for the canonical ABI; the workspace denies `unsafe_code`, so
 // allow it here (the hand-written code below contains no unsafe). `missing_docs`

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -62,8 +62,8 @@ impl LedgerGuest for Component {
     fn query_file(_path: String, _query: String) -> QueryResult {
         unimplemented!("{TODO}")
     }
-    fn batch(_source: String, _queries: Vec<String>) -> BatchResult {
-        unimplemented!("{TODO}")
+    fn batch(source: String, queries: Vec<String>) -> BatchResult {
+        convert::batch(&source, &queries)
     }
     fn batch_file(_path: String, _queries: Vec<String>) -> BatchResult {
         unimplemented!("{TODO}")

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -21,6 +21,8 @@ wit_bindgen::generate!({
     world: "rustledger",
 });
 
+mod convert;
+
 use exports::rustledger::ledger::builder::{
     Directive, Guest as BuilderGuest, InputDirective,
 };
@@ -42,8 +44,8 @@ impl LedgerGuest for Component {
     fn version() -> String {
         API_VERSION.to_string()
     }
-    fn load(_source: String) -> LoadResult {
-        unimplemented!("{TODO}")
+    fn load(source: String) -> LoadResult {
+        convert::load(&source, "<stdin>")
     }
     fn load_file(_path: String) -> LoadResult {
         unimplemented!("{TODO}")

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -87,28 +87,28 @@ impl BuilderGuest for Component {
 
 impl UtilGuest for Component {
     fn types() -> TypesInfo {
-        unimplemented!("{TODO}")
+        convert::types_info()
     }
-    fn is_encrypted(_path: String) -> bool {
-        unimplemented!("{TODO}")
+    fn is_encrypted(path: String) -> bool {
+        convert::is_encrypted(&path)
     }
-    fn get_account_type(_account: String) -> String {
-        unimplemented!("{TODO}")
+    fn get_account_type(account: String) -> String {
+        convert::get_account_type(&account)
     }
 }
 
 impl FormatGuest for Component {
-    fn format_source(_source: String) -> String {
-        unimplemented!("{TODO}")
+    fn format_source(source: String) -> String {
+        convert::format_source(&source)
     }
-    fn format_file(_path: String) -> String {
-        unimplemented!("{TODO}")
+    fn format_file(path: String) -> String {
+        convert::format_file(&path)
     }
-    fn format_entry(_entry: InputDirective) -> Result<String, String> {
-        unimplemented!("{TODO}")
+    fn format_entry(entry: InputDirective) -> Result<String, String> {
+        convert::format_entry(&entry)
     }
-    fn format_entries(_entries: Vec<InputDirective>) -> Result<String, String> {
-        unimplemented!("{TODO}")
+    fn format_entries(entries: Vec<InputDirective>) -> Result<String, String> {
+        convert::format_entries(&entries)
     }
 }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -80,11 +80,8 @@ impl BuilderGuest for Component {
     fn filter(entries: Vec<Directive>, begin_date: String, end_date: String) -> Vec<Directive> {
         convert::filter(entries, &begin_date, &end_date)
     }
-    fn clamp(_entries: Vec<Directive>, _begin_date: String, _end_date: String) -> Vec<Directive> {
-        // Deferred: the underlying `clamp_entries` is JSON-based (synthesizes
-        // directives via `json!`). Wiring it here cleanly needs a *typed* clamp
-        // on core directives — tracked in rustledger/rustledger#1401.
-        unimplemented!("entry.clamp: pending typed clamp (#1401)")
+    fn clamp(entries: Vec<Directive>, begin_date: String, end_date: String) -> Vec<Directive> {
+        convert::clamp(entries, &begin_date, &end_date)
     }
 }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -1,0 +1,113 @@
+//! rustledger embedding as a WASI Preview 2 component (#1384, Phase 2).
+//!
+//! Implements the WIT `rustledger` world (`wit/world.wit`) — the typed
+//! replacement for the `rustledger-ffi-wasi` JSON-RPC surface.
+//!
+//! Phase 2 is in progress (tracer-bullet): the toolchain and binding wiring are
+//! proven end-to-end via `version`; the remaining exports are stubbed and are
+//! being filled in against the existing loader/query logic, one interface at a
+//! time. Stubs `unimplemented!()` (a wasm trap) rather than returning silently
+//! wrong data.
+
+// wit-bindgen's `export!` macro emits `#[unsafe(export_name = …)]` shims and
+// unsafe blocks for the canonical ABI; the workspace denies `unsafe_code`, so
+// allow it here (the hand-written code below contains no unsafe). `missing_docs`
+// is allowed because the generated bindings are undocumented by construction.
+#![allow(unsafe_code)]
+#![allow(missing_docs)]
+
+wit_bindgen::generate!({
+    path: "wit/world.wit",
+    world: "rustledger",
+});
+
+use exports::rustledger::ledger::builder::{
+    Directive, Guest as BuilderGuest, InputDirective,
+};
+use exports::rustledger::ledger::format::Guest as FormatGuest;
+use exports::rustledger::ledger::ledger::{
+    BatchResult, Guest as LedgerGuest, LoadResult, QueryResult, ValidateResult,
+};
+use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
+
+/// The Component-Model api-version this build implements. Mirrors
+/// `rustledger-ffi-wasi`'s `API_VERSION` (additive 2.1 — per-position cost).
+const API_VERSION: &str = "2.1";
+
+const TODO: &str = "rustledger-ffi-component: export not yet wired (#1384 Phase 2)";
+
+struct Component;
+
+impl LedgerGuest for Component {
+    fn version() -> String {
+        API_VERSION.to_string()
+    }
+    fn load(_source: String) -> LoadResult {
+        unimplemented!("{TODO}")
+    }
+    fn load_file(_path: String) -> LoadResult {
+        unimplemented!("{TODO}")
+    }
+    fn validate(_source: String) -> ValidateResult {
+        unimplemented!("{TODO}")
+    }
+    fn validate_file(_path: String) -> ValidateResult {
+        unimplemented!("{TODO}")
+    }
+    fn query(_source: String, _query: String) -> QueryResult {
+        unimplemented!("{TODO}")
+    }
+    fn query_file(_path: String, _query: String) -> QueryResult {
+        unimplemented!("{TODO}")
+    }
+    fn batch(_source: String, _queries: Vec<String>) -> BatchResult {
+        unimplemented!("{TODO}")
+    }
+    fn batch_file(_path: String, _queries: Vec<String>) -> BatchResult {
+        unimplemented!("{TODO}")
+    }
+}
+
+impl BuilderGuest for Component {
+    fn create(_entry: InputDirective) -> Result<Directive, String> {
+        unimplemented!("{TODO}")
+    }
+    fn create_batch(_entries: Vec<InputDirective>) -> Result<Vec<Directive>, String> {
+        unimplemented!("{TODO}")
+    }
+    fn filter(_entries: Vec<Directive>, _begin_date: String, _end_date: String) -> Vec<Directive> {
+        unimplemented!("{TODO}")
+    }
+    fn clamp(_entries: Vec<Directive>, _begin_date: String, _end_date: String) -> Vec<Directive> {
+        unimplemented!("{TODO}")
+    }
+}
+
+impl UtilGuest for Component {
+    fn types() -> TypesInfo {
+        unimplemented!("{TODO}")
+    }
+    fn is_encrypted(_path: String) -> bool {
+        unimplemented!("{TODO}")
+    }
+    fn get_account_type(_account: String) -> String {
+        unimplemented!("{TODO}")
+    }
+}
+
+impl FormatGuest for Component {
+    fn format_source(_source: String) -> String {
+        unimplemented!("{TODO}")
+    }
+    fn format_file(_path: String) -> String {
+        unimplemented!("{TODO}")
+    }
+    fn format_entry(_entry: InputDirective) -> Result<String, String> {
+        unimplemented!("{TODO}")
+    }
+    fn format_entries(_entries: Vec<InputDirective>) -> Result<String, String> {
+        unimplemented!("{TODO}")
+    }
+}
+
+export!(Component);

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -380,10 +380,14 @@ interface ledger {
   /// Parse + book a ledger from source text.
   load: func(source: string) -> load-result;
   /// Like `load`, but from a file path (the host grants filesystem access).
-  /// `path-security` confines the include graph to the entry file's directory
-  /// tree (pass `true` unless cross-tree includes are needed). `plugins` names
-  /// the regular (post-booking) plugins to run, e.g. `["auto_accounts"]`.
-  load-file: func(path: string, path-security: bool, plugins: list<string>) -> load-result;
+  /// By default the include graph is confined to the entry file's directory
+  /// tree (path-traversal protection); set `allow-unrestricted-includes` to
+  /// `true` only when cross-tree includes are needed. The flag is phrased so
+  /// the safe behavior is the `false`/zero default — WIT has no field defaults,
+  /// so an under-specified caller stays confined rather than escaping the
+  /// sandbox. `plugins` names the regular (post-booking) plugins to run, e.g.
+  /// `["auto_accounts"]`.
+  load-file: func(path: string, allow-unrestricted-includes: bool, plugins: list<string>) -> load-result;
 
   /// Validate source text (parse + semantic checks).
   validate: func(source: string) -> validate-result;

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -1,0 +1,277 @@
+// rustledger embedding interface — typed WIT contract.
+//
+// Phase 1 of the WASI-p1 (JSON-RPC) -> p2 (Component Model) migration (#1384).
+// This is the single source of truth for the embedding wire shape, replacing
+// the hand-mirrored DTOs in `crates/rustledger-ffi-wasi/src/types`. Generated
+// bindings (wit-bindgen guest / wasmtime::component::bindgen! host) enforce the
+// shapes that are currently kept consistent by hand + review (e.g. the cost
+// shape footgun in #1399).
+//
+// Scope (this iteration): the read surface rustfava actually consumes —
+// version / load / validate / query (+ `-file` variants). The directive
+// construction surface (entry.create/clamp/filter) and util helpers
+// (getAccountType/isEncrypted/types) are tracked as remaining Phase 1 work.
+
+package rustledger:ledger@2.1.0;
+
+/// Shared data types, translated 1:1 from `types/output.rs`.
+interface types {
+  /// An amount: decimal number (string, to preserve full precision) + currency.
+  record amount {
+    number: string,
+    currency: string,
+  }
+
+  /// The numeric component of a cost. Mirrors `rustledger_core::CostNumber`;
+  /// the case IS the `kind` discriminator the JSON form tags by hand. Defined
+  /// once and reused for BOTH posting cost and position cost — the consistency
+  /// that #1399 had to enforce manually.
+  variant cost-number {
+    /// Per-unit cost, e.g. `{100 USD}`.
+    per-unit(string),
+    /// Total cost as written, e.g. `{{1000 USD}}` (pre-booking).
+    total(string),
+    /// Post-booking: (derived-per-unit, preserved-original-total).
+    per-unit-from-total(tuple<string, string>),
+  }
+
+  /// A cost: number + currency + optional acquisition date and lot label.
+  /// Every field optional to match the lean `PostingCost` JSON (bare `{USD}`
+  /// lot matches carry no `number`).
+  record cost {
+    number: option<cost-number>,
+    currency: option<string>,
+    date: option<string>,
+    label: option<string>,
+  }
+
+  /// A metadata value. The JSON DTO types this as arbitrary `serde_json::Value`,
+  /// but it is produced solely from `MetaValue`, a closed, non-recursive set:
+  /// string/account/currency/tag/link/date all render as text; number is a
+  /// decimal string; plus bool, amount, and absent.
+  variant meta-value {
+    text(string),
+    number(string),
+    boolean(bool),
+    amount(amount),
+    null,
+  }
+
+  /// One user metadata entry (preserves source order, unlike a map).
+  type meta-entry = tuple<string, meta-value>;
+
+  /// Directive metadata: source location + user key/values.
+  record meta {
+    filename: string,
+    lineno: u32,
+    hash: string,
+    user: list<meta-entry>,
+  }
+
+  /// A transaction posting.
+  record posting {
+    account: string,
+    units: option<amount>,
+    cost: option<cost>,
+    price: option<amount>,
+    flag: option<string>,
+    meta: list<meta-entry>,
+  }
+
+  // Per-kind directive payloads (WIT variant cases each carry one type).
+  record transaction {
+    date: string,
+    flag: string,
+    payee: option<string>,
+    narration: option<string>,
+    tags: list<string>,
+    links: list<string>,
+    postings: list<posting>,
+    meta: meta,
+  }
+  record open-dir {
+    date: string,
+    account: string,
+    currencies: list<string>,
+    booking: option<string>,
+    meta: meta,
+  }
+  record close-dir { date: string, account: string, meta: meta }
+  record balance-dir {
+    date: string,
+    account: string,
+    amount: amount,
+    tolerance: option<string>,
+    meta: meta,
+  }
+  record pad-dir {
+    date: string,
+    account: string,
+    source-account: string,
+    meta: meta,
+  }
+  record commodity-dir { date: string, currency: string, meta: meta }
+  record price-dir { date: string, currency: string, amount: amount, meta: meta }
+  record event-dir { date: string, event-type: string, value: string, meta: meta }
+  record note-dir { date: string, account: string, comment: string, meta: meta }
+  record document-dir {
+    date: string,
+    account: string,
+    path: string,
+    tags: list<string>,
+    links: list<string>,
+    meta: meta,
+  }
+  record query-dir { date: string, name: string, query-string: string, meta: meta }
+  record custom-dir {
+    date: string,
+    custom-type: string,
+    // `TypedValue`s; same closed shape as meta-value.
+    values: list<meta-value>,
+    meta: meta,
+  }
+
+  /// A loaded directive. Replaces the `type`-tagged `DirectiveJson` enum.
+  variant directive {
+    transaction(transaction),
+    open(open-dir),
+    close(close-dir),
+    balance(balance-dir),
+    pad(pad-dir),
+    commodity(commodity-dir),
+    price(price-dir),
+    event(event-dir),
+    note(note-dir),
+    document(document-dir),
+    query(query-dir),
+    custom(custom-dir),
+  }
+
+  /// A load / validate / query error.
+  record error {
+    message: string,
+    line: option<u32>,
+    column: option<u32>,
+    field: option<string>,
+    entry-index: option<u32>,
+    severity: string,
+    phase: string,
+  }
+
+  record plugin { name: string, config: option<string> }
+  record source-include { path: string, lineno: u32 }
+
+  /// Ledger options (resolved). Maps become ordered key/value lists.
+  record ledger-options {
+    title: option<string>,
+    operating-currency: list<string>,
+    name-assets: string,
+    name-liabilities: string,
+    name-equity: string,
+    name-income: string,
+    name-expenses: string,
+    documents: list<string>,
+    commodities: list<string>,
+    booking-method: string,
+    display-precision: list<tuple<string, u32>>,
+    render-commas: bool,
+    inferred-tolerance-default: list<tuple<string, string>>,
+    inferred-tolerance-multiplier: string,
+    infer-tolerance-from-cost: bool,
+    account-rounding: option<string>,
+    account-previous-balances: string,
+    account-previous-earnings: string,
+    account-previous-conversions: string,
+    account-current-earnings: string,
+    account-current-conversions: option<string>,
+    account-unrealized-gains: option<string>,
+    conversion-currency: option<string>,
+  }
+
+  /// A booked inventory position: units + optional realized cost (#1399).
+  record position { units: amount, cost: option<cost> }
+
+  /// An interval bucket (GROUP BY date functions).
+  record interval { unit: string }
+
+  /// A query result cell. Mirrors `rustledger_query::Value` as projected by
+  /// `value_to_json`.
+  ///
+  /// The Component Model forbids recursive types (verified: `wasm-tools`
+  /// rejects a `query-value` that contains itself, even through a `list`). The
+  /// two self-referential BQL cells — `object` (a map of cells) and `set` (a
+  /// list of cells) — are therefore carried in the `json` case as a serialized
+  /// JSON string rather than awkwardly flattened. Every other cell is fully
+  /// typed; `object`/`set` are rare in real query output. `metadata` is kept
+  /// typed because its values are already flat strings (not recursive).
+  variant query-value {
+    null,
+    boolean(bool),
+    integer(s64),
+    text(string),
+    date(string),
+    number(string),
+    amount(amount),
+    position(position),
+    inventory(list<position>),
+    string-set(list<string>),
+    metadata(list<tuple<string, string>>),
+    interval(interval),
+    json(string),
+  }
+
+  record column-info { name: string, datatype: string }
+}
+
+/// The embedding entrypoints. Replaces the JSON-RPC methods
+/// (ledger.load/loadFile, ledger.validate, query.execute, util.version).
+interface ledger {
+  use types.{directive, error, ledger-options, plugin, source-include, column-info, query-value};
+
+  record load-result {
+    entries: list<directive>,
+    errors: list<error>,
+    options: ledger-options,
+    plugins: list<plugin>,
+    includes: list<source-include>,
+  }
+
+  record validate-result {
+    valid: bool,
+    errors: list<error>,
+    parse-error-count: u32,
+    validate-error-count: u32,
+  }
+
+  record query-result {
+    columns: list<column-info>,
+    rows: list<list<query-value>>,
+    errors: list<error>,
+  }
+
+  /// The api-version string this component implements (e.g. "2.1"). The WIT
+  /// contract is itself the versioned wire shape; this exists for runtime
+  /// negotiation, replacing the `api_version` field formerly stamped onto every
+  /// JSON-RPC response.
+  version: func() -> string;
+
+  /// Parse + book a ledger from source text.
+  load: func(source: string) -> load-result;
+  /// Like `load`, but from a file path (the host grants filesystem access).
+  load-file: func(path: string) -> load-result;
+
+  /// Validate source text (parse + semantic checks).
+  validate: func(source: string) -> validate-result;
+  /// Like `validate`, but from a file path.
+  validate-file: func(path: string) -> validate-result;
+
+  /// Run a BQL query against source text.
+  query: func(source: string, query: string) -> query-result;
+  /// Like `query`, but the ledger is loaded from a file path.
+  query-file: func(path: string, query: string) -> query-result;
+}
+
+/// The component a host instantiates.
+world rustledger {
+  export ledger;
+}

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -1,16 +1,17 @@
 // rustledger embedding interface — typed WIT contract.
 //
-// Phase 1 of the WASI-p1 (JSON-RPC) -> p2 (Component Model) migration (#1384).
-// This is the single source of truth for the embedding wire shape, replacing
-// the hand-mirrored DTOs in `crates/rustledger-ffi-wasi/src/types`. Generated
+// The WASI-p1 (JSON-RPC) -> p2 (Component Model) migration (#1384). This is the
+// single source of truth for the embedding wire shape, replacing the
+// hand-mirrored DTOs in `crates/rustledger-ffi-wasi/src/types`. Generated
 // bindings (wit-bindgen guest / wasmtime::component::bindgen! host) enforce the
-// shapes that are currently kept consistent by hand + review (e.g. the cost
+// shapes that were previously kept consistent by hand + review (e.g. the cost
 // shape footgun in #1399).
 //
-// Scope (this iteration): the read surface rustfava actually consumes —
-// version / load / validate / query (+ `-file` variants). The directive
-// construction surface (entry.create/clamp/filter) and util helpers
-// (getAccountType/isEncrypted/types) are tracked as remaining Phase 1 work.
+// Scope: the full former JSON-RPC method surface, across four interfaces —
+// `ledger` (version / load / validate / query / batch + `-file` variants),
+// `builder` (create / create-batch / filter / clamp), `util` (types /
+// is-encrypted / get-account-type), and `format` (source / file / entry /
+// entries). All 20 exports are implemented in `crates/rustledger-ffi-component`.
 
 package rustledger:ledger@2.1.0;
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -58,6 +58,16 @@ interface types {
     null,
   }
 
+  /// A `custom` directive argument. `meta-value` collapses
+  /// string/account/currency/tag/link/date to `text`, so the original
+  /// `value-type` tag (`"account"`, `"currency"`, `"tag"`, `"link"`, `"date"`,
+  /// `"string"`, `"number"`, `"bool"`, `"amount"`, `"null"`) is carried
+  /// alongside the value to preserve the distinction the JSON-RPC surface emits.
+  record typed-value {
+    value-type: string,
+    value: meta-value,
+  }
+
   /// One user metadata entry (preserves source order, unlike a map).
   type meta-entry = tuple<string, meta-value>;
 
@@ -127,8 +137,9 @@ interface types {
   record custom-dir {
     date: string,
     custom-type: string,
-    // `TypedValue`s; same closed shape as meta-value.
-    values: list<meta-value>,
+    // Typed `custom` arguments — each keeps its `value-type` tag (account vs
+    // currency vs plain string, etc.), which a bare `meta-value` would lose.
+    values: list<typed-value>,
     meta: meta,
   }
 
@@ -319,6 +330,9 @@ interface types {
   record input-custom {
     date: string,
     custom-type: string,
+    // Stays `meta-value` (not `typed-value`): the input DTO reconstructs the
+    // value type from the value on load, so a caller-supplied tag would be
+    // dropped anyway. Output `custom-dir` carries the tag via `typed-value`.
     values: list<meta-value>,
     meta: list<meta-entry>,
   }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -221,6 +221,119 @@ interface types {
   }
 
   record column-info { name: string, datatype: string }
+
+  // ---- input / construction side (entry.create), from types/input.rs ----
+  //
+  // Reuses `amount`, `cost-number`, and `meta-value` (the closed set
+  // `json_to_meta_value` produces). The input records differ from the loaded
+  // `directive` records in two ways: metadata is user key/values only — no
+  // filename/lineno/hash, which the loader assigns — and costs carry the
+  // `merge` average-cost marker that the output cost lacks.
+
+  /// Input cost spec. Like `cost`, plus `merge` (the `*` on a cost spec that
+  /// triggers average-cost booking).
+  record input-cost {
+    number: option<cost-number>,
+    currency: option<string>,
+    date: option<string>,
+    label: option<string>,
+    merge: bool,
+  }
+
+  /// Input posting; metadata supplied as typed `meta-value`s.
+  record input-posting {
+    account: string,
+    units: option<amount>,
+    cost: option<input-cost>,
+    price: option<amount>,
+    meta: list<meta-entry>,
+  }
+
+  record input-transaction {
+    date: string,
+    flag: string,
+    payee: option<string>,
+    narration: option<string>,
+    tags: list<string>,
+    links: list<string>,
+    postings: list<input-posting>,
+    meta: list<meta-entry>,
+  }
+  record input-open {
+    date: string,
+    account: string,
+    currencies: list<string>,
+    booking: option<string>,
+    meta: list<meta-entry>,
+  }
+  record input-close { date: string, account: string, meta: list<meta-entry> }
+  record input-balance {
+    date: string,
+    account: string,
+    amount: amount,
+    meta: list<meta-entry>,
+  }
+  record input-pad {
+    date: string,
+    account: string,
+    source-account: string,
+    meta: list<meta-entry>,
+  }
+  record input-commodity { date: string, currency: string, meta: list<meta-entry> }
+  record input-price {
+    date: string,
+    currency: string,
+    amount: amount,
+    meta: list<meta-entry>,
+  }
+  record input-event {
+    date: string,
+    event-type: string,
+    value: string,
+    meta: list<meta-entry>,
+  }
+  record input-note {
+    date: string,
+    account: string,
+    comment: string,
+    meta: list<meta-entry>,
+  }
+  record input-document {
+    date: string,
+    account: string,
+    path: string,
+    tags: list<string>,
+    links: list<string>,
+    meta: list<meta-entry>,
+  }
+  record input-query {
+    date: string,
+    name: string,
+    query-string: string,
+    meta: list<meta-entry>,
+  }
+  record input-custom {
+    date: string,
+    custom-type: string,
+    values: list<meta-value>,
+    meta: list<meta-entry>,
+  }
+
+  /// A directive to construct (the `type`-tagged `InputEntry`).
+  variant input-directive {
+    transaction(input-transaction),
+    open(input-open),
+    close(input-close),
+    balance(input-balance),
+    pad(input-pad),
+    commodity(input-commodity),
+    price(input-price),
+    event(input-event),
+    note(input-note),
+    document(input-document),
+    query(input-query),
+    custom(input-custom),
+  }
 }
 
 /// The embedding entrypoints. Replaces the JSON-RPC methods
@@ -271,7 +384,22 @@ interface ledger {
   query-file: func(path: string, query: string) -> query-result;
 }
 
+/// Directive construction — replaces `entry.create` / `entry.createBatch`.
+/// Each input is validated and round-tripped through core, so the result is a
+/// loaded `directive`. Both calls are fallible; the batch is all-or-nothing
+/// (the first invalid entry fails the whole call), matching the JSON-RPC
+/// handler's `?`-propagation.
+interface builder {
+  use types.{input-directive, directive};
+
+  /// Construct one directive. `err` carries the validation message.
+  create: func(entry: input-directive) -> result<directive, string>;
+  /// Construct many; the first failure fails the whole call.
+  create-batch: func(entries: list<input-directive>) -> result<list<directive>, string>;
+}
+
 /// The component a host instantiates.
 world rustledger {
   export ledger;
+  export builder;
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -191,8 +191,11 @@ interface types {
   /// A booked inventory position: units + optional realized cost (#1399).
   record position { units: amount, cost: option<cost> }
 
+  /// The unit of a date GROUP-BY interval bucket.
+  enum interval-unit { day, week, month, quarter, year }
+
   /// An interval bucket (GROUP BY date functions).
-  record interval { unit: string }
+  record interval { count: s64, unit: interval-unit }
 
   /// A query result cell. Mirrors `rustledger_query::Value` as projected by
   /// `value_to_json`.
@@ -362,6 +365,12 @@ interface ledger {
     errors: list<error>,
   }
 
+  /// Load + run several queries in one parse (replaces `query.batch`).
+  record batch-result {
+    load: load-result,
+    queries: list<query-result>,
+  }
+
   /// The api-version string this component implements (e.g. "2.1"). The WIT
   /// contract is itself the versioned wire shape; this exists for runtime
   /// negotiation, replacing the `api_version` field formerly stamped onto every
@@ -382,13 +391,21 @@ interface ledger {
   query: func(source: string, query: string) -> query-result;
   /// Like `query`, but the ledger is loaded from a file path.
   query-file: func(path: string, query: string) -> query-result;
+
+  /// Load source once, then run several queries against it.
+  batch: func(source: string, queries: list<string>) -> batch-result;
+  /// Like `batch`, but the ledger is loaded from a file path.
+  batch-file: func(path: string, queries: list<string>) -> batch-result;
 }
 
-/// Directive construction — replaces `entry.create` / `entry.createBatch`.
-/// Each input is validated and round-tripped through core, so the result is a
-/// loaded `directive`. Both calls are fallible; the batch is all-or-nothing
-/// (the first invalid entry fails the whole call), matching the JSON-RPC
-/// handler's `?`-propagation.
+/// Directive construction & transformation — replaces `entry.create`,
+/// `entry.createBatch`, `entry.filter`, `entry.clamp`.
+///
+/// `create`/`create-batch` validate and round-trip typed input through core, so
+/// the result is a loaded `directive`; both are fallible and the batch is
+/// all-or-nothing (first invalid entry fails the call), matching the JSON-RPC
+/// handler's `?`-propagation. `filter`/`clamp` operate on already-loaded
+/// directives over a date window (`begin` inclusive, `end` exclusive).
 interface builder {
   use types.{input-directive, directive};
 
@@ -396,10 +413,59 @@ interface builder {
   create: func(entry: input-directive) -> result<directive, string>;
   /// Construct many; the first failure fails the whole call.
   create-batch: func(entries: list<input-directive>) -> result<list<directive>, string>;
+
+  /// Keep only directives within [begin, end).
+  filter: func(entries: list<directive>, begin-date: string, end-date: string) -> list<directive>;
+  /// Clamp directives to [begin, end), synthesizing opening-balance and
+  /// summary directives at the boundaries.
+  clamp: func(entries: list<directive>, begin-date: string, end-date: string) -> list<directive>;
+}
+
+/// Utility helpers — replaces `util.types` / `util.isEncrypted` /
+/// `util.getAccountType`.
+interface util {
+  /// Description of the MISSING sentinel.
+  record missing-sentinel {
+    description: string,
+    json-representation: string,
+  }
+
+  /// Static type metadata about this build (was `util.types`).
+  record types-info {
+    all-directives: list<string>,
+    booking-methods: list<string>,
+    missing: missing-sentinel,
+    account-types: list<string>,
+  }
+
+  /// The directive kinds, booking methods, MISSING sentinel, and account types.
+  types: func() -> types-info;
+  /// Whether the file at `path` is an encrypted (GPG) ledger.
+  is-encrypted: func(path: string) -> bool;
+  /// The account-type root (Assets/Liabilities/…) for an account name.
+  get-account-type: func(account: string) -> string;
+}
+
+/// Pretty-printing — replaces `format.source` / `format.entries`. Renders
+/// beancount text in canonical form.
+interface format {
+  use types.{input-directive};
+
+  /// Canonically reformat beancount source text.
+  format-source: func(source: string) -> string;
+  /// Canonically reformat the beancount file at `path`.
+  format-file: func(path: string) -> string;
+  /// Render one constructed directive to canonical beancount text. Fallible.
+  format-entry: func(entry: input-directive) -> result<string, string>;
+  /// Render constructed directives to canonical beancount text. Fallible: an
+  /// invalid input entry fails the call.
+  format-entries: func(entries: list<input-directive>) -> result<string, string>;
 }
 
 /// The component a host instantiates.
 world rustledger {
   export ledger;
   export builder;
+  export util;
+  export format;
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -380,7 +380,10 @@ interface ledger {
   /// Parse + book a ledger from source text.
   load: func(source: string) -> load-result;
   /// Like `load`, but from a file path (the host grants filesystem access).
-  load-file: func(path: string) -> load-result;
+  /// `path-security` confines the include graph to the entry file's directory
+  /// tree (pass `true` unless cross-tree includes are needed). `plugins` names
+  /// the regular (post-booking) plugins to run, e.g. `["auto_accounts"]`.
+  load-file: func(path: string, path-security: bool, plugins: list<string>) -> load-result;
 
   /// Validate source text (parse + semantic checks).
   validate: func(source: string) -> validate-result;

--- a/crates/rustledger-ffi-wasi/README.md
+++ b/crates/rustledger-ffi-wasi/README.md
@@ -6,6 +6,14 @@ A WASI module providing JSON-RPC 2.0 API for embedding Rustledger in any languag
 
 This crate compiles to a WebAssembly module that can be run via [wasmtime](https://wasmtime.dev/) or any WASI-compatible runtime. It provides a fast, portable way to use Rustledger's Beancount parsing, validation, and querying capabilities from any language.
 
+> **Dual-ship note.** This JSON-RPC-over-WASI (wasip1) surface is the current,
+> shipping embedding path (used by rustfava). A typed **WASI Preview 2 /
+> Component Model** successor is in development in `rustledger-ffi-component`
+> ([#1384](https://github.com/rustledger/rustledger/issues/1384)): it replaces
+> this hand-rolled JSON-RPC wire shape with a generated WIT contract. Both
+> coexist during the dual-ship window; this surface is retired in Phase 5. New
+> integrators who can target wasip2 should track the component surface.
+
 ## Usage
 
 Send JSON-RPC 2.0 requests via stdin:
@@ -95,12 +103,12 @@ echo '[
 
 Each element of `error.data.errors` is an object with the following fields:
 
-| Field       | Type           | Description |
+| Field | Type | Description |
 |-------------|----------------|-------------|
-| `message`   | string         | Rendered Display of the parser error. |
-| `kind_code` | integer        | Stable numeric discriminant (1-26, see `openrpc.json`'s `ParseErrorEntry` schema). Use this for structural detection — e.g., `kind_code === 26` is `BomInDirectiveBody` (mid-file BOM; clients can surface a 'Remove BOM' quick-fix). |
-| `hint`      | string \| null | Optional actionable suggestion (e.g., 'Remove the U+FEFF byte at this position…'). Render as a separate help/fix-it line below `message`. |
-| `span`      | object         | `{start: integer, end: integer}` byte range into the source. |
+| `message` | string | Rendered Display of the parser error. |
+| `kind_code` | integer | Stable numeric discriminant (1-26, see `openrpc.json`'s `ParseErrorEntry` schema). Use this for structural detection — e.g., `kind_code === 26` is `BomInDirectiveBody` (mid-file BOM; clients can surface a 'Remove BOM' quick-fix). |
+| `hint` | string | null | Optional actionable suggestion (e.g., 'Remove the U+FEFF byte at this position…'). Render as a separate help/fix-it line below `message`. |
+| `span` | object | `{start: integer, end: integer}` byte range into the source. |
 
 Example error response:
 
@@ -128,9 +136,9 @@ Example error response:
 ```
 
 > **Wire-shape note (v2.0):** prior to API version 2.0, `error.data.errors` was a `string[]` of rendered messages. As of 2.0 each entry is the `ParseErrorEntry` object above. The change is a wire-shape break and earned the major bump per the version policy on `API_VERSION`. Migration recipe for cross-version clients that want to bridge both: `errors.map(e => typeof e === 'string' ? { message: e, kind_code: null, hint: null, span: null } : e)`.
-| -32001 | Beancount validation error | The directives parsed but validation (account openness, balance assertion, etc.) failed. |
-| -32002 | BQL query error | The BQL query string did not parse or did not execute. |
-| -32003 | File I/O error | Could not read/open the requested file path. |
+> | -32001 | Beancount validation error | The directives parsed but validation (account openness, balance assertion, etc.) failed. |
+> | -32002 | BQL query error | The BQL query string did not parse or did not execute. |
+> | -32003 | File I/O error | Could not read/open the requested file path. |
 
 ## Examples
 

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -264,3 +264,149 @@ pub fn load_source(source: &str) -> LoadResult {
         includes,
     }
 }
+
+/// Convert loader `Options` into the wire DTO `LedgerOptions`. Moved here from
+/// the JSON-RPC router so both the router and the WIT component crate (#1384)
+/// can build options from a file load.
+#[must_use]
+pub fn build_ledger_options(options: &rustledger_loader::Options) -> LedgerOptions {
+    LedgerOptions {
+        title: options.title.clone(),
+        operating_currency: options.operating_currency.clone(),
+        name_assets: options.name_assets.clone(),
+        name_liabilities: options.name_liabilities.clone(),
+        name_equity: options.name_equity.clone(),
+        name_income: options.name_income.clone(),
+        name_expenses: options.name_expenses.clone(),
+        documents: options.documents.clone(),
+        commodities: Vec::new(),
+        booking_method: options.booking_method.clone(),
+        display_precision: options
+            .display_precision
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect(),
+        render_commas: options.render_commas,
+        inferred_tolerance_default: options
+            .inferred_tolerance_default
+            .iter()
+            .map(|(k, v)| (k.clone(), v.to_string()))
+            .collect(),
+        inferred_tolerance_multiplier: options.inferred_tolerance_multiplier.to_string(),
+        infer_tolerance_from_cost: options.infer_tolerance_from_cost,
+        account_rounding: options.account_rounding.clone(),
+        account_previous_balances: options.account_previous_balances.clone(),
+        account_previous_earnings: options.account_previous_earnings.clone(),
+        account_previous_conversions: options.account_previous_conversions.clone(),
+        account_current_earnings: options.account_current_earnings.clone(),
+        account_current_conversions: options.account_current_conversions.clone(),
+        account_unrealized_gains: options.account_unrealized_gains.clone(),
+        conversion_currency: options.conversion_currency.clone(),
+    }
+}
+
+/// Result of loading a file through the full loader (include graph resolved).
+///
+/// Unlike [`LoadResult`] (single-source), directives may come from several
+/// files, so each carries its own line number and originating file. The
+/// optional external-plugin pass is *not* run here — that is a JSON-RPC
+/// handler concern gated on a request field, and the WIT surface does not
+/// expose it.
+pub struct FileLoad {
+    pub directives: Vec<Directive>,
+    pub directive_lines: Vec<u32>,
+    pub directive_files: Vec<String>,
+    pub errors: Vec<Error>,
+    pub options: LedgerOptions,
+    pub plugins: Vec<Plugin>,
+    pub loaded_files: Vec<String>,
+}
+
+/// Load a ledger from a file path, resolving `include` directives and booking
+/// transactions. Shared by the JSON-RPC `ledger.loadFile` handler and the WIT
+/// component (#1384).
+///
+/// # Errors
+///
+/// Returns the loader error string if the entry file cannot be read/parsed.
+pub fn load_file(
+    path: &std::path::Path,
+    path_security: bool,
+) -> Result<FileLoad, String> {
+    let mut loader = rustledger_loader::Loader::new().with_path_security(path_security);
+    let load_result = loader
+        .load(path)
+        .map_err(|e| format!("Failed to load file: {e}"))?;
+
+    let mut errors: Vec<Error> = load_result
+        .errors
+        .iter()
+        .map(|e| Error::new(e.to_string()))
+        .collect();
+
+    // Directives + their line numbers / originating files (multi-file).
+    let mut directives: Vec<Directive> = Vec::new();
+    let mut directive_lines: Vec<u32> = Vec::new();
+    let mut directive_files: Vec<String> = Vec::new();
+    for spanned in &load_result.directives {
+        directives.push(spanned.value.clone());
+        let file_id = spanned.file_id as usize;
+        if let Some(sf) = load_result.source_map.get(file_id) {
+            let (line, _col) = sf.line_col(spanned.span.start);
+            directive_lines.push(line as u32);
+            directive_files.push(sf.path.display().to_string());
+        } else {
+            directive_lines.push(0);
+            directive_files.push("<unknown>".to_string());
+        }
+    }
+
+    // Booking + interpolation (loader does not book).
+    let booking_method = load_result
+        .options
+        .booking_method
+        .parse()
+        .unwrap_or(rustledger_core::BookingMethod::Strict);
+    let mut booking_engine = BookingEngine::with_method(booking_method);
+    booking_engine.register_account_methods(directives.iter());
+    for (i, directive) in directives.iter_mut().enumerate() {
+        if let Directive::Transaction(txn) = directive {
+            match booking_engine.book_and_interpolate(txn) {
+                Ok(result) => {
+                    booking_engine.apply(&result.transaction);
+                    *txn = result.transaction;
+                    rustledger_booking::normalize_prices(txn);
+                }
+                Err(e) => {
+                    errors.push(Error::new(e.to_string()).with_line(directive_lines[i]));
+                }
+            }
+        }
+    }
+
+    let options = build_ledger_options(&load_result.options);
+    let plugins: Vec<Plugin> = load_result
+        .plugins
+        .iter()
+        .map(|p| Plugin {
+            name: p.name.clone(),
+            config: p.config.clone(),
+        })
+        .collect();
+    let loaded_files: Vec<String> = load_result
+        .source_map
+        .files()
+        .iter()
+        .map(|sf| sf.path.display().to_string())
+        .collect();
+
+    Ok(FileLoad {
+        directives,
+        directive_lines,
+        directive_files,
+        errors,
+        options,
+        plugins,
+        loaded_files,
+    })
+}

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -329,10 +329,7 @@ pub struct FileLoad {
 /// # Errors
 ///
 /// Returns the loader error string if the entry file cannot be read/parsed.
-pub fn load_file(
-    path: &std::path::Path,
-    path_security: bool,
-) -> Result<FileLoad, String> {
+pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad, String> {
     let mut loader = rustledger_loader::Loader::new().with_path_security(path_security);
     let load_result = loader
         .load(path)
@@ -409,4 +406,116 @@ pub fn load_file(
         plugins,
         loaded_files,
     })
+}
+
+/// Run the named regular (post-booking) plugins over loaded directives, shared
+/// by the JSON-RPC `ledger.loadFile` handler and the WIT component (#1384).
+///
+/// Returns the (possibly rewritten) directives + their line numbers/files;
+/// plugin errors and unknown-plugin errors are pushed onto `errors`. No-ops if
+/// `plugin_names` is empty or `errors` is already non-empty (don't run plugins
+/// over a broken load).
+#[must_use]
+pub fn apply_plugins(
+    plugin_names: &[&str],
+    mut directives: Vec<Directive>,
+    mut directive_lines: Vec<u32>,
+    mut directive_files: Vec<String>,
+    errors: &mut Vec<Error>,
+    options: &LedgerOptions,
+) -> (Vec<Directive>, Vec<u32>, Vec<String>) {
+    use rustledger_plugin::{
+        NativePluginRegistry, PluginInput, PluginOptions, directive_to_wrapper,
+        wrapper_to_directive,
+    };
+
+    if plugin_names.is_empty() || !errors.is_empty() {
+        return (directives, directive_lines, directive_files);
+    }
+    let registry = NativePluginRegistry::global();
+
+    for plugin_name in plugin_names {
+        // External API runs plugins on already-booked input — synth plugins are
+        // a loader-internal concern and would re-emit Opens for already-opened
+        // accounts.
+        let Some(plugin) = registry.find_regular(plugin_name) else {
+            errors.push(Error::new(format!("Unknown plugin: {plugin_name}")));
+            continue;
+        };
+        let wrappers: Vec<_> = directives
+            .iter()
+            .enumerate()
+            .map(|(i, d)| {
+                let mut wrapper = directive_to_wrapper(d);
+                wrapper.filename = Some(
+                    directive_files
+                        .get(i)
+                        .cloned()
+                        .unwrap_or_else(|| "<unknown>".to_string()),
+                );
+                wrapper.lineno = Some(directive_lines.get(i).copied().unwrap_or(0));
+                wrapper
+            })
+            .collect();
+
+        let input = PluginInput {
+            directives: wrappers,
+            options: PluginOptions {
+                operating_currencies: options.operating_currency.clone(),
+                title: options.title.clone(),
+            },
+            config: None,
+        };
+
+        let input_dirs = input.directives.clone();
+        let output = plugin.process(input);
+
+        for err in output.errors {
+            errors.push(Error::new(err.message));
+        }
+
+        let mut new_directives = Vec::new();
+        let mut new_lines = Vec::new();
+        let mut new_files = Vec::new();
+        for op in &output.ops {
+            let wrapper = match op {
+                rustledger_plugin::PluginOp::Keep(i) => input_dirs.get(*i).cloned(),
+                rustledger_plugin::PluginOp::Modify(_, w)
+                | rustledger_plugin::PluginOp::Insert(w) => Some(w.clone()),
+                rustledger_plugin::PluginOp::Delete(_) => None,
+            };
+            if let Some(wrapper) = wrapper
+                && let Ok(directive) = wrapper_to_directive(&wrapper)
+            {
+                new_directives.push(directive);
+                new_lines.push(wrapper.lineno.unwrap_or(0));
+                new_files.push(wrapper.filename.unwrap_or_else(|| "<plugin>".to_string()));
+            }
+        }
+        directives = new_directives;
+        directive_lines = new_lines;
+        directive_files = new_files;
+    }
+    (directives, directive_lines, directive_files)
+}
+
+/// The five account-type roots, in declaration order.
+///
+/// Single source of truth for `util.types`' `account_types` and
+/// `util.getAccountType`, shared by both the JSON-RPC and Component-Model (WIT)
+/// surfaces so they cannot drift.
+pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income", "Expenses"];
+
+/// The lowercased account-type root for `account` — the segment before the
+/// first `:` — or `"unknown"` if it is not one of [`ACCOUNT_TYPES`].
+#[must_use]
+pub fn account_type(account: &str) -> &'static str {
+    match account.split(':').next() {
+        Some("Assets") => "assets",
+        Some("Liabilities") => "liabilities",
+        Some("Equity") => "equity",
+        Some("Income") => "income",
+        Some("Expenses") => "expenses",
+        _ => "unknown",
+    }
 }

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -6,9 +6,6 @@ use std::fs;
 use std::path::Path;
 
 use rustledger_core::NaiveDate;
-use rustledger_plugin::{
-    NativePluginRegistry, PluginInput, PluginOptions, directive_to_wrapper, wrapper_to_directive,
-};
 use rustledger_validate::{ValidationOptions, ValidationSession};
 
 use super::error::RpcError;
@@ -128,102 +125,22 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
     // defaults to `true` (confines includes to the entry file's directory
     // tree) — FFI is the most security-sensitive surface. Callers needing
     // cross-tree includes opt out via the request's `path_security: false`.
-    let fl = crate::helpers::load_file(path, params.path_security)
-        .map_err(|e| RpcError::file_error(e))?;
-    let mut directives = fl.directives;
-    let mut directive_lines = fl.directive_lines;
-    let mut directive_files = fl.directive_files;
+    let fl = crate::helpers::load_file(path, params.path_security).map_err(RpcError::file_error)?;
     let mut errors = fl.errors;
     let options = fl.options;
     let plugins = fl.plugins;
     let loaded_files = fl.loaded_files;
 
-    // Run plugins if requested
+    // Run requested plugins via the shared helper (also used by the WIT component).
     let run_plugins: Vec<&str> = params.plugins.iter().map(String::as_str).collect();
-    if !run_plugins.is_empty() && errors.is_empty() {
-        let registry = NativePluginRegistry::global();
-
-        for plugin_name in run_plugins {
-            // External API runs plugins on already-booked input — synth
-            // plugins are a loader-internal concern and would re-emit
-            // Opens for accounts the booking pass already opened.
-            if let Some(plugin) = registry.find_regular(plugin_name) {
-                let wrappers: Vec<_> = directives
-                    .iter()
-                    .enumerate()
-                    .map(|(i, d)| {
-                        let mut wrapper = directive_to_wrapper(d);
-                        wrapper.filename = Some(
-                            directive_files
-                                .get(i)
-                                .cloned()
-                                .unwrap_or_else(|| "<unknown>".to_string()),
-                        );
-                        wrapper.lineno = Some(directive_lines.get(i).copied().unwrap_or(0));
-                        wrapper
-                    })
-                    .collect();
-
-                let input = PluginInput {
-                    directives: wrappers,
-                    options: PluginOptions {
-                        operating_currencies: options.operating_currency.clone(),
-                        title: options.title.clone(),
-                    },
-                    config: None,
-                };
-
-                // Materialize the plugin's ops back into a flat wrapper list.
-                let input_dirs = input.directives.clone();
-                let output = plugin.process(input);
-
-                for err in output.errors {
-                    errors.push(Error::new(err.message));
-                }
-
-                let materialized = {
-                    let mut out: Vec<rustledger_plugin::types::DirectiveWrapper> =
-                        Vec::with_capacity(output.ops.len());
-                    for op in &output.ops {
-                        match op {
-                            rustledger_plugin::PluginOp::Keep(i) => {
-                                if let Some(w) = input_dirs.get(*i) {
-                                    out.push(w.clone());
-                                }
-                            }
-                            rustledger_plugin::PluginOp::Modify(_, w)
-                            | rustledger_plugin::PluginOp::Insert(w) => out.push(w.clone()),
-                            rustledger_plugin::PluginOp::Delete(_) => {}
-                        }
-                    }
-                    out
-                };
-
-                let mut new_directives = Vec::new();
-                let mut new_lines = Vec::new();
-                let mut new_files = Vec::new();
-
-                for wrapper in &materialized {
-                    if let Ok(directive) = wrapper_to_directive(wrapper) {
-                        new_directives.push(directive);
-                        new_lines.push(wrapper.lineno.unwrap_or(0));
-                        new_files.push(
-                            wrapper
-                                .filename
-                                .clone()
-                                .unwrap_or_else(|| "<plugin>".to_string()),
-                        );
-                    }
-                }
-
-                directives = new_directives;
-                directive_lines = new_lines;
-                directive_files = new_files;
-            } else {
-                errors.push(Error::new(format!("Unknown plugin: {plugin_name}")));
-            }
-        }
-    }
+    let (directives, directive_lines, directive_files) = crate::helpers::apply_plugins(
+        &run_plugins,
+        fl.directives,
+        fl.directive_lines,
+        fl.directive_files,
+        &mut errors,
+        &options,
+    );
 
     // `options`, `plugins`, `loaded_files` come from `helpers::load_file` above.
 
@@ -687,7 +604,7 @@ fn handle_types() -> Result<serde_json::Value, RpcError> {
             description: "Represents a missing/interpolated amount in a posting",
             json_representation: "null or {currency_only: string}",
         },
-        account_types: vec!["Assets", "Liabilities", "Equity", "Income", "Expenses"],
+        account_types: crate::helpers::ACCOUNT_TYPES.to_vec(),
     };
 
     serde_json::to_value(output).map_err(|e| RpcError::internal_error(e.to_string()))
@@ -710,21 +627,8 @@ fn handle_get_account_type(params: &serde_json::Value) -> Result<serde_json::Val
     let params: GetAccountTypeParams = serde_json::from_value(params.clone())
         .map_err(|e| RpcError::invalid_params(format!("Invalid params: {e}")))?;
 
-    let account_type = if let Some(first_component) = params.account.split(':').next() {
-        match first_component {
-            "Assets" => "assets",
-            "Liabilities" => "liabilities",
-            "Equity" => "equity",
-            "Income" => "income",
-            "Expenses" => "expenses",
-            _ => "unknown",
-        }
-    } else {
-        "unknown"
-    };
-
     let result = GetAccountTypeResult {
-        account_type: account_type.to_string(),
+        account_type: crate::helpers::account_type(&params.account).to_string(),
     };
     serde_json::to_value(result).map_err(|e| RpcError::internal_error(e.to_string()))
 }

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -5,9 +5,7 @@
 use std::fs;
 use std::path::Path;
 
-use rustledger_booking::BookingEngine;
-use rustledger_core::{Directive, NaiveDate};
-use rustledger_loader::Loader;
+use rustledger_core::NaiveDate;
 use rustledger_plugin::{
     NativePluginRegistry, PluginInput, PluginOptions, directive_to_wrapper, wrapper_to_directive,
 };
@@ -31,8 +29,8 @@ use crate::commands::query::execute_query;
 use crate::convert::directive_to_json;
 use crate::helpers::load_source;
 use crate::types::{
-    BatchOutput, DirectiveJson, Error, LedgerOptions, LoadOutput, Plugin, QueryOutput,
-    ValidateOutput, input_entry_to_directive,
+    BatchOutput, DirectiveJson, Error, LoadOutput, QueryOutput, ValidateOutput,
+    input_entry_to_directive,
 };
 
 /// Route a JSON-RPC request to the appropriate handler.
@@ -126,66 +124,19 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
 
     let path = Path::new(&params.path);
 
-    // Load using the full loader. `with_path_security` defaults to
-    // `true` (confines the include graph to the entry file's directory
-    // tree) — FFI is the most security-sensitive surface, so safe-by-
-    // default matters. Callers that legitimately need cross-tree
-    // includes (e.g., `include "../shared/accounts.bean"`) can opt out
-    // via the request's `path_security: false` field.
-    let mut loader = Loader::new().with_path_security(params.path_security);
-    let load_result = loader
-        .load(path)
-        .map_err(|e| RpcError::file_error(format!("Failed to load file: {e}")))?;
-
-    // Collect errors from loader
-    let mut errors: Vec<Error> = load_result
-        .errors
-        .iter()
-        .map(|e| Error::new(e.to_string()))
-        .collect();
-
-    // Convert directives and get line numbers/filenames
-    let mut directives: Vec<Directive> = Vec::new();
-    let mut directive_lines: Vec<u32> = Vec::new();
-    let mut directive_files: Vec<String> = Vec::new();
-
-    for spanned in &load_result.directives {
-        directives.push(spanned.value.clone());
-
-        let file_id = spanned.file_id as usize;
-        if let Some(source_file) = load_result.source_map.get(file_id) {
-            let (line, _col) = source_file.line_col(spanned.span.start);
-            directive_lines.push(line as u32);
-            directive_files.push(source_file.path.display().to_string());
-        } else {
-            directive_lines.push(0);
-            directive_files.push("<unknown>".to_string());
-        }
-    }
-
-    // Run booking and interpolation
-    let booking_method = load_result
-        .options
-        .booking_method
-        .parse()
-        .unwrap_or(rustledger_core::BookingMethod::Strict);
-    let mut booking_engine = BookingEngine::with_method(booking_method);
-    booking_engine.register_account_methods(directives.iter());
-
-    for (i, directive) in directives.iter_mut().enumerate() {
-        if let Directive::Transaction(txn) = directive {
-            match booking_engine.book_and_interpolate(txn) {
-                Ok(result) => {
-                    booking_engine.apply(&result.transaction);
-                    *txn = result.transaction;
-                    rustledger_booking::normalize_prices(txn);
-                }
-                Err(e) => {
-                    errors.push(Error::new(e.to_string()).with_line(directive_lines[i]));
-                }
-            }
-        }
-    }
+    // Resolve the include graph + book via the shared helper. `path_security`
+    // defaults to `true` (confines includes to the entry file's directory
+    // tree) — FFI is the most security-sensitive surface. Callers needing
+    // cross-tree includes opt out via the request's `path_security: false`.
+    let fl = crate::helpers::load_file(path, params.path_security)
+        .map_err(|e| RpcError::file_error(e))?;
+    let mut directives = fl.directives;
+    let mut directive_lines = fl.directive_lines;
+    let mut directive_files = fl.directive_files;
+    let mut errors = fl.errors;
+    let options = fl.options;
+    let plugins = fl.plugins;
+    let loaded_files = fl.loaded_files;
 
     // Run plugins if requested
     let run_plugins: Vec<&str> = params.plugins.iter().map(String::as_str).collect();
@@ -216,8 +167,8 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
                 let input = PluginInput {
                     directives: wrappers,
                     options: PluginOptions {
-                        operating_currencies: load_result.options.operating_currency.clone(),
-                        title: load_result.options.title.clone(),
+                        operating_currencies: options.operating_currency.clone(),
+                        title: options.title.clone(),
                     },
                     config: None,
                 };
@@ -274,26 +225,7 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
         }
     }
 
-    // Convert options
-    let options = build_ledger_options(&load_result.options);
-
-    // Convert plugins from loader result
-    let plugins: Vec<Plugin> = load_result
-        .plugins
-        .iter()
-        .map(|p| Plugin {
-            name: p.name.clone(),
-            config: p.config.clone(),
-        })
-        .collect();
-
-    // Get list of loaded files
-    let loaded_files: Vec<String> = load_result
-        .source_map
-        .files()
-        .iter()
-        .map(|sf| sf.path.display().to_string())
-        .collect();
+    // `options`, `plugins`, `loaded_files` come from `helpers::load_file` above.
 
     // Build entries
     let entries: Vec<DirectiveJson> = directives
@@ -801,38 +733,5 @@ fn handle_get_account_type(params: &serde_json::Value) -> Result<serde_json::Val
 // Helper functions
 // =============================================================================
 
-fn build_ledger_options(options: &rustledger_loader::Options) -> LedgerOptions {
-    LedgerOptions {
-        title: options.title.clone(),
-        operating_currency: options.operating_currency.clone(),
-        name_assets: options.name_assets.clone(),
-        name_liabilities: options.name_liabilities.clone(),
-        name_equity: options.name_equity.clone(),
-        name_income: options.name_income.clone(),
-        name_expenses: options.name_expenses.clone(),
-        documents: options.documents.clone(),
-        commodities: Vec::new(),
-        booking_method: options.booking_method.clone(),
-        display_precision: options
-            .display_precision
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect(),
-        render_commas: options.render_commas,
-        inferred_tolerance_default: options
-            .inferred_tolerance_default
-            .iter()
-            .map(|(k, v)| (k.clone(), v.to_string()))
-            .collect(),
-        inferred_tolerance_multiplier: options.inferred_tolerance_multiplier.to_string(),
-        infer_tolerance_from_cost: options.infer_tolerance_from_cost,
-        account_rounding: options.account_rounding.clone(),
-        account_previous_balances: options.account_previous_balances.clone(),
-        account_previous_earnings: options.account_previous_earnings.clone(),
-        account_previous_conversions: options.account_previous_conversions.clone(),
-        account_current_earnings: options.account_current_earnings.clone(),
-        account_current_conversions: options.account_current_conversions.clone(),
-        account_unrealized_gains: options.account_unrealized_gains.clone(),
-        conversion_currency: options.conversion_currency.clone(),
-    }
-}
+// `build_ledger_options` moved to `crate::helpers` so the WIT component
+// crate (#1384) can reuse it via `helpers::load_file`.

--- a/crates/rustledger-ffi-wasi/src/lib.rs
+++ b/crates/rustledger-ffi-wasi/src/lib.rs
@@ -31,14 +31,18 @@ pub mod convert;
 pub mod jsonrpc;
 
 pub(crate) mod commands;
-pub(crate) mod helpers;
+// `helpers` is `pub` so the WIT/Component-Model crate
+// (`rustledger-ffi-component`, #1384) can reuse the loader orchestration
+// (`load_source`) instead of duplicating it.
+pub mod helpers;
 pub(crate) mod types;
 
-// Re-export the wire-format DTOs that cross-binding tests inspect.
-// Keeping the surface narrow avoids documenting every RPC-response
-// type that lives in `types::*` but isn't part of the
-// `Directive → JSON` conversion contract.
-pub use types::{Amount, CostNumber, DirectiveJson, Meta, Posting, PostingCost, TypedValue};
+// Re-export the wire-format DTOs that cross-binding tests inspect, plus the
+// load-result DTOs the component crate maps into WIT types.
+pub use types::{
+    Amount, CostNumber, DirectiveJson, Error, Include, LedgerOptions, Meta, Plugin, Posting,
+    PostingCost, TypedValue,
+};
 
 /// API version this server compiled against. Reported as the
 /// `api_version` field on every method's response (`util.version`,

--- a/crates/rustledger-ffi-wasi/src/lib.rs
+++ b/crates/rustledger-ffi-wasi/src/lib.rs
@@ -43,6 +43,10 @@ pub use types::{
     Amount, CostNumber, DirectiveJson, Error, Include, LedgerOptions, Meta, Plugin, Posting,
     PostingCost, TypedValue,
 };
+// Input/construction types + converter the component crate maps WIT input into
+// (`entry.create`).
+pub use types::input::{InputAmount, InputCost, InputCostNumber, InputEntry, InputPosting};
+pub use types::input_entry_to_directive;
 
 /// API version this server compiled against. Reported as the
 /// `api_version` field on every method's response (`util.version`,

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 bench = false
 
 [dependencies]
+rustledger-core.workspace = true
 rustledger-plugin-types.workspace = true
 rust_decimal.workspace = true
 jiff.workspace = true
@@ -32,6 +33,7 @@ regex.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+rustledger-parser.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rustledger-ops/src/clamp.rs
+++ b/crates/rustledger-ops/src/clamp.rs
@@ -1,0 +1,330 @@
+//! Clamp directives to a date range, summarizing pre-range balances.
+//!
+//! Typed port of the JSON-based `clamp_entries` (`rustledger-ffi-wasi`). Operates
+//! on booked core [`Directive`]s instead of `serde_json::Value`, which removes
+//! the posting/cost JSON parsing the old version had to do. See
+//! rustledger/rustledger#1401.
+
+use std::collections::HashMap;
+
+use rustledger_core::{
+    Amount, Cost, CostNumber, CostSpec, Decimal, Directive, IncompleteAmount, Inventory, Metadata,
+    NaiveDate, Position, Posting, Span, Spanned, Transaction,
+};
+
+fn account_root(account: &str) -> &str {
+    account.split(':').next().unwrap_or("")
+}
+
+fn is_balance_sheet(account: &str) -> bool {
+    matches!(account_root(account), "Assets" | "Liabilities" | "Equity")
+}
+
+fn is_income_statement(account: &str) -> bool {
+    matches!(account_root(account), "Income" | "Expenses")
+}
+
+/// Type-priority tiebreaker for the final sort (mirrors `clamp_entries`).
+const fn type_priority(d: &Directive) -> u8 {
+    match d {
+        Directive::Open(_) => 0,
+        Directive::Balance(_) => 1,
+        Directive::Transaction(_) => 2,
+        Directive::Close(_) => 10,
+        _ => 5,
+    }
+}
+
+/// Build a [`Position`] from a booked posting's units + optional cost spec.
+/// Falls back to a cost-less position when the cost is absent or unresolved.
+fn posting_position(units: &Amount, cost: Option<&CostSpec>) -> Position {
+    let Some(spec) = cost else {
+        return Position::simple(units.clone());
+    };
+    let Some(cost_number) = spec.number else {
+        return Position::simple(units.clone());
+    };
+    // Per-unit value: PerUnit / PerUnitFromTotal yield it directly; a residual
+    // Total spec is divided by |units| (matches the old JSON behavior).
+    let per_unit = cost_number.per_unit().or(match cost_number {
+        CostNumber::Total { value } if !units.number.is_zero() => Some(value / units.number.abs()),
+        _ => None,
+    });
+    let (Some(number), Some(currency)) = (per_unit, spec.currency.clone()) else {
+        return Position::simple(units.clone());
+    };
+    Position::with_cost(
+        units.clone(),
+        Cost {
+            number,
+            currency,
+            date: spec.date,
+            label: spec.label.clone(),
+        },
+    )
+}
+
+/// A synthesized posting (used for summary/earnings transactions).
+fn synthetic_posting(
+    account: &str,
+    number: Decimal,
+    currency: &rustledger_core::Currency,
+    cost: Option<CostSpec>,
+) -> Spanned<Posting> {
+    Spanned::new(
+        Posting {
+            account: account.into(),
+            units: Some(IncompleteAmount::from(Amount {
+                number,
+                currency: currency.clone(),
+            })),
+            cost,
+            price: None,
+            flag: None,
+            meta: Metadata::default(),
+            comments: Vec::new(),
+            trailing_comments: Vec::new(),
+        },
+        Span::ZERO,
+    )
+}
+
+fn synthetic_transaction(date: NaiveDate, postings: Vec<Spanned<Posting>>) -> Directive {
+    Directive::Transaction(Transaction {
+        date,
+        flag: 'S',
+        payee: None,
+        narration: "Opening balance".into(),
+        tags: Vec::new(),
+        links: Vec::new(),
+        meta: Metadata::default(),
+        postings,
+        trailing_comments: Vec::new(),
+    })
+}
+
+/// One opening-balance transaction for an account's inventory.
+fn summary_transaction(account: &str, inventory: &Inventory, date: NaiveDate) -> Directive {
+    let mut postings = Vec::new();
+    for position in inventory.positions() {
+        let cost = position.cost.as_ref().map(|c| CostSpec {
+            number: Some(CostNumber::PerUnit { value: c.number }),
+            currency: Some(c.currency.clone()),
+            date: c.date,
+            label: c.label.clone(),
+            merge: false,
+        });
+        postings.push(synthetic_posting(
+            account,
+            position.units.number,
+            &position.units.currency,
+            cost,
+        ));
+    }
+    // Balancing Equity:Opening-Balances posting per position.
+    for position in inventory.positions() {
+        postings.push(synthetic_posting(
+            "Equity:Opening-Balances",
+            -position.units.number,
+            &position.units.currency,
+            None,
+        ));
+    }
+    synthetic_transaction(date, postings)
+}
+
+/// Close Income/Expenses P&L totals to Equity:Earnings:Previous.
+fn earnings_transaction(pnl: &HashMap<String, Decimal>, date: NaiveDate) -> Option<Directive> {
+    let mut currencies: Vec<&String> = pnl.keys().collect();
+    currencies.sort();
+    let mut postings = Vec::new();
+    for currency in currencies {
+        let number = pnl[currency];
+        if number.is_zero() {
+            continue;
+        }
+        let cur: rustledger_core::Currency = currency.as_str().into();
+        postings.push(synthetic_posting(
+            "Equity:Earnings:Previous",
+            number,
+            &cur,
+            None,
+        ));
+        postings.push(synthetic_posting(
+            "Equity:Opening-Balances",
+            -number,
+            &cur,
+            None,
+        ));
+    }
+    if postings.is_empty() {
+        return None;
+    }
+    Some(synthetic_transaction(date, postings))
+}
+
+/// Clamp `directives` to `[begin, end)`, synthesizing opening balances from
+/// pre-`begin` activity and carrying forward the latest prices.
+#[must_use]
+pub fn clamp(directives: &[Directive], begin: NaiveDate, end: NaiveDate) -> Vec<Directive> {
+    let mut balances: HashMap<String, Inventory> = HashMap::new();
+    let mut latest_prices: HashMap<(String, String), (NaiveDate, Directive)> = HashMap::new();
+    let mut filtered: Vec<Directive> = Vec::new();
+
+    for d in directives {
+        let date = d.date();
+        if date < begin {
+            match d {
+                Directive::Transaction(t) => {
+                    for sp in &t.postings {
+                        let p = &sp.value;
+                        if let Some(units) = p.units.as_ref().and_then(IncompleteAmount::as_amount)
+                        {
+                            let pos = posting_position(units, p.cost.as_ref());
+                            balances.entry(p.account.to_string()).or_default().add(pos);
+                        }
+                    }
+                }
+                Directive::Price(pr) => {
+                    let key = (pr.currency.to_string(), pr.amount.currency.to_string());
+                    let keep = latest_prices.get(&key).is_none_or(|(d0, _)| date >= *d0);
+                    if keep {
+                        latest_prices.insert(key, (date, d.clone()));
+                    }
+                }
+                Directive::Open(_) => filtered.push(d.clone()),
+                _ => {}
+            }
+        } else if date < end && !matches!(d, Directive::Commodity(_)) {
+            filtered.push(d.clone());
+        }
+    }
+
+    // Opening-balance summaries for balance-sheet accounts (sorted by name).
+    let mut bs_accounts: Vec<(&String, &Inventory)> = balances
+        .iter()
+        .filter(|(account, inv)| is_balance_sheet(account) && !inv.is_empty())
+        .collect();
+    bs_accounts.sort_by_key(|(account, _)| (*account).clone());
+    let mut summaries: Vec<Directive> = bs_accounts
+        .into_iter()
+        .map(|(account, inv)| summary_transaction(account, inv, begin))
+        .collect();
+
+    // Earnings: roll up Income/Expenses P&L.
+    let mut pnl: HashMap<String, Decimal> = HashMap::new();
+    for (account, inv) in &balances {
+        if is_income_statement(account) {
+            for position in inv.positions() {
+                *pnl.entry(position.units.currency.to_string()).or_default() +=
+                    position.units.number;
+            }
+        }
+    }
+    if let Some(earnings) = earnings_transaction(&pnl, begin) {
+        summaries.push(earnings);
+    }
+
+    let mut prices: Vec<Directive> = latest_prices.into_values().map(|(_, d)| d).collect();
+
+    let mut all = Vec::new();
+    all.append(&mut prices);
+    all.append(&mut summaries);
+    all.append(&mut filtered);
+    all.sort_by(|a, b| {
+        a.date()
+            .cmp(&b.date())
+            .then_with(|| type_priority(a).cmp(&type_priority(b)))
+            // Core directives carry no content hash; a Display key keeps the
+            // order deterministic (the JSON version sorted by meta.hash).
+            .then_with(|| a.to_string().cmp(&b.to_string()))
+    });
+    all
+}
+
+#[cfg(test)]
+mod tests {
+    // Comparing interned strings to literals via `to_string()` is fine in tests.
+    #![allow(clippy::cmp_owned)]
+
+    use super::*;
+    use rustledger_core::naive_date;
+    use rustledger_parser::parse;
+
+    fn dirs(src: &str) -> Vec<Directive> {
+        parse(src).directives.into_iter().map(|s| s.value).collect()
+    }
+    fn d(y: i32, m: u32, day: u32) -> NaiveDate {
+        naive_date(y, m, day).unwrap()
+    }
+    fn is_summary(dir: &Directive) -> bool {
+        matches!(dir, Directive::Transaction(t) if t.flag == 'S' && t.narration.to_string() == "Opening balance")
+    }
+    fn mentions(dir: &Directive, account: &str) -> bool {
+        matches!(dir, Directive::Transaction(t)
+            if t.postings.iter().any(|p| p.value.account.to_string() == account))
+    }
+
+    #[test]
+    fn summarizes_pre_begin_balance_into_opening() {
+        let input = dirs(
+            "2023-06-01 * \"old\"\n  Assets:Cash  100 USD\n  Equity:Opening-Balances  -100 USD\n\
+             2024-02-01 * \"in range\"\n  Assets:Cash  -5 USD\n  Expenses:Food  5 USD\n",
+        );
+        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+
+        // No pre-begin entries survive.
+        assert!(out.iter().all(|dir| dir.date() >= d(2024, 1, 1)));
+        // An opening-balance summary for Assets:Cash at `begin`.
+        assert!(
+            out.iter().any(|dir| is_summary(dir)
+                && dir.date() == d(2024, 1, 1)
+                && mentions(dir, "Assets:Cash")),
+            "expected an opening-balance summary mentioning Assets:Cash",
+        );
+        // The in-range transaction is kept.
+        assert!(out.iter().any(|dir| matches!(dir, Directive::Transaction(t)
+            if t.narration.to_string() == "in range")));
+    }
+
+    #[test]
+    fn drops_entries_after_end() {
+        let input = dirs("2025-01-01 * \"future\"\n  Assets:Cash 1 USD\n  Expenses:X -1 USD\n");
+        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        assert!(
+            out.iter()
+                .all(|dir| !matches!(dir, Directive::Transaction(t)
+            if t.narration.to_string() == "future"))
+        );
+    }
+
+    #[test]
+    fn excludes_commodity_in_range() {
+        let input = dirs("2024-03-01 commodity USD\n");
+        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        assert!(
+            out.iter()
+                .all(|dir| !matches!(dir, Directive::Commodity(_)))
+        );
+    }
+
+    #[test]
+    fn keeps_pre_begin_open() {
+        let input = dirs("2020-01-01 open Assets:Cash USD\n");
+        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        assert!(out.iter().any(|dir| matches!(dir, Directive::Open(_))));
+    }
+
+    #[test]
+    fn earnings_rolled_up_from_income() {
+        // Pre-begin income produces an Equity:Earnings:Previous summary.
+        let input =
+            dirs("2023-05-01 * \"salary\"\n  Assets:Cash  1000 USD\n  Income:Salary  -1000 USD\n");
+        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        assert!(
+            out.iter()
+                .any(|dir| mentions(dir, "Equity:Earnings:Previous")),
+            "expected an earnings roll-up posting",
+        );
+    }
+}

--- a/crates/rustledger-ops/src/lib.rs
+++ b/crates/rustledger-ops/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(missing_docs)]
 
 pub mod categorize;
+pub mod clamp;
 pub mod dedup;
 pub mod enrichment;
 pub mod fingerprint;

--- a/deny.toml
+++ b/deny.toml
@@ -111,7 +111,9 @@ skip = [
   { crate = "toml_datetime" },    # paired with toml
   { crate = "unicode-width" },    # transitive skew
   { crate = "wasm-encoder" },     # wasmtime stack versioning
+  { crate = "wasmparser" },       # wit-bindgen 0.239 (ffi-component #1384) vs wasmtime 0.248
   { crate = "wast" },             # wasmtime stack versioning
+  { crate = "wit-parser" },       # wit-bindgen 0.239 (ffi-component #1384) vs wasmtime 0.248
   { crate = "winnow" },           # toml parser version skew
 ]
 

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -16,6 +16,7 @@ rustledger provides multiple integration paths:
 | [Rust Crates](#rust-crates) | Rust applications | Rust |
 | [WASM Library](#webassembly-library) | Browsers, Node.js | JavaScript, TypeScript |
 | [WASI FFI](#wasi-ffi-json-rpc) | Embedding in any language | Python, Ruby, Go, etc. |
+| [Component Model (WIT)](#component-model-wit) | Typed embedding on wasip2 hosts (experimental) | Any wasip2 host |
 | [LSP](#language-server-protocol) | Editor integrations | Any LSP client |
 
 ## Command-Line Interface
@@ -358,6 +359,34 @@ echo '[
   {"jsonrpc":"2.0","method":"ledger.validate","params":{"source":"..."},"id":2}
 ]' | wasmtime rustledger-ffi-wasi.wasm
 ```
+
+## Component Model (WIT)
+
+> **Experimental / in development.** A typed WASI Preview 2 component
+> (`rustledger-ffi-component`, [#1384](https://github.com/rustledger/rustledger/issues/1384))
+> is the successor to the JSON-RPC WASI FFI above. It is not yet wired to a
+> consumer (rustfava still uses the JSON-RPC surface), and the JSON-RPC surface
+> is planned for retirement once this stabilizes.
+
+Instead of a hand-rolled JSON-RPC wire shape, this surface exposes a generated
+**WIT contract** (`crates/rustledger-ffi-component/wit/world.wit`, package
+`rustledger:ledger`). The same operations — `load` / `validate` / `query` /
+`batch` (+ `-file` variants), entry `create` / `filter` / `clamp`, `util`, and
+`format` — are strongly-typed component functions with no JSON envelope.
+
+A host consumes it via `wasmtime`'s component bindings; a guest/other language
+binds with `wit-bindgen`:
+
+```rust
+// Host side (Rust), via wasmtime's component model:
+wasmtime::component::bindgen!({ world: "rustledger", path: "world.wit" });
+// ... instantiate the component, then call typed methods:
+let version = inst.rustledger_ledger_ledger().call_version(&mut store)?;
+let result  = inst.rustledger_ledger_ledger().call_query(&mut store, source, "SELECT account, position")?;
+```
+
+Build the component with `cargo build -p rustledger-ffi-component --target wasm32-wasip2`. See `crates/rustledger-ffi-component/README.md` for the full
+surface and modeling decisions.
 
 ## Language Server Protocol
 

--- a/docs/reference/adr/0004-ts-types-from-rust-dtos.md
+++ b/docs/reference/adr/0004-ts-types-from-rust-dtos.md
@@ -53,40 +53,46 @@ not stay current.
 ### What ts-rs got right
 
 1. **Discriminated unions narrow correctly.** `DirectiveJson` emits
+
    ```ts
    export type DirectiveJson =
      | { "type": "transaction", ..., postings: Array<PostingJson>, ... }
      | { "type": "balance", ..., tolerance: string | null, ... }
      | ...
    ```
+
    so `switch (d.type) { case "balance": d.tolerance ... }` narrows. Same for `CostNumberJson` with its `kind` discriminator.
 
-2. **Untagged unions render exactly.** `MetaValueJson` becomes `string | boolean | { number: string, currency: string } | null` — identical to what we ship by hand.
+1. **Untagged unions render exactly.** `MetaValueJson` becomes `string | boolean | { number: string, currency: string } | null` — identical to what we ship by hand.
 
-3. **Doc comments translate to JSDoc.** Rustdoc on a field shows up as `/** ... */` above the TS field.
+1. **Doc comments translate to JSDoc.** Rustdoc on a field shows up as `/** ... */` above the TS field.
 
-4. **Cross-file imports compose cleanly.** Per-type files reference each other via `import type { MetaValueJson } from "./MetaValueJson"`.
+1. **Cross-file imports compose cleanly.** Per-type files reference each other via `import type { MetaValueJson } from "./MetaValueJson"`.
 
-5. **`#[ts(optional)]` solves the `Option<T> + skip_serializing_if = "Option::is_none"` mismatch.** Without it, ts-rs emits `field: T | null` (present-but-null); with it, `field?: T` (optional, matching wire absence). One attribute per Option field.
+1. **`#[ts(optional)]` solves the `Option<T> + skip_serializing_if = "Option::is_none"` mismatch.** Without it, ts-rs emits `field: T | null` (present-but-null); with it, `field?: T` (optional, matching wire absence). One attribute per Option field.
 
 ### Where ts-rs falls short
 
 1. **`TypedValueJson` discriminated narrowing is lost.** The Rust DTO is `struct TypedValueJson { value_type: String, value: MetaValueJson }` — a struct with two fields. ts-rs emits the corresponding wide TS:
+
    ```ts
    export type TypedValueJson = { type: string, value: MetaValueJson };
    ```
+
    The hand-written shape we ship today (post-#1215) is narrower:
+
    ```ts
    export type TypedValue =
      | { type: "string"; value: string }
      | { type: "amount"; value: { number: string; currency: string } }
      | ...
    ```
+
    This is a **structural Rust-side limitation**, not a ts-rs bug. The hand-written TS encodes per-variant payload constraints (`type: "amount"` implies `value` is an `AmountValue`) that the Rust DTO doesn't express. Restructuring the Rust DTO as a serde-tagged enum is awkward because the `null` variant needs `value: ()` (which doesn't serialize cleanly) or a custom `Deserialize` impl.
 
-2. **Per-type file output** doesn't directly produce our two `.d.ts` files (`beancount.d.ts`, `beancount_wasm.d.ts`). Needs a collation step.
+1. **Per-type file output** doesn't directly produce our two `.d.ts` files (`beancount.d.ts`, `beancount_wasm.d.ts`). Needs a collation step.
 
-3. **Cosmetic differences** — `Array<T>` instead of `T[]`; trailing commas in object types. tsc accepts both; ESLint may complain but it's a one-line `.eslintrc` exception.
+1. **Cosmetic differences** — `Array<T>` instead of `T[]`; trailing commas in object types. tsc accepts both; ESLint may complain but it's a one-line `.eslintrc` exception.
 
 ## Decision
 
@@ -149,7 +155,7 @@ hand-maintained:
 1. **Python compat layer** — `crates/rustledger-ffi-wasi/python/compat.py`
    was hand-edited. Same class of drift bug ADR-0004 closed for TS was
    still live for Python.
-2. **External integrator contract** — no machine-readable wire-format
+1. **External integrator contract** — no machine-readable wire-format
    schema for non-Rust/non-TS consumers (LLM tool builders, third-party
    SDK authors, the MCP server).
 
@@ -163,13 +169,12 @@ into `datamodel-code-generator`:
    serde attributes already on the DTOs (`#[serde(tag = "type")]`,
    `#[serde(rename = ...)]`, `#[serde(skip_serializing_if = ...)]`) so
    the cost is one extra derive per type, no per-field annotation.
-2. A new `#[ignore]`-by-default test (`export_index_schema`) walks the
+1. A new `#[ignore]`-by-default test (`export_index_schema`) walks the
    graph from `ParseResult` and writes `bindings/index.schema.json`
    (draft-2020-12, with all DTOs under `$defs`).
-3. `scripts/regen-bindings.sh` (renamed from `regen-ts-bindings.sh`)
+1. `scripts/regen-bindings.sh` (renamed from `regen-ts-bindings.sh`)
    gains two new phases: run the schema export test, then invoke
-   `datamodel-codegen --output-model-type pydantic_v2.BaseModel
-   --input-file-type jsonschema` to emit `bindings/types.py`. CI's
+   `datamodel-codegen --output-model-type pydantic_v2.BaseModel --input-file-type jsonschema` to emit `bindings/types.py`. CI's
    `bindings-fresh` job (renamed from `ts-bindings-fresh`) checks all
    three artifacts via `git diff --exit-code`.
 
@@ -199,8 +204,7 @@ is what the ecosystem actually supports.
 - **`TypedValueJson` narrowing is NOT applied to JSON Schema.** TS
   consumers get the hand-tuned discriminated union (per Phase 1).
   Python consumers get the wide `{type, value}` form. Pydantic v2's
-  discriminated-union ergonomics (`Annotated[Union[...],
-  Field(discriminator=...)]`) don't map cleanly from a TS literal-union
+  discriminated-union ergonomics (`Annotated[Union[...], Field(discriminator=...)]`) don't map cleanly from a TS literal-union
   override; rather than maintain two narrowings, we ship the wide form
   to Python. JSON Schema consumers can apply their own narrowing if
   needed.
@@ -222,3 +226,10 @@ is what the ecosystem actually supports.
 - #1232 — Phase 3 design issue (Python + JSON Schema).
 - PRs #1209, #1210, #1211, #1212, #1215, #1216 — the audit cascade that motivated this work.
 - `crates/rustledger-wasm/examples/tsrs_spike.rs` — the spike code this ADR is based on.
+- [ADR-0006](0006-wit-component-model-embedding.md) — the WIT/Component-Model
+  embedding contract (#1384). It supersedes the **FFI-WASI/embedding** portion
+  of this ADR's remit (the "equivalent FFI-WASI types" of Decision §1 and the
+  embedding Python stubs of Phase 3): the typed WIT contract eliminates the
+  hand-mirrored embedding DTOs rather than generating consumers from them. This
+  ADR continues to govern the `rustledger-wasm` npm/TypeScript surface, which is
+  unaffected.

--- a/docs/reference/adr/0006-wit-component-model-embedding.md
+++ b/docs/reference/adr/0006-wit-component-model-embedding.md
@@ -1,0 +1,161 @@
+# ADR-0006: WIT / Component-Model embedding contract
+
+## Status
+
+Proposed (June 2026). Phase 1 (the typed WIT contract) and Phase 2 (all 20
+exports wired; builds as a real `wasm32-wasip2` component; parity harness)
+landed in #1384. The JSON-RPC embedding surface (`rustledger-ffi-wasi`,
+WASI Preview 1) remains the shipped, supported path during the dual-ship
+window; the Component-Model path (`rustledger-ffi-component`, WASI Preview 2)
+is not yet a release artifact (`publish = false`). The retire-JSON-RPC step
+(Phase 5) is planned, not accepted.
+
+## Context
+
+`rustledger-ffi-wasi` embeds rustledger in any language via a JSON-RPC 2.0 API
+over WASI Preview 1 (see `docs/guides/integration.md`, "WASI FFI (JSON-RPC)").
+Its wire shape is a set of hand-written DTOs (`crates/rustledger-ffi-wasi/ src/types/`) that mirror the core types by hand, plus consumer stubs generated
+from those DTOs (ADR-0004: ts-rs TypeScript, schemars JSON Schema, Pydantic).
+
+ADR-0004 attacks wire-format drift by generating *consumers* from the
+hand-mirrored DTOs. It does not remove the DTOs themselves, and it does not
+give the **host** side of an embedding any generated, enforced contract — the
+host (e.g. rustfava) and the guest agree on the JSON shape by convention and
+review. #1399 is a concrete instance of that cost: the cost shape had to be
+kept consistent between posting cost and position cost by hand.
+
+The WASI Component Model (Preview 2) offers a different fix: a typed `.wit`
+interface is the single source of truth, and binding generators emit typed
+Rust on **both** sides (`wit-bindgen` for the guest, `wasmtime::component:: bindgen!` for the host). The shapes that JSON-RPC keeps consistent by review
+become compile-time-enforced.
+
+This ADR records the decision to build that contract and the constraints the
+translation surfaced.
+
+## Decision
+
+Introduce `crates/rustledger-ffi-component`: a `wasm32-wasip2` component whose
+`wit/world.wit` is the single source of truth for the embedding wire shape,
+replacing the hand-mirrored DTOs of `rustledger-ffi-wasi` for embedding.
+
+### 1. The WIT contract is the wire shape
+
+`wit/world.wit` (package `rustledger:ledger`) translates the `types/output.rs`
+and `types/input.rs` DTOs 1:1 into WIT records/variants and exports four
+interfaces (`ledger`, `builder`, `util`, `format`) from the `rustledger`
+world — the entire former JSON-RPC method surface. The contract is itself the
+versioned wire shape; a `version()` func remains for runtime negotiation,
+replacing the per-response `api_version` string (a JSON-RPC-ism).
+
+### 2. The Component Model forbids recursive types — `json(string)` escape hatch
+
+WIT/the Component Model cannot express recursive types (verified: `wasm-tools`
+rejects a `query-value` that contains itself, even through a `list`). Two BQL
+query cells are self-referential: `object` (a map of cells) and `set` (a list
+of cells). These two cases — and only these — are carried in a single,
+clearly-named `json(string)` case that serializes the cell as JSON. Every other
+`query-value` case is fully typed; `object`/`set` are rare in real query output.
+This is the one place WIT cannot fully express the JSON shape, and is the key
+finding of Phase 1.
+
+### 3. `meta-value` is a closed, non-recursive variant
+
+The JSON DTO types user metadata as arbitrary `serde_json::Value`, but it is
+only ever produced from core `MetaValue` — a finite, non-nesting set
+(text / number / boolean / amount / null). So the feared "recursive
+meta-value" does not exist on this side; it maps cleanly to a closed WIT
+`variant` with no escape hatch needed.
+
+### 4. `cost` is defined once and reused
+
+A single `cost` / `cost-number` shape is used for both posting cost and
+position cost. The consistency #1399 had to enforce by hand + review is now
+structural — by construction, `cost.number` is the same `cost-number` variant
+everywhere.
+
+### 5. Maps become ordered `list<tuple<...>>`
+
+WIT has no map type. `Meta.user`, `display_precision`, and
+`inferred_tolerance_default` become key/value lists, which also preserves
+source order.
+
+### 6. Dual-ship, then retire JSON-RPC
+
+During the migration both crates coexist. `rustledger-ffi-component` reuses
+`rustledger-ffi-wasi`'s loader orchestration (`load_source`) and core→DTO
+conversion (`directive_to_json`) and maps those DTOs into WIT types, so there
+is one source of conversion logic, not two. The crate is not yet a release
+artifact. The plan:
+
+- **Phase 1–2 (#1384, landed):** the contract + all 20 exports wired, builds as
+  a wasip2 component, parity harness asserts the component agrees with the
+  JSON-RPC path.
+- **Phase 3+:** release artifact, broaden parity coverage, wire the
+  component build into CI, migrate rustfava to the component.
+- **Phase 5:** retire the WASI-p1 JSON-RPC surface. When it is removed, the
+  shared loader/conversion logic moves out of `rustledger-ffi-wasi` to a
+  neutral home.
+
+## Consequences
+
+### Positive
+
+- **Host and guest share one generated, enforced contract.** The shapes
+  JSON-RPC keeps consistent by review (e.g. the #1399 cost footgun) become
+  compile-time errors on either side if they drift.
+- **Single source of truth for the embedding wire shape** is the `.wit` file,
+  removing the hand-mirrored embedding DTOs (for the embedding surface) that
+  ADR-0004 could only generate consumers *from*, not eliminate.
+- **No per-response `api_version` bookkeeping**; the contract is versioned.
+- **Cost / meta-value consistency is structural**, not review-enforced.
+
+### Negative
+
+- **`object`/`set` query cells are not typed** — they ship as a `json(string)`
+  escape hatch. Consumers of those rare cells parse JSON, as before.
+- **Two embedding crates coexist during the dual-ship window**, with
+  `rustledger-ffi-component` depending on `rustledger-ffi-wasi` for shared
+  logic. This is temporary coupling, resolved at Phase 5.
+- **New toolchain surface:** `wasm32-wasip2` target, `wit-bindgen`, and a
+  `wasmtime` component host for the parity harness.
+- **Metadata fidelity gap (in progress):** numeric metadata currently surfaces
+  as `meta-value::text` because the reused DTO stringifies it; faithful typing
+  needs the core `MetaValue`, which `directive_to_json` flattens.
+
+### Neutral
+
+- The WIT contract supersedes the **FFI-WASI/embedding** portion of ADR-0004's
+  remit (the "equivalent FFI-WASI types" of ADR-0004 §1 and the embedding
+  Python stubs of ADR-0004 Phase 3). ADR-0004 continues to govern the
+  `rustledger-wasm` npm/TypeScript surface, which is unaffected.
+
+## Alternatives considered
+
+- **Extend ADR-0004 codegen to the JSON-RPC DTOs (status quo, generate more
+  consumers).** Keeps the hand-mirrored DTOs and the JSON-RPC transport;
+  generates the host side from the same DTOs. Does not give the host a
+  *typed, enforced* contract and keeps the JSON-RPC-isms (`api_version`,
+  untyped `serde_json::Value` metadata). The WIT contract removes the DTOs for
+  embedding rather than generating more from them.
+- **Flatten `object`/`set` cells into typed WIT.** Impossible under the
+  recursive-type prohibition without an unbounded-depth encoding; the
+  `json(string)` escape hatch is the pragmatic choice for two rare cell kinds.
+- **`cargo-component` build.** Not needed — `wasm32-wasip2` emits a component
+  directly from a `cdylib`.
+
+## Related
+
+- #1384 — the WASI-p1 → p2 migration (this work).
+- #1399 — the cost-shape consistency the typed `cost` now enforces structurally.
+- #1401 — typed `rustledger_ops::clamp` used by the `builder` interface.
+- #1402 — follow-ups: hoist the plugin pass into the loader, move the
+  account-type taxonomy to `rustledger-core`, add an end-to-end `load-file`
+  parity test.
+- [ADR-0004](0004-ts-types-from-rust-dtos.md) — generating wire-format bindings
+  from the hand-mirrored DTOs; this ADR supersedes the FFI-WASI/embedding
+  portion of its remit (see Neutral).
+- [ADR-0001](0001-crate-organization.md) — crate organization; adds
+  `rustledger-ffi-component`.
+- `crates/rustledger-ffi-component/wit/world.wit` — the contract.
+- `crates/rustledger-ffi-component/README.md` — modeling decisions and status.
+- `docs/guides/integration.md` — the Component Model (WIT) integration section.

--- a/docs/reference/adr/index.md
+++ b/docs/reference/adr/index.md
@@ -15,6 +15,7 @@ ADRs document significant architectural decisions made during rustledger develop
 | [ADR-0003](0003-parser-design.md) | Parser Design | Accepted |
 | [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate wire-format bindings from Rust DTOs | Accepted (Phase 1 + 2 + 3) |
 | [ADR-0005](0005-cst-conversion-performance.md) | CST Conversion Performance (parse cache; green-tree declined) | Accepted |
+| [ADR-0006](0006-wit-component-model-embedding.md) | WIT / Component-Model embedding contract | Proposed |
 
 ## About ADRs
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -52,14 +52,22 @@ This document describes rustledger's crate structure and data flow.
               └────────────────────────► core, parser, booking, validate, loader, query, completion
                                                             └──► core, ops, plugin, plugin-types
 
-    ┌─────────────────────┐
-    │   rustledger-ops    │
-    │ (dedup, categorize, │
-    │  reconcile, etc.)   │
-    └────────┬────────────┘
-              │
+    ┌─────────────────────┐   ┌──────────────────────────┐
+    │   rustledger-ops    │   │ rustledger-ffi-component │
+    │ (dedup, categorize, │   │ (WASI p2 / Component     │
+    │  reconcile, etc.)   │   │  Model, typed WIT)       │
+    └────────┬────────────┘   └────────┬─────────────────┘
+              │                         │
+              │                         └──► ffi-wasi (shared loader/conversion during dual-ship), core, ops, query, ...
               └──► plugin-types only
 ```
+
+> The two FFI/embedding surfaces — `rustledger-ffi-wasi` (wasip1 JSON-RPC, the
+> current shipping path) and `rustledger-ffi-component` (wasip2 Component Model,
+> the typed-WIT successor) — coexist during the [#1384](https://github.com/rustledger/rustledger/issues/1384)
+> dual-ship window. The component reuses `ffi-wasi`'s loader/conversion logic;
+> that shared code moves to a neutral home when the JSON-RPC surface is retired
+> (Phase 5).
 
 ## Crate Descriptions
 
@@ -95,7 +103,8 @@ This document describes rustledger's crate structure and data flow.
 |-------|---------|
 | `rustledger` | CLI binary (`rledger`, `bean-*` commands) |
 | `rustledger-wasm` | WebAssembly bindings for JS/TS |
-| `rustledger-ffi-wasi` | FFI via WASI JSON-RPC for embedding |
+| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — current shipping surface |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract); successor to `-ffi-wasi`, dual-shipped during the [#1384](https://github.com/rustledger/rustledger/issues/1384) migration |
 
 ## Data Flow
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,15 @@
           # WASI target (for wasmtime/Python)
           rustWasi = inputs'.fenix.packages.targets.wasm32-wasip1.stable.rust-std;
 
-          # Combined toolchain with WASM + WASI
+          # WASI Preview 2 / Component Model target (rustledger-ffi-component, #1384)
+          rustWasi2 = inputs'.fenix.packages.targets.wasm32-wasip2.stable.rust-std;
+
+          # Combined toolchain with WASM + WASI (p1 + p2)
           rustToolchainWithWasm = inputs'.fenix.packages.combine [
             rustToolchain
             rustWasm
             rustWasi
+            rustWasi2
           ];
 
           # Crane lib with our toolchain

--- a/spec/impl/api.md
+++ b/spec/impl/api.md
@@ -311,6 +311,23 @@ if (ledger.is_valid()) {
 }
 ```
 
+## Embedding / FFI Surfaces
+
+Beyond the in-process Rust API and the JS/TS WASM bindings, rustledger exposes
+two cross-language embedding surfaces over WebAssembly. Both coexist during the
+[#1384](https://github.com/rustledger/rustledger/issues/1384) dual-ship window:
+
+- **JSON-RPC over WASI (wasip1)** — `rustledger-ffi-wasi`. A JSON-RPC 2.0
+  request/response wire shape over stdin/stdout. The current shipping surface
+  (consumed by rustfava). See `crates/rustledger-ffi-wasi/README.md`.
+- **Component Model (wasip2), typed WIT** — `rustledger-ffi-component`. A typed
+  WIT contract (`wit/world.wit`, package `rustledger:ledger`) is the single
+  source of truth for the wire shape; the same operations are exposed as
+  strongly-typed component functions (no JSON envelope), consumed via
+  `wit-bindgen` (guest) or `wasmtime::component::bindgen!` (host). The successor
+  surface; the JSON-RPC one is retired in Phase 5. See
+  `crates/rustledger-ffi-component/README.md`.
+
 ## Serialization Format
 
 ### Binary Format (for caching)

--- a/spec/impl/architecture.md
+++ b/spec/impl/architecture.md
@@ -49,12 +49,15 @@ rustledger/
 │   ├── rustledger-booking/      # Interpolation and booking engine (7 methods)
 │   ├── rustledger-validate/     # Validation rules (26 error codes)
 │   ├── rustledger-query/        # BQL query engine
+│   ├── rustledger-completion/   # Editor-agnostic completion logic (LSP + WASM)
 │   ├── rustledger-plugin/       # Native + WASM + Python plugin system
 │   ├── rustledger-plugin-types/ # WASM plugin interface types
 │   ├── rustledger-importer/     # CSV/OFX bank statement import
+│   ├── rustledger-ops/          # Pure operations on directives (dedup, categorize, reconcile)
 │   ├── rustledger-lsp/          # Language Server Protocol
 │   ├── rustledger-wasm/         # WebAssembly bindings for JS/TS
-│   ├── rustledger-ffi-wasi/     # FFI via WASI JSON-RPC
+│   ├── rustledger-ffi-wasi/     # FFI via WASI (wasip1) JSON-RPC — current surface
+│   ├── rustledger-ffi-component/ # FFI via WASI p2 / Component Model (typed WIT) — successor (#1384)
 │   └── rustledger/              # CLI tools (rledger, bean-* commands)
 ├── packages/
 │   ├── vscode/                  # VS Code extension (LSP client)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -347,6 +347,14 @@ criteria = "safe-to-deploy"
 version = "2.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.futures-executor]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-macro]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+
 [[exemptions.generic-array]]
 version = "0.14.7"
 criteria = "safe-to-deploy"
@@ -1045,10 +1053,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
 version = "0.52.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
-version = "0.59.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -163,68 +163,68 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.132.1"
-when = "2026-06-05"
+version = "0.132.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.csv]]
@@ -455,13 +455,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -756,6 +756,11 @@ when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
+version = "0.239.0"
+when = "2025-09-09"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wasm-encoder]]
 version = "0.244.0"
 when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
@@ -775,6 +780,11 @@ version = "0.236.0"
 when = "2025-07-28"
 user-id = 73222
 user-login = "wasmtime-publish"
+
+[[publisher.wasmparser]]
+version = "0.239.0"
+when = "2025-09-09"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
 version = "0.244.0"
@@ -797,83 +807,83 @@ when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -887,18 +897,18 @@ when = "2026-06-12"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.winapi-util]]
@@ -909,8 +919,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "45.0.1"
-when = "2026-06-05"
+version = "45.0.2"
+when = "2026-06-15"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows-core]]
@@ -991,6 +1001,11 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wit-bindgen]]
+version = "0.46.0"
+when = "2025-09-10"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen]]
 version = "0.51.0"
 when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
@@ -1001,8 +1016,18 @@ when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-core]]
+version = "0.46.0"
+when = "2025-09-10"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-core]]
 version = "0.51.0"
 when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-rust]]
+version = "0.46.0"
+when = "2025-09-10"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust]]
@@ -1011,13 +1036,28 @@ when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust-macro]]
+version = "0.46.0"
+when = "2025-09-10"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-rust-macro]]
 version = "0.51.0"
 when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-component]]
+version = "0.239.0"
+when = "2025-09-09"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wit-component]]
 version = "0.244.0"
 when = "2026-01-06"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wit-parser]]
+version = "0.239.0"
+when = "2025-09-09"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]


### PR DESCRIPTION
Implements the typed WIT / Component-Model embedding surface for **#1384** — the replacement for the hand-mirrored JSON-RPC DTOs. This branch now spans **both phases**: the contract *and* the wasip2 guest that implements it.

## Phase 1 — the contract (`wit/world.wit`)

The read + construction surface, translated 1:1 from `types/output.rs`: `amount`, `cost-number`, `cost`, `meta`/`meta-value`, `posting`, all 12 `directive` cases, `error`, `plugin`, `source-include`, `ledger-options`, `position`, `column-info`, `query-value`, and the result records.

What the translation surfaced:
1. **`cost` is defined once and reused for posting + position cost** — the consistency #1399 enforced by hand is now structural.
2. **`meta-value` is a closed, non-recursive variant** — the DTO's "arbitrary `serde_json::Value`" metadata only ever comes from the finite `MetaValue` set.
3. **The Component Model forbids recursive types** (verified — `wasm-tools` rejects a self-referential `query-value`), so BQL `object`/`set` query cells use a `json(string)` escape hatch.

## Phase 2 — the guest crate (`rustledger-ffi-component`)

- A `wasm32-wasip2` cdylib that emits a Component directly (no cargo-component), implementing **all 20 exports** across the `ledger` / `builder` / `util` / `format` interfaces. Each Guest method delegates to a mechanical DTO↔WIT conversion layer that reuses `rustledger-ffi-wasi`'s loader/query orchestration wholesale.
- **Parity harness** (`rustledger-ffi-component-tests`): instantiates the component in a wasmtime host via `bindgen!` and asserts agreement with the JSON-RPC path on the same inputs. This is what actually *runs* the conversion code.
- **Typed `clamp`** landed in `rustledger-ops` (#1401) operating on core `Directive`s, wired into the component.

## Review hardening (three deep-review passes)

The parity harness initially gave false confidence (its ledgers were too simple), so successive reviews found and fixed real divergences from the JSON-RPC handlers:
- `query`/`batch` now run `merge_with_padding` (correct padded balances) and short-circuit on parse errors instead of swallowing them; `filter` restores `filter_entries`' special-casing (drop commodity, keep pre-begin opens). Regression tests added.
- `load-file` restored the **plugins pass** and **path-security opt-out** that the first cut dropped, via a shared `helpers::apply_plugins` used by both the JSON-RPC router and the component.
- The include-security flag is **safe-by-default**: `allow-unrestricted-includes: bool` (zero = confined), since WIT has no field defaults.
- De-duplicated converters/taxonomy (`pairs<V>`, `input_meta`, shared `ACCOUNT_TYPES`/`account_type`).

## Verification

- `wasm-tools component wit` — WIT validates and round-trips.
- `wasip2` component builds clean; `cargo clippy -D warnings` clean on both FFI crates.
- `rustledger-ffi-wasi` 58+ tests pass; component parity 7/7.

## Follow-ups

Tracked in **#1402**: hoist the requested-plugin pass into the loader, move the account-type taxonomy to `rustledger-core`, and add an end-to-end `load-file` parity test (needs WASI filesystem-preopen plumbing).

Part of #1384. Clamp work: #1401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
