### PR TITLE
fix(documents): warn (don't error) on discovered docs for unopened accounts

### DIFF
--- a/crates/rustledger-loader/tests/fixtures/doc_discovery_unknown.beancount
+++ b/crates/rustledger-loader/tests/fixtures/doc_discovery_unknown.beancount
@@ -1,0 +1,6 @@
+option "title" "Document Discovery — unknown account (#1434)"
+option "documents" "documents_unknown"
+
+; The document tree has documents_unknown/Expenses/Electricity/... but only
+; Expenses:Home:Electricity is opened — a stale path after an account rename.
+2026-01-01 open Expenses:Home:Electricity

--- a/crates/rustledger-loader/tests/fixtures/documents_unknown/Expenses/Electricity/2026-01-01.edf.txt
+++ b/crates/rustledger-loader/tests/fixtures/documents_unknown/Expenses/Electricity/2026-01-01.edf.txt
@@ -1,0 +1,1 @@
+EDF electricity bill

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -978,6 +978,69 @@ fn test_document_discovery_no_duplicates() {
     );
 }
 
+/// Regression for #1434: a discovered document under a directory that maps to
+/// an *unopened* account must not become a hard `E1001` error. `bean-check`
+/// skips such files silently; rustledger skips synthesizing the document but
+/// emits a warning naming the file (so a stale path after an account rename is
+/// noticed), and the load still succeeds without an error.
+#[test]
+fn test_document_discovery_unknown_account_warns_not_errors() {
+    use rustledger_loader::{ErrorSeverity, LoadOptions, load};
+
+    let path = fixtures_path("doc_discovery_unknown.beancount");
+    let ledger = load(&path, &LoadOptions::default()).expect("should load");
+
+    // No document is synthesized for the unopened account.
+    let doc_count = ledger
+        .directives
+        .iter()
+        .filter(|d| matches!(d.value, rustledger_core::Directive::Document(_)))
+        .count();
+    assert_eq!(
+        doc_count, 0,
+        "a document for an unopened account should be skipped, not synthesized"
+    );
+
+    // No error-severity diagnostic — so `rledger check` passes, like bean-check.
+    let errors: Vec<&str> = ledger
+        .errors
+        .iter()
+        .filter(|e| matches!(e.severity, ErrorSeverity::Error))
+        .map(|e| e.message.as_str())
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "should not error on a stale-account document, got: {errors:?}"
+    );
+
+    // ...but a warning names the unopened account, the file, and suggests the
+    // opened account sharing the same leaf (the rename case).
+    let warning = ledger
+        .errors
+        .iter()
+        .find(|e| {
+            matches!(e.severity, ErrorSeverity::Warning)
+                && e.message.contains("Expenses:Electricity")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected an unknown-account warning, got: {:?}",
+                ledger
+                    .errors
+                    .iter()
+                    .map(|e| (&e.severity, &e.message))
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert!(warning.message.contains("unknown account"));
+    assert!(warning.message.contains("edf.txt"), "should name the file");
+    assert!(
+        warning.message.contains("Expenses:Home:Electricity"),
+        "should suggest the renamed account, got: {}",
+        warning.message
+    );
+}
+
 // ============================================================================
 // Plugin execution through process::process() pipeline (Issue #788)
 // ============================================================================

--- a/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
+++ b/crates/rustledger-plugin/src/native/plugins/document_discovery.rs
@@ -131,6 +131,38 @@ impl NativePlugin for DocumentDiscoveryPlugin {
             }
         }
 
+        // Accounts opened in the ledger. This is exactly the set the validator
+        // treats as known (`validate_document` checks `state.accounts`, which
+        // is populated only by `open`), so a document we skip here is precisely
+        // one that would otherwise hard-fail `E1001 AccountNotOpen`.
+        //
+        // Like beancount, we don't synthesize documents for unknown accounts
+        // (so `check` passes, matching `bean-check`). Unlike beancount — which
+        // drops them silently — we surface a *warning* per unknown account, to
+        // catch the common footgun of a stale `documents/` path after an
+        // account rename (a deliberate, more-helpful deviation; #1434). Warnings
+        // don't affect the exit code, so compatibility is preserved.
+        //
+        // Note the asymmetry (intentional — do not "fix" it): an *explicit*
+        // `document` directive to an unopened account still hard-errors via the
+        // validator, matching beancount's `validate_active_accounts`. Only
+        // auto-discovery is lenient, because beancount's discovery never emits
+        // the directive in the first place.
+        let opened: std::collections::HashSet<String> = input
+            .directives
+            .iter()
+            .filter_map(|w| match &w.data {
+                DirectiveData::Open(o) => Some(o.account.clone()),
+                _ => None,
+            })
+            .collect();
+
+        // Files found under directories that map to an unopened account,
+        // grouped by account (BTreeMap → deterministic, one warning per
+        // account instead of one per file).
+        let mut unknown: std::collections::BTreeMap<String, Vec<String>> =
+            std::collections::BTreeMap::new();
+
         // Scan each directory
         for dir in &config.directories {
             let dir_path = Path::new(dir);
@@ -142,7 +174,9 @@ impl NativePlugin for DocumentDiscoveryPlugin {
                 dir_path,
                 dir,
                 &existing_docs,
+                &opened,
                 &mut new_directives,
+                &mut unknown,
                 &mut errors,
                 0, // Initial depth
             ) {
@@ -150,6 +184,13 @@ impl NativePlugin for DocumentDiscoveryPlugin {
                     "Error scanning documents in {dir}: {e}"
                 )));
             }
+        }
+
+        // One aggregated warning per unknown account.
+        for (account, paths) in &unknown {
+            errors.push(PluginError::warning(unknown_account_warning(
+                account, paths, &opened,
+            )));
         }
 
         // Keep all input directives, then insert discovered documents.
@@ -169,6 +210,56 @@ impl NativePlugin for DocumentDiscoveryPlugin {
 /// validator sees them.
 impl SynthPlugin for DocumentDiscoveryPlugin {}
 
+/// Max "did you mean" suggestions to list in a warning.
+const MAX_SUGGESTIONS: usize = 3;
+
+/// Opened accounts that plausibly match `account` — sharing both the root
+/// (first segment) and the leaf (last segment). This finds the sibling-rename
+/// case (`Expenses:Electricity` → `Expenses:Home:Electricity`) without the
+/// false positives of a leaf-only match (e.g. `Income:Refunds:Electricity`).
+fn suggested_accounts(account: &str, opened: &std::collections::HashSet<String>) -> Vec<String> {
+    let root = account.split(':').next();
+    let leaf = account.rsplit(':').next();
+    let mut hits: Vec<String> = opened
+        .iter()
+        .filter(|a| a.split(':').next() == root && a.rsplit(':').next() == leaf)
+        .filter(|a| a.as_str() != account)
+        .cloned()
+        .collect();
+    hits.sort_unstable();
+    hits.truncate(MAX_SUGGESTIONS);
+    hits
+}
+
+/// Build the (aggregated) warning for documents discovered under a directory
+/// that maps to an account that is not open. Names the account, how many files
+/// were skipped (with an example), and suggests likely-intended opened
+/// accounts (the account-rename case).
+fn unknown_account_warning(
+    account: &str,
+    paths: &[String],
+    opened: &std::collections::HashSet<String>,
+) -> String {
+    let example = paths.first().map_or("", String::as_str);
+    let more = paths.len().saturating_sub(1);
+    let files = if more == 0 {
+        example.to_string()
+    } else {
+        format!("{example} (+{more} more)")
+    };
+    let suggestions = suggested_accounts(account, opened);
+    let hint = if suggestions.is_empty() {
+        String::new()
+    } else {
+        format!("; did you mean: {}?", suggestions.join(", "))
+    };
+    format!(
+        "{n} document(s) reference unknown account '{account}' and were skipped \
+         (no such account is open): {files}{hint}",
+        n = paths.len()
+    )
+}
+
 /// Recursively scan a directory for document files.
 ///
 /// # Security
@@ -179,7 +270,9 @@ fn scan_documents(
     path: &std::path::Path,
     base_dir: &str,
     existing: &std::collections::HashSet<String>,
+    opened: &std::collections::HashSet<String>,
     directives: &mut Vec<DirectiveWrapper>,
+    unknown: &mut std::collections::BTreeMap<String, Vec<String>>,
     errors: &mut Vec<PluginError>,
     depth: usize,
 ) -> std::io::Result<()> {
@@ -215,7 +308,9 @@ fn scan_documents(
                 &entry_path,
                 base_dir,
                 existing,
+                opened,
                 directives,
+                unknown,
                 errors,
                 depth + 1,
             )?;
@@ -253,6 +348,17 @@ fn scan_documents(
 
                             // Skip if already exists (compare canonical paths)
                             if existing.contains(&canonical) {
+                                continue;
+                            }
+
+                            // Only synthesize documents for opened accounts
+                            // (see the note in `process`). A file under an
+                            // unopened account — e.g. a stale path after an
+                            // account rename — is collected for an aggregated
+                            // warning and skipped, never synthesized into a
+                            // hard `E1001`. (#1434)
+                            if !opened.contains(&account) {
+                                unknown.entry(account).or_default().push(full_path);
                                 continue;
                             }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -553,8 +553,11 @@ fn validate_phase_inner<D: ValidatableDirective>(
                 }
                 if error.note.is_none() && file_id == SYNTHESIZED_FILE_ID {
                     error.note = Some(
-                        "directive was synthesized by a plugin (no source location); \
-                         check your `plugin \"…\"` declarations for the responsible plugin"
+                        "directive was synthesized by a plugin (no source location \
+                         in your files); the responsible plugin is either an \
+                         enabled auto-plugin (e.g. `auto_accounts`, or document \
+                         discovery via `option \"documents\"`) or one of your \
+                         `plugin \"…\"` declarations"
                             .to_string(),
                     );
                 }


### PR DESCRIPTION
Closes #1434.

With `option "documents"`, a file under a directory mapping to an account that is **never opened** (e.g. a stale path after an account rename — `documents/Expenses/Electricity/...` while only `Expenses:Home:Electricity` is opened) was synthesized into a `Document` directive and then hard-failed with `E1001 Invalid reference to unknown account`, where Python `bean-check` passes silently.

## What changed
**1. Discovery mirrors beancount (the compat fix).** `document_discovery` now only synthesizes documents for **opened** accounts. That set is *exactly* what the validator treats as known (`validate_document` checks `state.accounts`, populated only by `open`), so a skipped file is provably one that would otherwise have errored — no document that would have validated is ever hidden. A file under an unopened account is **skipped** and reported as a single **aggregated warning per account** (an example file + `(+N more)`), with a "did you mean" suggestion of opened accounts sharing the account's **root and leaf** (catching the rename case without leaf-only false positives). Warnings don't affect the exit code, so `rledger check` passes like `bean-check` — but the user still discovers the stale path.

  Intentional asymmetry (documented in-code): an **explicit** `document` directive to an unopened account still hard-errors, matching beancount's `validate_active_accounts`. Only auto-discovery is lenient, because beancount's discovery never emits the directive at all.

**2. Better attribution note (#1434's second complaint).** A plugin-synthesized directive's error no longer advises users to "check your `plugin \"…\"` declarations" — a dead end for option-driven implicit plugins (`auto_accounts`, document discovery) the user never declared. The note now names both possibilities.

## Design note
This is a deliberate, *more-helpful* deviation: beancount drops these files **silently**; we drop them with a warning so the rename footgun is caught (the reporter explicitly valued rledger catching it). It's not a ledger-correctness issue, so a hard error that breaks `check` was disproportionate.

## Tests
- New `test_document_discovery_unknown_account_warns_not_errors` (+ fixture): asserts 0 documents synthesized, **no error-severity** diagnostic, and a warning naming the account, the file, and the suggested rename target.
- Existing doc-discovery tests unchanged (their fixtures open the relevant accounts).
- The existing synthesized-note attribution test still passes (reword keeps the asserted phrase).

fmt + clippy (`-D warnings`) clean; loader + plugin + validate suites green.