### PR TITLE
feat(ffi-component): stateful resource session ledger handle (#1384)

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -494,3 +494,67 @@ fn load_file_runs_auto_accounts_synth() -> Result<()> {
     assert_generated_opens(&loaded.entries, "component load_file");
     Ok(())
 }
+
+const LEDGER_WITH_COST: &str = "\
+2023-01-01 open Assets:Cash USD
+2023-01-01 open Expenses:Food USD
+2023-06-15 * \"old\"
+  Expenses:Food  5 USD
+  Assets:Cash
+2024-02-10 * \"Coffee\"
+  Expenses:Food  7 USD {2 USD}
+  Assets:Cash  -14 USD
+";
+
+/// The stateful `resource session` (#173): construct once, then info/query/
+/// clamp run against the held ledger. Crucially `clamp` operates on the held
+/// core directives, so cost basis survives with no WIT->core->WIT round-trip.
+#[test]
+fn session_clamp_preserves_cost_basis() -> Result<()> {
+    use rustledger::ledger::types::{CostNumber, Directive};
+
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let ledger = inst.rustledger_ledger_ledger();
+    let session = ledger.session();
+
+    let handle = session.call_constructor(&mut store, LEDGER_WITH_COST)?;
+
+    // `info` materializes the load result once; entry count matches the loader.
+    let info = session.call_info(&mut store, handle)?;
+    let expected = rustledger_ffi_wasi::helpers::load_source(LEDGER_WITH_COST)
+        .directives
+        .len();
+    assert_eq!(info.entries.len(), expected);
+    assert!(info.errors.is_empty(), "load errored: {:?}", info.errors);
+
+    // Query runs against the held ledger.
+    let q = session.call_query(&mut store, handle, "SELECT account, position")?;
+    assert!(q.errors.is_empty(), "query errored: {:?}", q.errors);
+    assert!(!q.rows.is_empty());
+
+    // Clamp on the held core directives preserves the per-unit cost basis.
+    let clamped = session.call_clamp(&mut store, handle, "2024-01-01", "2024-12-31")?;
+    let coffee = clamped
+        .iter()
+        .find_map(|d| match d {
+            Directive::Transaction(t) if t.narration.as_deref() == Some("Coffee") => Some(t),
+            _ => None,
+        })
+        .expect("Coffee transaction survived the clamp window");
+    let cost = coffee.postings[0]
+        .cost
+        .as_ref()
+        .expect("Coffee posting kept its cost");
+    assert!(
+        matches!(&cost.number, Some(CostNumber::PerUnit(v)) if v == "2"),
+        "cost basis preserved through clamp: {:?}",
+        cost.number,
+    );
+
+    handle.resource_drop(&mut store)?;
+    Ok(())
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -662,7 +662,6 @@ pub fn batch_file(path: &str, queries: &[String]) -> out::BatchResult {
                 options: options(ffi::LedgerOptions::default()),
                 plugins: vec![],
                 includes: vec![],
-                padded: std::cell::OnceCell::new(),
             },
             queries: vec![],
         },

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -662,6 +662,7 @@ pub fn batch_file(path: &str, queries: &[String]) -> out::BatchResult {
                 options: options(ffi::LedgerOptions::default()),
                 plugins: vec![],
                 includes: vec![],
+                padded: std::cell::OnceCell::new(),
             },
             queries: vec![],
         },
@@ -1113,7 +1114,7 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         .collect()
 }
 
-// ---- stateful ledger handle (`resource session`, #173) -------------------
+// ---- stateful ledger handle (`resource session`, rustfava#173) -------------------
 //
 // Normalizes the source and file load paths into one held state so the
 // `query`/`filter`/`clamp` methods don't care which produced it. The win over
@@ -1132,6 +1133,8 @@ pub struct SessionState {
     options: wit::LedgerOptions,
     plugins: Vec<ffi::Plugin>,
     includes: Vec<(String, u32)>,
+    /// Pad-expanded directives for querying, computed once on first `query`.
+    padded: std::cell::OnceCell<Vec<rustledger_core::Directive>>,
 }
 
 impl SessionState {
@@ -1151,6 +1154,7 @@ impl SessionState {
                 .into_iter()
                 .map(|i| (i.path, i.lineno))
                 .collect(),
+            padded: std::cell::OnceCell::new(),
         }
     }
 
@@ -1183,6 +1187,7 @@ impl SessionState {
                     options: options(opts),
                     plugins: plugin_dtos,
                     includes: loaded_files.into_iter().map(|p| (p, 0)).collect(),
+                    padded: std::cell::OnceCell::new(),
                 }
             }
             Err(e) => Self {
@@ -1193,6 +1198,7 @@ impl SessionState {
                 options: options(ffi::LedgerOptions::default()),
                 plugins: vec![],
                 includes: vec![],
+                padded: std::cell::OnceCell::new(),
             },
         }
     }
@@ -1244,8 +1250,10 @@ impl SessionState {
                 errors: self.errors.clone(),
             };
         }
-        let directives = rustledger_booking::merge_with_padding(&self.directives);
-        run_query(&directives, query_str)
+        let directives = self
+            .padded
+            .get_or_init(|| rustledger_booking::merge_with_padding(&self.directives));
+        run_query(directives, query_str)
     }
 
     /// Keep only directives within `[begin, end)`. Reuses the free `filter`'s
@@ -1256,7 +1264,7 @@ impl SessionState {
 
     /// Clamp to `[begin, end)`, running `rustledger_ops::clamp` **directly on
     /// the held core directives** — no WIT -> core -> WIT round-trip, the value
-    /// the resource exists to deliver (#173).
+    /// the resource exists to deliver (rustfava#173).
     pub fn clamp(&self, begin: &str, end: &str) -> Vec<wit::Directive> {
         let (Ok(begin_date), Ok(end_date)) = (
             begin.parse::<rustledger_core::NaiveDate>(),

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -461,7 +461,7 @@ fn query_loaded(loaded: &ffi::helpers::LoadResult, query_str: &str) -> out::Quer
 }
 
 /// Run one query against already-loaded, pad-expanded directives.
-fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out::QueryResult {
+pub fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out::QueryResult {
     let parsed = match parse_query(query_str) {
         Ok(q) => q,
         Err(e) => {
@@ -1111,4 +1111,162 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         .iter()
         .map(|d| directive(ffi::convert::directive_to_json(d, 0, "<clamped>")))
         .collect()
+}
+
+// ---- stateful ledger handle (`resource session`, #173) -------------------
+//
+// Normalizes the source and file load paths into one held state so the
+// `query`/`filter`/`clamp` methods don't care which produced it. The win over
+// the free functions: these run against the held *core* directives, so they
+// never re-parse source nor round-trip a directive list through the host.
+
+/// Held state behind a `session` resource: the booked core directives + their
+/// per-directive provenance, plus the load metadata, normalized across the
+/// source and file load paths. Errors are pre-converted to WIT form (the file
+/// path's failure case has only a message, not a rich `ffi::Error`).
+pub struct SessionState {
+    directives: Vec<rustledger_core::Directive>,
+    lines: Vec<u32>,
+    files: Vec<String>,
+    errors: Vec<wit::Error>,
+    options: wit::LedgerOptions,
+    plugins: Vec<ffi::Plugin>,
+    includes: Vec<(String, u32)>,
+}
+
+impl SessionState {
+    /// Parse + book from source text (single synthetic `<stdin>` filename).
+    pub fn from_source(source: &str) -> Self {
+        let loaded = ffi::helpers::load_source(source);
+        let files = vec!["<stdin>".to_string(); loaded.directives.len()];
+        Self {
+            directives: loaded.directives,
+            lines: loaded.directive_lines,
+            files,
+            errors: loaded.errors.into_iter().map(error).collect(),
+            options: options(loaded.options),
+            plugins: loaded.plugins,
+            includes: loaded
+                .includes
+                .into_iter()
+                .map(|i| (i.path, i.lineno))
+                .collect(),
+        }
+    }
+
+    /// Parse + book from a file path. Mirrors the free `load_file`'s handling
+    /// (path-security flag inversion, requested-plugin pass, per-directive
+    /// file provenance); a load failure becomes an empty ledger whose single
+    /// error carries the message.
+    pub fn from_file(path: &str, allow_unrestricted_includes: bool, plugins: &[String]) -> Self {
+        let path_security = !allow_unrestricted_includes;
+        match ffi::helpers::load_file(std::path::Path::new(path), path_security) {
+            Ok(fl) => {
+                let mut errors = fl.errors;
+                let opts = fl.options;
+                let plugin_dtos = fl.plugins;
+                let loaded_files = fl.loaded_files;
+                let plugin_names: Vec<&str> = plugins.iter().map(String::as_str).collect();
+                let (directives, lines, files) = ffi::helpers::apply_plugins(
+                    &plugin_names,
+                    fl.directives,
+                    fl.directive_lines,
+                    fl.directive_files,
+                    &mut errors,
+                    &opts,
+                );
+                Self {
+                    directives,
+                    lines,
+                    files,
+                    errors: errors.into_iter().map(error).collect(),
+                    options: options(opts),
+                    plugins: plugin_dtos,
+                    includes: loaded_files.into_iter().map(|p| (p, 0)).collect(),
+                }
+            }
+            Err(e) => Self {
+                directives: vec![],
+                lines: vec![],
+                files: vec![],
+                errors: vec![simple_error(e)],
+                options: options(ffi::LedgerOptions::default()),
+                plugins: vec![],
+                includes: vec![],
+            },
+        }
+    }
+
+    /// The held directives as WIT, carrying their real line/file provenance.
+    fn entries(&self) -> Vec<wit::Directive> {
+        self.directives
+            .iter()
+            .enumerate()
+            .map(|(i, d)| {
+                let line = self.lines.get(i).copied().unwrap_or(0);
+                let file = self.files.get(i).map_or("<unknown>", String::as_str);
+                directive(ffi::convert::directive_to_json(d, line, file))
+            })
+            .collect()
+    }
+
+    /// The load result the host materializes once (entries/errors/options/...).
+    pub fn info(&self) -> out::LoadResult {
+        out::LoadResult {
+            entries: self.entries(),
+            errors: self.errors.clone(),
+            options: self.options.clone(),
+            plugins: self
+                .plugins
+                .iter()
+                .map(|p| wit::Plugin {
+                    name: p.name.clone(),
+                    config: p.config.clone(),
+                })
+                .collect(),
+            includes: self
+                .includes
+                .iter()
+                .map(|(path, lineno)| wit::SourceInclude {
+                    path: path.clone(),
+                    lineno: *lineno,
+                })
+                .collect(),
+        }
+    }
+
+    /// Run a BQL query against the held ledger (no re-parse).
+    pub fn query(&self, query_str: &str) -> out::QueryResult {
+        if !self.errors.is_empty() {
+            return out::QueryResult {
+                columns: vec![],
+                rows: vec![],
+                errors: self.errors.clone(),
+            };
+        }
+        let directives = rustledger_booking::merge_with_padding(&self.directives);
+        run_query(&directives, query_str)
+    }
+
+    /// Keep only directives within `[begin, end)`. Reuses the free `filter`'s
+    /// date predicate over the held directives (filter is lossless).
+    pub fn filter(&self, begin: &str, end: &str) -> Vec<wit::Directive> {
+        filter(self.entries(), begin, end)
+    }
+
+    /// Clamp to `[begin, end)`, running `rustledger_ops::clamp` **directly on
+    /// the held core directives** — no WIT -> core -> WIT round-trip, the value
+    /// the resource exists to deliver (#173).
+    pub fn clamp(&self, begin: &str, end: &str) -> Vec<wit::Directive> {
+        let (Ok(begin_date), Ok(end_date)) = (
+            begin.parse::<rustledger_core::NaiveDate>(),
+            end.parse::<rustledger_core::NaiveDate>(),
+        ) else {
+            return self.entries();
+        };
+        rustledger_ops::clamp::clamp(&self.directives, begin_date, end_date)
+            .iter()
+            .map(|d| directive(ffi::convert::directive_to_json(d, 0, "<clamped>")))
+            .collect()
+    }
 }

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -33,7 +33,8 @@ mod convert;
 use exports::rustledger::ledger::builder::{Directive, Guest as BuilderGuest, InputDirective};
 use exports::rustledger::ledger::format::Guest as FormatGuest;
 use exports::rustledger::ledger::ledger::{
-    BatchResult, Guest as LedgerGuest, LoadResult, QueryResult, ValidateResult,
+    BatchResult, Guest as LedgerGuest, GuestSession, LoadResult, QueryResult, Session,
+    ValidateResult,
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
@@ -44,6 +45,8 @@ const API_VERSION: &str = "2.1";
 struct Component;
 
 impl LedgerGuest for Component {
+    type Session = LedgerSession;
+
     fn version() -> String {
         API_VERSION.to_string()
     }
@@ -74,6 +77,43 @@ impl LedgerGuest for Component {
     }
     fn batch_file(path: String, queries: Vec<String>) -> BatchResult {
         convert::batch_file(&path, &queries)
+    }
+}
+
+/// A loaded, booked ledger held in the component (`resource session`, #173).
+/// Parses + books once in `new`/`from_file`; `query`/`filter`/`clamp` run on
+/// the held ledger via [`convert::SessionState`] with no re-parse or re-render.
+struct LedgerSession {
+    state: convert::SessionState,
+}
+
+impl GuestSession for LedgerSession {
+    fn new(source: String) -> Self {
+        Self {
+            state: convert::SessionState::from_source(&source),
+        }
+    }
+
+    fn from_file(path: String, allow_unrestricted_includes: bool, plugins: Vec<String>) -> Session {
+        Session::new(Self {
+            state: convert::SessionState::from_file(&path, allow_unrestricted_includes, &plugins),
+        })
+    }
+
+    fn info(&self) -> LoadResult {
+        self.state.info()
+    }
+
+    fn query(&self, query: String) -> QueryResult {
+        self.state.query(&query)
+    }
+
+    fn filter(&self, begin_date: String, end_date: String) -> Vec<Directive> {
+        self.state.filter(&begin_date, &end_date)
+    }
+
+    fn clamp(&self, begin_date: String, end_date: String) -> Vec<Directive> {
+        self.state.clamp(&begin_date, &end_date)
     }
 }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -80,7 +80,7 @@ impl LedgerGuest for Component {
     }
 }
 
-/// A loaded, booked ledger held in the component (`resource session`, #173).
+/// A loaded, booked ledger held in the component (`resource session`, rustfava#173).
 /// Parses + books once in `new`/`from_file`; `query`/`filter`/`clamp` run on
 /// the held ledger via [`convert::SessionState`] with no re-parse or re-render.
 struct LedgerSession {

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -423,7 +423,7 @@ interface ledger {
   /// Like `batch`, but the ledger is loaded from a file path.
   batch-file: func(path: string, queries: list<string>) -> batch-result;
 
-  /// A loaded, booked ledger held inside the component (#173, rustfava#173).
+  /// A loaded, booked ledger held inside the component (rustfava#173, rustfava#173).
   ///
   /// The stateful, typed successor to the free `load`/`query`/`clamp`
   /// functions: the host constructs one handle, then runs `query`/`filter`/
@@ -435,7 +435,7 @@ interface ledger {
   ///
   /// `query`/`filter`/`clamp` operate on the held *core* directives directly,
   /// so they never round-trip through the host's directive representation —
-  /// removing a whole class of shape-translation bugs (rustfava #173).
+  /// removing a whole class of shape-translation bugs (rustfava rustfava#173).
   resource session {
     /// Parse + book a ledger from source text.
     constructor(source: string);

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -422,6 +422,39 @@ interface ledger {
   batch: func(source: string, queries: list<string>) -> batch-result;
   /// Like `batch`, but the ledger is loaded from a file path.
   batch-file: func(path: string, queries: list<string>) -> batch-result;
+
+  /// A loaded, booked ledger held inside the component (#173, rustfava#173).
+  ///
+  /// The stateful, typed successor to the free `load`/`query`/`clamp`
+  /// functions: the host constructs one handle, then runs `query`/`filter`/
+  /// `clamp` against the *held* ledger with no re-parse and no re-render —
+  /// where the free functions re-parse `source` (or force the host to
+  /// re-serialize entries to text) on every call. `info` materializes the
+  /// load result (entries/errors/options/plugins/includes) once for the host's
+  /// own model.
+  ///
+  /// `query`/`filter`/`clamp` operate on the held *core* directives directly,
+  /// so they never round-trip through the host's directive representation —
+  /// removing a whole class of shape-translation bugs (rustfava #173).
+  resource session {
+    /// Parse + book a ledger from source text.
+    constructor(source: string);
+    /// Parse + book from a file path. Include-graph confinement and
+    /// `allow-unrestricted-includes` / `plugins` semantics match `load-file`;
+    /// load failures are surfaced via `info().errors`, not a trap.
+    from-file: static func(path: string, allow-unrestricted-includes: bool, plugins: list<string>) -> session;
+
+    /// Everything the host needs at load time: entries, errors, options,
+    /// plugins, and the resolved include graph.
+    info: func() -> load-result;
+    /// Run a BQL query against the held ledger.
+    query: func(query: string) -> query-result;
+    /// Keep only directives within `[begin, end)`.
+    filter: func(begin-date: string, end-date: string) -> list<directive>;
+    /// Clamp to `[begin, end)`, synthesizing opening-balance and summary
+    /// directives at the boundaries.
+    clamp: func(begin-date: string, end-date: string) -> list<directive>;
+  }
 }
 
 /// Directive construction & transformation — replaces `entry.create`,


### PR DESCRIPTION
Phase 1 of the rustfava↔rustledger boundary redesign (rustfava #173, part of #1384). De-risked first by the `spike/ledger-resource` spike; this is the production contract + impl.

## What
A Component-Model **`resource session`** in the WIT: `constructor(source)` / `from-file(path, …)` build a handle that holds the booked ledger *inside the component*, and the methods run against it:

| method | returns |
|---|---|
| `info()` | `load-result` (entries/errors/options/plugins/includes) — materialized once for the host |
| `query(q)` | `query-result` — BQL against the held ledger |
| `filter(begin, end)` | `list<directive>` within `[begin, end)` |
| `clamp(begin, end)` | `list<directive>`, opening-balance + summary synthesized |

## Why
Embedders (rustfava) today re-parse `source` — or re-serialize already-loaded entries back to beancount text — on every query/clamp, and shuttle directive lists across the FFI boundary per op. The handle removes both: **parse + book once, operate server-side.**

Critically, `clamp`/`filter` run on the held **core** directives. `clamp` calls `rustledger_ops::clamp` directly rather than round-tripping `WIT → core → WIT`, which is faster *and* sidesteps the shape-translation drift that round-trip caused on the host (rustfava #173 — the cost-basis / typed-value bug class).

## How
Reuses the existing converters wholesale via a normalized `SessionState` that flattens the two load paths (`load_source`'s `LoadResult` vs `load_file`'s `FileLoad`) into one held representation, so the methods don't care which produced it. The free `load`/`query`/`clamp` functions stay for back-compat during the dual-ship window.

## Tests
New host parity test `session_clamp_preserves_cost_basis` (construct → info → query → clamp; asserts the per-unit cost survives clamp) alongside the existing 13 — **14/14 green**. clippy (`-D warnings`, wasip2) + fmt clean.

Next (rustfava #173): the rustfava adapter consumes this handle, then the full-suite gate, then the default flip.