### PR TITLE
fix(importer): feature-gate wasmtime so --no-default-features drops cranelift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,25 @@ jobs:
             issue=$(basename "$f" .beancount | sed 's/issue-//')
             echo "- [#$issue](https://github.com/rustledger/rustledger/issues/$issue)" >> $GITHUB_STEP_SUMMARY
           done
+  # Slim-build ratchet (#1427/#867): `cargo install rustledger
+  # --no-default-features` must stay wasmtime/cranelift-free so the minimal
+  # native binary builds on platforms where cranelift can't (e.g. Termux). Two
+  # regressions shipped without this guard; the script fails if `wasmtime`
+  # re-enters the no-default dependency tree.
+  slim-build-no-wasmtime:
+    name: Slim Build (no wasmtime)
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - name: Forbid wasmtime in --no-default-features build
+        run: ./scripts/check-slim-no-wasmtime.sh
+
   # WIT/Component-Model parity (#1384/#1402). The `rustledger-ffi-component-tests`
   # tests SKIP unless the wasip2 artifact exists, and the `Test` job above never
   # builds it — so without this job the entire component surface is unverified by

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -15,10 +15,24 @@ readme = "README.md"
 [lib]
 bench = false
 
+[features]
+default = []
+# Load sandboxed `.wasm` importers (wave 2.3b). Pulls `wasmtime` (→
+# `cranelift-codegen`), so it is OFF by default: a `--no-default-features`
+# build stays slim and compiles on platforms where cranelift can't (e.g.
+# Termux/aarch64). See #1427 / #867.
+wasm-importer = [
+  "dep:wasmtime",
+  "dep:rmp-serde",
+  "dep:serde",
+  "dep:thiserror",
+  "dep:rustledger-plugin",
+]
+
 [dependencies]
 rustledger-core.workspace = true
 rustledger-ops.workspace = true
-rustledger-plugin = { workspace = true, features = ["wasm-runtime"] }
+rustledger-plugin = { workspace = true, features = ["wasm-runtime"], optional = true }
 rustledger-plugin-types.workspace = true
 jiff.workspace = true
 rust_decimal.workspace = true
@@ -31,10 +45,10 @@ ofxy.workspace = true
 # rustledger-plugin (not just -plugin-types) for `convert::wrapper_to_directive`
 # — the canonical wire-format → host-Directive converter, shared with the
 # directive plugin path.
-wasmtime = { workspace = true }
-rmp-serde = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
+wasmtime = { workspace = true, optional = true }
+rmp-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 # `ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`, so
 # we need chrono in the dep tree to call its inherent `.format()` method.
 # IMPORTANT: chrono types must NOT leak into this crate's public API — they

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -38,6 +38,7 @@ pub mod csv_inference;
 pub mod ofx_importer;
 pub mod registry;
 pub mod test_fixtures;
+#[cfg(feature = "wasm-importer")]
 pub mod wasm;
 
 use anyhow::Result;
@@ -47,7 +48,10 @@ use std::path::Path;
 
 pub use config::ImporterConfig;
 pub use ofx_importer::OfxImporter;
-pub use registry::{ImporterRegistry, WasmDirScanReport};
+pub use registry::ImporterRegistry;
+#[cfg(feature = "wasm-importer")]
+pub use registry::WasmDirScanReport;
+#[cfg(feature = "wasm-importer")]
 pub use wasm::{WasmImporter, WasmImporterError, WasmRuntimeConfig};
 
 use rustledger_ops::fingerprint::Fingerprint;

--- a/crates/rustledger-importer/src/registry.rs
+++ b/crates/rustledger-importer/src/registry.rs
@@ -3,10 +3,13 @@
 use crate::config::ImporterConfig;
 use crate::csv_importer::CsvImporter;
 use crate::ofx_importer::OfxImporter;
+#[cfg(feature = "wasm-importer")]
 use crate::wasm::{WasmImporter, WasmImporterError};
 use crate::{ImportResult, Importer};
 use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(feature = "wasm-importer")]
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Registry of importers.
@@ -52,6 +55,7 @@ impl ImporterRegistry {
     /// file I/O, wasmtime compile failure, validation failure (missing
     /// required exports, forbidden imports), or `metadata()` decode
     /// failure.
+    #[cfg(feature = "wasm-importer")]
     pub fn register_wasm_from_path(
         &mut self,
         path: impl Into<PathBuf>,
@@ -96,6 +100,7 @@ impl ImporterRegistry {
     /// (e.g. dir doesn't exist) — without that, the scan can't even
     /// start. Per-file failures land inside
     /// [`WasmDirScanReport::failures`].
+    #[cfg(feature = "wasm-importer")]
     pub fn register_wasm_dir(
         &mut self,
         dir: impl AsRef<Path>,
@@ -206,6 +211,7 @@ impl Default for ImporterRegistry {
 /// failures so callers can log/report both. A single broken module
 /// in a dir with 19 good ones leaves the 19 registered; the broken
 /// one's path + error land in [`Self::failures`].
+#[cfg(feature = "wasm-importer")]
 #[derive(Debug, Default)]
 pub struct WasmDirScanReport {
     /// `metadata.name` of each successfully-loaded module, in load
@@ -396,8 +402,10 @@ mod tests {
 
     // ===== WASM discovery tests =====
 
+    #[cfg(feature = "wasm-importer")]
     use crate::test_fixtures::metadata_wat;
 
+    #[cfg(feature = "wasm-importer")]
     fn write_wat_to(dir: &Path, file_name: &str, importer_name: &str) -> PathBuf {
         let bytes = wat::parse_str(metadata_wat(importer_name)).expect("WAT parses");
         let path = dir.join(file_name);
@@ -406,6 +414,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_from_path_loads_and_returns_metadata_name() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = write_wat_to(tmp.path(), "abc.wasm", "abc");
@@ -421,6 +430,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_dir_loads_only_wasm_files_in_sorted_order() {
         let tmp = tempfile::tempdir().expect("tempdir");
         // Out-of-order names to verify sort.
@@ -444,6 +454,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_dir_returns_empty_for_dir_with_no_wasm_files() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(tmp.path().join("README.md"), "just docs").unwrap();
@@ -456,6 +467,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_dir_matches_uppercase_extension_too() {
         let tmp = tempfile::tempdir().expect("tempdir");
         // Mixed case extensions: all should be picked up.
@@ -472,6 +484,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_dir_errors_on_nonexistent_dir() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let missing = tmp.path().join("does-not-exist");
@@ -490,6 +503,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_dir_skip_and_collect_keeps_loading_past_failures() {
         // Skip-and-collect semantics: one broken module doesn't
         // prevent the others from loading. The good modules end up
@@ -521,6 +535,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "wasm-importer")]
     fn register_wasm_wins_identify_collision_when_registered_before_builtins() {
         // The actual precedence guarantee the CLI helper relies on:
         // when a WASM importer's `identify()` returns true for the

--- a/crates/rustledger-importer/tests/wasm_importer_e2e.rs
+++ b/crates/rustledger-importer/tests/wasm_importer_e2e.rs
@@ -42,6 +42,7 @@
 //! round-trip) was never exercised. The first revision of this PR fell
 //! into exactly that trap — the test passed in 180 ms because cargo
 //! couldn't find the wasm32 target and the graceful-skip path ran.
+#![cfg(feature = "wasm-importer")]
 
 use std::path::{Path, PathBuf};
 

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -18,9 +18,17 @@ bench = false
 
 [features]
 default = ["python-plugin-wasm"]
-# Enable Python plugin support via WASM sandbox (adds ~30s to build time)
-# This allows running existing Python beancount plugins
-python-plugin-wasm = ["rustledger-plugin/python-plugins", "rustledger-loader/wasm-plugins", "rustledger-loader/python-plugins"]
+# Enable Python plugin support via WASM sandbox (adds ~30s to build time).
+# This allows running existing Python beancount plugins, the WASM importer
+# loader, and the directive-plugin runtime — all of which pull `wasmtime`
+# (→ `cranelift-codegen`). Off via `--no-default-features` for a slim native
+# binary that builds where cranelift can't (e.g. Termux/aarch64); see #1427.
+python-plugin-wasm = [
+    "rustledger-plugin/python-plugins",
+    "rustledger-importer/wasm-importer",
+    "rustledger-loader/wasm-plugins",
+    "rustledger-loader/python-plugins",
+]
 # Agent-native CLI (#1291). Pulls in the async/agent-only dependencies
 # (`agcli`, `tokio`) so the synchronous `rledger` CLI/lib don't carry them by
 # default. Required to build the `ag-rledger` binary and to run its
@@ -51,6 +59,12 @@ rustledger-loader.workspace = true
 rustledger-booking.workspace = true
 rustledger-validate.workspace = true
 rustledger-query.workspace = true
+# Both default to their wasmtime-free feature set (rustledger-plugin's workspace
+# entry is default-features = false; rustledger-importer's `default` is empty).
+# `python-plugin-wasm` re-enables `rustledger-plugin/python-plugins` and
+# `rustledger-importer/wasm-importer`; the CLI's base build uses only the
+# wasmtime-free APIs (`convert`/`types`) and gates the plugin-runtime + WASM
+# importer paths behind that feature. See #1427.
 rustledger-plugin.workspace = true
 rustledger-ops.workspace = true
 rustledger-importer.workspace = true

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -4,7 +4,9 @@ use anyhow::{Context, Result, anyhow};
 use rustledger_importer::ImporterConfig;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(feature = "python-plugin-wasm")]
+use std::path::PathBuf;
 
 /// Top-level importers configuration file.
 #[derive(Debug, Deserialize)]
@@ -15,12 +17,14 @@ pub(super) struct ImportersFile {
     /// (`wasm_importer_dir = ["a", "b"]`). The CLI
     /// `--wasm-importer-dir` flag(s) override this setting entirely
     /// when present.
+    #[cfg(feature = "python-plugin-wasm")]
     #[serde(default)]
     pub(super) wasm_importer_dir: WasmDirSetting,
     #[serde(default)]
     pub(super) importers: Vec<ImporterEntry>,
 }
 
+#[cfg(feature = "python-plugin-wasm")]
 /// TOML-side representation of `wasm_importer_dir` — accepts a
 /// bare string or a list of strings so the common single-dir case
 /// stays ergonomic while multi-dir is also expressible.
@@ -33,6 +37,7 @@ pub(super) enum WasmDirSetting {
     Many(Vec<PathBuf>),
 }
 
+#[cfg(feature = "python-plugin-wasm")]
 impl WasmDirSetting {
     /// Normalize into a flat `Vec<PathBuf>` for the registry-build
     /// pipeline. Empty for [`Self::None`].
@@ -45,6 +50,7 @@ impl WasmDirSetting {
     }
 }
 
+#[cfg(feature = "python-plugin-wasm")]
 /// Expand a leading `~` in a path to the user's home directory.
 /// Without this, `wasm_importer_dir = "~/imp"` in `importers.toml`
 /// would be read as a literal `~/imp` path that doesn't exist — a

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -61,9 +61,11 @@ use crate::cmd::completions::ShellType;
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use config::{
-    build_config_from_entry, expand_tilde, find_importers_config, find_matching_importers,
-    load_importers_config,
+    build_config_from_entry, find_importers_config, find_matching_importers, load_importers_config,
 };
+// Used only by the WASM-importer-dir resolution path (gated below).
+#[cfg(feature = "python-plugin-wasm")]
+use config::expand_tilde;
 use duplicate::{is_duplicate, load_existing_transactions};
 use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig};
@@ -322,6 +324,7 @@ fn select_importer(registry: &ImporterRegistry, file: &Path, args: &Args) -> Arc
 /// (no flag, soft-discover from default locations, errors warn-and-
 /// degrade). CLI `--wasm-importer-dir` flags override both and
 /// short-circuit the toml lookup entirely.
+#[cfg(feature = "python-plugin-wasm")]
 fn resolve_scan_dirs(args: &Args) -> Result<Vec<PathBuf>> {
     if !args.wasm_importer_dir.is_empty() {
         return Ok(args.wasm_importer_dir.clone());
@@ -335,6 +338,7 @@ fn resolve_scan_dirs(args: &Args) -> Result<Vec<PathBuf>> {
 /// User passed `--config <path>` explicitly. Missing or malformed
 /// file is a real error — the user asked for this file by name, so
 /// silently degrading would hide the bug they want to know about.
+#[cfg(feature = "python-plugin-wasm")]
 fn resolve_scan_dirs_explicit(path: &Path) -> Result<Vec<PathBuf>> {
     let cfg_path = find_importers_config(Some(path))?
         .ok_or_else(|| anyhow!("Importers config not found: {}", path.display()))?;
@@ -352,6 +356,7 @@ fn resolve_scan_dirs_explicit(path: &Path) -> Result<Vec<PathBuf>> {
 /// A missing file is expected; a malformed file is unusual but not
 /// fatal (the user didn't explicitly point at it). Print a warning
 /// for the malformed case so the user can find their mistake.
+#[cfg(feature = "python-plugin-wasm")]
 fn resolve_scan_dirs_implicit() -> Vec<PathBuf> {
     let cfg_path = match find_importers_config(None) {
         Ok(Some(p)) => p,
@@ -391,38 +396,46 @@ fn resolve_scan_dirs_implicit() -> Vec<PathBuf> {
 /// Per-dir scan failures (a single malformed `.wasm` among many) are
 /// logged to stderr but don't abort startup — see [`register_wasm_dir`]'s
 /// skip-and-collect semantics.
+#[cfg_attr(not(feature = "python-plugin-wasm"), allow(unused_variables))]
 fn build_registry(args: &Args) -> Result<ImporterRegistry> {
     let mut registry = ImporterRegistry::new();
 
-    // 1. CLI --wasm-importer paths (explicit precedence — registered
-    //    first so they win identify()). Single-file failures abort
-    //    because the user explicitly named this path; if it's wrong,
-    //    silently skipping would be worse than erroring out.
-    for path in &args.wasm_importer {
-        let name = registry
-            .register_wasm_from_path(path)
-            .with_context(|| format!("failed to load WASM importer {}", path.display()))?;
-        eprintln!("loaded WASM importer `{name}` from {}", path.display());
-    }
-
-    // 2. Directory scan(s): CLI flags override toml entirely.
-    //    Multiple dirs are scanned in order. `~` is expanded for
-    //    toml-supplied paths (CLI paths get shell expansion).
-    let scan_dirs: Vec<PathBuf> = resolve_scan_dirs(args)?;
-    for dir in &scan_dirs {
-        let report = registry
-            .register_wasm_dir(dir)
-            .with_context(|| format!("failed to scan WASM importer directory {}", dir.display()))?;
-        if !report.loaded.is_empty() || !report.failures.is_empty() {
-            eprintln!(
-                "WASM importer scan {}: loaded {}, failed {}",
-                dir.display(),
-                report.loaded.len(),
-                report.failures.len(),
-            );
+    // 1 + 2. WASM importer loading (sandboxed `.wasm` importers). Gated behind
+    //    `python-plugin-wasm` so a `--no-default-features` build carries no
+    //    `wasmtime`/cranelift dependency (#1427); without the feature the
+    //    `--wasm-importer`/`--wasm-importer-dir` flags are accepted but inert.
+    #[cfg(feature = "python-plugin-wasm")]
+    {
+        // 1. CLI --wasm-importer paths (explicit precedence — registered
+        //    first so they win identify()). Single-file failures abort
+        //    because the user explicitly named this path; if it's wrong,
+        //    silently skipping would be worse than erroring out.
+        for path in &args.wasm_importer {
+            let name = registry
+                .register_wasm_from_path(path)
+                .with_context(|| format!("failed to load WASM importer {}", path.display()))?;
+            eprintln!("loaded WASM importer `{name}` from {}", path.display());
         }
-        for (failed_path, err) in &report.failures {
-            eprintln!("  warning: failed to load {}: {err}", failed_path.display());
+
+        // 2. Directory scan(s): CLI flags override toml entirely.
+        //    Multiple dirs are scanned in order. `~` is expanded for
+        //    toml-supplied paths (CLI paths get shell expansion).
+        let scan_dirs: Vec<PathBuf> = resolve_scan_dirs(args)?;
+        for dir in &scan_dirs {
+            let report = registry.register_wasm_dir(dir).with_context(|| {
+                format!("failed to scan WASM importer directory {}", dir.display())
+            })?;
+            if !report.loaded.is_empty() || !report.failures.is_empty() {
+                eprintln!(
+                    "WASM importer scan {}: loaded {}, failed {}",
+                    dir.display(),
+                    report.loaded.len(),
+                    report.failures.len(),
+                );
+            }
+            for (failed_path, err) in &report.failures {
+                eprintln!("  warning: failed to load {}: {err}", failed_path.display());
+            }
         }
     }
 
@@ -1219,6 +1232,7 @@ default_expense = "Expenses:Uncategorized"
     }
 
     #[test]
+    #[cfg(feature = "python-plugin-wasm")]
     fn resolve_scan_dirs_propagates_error_for_explicit_missing_config() {
         // --config /missing.toml should error loudly, not silently
         // degrade to "no WASM scan dirs".
@@ -1239,6 +1253,7 @@ default_expense = "Expenses:Uncategorized"
     }
 
     #[test]
+    #[cfg(feature = "python-plugin-wasm")]
     fn resolve_scan_dirs_soft_fails_for_implicit_missing_config() {
         // No --config provided, no importers.toml in cwd/XDG → empty
         // scan dirs, no error. This is the right behavior because
@@ -2425,6 +2440,7 @@ filename_pattern = "statement*"
     }
 
     #[test]
+    #[cfg(feature = "python-plugin-wasm")]
     fn expand_tilde_resolves_tilde_prefix() {
         use super::config::expand_tilde;
         if let Some(home) = dirs::home_dir() {

--- a/scripts/check-slim-no-wasmtime.sh
+++ b/scripts/check-slim-no-wasmtime.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Guard: `cargo install rustledger --no-default-features` must NOT pull
+# `wasmtime` (→ `cranelift-codegen`). The slim native binary (e.g. for
+# price-download only) has to build on platforms where cranelift can't compile,
+# such as Termux/aarch64. Two earlier regressions (#867, then #1427) shipped
+# because nothing enforced this; this ratchet keeps it from happening a third
+# time. See also #1395.
+set -euo pipefail
+
+# `cargo tree -i <pkg>` exits 0 and prints the inverse tree when the package IS
+# in the graph, and exits non-zero ("did not match any packages") when it is
+# absent — which is exactly the state we want.
+if cargo tree -p rustledger --no-default-features -i wasmtime >/tmp/slim-wasmtime.txt 2>/dev/null; then
+  echo "ERROR: wasmtime is in the --no-default-features dependency tree of rustledger." >&2
+  echo "A no-default build must be wasmtime/cranelift-free (#1427/#867). Offending paths:" >&2
+  cat /tmp/slim-wasmtime.txt >&2
+  exit 1
+fi
+
+echo "OK: the --no-default-features rustledger build is wasmtime-free."


### PR DESCRIPTION
**Closes #1427** (regression of #867). `cargo install rustledger --no-default-features` still compiled `cranelift-codegen`, which can't build on Termux/aarch64.

## Root cause
Two **unconditional** paths to `wasmtime` survived `--no-default-features`:
1. `rustledger-importer` depended on `wasmtime` (+ `rustledger-plugin`'s `wasm-runtime`) unconditionally for the WASM importer loader (added in #1131 — this is what re-broke #867).
2. The CLI pulled `rustledger-importer`/`rustledger-plugin` with their default, wasmtime-enabling features.

## Fix
Gate the WASM importer behind a new **`wasm-importer`** feature (off by default):
- **rustledger-importer**: `wasmtime`/`rmp-serde`/`serde`/`thiserror`/`rustledger-plugin` are now `optional`, enabled only by `wasm-importer`. The `wasm` module, the registry's `register_wasm_*` methods + `WasmDirScanReport`, and the e2e test are `#[cfg(feature = "wasm-importer")]`.
- **CLI**: both crates resolve to their wasmtime-free feature sets by default; the existing default `python-plugin-wasm` feature re-enables `rustledger-importer/wasm-importer`. The extract command's WASM-importer-dir loading + its `resolve_scan_dirs`/`WasmDirSetting`/`expand_tilde` helpers are gated behind `python-plugin-wasm` (the CLI's plugin-runtime paths were already gated).

## Verification
- `cargo tree -p rustledger --no-default-features -i wasmtime` → **"did not match any packages"** (wasmtime/cranelift gone).
- Both configs build **clean** (no warnings); `cargo clippy -- -D warnings` clean in both.
- Default build unchanged: WASM importer + Python-plugin sandbox present; **364 lib tests pass** (incl. the gated `register_wasm_*`/`resolve_scan_dirs`/`expand_tilde` tests). Importer no-default tests pass.
- A `--no-default-features` build keeps `check`/`query`/price-download — the use case the reporter needs.

## Regression guard
`scripts/check-slim-no-wasmtime.sh` + a CI job (`Slim Build (no wasmtime)`) fail if `wasmtime` re-enters the no-default dependency tree — so #867→#1427 can't happen a third time (ties into #1395).

## How to test
```sh
cargo build -p rustledger --no-default-features          # no cranelift compiled
cargo tree -p rustledger --no-default-features -i wasmtime   # "did not match any packages"
cargo build -p rustledger                                # default: full feature set
```