### PR TITLE
refactor(extract): harden CSV locale inference (follow-up to #1440)

### DIFF
--- a/crates/rustledger-importer/src/csv_inference.rs
+++ b/crates/rustledger-importer/src/csv_inference.rs
@@ -15,7 +15,12 @@ use format_num_pattern::Locale;
 use crate::config::{ColumnSpec, CsvConfig};
 
 /// Result of CSV format inference.
+///
+/// `#[non_exhaustive]`: constructed only by [`infer_csv_config`]; marked so that
+/// adding inferred fields (as `amount_locale` was) is not a breaking change for
+/// downstream consumers of `rustledger-importer`.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct InferredCsvConfig {
     /// Detected field delimiter.
     pub delimiter: char,
@@ -212,6 +217,14 @@ pub fn infer_csv_config(content: &str) -> Option<InferredCsvConfig> {
 /// followed by 1-2 digits, so a thousands group like `1,234` stays
 /// period-style while a decorated amount like `-54,23€` is still comma-decimal.
 /// Each sampled cell across the amount-bearing columns votes; the majority wins.
+///
+/// # Limitation
+///
+/// Inference needs a comma somewhere in the sample. A comma-decimal export
+/// whose sampled amounts are all period-grouped integers (`1.234` meaning 1234)
+/// carries no distinguishing signal from period-decimal `1.234` (= 1.234), so
+/// it returns `None` and the amounts are read as POSIX. There is no local way to
+/// disambiguate the two; pass `--amount-locale de_DE` for such files.
 fn infer_amount_locale(
     sample: &[&Vec<String>],
     cols: impl Iterator<Item = usize>,

--- a/crates/rustledger-importer/src/csv_inference.rs
+++ b/crates/rustledger-importer/src/csv_inference.rs
@@ -16,9 +16,12 @@ use crate::config::{ColumnSpec, CsvConfig};
 
 /// Result of CSV format inference.
 ///
-/// `#[non_exhaustive]`: constructed only by [`infer_csv_config`]; marked so that
-/// adding inferred fields (as `amount_locale` was) is not a breaking change for
-/// downstream consumers of `rustledger-importer`.
+/// Constructed only by [`infer_csv_config`]. Marked `#[non_exhaustive]` so that
+/// *future* inferred fields can be added without breaking downstream consumers
+/// of `rustledger-importer`. Adding the attribute is itself a one-time breaking
+/// change for any external code that built this struct with a literal or matched
+/// it exhaustively (there is none in this workspace — it is only constructed
+/// here and consumed by field access via [`Self::to_csv_config`]).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct InferredCsvConfig {

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -1,7 +1,6 @@
 //! Importers TOML configuration for extract command.
 
 use anyhow::{Context, Result, anyhow};
-use format_num_pattern::Locale;
 use rustledger_importer::ImporterConfig;
 use rustledger_importer::config::CsvConfigBuilder;
 use serde::Deserialize;
@@ -9,7 +8,6 @@ use std::collections::HashMap;
 use std::path::Path;
 #[cfg(feature = "python-plugin-wasm")]
 use std::path::PathBuf;
-use std::str::FromStr;
 
 /// Top-level importers configuration file.
 #[derive(Debug, Deserialize)]
@@ -253,9 +251,7 @@ pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterC
         builder = builder.credit_column(&col);
     }
     if let Some(ref locale) = entry.amount_locale {
-        let locale =
-            Locale::from_str(locale).map_err(|_| anyhow!("{locale} is not a valid locale"))?;
-        builder = builder.amount_locale(locale);
+        builder = builder.amount_locale(super::parse_amount_locale(locale)?);
     }
     if let Some(ref format) = entry.amount_format {
         builder = builder.amount_format(format);

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -451,6 +451,13 @@ fn build_registry(args: &Args) -> Result<ImporterRegistry> {
     Ok(registry)
 }
 
+/// Parse an `--amount-locale` value (e.g. `de_DE`, `en_US`) into a [`Locale`],
+/// with a consistent error for an unrecognized name. Shared by the `--auto`
+/// and raw-CLI config paths.
+fn parse_amount_locale(name: &str) -> Result<Locale> {
+    Locale::from_str(name).map_err(|_| anyhow!("{name} is not a valid locale"))
+}
+
 /// Run the extract command with the given arguments, writing extracted
 /// directives to stdout.
 ///
@@ -636,9 +643,7 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             // locale (override if given, otherwise the inferred one) so the
             // printed summary matches what's actually used.
             if let Some(locale) = &args.amount_locale {
-                let Ok(locale) = Locale::from_str(locale) else {
-                    return Err(anyhow!("{locale} is not a valid locale"));
-                };
+                let locale = parse_amount_locale(locale)?;
                 csv_config.amount_locale = Some(locale);
                 eprintln!("  amount_locale: {locale:?} (from --amount-locale)");
             } else if let Some(locale) = inferred.amount_locale {
@@ -703,11 +708,7 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             }
 
             if let Some(locale) = &args.amount_locale {
-                let Ok(locale) = Locale::from_str(locale) else {
-                    return Err(anyhow!("{locale} is not a valid locale"));
-                };
-
-                builder = builder.amount_locale(locale);
+                builder = builder.amount_locale(parse_amount_locale(locale)?);
             }
 
             if let Some(format) = &args.amount_format {


### PR DESCRIPTION
Follow-up to #1440 from a deep review. No behavior change for end users; hardening only.

- **Dedupe** the `--amount-locale` parse into a shared `parse_amount_locale` helper. It was duplicated across the `--auto` and raw-CLI config paths with the same `Locale::from_str` + `"{name} is not a valid locale"` error.
- **`#[non_exhaustive]` on `InferredCsvConfig`** so future inferred fields (like `amount_locale` in #1440) aren't a breaking change for downstream consumers of `rustledger-importer` — the semver CI gate only covers `rustledger-plugin-types`, so this API surface was unguarded.
- **Document the inherent-ambiguity limitation** on `infer_amount_locale`: a comma-decimal export whose sampled amounts are all period-grouped integers (`1.234` meaning 1234) carries no signal distinguishing it from period-decimal `1.234`, so it stays POSIX. Escape hatch is `--amount-locale de_DE`. Tracked in #1441.

Related follow-up gaps filed: #1441 (period-grouped-integer ambiguity), #1442 (`looks_like_number` rejects EU amounts ≥ 1,000,000).

Verified: EU `--auto` still infers `de_DE`, the shared helper returns the consistent error, 137 importer tests pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)