### PR TITLE
ci(release): build + attach the FFI-Component (wasip2) wasm

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -363,6 +363,35 @@ jobs:
           path: |
             rustledger-ffi-wasi-*.wasm
             rustledger-ffi-wasi-*.sha256
+  build-ffi-component:
+    name: Build FFI-Component
+    needs: validate-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: wasm32-wasip2
+      - name: Build FFI-Component binary
+        # wasm32-wasip2 emits the WASI Preview 2 component directly from the
+        # cdylib (no cargo-component needed).
+        run: cargo build --release --target wasm32-wasip2 -p rustledger-ffi-component
+      - name: Package FFI-Component
+        run: |
+          VERSION=$RELEASE_TAG
+          cp target/wasm32-wasip2/release/rustledger_ffi_component.wasm "rustledger-ffi-component-${VERSION}.wasm"
+          shasum -a 256 "rustledger-ffi-component-${VERSION}.wasm" > "rustledger-ffi-component-${VERSION}.wasm.sha256"
+      - name: Upload FFI-Component artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ffi-component-package
+          path: |
+            rustledger-ffi-component-*.wasm
+            rustledger-ffi-component-*.sha256
   build-vscode:
     name: Build VS Code Extension
     needs: validate-version
@@ -397,7 +426,7 @@ jobs:
             packages/vscode/rustledger-vscode.vsix.sha256
   release:
     name: Create Release
-    needs: [build, build-wasm, build-ffi-wasi, build-vscode]
+    needs: [build, build-wasm, build-ffi-wasi, build-ffi-component, build-vscode]
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,7 +89,7 @@ gh release create v0.14.0 --target "$(git rev-parse HEAD)" --generate-notes
 
 This creates the `v0.14.0` tag and triggers two workflows:
 
-- `release-build.yml` — builds binaries for all 8 platforms, the WASM package, the FFI-WASI binary, and the VS Code extension; attaches them to the release.
+- `release-build.yml` — builds binaries for all 8 platforms, the WASM package, the FFI-WASI binary, the FFI-Component (wasip2) wasm, and the VS Code extension; attaches them to the release.
 - `release-publish.yml` — distributes to crates.io, npm, Docker, Scoop, COPR, AUR (Homebrew autobumps separately).
 
 The full release takes ~30–45 minutes.
@@ -153,7 +153,7 @@ Trusted-publish tokens are publish-scoped only — they cannot run `npm dist-tag
 
 | File | Purpose |
 |------|---------|
-| `release-build.yml` | Builds binaries, WASM, FFI-WASI, VSCode extension; attaches to GitHub Release |
+| `release-build.yml` | Builds binaries, WASM, FFI-WASI, FFI-Component, VSCode extension; attaches to GitHub Release |
 | `release-publish.yml` | Distributes to crates.io, npm, Docker, Scoop, COPR, AUR (Homebrew autobumps separately) |
 
 ## Adding a new workspace crate

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -11,7 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 authors.workspace = true
 readme = "README.md"
-# Work in progress (#1384 Phase 2): not yet a published/release artifact.
+# Shipped as a prebuilt wasip2 component attached to GitHub releases
+# (`rustledger-ffi-component-<version>.wasm`, see release-build.yml), but not
+# published to crates.io — it is a wasm artifact, not a consumable Rust library.
 publish = false
 
 [lib]


### PR DESCRIPTION
## What

Adds a `build-ffi-component` job to `release-build.yml` (mirroring `build-ffi-wasi`) that builds `rustledger-ffi-component` for `wasm32-wasip2` and attaches `rustledger-ffi-component-<version>.wasm` (+ `.sha256`) to each GitHub release.

## Why

The component (WIT / WASI Preview 2) FFI surface had **no downloadable artifact** — `rustledger-ffi-component/Cargo.toml` was marked `# not yet a published/release artifact`, and the release pipeline only built the wasip1 `ffi-wasi` wasm. So in-process component embedders (e.g. rustfava's experimental `RUSTFAVA_RUSTLEDGER_BACKEND=component` engine) had nothing to download — the component had to be built by hand.

This makes the component a first-class release asset, exactly the way `rustledger-ffi-wasi-<version>.wasm` already serves the JSON-RPC engine.

## Details

- New `build-ffi-component` job: `stable` toolchain + `wasm32-wasip2` target → `cargo build --release --target wasm32-wasip2 -p rustledger-ffi-component`. The cdylib emits the component directly (no `cargo-component`).
- Packages `rustledger-ffi-component-<version>.wasm` + `.sha256`; the existing `release` job attaches them via its `artifacts/*.wasm` / `*.sha256` globs.
- Added to the `release` job's `needs`.
- `publish = false` stays (it's a wasm artifact, not a crates.io library) → **`release-publish.yml` unchanged** (the crates.io `CRATES` list correctly excludes it).
- Updated the `Cargo.toml` comment and `RELEASING.md` to reflect the new artifact.

## Testing

- Workflow YAML validated; job graph parses (`release.needs` includes `build-ffi-component`).
- Build command verified locally → `target/wasm32-wasip2/release/rustledger_ffi_component.wasm`.
- The release workflow only runs on tag push, so it'll be exercised end-to-end at the next release.

## Pre-existing follow-up (not addressed here)

The `release` job's "Package WASM for release" step does `cp artifacts/*.wasm … wasm-pkg/`, which sweeps **every** wasm (the browser wasm-pack output **and** the FFI wasms) into the `@rustledger/wasm` npm tarball. This already pulls in `ffi-wasi`; this PR adds `ffi-component` to that sweep too. Scoping that `cp` to just the wasm-pack browser wasm (`rustledger_wasm_bg.wasm`) would de-bloat the npm package, but it touches the npm-publish path and deserves its own carefully-tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)