### PR TITLE
feat(ffi-component): builder.query-entries — query a loaded directive set

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -558,3 +558,37 @@ fn session_clamp_preserves_cost_basis() -> Result<()> {
     handle.resource_drop(&mut store)?;
     Ok(())
 }
+
+/// `builder.query-entries` (rustfava#173): query an already-loaded directive
+/// set directly, matching the source-based `query` — the typed alternative to
+/// re-rendering entries to source.
+#[test]
+fn query_entries_matches_source_query() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let q = "SELECT account, position";
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, LEDGER)?;
+    let via_entries =
+        inst.rustledger_ledger_builder()
+            .call_query_entries(&mut store, &loaded.entries, q)?;
+    let via_source = inst
+        .rustledger_ledger_ledger()
+        .call_query(&mut store, LEDGER, q)?;
+    assert!(
+        via_entries.errors.is_empty(),
+        "query-entries errored: {:?}",
+        via_entries.errors
+    );
+    assert!(!via_entries.rows.is_empty());
+    assert_eq!(
+        via_entries.rows.len(),
+        via_source.rows.len(),
+        "query-entries must match source query row count",
+    );
+    Ok(())
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1113,6 +1113,19 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         .collect()
 }
 
+/// Run a BQL query against an already-loaded directive set (rustfava#173).
+/// The typed counterpart to `filter`/`clamp`: converts the WIT directives to
+/// core, expands pads (as the source-based query does), then runs the query —
+/// so the embedder queries the directives it holds with no re-parse/re-render.
+pub fn query_entries(entries: &[wit::Directive], query_str: &str) -> out::QueryResult {
+    let core: Vec<rustledger_core::Directive> = entries
+        .iter()
+        .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok())
+        .collect();
+    let directives = rustledger_booking::merge_with_padding(&core);
+    run_query(&directives, query_str)
+}
+
 // ---- stateful ledger handle (`resource session`, rustfava#173) -------------------
 //
 // Normalizes the source and file load paths into one held state so the

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -130,6 +130,9 @@ impl BuilderGuest for Component {
     fn clamp(entries: Vec<Directive>, begin_date: String, end_date: String) -> Vec<Directive> {
         convert::clamp(entries, &begin_date, &end_date)
     }
+    fn query_entries(entries: Vec<Directive>, query: String) -> QueryResult {
+        convert::query_entries(&entries, &query)
+    }
 }
 
 impl UtilGuest for Component {

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -467,6 +467,7 @@ interface ledger {
 /// directives over a date window (`begin` inclusive, `end` exclusive).
 interface builder {
   use types.{input-directive, directive};
+  use ledger.{query-result};
 
   /// Construct one directive. `err` carries the validation message.
   create: func(entry: input-directive) -> result<directive, string>;
@@ -478,6 +479,12 @@ interface builder {
   /// Clamp directives to [begin, end), synthesizing opening-balance and
   /// summary directives at the boundaries.
   clamp: func(entries: list<directive>, begin-date: string, end-date: string) -> list<directive>;
+
+  /// Run a BQL query directly against an already-loaded directive set
+  /// (rustfava#173). The typed counterpart to `filter`/`clamp`: the embedder
+  /// passes the directives it holds (e.g. a filtered view) instead of source
+  /// text, so there is no re-parse and no re-render to beancount.
+  query-entries: func(entries: list<directive>, query: string) -> query-result;
 }
 
 /// Utility helpers — replaces `util.types` / `util.isEncrypted` /


### PR DESCRIPTION
Adds `builder.query-entries(entries: list<directive>, query: string) -> query-result` — the typed counterpart to the existing `filter`/`clamp`. The embedder passes the directives it already holds and gets BQL results, with **no re-parse of source and no re-render to beancount text**.

## Why
rustfava runs queries over *filtered* entry subsets (rustfava #173). Its options were both bad: re-parse the original source (ignores the filter) or re-render the subset to beancount text and re-parse it (fragile — invalid rendered text crashes the parser, the actual bug). `query-entries` gives it the same typed entry-set path it already uses for `clamp`, so **query/filter/clamp are symmetric over the WIT contract** — no source text round-trip anywhere.

## Impl
Mirrors `clamp`'s `WIT → core` conversion (`loaded_directive_to_input` + `input_entry_to_directive`), then pad-expands (`merge_with_padding`) and runs the query — matching what the source-based `query` does.

## Tests
New host parity test `query_entries_matches_source_query` asserts it matches the source `query`'s row count. clippy (`-D warnings`, wasip2) + fmt clean; 15/15 host parity tests pass.

Next: cut a release so rustfava can consume it, then reroute `query_shell` through it and delete `_entries_to_source` (rustfava #173).