### PR TITLE
chore: release v0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "agcli",
  "anyhow",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3274,11 +3274,11 @@ dependencies = [
 
 [[package]]
 name = "rustledger-completion"
-version = "0.16.2"
+version = "0.16.3"
 
 [[package]]
 name = "rustledger-core"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "criterion",
  "imbl",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "jiff",
  "rustledger-booking",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component-tests"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "rustledger-ffi-wasi",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.2",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "blake3",
  "glob",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "crossbeam-channel",
  "jiff",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "blake3",
  "jiff",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "blake3",
  "criterion",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-only"
@@ -189,19 +189,19 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.16.2", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.16.2", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.16.2", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.16.2", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.16.2", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.16.2", path = "crates/rustledger-query" }
-rustledger-completion = { version = "0.16.2", path = "crates/rustledger-completion" }
-rustledger-plugin = { version = "0.16.2", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.16.2", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.16.2", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.16.2", path = "crates/rustledger-ops" }
-rustledger-ffi-wasi = { version = "0.16.2", path = "crates/rustledger-ffi-wasi" }
-rustledger-wasm = { version = "0.16.2", path = "crates/rustledger-wasm" }
+rustledger-core = { version = "0.16.3", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.16.3", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.16.3", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.16.3", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.16.3", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.16.3", path = "crates/rustledger-query" }
+rustledger-completion = { version = "0.16.3", path = "crates/rustledger-completion" }
+rustledger-plugin = { version = "0.16.3", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.16.3", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.16.3", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.16.3", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.16.3", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.16.3", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-completion"
 description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Rustledger FFI via WASI - JSON API for embedding in any language"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
   "homepage": "https://rustledger.github.io",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@rustledger/wasm": "^0.16.2"
+    "@rustledger/wasm": "^0.16.3"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/packaging/rpm/rustledger.spec
+++ b/packaging/rpm/rustledger.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           rustledger
-Version:        0.16.2
+Version:        0.16.3
 Release:        1%{?dist}
 Summary:        Fast, pure Rust implementation of Beancount double-entry accounting
 
 License:        GPL-3.0-only
 URL:            https://rustledger.github.io
-Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.16.2.tar.gz
+Source0:        https://github.com/rustledger/rustledger/archive/refs/tags/v0.16.3.tar.gz
 
 # Must match `workspace.package.rust-version` in Cargo.toml.
 # Edition 2024 stabilized in 1.85, so older toolchains fail at parse
@@ -24,7 +24,7 @@ bookkeeping language. It provides a 10-30x faster alternative to Python beancoun
 with full syntax compatibility.
 
 %prep
-%setup -q -n rustledger-0.16.2
+%setup -q -n rustledger-0.16.3
 
 %build
 cargo build --release


### PR DESCRIPTION
Bump to v0.16.3.

Headline: typed stateful `resource session` ledger handle in the Component-Model FFI (#1421) — load once, run query/filter/clamp server-side with no re-parse or directive round-trip. Unblocks the rustfava boundary redesign (rustfava #173).

Version surface bumped per RELEASING.md: workspace + 13 dep pins, 15 crate Cargo.tomls, mcp-server package.json, rpm spec (Version/Source0/%setup), Cargo.lock + fixture locks. cargo check --workspace --all-features --all-targets clean.