### PR TITLE
fix(booking): AVERAGE realizes a single weighted-average pool

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -771,22 +771,41 @@ impl Inventory {
             });
         }
 
-        let cost_basis = average_cost_from_positions(&matching, total_units)?
-            .map(|(avg_cost, currency)| Amount::new(reduction * avg_cost, currency));
+        let avg = average_cost_from_positions(&matching, total_units)?;
+        let cost_basis = avg
+            .as_ref()
+            .map(|(avg_cost, currency)| Amount::new(reduction * *avg_cost, currency.clone()));
 
-        let matched: MatchedLots = matching.into_iter().cloned().collect();
+        // Build a position of `number` units of the reduced currency at the
+        // average cost (or costless if the lots had no cost).
+        let at_avg_cost = |number: Decimal| -> Position {
+            let amount = Amount::new(number, units.currency.clone());
+            match &avg {
+                Some((avg_cost, currency)) => {
+                    Position::with_cost(amount, Cost::new(*avg_cost, currency.clone()))
+                }
+                None => Position::simple(amount),
+            }
+        };
+
+        // A reduction under AVERAGE matches a SINGLE synthetic lot of the
+        // reduced quantity at the average cost, not every underlying lot.
+        // Returning the full lot set made the consumer (book.rs) expand the
+        // reduction into one posting per lot and remove the entire position
+        // (and book a garbage gain). The taken units carry the inventory sign,
+        // matching the FIFO/ordered convention.
+        let matched: MatchedLots = smallvec![at_avg_cost(reduction)];
+
         let new_units = total_units + units.number;
 
         // Remove all positions of this currency
         self.positions
             .retain(|p| p.units.currency != units.currency);
 
-        // Add back the remainder if non-zero
+        // Add back the remainder (if non-zero) at the average cost, so a later
+        // reduction sees the correct basis instead of a costless position.
         if !new_units.is_zero() {
-            self.positions.push_back(Position::simple(Amount::new(
-                new_units,
-                units.currency.clone(),
-            )));
+            self.positions.push_back(at_avg_cost(new_units));
         }
 
         self.rebuild_index();
@@ -795,6 +814,58 @@ impl Inventory {
             matched,
             cost_basis,
         })
+    }
+
+    /// Collapse every cost-bearing lot of each currency into a single
+    /// weighted-average-cost lot. Cost-less (cash) positions are left untouched.
+    ///
+    /// This realizes the balance of an AVERAGE-booked account, where all lots of
+    /// a commodity share one running cost. The journal keeps the real per-lot
+    /// costs; only this realized view merges them (matching hledger's pool
+    /// model). A currency whose lots net to zero is removed; a currency whose
+    /// lots have mismatched cost currencies is left untouched.
+    pub fn merge_average(&mut self) {
+        let currencies: std::collections::BTreeSet<Currency> = self
+            .positions
+            .iter()
+            .filter(|p| p.cost.is_some())
+            .map(|p| p.units.currency.clone())
+            .collect();
+
+        for currency in currencies {
+            let (total_units, avg) = {
+                let matching: Vec<&Position> = self
+                    .positions
+                    .iter()
+                    .filter(|p| p.units.currency == currency && p.cost.is_some())
+                    .collect();
+                let total_units: Decimal = matching.iter().map(|p| p.units.number).sum();
+                let avg = if total_units.is_zero() {
+                    None
+                } else {
+                    average_cost_from_positions(&matching, total_units)
+                        .ok()
+                        .flatten()
+                };
+                (total_units, avg)
+            };
+
+            // Couldn't average a non-zero position (cost-currency mismatch):
+            // leave its lots untouched rather than corrupt them.
+            if !total_units.is_zero() && avg.is_none() {
+                continue;
+            }
+
+            self.positions
+                .retain(|p| !(p.units.currency == currency && p.cost.is_some()));
+            if let Some((avg_cost, cost_currency)) = avg {
+                self.positions.push_back(Position::with_cost(
+                    Amount::new(total_units, currency.clone()),
+                    Cost::new(avg_cost, cost_currency),
+                ));
+            }
+        }
+        self.rebuild_index();
     }
 
     /// Cost merge `{*}`: merge all lots of the currency into a single
@@ -1372,6 +1443,89 @@ mod reduction_tests {
             )
             .unwrap();
         assert_eq!(r.cost_basis.unwrap().number, dec!(500)); // only the STK lot
+    }
+
+    #[test]
+    fn reduce_average_partial_multi_lot_matches_single_synthetic_lot() {
+        // Regression: a partial AVERAGE sale across multiple lots matches a
+        // SINGLE synthetic lot of the reduced quantity at the average cost, not
+        // every underlying lot. Returning the full lot set made the consumer
+        // (book.rs) expand the reduction into one posting per lot, emptying the
+        // position and booking a garbage gain.
+        let mut i = Inventory::new();
+        i.add(lot(10, 150, 1));
+        i.add(lot(10, 170, 2));
+        let r = i
+            .reduce(
+                &sell_stk(5),
+                Some(&CostSpec::default()),
+                BookingMethod::Average,
+            )
+            .unwrap();
+
+        // One synthetic matched lot at the average cost {160}; basis 5*160=800.
+        assert_eq!(r.matched.len(), 1);
+        assert_eq!(r.cost_basis.as_ref().unwrap().number, dec!(800));
+        assert_eq!(r.matched[0].cost.as_ref().unwrap().number, dec!(160));
+
+        // 15 STK remain as a single lot carrying the average cost {160}.
+        assert_eq!(i.units("STK"), dec!(15));
+        let remaining: Vec<&Position> = i
+            .positions()
+            .filter(|p| p.units.currency == "STK")
+            .collect();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].cost.as_ref().unwrap().number, dec!(160));
+    }
+
+    #[test]
+    fn merge_average_collapses_lots_to_single_weighted_lot() {
+        // The realized balance of an AVERAGE account is one pool at the
+        // weighted-average cost: (10*150 + 10*170 - 5*160) / 15 = 160.
+        let mut i = Inventory::new();
+        i.add(lot(10, 150, 1));
+        i.add(lot(10, 170, 2));
+        i.add(Position::with_cost(
+            Amount::new(dec!(-5), "STK"),
+            Cost::new(dec!(160), "USD"),
+        ));
+        i.merge_average();
+        let stk: Vec<&Position> = i
+            .positions()
+            .filter(|p| p.units.currency == "STK")
+            .collect();
+        assert_eq!(stk.len(), 1);
+        assert_eq!(stk[0].units.number, dec!(15));
+        assert_eq!(stk[0].cost.as_ref().unwrap().number, dec!(160));
+    }
+
+    #[test]
+    fn merge_average_net_zero_removes_lots() {
+        let mut i = Inventory::new();
+        i.add(lot(10, 150, 1));
+        i.add(Position::with_cost(
+            Amount::new(dec!(-10), "STK"),
+            Cost::new(dec!(160), "USD"),
+        ));
+        i.merge_average();
+        assert_eq!(
+            i.positions().filter(|p| p.units.currency == "STK").count(),
+            0
+        );
+    }
+
+    #[test]
+    fn merge_average_leaves_costless_positions_untouched() {
+        let mut i = Inventory::new();
+        i.add(Position::simple(Amount::new(dec!(100), "USD")));
+        i.add(lot(10, 150, 1));
+        i.merge_average();
+        // Cash stays; the single STK lot stays a single lot.
+        assert_eq!(i.units("USD"), dec!(100));
+        assert_eq!(
+            i.positions().filter(|p| p.units.currency == "STK").count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -792,9 +792,10 @@ impl Inventory {
         // reduced quantity at the average cost, not every underlying lot.
         // Returning the full lot set made the consumer (book.rs) expand the
         // reduction into one posting per lot and remove the entire position
-        // (and book a garbage gain). The taken units carry the inventory sign,
-        // matching the FIFO/ordered convention.
-        let matched: MatchedLots = smallvec![at_avg_cost(reduction)];
+        // (and book a garbage gain). The taken units carry the *inventory* sign
+        // (`total_units.signum()`), matching the FIFO/ordered convention — so
+        // covering a short (negative pool) yields a negative matched lot.
+        let matched: MatchedLots = smallvec![at_avg_cost(reduction * total_units.signum())];
 
         let new_units = total_units + units.number;
 
@@ -1464,9 +1465,11 @@ mod reduction_tests {
             .unwrap();
 
         // One synthetic matched lot at the average cost {160}; basis 5*160=800.
+        // Long pool: the matched lot carries the inventory (positive) sign.
         assert_eq!(r.matched.len(), 1);
         assert_eq!(r.cost_basis.as_ref().unwrap().number, dec!(800));
         assert_eq!(r.matched[0].cost.as_ref().unwrap().number, dec!(160));
+        assert_eq!(r.matched[0].units.number, dec!(5));
 
         // 15 STK remain as a single lot carrying the average cost {160}.
         assert_eq!(i.units("STK"), dec!(15));
@@ -1476,6 +1479,28 @@ mod reduction_tests {
             .collect();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].cost.as_ref().unwrap().number, dec!(160));
+    }
+
+    #[test]
+    fn reduce_average_short_cover_matched_lot_carries_inventory_sign() {
+        // Covering a short (positive units reducing a negative pool) must return
+        // a matched lot with the inventory (negative) sign, like FIFO/ordered.
+        let mut i = Inventory::new();
+        i.add(Position::with_cost(
+            Amount::new(dec!(-10), "STK"),
+            Cost::new(dec!(150), "USD"),
+        ));
+        let r = i
+            .reduce(
+                &Amount::new(dec!(5), "STK"),
+                Some(&CostSpec::default()),
+                BookingMethod::Average,
+            )
+            .unwrap();
+        assert_eq!(r.matched.len(), 1);
+        assert_eq!(r.matched[0].units.number, dec!(-5));
+        // Short pool shrinks from -10 to -5.
+        assert_eq!(i.units("STK"), dec!(-5));
     }
 
     #[test]

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -232,6 +232,30 @@ impl<'a> Executor<'a> {
         }
         Ok(row)
     }
+
+    /// True when every posting in `group` belongs to a single account that is
+    /// AVERAGE-booked. Such a group's summed inventory should be realized as one
+    /// weighted-average pool (`Inventory::merge_average`). Returns false for
+    /// empty/mixed-account groups, so non-aggregated-by-account sums are
+    /// unaffected.
+    fn group_is_single_average_account(&self, group: &[&PostingContext]) -> bool {
+        let mut account: Option<&str> = None;
+        for ctx in group {
+            let a = ctx.transaction.postings[ctx.posting_index].account.as_str();
+            match account {
+                None => account = Some(a),
+                Some(prev) if prev != a => return false,
+                _ => {}
+            }
+        }
+        account.is_some_and(|a| {
+            self.account_info
+                .get(a)
+                .and_then(|info| info.booking.as_deref())
+                .is_some_and(|b| b.eq_ignore_ascii_case("AVERAGE"))
+        })
+    }
+
     pub(super) fn evaluate_aggregate_expr(
         &self,
         expr: &Expr,
@@ -301,6 +325,13 @@ impl<'a> Executor<'a> {
                                     total_number,
                                     "__NUMBER__".to_string(),
                                 )));
+                            }
+                            // Realize an AVERAGE-booked account as a single
+                            // weighted-average pool: the journal keeps the real
+                            // per-lot costs, but the account's balance merges
+                            // them (matching its booking method).
+                            if self.group_is_single_average_account(group) {
+                                total_inventory.merge_average();
                             }
                             Ok(Value::Inventory(Box::new(total_inventory)))
                         } else if has_numbers {

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHashMap;
 
 use regex::{Regex, RegexBuilder};
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, Directive, Inventory, Metadata, NaiveDate, Position};
+use rustledger_core::{Amount, Directive, Inventory, NaiveDate, Position};
 #[cfg(test)]
 use rustledger_core::{MetaValue, Transaction};
 use rustledger_loader::SourceMap;
@@ -127,21 +127,14 @@ impl<'a> Executor<'a> {
             match directive {
                 Directive::Open(open) => {
                     let account = open.account.to_string();
-                    let info = account_info.entry(account).or_insert_with(|| AccountInfo {
-                        open_date: None,
-                        close_date: None,
-                        open_meta: Metadata::default(),
-                    });
+                    let info = account_info.entry(account).or_default();
                     info.open_date = Some(open.date);
                     info.open_meta.clone_from(&open.meta);
+                    info.booking.clone_from(&open.booking);
                 }
                 Directive::Close(close) => {
                     let account = close.account.to_string();
-                    let info = account_info.entry(account).or_insert_with(|| AccountInfo {
-                        open_date: None,
-                        close_date: None,
-                        open_meta: Metadata::default(),
-                    });
+                    let info = account_info.entry(account).or_default();
                     info.close_date = Some(close.date);
                 }
                 _ => {}
@@ -210,21 +203,14 @@ impl<'a> Executor<'a> {
             match &spanned.value {
                 Directive::Open(open) => {
                     let account = open.account.to_string();
-                    let info = account_info.entry(account).or_insert_with(|| AccountInfo {
-                        open_date: None,
-                        close_date: None,
-                        open_meta: Metadata::default(),
-                    });
+                    let info = account_info.entry(account).or_default();
                     info.open_date = Some(open.date);
                     info.open_meta.clone_from(&open.meta);
+                    info.booking.clone_from(&open.booking);
                 }
                 Directive::Close(close) => {
                     let account = close.account.to_string();
-                    let info = account_info.entry(account).or_insert_with(|| AccountInfo {
-                        open_date: None,
-                        close_date: None,
-                        open_meta: Metadata::default(),
-                    });
+                    let info = account_info.entry(account).or_default();
                     info.close_date = Some(close.date);
                 }
                 _ => {}
@@ -2811,6 +2797,7 @@ mod tests {
     use super::*;
     use crate::parse;
     use rust_decimal_macros::dec;
+    use rustledger_core::Metadata;
     use rustledger_core::Posting;
 
     fn date(year: i32, month: u32, day: u32) -> NaiveDate {

--- a/crates/rustledger-query/src/executor/types.rs
+++ b/crates/rustledger-query/src/executor/types.rs
@@ -399,7 +399,7 @@ pub struct WindowContext {
 }
 
 /// Account information cached from Open/Close directives.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AccountInfo {
     /// Date the account was opened.
     pub open_date: Option<NaiveDate>,
@@ -407,6 +407,10 @@ pub struct AccountInfo {
     pub close_date: Option<NaiveDate>,
     /// Metadata from the Open directive.
     pub open_meta: Metadata,
+    /// Booking method string from the Open directive (e.g. `"AVERAGE"`), if any.
+    /// Stored raw to avoid coupling the query crate to the booking-method enum;
+    /// used to realize AVERAGE accounts as a single weighted-average pool.
+    pub booking: Option<String>,
 }
 
 /// An in-memory table created by CREATE TABLE.

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -699,6 +699,72 @@ fn test_journal_position_column_preserves_cost() {
     assert_eq!(cost.currency.as_str(), "USD");
 }
 
+#[test]
+fn test_average_account_sum_position_merges_to_single_pool() {
+    // An AVERAGE-booked account realizes its balance as one weighted-average
+    // pool: 10 AAPL {150} + 10 AAPL {170} -> 20 AAPL {160}. A FIFO account keeps
+    // the separate lots. The journal keeps the real per-lot costs either way.
+    fn buy(account: &str, qty: i64, price: i64) -> Posting {
+        Posting::new(
+            account,
+            Amount::new(rust_decimal::Decimal::from(qty), "AAPL"),
+        )
+        .with_cost(
+            CostSpec::empty()
+                .with_number(rustledger_core::CostNumber::PerUnit {
+                    value: rust_decimal::Decimal::from(price),
+                })
+                .with_currency("USD"),
+        )
+    }
+    fn ledger(booking: &str) -> Vec<Directive> {
+        let mut open = Open::new(date(2024, 1, 1), "Assets:B");
+        open.booking = Some(booking.to_string());
+        vec![
+            Directive::Open(open),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 2, 1), "b1")
+                    .with_synthesized_posting(buy("Assets:B", 10, 150))
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-1500), "USD"),
+                    )),
+            ),
+            Directive::Transaction(
+                Transaction::new(date(2024, 3, 1), "b2")
+                    .with_synthesized_posting(buy("Assets:B", 10, 170))
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Cash",
+                        Amount::new(dec!(-1700), "USD"),
+                    )),
+            ),
+        ]
+    }
+    let q = "SELECT account, sum(position) WHERE account = 'Assets:B' GROUP BY account";
+
+    let avg = execute_query(q, &ledger("AVERAGE"));
+    let inv = match &avg.rows[0][1] {
+        Value::Inventory(i) => i,
+        other => panic!("expected inventory, got {other:?}"),
+    };
+    let lots: Vec<_> = inv.positions().collect();
+    assert_eq!(
+        lots.len(),
+        1,
+        "AVERAGE must merge to one pool, got {lots:?}"
+    );
+    assert_eq!(lots[0].units.number, dec!(20));
+    assert_eq!(lots[0].cost.as_ref().unwrap().number, dec!(160));
+
+    let fifo = execute_query(q, &ledger("FIFO"));
+    let inv = match &fifo.rows[0][1] {
+        Value::Inventory(i) => i,
+        other => panic!("expected inventory, got {other:?}"),
+    };
+    assert_eq!(inv.positions().count(), 2, "FIFO must keep separate lots");
+}
+
 /// Regression test for #955 deep review: `JOURNAL ... FROM <filter>` should
 /// only count postings from transactions that pass the FROM filter into the
 /// cumulative balance. A wildcard `JOURNAL "Assets"` over a ledger with two

--- a/docs/reference/adr/0007-average-booking-realization.md
+++ b/docs/reference/adr/0007-average-booking-realization.md
@@ -1,0 +1,78 @@
+# ADR-0007: AVERAGE booking realizes a single weighted-average pool
+
+## Status
+
+Accepted
+
+## Context
+
+Rustledger supports an `AVERAGE` booking method on accounts (`open ... "AVERAGE"`)
+— a weighted-average-cost (WAC) model where all lots of a commodity share one
+running cost. Python Beancount notably does *not* implement AVERAGE (it errors
+with "AVERAGE method is not supported"), so there is no upstream oracle.
+
+The original implementation was broken in two ways, found by dogfooding:
+
+- A partial sale across multiple lots returned **every** matched lot from
+  `reduce_average`, which the booking consumer (`book.rs`) expanded into one
+  reduction posting per lot — silently **emptying the whole position** and
+  booking a garbage capital gain.
+- The account balance showed each purchase lot separately
+  (`10 {150}  10 {170}  -5 {160}`) instead of a single pool.
+
+We surveyed how WAC is actually modeled — hledger `SPEC-lots`, Beancount PR #591
+("AVERAGE booking ≡ `{*}` lot merging"), GnuCash "scrub by average cost",
+ERPNext / Odoo (AVCO), QuickBooks Desktop. **They are unanimous: AVERAGE is a
+single running weighted-average pool**, recomputed on each acquisition; a sale
+draws COGS at the current average and leaves the average unchanged. Keeping
+separate lots is the FIFO / specific-identification model, not average.
+
+Two design risks that make AVERAGE "rare in PTA" were investigated and found not
+to apply to rustledger:
+
+- **Rolling-state balance assertions.** Editing a past transaction shifts the
+  running average for every later one, which would make cost-bearing balance
+  assertions history-dependent. Rustledger's `balance` assertions are
+  **quantity-only** (they ignore the `{cost}` annotation today), so there is no
+  rolling-state interaction to manage.
+- **Decimal precision.** Repeating-decimal averages (e.g. `2450/15 = 163.333…`)
+  compute exactly under `rust_decimal` (28 digits); gains were already correct
+  to full precision.
+
+## Decision
+
+Model an `AVERAGE` account as **one weighted-average pool**, realized at the
+balance, while the **journal keeps the real per-lot purchase costs** (matching
+hledger: the pool is rewritten, the journal is not).
+
+- `Inventory::reduce_average` returns a **single synthetic matched lot** of the
+  reduced quantity at the average cost, and keeps the average cost on the
+  remainder.
+- `Inventory::merge_average` collapses all cost-bearing lots of a currency into
+  one weighted-average lot (`Σ(units·cost) / Σ units`); cost-less (cash)
+  positions and net-zero currencies are handled cleanly.
+- The query **realizes** an AVERAGE account as a single pool: the query
+  `AccountInfo` carries the account's booking method, and `sum(position)` over a
+  group whose postings all belong to one AVERAGE account calls `merge_average`.
+  FIFO / LIFO / STRICT / HIFO / NONE accounts are unaffected.
+
+## Consequences
+
+- The realized balance of an AVERAGE account is a single `N COMM {avg}` lot, as
+  every other WAC implementation produces. Capital gains use the running
+  average.
+- The journal (`JOURNAL`, the raw postings) still shows the true acquisition
+  costs, preserving the audit trail. Only aggregated balances merge.
+- The realization merge is applied in the per-account aggregation path. A bare
+  `sum(position)` that spans *multiple* accounts is left unmerged (merging across
+  accounts is ill-defined); this is a documented seam, not a correctness issue.
+- Because `balance` assertions are quantity-only, AVERAGE introduces no
+  rolling-state assertion problems. If cost-aware balance assertions are added
+  later, their interaction with the rolling average must be revisited.
+
+## Prior art
+
+- hledger `SPEC-lots` — single running pool; pool cost rewritten on acquisition.
+- Beancount PR #591 / issue #213 — AVERAGE ≡ automatic `{*}` lot merging.
+- GnuCash average-cost scrub; ERPNext Moving Average; Odoo AVCO; QuickBooks
+  Desktop average costing.

--- a/docs/reference/adr/index.md
+++ b/docs/reference/adr/index.md
@@ -16,6 +16,7 @@ ADRs document significant architectural decisions made during rustledger develop
 | [ADR-0004](0004-ts-types-from-rust-dtos.md) | Generate wire-format bindings from Rust DTOs | Accepted (Phase 1 + 2 + 3) |
 | [ADR-0005](0005-cst-conversion-performance.md) | CST Conversion Performance (parse cache; green-tree declined) | Accepted |
 | [ADR-0006](0006-wit-component-model-embedding.md) | WIT / Component-Model embedding contract | Proposed |
+| [ADR-0007](0007-average-booking-realization.md) | AVERAGE booking realizes a single weighted-average pool | Accepted |
 
 ## About ADRs
 


### PR DESCRIPTION
Found by dogfooding. A partial sale under the `AVERAGE` booking method silently **emptied the whole position** and booked a garbage capital gain, and the balance showed every purchase lot separately instead of one pool. Closes #2 (dogfooding tracker).

## Approach (grounded in prior art)
Beancount doesn't implement AVERAGE, so there's no upstream oracle. I surveyed how weighted-average cost is actually modeled — **hledger `SPEC-lots`, beancount PR #591, GnuCash, ERPNext/Odoo AVCO, QuickBooks Desktop** — and they're unanimous: AVERAGE is a **single running weighted-average pool**, not separate lots. The design and rationale are recorded in **ADR-0007**.

## Changes
- `Inventory::reduce_average` returns a **single synthetic matched lot** of the reduced quantity at the average cost (it was returning every lot, which `book.rs` expanded into one reduction posting per lot → emptied the position). The remainder keeps the average cost.
- New `Inventory::merge_average` collapses a currency's cost lots into one weighted-average lot.
- The query **realizes** an AVERAGE account as one pool: `AccountInfo` carries the account's booking method, and `sum(position)` over a single AVERAGE account merges the lots. **The journal keeps the real per-lot costs; only the balance merges** (hledger's model). FIFO/LIFO/STRICT/HIFO/NONE are unaffected.

## Verification
Validated against a weighted-average-cost reference oracle:

| Scenario | Pool | Gain |
|---|---|---|
| partial sell (10@150, 10@170, sell 5) | `15 {160}` | −200 |
| sell-all | `0` | −800 |
| interleaved buy/sell/buy/sell | `10 {163.33}` | −258.33 |

All exact. FIFO accounts still show separate lots.

Two usual AVERAGE pitfalls were investigated and **don't apply** here (see ADR): `balance` assertions are quantity-only (no rolling-state issue), and gains compute exactly under `rust_decimal`.

## Tests
`merge_average` (3 unit tests), `reduce_average_partial_multi_lot_matches_single_synthetic_lot`, and a query integration test (`test_average_account_sum_position_merges_to_single_pool` — AVERAGE merges, FIFO doesn't). Full `rustledger-core` (406+, incl. `prop_average_*` property tests) and `rustledger-query` (142 + 380) suites green; clippy clean.

This touches the core booking engine, so it warrants the compat-suite + booking scrutiny in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)