### PR TITLE
fix(ffi): run pre-booking synth pass through the FFI load surface

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -426,3 +426,71 @@ fn load_file_runs_requested_plugin() -> Result<()> {
     );
     Ok(())
 }
+
+/// The component must run the pre-booking SYNTH pass (`auto_accounts`) declared
+/// in a ledger, generating `Open` directives that surface with the generated
+/// marker (`meta.lineno == 0`) — through BOTH `load` (string) and `load-file`.
+///
+/// Regression guard for the duplicated-pipeline bug where the reused `ffi-wasi`
+/// helpers hand-rolled a partial loader that skipped synth entirely.
+const AUTO_ACCOUNTS_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+plugin \"auto_accounts\"
+
+2024-01-15 * \"Paycheck\"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5000 USD
+
+2024-01-20 * \"Groceries\"
+  Expenses:Food                            50 USD
+  Assets:Bank:Checking                    -50 USD
+";
+
+const SYNTH_ACCOUNTS: [&str; 3] = ["Assets:Bank:Checking", "Income:Salary", "Expenses:Food"];
+
+fn assert_generated_opens(entries: &[rustledger::ledger::types::Directive], surface: &str) {
+    use rustledger::ledger::types::Directive;
+    let opens: Vec<(String, u32)> = entries
+        .iter()
+        .filter_map(|d| match d {
+            Directive::Open(o) => Some((o.account.clone(), o.meta.lineno)),
+            _ => None,
+        })
+        .collect();
+    for acct in SYNTH_ACCOUNTS {
+        assert!(
+            opens.iter().any(|(a, line)| a == acct && *line == 0),
+            "{surface}: auto_accounts should synthesize a generated Open (lineno 0) for {acct}; got: {opens:?}",
+        );
+    }
+}
+
+#[test]
+fn load_runs_auto_accounts_synth() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, AUTO_ACCOUNTS_LEDGER)?;
+    assert_generated_opens(&loaded.entries, "component load");
+    Ok(())
+}
+
+#[test]
+fn load_file_runs_auto_accounts_synth() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    std::fs::write(dir.path().join("main.bean"), AUTO_ACCOUNTS_LEDGER)?;
+    let (mut store, inst) = instantiate_in(dir.path())?;
+    let loaded =
+        inst.rustledger_ledger_ledger()
+            .call_load_file(&mut store, "/work/main.bean", true, &[])?;
+    assert_generated_opens(&loaded.entries, "component load_file");
+    Ok(())
+}

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -140,14 +140,58 @@ pub fn load_source(source: &str) -> LoadResult {
         }
     }
 
+    // Run the pre-booking SYNTH pass (`auto_accounts`, `document_discovery`)
+    // over the parsed directives, reusing the *canonical* loader entry point
+    // (`run_plugins` — the same function `process::load` calls) instead of a
+    // fork. The string surface cannot use the file-based pipeline wholesale
+    // (it has no filesystem to resolve `include`s against and must preserve
+    // unresolved-include reporting), so it invokes the shared synth stage
+    // directly. Without this, a file-declared `plugin "auto_accounts"` never
+    // generated Open directives through `ledger.load`/`validate`/`query`.
+    let mut synth_dirs: Vec<Spanned<Directive>> = parse_result.directives.clone();
+    let mut source_map = rustledger_loader::SourceMap::new();
+    source_map.add_file(
+        std::path::PathBuf::from("<source>"),
+        std::sync::Arc::from(source),
+    );
+    let synth_plugins: Vec<rustledger_loader::Plugin> = parse_result
+        .plugins
+        .iter()
+        .map(|(name, config, span)| rustledger_loader::Plugin {
+            name: name.clone(),
+            config: config.clone(),
+            span: *span,
+            file_id: 0,
+            force_python: false,
+        })
+        .collect();
+    let mut synth_errors: Vec<rustledger_loader::LedgerError> = Vec::new();
+    let _ = rustledger_loader::run_plugins(
+        &mut synth_dirs,
+        &synth_plugins,
+        &rustledger_loader::Options::default(),
+        &rustledger_loader::LoadOptions::default(),
+        &source_map,
+        &mut synth_errors,
+        rustledger_loader::PluginPass::PreBookingSynth,
+    );
+    errors.extend(synth_errors.iter().map(ledger_error_to_ffi));
+
     // Collect directive line numbers, commodities, and precision
     let mut directive_lines: Vec<u32> = Vec::new();
     let mut commodities: HashSet<String> = HashSet::new();
     let mut precision_tracker = PrecisionTracker::new();
 
     let mut directives: Vec<Directive> = Vec::new();
-    for spanned in &parse_result.directives {
-        let line = lookup.byte_to_line(spanned.span.start);
+    for spanned in &synth_dirs {
+        // Synth-generated directives carry `SYNTHESIZED_FILE_ID`, absent from
+        // the single-file source map, so they surface as line 0 — the
+        // "generated entry" fingerprint embedders key on.
+        let line = if source_map.get(spanned.file_id as usize).is_some() {
+            lookup.byte_to_line(spanned.span.start)
+        } else {
+            0
+        };
         directive_lines.push(line);
 
         // Collect commodities and track precision
@@ -250,8 +294,10 @@ pub fn load_source(source: &str) -> LoadResult {
         })
         .collect();
 
-    // Clone spanned directives for validation
-    let spanned_directives: Vec<Spanned<Directive>> = parse_result.directives.clone();
+    // Spanned directives for validation — the synth-expanded set, so the
+    // `ledger.validate` session sees auto-generated Opens (no spurious
+    // "account not opened" diagnostics).
+    let spanned_directives: Vec<Spanned<Directive>> = synth_dirs;
 
     LoadResult {
         directives,
@@ -330,25 +376,36 @@ pub struct FileLoad {
 ///
 /// Returns the loader error string if the entry file cannot be read/parsed.
 pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad, String> {
-    let mut loader = rustledger_loader::Loader::new().with_path_security(path_security);
-    let load_result = loader
-        .load(path)
-        .map_err(|e| format!("Failed to load file: {e}"))?;
-
-    let mut errors: Vec<Error> = load_result
-        .errors
-        .iter()
-        .map(|e| Error::new(e.to_string()))
-        .collect();
+    // Route through the single canonical pipeline (`process::load`:
+    // sort → synth → book → regular → finalize) rather than re-implementing a
+    // partial loader here. This keeps the FFI surface in lock-step with the
+    // native loader — crucially it runs the pre-booking SYNTH pass
+    // (`auto_accounts`, `document_discovery`) that the previous hand-rolled
+    // parse-and-book path silently skipped (see `tests/load_synth_plugins.rs`).
+    //
+    // `validate: false` preserves this surface's historical load-only error
+    // contract (booking errors surface; semantic-validation errors do not, and
+    // remain the concern of the `ledger.validate` endpoint); `run_plugins`
+    // (default `true`) is what enables the synth pass.
+    let options = rustledger_loader::LoadOptions {
+        path_security,
+        validate: false,
+        ..Default::default()
+    };
+    let ledger =
+        rustledger_loader::load(path, &options).map_err(|e| format!("Failed to load file: {e}"))?;
 
     // Directives + their line numbers / originating files (multi-file).
+    // Synth-generated directives carry a `file_id` absent from the source map,
+    // so they fall through to line 0 / `<unknown>` — the "generated entry"
+    // fingerprint embedders key on to forbid editing synthesized directives.
     let mut directives: Vec<Directive> = Vec::new();
     let mut directive_lines: Vec<u32> = Vec::new();
     let mut directive_files: Vec<String> = Vec::new();
-    for spanned in &load_result.directives {
+    for spanned in &ledger.directives {
         directives.push(spanned.value.clone());
         let file_id = spanned.file_id as usize;
-        if let Some(sf) = load_result.source_map.get(file_id) {
+        if let Some(sf) = ledger.source_map.get(file_id) {
             let (line, _col) = sf.line_col(spanned.span.start);
             directive_lines.push(line as u32);
             directive_files.push(sf.path.display().to_string());
@@ -358,31 +415,9 @@ pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad
         }
     }
 
-    // Booking + interpolation (loader does not book).
-    let booking_method = load_result
-        .options
-        .booking_method
-        .parse()
-        .unwrap_or(rustledger_core::BookingMethod::Strict);
-    let mut booking_engine = BookingEngine::with_method(booking_method);
-    booking_engine.register_account_methods(directives.iter());
-    for (i, directive) in directives.iter_mut().enumerate() {
-        if let Directive::Transaction(txn) = directive {
-            match booking_engine.book_and_interpolate(txn) {
-                Ok(result) => {
-                    booking_engine.apply(&result.transaction);
-                    *txn = result.transaction;
-                    rustledger_booking::normalize_prices(txn);
-                }
-                Err(e) => {
-                    errors.push(Error::new(e.to_string()).with_line(directive_lines[i]));
-                }
-            }
-        }
-    }
-
-    let options = build_ledger_options(&load_result.options);
-    let plugins: Vec<Plugin> = load_result
+    let errors: Vec<Error> = ledger.errors.iter().map(ledger_error_to_ffi).collect();
+    let options = build_ledger_options(&ledger.options);
+    let plugins: Vec<Plugin> = ledger
         .plugins
         .iter()
         .map(|p| Plugin {
@@ -390,7 +425,7 @@ pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad
             config: p.config.clone(),
         })
         .collect();
-    let loaded_files: Vec<String> = load_result
+    let loaded_files: Vec<String> = ledger
         .source_map
         .files()
         .iter()
@@ -406,6 +441,27 @@ pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad
         plugins,
         loaded_files,
     })
+}
+
+/// Convert a loader [`rustledger_loader::LedgerError`] (produced by the
+/// canonical `process::load` pipeline) into the FFI wire [`Error`], preserving
+/// the message, source line, and processing phase. Errors tagged `"validate"`
+/// keep that phase (the `ledger.validate`/`query` handlers count phases); all
+/// others map to the default `"parse"` phase, matching the wire contract.
+fn ledger_error_to_ffi(e: &rustledger_loader::LedgerError) -> Error {
+    let mut err = Error::new(e.message.clone());
+    if let Some(loc) = &e.location {
+        err = err.with_line(loc.line as u32);
+    }
+    // The wire `Error` distinguishes only "parse" vs "validate". The
+    // `ledger.validate`/`query` handlers gate semantic validation on
+    // *parse*-phase errors only, so anything that is not a parse error
+    // (booking → "validate", plugin/synth → "plugin") must NOT be reported as
+    // "parse", or it would wrongly suppress validation.
+    if e.phase != "parse" {
+        err = err.validate_phase();
+    }
+    err
 }
 
 /// Run the named regular (post-booking) plugins over loaded directives, shared

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -148,6 +148,11 @@ pub fn load_source(source: &str) -> LoadResult {
     // unresolved-include reporting), so it invokes the shared synth stage
     // directly. Without this, a file-declared `plugin "auto_accounts"` never
     // generated Open directives through `ledger.load`/`validate`/`query`.
+    // Booking is gated only on *parse* success (it must run on the same input
+    // the canonical pipeline books, regardless of synth/plugin diagnostics).
+    // Capture that state now, before the synth pass appends its own errors.
+    let no_parse_errors = errors.is_empty();
+
     let mut synth_dirs: Vec<Spanned<Directive>> = parse_result.directives.clone();
     let mut source_map = rustledger_loader::SourceMap::new();
     source_map.add_file(
@@ -157,16 +162,22 @@ pub fn load_source(source: &str) -> LoadResult {
     let synth_plugins: Vec<rustledger_loader::Plugin> = parse_result
         .plugins
         .iter()
-        .map(|(name, config, span)| rustledger_loader::Plugin {
-            name: name.clone(),
-            config: config.clone(),
-            span: *span,
-            file_id: 0,
-            force_python: false,
+        .map(|(name, config, span)| {
+            // Mirror the loader: a `python:` prefix forces Python execution and
+            // is stripped from the resolved module name.
+            let force_python = name.starts_with("python:");
+            let name = name.strip_prefix("python:").unwrap_or(name).to_string();
+            rustledger_loader::Plugin {
+                name,
+                config: config.clone(),
+                span: *span,
+                file_id: 0,
+                force_python,
+            }
         })
         .collect();
     let mut synth_errors: Vec<rustledger_loader::LedgerError> = Vec::new();
-    let _ = rustledger_loader::run_plugins(
+    let synth_result = rustledger_loader::run_plugins(
         &mut synth_dirs,
         &synth_plugins,
         &rustledger_loader::Options::default(),
@@ -176,6 +187,11 @@ pub fn load_source(source: &str) -> LoadResult {
         rustledger_loader::PluginPass::PreBookingSynth,
     );
     errors.extend(synth_errors.iter().map(ledger_error_to_ffi));
+    if let Err(e) = synth_result {
+        // A fatal synth-pass error must not be silently dropped (it is tagged
+        // non-parse so it does not suppress booking or `ledger.validate`).
+        errors.push(Error::new(format!("synth plugin pass failed: {e}")).validate_phase());
+    }
 
     // Collect directive line numbers, commodities, and precision
     let mut directive_lines: Vec<u32> = Vec::new();
@@ -238,8 +254,9 @@ pub fn load_source(source: &str) -> LoadResult {
     // Run booking and interpolation on transactions (sequential)
     // This fills in empty cost specs via lot matching, normalizes total prices,
     // and interpolates missing amounts. Must be sequential because lot matching
-    // depends on prior inventory state.
-    if errors.is_empty() {
+    // depends on prior inventory state. Gated on parse success only — synth
+    // diagnostics appended above must not suppress booking.
+    if no_parse_errors {
         let booking_method = options
             .booking_method
             .parse()
@@ -445,9 +462,11 @@ pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad
 
 /// Convert a loader [`rustledger_loader::LedgerError`] (produced by the
 /// canonical `process::load` pipeline) into the FFI wire [`Error`], preserving
-/// the message, source line, and processing phase. Errors tagged `"validate"`
-/// keep that phase (the `ledger.validate`/`query` handlers count phases); all
-/// others map to the default `"parse"` phase, matching the wire contract.
+/// the message and source line. The wire `Error` distinguishes only two phases:
+/// `"parse"`-phase errors keep the default `"parse"`; every other phase
+/// (`"validate"`, `"plugin"`) maps to `"validate"`. The `ledger.validate`/
+/// `query` handlers gate semantic validation on parse-phase errors only, so
+/// non-parse diagnostics must not be reported as `"parse"`.
 fn ledger_error_to_ffi(e: &rustledger_loader::LedgerError) -> Error {
     let mut err = Error::new(e.message.clone());
     if let Some(loc) = &e.location {

--- a/crates/rustledger-ffi-wasi/tests/load_synth_plugins.rs
+++ b/crates/rustledger-ffi-wasi/tests/load_synth_plugins.rs
@@ -1,0 +1,227 @@
+//! Integration tests pinning that the FFI load surface runs the pre-booking
+//! SYNTH plugin pass (`auto_accounts`, `document_discovery`).
+//!
+//! ## Why this file exists
+//!
+//! The FFI `load_file` / `load_source` helpers used to hand-roll a *partial*
+//! loader (parse + a manual booking loop) that ran in parallel to the canonical
+//! `rustledger_loader::process::load` pipeline. That hand-rolled path skipped
+//! the pre-booking synth pass entirely, so `auto_accounts` never generated
+//! `Open` directives through ANY FFI surface — even though the native loader
+//! did (proven by `rustledger-loader`'s `test_plugin_execution_auto_accounts`).
+//! No FFI/component test asserted synth behavior, so the divergence shipped
+//! green. These tests close that gap and guard against the duplicated pipeline
+//! drifting again.
+//!
+//! ## Assertion strategy
+//!
+//! Each synth test pins TWO properties:
+//!  1. the synth `Open` directives are present, AND
+//!  2. they carry NO real source position (lineno 0 / `<unknown>` file) — the
+//!     "generated entry" fingerprint that embedders (rustfava) key on to forbid
+//!     editing synthesized directives.
+
+use rustledger_core::Directive;
+use rustledger_ffi_wasi::helpers::{load_file, load_source};
+use rustledger_ffi_wasi::jsonrpc::process_request;
+use std::fs;
+use tempfile::TempDir;
+
+/// Ledger that declares `plugin "auto_accounts"` and contains NO explicit
+/// `open` directives — the synth pass must generate one per used account.
+const AUTO_ACCOUNTS_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+plugin \"auto_accounts\"
+
+2024-01-15 * \"Paycheck\"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5000 USD
+
+2024-01-20 * \"Groceries\"
+  Expenses:Food                            50 USD
+  Assets:Bank:Checking                    -50 USD
+";
+
+/// A valid ledger with explicit opens and no synth plugin — used to prove the
+/// fix does NOT fabricate generated directives for ordinary ledgers.
+const EXPLICIT_OPENS_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Income:Salary USD
+
+2024-01-15 * \"Paycheck\"
+  Assets:Bank:Checking                    5000 USD
+  Income:Salary                          -5000 USD
+";
+
+const EXPECTED_ACCOUNTS: [&str; 3] = ["Assets:Bank:Checking", "Income:Salary", "Expenses:Food"];
+
+fn open_accounts(dirs: &[Directive]) -> Vec<String> {
+    dirs.iter()
+        .filter_map(|d| match d {
+            Directive::Open(o) => Some(o.account.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `helpers::load_file` must run `auto_accounts` and surface the generated
+/// Opens with no real source position.
+#[test]
+fn load_file_runs_auto_accounts_synth() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("main.beancount");
+    fs::write(&path, AUTO_ACCOUNTS_LEDGER).expect("write ledger");
+
+    let fl = load_file(&path, true).expect("load_file should succeed");
+    let opens = open_accounts(&fl.directives);
+    for acct in EXPECTED_ACCOUNTS {
+        assert!(
+            opens.iter().any(|a| a == acct),
+            "auto_accounts should synthesize an Open for {acct} via load_file; got opens: {opens:?}"
+        );
+    }
+
+    // Each synthesized Open carries no real file/line (the generated marker).
+    for (i, d) in fl.directives.iter().enumerate() {
+        if let Directive::Open(o) = d {
+            let acct = o.account.to_string();
+            if EXPECTED_ACCOUNTS.contains(&acct.as_str()) {
+                assert_eq!(
+                    fl.directive_lines[i], 0,
+                    "synth Open {acct} must have lineno 0"
+                );
+                assert_eq!(
+                    fl.directive_files[i], "<unknown>",
+                    "synth Open {acct} must have <unknown> originating file"
+                );
+            }
+        }
+    }
+
+    // Synth runs before booking, so no "account not opened" diagnostic fires.
+    assert!(
+        !fl.errors
+            .iter()
+            .any(|e| e.message.to_lowercase().contains("not opened")),
+        "no account-not-opened error expected; got: {:?}",
+        fl.errors
+            .iter()
+            .map(|e| e.message.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// `helpers::load_source` (string surface, used by `ledger.load` and the
+/// component crate) must also run the synth pass.
+#[test]
+fn load_source_runs_auto_accounts_synth() {
+    let lr = load_source(AUTO_ACCOUNTS_LEDGER);
+    let opens = open_accounts(&lr.directives);
+    for acct in EXPECTED_ACCOUNTS {
+        assert!(
+            opens.iter().any(|a| a == acct),
+            "auto_accounts should synthesize an Open for {acct} via load_source; got opens: {opens:?}"
+        );
+    }
+    for (i, d) in lr.directives.iter().enumerate() {
+        if let Directive::Open(o) = d
+            && EXPECTED_ACCOUNTS.contains(&o.account.to_string().as_str())
+        {
+            assert_eq!(lr.directive_lines[i], 0, "synth Open must have lineno 0");
+        }
+    }
+}
+
+/// End-to-end through the JSON-RPC `ledger.loadFile` handler: the synth Opens
+/// must appear in `result.entries[]` with `meta.lineno == 0` (the generated
+/// fingerprint a JSON consumer sees).
+#[test]
+fn jsonrpc_load_file_emits_synth_opens() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("main.beancount");
+    fs::write(&path, AUTO_ACCOUNTS_LEDGER).expect("write ledger");
+    let path_str = path.to_str().expect("utf-8 path");
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "ledger.loadFile",
+        "params": { "path": path_str },
+    })
+    .to_string();
+    let response = serde_json::to_value(process_request(&req)).unwrap();
+
+    let entries = response
+        .pointer("/result/entries")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected entries array; response: {response}"));
+
+    for acct in EXPECTED_ACCOUNTS {
+        let synth_open = entries.iter().find(|e| {
+            e.get("account").and_then(|a| a.as_str()) == Some(acct)
+                && e.pointer("/meta/lineno")
+                    .and_then(serde_json::Value::as_u64)
+                    == Some(0)
+        });
+        assert!(
+            synth_open.is_some(),
+            "expected a generated Open for {acct} with meta.lineno==0; entries: {entries:?}"
+        );
+    }
+}
+
+/// End-to-end through `ledger.load` (string surface).
+#[test]
+fn jsonrpc_load_emits_synth_opens() {
+    let req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "ledger.load",
+        "params": { "source": AUTO_ACCOUNTS_LEDGER },
+    })
+    .to_string();
+    let response = serde_json::to_value(process_request(&req)).unwrap();
+
+    let entries = response
+        .pointer("/result/entries")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected entries array; response: {response}"));
+
+    for acct in EXPECTED_ACCOUNTS {
+        assert!(
+            entries.iter().any(|e| {
+                e.get("account").and_then(|a| a.as_str()) == Some(acct)
+                    && e.pointer("/meta/lineno")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(0)
+            }),
+            "expected a generated Open for {acct} with meta.lineno==0 via ledger.load"
+        );
+    }
+}
+
+/// Regression guard: a plain ledger with explicit opens and no synth plugin
+/// must NOT gain spurious generated directives, and its real opens keep their
+/// true source positions.
+#[test]
+fn load_file_no_synth_for_plain_ledger() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("main.beancount");
+    fs::write(&path, EXPLICIT_OPENS_LEDGER).expect("write ledger");
+
+    let fl = load_file(&path, true).expect("load_file should succeed");
+    let opens = open_accounts(&fl.directives);
+    assert_eq!(
+        opens.len(),
+        2,
+        "plain ledger should keep exactly its 2 explicit opens, got: {opens:?}"
+    );
+    // Every directive has a real (>0) line and a concrete originating file.
+    for (i, line) in fl.directive_lines.iter().enumerate() {
+        assert!(
+            *line > 0,
+            "explicit directive {i} should have a real lineno, got 0"
+        );
+        assert_ne!(
+            fl.directive_files[i], "<unknown>",
+            "explicit directive {i} should have a real file"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The FFI `load_file`/`load_source` helpers hand-rolled a **partial loader** (parse + a manual booking loop) that ran in parallel to the canonical `rustledger_loader::process::load` pipeline. That fork skipped the **pre-booking SYNTH pass** entirely, so `auto_accounts` / `document_discovery` never generated directives through **any** FFI surface — JSON-RPC `ledger.load`/`ledger.loadFile`, or the WIT component (which delegates to the same helpers).

The native loader runs synth correctly (`rustledger-loader`'s `test_plugin_execution_auto_accounts` proves it), but **no `rustledger-ffi-wasi` or `rustledger-ffi-component` test asserted synth through the FFI**, so the divergence shipped green.

This was surfaced while embedding the engine in rustfava: a ledger declaring `plugin "auto_accounts"` produced **zero** generated `Open` directives through the FFI.

## Fix — collapse the duplicated pipeline

- **`load_file`** now delegates to `rustledger_loader::load` (the canonical `process::load`: `sort → synth → book → regular → finalize`). The hand-rolled booking loop is removed. `validate: false` preserves this surface's load-only error contract; `run_plugins` (default `true`) brings the synth pass.
- **`load_source`** (string surface) reuses the canonical `run_plugins(.., PreBookingSynth)` entry point rather than a fork, preserving its parse/book/error-phase and unresolved-include reporting so `ledger.validate`/`query` are unaffected.
- The **WIT component** inherits the fix (it delegates to these helpers).

Synth-generated directives surface with `lineno 0` / `<unknown>` file — the "generated entry" marker embedders rely on.

## Close the coverage gap

- New `rustledger-ffi-wasi/tests/load_synth_plugins.rs` — asserts synth generation through `load_file`, `load_source`, and the JSON-RPC `loadFile`/`load` handlers, plus a regression guard that plain ledgers gain **no** spurious generated directives. (Verified failing before / passing after.)
- New parity cases in `rustledger-ffi-component-tests` — assert synth through the **real wasm component**'s `load` and `load-file`.

## Testing

- `cargo test -p rustledger-ffi-wasi` — 63 unit + 11 integration ✅
- `cargo build -p rustledger-ffi-component --target wasm32-wasip2 && cargo test -p rustledger-ffi-component-tests` — 13 ✅ (incl. the 2 new synth parity tests)
- clippy + fmt clean; no snapshot churn

## Out of scope (follow-ups)

- Whether the FFI load path should also run **validation** (kept `validate: false` to scope this to the synth bug).
- Cutting a release so embedders (rustfava) pick up the fixed wasm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)