### PR TITLE
fix(lsp): char-safe truncation in folding summary (#1415)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/folding.rs
+++ b/crates/rustledger-lsp/src/handlers/folding.rs
@@ -131,8 +131,12 @@ fn format_transaction_summary(txn: &rustledger_core::Transaction) -> String {
         format!("{} {} ...", date, payee)
     } else if !txn.narration.is_empty() {
         let narration = txn.narration.to_string();
-        let truncated = if narration.len() > 30 {
-            format!("{}...", &narration[..30])
+        // Truncate by characters, not bytes: byte-slicing (`&narration[..30]`)
+        // panics when byte 30 falls inside a multibyte UTF-8 char, e.g. Korean
+        // (3 bytes/char) — issue #1415.
+        let truncated = if narration.chars().count() > 30 {
+            let prefix: String = narration.chars().take(30).collect();
+            format!("{prefix}...")
         } else {
             narration
         };
@@ -167,6 +171,40 @@ fn is_section_header(line: &str) -> bool {
 mod tests {
     use super::*;
     use rustledger_parser::parse;
+
+    /// Regression for #1415: folding must not panic on a non-ASCII narration
+    /// longer than the 30-char truncation threshold. The old code byte-sliced
+    /// `&narration[..30]`, which panics when byte 30 falls inside a multibyte
+    /// UTF-8 char (e.g. Korean, 3 bytes/char).
+    #[test]
+    fn folding_long_non_ascii_narration_does_not_panic() {
+        // 26 ASCII chars then Korean, so byte 30 lands inside a 3-byte char.
+        let narration = "aaaaaaaaaaaaaaaaaaaaaaaaaa가나다라마바사";
+        // The exact condition the old byte-slice violated.
+        assert!(!narration.is_char_boundary(30));
+        assert!(narration.chars().count() > 30);
+
+        let source =
+            format!("2024-01-15 * \"{narration}\"\n  Assets:Bank  -5.00 USD\n  Expenses:Food\n");
+        let result = parse(&source);
+        let params = FoldingRangeParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        // Must not panic, and the collapsed summary truncates on a char boundary.
+        let ranges =
+            handle_folding_ranges(&params, &source, &result, PositionEncoding::Utf16).unwrap();
+        let txn_fold = ranges
+            .iter()
+            .find(|r| r.start_line == 0)
+            .expect("transaction fold range");
+        let collapsed = txn_fold.collapsed_text.as_ref().expect("collapsed summary");
+        assert!(collapsed.ends_with("..."), "got: {collapsed}");
+    }
 
     #[test]
     fn test_folding_transaction() {


### PR DESCRIPTION
Closes #1415.

## Bug

`textDocument/foldingRange` **panicked** — `byte index N is not a char boundary` at `folding.rs:135` — on a transaction whose narration is >30 bytes and whose 30th byte lands inside a multibyte UTF-8 character (e.g. Korean, 3 bytes/char). A panic in a request handler takes down the LSP for the session.

## Cause

`format_transaction_summary` truncated the narration with a **byte** slice:
```rust
if narration.len() > 30 { format!("{}...", &narration[..30]) }
```
`&narration[..30]` is a byte index; for non-ASCII text byte 30 can split a char → panic.

## Fix

Truncate by **characters**:
```rust
if narration.chars().count() > 30 {
    let prefix: String = narration.chars().take(30).collect();
    format!("{prefix}...")
}
```

## Tests

- `folding_long_non_ascii_narration_does_not_panic`: a mixed ASCII+Korean narration with `assert!(!narration.is_char_boundary(30))` (the exact condition the old slice violated) — drives the real `handle_folding_ranges` path and asserts no panic + a char-boundary-truncated summary.
- Full `rustledger-lsp` suite green (240 + integration); clippy + fmt clean.

## Related (not in this PR)

`signature_help.rs:84` has the same class of byte-slice (`&text[..10]` for the date prefix) — safe today only because lines start ASCII, but worth hardening in a follow-up if a line can start non-ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)