### PR TITLE
fix(extract): numeric column indices + word-boundary CSV header matching

### DIFF
--- a/crates/rustledger-importer/src/csv_inference.rs
+++ b/crates/rustledger-importer/src/csv_inference.rs
@@ -326,6 +326,24 @@ const DATE_FORMATS: &[&str] = &[
     "%d/%m/%y",  // 15/01/24
 ];
 
+/// Whole-word keyword match against a (lowercased) CSV header.
+///
+/// A keyword matches only when it appears delimited by non-alphanumeric
+/// characters or string boundaries, so short tokens like "in"/"out" no longer
+/// match inside "running balance", "routing number", "beginning balance", etc.
+/// (which made `--auto` steal a running-balance column as the credit/amount).
+/// Multi-word keywords such as "transaction date" are matched as phrases.
+fn header_matches(header_lower: &str, keywords: &[&str]) -> bool {
+    keywords.iter().any(|kw| {
+        header_lower.match_indices(kw).any(|(start, matched)| {
+            let before = header_lower[..start].chars().next_back();
+            let after = header_lower[start + matched.len()..].chars().next();
+            before.is_none_or(|c| !c.is_alphanumeric())
+                && after.is_none_or(|c| !c.is_alphanumeric())
+        })
+    })
+}
+
 /// Find the date column and its format.
 fn find_date_column(
     headers: &[&str],
@@ -344,7 +362,7 @@ fn find_date_column(
 
     for (i, header) in headers.iter().enumerate() {
         let lower = header.to_lowercase();
-        if date_keywords.iter().any(|kw| lower.contains(kw)) {
+        if header_matches(&lower, &date_keywords) {
             candidates.push(i);
         }
     }
@@ -403,11 +421,11 @@ fn find_amount_columns(
     // Check headers first
     for (i, header) in headers.iter().enumerate() {
         let lower = header.to_lowercase();
-        if debit_keywords.iter().any(|kw| lower.contains(kw)) {
+        if header_matches(&lower, &debit_keywords) {
             debit_col = Some(i);
-        } else if credit_keywords.iter().any(|kw| lower.contains(kw)) {
+        } else if header_matches(&lower, &credit_keywords) {
             credit_col = Some(i);
-        } else if amount_keywords.iter().any(|kw| lower.contains(kw)) {
+        } else if header_matches(&lower, &amount_keywords) {
             amount_col = Some(i);
         }
     }
@@ -498,10 +516,9 @@ fn find_text_columns(
             continue;
         }
         let lower = header.to_lowercase();
-        if payee_keywords.iter().any(|kw| lower.contains(kw)) && payee_col.is_none() {
+        if header_matches(&lower, &payee_keywords) && payee_col.is_none() {
             payee_col = Some(i);
-        } else if narration_keywords.iter().any(|kw| lower.contains(kw)) && narration_col.is_none()
-        {
+        } else if header_matches(&lower, &narration_keywords) && narration_col.is_none() {
             narration_col = Some(i);
         }
     }
@@ -674,6 +691,29 @@ Date,Description,Debit,Credit
         assert!(config.debit_column.is_some());
         assert!(config.credit_column.is_some());
         assert!(config.amount_column.is_none());
+    }
+
+    #[test]
+    fn infer_does_not_steal_running_balance_as_credit() {
+        // Regression: "Running Balance" must not be classified as the credit
+        // column. The word "running" contains the letters "in", which the old
+        // substring match treated as the `in` credit keyword, stealing the
+        // running balance as the amount. With Debit + Credit + Running Balance,
+        // the pair must be the real Debit/Credit columns.
+        let csv = "\
+Date,Description,Debit,Credit,Running Balance
+2024-01-15,Deposit,,100.00,1100.00
+2024-01-16,Withdraw,40.00,,1060.00
+";
+        let config = infer_csv_config(csv).expect("should infer config");
+        match &config.debit_column {
+            Some(ColumnSpec::Name(n)) => assert_eq!(n, "Debit"),
+            other => panic!("debit column should be 'Debit', got {other:?}"),
+        }
+        match &config.credit_column {
+            Some(ColumnSpec::Name(n)) => assert_eq!(n, "Credit"),
+            other => panic!("credit column should be 'Credit', got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result, anyhow};
 use format_num_pattern::Locale;
 use rustledger_importer::ImporterConfig;
+use rustledger_importer::config::CsvConfigBuilder;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -124,6 +125,24 @@ pub(super) struct ImporterEntry {
     pub(super) mappings: HashMap<String, String>,
 }
 
+/// Apply a CSV column flag that may be a header name or a bare 0-based index.
+///
+/// CSV column flags are documented as "name or index". A value that parses as a
+/// non-negative integer is treated as a positional index (so headerless CSVs
+/// import correctly); anything else is a column name. Shared by the CLI-argument
+/// and `importers.toml` config paths so both honor numeric columns.
+pub(super) fn apply_column(
+    builder: CsvConfigBuilder,
+    col: &str,
+    by_index: impl FnOnce(CsvConfigBuilder, usize) -> CsvConfigBuilder,
+    by_name: impl FnOnce(CsvConfigBuilder, &str) -> CsvConfigBuilder,
+) -> CsvConfigBuilder {
+    match col.parse::<usize>() {
+        Ok(i) => by_index(builder, i),
+        Err(_) => by_name(builder, col),
+    }
+}
+
 /// Parse a TOML value as a column spec string (either a string name or integer index).
 pub(super) fn parse_column_value(value: &toml::Value) -> Option<String> {
     match value {
@@ -183,7 +202,12 @@ pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterC
     if let Some(ref val) = entry.date_column
         && let Some(col) = parse_column_value(val)
     {
-        builder = builder.date_column(&col);
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::date_column_index,
+            |b, n| b.date_column(n),
+        );
     }
     if let Some(ref fmt) = entry.date_format {
         builder = builder.date_format(fmt);
@@ -191,17 +215,32 @@ pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterC
     if let Some(ref val) = entry.narration_column
         && let Some(col) = parse_column_value(val)
     {
-        builder = builder.narration_column(&col);
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::narration_column_index,
+            |b, n| b.narration_column(n),
+        );
     }
     if let Some(ref val) = entry.payee_column
         && let Some(col) = parse_column_value(val)
     {
-        builder = builder.payee_column(&col);
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::payee_column_index,
+            |b, n| b.payee_column(n),
+        );
     }
     if let Some(ref val) = entry.amount_column
         && let Some(col) = parse_column_value(val)
     {
-        builder = builder.amount_column(&col);
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::amount_column_index,
+            |b, n| b.amount_column(n),
+        );
     }
     if let Some(ref val) = entry.debit_column
         && let Some(col) = parse_column_value(val)

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -63,7 +63,8 @@ use crate::cmd::completions::ShellType;
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use config::{
-    build_config_from_entry, find_importers_config, find_matching_importers, load_importers_config,
+    apply_column, build_config_from_entry, find_importers_config, find_matching_importers,
+    load_importers_config,
 };
 // Used only by the WASM-importer-dir resolution path (gated below).
 #[cfg(feature = "python-plugin-wasm")]
@@ -71,6 +72,7 @@ use config::expand_tilde;
 use duplicate::{is_duplicate, load_existing_transactions};
 use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig};
+use rustledger_importer::config::CsvConfigBuilder;
 use rustledger_importer::{Importer, ImporterConfig, ImporterRegistry, csv_importer::CsvImporter};
 use rustledger_parser::format::canonicalize_directives;
 use std::fs;
@@ -639,18 +641,41 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             let mut builder = ImporterConfig::csv()
                 .account(&args.account)
                 .currency(&args.currency)
-                .date_column(&args.date_column)
                 .date_format(&args.date_format)
-                .narration_column(&args.narration_column)
-                .amount_column(&args.amount_column)
                 .delimiter(args.delimiter)
                 .skip_rows(args.skip_rows)
                 .invert_sign(args.invert_sign)
                 .skip_zero_amounts(!args.include_zero_amounts)
                 .has_header(!args.no_header);
 
+            // Column flags accept either a header name or a 0-based index (see
+            // `apply_column`), so headerless CSVs can be imported positionally.
+            builder = apply_column(
+                builder,
+                &args.date_column,
+                CsvConfigBuilder::date_column_index,
+                |b, n| b.date_column(n),
+            );
+            builder = apply_column(
+                builder,
+                &args.narration_column,
+                CsvConfigBuilder::narration_column_index,
+                |b, n| b.narration_column(n),
+            );
+            builder = apply_column(
+                builder,
+                &args.amount_column,
+                CsvConfigBuilder::amount_column_index,
+                |b, n| b.amount_column(n),
+            );
+
             if let Some(payee) = &args.payee_column {
-                builder = builder.payee_column(payee);
+                builder = apply_column(
+                    builder,
+                    payee,
+                    CsvConfigBuilder::payee_column_index,
+                    |b, n| b.payee_column(n),
+                );
             }
 
             if let Some(debit) = &args.debit_column {
@@ -905,6 +930,42 @@ narration_column = 1
         assert_eq!(
             parse_column_value(entry.amount_column.as_ref().unwrap()),
             Some("3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_cli_numeric_column_args_extract_by_index() {
+        // Regression: numeric --date-column/--amount-column/--payee-column
+        // values are treated as 0-based indices (flags documented as "name or
+        // index"), so a headerless CSV imports instead of every row being
+        // dropped because no header matches "0"/"1"/"2".
+        use clap::Parser;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("noheader.csv");
+        std::fs::write(&path, "2024-01-15,Coffee,-5.00\n2024-01-16,Lunch,-12.00\n").unwrap();
+
+        let args = Args::parse_from([
+            "extract",
+            "--no-header",
+            "--date-column",
+            "0",
+            "--payee-column",
+            "1",
+            "--amount-column",
+            "2",
+            path.to_str().unwrap(),
+        ]);
+        let mut out = Vec::new();
+        run_with_writer(&args, &path, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+
+        assert!(text.contains("Coffee"), "first row not imported: {text}");
+        assert!(text.contains("-5.00"), "first amount missing: {text}");
+        assert!(text.contains("Lunch"), "second row not imported: {text}");
+        assert_eq!(
+            text.matches("2024-01-").count(),
+            2,
+            "both rows should import via positional indices: {text}"
         );
     }
 


### PR DESCRIPTION
Two `rledger extract` (CSV import) bugs found by dogfooding, both silent failures with no Beancount oracle needed.

## Fixes
- **Numeric column flags ignored** (`a282a29f`). `--date-column`/`--narration-column`/`--amount-column`/`--payee-column` are documented as "name or index", and `importers.toml` permits integer columns, but both paths only ever built `ColumnSpec::Name` — so `--date-column 0` was looked up as a header literally named "0" and every row was dropped (`missing date column`). A shared `config::apply_column` helper now treats a bare integer as a 0-based positional index in both the CLI-args and `importers.toml` paths, so headerless CSVs import.
- **CSV header keyword matching too loose** (`5f3533e5`). `--auto` inference matched column-role keywords as substrings, so the short credit/debit tokens `in`/`out` matched inside names like "Running Balance" (the letters "in" in "running"), "Beginning Balance", "Routing", "Interest". With Debit + Credit + Running Balance present, the running-balance column was stolen as the credit column and booked as the amount — Deposit 100 → 1100, Withdraw −40 → 1020 — silently, at "90% confidence". A shared `header_matches()` now requires whole-word (boundary-delimited) matches across the date/amount/debit/credit/payee/narration classifiers; multi-word keywords like "transaction date" still match as phrases.

## Verification
New regression tests: `test_cli_numeric_column_args_extract_by_index` (extract command), `infer_does_not_steal_running_balance_as_credit` (csv-inference). rustledger-importer (133 lib tests) and extract_cmd suites green; clippy clean. The header-row *detection* counter is intentionally left as substring matching (different mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)