### PR TITLE
fix(lsp): surface ledger summary in completion-resolve detail (#1408)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/completion_resolve.rs
+++ b/crates/rustledger-lsp/src/handlers/completion_resolve.rs
@@ -43,20 +43,33 @@ pub fn handle_completion_resolve(
     if resolved.documentation.is_none() {
         let label = &item.label;
         if is_account_like(label) {
-            resolved.documentation = Some(resolve_account_documentation(label, directives));
+            let (doc, detail) = resolve_account_documentation(label, directives);
+            resolved.documentation = Some(doc);
+            // Surface the ledger-wide summary in `detail` too — clients that
+            // show `detail` inline (and not the documentation popup) otherwise
+            // only see the generic kind hint set by the producer (issue #1408).
+            if let Some(detail) = detail {
+                resolved.detail = Some(detail);
+            }
         } else if is_currency_like_simple(label) {
-            resolved.documentation = Some(resolve_currency_documentation(label, directives));
+            let (doc, detail) = resolve_currency_documentation(label, directives);
+            resolved.documentation = Some(doc);
+            if let Some(detail) = detail {
+                resolved.detail = Some(detail);
+            }
         }
     }
 
     resolved
 }
 
-/// Resolve documentation for an account completion.
+/// Resolve documentation (and a concise `detail` summary) for an account
+/// completion. Returns the markdown popup plus, when the account has activity,
+/// a one-line `detail` like `"3500 USD · 2 txns"`.
 fn resolve_account_documentation(
     account: &str,
     directives: &[Spanned<Directive>],
-) -> Documentation {
+) -> (Documentation, Option<String>) {
     let mut balances: HashMap<String, Decimal> = HashMap::new();
     let mut transaction_count = 0;
     let mut first_date: Option<rustledger_core::NaiveDate> = None;
@@ -107,17 +120,38 @@ fn resolve_account_documentation(
         doc.push_str("_No transactions found_");
     }
 
-    Documentation::MarkupContent(MarkupContent {
+    // One-line summary for the completion `detail` field: balances
+    // (currency-sorted for stable output) and the transaction count.
+    let detail = if transaction_count > 0 {
+        let mut parts: Vec<String> = balances
+            .iter()
+            .map(|(currency, amount)| format!("{amount} {currency}"))
+            .collect();
+        parts.sort();
+        let balance_str = parts.join(", ");
+        Some(if balance_str.is_empty() {
+            format!("{transaction_count} txns")
+        } else {
+            format!("{balance_str} · {transaction_count} txns")
+        })
+    } else {
+        None
+    };
+
+    let documentation = Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
         value: doc,
-    })
+    });
+    (documentation, detail)
 }
 
-/// Resolve documentation for a currency completion.
+/// Resolve documentation (and a concise `detail` summary) for a currency
+/// completion. Returns the markdown popup plus, when the currency is used, a
+/// one-line `detail` like `"12 postings · 155 USD"` (latest price).
 fn resolve_currency_documentation(
     currency: &str,
     directives: &[Spanned<Directive>],
-) -> Documentation {
+) -> (Documentation, Option<String>) {
     let mut prices: Vec<(rustledger_core::NaiveDate, Decimal, String)> = Vec::new();
     let mut usage_count = 0;
 
@@ -161,10 +195,22 @@ fn resolve_currency_documentation(
         }
     }
 
-    Documentation::MarkupContent(MarkupContent {
+    // One-line `detail`: usage count plus the latest price, when known.
+    let detail = if usage_count > 0 || !prices.is_empty() {
+        let mut summary = format!("{usage_count} postings");
+        if let Some((_, amount, quote)) = prices.first() {
+            summary.push_str(&format!(" · {amount} {quote}"));
+        }
+        Some(summary)
+    } else {
+        None
+    };
+
+    let documentation = Documentation::MarkupContent(MarkupContent {
         kind: MarkupKind::Markdown,
         value: doc,
-    })
+    });
+    (documentation, detail)
 }
 
 #[cfg(test)]
@@ -192,6 +238,11 @@ mod tests {
 
         let resolved = handle_completion_resolve(item, &result.directives);
         assert!(resolved.documentation.is_some());
+
+        // `detail` now carries the ledger summary too (issue #1408).
+        let detail = resolved.detail.clone().expect("detail summary set");
+        assert!(detail.contains("95"), "detail balance; got: {detail}");
+        assert!(detail.contains("2 txns"), "detail count; got: {detail}");
 
         if let Some(Documentation::MarkupContent(content)) = resolved.documentation {
             assert!(content.value.contains("Assets:Bank"));
@@ -282,6 +333,11 @@ mod tests {
 
         let resolved = handle_completion_resolve(item, &result.directives);
         assert!(resolved.documentation.is_some());
+
+        // `detail` carries usage + latest price (issue #1408).
+        let detail = resolved.detail.clone().expect("detail summary set");
+        assert!(detail.contains("postings"), "detail usage; got: {detail}");
+        assert!(detail.contains("155"), "detail latest price; got: {detail}");
 
         if let Some(Documentation::MarkupContent(content)) = resolved.documentation {
             assert!(content.value.contains("AAPL"));

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -815,3 +815,81 @@ fn scratch_file_not_in_journal_uses_single_file_mode() {
         cmd.title
     );
 }
+
+/// Reproduction for #1408: `completionItem/resolve` must return a SINGLE
+/// `CompletionItem` (not an array — a protocol violation), and when a
+/// `journalFile` is configured its documentation must aggregate over the whole
+/// loaded ledger, not the ephemeral buffer the completion was triggered in.
+#[cfg(unix)]
+#[test]
+fn completion_resolve_returns_single_item_and_uses_journal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("main.beancount");
+    std::fs::write(
+        &journal_path,
+        "2024-01-01 open Assets:Bank:Checking USD\n\
+         2024-01-01 open Income:Salary\n\
+         2024-01-15 * \"Paycheck\"\n  \
+           Assets:Bank:Checking   5000 USD\n  \
+           Income:Salary\n\
+         2024-02-20 * \"Rent\"\n  \
+           Assets:Bank:Checking  -1500 USD\n  \
+           Expenses:Rent\n",
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path.clone()));
+    client.initialize();
+
+    // An *ephemeral* buffer distinct from the journal (mirrors a client's
+    // __test__.bean completion buffer).
+    let buf_uri = format!("file://{}", tmp.path().join("__buf__.beancount").display());
+    client.open_document(&buf_uri, "2024-03-01 * \"x\"\n  Assets:Bank:Checking\n");
+
+    // Resolve an account completion item whose `data.uri` points at the
+    // ephemeral buffer — resolve must still aggregate over the loaded journal.
+    let item = serde_json::json!({
+        "label": "Assets:Bank:Checking",
+        "detail": "Account",
+        "data": { "uri": buf_uri },
+    });
+    let id = client.next_request_id();
+    let req = lsp_server::Request {
+        id: id.clone(),
+        method: <lsp_types::request::ResolveCompletionItem as lsp_types::request::Request>::METHOD
+            .to_string(),
+        params: item,
+    };
+    client.raw_send_request(req).expect("send resolve");
+    let resp = client.expect_response(&id);
+    let result = resp.result.expect("resolve returned a result");
+
+    // Finding 1: the result must be a single object, not an array.
+    assert!(
+        result.is_object(),
+        "completionItem/resolve must return a single CompletionItem object, got: {result}"
+    );
+
+    // Finding 2: documentation must reflect the loaded journal (2 txns, 3500 net).
+    let resolved: lsp_types::CompletionItem =
+        serde_json::from_value(result).expect("deserialize CompletionItem");
+    // The ledger summary is also surfaced in `detail` (issue #1408), where
+    // clients that don't render the documentation popup can still see it.
+    let detail = resolved.detail.clone().expect("detail summary set");
+    assert!(
+        detail.contains("3500") && detail.contains("2 txns"),
+        "detail should summarize the journal balance/count; got: {detail}"
+    );
+    let doc = match resolved.documentation {
+        Some(lsp_types::Documentation::MarkupContent(m)) => m.value,
+        other => panic!("expected markdown documentation, got {other:?}"),
+    };
+    assert!(
+        doc.contains("2 transactions"),
+        "resolve should aggregate over the journal (2 txns); got:\n{doc}"
+    );
+    assert!(
+        doc.contains("3500"),
+        "resolve should show the journal balance 5000-1500=3500; got:\n{doc}"
+    );
+}


### PR DESCRIPTION
Closes #1408.

## Investigation: the two reported findings don't reproduce on v0.16.1

I added an end-to-end protocol test (`completion_resolve_returns_single_item_and_uses_journal`) that drives a real `rledger-lsp` over the in-process harness: load a `journalFile`, open a *separate* ephemeral buffer, then send a raw `completionItem/resolve` for an account whose `data.uri` points at the buffer. It asserts on the actual wire response. Results:

- **Finding 1 ("resolve returns an array of 9 items — protocol violation")** — does **not** reproduce. The response is a single `CompletionItem` object. `completionItem/resolve` is dispatched synchronously and the handler serializes exactly one item (`main_loop.rs`); there's no path that returns the completion list. The reporter's "array" was most likely client-side response/id matching (the `textDocument/completion` response arriving while the resolve was in flight).
- **Finding 2 ("journalFile ignored during resolve")** — does **not** reproduce either. The resolve handler reads `ledger_state.directives()` (the full loaded journal) regardless of the item's `data.uri`, so the documentation already aggregates over the whole ledger (verified: 2 txns / 3500 balance from the journal, not the 1-posting buffer).

## The real gap (and the fix)

The reporter observed `detail` staying `"Account"` and concluded the ledger was ignored — but the ledger-wide info was being computed into `documentation` (the popup), **not** `detail`. Clients that surface `detail` inline (and the reporter's manual JSON-RPC probe) never saw it.

So resolve now **also fills `detail`** with a concise ledger summary:
- accounts → `"3500 USD · 2 txns"` (balances currency-sorted for stable output)
- currencies → `"12 postings · 155 USD"` (latest price)

## Tests

- New protocol test pinning single-item response + journal-aware documentation **and** detail.
- Unit tests extended to assert the new `detail` summary.
- Full `rustledger-lsp` suite green (239 unit + integration), clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)