### PR TITLE
fix(loader): actionable error for module-name Python plugin refs

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1143,7 +1143,40 @@ pub fn run_plugins(
                             apply_plugin_ops(directives, ops, errors, source_map)?;
                         }
                         Err(e) => {
-                            errors.push(LedgerError::error("E8002", e).with_phase("plugin"));
+                            // A bare module name (beancount's `plugin "pkg.mod"`)
+                            // is unsupported by design — only file-path
+                            // references load (see `discover_module_source`). The
+                            // raw "module not found" reads as a venv/PYTHONPATH
+                            // problem, so say it is unsupported and point at the
+                            // file path instead, resolving it via system Python
+                            // when possible. (#1432)
+                            let is_module_ref =
+                                ext != "py" && !raw_name.contains(std::path::MAIN_SEPARATOR);
+                            if is_module_ref {
+                                use rustledger_plugin::python::{
+                                    is_python_available, suggest_module_path,
+                                };
+                                let hint = is_python_available()
+                                    .then(|| suggest_module_path(raw_name))
+                                    .flatten();
+                                let msg = match hint {
+                                    Some(path) => format!(
+                                        "Python plugin \"{raw_name}\" is not supported by module \
+                                         name; reference the file directly: plugin \"{path}\""
+                                    ),
+                                    None => format!(
+                                        "Python plugin \"{raw_name}\" is not supported by module \
+                                         name; reference the file directly, e.g. plugin \"./{}.py\". \
+                                         The plugin sandbox cannot see the host venv, so the plugin \
+                                         must be self-contained (stdlib plus the beancount compat \
+                                         shim).",
+                                        raw_name.rsplit('.').next().unwrap_or(raw_name)
+                                    ),
+                                };
+                                errors.push(LedgerError::error("E8004", msg).with_phase("plugin"));
+                            } else {
+                                errors.push(LedgerError::error("E8002", e).with_phase("plugin"));
+                            }
                         }
                     }
                 }

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1127,6 +1127,25 @@ pub fn run_plugins(
                             continue;
                         }
                     };
+
+                    // A bare module name (beancount's `plugin "pkg.mod"`) is
+                    // unsupported by design — only file-path references load.
+                    // Reject it up front with an actionable message rather than
+                    // spinning up the runtime just to fail and relabel the
+                    // error (which would also mask genuine runtime failures).
+                    // (#1432)
+                    if is_python_module_name(&resolved, raw_name) {
+                        let file = rustledger_plugin::python::suggest_module_path(raw_name);
+                        errors.push(
+                            LedgerError::error(
+                                "E8004",
+                                module_ref_message(raw_name, file.as_deref()),
+                            )
+                            .with_phase("plugin"),
+                        );
+                        continue;
+                    }
+
                     let wrappers = build_wrappers(directives, source_map);
                     match run_python_plugin(
                         raw_name,
@@ -1143,40 +1162,11 @@ pub fn run_plugins(
                             apply_plugin_ops(directives, ops, errors, source_map)?;
                         }
                         Err(e) => {
-                            // A bare module name (beancount's `plugin "pkg.mod"`)
-                            // is unsupported by design — only file-path
-                            // references load (see `discover_module_source`). The
-                            // raw "module not found" reads as a venv/PYTHONPATH
-                            // problem, so say it is unsupported and point at the
-                            // file path instead, resolving it via system Python
-                            // when possible. (#1432)
-                            let is_module_ref =
-                                ext != "py" && !raw_name.contains(std::path::MAIN_SEPARATOR);
-                            if is_module_ref {
-                                use rustledger_plugin::python::{
-                                    is_python_available, suggest_module_path,
-                                };
-                                let hint = is_python_available()
-                                    .then(|| suggest_module_path(raw_name))
-                                    .flatten();
-                                let msg = match hint {
-                                    Some(path) => format!(
-                                        "Python plugin \"{raw_name}\" is not supported by module \
-                                         name; reference the file directly: plugin \"{path}\""
-                                    ),
-                                    None => format!(
-                                        "Python plugin \"{raw_name}\" is not supported by module \
-                                         name; reference the file directly, e.g. plugin \"./{}.py\". \
-                                         The plugin sandbox cannot see the host venv, so the plugin \
-                                         must be self-contained (stdlib plus the beancount compat \
-                                         shim).",
-                                        raw_name.rsplit('.').next().unwrap_or(raw_name)
-                                    ),
-                                };
-                                errors.push(LedgerError::error("E8004", msg).with_phase("plugin"));
-                            } else {
-                                errors.push(LedgerError::error("E8002", e).with_phase("plugin"));
-                            }
+                            // A genuine load/execution failure of a real plugin
+                            // file — surface the underlying error verbatim.
+                            // (Module-name references are rejected up front, so
+                            // this no longer masks runtime failures — #1432.)
+                            errors.push(LedgerError::error("E8002", e).with_phase("plugin"));
                         }
                     }
                 }
@@ -1193,33 +1183,26 @@ pub fn run_plugins(
                     );
                 }
             } else {
-                // Completely unknown plugin name — try to suggest a module path
+                // Completely unknown plugin name. If system Python can resolve
+                // it as a module, point at the file (same guidance as the
+                // module-name path above); otherwise it is genuinely not found.
                 #[cfg(feature = "python-plugins")]
                 {
-                    use rustledger_plugin::python::{is_python_available, suggest_module_path};
-                    let suggestion = if is_python_available() {
-                        suggest_module_path(raw_name)
-                    } else {
-                        None
-                    };
-                    if let Some(module_path) = suggestion {
-                        errors.push(
-                                LedgerError::error(
-                                    "E8004",
-                                    format!(
-                                        "Cannot resolve Python module '{raw_name}'. Replace with: plugin \"{module_path}\""
-                                    ),
-                                )
-                                .with_phase("plugin"),
-                            );
-                    } else {
-                        errors.push(
+                    match rustledger_plugin::python::suggest_module_path(raw_name) {
+                        Some(module_path) => errors.push(
+                            LedgerError::error(
+                                "E8004",
+                                module_ref_message(raw_name, Some(&module_path)),
+                            )
+                            .with_phase("plugin"),
+                        ),
+                        None => errors.push(
                             LedgerError::error(
                                 "E8001",
                                 format!("Plugin not found: \"{raw_name}\""),
                             )
                             .with_phase("plugin"),
-                        );
+                        ),
                     }
                 }
                 #[cfg(not(feature = "python-plugins"))]
@@ -1635,6 +1618,40 @@ fn run_wasm_plugin(
     }
 
     Ok((output.ops, errors))
+}
+
+/// Whether `raw_name` is a bare Python *module name* (beancount's
+/// `plugin "pkg.mod"`) rather than a file reference: no `.py` extension, no
+/// path separator, and no such file at `resolved`. Module names are unsupported
+/// by design — only file paths load (see `discover_module_source`). Mirrors the
+/// file-vs-module test used by the Python runtime (case-insensitive extension).
+#[cfg(feature = "python-plugins")]
+fn is_python_module_name(resolved: &std::path::Path, raw_name: &str) -> bool {
+    !resolved.exists()
+        && !std::path::Path::new(raw_name)
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("py"))
+        && !raw_name.contains(std::path::MAIN_SEPARATOR)
+}
+
+/// Actionable error for a Python plugin referenced by module name. `file` is the
+/// module's resolved source path when system Python could find it. The raw
+/// "module not found" reads as a venv/PYTHONPATH problem, so name the
+/// unsupported form and point at the file path instead. (#1432)
+#[cfg(feature = "python-plugins")]
+fn module_ref_message(raw_name: &str, file: Option<&str>) -> String {
+    match file {
+        Some(path) => format!(
+            "Python plugin \"{raw_name}\" is not supported by module name; \
+             reference the file directly: plugin \"{path}\""
+        ),
+        None => format!(
+            "Python plugin \"{raw_name}\" is not supported by module name; \
+             reference the file directly, e.g. plugin \"/path/to/plugin.py\". \
+             The plugin sandbox cannot see the host venv, so the plugin must be \
+             self-contained (stdlib plus the beancount compat shim)."
+        ),
+    }
 }
 
 /// Run a Python module plugin via the WASI-based Python runtime.

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1627,11 +1627,15 @@ fn run_wasm_plugin(
 /// file-vs-module test used by the Python runtime (case-insensitive extension).
 #[cfg(feature = "python-plugins")]
 fn is_python_module_name(resolved: &std::path::Path, raw_name: &str) -> bool {
+    // Treat both `/` and the platform separator as path markers: forward
+    // slashes are common (and accepted) even on Windows, where
+    // `MAIN_SEPARATOR` is `\`, so a `plugins/foo.py` ref must not be mistaken
+    // for a module name.
     !resolved.exists()
         && !std::path::Path::new(raw_name)
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("py"))
-        && !raw_name.contains(std::path::MAIN_SEPARATOR)
+        && !raw_name.contains(['/', std::path::MAIN_SEPARATOR])
 }
 
 /// Actionable error for a Python plugin referenced by module name. `file` is the
@@ -1835,5 +1839,62 @@ mod sanitize_tests {
         });
         sanitize_inner_posting_spans(&mut d, &sm); // no panic, no change
         assert!(matches!(d, Directive::Open(_)));
+    }
+}
+
+#[cfg(all(test, feature = "python-plugins"))]
+mod python_plugin_ref_tests {
+    use super::{is_python_module_name, module_ref_message};
+    use std::path::Path;
+
+    #[test]
+    fn bare_module_name_is_a_module() {
+        // No `.py`, no separator, and the resolved path does not exist.
+        let missing = Path::new("/nonexistent/beancount.plugins.foo");
+        assert!(is_python_module_name(missing, "beancount.plugins.foo"));
+    }
+
+    #[test]
+    fn py_file_is_not_a_module() {
+        let missing = Path::new("/nonexistent/myplugin.py");
+        assert!(!is_python_module_name(missing, "myplugin.py"));
+        // Case-insensitive extension (mirrors the runtime).
+        assert!(!is_python_module_name(
+            Path::new("/nonexistent/MyPlugin.PY"),
+            "MyPlugin.PY"
+        ));
+    }
+
+    #[test]
+    fn path_separated_ref_is_not_a_module() {
+        // Both `/` and the platform separator count as path markers, so a
+        // forward-slash ref is a file even on Windows.
+        assert!(!is_python_module_name(
+            Path::new("/nonexistent/plugins/foo"),
+            "plugins/foo"
+        ));
+    }
+
+    #[test]
+    fn existing_file_is_not_a_module() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("pkg.mod");
+        std::fs::write(&file, "").unwrap();
+        // A real file named like a module is still a file reference.
+        assert!(!is_python_module_name(&file, "pkg.mod"));
+    }
+
+    #[test]
+    fn message_uses_resolved_path_when_known() {
+        let msg = module_ref_message("pkg.mod", Some("/abs/pkg/mod.py"));
+        assert!(msg.contains("is not supported by module name"));
+        assert!(msg.contains("plugin \"/abs/pkg/mod.py\""));
+    }
+
+    #[test]
+    fn message_falls_back_to_guidance_when_unresolved() {
+        let msg = module_ref_message("pkg.mod", None);
+        assert!(msg.contains("reference the file directly"));
+        assert!(msg.contains("self-contained"));
     }
 }

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -1314,6 +1314,54 @@ fn test_python_module_plugin_reports_error() {
     );
 }
 
+/// Regression for #1432: a Python plugin referenced by *module name* must give
+/// an actionable error ("not supported by module name; reference the file
+/// directly") rather than the misleading "execution failed: module not found",
+/// which reads as a venv/PYTHONPATH problem the user cannot fix.
+#[cfg(feature = "python-plugins")]
+#[test]
+fn test_python_module_plugin_error_is_actionable() {
+    use rustledger_loader::{LoadOptions, load};
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.beancount");
+    // A module name that the host Python cannot resolve, so the message is
+    // deterministic regardless of what is installed.
+    std::fs::write(
+        &path,
+        "plugin \"definitely.not.a.real.module.zzz\"\n2024-01-01 open Assets:Bank USD\n",
+    )
+    .unwrap();
+
+    let options = LoadOptions::default();
+    let ledger = load(&path, &options).expect("should not panic");
+
+    let plugin_err = ledger
+        .errors
+        .iter()
+        .find(|e| e.message.contains("definitely.not.a.real.module.zzz"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a plugin error, got: {:?}",
+                ledger.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+            )
+        });
+
+    // Actionable: names the unsupported form and points at the file-path fix.
+    assert!(
+        plugin_err.message.contains("not supported by module name")
+            && plugin_err.message.contains("reference the file directly"),
+        "expected an actionable file-path message, got: {:?}",
+        plugin_err.message
+    );
+    // Must NOT surface the misleading raw runtime error.
+    assert!(
+        !plugin_err.message.contains("execution failed"),
+        "should not surface the confusing 'execution failed' wrapper, got: {:?}",
+        plugin_err.message
+    );
+}
+
 /// Test that missing WASM file produces a clear error.
 #[cfg(feature = "wasm-plugins")]
 #[test]

--- a/docs/migration/from-beancount.md
+++ b/docs/migration/from-beancount.md
@@ -126,15 +126,27 @@ For custom Python plugins, you have options:
 
 ### Check Plugin Equivalents
 
-Many Python plugins have native Rust equivalents:
+Many Python plugins have native Rust equivalents. When a plugin name matches a built-in, the declaration is **unchanged** — it resolves to the native Rust implementation:
 
 ```beancount
-; Before (Python)
-plugin "beancount.plugins.auto_accounts"
-
-; After (rustledger) - same syntax, native implementation
+; Before (Python) and after (rustledger) — identical.
+; Resolves to the native `auto_accounts`, not Python.
 plugin "beancount.plugins.auto_accounts"
 ```
+
+### Custom Python Plugins: Reference by File Path
+
+beancount's **module-name** plugin syntax does **not** carry over for custom plugins (those without a native equivalent). rustledger does not search the system Python path, so a bare module name is rejected — reference the file directly instead:
+
+```beancount
+; ❌ Not supported for a custom plugin
+plugin "mypackage.mymodule"
+
+; ✅ Reference the .py file (absolute, or relative to the ledger)
+plugin "/abs/path/to/mymodule.py"
+```
+
+The plugin also runs in a sandbox that cannot see your virtualenv, so it must be **self-contained** (standard library plus the bundled beancount compat shim). See [Referencing a Python Plugin](../reference/plugins.md#referencing-a-python-plugin) for the full model.
 
 ## Performance Comparison
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -259,11 +259,29 @@ Or use `rledger doctor missing-open` to generate them.
 
 ## Document Errors (E8xxx)
 
-### E8001: Document Not Found
+### E8001: Document Not Found / Plugin Not Found
 
-**Cause**: Document directive references missing file.
+**Cause**: A `document` directive references a missing file, or a `plugin` name does not match any built-in, WASM, or resolvable Python plugin.
 
-**Fix**: Ensure file exists at specified path.
+**Fix**: Ensure the document file exists at the specified path; for plugins, check the name against the [Plugins Reference](plugins.md).
+
+### E8002: Plugin Execution Failed
+
+**Cause**: A plugin file was found but failed to load or run (e.g. a Python plugin raised, or its runtime could not be initialized). The message carries the underlying error.
+
+**Fix**: Read the embedded error. For Python plugins, ensure the file is [self-contained](plugins.md#the-plugin-sandbox-plugins-must-be-self-contained) (the sandbox cannot see your virtualenv).
+
+### E8004: Python Plugin Referenced by Module Name
+
+**Cause**: A custom Python plugin was referenced by **module name** (e.g. `plugin "mypackage.mymodule"`). rustledger does not search the system Python path, so only file-path references load.
+
+**Fix**: Reference the `.py` file directly — e.g. `plugin "/abs/path/to/mymodule.py"`. See [Referencing a Python Plugin](plugins.md#referencing-a-python-plugin).
+
+### E8005: Python Plugin Requires Feature
+
+**Cause**: A Python plugin was referenced in a build without the `python-plugins` feature.
+
+**Fix**: Use a build with Python plugin support, or switch to a native/WASM plugin.
 
 ## Date Warnings (E10xxx)
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -730,6 +730,36 @@ Python plugin support is experimental and significantly slower than native plugi
 
 rustledger can run some Python beancount plugins using CPython compiled to WebAssembly (WASI). This is primarily for migration purposes.
 
+### Referencing a Python Plugin
+
+How a plugin name resolves depends on whether it matches a built-in:
+
+- **Built-in name → native implementation.** If the name matches a built-in plugin, rustledger runs the native Rust version, regardless of the `beancount.plugins.` prefix. So `plugin "beancount.plugins.auto_accounts"` "just works" — it resolves to the native `auto_accounts`, _not_ to Python. (See [Supported Python Plugins](#supported-python-plugins).)
+
+- **Custom Python plugin → file path required.** A plugin with no native equivalent must be referenced by **file path**, not by module name. beancount's `plugin "mypackage.mymodule"` form is **not** supported:
+
+  ```beancount
+  ; ❌ Not supported — module names do not resolve to the host environment
+  plugin "mypackage.mymodule"
+
+  ; ✅ Reference the file directly (absolute, or relative to the ledger)
+  plugin "/abs/path/to/mymodule.py"
+  plugin "./plugins/mymodule.py"
+  ```
+
+  Referencing a custom plugin by module name fails with `… is not supported by module name; reference the file directly: plugin "…"`. This is intentional: rustledger does not search the system Python path, keeping it explicit which plugins still need native Rust implementations.
+
+### The Plugin Sandbox: Plugins Must Be Self-Contained
+
+Python plugins run in a pinned CPython-WASI sandbox (wasmtime). On `sys.path` it sees only:
+
+- the **plugin source file**, plus a bundled `beancount.core.data` **compatibility shim**, and
+- the **bundled CPython standard library**.
+
+The host's virtualenv / `site-packages` is **never** mounted — there is no `VIRTUAL_ENV` or `site-packages` handling, by design (the sandbox has no host filesystem access). So even with the correct file-path reference, a plugin only loads if it is **self-contained**: standard library plus whatever the compat shim provides.
+
+The compat shim covers the common beancount plugin surface — the `beancount.core.data` namedtuples (`Transaction`, `Posting`, `Amount`, `Open`, `Close`, `Balance`, `Price`, `Custom`, `Cost`, …) and the `beancount.core.{amount,getters,flags}` helpers. A plugin that imports third-party packages, C extensions, or unbundled stdlib modules will not load — rewrite it as a [native Rust plugin](../guides/custom-plugins.md) instead.
+
 ### Supported Python Plugins
 
 Most Python beancount plugins have native equivalents:
@@ -761,6 +791,7 @@ Most Python beancount plugins have native equivalents:
 - **First run**: Downloads ~14MB CPython-WASI runtime
 - **Compilation**: First execution compiles WASM (~30 seconds)
 - **Not all plugins work**: C extensions and some stdlib modules unavailable
+- **File-path references only**: custom Python plugins must be referenced by file path and be self-contained — see [Referencing a Python Plugin](#referencing-a-python-plugin)
 - **Debugging**: Error messages may be less helpful
 
 ### Migrating from Python Plugins


### PR DESCRIPTION
Implements **Gap 1 of #1432**: a Python plugin referenced by *module name* (beancount's `plugin "pkg.mod"`) now produces an actionable error pointing at the file-path requirement, instead of a misleading "module not found".

## Problem
Module-name references are unsupported by design — only file paths load (`discover_module_source`). But a name like `beancount.plugins.auto_accounts` contains a dot, so it routes into the Python-plugin branch, spins up the runtime, and fails inside `execute_module`, surfacing as:

```
E8002: Python plugin 'beancount.plugins.auto_accounts' execution failed:
       Python plugin module not found: beancount.plugins.auto_accounts
```

Doubly confusing — "execution failed" **and** "module not found" — so users (reasonably) suspect a venv/PYTHONPATH problem rather than an unsupported declaration form. The existing `suggest_module_path()` + `E8004` hint was **unreachable** for real module names, because they always contain a dot and get diverted into the Python branch before reaching it.

## Fix
In the Python-plugin error path, detect the bare-module-name case (`ext != "py"` and no path separator) and emit an actionable **E8004**:
- **Resolvable** (host Python finds it): `Python plugin "pkg.mod" is not supported by module name; reference the file directly: plugin "/abs/path/pkg/mod.py"`
- **Unresolvable**: a generic variant that still names the file-path requirement *and* notes the sandbox can't see the host venv, so the plugin must be self-contained (stdlib + beancount compat shim).

This also unifies the error code with the parallel unknown-plugin branch (both `E8004`).

## Tests
- New `test_python_module_plugin_error_is_actionable` (gated on `python-plugins`): uses an unresolvable module name for a deterministic message; asserts it contains "not supported by module name" + "reference the file directly" and does **not** contain "execution failed".
- Strengthened the existing `test_python_module_plugin_reports_error`.

## Verification
`cargo fmt --check` clean · `cargo clippy --features python-plugins -- -D warnings` clean · full `loader_test` suite **64/64** pass.

## Scope
This is Gap 1 only. Gaps 2-3 (document the file-path + self-contained-sandbox model in `docs/reference/plugins.md` and `docs/migration/from-beancount.md`) remain open under #1432.