### PR TITLE
fix(query): beanquery compat — getitem(meta), positional ORDER BY/GROUP BY, metadata rendering

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -67,7 +67,10 @@ impl<'a> Executor<'a> {
     /// replace it with the aliased expression. For example, in:
     ///   `SELECT month(date) AS m, COUNT(*) GROUP BY m`
     /// the GROUP BY `m` is resolved to `month(date)`.
-    pub(super) fn resolve_group_by_aliases(group_exprs: &[Expr], targets: &[Target]) -> Vec<Expr> {
+    pub(super) fn resolve_group_by_aliases(
+        group_exprs: &[Expr],
+        targets: &[Target],
+    ) -> Result<Vec<Expr>, QueryError> {
         let alias_map: HashMap<String, Expr> = targets
             .iter()
             .filter_map(|t| t.alias.as_ref().map(|a| (a.to_uppercase(), t.expr.clone())))
@@ -79,19 +82,24 @@ impl<'a> Executor<'a> {
                 // Positional ordinal: `GROUP BY 1` groups by the 1st SELECT
                 // column (1-based, beanquery/SQL semantics). Without this the
                 // integer is grouped on as a constant, collapsing every row
-                // into one group.
-                if let Expr::Literal(Literal::Integer(n)) = expr
-                    && *n >= 1
-                    && (*n as usize) <= targets.len()
-                {
-                    return targets[(*n as usize) - 1].expr.clone();
+                // into one group. Out-of-range positions error, matching the
+                // `ORDER BY <n>` behavior, rather than silently collapsing.
+                if let Expr::Literal(Literal::Integer(n)) = expr {
+                    let n = *n;
+                    if n < 1 || (n as usize) > targets.len() {
+                        return Err(QueryError::Evaluation(format!(
+                            "GROUP BY position {n} is out of range (1..={})",
+                            targets.len()
+                        )));
+                    }
+                    return Ok(targets[(n as usize) - 1].expr.clone());
                 }
                 if let Expr::Column(name) = expr
                     && let Some(target_expr) = alias_map.get(&name.to_uppercase())
                 {
-                    target_expr.clone()
+                    Ok(target_expr.clone())
                 } else {
-                    expr.clone()
+                    Ok(expr.clone())
                 }
             })
             .collect()

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use rust_decimal::Decimal;
 use rustledger_core::{Amount, Inventory, Position};
 
-use crate::ast::{Expr, Target, UnaryOperator};
+use crate::ast::{Expr, Literal, Target, UnaryOperator};
 use crate::error::QueryError;
 
 use super::Executor;
@@ -76,6 +76,16 @@ impl<'a> Executor<'a> {
         group_exprs
             .iter()
             .map(|expr| {
+                // Positional ordinal: `GROUP BY 1` groups by the 1st SELECT
+                // column (1-based, beanquery/SQL semantics). Without this the
+                // integer is grouped on as a constant, collapsing every row
+                // into one group.
+                if let Expr::Literal(Literal::Integer(n)) = expr
+                    && *n >= 1
+                    && (*n as usize) <= targets.len()
+                {
+                    return targets[(*n as usize) - 1].expr.clone();
+                }
                 if let Expr::Column(name) = expr
                     && let Some(target_expr) = alias_map.get(&name.to_uppercase())
                 {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -270,6 +270,13 @@ impl Executor<'_> {
 
         let mut hidden = Vec::new();
         for spec in order_by {
+            // Positional ordinals (`ORDER BY 1`) reference an existing SELECT
+            // column by position; they are resolved in `sort_results` and must
+            // not be materialized as a hidden constant column (which would make
+            // the sort key the literal integer for every row).
+            if matches!(spec.expr, Expr::Literal(crate::ast::Literal::Integer(_))) {
+                continue;
+            }
             // For aggregate queries, only allow ORDER BY on expressions that are
             // in GROUP BY or are themselves aggregates.
             if let Some(group_by) = &query.group_by {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -90,7 +90,7 @@ impl Executor<'_> {
             // - Otherwise, implicitly group by non-aggregate columns in SELECT
             //   (matches Python beancount behavior)
             let group_by_exprs: Option<Vec<Expr>> = if let Some(ref group_exprs) = query.group_by {
-                Some(Self::resolve_group_by_aliases(group_exprs, &query.targets))
+                Some(Self::resolve_group_by_aliases(group_exprs, &query.targets)?)
             } else {
                 let implicit = Self::extract_implicit_group_by_exprs(&query.targets);
                 if implicit.is_empty() {
@@ -208,7 +208,8 @@ impl Executor<'_> {
         // means the strip-hidden step below operates on the
         // pre-pivot shape where hidden cols are still trailing).
         if let Some(order_by) = &query.order_by {
-            self.sort_results(&mut result, order_by)?;
+            let visible_cols = result.columns.len() - num_hidden;
+            self.sort_results(&mut result, order_by, visible_cols)?;
         } else if has_grouping && !result.rows.is_empty() && !result.columns.is_empty() {
             // When there's GROUP BY (explicit or implicit) but no ORDER BY, sort by
             // the first column for deterministic output (matches Python beancount behavior).
@@ -223,7 +224,8 @@ impl Executor<'_> {
                 expr: Expr::Column(first_col),
                 direction: SortDirection::Asc,
             }];
-            self.sort_results(&mut result, &default_order)?;
+            let visible_cols = result.columns.len() - num_hidden;
+            self.sort_results(&mut result, &default_order, visible_cols)?;
         }
 
         // Remove hidden columns after sorting (BEFORE PIVOT). With this
@@ -367,7 +369,8 @@ impl Executor<'_> {
 
         // Apply ORDER BY
         if let Some(order_by) = &outer_query.order_by {
-            self.sort_results(&mut result, order_by)?;
+            let visible_cols = result.columns.len();
+            self.sort_results(&mut result, order_by, visible_cols)?;
         }
 
         // Apply LIMIT
@@ -480,7 +483,8 @@ impl Executor<'_> {
 
         // Apply ORDER BY
         if let Some(order_by) = &query.order_by {
-            self.sort_results(&mut result, order_by)?;
+            let visible_cols = result.columns.len() - num_hidden;
+            self.sort_results(&mut result, order_by, visible_cols)?;
         }
 
         // Remove hidden columns after sorting
@@ -519,7 +523,7 @@ impl Executor<'_> {
         // Determine GROUP BY expressions.
         // If no explicit GROUP BY, implicitly group by non-aggregate columns (beancount compat).
         let group_by_exprs: Option<Vec<Expr>> = if let Some(ref exprs) = query.group_by {
-            Some(Self::resolve_group_by_aliases(exprs, &query.targets))
+            Some(Self::resolve_group_by_aliases(exprs, &query.targets)?)
         } else {
             let implicit = Self::extract_implicit_group_by_exprs(&query.targets);
             if implicit.is_empty() {
@@ -619,7 +623,8 @@ impl Executor<'_> {
 
         // Apply ORDER BY
         if let Some(order_by) = &query.order_by {
-            self.sort_results(&mut result, order_by)?;
+            let visible_cols = result.columns.len();
+            self.sort_results(&mut result, order_by, visible_cols)?;
         }
 
         // Apply LIMIT

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -169,7 +169,8 @@ impl Executor<'_> {
                 Ok(obj.get(&key).cloned().unwrap_or(Value::Null))
             }
             _ => Err(QueryError::Type(
-                "GETITEM expects (inventory|metadata, string)".to_string(),
+                "GETITEM expects (inventory, string), (metadata, string), or (object, string)"
+                    .to_string(),
             )),
         }
     }

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -159,8 +159,17 @@ impl Executor<'_> {
                     Ok(Value::Amount(Amount::new(total, currency)))
                 }
             }
+            // `getitem(meta, "key")` reads the metadata dict, returning the
+            // value or null when absent. Mirrors beanquery, where getitem is
+            // `dict.get(key)` on the meta map.
+            (Value::Metadata(meta), Value::String(key)) => {
+                Ok(Self::meta_value_to_value(meta.get(&key)))
+            }
+            (Value::Object(obj), Value::String(key)) => {
+                Ok(obj.get(&key).cloned().unwrap_or(Value::Null))
+            }
             _ => Err(QueryError::Type(
-                "GETITEM expects (inventory, string)".to_string(),
+                "GETITEM expects (inventory|metadata, string)".to_string(),
             )),
         }
     }

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -31,6 +31,20 @@ impl Executor<'_> {
         for spec in order_by {
             // Try to resolve the expression to a column index
             let idx = match &spec.expr {
+                // Positional ORDER BY: `ORDER BY 1` sorts by the first SELECT
+                // column (1-based), matching beanquery / SQL. Without this the
+                // integer is treated as a constant expression and silently
+                // no-ops the sort.
+                Expr::Literal(Literal::Integer(n)) => {
+                    let n = *n;
+                    if n < 1 || (n as usize) > result.columns.len() {
+                        return Err(QueryError::Evaluation(format!(
+                            "ORDER BY position {n} is out of range (1..={})",
+                            result.columns.len()
+                        )));
+                    }
+                    (n as usize) - 1
+                }
                 Expr::Column(name) => column_indices
                     .get(name.as_str())
                     .copied()
@@ -395,8 +409,18 @@ impl Executor<'_> {
                 format!("({})", strs.join(", "))
             }
             Value::Metadata(meta) => {
-                // Format metadata as key=value pairs
-                let pairs: Vec<String> = meta.iter().map(|(k, v)| format!("{k}: {v:?}")).collect();
+                // Render each metadata value through the same Value path as
+                // every other cell, so a string shows as `good` rather than
+                // the Debug form `String("good")`.
+                let pairs: Vec<String> = meta
+                    .iter()
+                    .map(|(k, v)| {
+                        format!(
+                            "{k}: {}",
+                            Self::value_to_string(&Self::meta_value_to_value(Some(v)))
+                        )
+                    })
+                    .collect();
                 format!("{{{}}}", pairs.join(", "))
             }
             Value::Interval(i) => format!("{} {:?}", i.count, i.unit),

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -13,6 +13,12 @@ impl Executor<'_> {
         &self,
         result: &mut QueryResult,
         order_by: &[OrderSpec],
+        // Number of user-visible SELECT columns. `result.columns` may have
+        // trailing hidden ORDER BY columns appended (stripped after sorting),
+        // so positional ordinals must be range-checked against this, not
+        // `result.columns.len()`, or `ORDER BY <n>` could address a hidden
+        // column instead of erroring.
+        visible_cols: usize,
     ) -> Result<(), QueryError> {
         if order_by.is_empty() {
             return Ok(());
@@ -37,10 +43,9 @@ impl Executor<'_> {
                 // no-ops the sort.
                 Expr::Literal(Literal::Integer(n)) => {
                     let n = *n;
-                    if n < 1 || (n as usize) > result.columns.len() {
+                    if n < 1 || (n as usize) > visible_cols {
                         return Err(QueryError::Evaluation(format!(
-                            "ORDER BY position {n} is out of range (1..={})",
-                            result.columns.len()
+                            "ORDER BY position {n} is out of range (1..={visible_cols})"
                         )));
                     }
                     (n as usize) - 1

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -9249,6 +9249,144 @@ fn test_entry_meta_from_postings_table() {
 }
 
 #[test]
+fn test_getitem_reads_posting_metadata() {
+    // Regression: `getitem(meta, key)` must read the metadata dict (beanquery's
+    // `dict.get` semantics), returning the value or null, instead of rejecting
+    // it with "GETITEM expects (inventory, string)". Found by dogfooding;
+    // beanquery returns the value on the matching posting and null elsewhere.
+    let mut food = Posting::new("Expenses:Food", Amount::new(dec!(10), "USD"));
+    food.meta.insert(
+        "rating".to_string(),
+        rustledger_core::MetaValue::String("good".to_string()),
+    );
+    let directives = vec![
+        Directive::Open(Open::new(date(2022, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2022, 1, 1), "Expenses:Food")),
+        Directive::Transaction({
+            let mut txn = Transaction::new(date(2022, 4, 1), "Lunch");
+            txn.postings = vec![
+                rustledger_core::Spanned::synthesized(food),
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-10), "USD"),
+                )),
+            ];
+            txn
+        }),
+    ];
+
+    let result = execute_query("SELECT account, getitem(meta, 'rating')", &directives);
+    assert_eq!(result.rows.len(), 2);
+    assert_eq!(result.rows[0][1], Value::String("good".to_string()));
+    assert_eq!(result.rows[1][1], Value::Null);
+}
+
+#[test]
+fn test_order_by_positional_ordinal() {
+    // Regression: `ORDER BY <n>` sorts by the n-th SELECT column (1-based,
+    // beanquery/SQL semantics) instead of treating the integer as a constant
+    // expression, which silently no-ops the sort. Out-of-range positions error.
+    let directives = vec![
+        Directive::Open(Open::new(date(2022, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2022, 1, 1), "Expenses:Food")),
+        Directive::Open(Open::new(date(2022, 1, 1), "Expenses:Auto")),
+        Directive::Transaction({
+            let mut txn = Transaction::new(date(2022, 4, 1), "x");
+            txn.postings = vec![
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(30), "USD"),
+                )),
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Expenses:Auto",
+                    Amount::new(dec!(10), "USD"),
+                )),
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-40), "USD"),
+                )),
+            ];
+            txn
+        }),
+    ];
+    let accounts = |q: &str| -> Vec<Value> {
+        execute_query(q, &directives)
+            .rows
+            .iter()
+            .map(|row| row[0].clone())
+            .collect()
+    };
+
+    // ORDER BY 1 -> first column (account) ascending.
+    assert_eq!(
+        accounts("SELECT account, number ORDER BY 1"),
+        vec![
+            Value::String("Assets:Cash".to_string()),
+            Value::String("Expenses:Auto".to_string()),
+            Value::String("Expenses:Food".to_string()),
+        ]
+    );
+    // ORDER BY 2 DESC -> second column (number) descending: 30, 10, -40.
+    assert_eq!(
+        accounts("SELECT account, number ORDER BY 2 DESC"),
+        vec![
+            Value::String("Expenses:Food".to_string()),
+            Value::String("Expenses:Auto".to_string()),
+            Value::String("Assets:Cash".to_string()),
+        ]
+    );
+    // Out-of-range position errors instead of silently no-opping.
+    let err = execute_query_err("SELECT account ORDER BY 5", &directives);
+    assert!(err.to_string().contains("out of range"), "got: {err}");
+}
+
+#[test]
+fn test_group_by_positional_ordinal() {
+    // Regression: `GROUP BY <n>` groups by the n-th SELECT column (1-based)
+    // instead of grouping on the integer as a constant, which collapsed every
+    // row into a single group with a wrong aggregate. Mirrors the ORDER BY fix.
+    let directives = vec![
+        Directive::Open(Open::new(date(2022, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2022, 1, 1), "Expenses:Food")),
+        Directive::Open(Open::new(date(2022, 1, 1), "Expenses:Auto")),
+        Directive::Transaction({
+            let mut txn = Transaction::new(date(2022, 4, 1), "x");
+            txn.postings = vec![
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Expenses:Food",
+                    Amount::new(dec!(30), "USD"),
+                )),
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Expenses:Auto",
+                    Amount::new(dec!(10), "USD"),
+                )),
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-40), "USD"),
+                )),
+            ];
+            txn
+        }),
+    ];
+    let result = execute_query("SELECT account, sum(number) GROUP BY 1", &directives);
+    // One group per distinct account, not a single collapsed group.
+    assert_eq!(result.rows.len(), 3);
+    let mut accounts: Vec<String> = result
+        .rows
+        .iter()
+        .map(|r| match &r[0] {
+            Value::String(s) => s.clone(),
+            other => panic!("expected account string, got {other:?}"),
+        })
+        .collect();
+    accounts.sort();
+    assert_eq!(
+        accounts,
+        vec!["Assets:Cash", "Expenses:Auto", "Expenses:Food"]
+    );
+}
+
+#[test]
 fn test_entry_meta_from_entries_table() {
     let directives = vec![
         Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -9384,6 +9384,11 @@ fn test_group_by_positional_ordinal() {
         accounts,
         vec!["Assets:Cash", "Expenses:Auto", "Expenses:Food"]
     );
+
+    // Out-of-range position errors instead of silently grouping on the
+    // constant (which would collapse every row into one group).
+    let err = execute_query_err("SELECT account, sum(number) GROUP BY 5", &directives);
+    assert!(err.to_string().contains("out of range"), "got: {err}");
 }
 
 #[test]

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -574,7 +574,7 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
         }
         Value::Metadata(meta) => meta
             .iter()
-            .map(|(k, v)| format!("{k}: {v:?}"))
+            .map(|(k, v)| format!("{k}: {v}"))
             .collect::<Vec<_>>()
             .join(", "),
         Value::Interval(interval) => {
@@ -596,6 +596,28 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
             format!("{{{}}}", pairs.join(", "))
         }
         Value::Null => String::new(),
+    }
+}
+
+/// Convert a metadata value to a typed JSON value, mirroring `value_to_json`'s
+/// conventions (decimals as strings to preserve precision). Without this the
+/// JSON output leaked the Rust Debug form (e.g. `"String(\"good\")"`).
+fn meta_value_to_json(v: &rustledger_core::MetaValue) -> serde_json::Value {
+    use rustledger_core::MetaValue;
+    match v {
+        MetaValue::String(s) => serde_json::Value::String(s.clone()),
+        MetaValue::Number(n) => serde_json::json!(n.to_string()),
+        MetaValue::Bool(b) => serde_json::Value::Bool(*b),
+        MetaValue::Date(d) => serde_json::Value::String(d.to_string()),
+        MetaValue::Amount(a) => serde_json::json!({
+            "number": a.number.to_string(),
+            "currency": a.currency,
+        }),
+        MetaValue::Account(a) => serde_json::Value::String(a.to_string()),
+        MetaValue::Currency(c) => serde_json::Value::String(c.to_string()),
+        MetaValue::Tag(t) => serde_json::Value::String(t.to_string()),
+        MetaValue::Link(l) => serde_json::Value::String(l.to_string()),
+        MetaValue::None => serde_json::Value::Null,
     }
 }
 
@@ -634,7 +656,7 @@ fn value_to_json(value: &Value) -> serde_json::Value {
         Value::Metadata(meta) => {
             let obj: serde_json::Map<String, serde_json::Value> = meta
                 .iter()
-                .map(|(k, v)| (k.clone(), serde_json::json!(format!("{v:?}"))))
+                .map(|(k, v)| (k.clone(), meta_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
@@ -781,6 +803,27 @@ mod tests {
             "sub-cent USD residual must render as blank to match bean-query; \
              got {rendered:?}"
         );
+    }
+
+    #[test]
+    fn test_metadata_renders_values_not_debug_form() {
+        // Regression: a metadata dict must render its values through the normal
+        // value path, not the Rust Debug form `String("good")`, in both the
+        // text and JSON output.
+        use rustledger_core::{MetaValue, Metadata};
+        let mut meta = Metadata::default();
+        meta.insert("rating".to_string(), MetaValue::String("good".to_string()));
+        let value = Value::Metadata(Box::new(meta));
+
+        let text = format_value(&value, false, &DisplayContext::new());
+        assert!(
+            !text.contains("String("),
+            "Debug form leaked in text: {text:?}"
+        );
+        assert!(text.contains("rating: \"good\""), "got: {text:?}");
+
+        let json = value_to_json(&value);
+        assert_eq!(json["rating"], serde_json::json!("good"));
     }
 
     /// Sister test: a position that's NOT sub-precision should still render.


### PR DESCRIPTION
Four BQL query-engine divergences from beanquery, found by dogfooding `rledger` as a Beancount user and each re-verified against real beanquery + pinned with a regression test.

## Fixes
- **`getitem(meta, key)`** now reads the metadata dict (beanquery `dict.get` semantics) instead of rejecting it with `GETITEM expects (inventory, string)`. Returns the value or null; exact beanquery parity.
- **`ORDER BY <n>`** resolves a 1-based positional ordinal to the Nth SELECT column instead of treating the integer as a constant (which silently no-opped the sort). Out-of-range positions now error.
- **`GROUP BY <n>`** likewise resolves positional ordinals, instead of grouping on the constant — which collapsed every row into a single group with a wrong aggregate.
- **Metadata rendering**: a metadata dict renders its values through the normal value path in both text and JSON output (`rating: "good"` / `{"rating":"good"}`) instead of leaking the Rust Debug form (`String("good")`).

## Verification
Each behavior was checked against beanquery on the same input before and after. New regression tests: `test_getitem_reads_posting_metadata`, `test_order_by_positional_ordinal`, `test_group_by_positional_ordinal` (rustledger-query), `test_metadata_renders_values_not_debug_form` (rustledger CLI). `bql_integration_test` suite green (380 passed); clippy clean.

## Notes
- Two of the originating findings were imprecise: `ORDER BY <n>` was a silent no-op (not a rejection), and `GROUP BY <n>` surfaced as a separate, worse bug (row collapse). Both corrected here.
- `getitem(meta, …)` is fixed for the default query form; the explicit `FROM #postings` form resolves `meta` via a different path and is left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)