### PR TITLE
docs: correct FFI surface status (component primary, wasip1 legacy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,8 @@ The project is a Cargo workspace with 16 crates plus editor extensions:
 | `rustledger` | CLI tool (`rledger check`, `rledger query`, etc.) |
 | `rustledger-wasm` | WebAssembly library target |
 | `rustledger-lsp` | Language Server Protocol implementation |
-| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — current shipping surface |
-| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract); successor to `-ffi-wasi`, dual-shipped during #1384 |
+| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — legacy, slated for removal in Phase 5 (#1419) |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract, `rustledger:ledger@2.1.0`) — primary embedding surface, default in the rustfava embedder (#1384 Phase 4) |
 
 | Package | Purpose |
 |---------|---------|

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -5,24 +5,31 @@ replacing the hand-rolled JSON-RPC wire shape of `rustledger-ffi-wasi`. Part of
 the WASI-p1 → p2 migration ([#1384](https://github.com/rustledger/rustledger/issues/1384)).
 
 `wit/world.wit` is the single source of truth for the wire shape; `src/lib.rs`
-
-- `src/convert.rs` implement the `rustledger` world's exports.
+and `src/convert.rs` implement the `rustledger` world's exports.
 
 ## Status
 
-- **Workspace member**, but not yet a published release artifact (`publish = false`).
-- **All 20 exports are implemented and build as a real wasip2 component**, across
-  four interfaces: `ledger` (load / validate / query / batch + their `-file`
-  variants), `builder` (create / create-batch / filter / clamp), `util` (types /
+- **Workspace member**, not on crates.io (`publish = false`) — but it *is*
+  released: the built wasip2 component is shipped as a prebuilt `.wasm` artifact
+  on GitHub releases (v0.16.3+).
+- **The full export surface is implemented and builds as a real wasip2
+  component**, across four interfaces: `ledger` (load / validate / query / batch
+  + their `-file` variants, plus a stateful `session` resource), `builder`
+  (create / create-batch / filter / clamp / query-entries), `util` (types /
   is-encrypted / get-account-type), `format` (source / file / entry / entries).
 - Exports reuse `rustledger-ffi-wasi`'s loader/query/ops logic via shared
   helpers; the DTO↔WIT conversion lives in `src/convert.rs`.
 - **Parity-tested** by `rustledger-ffi-component-tests`: it instantiates the
   built component in a wasmtime host (typed `bindgen!`, no JSON-RPC) and asserts
   agreement with the reused `rustledger-ffi-wasi` path.
-- **Not yet wired to a consumer** — rustfava still uses the JSON-RPC surface.
-  Both coexist during the dual-ship window; the JSON-RPC surface is retired in
-  Phase 5.
+- **The default rustfava backend** — rustfava loads this prebuilt wasip2
+  component as its primary embedding path
+  ([#172](https://github.com/rustledger/rustledger/issues/172) /
+  rustfava [#183](https://github.com/rustledger/rustfava/pull/183), Phase 4).
+  The JSON-RPC (wasip1) surface of `rustledger-ffi-wasi` still exists — its
+  deprecation/removal is Phase 5
+  ([#1419](https://github.com/rustledger/rustledger/issues/1419), deferred) — but
+  it is no longer the default consumer path; the two dual-ship until then.
 
 ```bash
 # the wasip2 target lives in the default dev shell (flake.nix)
@@ -37,7 +44,9 @@ wit-bindgen rust crates/rustledger-ffi-component/wit/world.wit --out-dir /tmp/g
 ## Scope covered
 
 **Read surface** (`interface ledger`) — `version`, `load`, `validate`, `query`,
-and their `-file` variants — translated 1:1 from `types/output.rs`: `amount`,
+and their `-file` variants. `load` takes `load(source, filename)`: the
+`filename` is recorded as the directives' source location (pass `<stdin>` if
+unknown). Translated 1:1 from `types/output.rs`: `amount`,
 `cost-number`, `cost`, `meta`/`meta-value`, `posting`, all 12 `directive` cases,
 `error`, `plugin`, `source-include`, `ledger-options`, `position`,
 `column-info`, `query-value`, and the load/validate/query result records.
@@ -49,8 +58,29 @@ batch all-or-nothing per the handler) plus `filter` / `clamp` over a date window
 (`entry.filter` / `entry.clamp`). Reuses `amount`, `cost-number`, `meta-value`;
 input metadata is user key/values only (source location is assigned on load).
 
+`clamp` preserves the source provenance (`filename`/`lineno`) of in-window
+directives — it routes through the shared, meta-preserving `commands::clamp` and
+matches its outputs back to the original WIT directives. Only the *synthesized*
+opening-balance/summary boundary transactions get synthetic source locations.
+
+`query-entries` runs a typed BQL query directly against an already-loaded
+directive set — the counterpart to `filter`/`clamp`. The embedder passes the
+directives it holds (e.g. a filtered view) instead of source text, so there is
+no re-parse and no re-render to beancount text.
+
 **Batch** (`interface ledger`) — `batch` / `batch-file` (`query.batch`): load
 once, run several queries.
+
+**Session** (`interface ledger`, `resource session`) — a stateful, typed handle
+to a loaded, booked ledger held inside the component. The host constructs one
+(`constructor(source)` or the static `from-file(path, …)`), then runs
+`info` (materialize the load result once), `query`, `filter`, and `clamp`
+against the *held* ledger. Because the booked core directives stay inside the
+component, these calls re-use the parse/booking with no re-parse and no
+re-render — where the free `load`/`query`/`clamp` functions re-parse `source`
+(or force the host to re-serialize entries to text) on every call, and operating
+on the held core directives also avoids round-tripping through the host's
+directive representation.
 
 **Util** (`interface util`) — `types` / `is-encrypted` / `get-account-type`
 (`util.types` / `util.isEncrypted` / `util.getAccountType`).
@@ -96,7 +126,10 @@ once, run several queries.
   needs the core `MetaValue` (`directive_to_json` flattens it).
 - **Broaden parity coverage** (all exports; field-level diff) and wire the
   component-build step + an end-to-end `load-file` parity test into CI ([#1402](https://github.com/rustledger/rustledger/issues/1402)).
-- **Phase 3+:** release artifact, then rustfava migration; **Phase 5** retires
-  the JSON-RPC surface and moves the shared loader/conversion logic to a neutral
-  home. See [#1384](https://github.com/rustledger/rustledger/issues/1384) for the
-  full plan.
+- **Phase 5** (deferred) — deprecate then remove the JSON-RPC (wasip1) surface
+  and move the shared loader/conversion logic to a neutral home
+  ([#1419](https://github.com/rustledger/rustledger/issues/1419)). This is the
+  one remaining open phase; Phase 3 (release artifact) and Phase 4 (rustfava
+  migration — now the default backend) are done. See
+  [#1384](https://github.com/rustledger/rustledger/issues/1384) for the full
+  plan.

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -5,8 +5,11 @@
 //!
 //! All four interfaces (`ledger`, `builder`, `util`, `format`) are wired: each
 //! Guest method delegates to [`convert`], which maps between the WIT types and
-//! the loader/query logic reused from `rustledger-ffi-wasi`. Parity with the
-//! JSON-RPC surface is exercised by `rustledger-ffi-component-tests`.
+//! the loader/query logic reused from `rustledger-ffi-wasi`. `ledger` also
+//! exports a stateful `session` resource (a held, booked ledger queried/filtered
+//! /clamped without re-parsing) and `builder` a `query-entries` func (BQL over an
+//! already-loaded directive set). Parity with the JSON-RPC surface is exercised
+//! by `rustledger-ffi-component-tests`.
 
 // This is a wasip2 component: `wit-bindgen`'s `export!` emits canonical-ABI
 // shims that don't link as a native `cdylib` (e.g. a `cargo build --workspace`
@@ -80,7 +83,7 @@ impl LedgerGuest for Component {
     }
 }
 
-/// A loaded, booked ledger held in the component (`resource session`, rustfava#173).
+/// A loaded, booked ledger held in the component (`resource session`, #1421).
 /// Parses + books once in `new`/`from_file`; `query`/`filter`/`clamp` run on
 /// the held ledger via [`convert::SessionState`] with no re-parse or re-render.
 struct LedgerSession {

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -8,10 +8,11 @@
 // shape footgun in #1399).
 //
 // Scope: the full former JSON-RPC method surface, across four interfaces —
-// `ledger` (version / load / validate / query / batch + `-file` variants),
-// `builder` (create / create-batch / filter / clamp), `util` (types /
-// is-encrypted / get-account-type), and `format` (source / file / entry /
-// entries). All 20 exports are implemented in `crates/rustledger-ffi-component`.
+// `ledger` (version / load / validate / query / batch + `-file` variants, plus a
+// stateful `session` resource), `builder` (create / create-batch / filter /
+// clamp / query-entries), `util` (types / is-encrypted / get-account-type), and
+// `format` (source / file / entry / entries). All exports are implemented in
+// `crates/rustledger-ffi-component`.
 
 package rustledger:ledger@2.1.0;
 
@@ -424,7 +425,7 @@ interface ledger {
   /// Like `batch`, but the ledger is loaded from a file path.
   batch-file: func(path: string, queries: list<string>) -> batch-result;
 
-  /// A loaded, booked ledger held inside the component (rustfava#173, rustfava#173).
+  /// A loaded, booked ledger held inside the component (#1421).
   ///
   /// The stateful, typed successor to the free `load`/`query`/`clamp`
   /// functions: the host constructs one handle, then runs `query`/`filter`/
@@ -436,7 +437,7 @@ interface ledger {
   ///
   /// `query`/`filter`/`clamp` operate on the held *core* directives directly,
   /// so they never round-trip through the host's directive representation —
-  /// removing a whole class of shape-translation bugs (rustfava rustfava#173).
+  /// removing a whole class of shape-translation bugs (#1421).
   resource session {
     /// Parse + book a ledger from source text.
     constructor(source: string);
@@ -482,7 +483,7 @@ interface builder {
   clamp: func(entries: list<directive>, begin-date: string, end-date: string) -> list<directive>;
 
   /// Run a BQL query directly against an already-loaded directive set
-  /// (rustfava#173). The typed counterpart to `filter`/`clamp`: the embedder
+  /// (#1423). The typed counterpart to `filter`/`clamp`: the embedder
   /// passes the directives it holds (e.g. a filtered view) instead of source
   /// text, so there is no re-parse and no re-render to beancount.
   query-entries: func(entries: list<directive>, query: string) -> query-result;

--- a/crates/rustledger-ffi-wasi/CHANGELOG.md
+++ b/crates/rustledger-ffi-wasi/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Status:** this JSON-RPC-over-WASI (wasip1) surface is now the
+> legacy/fallback embedding path. The typed `rustledger-ffi-component`
+> (wasip2 / Component Model, #1384) is the default in rustfava as of
+> Phase 4. Deprecation and removal of this surface is planned for Phase 5
+> ([#1419](https://github.com/rustledger/rustledger/issues/1419)).
+
+## [0.16.5](https://github.com/rustledger/rustledger/compare/v0.16.4...v0.16.5) - 2026-06-18
+
+### Features
+
+- *(ffi-component)* preserve clamp provenance metadata and add a load
+  `filename` parameter so component-produced entries carry source
+  context. (#1425)
+
+## [0.16.4](https://github.com/rustledger/rustledger/compare/v0.16.3...v0.16.4) - 2026-06-17
+
+### Features
+
+- *(ffi-component)* `builder.query-entries` — run a BQL query against an
+  already-loaded directive set. (#1423)
+
+## [0.16.3](https://github.com/rustledger/rustledger/compare/v0.16.2...v0.16.3) - 2026-06-17
+
+### Features
+
+- *(ffi-component)* stateful resource session ledger handle, completing
+  the Component Model surface. (#1384, #1421)
+
+## [0.16.2](https://github.com/rustledger/rustledger/compare/v0.16.1...v0.16.2) - 2026-06-17
+
+### Miscellaneous
+
+- *(ci)* build and attach the FFI-Component (wasip2) `.wasm` to releases.
+  (#1410)
+
+## [0.16.1](https://github.com/rustledger/rustledger/compare/v0.16.0...v0.16.1) - 2026-06-16
+
 ### Features
 
 - `Inventory` and `Position` query result values now include an optional
@@ -16,6 +53,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   omitted). Additive and backward compatible — units-only consumers ignore it
   — so `api_version` is bumped to `2.1` (minor). Enables embedders to build
   cost-/lot-aware views from query output. (#1398)
+- *(ffi)* WIT / Component Model embedding surface (`rustledger-ffi-component`):
+  all 20 exports wired (load, validate, query, batch, format, util, builder
+  create/filter/clamp) with a wasmtime parity harness pinning the component
+  output to this JSON-RPC binding. This is the start of the dual-ship window.
+  (#1384, #1401)
+
+### Bug Fixes
+
+- *(ffi)* run the pre-booking synth plugin pass through the FFI load
+  surface so plugin-synthesized Opens are visible to validation. (#1404)
+- *(ffi)* preserve custom-directive value types via WIT typed-value, and
+  gate the wasip2 component crate to wasm targets. (#1384)
+
+## [0.16.0](https://github.com/rustledger/rustledger/compare/v0.15.0...v0.16.0) - 2026-06-15
+
+### Features
+
 - `ParseErrorEntry.kind_code` exposes the stable numeric discriminant
   from `rustledger_parser::ParseError::kind_code()`. Codes 1-26
   documented in `openrpc.json`'s `ParseErrorEntry` schema. Notably,
@@ -27,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   BOM diagnostic). Render below `message` as a help/fix-it line.
 - `ParseErrorEntry.span` carries the byte range of the failed entry
   for source-location-aware UX (highlight, navigate-to).
+- *(ffi-wasi)* emit `Document.tags` and `Document.links`, and accept them
+  on RPC input. (#1208, #1212, #1213, #1216)
 
 ### Breaking Changes
 
@@ -50,7 +106,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `kind_code`/`hint`/`span` so legacy entries bridged through the
   recipe above still validate; 2.0+ servers always emit the
   integer/object form. See `README.md` for the full
-  `ParseErrorEntry` shape and an example.
+  `ParseErrorEntry` shape and an example. (#1244)
+
+### Refactoring
+
+- *(core)* make `CostSpec` invalid states unrepresentable, underpinning
+  the typed `CostNumber` wire shape. (#1164, #1178)
+- source-faithful pad architecture across loader/booking/report/ffi/wasm.
+  (#1288, #1300, #1302)
+
+## [0.15.0](https://github.com/rustledger/rustledger/compare/v0.14.1...v0.15.0) - 2026-05-15
+
+Released; see git history / GitHub release v0.15.0. No FFI-WASI wire-shape
+changes — this cycle was primarily BQL query-engine and validation-phase
+work (validate typestate phases, `PluginOp` protocol; refs #1115, #1116,
+#1117).
+
+## [0.14.1](https://github.com/rustledger/rustledger/compare/v0.14.0...v0.14.1) - 2026-04-27
+
+Released; see git history / GitHub release v0.14.1. No FFI-WASI changes.
+
+## [0.14.0](https://github.com/rustledger/rustledger/compare/v0.13.0...v0.14.0) - 2026-04-26
+
+Released; see git history / GitHub release v0.14.0. No FFI-WASI wire-shape
+changes — release/CI tooling, BQL query fixes, and the new
+`rustledger-ops` crate.
 
 ## [0.13.0](https://github.com/rustledger/rustledger/compare/v0.12.0...v0.13.0) - 2026-04-21
 

--- a/crates/rustledger-ffi-wasi/README.md
+++ b/crates/rustledger-ffi-wasi/README.md
@@ -1,18 +1,22 @@
 # rustledger-ffi-wasi
 
-A WASI module providing JSON-RPC 2.0 API for embedding Rustledger in any language.
+A WASI module providing JSON-RPC 2.0 API for embedding Rustledger in any language. **Legacy/fallback surface** — the typed WASI Preview 2 component (`rustledger-ffi-component`) is now the default embedding path; see the note below.
 
 ## Overview
 
 This crate compiles to a WebAssembly module that can be run via [wasmtime](https://wasmtime.dev/) or any WASI-compatible runtime. It provides a fast, portable way to use Rustledger's Beancount parsing, validation, and querying capabilities from any language.
 
-> **Dual-ship note.** This JSON-RPC-over-WASI (wasip1) surface is the current,
-> shipping embedding path (used by rustfava). A typed **WASI Preview 2 /
-> Component Model** successor is in development in `rustledger-ffi-component`
-> ([#1384](https://github.com/rustledger/rustledger/issues/1384)): it replaces
-> this hand-rolled JSON-RPC wire shape with a generated WIT contract. Both
-> coexist during the dual-ship window; this surface is retired in Phase 5. New
-> integrators who can target wasip2 should track the component surface.
+> **Legacy/fallback note.** This JSON-RPC-over-WASI (wasip1) surface is now the
+> **legacy/fallback** embedding path. The typed **WASI Preview 2 / Component
+> Model** successor, `rustledger-ffi-component`
+> ([#1384](https://github.com/rustledger/rustledger/issues/1384)), is the
+> **default** surface in rustfava as of Phase 4 — it replaces this hand-rolled
+> JSON-RPC wire shape with a generated WIT contract. This JSON-RPC surface is
+> slated for deprecation and removal in Phase 5
+> ([#1419](https://github.com/rustledger/rustledger/issues/1419)). **New
+> integrators should target the component** (`rustledger-ffi-component`); this
+> surface remains only as a fallback for runtimes that cannot yet host a wasip2
+> component.
 
 ## Usage
 

--- a/crates/rustledger-ffi-wasi/openrpc.json
+++ b/crates/rustledger-ffi-wasi/openrpc.json
@@ -573,19 +573,6 @@
       }
     },
     {
-      "name": "util.schema",
-      "summary": "Get JSON Schema",
-      "description": "Returns the JSON Schema for the API types.",
-      "params": [],
-      "result": {
-        "name": "JsonSchema",
-        "description": "JSON Schema document",
-        "schema": {
-          "type": "object"
-        }
-      }
-    },
-    {
       "name": "util.isEncrypted",
       "summary": "Check if file is encrypted",
       "description": "Checks if the given path appears to be an encrypted file (based on extension).",
@@ -729,9 +716,23 @@
             "items": {
               "$ref": "#/components/schemas/Error"
             }
+          },
+          "parse_error_count": {
+            "type": "integer",
+            "description": "Number of parse-phase errors (syntactic)"
+          },
+          "validate_error_count": {
+            "type": "integer",
+            "description": "Number of validate-phase errors (semantic)"
           }
         },
-        "required": ["api_version", "valid", "errors"]
+        "required": [
+          "api_version",
+          "valid",
+          "errors",
+          "parse_error_count",
+          "validate_error_count"
+        ]
       },
       "QueryOutput": {
         "type": "object",

--- a/crates/rustledger-ffi-wasi/src/lib.rs
+++ b/crates/rustledger-ffi-wasi/src/lib.rs
@@ -8,6 +8,19 @@
 
 //! Library surface for the rustledger FFI-WASI binding.
 //!
+//! # Legacy/fallback surface
+//!
+//! This is the **legacy/fallback** wasip1 JSON-RPC FFI. The typed
+//! WASI Preview 2 / Component Model binding,
+//! [`rustledger-ffi-component`](https://github.com/rustledger/rustledger/issues/1384)
+//! (#1384), is now the **default** embedding path (it ships a generated
+//! WIT contract instead of this hand-rolled JSON-RPC wire shape, and is
+//! the default in rustfava as of Phase 4). This JSON-RPC surface is
+//! slated for deprecation and removal in Phase 5
+//! ([#1419](https://github.com/rustledger/rustledger/issues/1419)). **New
+//! integrators should target the component**; this crate remains only as
+//! a fallback for runtimes that cannot yet host a wasip2 component.
+//!
 //! Most consumers run this crate as a WASI module (see `main.rs` and
 //! the JSON-RPC API doc on the binary). But the `Directive → JSON`
 //! conversion functions and DTO types are also useful as a library

--- a/crates/rustledger-ffi-wasi/src/main.rs
+++ b/crates/rustledger-ffi-wasi/src/main.rs
@@ -1,5 +1,10 @@
 //! Rustledger FFI via WASI - JSON-RPC 2.0 API for embedding in any language.
 //!
+//! **Legacy/fallback surface.** The typed `rustledger-ffi-component`
+//! (wasip2 / Component Model, #1384) is now the default embedding path;
+//! new integrators should target it. This JSON-RPC surface is slated for
+//! removal in Phase 5 (#1419).
+//!
 //! This is a WASI module that can be run via wasmtime (or any WASI runtime).
 //!
 //! # Usage

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -71,7 +71,8 @@ rustledger/
 │   ├── rustledger-ops/          # Pure directive operations
 │   ├── rustledger-lsp/          # LSP server
 │   ├── rustledger-wasm/         # WASM target
-│   ├── rustledger-ffi-wasi/     # WASI FFI
+│   ├── rustledger-ffi-component/ # Primary embedding surface (wasip2 / Component Model)
+│   ├── rustledger-ffi-wasi/     # WASI FFI (wasip1 JSON-RPC) — legacy
 │   └── rustledger/              # CLI binary
 ├── spec/                     # Specifications
 └── tests/                    # Integration tests

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -15,8 +15,8 @@ rustledger provides multiple integration paths:
 | [CLI](#command-line-interface) | Shell scripts, CI/CD pipelines | Any (subprocess) |
 | [Rust Crates](#rust-crates) | Rust applications | Rust |
 | [WASM Library](#webassembly-library) | Browsers, Node.js | JavaScript, TypeScript |
-| [WASI FFI](#wasi-ffi-json-rpc) | Embedding in any language | Python, Ruby, Go, etc. |
-| [Component Model (WIT)](#component-model-wit) | Typed embedding on wasip2 hosts (experimental) | Any wasip2 host |
+| [Component Model (WIT)](#component-model-wit) | **Recommended** typed embedding on wasip2 hosts (primary embedding path) | Any wasip2 host |
+| [WASI FFI](#wasi-ffi-json-rpc) | Embedding via JSON-RPC (legacy — deprecated, slated for Phase 5 removal) | Python, Ruby, Go, etc. |
 | [LSP](#language-server-protocol) | Editor integrations | Any LSP client |
 
 ## Command-Line Interface
@@ -223,6 +223,14 @@ ledger.free();
 
 ## WASI FFI (JSON-RPC)
 
+> **Legacy / deprecated.** This wasip1 JSON-RPC surface
+> (`rustledger-ffi-wasi`) is the older embedding path. New integrations should
+> prefer the typed [Component Model (WIT)](#component-model-wit) surface, which
+> is now the primary, default embedding path (the default backend in rustfava).
+> The JSON-RPC surface is slated for removal in Phase 5
+> ([#1419](https://github.com/rustledger/rustledger/issues/1419)). The reference
+> below remains accurate for as long as it ships.
+
 The WASI FFI module exposes a JSON-RPC 2.0 API that can be embedded in any language with a WASI runtime. This is ideal for building an API server or embedding in Python, Ruby, Go, etc.
 
 ### Quick Start
@@ -362,17 +370,46 @@ echo '[
 
 ## Component Model (WIT)
 
-> **Experimental / in development.** A typed WASI Preview 2 component
+> **Recommended embedding surface.** The typed WASI Preview 2 component
 > (`rustledger-ffi-component`, [#1384](https://github.com/rustledger/rustledger/issues/1384))
-> is the successor to the JSON-RPC WASI FFI above. It is not yet wired to a
-> consumer (rustfava still uses the JSON-RPC surface), and the JSON-RPC surface
-> is planned for retirement once this stabilizes.
+> is the primary, default embedding path. It is the default backend in rustfava
+> as of #1384 Phase 4 (rustfava [#183](https://github.com/rustledger/rustfava/pull/183))
+> and ships as a prebuilt wasip2 component artifact. The legacy JSON-RPC WASI FFI
+> above remains available but is slated for removal in Phase 5
+> ([#1419](https://github.com/rustledger/rustledger/issues/1419)).
 
 Instead of a hand-rolled JSON-RPC wire shape, this surface exposes a generated
-**WIT contract** (`crates/rustledger-ffi-component/wit/world.wit`, package
-`rustledger:ledger`). The same operations — `load` / `validate` / `query` /
-`batch` (+ `-file` variants), entry `create` / `filter` / `clamp`, `util`, and
-`format` — are strongly-typed component functions with no JSON envelope.
+**WIT contract** (`crates/rustledger-ffi-component/wit/world.wit`, versioned
+package `rustledger:ledger@2.1.0`). The same operations — `load` / `validate` /
+`query` / `batch` (+ `-file` variants), entry `create` / `filter` / `clamp`,
+`util`, and `format` — are strongly-typed component functions with no JSON
+envelope. The contract itself is the versioned wire shape; a `version()` func
+remains for runtime negotiation in place of the old per-response `api_version`.
+
+### Surface
+
+The world exports four interfaces — `ledger`, `builder`, `util`, and `format`:
+
+- **`ledger`** — `version`, `load(source, filename)` (the `filename` is recorded
+  as the directives' source location; pass `<stdin>` if unknown), `validate`,
+  `query`, `batch`, plus their `-file` variants.
+- **`ledger.session`** — a stateful `resource` holding a loaded, booked ledger
+  inside the component (rustfava [#173](https://github.com/rustledger/rustfava/issues/173)).
+  The host constructs one handle (`constructor(source)` or
+  `from-file(path, …)`), then runs `info`, `query`, `filter`, and `clamp`
+  against the *held* ledger with no re-parse and no re-render — the typed,
+  stateful successor to the free `load`/`query`/`clamp` functions.
+- **`builder`** — `create` / `create-batch` (validate and round-trip typed input
+  through core; both fallible, batch all-or-nothing), `filter` / `clamp` over a
+  date window, and `query-entries`, which runs a BQL query directly against an
+  already-loaded directive set (the embedder passes the directives it holds, so
+  there is no re-parse and no re-render to beancount text).
+- **`util`** — `types` / `is-encrypted` / `get-account-type`.
+- **`format`** — `format-source` / `-file` / `-entry` / `-entries`.
+
+`clamp` is provenance-preserving: in-window directives keep their original
+`filename`/`lineno`, and only the *synthesized* opening-balance / summary
+boundary directives get synthetic source locations.
 
 A host consumes it via `wasmtime`'s component bindings; a guest/other language
 binds with `wit-bindgen`:
@@ -409,22 +446,29 @@ See [Editor Integration](editor-integration.md) for setup instructions.
 
 ## Comparison
 
-| Feature | CLI | Rust | WASM | WASI FFI | LSP |
-|---------|-----|------|------|----------|-----|
-| Parse ledger | Y | Y | Y | Y | - |
-| Validate | Y | Y | Y | Y | Y |
-| BQL queries | Y | Y | Y | Y | - |
-| Format | Y | Y | Y | Y | Y |
-| File access | Y | Y | - | Y | Y |
-| Plugins | Y | Y | Y | Y | Y |
-| Editor features | - | - | Y | - | Y |
-| Streaming | - | Y | - | - | - |
+The embedding columns below cover both surfaces: **Component** is the
+recommended Component Model (WIT) path, and **WASI FFI** is the legacy JSON-RPC
+surface (slated for Phase 5 removal). They expose the same operations.
+
+| Feature | CLI | Rust | WASM | Component | WASI FFI | LSP |
+|---------|-----|------|------|-----------|----------|-----|
+| Parse ledger | Y | Y | Y | Y | Y | - |
+| Validate | Y | Y | Y | Y | Y | Y |
+| BQL queries | Y | Y | Y | Y | Y | - |
+| Format | Y | Y | Y | Y | Y | Y |
+| File access | Y | Y | - | Y | Y | Y |
+| Plugins | Y | Y | Y | Y | Y | Y |
+| Editor features | - | - | Y | - | - | Y |
+| Streaming | - | Y | - | - | - | - |
 
 ## Which Should I Use?
 
 - **Building a web app?** Use WASM
 - **Building a desktop app in Rust?** Use the crates directly
-- **Building a Python/Ruby/Go service?** Use WASI FFI with JSON-RPC
+- **Embedding in another language / host?** Use the **Component Model (WIT)**
+  surface — it is the recommended, default embedding path. (The legacy JSON-RPC
+  WASI FFI remains available as a transitional option, but is being retired in
+  Phase 5.)
 - **Writing shell scripts?** Use CLI with `--format json`
 - **Building an editor plugin?** Use LSP
-- **Need maximum performance?** Use Rust crates or WASI FFI
+- **Need maximum performance?** Use Rust crates or the Component Model surface

--- a/docs/reference/adr/0006-wit-component-model-embedding.md
+++ b/docs/reference/adr/0006-wit-component-model-embedding.md
@@ -2,13 +2,20 @@
 
 ## Status
 
-Proposed (June 2026). Phase 1 (the typed WIT contract) and Phase 2 (all 20
+Accepted (June 2026). Phase 1 (the typed WIT contract) and Phase 2 (all 20
 exports wired; builds as a real `wasm32-wasip2` component; parity harness)
-landed in #1384. The JSON-RPC embedding surface (`rustledger-ffi-wasi`,
-WASI Preview 1) remains the shipped, supported path during the dual-ship
-window; the Component-Model path (`rustledger-ffi-component`, WASI Preview 2)
-is not yet a release artifact (`publish = false`). The retire-JSON-RPC step
-(Phase 5) is planned, not accepted.
+landed in #1384. Phase 3 (release artifact — the built wasip2 component ships as
+a prebuilt `.wasm` on GitHub releases) and Phase 4 (rustfava default) have since
+**landed**: the Component-Model path (`rustledger-ffi-component`, WASI Preview 2,
+package `rustledger:ledger@2.1.0`) is now the **primary, default embedding
+surface** — the default backend in rustfava (rustfava
+[#183](https://github.com/rustledger/rustfava/pull/183) / rustfava #173). The
+JSON-RPC embedding surface (`rustledger-ffi-wasi`, WASI Preview 1) is now
+**legacy**; the two dual-ship until Phase 5. The component crate is not on
+crates.io (`publish = false`) because it ships as a wasm artifact, not a Rust
+library. The retire-JSON-RPC step (Phase 5,
+[#1419](https://github.com/rustledger/rustledger/issues/1419)) is the
+planned-but-deferred next step.
 
 ## Context
 
@@ -90,10 +97,14 @@ artifact. The plan:
 - **Phase 1–2 (#1384, landed):** the contract + all 20 exports wired, builds as
   a wasip2 component, parity harness asserts the component agrees with the
   JSON-RPC path.
-- **Phase 3+:** release artifact, broaden parity coverage, wire the
-  component build into CI, migrate rustfava to the component.
-- **Phase 5:** retire the WASI-p1 JSON-RPC surface. When it is removed, the
-  shared loader/conversion logic moves out of `rustledger-ffi-wasi` to a
+- **Phase 3 (landed):** release artifact — the built wasip2 component ships as a
+  prebuilt `.wasm` on GitHub releases; broaden parity coverage and wire the
+  component build into CI.
+- **Phase 4 (landed):** migrate rustfava to the component — it is now rustfava's
+  default embedding backend (rustfava #183 / #173).
+- **Phase 5 ([#1419](https://github.com/rustledger/rustledger/issues/1419),
+  planned/deferred):** retire the WASI-p1 JSON-RPC surface. When it is removed,
+  the shared loader/conversion logic moves out of `rustledger-ffi-wasi` to a
   neutral home.
 
 ## Consequences

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -62,12 +62,16 @@ This document describes rustledger's crate structure and data flow.
               └──► plugin-types only
 ```
 
-> The two FFI/embedding surfaces — `rustledger-ffi-wasi` (wasip1 JSON-RPC, the
-> current shipping path) and `rustledger-ffi-component` (wasip2 Component Model,
-> the typed-WIT successor) — coexist during the [#1384](https://github.com/rustledger/rustledger/issues/1384)
-> dual-ship window. The component reuses `ffi-wasi`'s loader/conversion logic;
-> that shared code moves to a neutral home when the JSON-RPC surface is retired
-> (Phase 5).
+> The two FFI/embedding surfaces — `rustledger-ffi-component` (wasip2 Component
+> Model, typed WIT) and `rustledger-ffi-wasi` (wasip1 JSON-RPC) — coexist during
+> the [#1384](https://github.com/rustledger/rustledger/issues/1384) dual-ship
+> window. The Component Model surface is now the **primary/default embedding
+> path**: it is the default backend in the rustfava embedder as of Phase 4
+> (rustfava [#183](https://github.com/rustledger/rustfava/pull/183)). The JSON-RPC
+> surface is **legacy**, pending removal in Phase 5
+> ([#1419](https://github.com/rustledger/rustledger/issues/1419), deferred). The
+> component currently reuses `ffi-wasi`'s loader/conversion logic; that shared
+> code moves to a neutral home when the JSON-RPC surface is retired.
 
 ## Crate Descriptions
 
@@ -103,8 +107,8 @@ This document describes rustledger's crate structure and data flow.
 |-------|---------|
 | `rustledger` | CLI binary (`rledger`, `bean-*` commands) |
 | `rustledger-wasm` | WebAssembly bindings for JS/TS |
-| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — current shipping surface |
-| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract); successor to `-ffi-wasi`, dual-shipped during the [#1384](https://github.com/rustledger/rustledger/issues/1384) migration |
+| `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — legacy, slated for removal in Phase 5 ([#1419](https://github.com/rustledger/rustledger/issues/1419)) |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract, `rustledger:ledger@2.1.0`) — primary embedding surface, default in the rustfava embedder ([#1384](https://github.com/rustledger/rustledger/issues/1384) Phase 4) |
 
 ## Data Flow
 


### PR DESCRIPTION
Full review + fix of the rustledger FFI docs. They were **accurate in detail but inverted in narrative** — uniformly treating the wasip1 JSON-RPC surface (`rustledger-ffi-wasi`) as primary and the wasip2 Component Model surface (`rustledger-ffi-component`) as experimental/future. That's backwards as of #1384 Phase 4 / rustfava #183: the component is now the **default** rustfava engine, shipped as a prebuilt wasip2 artifact (v0.16.3+).

## Framing flip (component = primary/default; wasip1 = legacy, Phase 5/#1419 removal)
`ffi-component/README.md`, `src/lib.rs`, `wit/world.wit`; `ffi-wasi/README.md`, `src/lib.rs`, `src/main.rs`; `docs/guides/integration.md`, `docs/reference/architecture.md`, `docs/reference/adr/0006-*.md`, `docs/development/index.md`, repo-root `CLAUDE.md`.

## Document the component's now-shipped surface
Stateful `session` resource (#1421), `builder.query-entries` (#1423), provenance-preserving `clamp` (#1425), the `load(source, filename)` signature (#1425), and WIT package `rustledger:ledger@2.1.0` — previously undocumented.

## Accuracy fixes
- **openrpc.json**: removed the phantom `util.schema` method (no matching router arm → it returns method-not-found); added the always-emitted `parse_error_count`/`validate_error_count` to `ValidateOutput`.
- **CHANGELOG.md**: backfilled 0.14.0 → 0.16.5 and moved the shipped 2.0/2.1 wire-shape entries out of `[Unreleased]`.
- **world.wit**: fixed duplicated/garbled issue refs (now #1421 session / #1423 query-entries).

## Verification
All claims verified against the code (`world.wit`/`lib.rs`/`convert.rs`/`router.rs`/`output.rs`). `cargo check -p rustledger-ffi-wasi` and `cargo doc` (wasip2) pass; openrpc.json validated as JSON. JSON-RPC reference tables, build commands, and error codes were left verbatim (they're correct) — only the relative framing changed.