### PR TITLE
ci(component): gate WIT contract changes on a version bump (#1395)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,12 +395,32 @@ jobs:
         run: cargo build -p rustledger-ffi-component --target wasm32-wasip2
       - name: Run parity tests
         run: cargo test -p rustledger-ffi-component-tests
+
+  # Wire-contract version gate (#1395). The Component-Model `world.wit` is the
+  # versioned wire contract that replaced the hand-parsed FFI-WASI JSON format
+  # (#1384). An interface change must bump `package rustledger:ledger@X.Y.Z;` so
+  # a wire-shape change can't ship silently — the failure that pinned rustfava
+  # to v0.11 for five releases (the v0.16 cost-number break).
+  #
+  # Runs on EVERY PR (no `should_build` gate) so it self-validates and stays a
+  # meaningful required check; the script no-ops when the WIT interface is
+  # unchanged (comments/whitespace ignored), so non-WIT PRs pass trivially.
+  wit-version-gate:
+    name: WIT Version Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+      - name: WIT interface change requires a package-version bump
+        run: ./scripts/check-wit-version-bump.sh "${{ github.event.pull_request.base.sha }}"
+
   # Gate job - all core checks must pass (or be skipped on non-code PRs)
   build:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bindings-fresh, component-parity]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bindings-fresh, component-parity, wit-version-gate]
     steps:
       - name: Check results
         run: |
@@ -410,6 +430,15 @@ jobs:
           echo "plugin-test-quality result: $plugin_quality"
           if [[ "$plugin_quality" != "success" ]]; then
             echo "plugin-test-quality must pass"
+            exit 1
+          fi
+
+          # wit-version-gate always runs (no should_build gate), so its result
+          # is always required — a WIT contract change must bump the version.
+          wit_gate="${{ needs.wit-version-gate.result }}"
+          echo "wit-version-gate result: $wit_gate"
+          if [[ "$wit_gate" != "success" ]]; then
+            echo "wit-version-gate must pass"
             exit 1
           fi
 

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -89,15 +89,43 @@ const LEDGER: &str = "\
   Assets:Cash
 ";
 
+/// The `major.minor` of the `package rustledger:ledger@X.Y.Z;` line in the WIT
+/// contract — the single source of truth the runtime `version()` (i.e. the
+/// `API_VERSION` const) must mirror.
+fn wit_package_api_version() -> String {
+    const WIT: &str = include_str!("../../rustledger-ffi-component/wit/world.wit");
+    let full = WIT
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("package rustledger:ledger@"))
+        .and_then(|s| s.split(';').next())
+        .expect("world.wit must declare `package rustledger:ledger@X.Y.Z;`")
+        .trim();
+    let mut parts = full.split('.');
+    let major = parts.next().expect("major");
+    let minor = parts.next().expect("minor");
+    format!("{major}.{minor}")
+}
+
+/// The runtime `version()` (the `API_VERSION` const) must stay in lockstep with
+/// the WIT package version (#1395). If a contract change bumps
+/// `package rustledger:ledger@X.Y.Z;` but not `API_VERSION` (or vice-versa),
+/// embedders negotiating on `version()` would see a version that doesn't match
+/// the actual contract. The CI `wit-version-gate` ensures the *package* version
+/// is bumped on a WIT change; this test ensures the *runtime* version tracks it.
 #[test]
-fn version_matches() -> Result<()> {
+fn version_matches_wit_package() -> Result<()> {
     if !component_path().exists() {
         eprintln!("skip: component wasm not built");
         return Ok(());
     }
     let (mut store, inst) = instantiate()?;
     let version = inst.rustledger_ledger_ledger().call_version(&mut store)?;
-    assert_eq!(version, "2.1");
+    assert_eq!(
+        version,
+        wit_package_api_version(),
+        "runtime version() / API_VERSION must equal the world.wit package \
+         major.minor — bump them together",
+    );
     Ok(())
 }
 

--- a/scripts/check-wit-version-bump.sh
+++ b/scripts/check-wit-version-bump.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# CI gate (#1395): a change to the Component-Model WIT contract
+# (`crates/rustledger-ffi-component/wit/world.wit`) MUST be accompanied by a
+# package-version bump, so a wire-shape change cannot ship without a conscious,
+# visible version decision.
+#
+# The Component Model replaced the hand-parsed FFI-WASI JSON wire format as the
+# primary embedding surface (#1384). Its `world.wit` *is* the diffable contract,
+# but the version (`package rustledger:ledger@X.Y.Z;`) is still hand-maintained
+# with nothing tying it to a contract change. This gate is that tie.
+#
+# "Change" means a change to the WIT *interface*: comments (`// ...`) and blank
+# lines are ignored, so doc-only edits don't force a bump. On any interface
+# change, the package version must differ from the base.
+#
+# Usage: check-wit-version-bump.sh [base-ref]   (default: origin/main)
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+WIT="crates/rustledger-ffi-component/wit/world.wit"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+    echo "check-wit-version-bump: base ref '${BASE_REF}' not found; skipping." >&2
+    exit 0
+fi
+
+# New file (not present on base) — nothing to compare against.
+if ! git cat-file -e "${BASE_REF}:${WIT}" 2>/dev/null; then
+    echo "check-wit-version-bump: '${WIT}' is new on this branch; skipping." >&2
+    exit 0
+fi
+
+# Semantic content = drop line comments and blank/whitespace-only lines.
+semantic() {
+    sed -E 's://.*$::' | sed -E 's/[[:space:]]+$//' | grep -vE '^[[:space:]]*$' || true
+}
+
+old_iface="$(git show "${BASE_REF}:${WIT}" | semantic)"
+new_iface="$(semantic <"${WIT}")"
+
+if [ "${old_iface}" = "${new_iface}" ]; then
+    echo "check-wit-version-bump: no WIT interface change (comments/whitespace only). OK."
+    exit 0
+fi
+
+ver_re='package rustledger:ledger@[0-9]+\.[0-9]+\.[0-9]+'
+old_ver="$(git show "${BASE_REF}:${WIT}" | grep -oE "${ver_re}" || true)"
+new_ver="$(grep -oE "${ver_re}" "${WIT}" || true)"
+
+if [ -n "${new_ver}" ] && [ "${old_ver}" != "${new_ver}" ]; then
+    echo "check-wit-version-bump: WIT interface changed and version bumped (${old_ver} -> ${new_ver}). OK."
+    exit 0
+fi
+
+cat >&2 <<EOF
+ERROR: ${WIT} interface changed but the package version was not bumped.
+
+  current: ${new_ver:-<none>}
+  base:    ${old_ver:-<none>}
+
+The Component-Model wire contract is versioned (#1395). A shape change must bump
+'package rustledger:ledger@X.Y.Z;' (and the mirrored API_VERSION const in
+crates/rustledger-ffi-component/src/lib.rs):
+  - additive / backwards-compatible change -> bump MINOR  (X.Y+1.0)
+  - breaking change                        -> bump MAJOR  (X+1.0.0)
+
+If you believe this is a no-op interface change, it should not appear in the
+semantic diff (only comments/whitespace differ); re-check the edit.
+EOF
+exit 1


### PR DESCRIPTION
Implements the one durable guardrail from #1395, retargeted to the surface that's actually primary now.

## Context
#1395 asked for wire-format stability so breaking changes can't ship silently (the v0.16 cost-number break that pinned rustfava to v0.11 for five releases). Since it was filed, the **Component Model migration (#1384) shipped and is the default** — a typed `world.wit` contract with generated host bindings, plus a consumer-side version check in rustfava (`_check_api_version`). The remaining hole is that the WIT's *version* is hand-maintained with nothing tying it to a contract change. This PR is that tie.

## Changes
- **`scripts/check-wit-version-bump.sh` + required `WIT Version Gate` CI job.** If `world.wit`'s interface changes (comments/whitespace ignored), the `package rustledger:ledger@X.Y.Z;` version must be bumped, or the job fails with guidance (minor = additive, major = breaking). Wired into the `build` aggregator; no-ops on non-WIT PRs (so it's safe as a required check).
- **`version_matches_wit_package` parity test.** The runtime `version()` (the `API_VERSION` const) must equal the WIT package `major.minor`, so the value embedders negotiate on can't drift from the contract. Replaces the hard-coded `assert_eq!(version, "2.1")`.

## Validation
Gate script exercised on all four cases (no change → skip; interface change w/o bump → **fail**; same change w/ bump → pass; comment-only → pass). Component builds; parity suite **15/15** incl. the new lockstep test. `ci.yml` YAML validated.

## Scope note
This is deliberately *not* the full #1395 checklist: the FFI-WASI snapshot/version-gate items target a surface slated for removal (#1419), so they're intentionally dropped. See my status comment on #1395 for the re-scope.