### PR TITLE
refactor(ffi): WIT follow-ups — plugin-op contract, taxonomy to core, load-file tests (#1402)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,12 +354,34 @@ jobs:
             issue=$(basename "$f" .beancount | sed 's/issue-//')
             echo "- [#$issue](https://github.com/rustledger/rustledger/issues/$issue)" >> $GITHUB_STEP_SUMMARY
           done
+  # WIT/Component-Model parity (#1384/#1402). The `rustledger-ffi-component-tests`
+  # tests SKIP unless the wasip2 artifact exists, and the `Test` job above never
+  # builds it — so without this job the entire component surface is unverified by
+  # CI. Build the component for wasm32-wasip2 first, then run the parity harness
+  # so the tests actually execute.
+  component-parity:
+    name: Component Parity (wasip2)
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: wasm32-wasip2
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - name: Build the wasip2 component
+        run: cargo build -p rustledger-ffi-component --target wasm32-wasip2
+      - name: Run parity tests
+        run: cargo test -p rustledger-ffi-component-tests
   # Gate job - all core checks must pass (or be skipped on non-code PRs)
   build:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bindings-fresh]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bindings-fresh, component-parity]
     steps:
       - name: Check results
         run: |
@@ -382,7 +404,7 @@ jobs:
           # part of the gate (ADR-0004 Phase 3 / #1232): wire-format
           # drift in the generated TS / JSON Schema / Python artifacts
           # blocks merge just like any other failure.
-          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.hot-path-collections.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }}"
+          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.hot-path-collections.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }} ${{ needs.component-parity.result }}"
           echo "Job results: $results"
 
           if echo "$results" | grep -qE '(failure|cancelled)'; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,6 +3316,7 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "rustledger-ffi-wasi",
+ "tempfile",
  "wasmtime",
  "wasmtime-wasi",
 ]

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -322,10 +322,15 @@ pub fn is_subaccount_or_equal(child: &str, parent: &str) -> bool {
 
 /// The five Beancount root account types, in declaration order.
 ///
-/// The single source of truth for root-type names; the FFI surfaces
-/// (`util.types`, `util.getAccountType`) and any other consumer share this so
-/// they cannot drift. These are the default English roots; the `name_*` loader
-/// options can rename them per-ledger, which this constant does not model.
+/// The canonical root-type list for core consumers: the FFI surfaces
+/// (`util.types`, `util.getAccountType`), the query account-type sort order, and
+/// the LSP account-type check all reference this so they cannot drift.
+/// (`rustledger-completion` keeps its own copy — it is a minimal crate that does
+/// not depend on `rustledger-core`.)
+///
+/// These are the default English roots; the `name_*` loader options can rename
+/// them per-ledger, which this constant does not model — do not use it to
+/// classify accounts in a config-aware context.
 pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income", "Expenses"];
 
 /// The lowercased root account type for `account` — the segment before the

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -320,9 +320,47 @@ pub fn is_subaccount_or_equal(child: &str, parent: &str) -> bool {
     child.len() > parent_len && child.as_bytes()[parent_len] == b':' && child.starts_with(parent)
 }
 
+/// The five Beancount root account types, in declaration order.
+///
+/// The single source of truth for root-type names; the FFI surfaces
+/// (`util.types`, `util.getAccountType`) and any other consumer share this so
+/// they cannot drift. These are the default English roots; the `name_*` loader
+/// options can rename them per-ledger, which this constant does not model.
+pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income", "Expenses"];
+
+/// The lowercased root account type for `account` — the segment before the
+/// first `:` — or `"unknown"` if it is not one of [`ACCOUNT_TYPES`].
+#[must_use]
+pub fn account_type(account: &str) -> &'static str {
+    match account.split(':').next() {
+        Some("Assets") => "assets",
+        Some("Liabilities") => "liabilities",
+        Some("Equity") => "equity",
+        Some("Income") => "income",
+        Some("Expenses") => "expenses",
+        _ => "unknown",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn account_type_classifies_roots_and_unknown() {
+        assert_eq!(account_type("Assets:Bank:Checking"), "assets");
+        assert_eq!(account_type("Liabilities:CC"), "liabilities");
+        assert_eq!(account_type("Equity:Opening"), "equity");
+        assert_eq!(account_type("Income:Salary"), "income");
+        assert_eq!(account_type("Expenses:Food"), "expenses");
+        // Bare root (no colon) still classifies.
+        assert_eq!(account_type("Assets"), "assets");
+        // Non-root / empty → unknown.
+        assert_eq!(account_type("Frobnicate:X"), "unknown");
+        assert_eq!(account_type(""), "unknown");
+        // Case-sensitive, like Beancount.
+        assert_eq!(account_type("assets:bank"), "unknown");
+    }
 
     #[test]
     fn test_construction_from_str() {

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -78,7 +78,9 @@ pub use format::{
     Alignment, FormatConfig, FormatLine, format_directive_lines, format_directives,
     format_posting_line, posting_format_line, render_lines, resolve_alignment,
 };
-pub use identifiers::{Account, Currency, Link, Tag, is_subaccount_or_equal};
+pub use identifiers::{
+    ACCOUNT_TYPES, Account, Currency, Link, Tag, account_type, is_subaccount_or_equal,
+};
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{

--- a/crates/rustledger-ffi-component-tests/Cargo.toml
+++ b/crates/rustledger-ffi-component-tests/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 wasmtime = { version = "45", features = ["component-model"] }
 wasmtime-wasi = "45"
 anyhow = "1"
+tempfile.workspace = true
 rustledger-ffi-wasi.workspace = true
 
 [lints]

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -357,9 +357,17 @@ fn load_file_path_security_confines_cross_tree_includes() -> Result<()> {
         false,
         &[],
     )?;
+    // Assert specifically on the path-traversal rejection, not just any error,
+    // so an incidental I/O or parse failure can't make this pass for the wrong
+    // reason. (The unrestricted branch below resolving cleanly already proves
+    // the file is readable and well-formed.)
     assert!(
-        !confined.errors.is_empty(),
-        "cross-tree include must error when confined (path security on)",
+        confined
+            .errors
+            .iter()
+            .any(|e| e.message.contains("path traversal not allowed")),
+        "confined load must reject the cross-tree include with a path-traversal error, got: {:?}",
+        confined.errors,
     );
     // Unrestricted (true): the same include resolves cleanly.
     let open = inst.rustledger_ledger_ledger().call_load_file(

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -18,7 +18,7 @@
 use anyhow::Result;
 use wasmtime::component::{Component, Linker, ResourceTable};
 use wasmtime::{Engine, Store};
-use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 wasmtime::component::bindgen!({
     world: "rustledger",
@@ -54,6 +54,27 @@ fn instantiate() -> Result<(Store<Host>, Rustledger)> {
         Host {
             table: ResourceTable::new(),
             wasi: WasiCtxBuilder::new().build(),
+        },
+    );
+    let inst = Rustledger::instantiate(&mut store, &component, &linker)?;
+    Ok((store, inst))
+}
+
+/// Like [`instantiate`], but grants the guest read access to `host_dir`,
+/// mounted at `/work`, so `load-file` can read files through WASI.
+fn instantiate_in(host_dir: &std::path::Path) -> Result<(Store<Host>, Rustledger)> {
+    let engine = Engine::default();
+    let component = Component::from_file(&engine, component_path())?;
+    let mut linker = Linker::<Host>::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker)?;
+    let wasi = WasiCtxBuilder::new()
+        .preopened_dir(host_dir, "/work", DirPerms::READ, FilePerms::READ)?
+        .build();
+    let mut store = Store::new(
+        &engine,
+        Host {
+            table: ResourceTable::new(),
+            wasi,
         },
     );
     let inst = Rustledger::instantiate(&mut store, &component, &linker)?;
@@ -274,6 +295,126 @@ fn custom_directive_values_keep_their_type_tag() -> Result<()> {
     assert!(
         types.contains(&"string"),
         "quoted arg must keep value-type \"string\", got {types:?}",
+    );
+    Ok(())
+}
+
+// End-to-end `load-file` tests (#1402). These exercise the file path through
+// WASI: the host preopens a temp dir at `/work`, the guest reads `.bean` files
+// from it. This is the only coverage of the `load-file` export and its
+// `allow-unrestricted-includes` / `plugins` parameters.
+
+#[test]
+fn load_file_reads_and_resolves_includes() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    std::fs::write(
+        dir.path().join("sub.bean"),
+        "2024-01-01 open Assets:Cash USD\n",
+    )?;
+    std::fs::write(
+        dir.path().join("main.bean"),
+        "include \"sub.bean\"\n2024-01-02 open Expenses:Food USD\n",
+    )?;
+    let (mut store, inst) = instantiate_in(dir.path())?;
+    let r =
+        inst.rustledger_ledger_ledger()
+            .call_load_file(&mut store, "/work/main.bean", true, &[])?;
+    assert!(r.errors.is_empty(), "load_file errored: {:?}", r.errors);
+    // Opens from both the entry file and the included file.
+    assert!(
+        r.entries.len() >= 2,
+        "expected entries from main + included file, got {}",
+        r.entries.len(),
+    );
+    Ok(())
+}
+
+#[test]
+fn load_file_path_security_confines_cross_tree_includes() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    std::fs::create_dir(dir.path().join("entry"))?;
+    std::fs::create_dir(dir.path().join("sibling"))?;
+    std::fs::write(
+        dir.path().join("sibling/data.bean"),
+        "2024-01-01 open Assets:Cash USD\n",
+    )?;
+    std::fs::write(
+        dir.path().join("entry/main.bean"),
+        "include \"../sibling/data.bean\"\n2024-01-02 open Expenses:Food USD\n",
+    )?;
+    let (mut store, inst) = instantiate_in(dir.path())?;
+    // Confined (allow-unrestricted-includes = false): the `../sibling` include
+    // escapes the entry file's directory tree and must be rejected.
+    let confined = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/entry/main.bean",
+        false,
+        &[],
+    )?;
+    assert!(
+        !confined.errors.is_empty(),
+        "cross-tree include must error when confined (path security on)",
+    );
+    // Unrestricted (true): the same include resolves cleanly.
+    let open = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/entry/main.bean",
+        true,
+        &[],
+    )?;
+    assert!(
+        open.errors.is_empty(),
+        "cross-tree include should resolve when unrestricted: {:?}",
+        open.errors,
+    );
+    Ok(())
+}
+
+#[test]
+fn load_file_runs_requested_plugin() -> Result<()> {
+    if !component_path().exists() {
+        return Ok(());
+    }
+    use rustledger::ledger::types::Directive;
+    let dir = tempfile::tempdir()?;
+    // A lot purchased at cost; `implicit_prices` synthesizes a Price directive.
+    std::fs::write(
+        dir.path().join("main.bean"),
+        "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Assets:Stock STOCK
+2024-01-02 * \"buy\"
+  Assets:Stock  10 STOCK {5 USD}
+  Assets:Cash  -50 USD
+",
+    )?;
+    let (mut store, inst) = instantiate_in(dir.path())?;
+    let without =
+        inst.rustledger_ledger_ledger()
+            .call_load_file(&mut store, "/work/main.bean", true, &[])?;
+    let with = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/main.bean",
+        true,
+        &["implicit_prices".to_string()],
+    )?;
+    let count_prices = |entries: &[Directive]| {
+        entries
+            .iter()
+            .filter(|d| matches!(d, Directive::Price(_)))
+            .count()
+    };
+    assert!(
+        count_prices(&with.entries) > count_prices(&without.entries),
+        "implicit_prices should synthesize a Price directive: without={} with={}",
+        count_prices(&without.entries),
+        count_prices(&with.entries),
     );
     Ok(())
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -400,8 +400,12 @@ interface ledger {
   /// `true` only when cross-tree includes are needed. The flag is phrased so
   /// the safe behavior is the `false`/zero default — WIT has no field defaults,
   /// so an under-specified caller stays confined rather than escaping the
-  /// sandbox. `plugins` names the regular (post-booking) plugins to run, e.g.
-  /// `["auto_accounts"]`.
+  /// sandbox. `plugins` names *additional* regular (post-booking) plugins to run
+  /// beyond those the ledger declares, e.g. `["auto_accounts"]`; they run by
+  /// name with no config. The ledger's own `plugin "name" "config"` directives
+  /// already run (with their config) during the load — a plugin that needs
+  /// configuration must be declared in the ledger, since this list carries only
+  /// names.
   load-file: func(path: string, allow-unrestricted-includes: bool, plugins: list<string>) -> load-result;
 
   /// Validate source text (parse + semantic checks).

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -474,6 +474,14 @@ pub fn apply_plugins(
             errors.push(Error::new(err.message));
         }
 
+        // Validate the op set against the shared contract (same check the loader
+        // pipeline runs). On violation, record it and keep the directives as-is
+        // for this plugin rather than materializing a malformed op set.
+        if let Err(msg) = rustledger_plugin::validate_op_coverage(directives.len(), &output.ops) {
+            errors.push(Error::new(msg));
+            continue;
+        }
+
         let mut new_directives = Vec::new();
         let mut new_lines = Vec::new();
         let mut new_files = Vec::new();

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -474,11 +474,12 @@ pub fn apply_plugins(
             errors.push(Error::new(err.message));
         }
 
-        // Validate the op set against the shared contract (same check the loader
-        // pipeline runs). On violation, record it and keep the directives as-is
-        // for this plugin rather than materializing a malformed op set.
+        // Validate the op set against the shared contract (the same coverage
+        // check the loader pipeline runs). On violation, record it — naming the
+        // plugin, since this surface runs a caller-supplied list — and keep the
+        // directives as-is rather than materializing a malformed op set.
         if let Err(msg) = rustledger_plugin::validate_op_coverage(directives.len(), &output.ops) {
-            errors.push(Error::new(msg));
+            errors.push(Error::new(format!("plugin '{plugin_name}': {msg}")));
             continue;
         }
 

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -499,23 +499,8 @@ pub fn apply_plugins(
     (directives, directive_lines, directive_files)
 }
 
-/// The five account-type roots, in declaration order.
-///
-/// Single source of truth for `util.types`' `account_types` and
-/// `util.getAccountType`, shared by both the JSON-RPC and Component-Model (WIT)
-/// surfaces so they cannot drift.
-pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income", "Expenses"];
-
-/// The lowercased account-type root for `account` — the segment before the
-/// first `:` — or `"unknown"` if it is not one of [`ACCOUNT_TYPES`].
-#[must_use]
-pub fn account_type(account: &str) -> &'static str {
-    match account.split(':').next() {
-        Some("Assets") => "assets",
-        Some("Liabilities") => "liabilities",
-        Some("Equity") => "equity",
-        Some("Income") => "income",
-        Some("Expenses") => "expenses",
-        _ => "unknown",
-    }
-}
+// The account-type taxonomy lives in `rustledger-core` (the type-owning crate)
+// so every crate shares one source of truth. Re-exported here for the FFI
+// call sites (`util.types`, `util.getAccountType`) that already reference
+// `helpers::{ACCOUNT_TYPES, account_type}`.
+pub use rustledger_core::{ACCOUNT_TYPES, account_type};

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -411,6 +411,13 @@ pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad
 /// Run the named regular (post-booking) plugins over loaded directives, shared
 /// by the JSON-RPC `ledger.loadFile` handler and the WIT component (#1384).
 ///
+/// These are *additional*, caller-requested plugins, run by name with no
+/// config. The ledger's own `plugin "name" "config"` directives have already
+/// run (with their config) inside the loader during `load_file`, so this is for
+/// plugins a host wants beyond the ones the ledger declares. A plugin that needs
+/// configuration must be declared in the ledger — the by-name request surface
+/// (the WIT `plugins: list<string>` / JSON-RPC `plugins`) cannot carry config.
+///
 /// Returns the (possibly rewritten) directives + their line numbers/files;
 /// plugin errors and unknown-plugin errors are pushed onto `errors`. No-ops if
 /// `plugin_names` is empty or `errors` is already non-empty (don't run plugins

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1302,54 +1302,12 @@ fn apply_plugin_ops(
     use rustledger_plugin::PluginOp;
     use rustledger_plugin::wrapper_to_directive;
 
-    let n = directives.len();
-
-    // Validate: every input index in {Keep, Modify, Delete} exactly once.
-    let mut seen = vec![false; n];
-    for op in &ops {
-        let idx = match op {
-            PluginOp::Keep(i) | PluginOp::Modify(i, _) | PluginOp::Delete(i) => Some(*i),
-            PluginOp::Insert(_) => None,
-        };
-        if let Some(i) = idx {
-            if i >= n {
-                errors.push(
-                    LedgerError::error(
-                        "PLUGIN",
-                        format!(
-                            "plugin op references out-of-bounds input index {i} (input has {n} directives)"
-                        ),
-                    )
-                    .with_phase("plugin"),
-                );
-                return Ok(());
-            }
-            if seen[i] {
-                errors.push(
-                    LedgerError::error(
-                        "PLUGIN",
-                        format!("plugin op references input index {i} more than once"),
-                    )
-                    .with_phase("plugin"),
-                );
-                return Ok(());
-            }
-            seen[i] = true;
-        }
-    }
-    for (i, was_seen) in seen.iter().enumerate() {
-        if !was_seen {
-            errors.push(
-                LedgerError::error(
-                    "PLUGIN",
-                    format!(
-                        "plugin omitted input directive {i} (must appear in exactly one of Keep/Modify/Delete)"
-                    ),
-                )
-                .with_phase("plugin"),
-            );
-            return Ok(());
-        }
+    // Validate the op set forms a complete cover of the input — the contract is
+    // single-sourced in `rustledger-plugin` so the loader and FFI surfaces stay
+    // in lock-step. On violation, surface the error and leave directives as-is.
+    if let Err(msg) = rustledger_plugin::validate_op_coverage(directives.len(), &ops) {
+        errors.push(LedgerError::error("PLUGIN", msg).with_phase("plugin"));
+        return Ok(());
     }
 
     // Materialize new directives, preserving spans for Keep/Modify.

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -449,12 +449,10 @@ pub fn is_account_like(s: &str) -> bool {
             || s.starts_with("Expenses"))
 }
 
-/// Check if a string is a standard account type.
+/// Check if a string is a standard root account type.
+#[must_use]
 pub fn is_account_type(s: &str) -> bool {
-    matches!(
-        s,
-        "Assets" | "Liabilities" | "Equity" | "Income" | "Expenses"
-    )
+    rustledger_core::ACCOUNT_TYPES.contains(&s)
 }
 
 /// Check if a string looks like a currency (simple format check).

--- a/crates/rustledger-plugin-types/src/lib.rs
+++ b/crates/rustledger-plugin-types/src/lib.rs
@@ -249,6 +249,54 @@ pub enum PluginOp {
     Delete(usize),
 }
 
+/// Validate that `ops` form a complete, non-overlapping cover of the input.
+///
+/// Every one of the `n` input directives must appear in exactly one of
+/// `Keep`/`Modify`/`Delete`, with no out-of-bounds or duplicate references.
+/// [`PluginOp::Insert`] adds new directives and references no input index.
+///
+/// This is the single source of truth for the plugin-op contract, shared by the
+/// loader's in-pipeline pass (`rustledger_loader::process::apply_plugin_ops`)
+/// and the FFI's requested-plugin pass (`rustledger_ffi_wasi::helpers`), so the
+/// two surfaces cannot drift on what a well-formed op set is. The
+/// representation-specific materialization (span preservation, posting-span
+/// sanitization) stays with each caller.
+///
+/// # Errors
+/// Returns a human-readable message describing the first violation found
+/// (out-of-bounds index, an index referenced more than once, or an input
+/// directive omitted from every `Keep`/`Modify`/`Delete`).
+pub fn validate_op_coverage(n: usize, ops: &[PluginOp]) -> Result<(), String> {
+    let mut seen = vec![false; n];
+    for op in ops {
+        let idx = match op {
+            PluginOp::Keep(i) | PluginOp::Modify(i, _) | PluginOp::Delete(i) => Some(*i),
+            PluginOp::Insert(_) => None,
+        };
+        if let Some(i) = idx {
+            if i >= n {
+                return Err(format!(
+                    "plugin op references out-of-bounds input index {i} (input has {n} directives)"
+                ));
+            }
+            if seen[i] {
+                return Err(format!(
+                    "plugin op references input index {i} more than once"
+                ));
+            }
+            seen[i] = true;
+        }
+    }
+    for (i, was_seen) in seen.iter().enumerate() {
+        if !was_seen {
+            return Err(format!(
+                "plugin omitted input directive {i} (must appear in exactly one of Keep/Modify/Delete)"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Ledger options passed to plugins.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PluginOptions {
@@ -1108,6 +1156,33 @@ pub fn sort_directives(directives: &mut [DirectiveWrapper]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn op_coverage_accepts_complete_cover_and_rejects_violations() {
+        use PluginOp::{Delete, Keep};
+        // Every input index covered exactly once.
+        assert!(validate_op_coverage(3, &[Keep(0), Delete(1), Keep(2)]).is_ok());
+        // No input, no ops: trivially complete.
+        assert!(validate_op_coverage(0, &[]).is_ok());
+        // Out-of-bounds index.
+        assert!(
+            validate_op_coverage(2, &[Keep(0), Keep(2)])
+                .unwrap_err()
+                .contains("out-of-bounds")
+        );
+        // Same index referenced twice.
+        assert!(
+            validate_op_coverage(2, &[Keep(0), Delete(0)])
+                .unwrap_err()
+                .contains("more than once")
+        );
+        // An input directive omitted entirely.
+        assert!(
+            validate_op_coverage(2, &[Keep(0)])
+                .unwrap_err()
+                .contains("omitted")
+        );
+    }
 
     #[test]
     fn test_plugin_error_builder() {

--- a/crates/rustledger-plugin/src/lib.rs
+++ b/crates/rustledger-plugin/src/lib.rs
@@ -67,5 +67,5 @@ pub use runtime::{
 };
 pub use types::{
     DirectiveWrapper, PluginError, PluginErrorSeverity, PluginInput, PluginOp, PluginOptions,
-    PluginOutput,
+    PluginOutput, validate_op_coverage,
 };

--- a/crates/rustledger-query/src/executor/functions/account.rs
+++ b/crates/rustledger-query/src/executor/functions/account.rs
@@ -206,15 +206,13 @@ impl Executor<'_> {
     /// - Expenses = 4
     /// - Other = 5 (for custom account types)
     pub(crate) fn account_type_index(account: &str) -> u8 {
-        // Extract the first component (root account type)
+        // Extract the first component (root account type) and look it up in the
+        // canonical root list (`rustledger_core::ACCOUNT_TYPES`); custom types
+        // (not in the list) sort last.
         let root = account.split(':').next().unwrap_or(account);
-        match root {
-            "Assets" => 0,
-            "Liabilities" => 1,
-            "Equity" => 2,
-            "Income" => 3,
-            "Expenses" => 4,
-            _ => 5, // Custom account types sort last
-        }
+        rustledger_core::ACCOUNT_TYPES
+            .iter()
+            .position(|t| *t == root)
+            .map_or(5, |i| i as u8)
     }
 }


### PR DESCRIPTION
Resolves the three follow-ups from the WIT/Component-Model work, tracked in **#1402** (surfaced by the deep reviews of #1384).

## 1. Single-source the plugin-op contract (`2f5f42eb`)
The loader's in-pipeline regular-plugin pass and the FFI's requested-plugin pass each rendered the `PluginOp` "complete-cover" contract independently — and the FFI's copy **skipped op-coverage validation entirely**. The data models differ (loader: `Vec<Spanned<Directive>>` + `SourceMap`; FFI: flat `Vec<Directive>` + parallel arrays), so rather than force one onto the other, I extracted the genuinely-shared part — the pure validation — into `rustledger_plugin_types::validate_op_coverage`, called by both:
- the loader's `apply_plugin_ops` (replaces ~48 lines of inline validation; identical messages/behavior),
- `helpers::apply_plugins` (the coverage check it was missing — a misbehaving plugin's malformed ops were silently mishandled before).

The representation-specific materialization (the loader's span preservation + posting-span sanitization for the LSP) correctly stays per-caller.

## 2. Account-type taxonomy → `rustledger-core` (`7b4e76d4`)
`ACCOUNT_TYPES` + `account_type` moved from the `rustledger-ffi-wasi` FFI crate into `rustledger-core` (`identifiers`, next to `Account`), re-exported from `ffi-wasi::helpers` so the call sites (`util.types`, `util.getAccountType`) are unchanged. Behavior identical (default English roots; the `name_*` loader options that rename them per-ledger are still not modeled — noted in the doc).

## 3. End-to-end `load-file` parity tests (`d4c5b4b2`)
The harness exercised load/query/filter/clamp but never `load-file`. Added an `instantiate_in(host_dir)` helper that preopens a temp dir at `/work` in the wasmtime `WasiCtx`, and three tests:
- reads a file and resolves a relative `include`,
- `allow-unrestricted-includes = false` confines a `../sibling` include (errors), `true` resolves it,
- `implicit_prices` in `plugins` synthesizes a Price directive absent without it.

## Verification
- `rustledger-core` (406), `rustledger-loader` (63), `rustledger-ffi-wasi` (63), `rustledger-plugin-types` tests pass.
- `cargo clippy -D warnings` clean on all changed crates.
- Component rebuilds for `wasm32-wasip2`; **11/11 parity tests pass**.

Closes #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
