### PR TITLE
fix(extract): honor amount_locale/amount_format from importers.toml

### DIFF
--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -1,12 +1,14 @@
 //! Importers TOML configuration for extract command.
 
 use anyhow::{Context, Result, anyhow};
+use format_num_pattern::Locale;
 use rustledger_importer::ImporterConfig;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 #[cfg(feature = "python-plugin-wasm")]
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// Top-level importers configuration file.
 #[derive(Debug, Deserialize)]
@@ -97,6 +99,12 @@ pub(super) struct ImporterEntry {
     pub(super) debit_column: Option<toml::Value>,
     /// Credit column name or index.
     pub(super) credit_column: Option<toml::Value>,
+    /// Amount locale for number parsing (e.g. `de_DE` so `21,12` reads as
+    /// 21.12). Mirrors the `--amount-locale` CLI flag.
+    pub(super) amount_locale: Option<String>,
+    /// Amount format pattern (`format_num_pattern` style). Mirrors the
+    /// `--amount-format` CLI flag.
+    pub(super) amount_format: Option<String>,
     /// CSV delimiter character.
     pub(super) delimiter: Option<String>,
     /// Number of rows to skip.
@@ -205,6 +213,14 @@ pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterC
     {
         builder = builder.credit_column(&col);
     }
+    if let Some(ref locale) = entry.amount_locale {
+        let locale =
+            Locale::from_str(locale).map_err(|_| anyhow!("{locale} is not a valid locale"))?;
+        builder = builder.amount_locale(locale);
+    }
+    if let Some(ref format) = entry.amount_format {
+        builder = builder.amount_format(format);
+    }
     if let Some(ref delim) = entry.delimiter
         && let Some(c) = delim.chars().next()
     {
@@ -257,4 +273,45 @@ pub(super) fn find_matching_importers<'a>(
         .iter()
         .filter(|imp| importer_matches_filename(imp, filename))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustledger_importer::config::ImporterType;
+
+    /// Regression for #1133: `amount_locale` / `amount_format` set in
+    /// `importers.toml` were silently ignored — only the matching CLI flags
+    /// (`--amount-locale` / `--amount-format`) applied them.
+    #[test]
+    fn build_config_from_entry_applies_amount_locale_and_format() {
+        let src = r##"
+[[importers]]
+name = "de-locale"
+account = "Assets:Bank"
+amount_locale = "de_DE"
+
+[[importers]]
+name = "de-format"
+account = "Assets:Bank"
+amount_locale = "de_DE"
+amount_format = "#.##0,00"
+"##;
+        let file: ImportersFile = toml::from_str(src).expect("toml parses");
+
+        // amount_locale: in de_DE the comma is the decimal separator, so
+        // "21,12" reads as 21.12 (the #1133 bug read it as 2112).
+        let cfg = build_config_from_entry(&file.importers[0]).expect("config builds");
+        let ImporterType::Csv(csv) = &cfg.importer_type;
+        let fmt = csv.compile_amount_format().expect("format compiles");
+        assert_eq!(
+            fmt.parse("21,12").expect("amount parses").to_string(),
+            "21.12"
+        );
+
+        // amount_format also flows through from the toml entry.
+        let cfg = build_config_from_entry(&file.importers[1]).expect("config builds");
+        let ImporterType::Csv(csv) = &cfg.importer_type;
+        assert_eq!(csv.amount_format.as_deref(), Some("#.##0,00"));
+    }
 }

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -22,6 +22,8 @@
 //! date_column = "Transaction Date"
 //! amount_column = "Amount"
 //! date_format = "%m/%d/%Y"
+//! # amount_locale = "de_DE"    # optional: comma as the decimal separator
+//! # amount_format = "#.##0,00" # optional: explicit number-format pattern
 //!
 //! [importers.mappings]
 //! "AMAZON" = "Expenses:Shopping"
@@ -931,6 +933,8 @@ narration_column = 1
             amount_column: Some(toml::Value::String("Amount".to_string())),
             debit_column: None,
             credit_column: None,
+            amount_locale: None,
+            amount_format: None,
             delimiter: None,
             skip_rows: None,
             skip_header: None,
@@ -963,6 +967,8 @@ narration_column = 1
             amount_column: None,
             debit_column: None,
             credit_column: None,
+            amount_locale: None,
+            amount_format: None,
             delimiter: None,
             skip_rows: None,
             skip_header: None,
@@ -994,6 +1000,8 @@ narration_column = 1
             amount_column: None,
             debit_column: None,
             credit_column: None,
+            amount_locale: None,
+            amount_format: None,
             delimiter: None,
             skip_rows: None,
             skip_header: None,
@@ -1026,6 +1034,8 @@ narration_column = 1
             amount_column: None,
             debit_column: Some(toml::Value::String("Debit".to_string())),
             credit_column: Some(toml::Value::String("Credit".to_string())),
+            amount_locale: None,
+            amount_format: None,
             delimiter: Some(";".to_string()),
             skip_rows: Some(2),
             skip_header: Some(true),


### PR DESCRIPTION
**Closes #1133.** `amount_locale` / `amount_format` were applied only from the `--amount-locale` / `--amount-format` CLI flags, never from an `importers.toml` `[[importers]]` entry. So `amount-locale = "de_DE"` in the config file had no effect (German `21,12` parsed as `2112` instead of `21.12`), while the CLI flag worked. The reporter traced it to `config.rs` not reading the keys.

## Fix
Add `amount_locale` / `amount_format` to `ImporterEntry` and apply them in `build_config_from_entry`, mirroring the CLI path exactly (locale parsed via `Locale::from_str`, same "not a valid locale" error). A full cross-check confirmed this was the *only* config-vs-flag parity gap; every other importer option was already read from both sources.

## Test
New regression test (`build_config_from_entry_applies_amount_locale_and_format`): builds an importer from a TOML entry with `amount_locale = "de_DE"` and asserts `21,12` parses as `21.12` (it parsed as `2112` before the fix under the POSIX default), and that `amount_format` flows through. The two documented `importers.toml` keys are added to the module example.

## Verify
```sh
cargo test -p rustledger --lib build_config_from_entry   # incl. the new test
cargo clippy -p rustledger --all-targets                 # clean
```