### PR TITLE
feat(ffi-component): preserve clamp provenance + load filename param

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -110,7 +110,7 @@ fn load_entry_count_matches_jsonrpc() -> Result<()> {
     let (mut store, inst) = instantiate()?;
     let result = inst
         .rustledger_ledger_ledger()
-        .call_load(&mut store, LEDGER)?;
+        .call_load(&mut store, LEDGER, "<stdin>")?;
     let expected = rustledger_ffi_wasi::helpers::load_source(LEDGER)
         .directives
         .len();
@@ -164,9 +164,9 @@ fn clamp_runs_and_summarizes_pre_range() -> Result<()> {
         return Ok(());
     }
     let (mut store, inst) = instantiate()?;
-    let loaded = inst
-        .rustledger_ledger_ledger()
-        .call_load(&mut store, LEDGER_WITH_HISTORY)?;
+    let loaded =
+        inst.rustledger_ledger_ledger()
+            .call_load(&mut store, LEDGER_WITH_HISTORY, "<stdin>")?;
     let clamped = inst.rustledger_ledger_builder().call_clamp(
         &mut store,
         &loaded.entries,
@@ -243,7 +243,9 @@ fn filter_keeps_pre_begin_open_and_drops_commodity() -> Result<()> {
   Assets:Cash  1 USD
   Expenses:Y  -1 USD
 ";
-    let loaded = inst.rustledger_ledger_ledger().call_load(&mut store, src)?;
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, src, "<stdin>")?;
     let filtered = inst.rustledger_ledger_builder().call_filter(
         &mut store,
         &loaded.entries,
@@ -274,7 +276,9 @@ fn custom_directive_values_keep_their_type_tag() -> Result<()> {
     // string. `meta-value` alone would flatten both to `text`; `typed-value`
     // must preserve `value-type` ("account" vs "string").
     let src = "2024-01-01 custom \"budget\" Assets:Cash \"monthly\"\n";
-    let loaded = inst.rustledger_ledger_ledger().call_load(&mut store, src)?;
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, src, "<stdin>")?;
     let custom = loaded
         .entries
         .iter()
@@ -472,9 +476,9 @@ fn load_runs_auto_accounts_synth() -> Result<()> {
         return Ok(());
     }
     let (mut store, inst) = instantiate()?;
-    let loaded = inst
-        .rustledger_ledger_ledger()
-        .call_load(&mut store, AUTO_ACCOUNTS_LEDGER)?;
+    let loaded =
+        inst.rustledger_ledger_ledger()
+            .call_load(&mut store, AUTO_ACCOUNTS_LEDGER, "<stdin>")?;
     assert_generated_opens(&loaded.entries, "component load");
     Ok(())
 }
@@ -572,7 +576,7 @@ fn query_entries_matches_source_query() -> Result<()> {
     let q = "SELECT account, position";
     let loaded = inst
         .rustledger_ledger_ledger()
-        .call_load(&mut store, LEDGER)?;
+        .call_load(&mut store, LEDGER, "<stdin>")?;
     let via_entries =
         inst.rustledger_ledger_builder()
             .call_query_entries(&mut store, &loaded.entries, q)?;

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1103,14 +1103,133 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         // Unparsable bounds: return the input unchanged (no error channel).
         return entries;
     };
-    let core: Vec<rustledger_core::Directive> = entries
+
+    // Route through the shared, meta-preserving `commands::clamp` (the path the
+    // JSON-RPC surface uses) so in-window entries keep their original
+    // `filename`/`lineno`. We index the inputs by location and feed JSON
+    // entries carrying that meta; in-window outputs are then matched back to the
+    // original WIT directive (full fidelity + provenance), and only the
+    // synthesized boundary transactions are built from JSON. (rustfava#173)
+    let mut by_loc: std::collections::HashMap<(String, u32), wit::Directive> =
+        std::collections::HashMap::new();
+    let mut json_entries: Vec<serde_json::Value> = Vec::new();
+    for d in &entries {
+        let (file, line) = wit_directive_location(d);
+        if let Ok(core) = ffi::input_entry_to_directive(&loaded_directive_to_input(d))
+            && let Ok(value) =
+                serde_json::to_value(ffi::convert::directive_to_json(&core, line, &file))
+        {
+            json_entries.push(value);
+        }
+        by_loc.insert((file, line), d.clone());
+    }
+
+    let result = ffi::commands::clamp::clamp_entries(json_entries, begin_date, end_date);
+    result
+        .entries
         .iter()
-        .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok())
-        .collect();
-    rustledger_ops::clamp::clamp(&core, begin_date, end_date)
-        .iter()
-        .map(|d| directive(ffi::convert::directive_to_json(d, 0, "<clamped>")))
+        .map(|entry| {
+            let file = entry
+                .pointer("/meta/filename")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            let line = entry
+                .pointer("/meta/lineno")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|n| u32::try_from(n).ok())
+                .unwrap_or(0);
+            by_loc
+                .get(&(file.to_string(), line))
+                .cloned()
+                .unwrap_or_else(|| synthesized_transaction_to_wit(entry))
+        })
         .collect()
+}
+
+/// The source location (`filename`, `lineno`) of a loaded WIT directive.
+fn wit_directive_location(d: &wit::Directive) -> (String, u32) {
+    let m = match d {
+        wit::Directive::Transaction(x) => &x.meta,
+        wit::Directive::Open(x) => &x.meta,
+        wit::Directive::Close(x) => &x.meta,
+        wit::Directive::Balance(x) => &x.meta,
+        wit::Directive::Pad(x) => &x.meta,
+        wit::Directive::Commodity(x) => &x.meta,
+        wit::Directive::Price(x) => &x.meta,
+        wit::Directive::Event(x) => &x.meta,
+        wit::Directive::Note(x) => &x.meta,
+        wit::Directive::Document(x) => &x.meta,
+        wit::Directive::Query(x) => &x.meta,
+        wit::Directive::Custom(x) => &x.meta,
+    };
+    (m.filename.clone(), m.lineno)
+}
+
+/// Build a WIT transaction from a synthesized clamp boundary entry. These are
+/// opening-balance transactions (`<summarization>`, simple `account` + `units`
+/// postings) — the only directive kind `commands::clamp` synthesizes.
+fn synthesized_transaction_to_wit(entry: &serde_json::Value) -> wit::Directive {
+    let s = |k: &str| {
+        entry
+            .get(k)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    let postings = entry
+        .get("postings")
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .map(|p| wit::Posting {
+                    account: p
+                        .get("account")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    units: p.get("units").and_then(|u| {
+                        Some(wit::Amount {
+                            number: u.get("number")?.as_str()?.to_string(),
+                            currency: u.get("currency")?.as_str()?.to_string(),
+                        })
+                    }),
+                    cost: None,
+                    price: None,
+                    flag: p
+                        .get("flag")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                    meta: vec![],
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    wit::Directive::Transaction(wit::Transaction {
+        date: s("date"),
+        flag: s("flag"),
+        payee: None,
+        narration: entry
+            .get("narration")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        tags: vec![],
+        links: vec![],
+        postings,
+        meta: wit::Meta {
+            filename: entry
+                .pointer("/meta/filename")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<summarization>")
+                .to_string(),
+            lineno: 0,
+            hash: entry
+                .pointer("/meta/hash")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            user: vec![],
+        },
+    })
 }
 
 /// Run a BQL query against an already-loaded directive set (rustfava#173).

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -50,8 +50,8 @@ impl LedgerGuest for Component {
     fn version() -> String {
         API_VERSION.to_string()
     }
-    fn load(source: String) -> LoadResult {
-        convert::load(&source, "<stdin>")
+    fn load(source: String, filename: String) -> LoadResult {
+        convert::load(&source, &filename)
     }
     fn load_file(
         path: String,

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -392,8 +392,9 @@ interface ledger {
   /// JSON-RPC response.
   version: func() -> string;
 
-  /// Parse + book a ledger from source text.
-  load: func(source: string) -> load-result;
+  /// Parse + book a ledger from source text. `filename` is recorded as the
+  /// directives' source location (e.g. `<string>`); pass `<stdin>` if unknown.
+  load: func(source: string, filename: string) -> load-result;
   /// Like `load`, but from a file path (the host grants filesystem access).
   /// By default the include graph is confined to the entry file's directory
   /// tree (path-traversal protection); set `allow-unrestricted-includes` to

--- a/crates/rustledger-ffi-wasi/src/lib.rs
+++ b/crates/rustledger-ffi-wasi/src/lib.rs
@@ -30,7 +30,7 @@
 pub mod convert;
 pub mod jsonrpc;
 
-pub(crate) mod commands;
+pub mod commands;
 // `helpers` is `pub` so the WIT/Component-Model crate
 // (`rustledger-ffi-component`, #1384) can reuse the loader orchestration
 // (`load_source`) instead of duplicating it.


### PR DESCRIPTION
Two component fixes that let rustfava reach a fully-green suite via the component backend (rustfava #173).

## clamp: preserve in-window source provenance
`convert::clamp` went WIT → core → `rustledger_ops::clamp` → `directive_to_json(d, 0, "<clamped>")`, stamping **every** output with line 0 / `<clamped>` — so in-window entries lost their `filename`/`lineno` and the host treated them as generated (journal export rendered them via `to_string` instead of their source slice, diverging).

Now it routes through the shared, meta-preserving `commands::clamp` (the path JSON-RPC uses): inputs are indexed by `(filename, lineno)` and fed as JSON entries carrying that meta; in-window outputs are matched back to the **original WIT directive** (full fidelity + provenance), and only the synthesized boundary transactions (flag `S`, simple postings) are built from JSON. `commands` is made `pub` in `rustledger-ffi-wasi`.

## load: filename param
The WIT `load` hardcoded `<stdin>`; the JSON-RPC `ledger.load` takes a `filename`. Added it to the WIT `load` so embedders record the real source name (e.g. `<string>`) — fixes `InsertEntryOption.filename` divergence.

## Validation
Host parity tests 15/15. With these + the rustfava companions (narration default, `load` filename), the **full rustfava suite passes via the component: 5 → 0**. clippy (`-D warnings`, wasip2) + fmt clean.

Next: release so rustfava can consume it, then flip the default.