### PR TITLE
fix(check): match bean-check on close-with-balance; move advisory to lint

### DIFF
--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -175,6 +175,16 @@ impl ErrorCode {
     }
 }
 
+/// Whether a rendered diagnostic code string (e.g. `"E1004"`) is advisory-only.
+///
+/// The string-keyed counterpart to [`ErrorCode::is_advisory_only`], for
+/// consumers (the CLI `check`/`lint` split) that only carry the code string.
+/// Keeping it here means the set of advisory-only codes lives in one place.
+#[must_use]
+pub fn is_advisory_only_code(code: &str) -> bool {
+    code == ErrorCode::AccountCloseNotEmpty.code()
+}
+
 /// Severity level for validation messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Severity {

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -139,6 +139,15 @@ impl ErrorCode {
         matches!(self, Self::DateOutOfOrder)
     }
 
+    /// Whether this diagnostic is advisory-only and must NOT be surfaced by
+    /// `check` (which mirrors `bean-check`). Python beancount does not flag
+    /// closing an account with a residual balance, so `check` stays silent; the
+    /// advisory is surfaced instead by `rledger lint closed-nonempty`.
+    #[must_use]
+    pub const fn is_advisory_only(&self) -> bool {
+        matches!(self, Self::AccountCloseNotEmpty)
+    }
+
     /// Get the severity level.
     #[must_use]
     pub const fn severity(&self) -> Severity {

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -47,7 +47,7 @@
 mod error;
 mod validators;
 
-pub use error::{ErrorCode, Severity, ValidationError};
+pub use error::{ErrorCode, Severity, ValidationError, is_advisory_only_code};
 pub use validators::balance::balance_tolerance;
 
 /// Which phase of two-phase validation to run.

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -6,6 +6,15 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use rustledger_core::Directive;
 use rustledger_loader::LoadError;
+
+/// True for validate codes that are advisory-only: produced by validation and
+/// reported by `rledger lint`, but NOT surfaced by `check` (which mirrors
+/// `bean-check`). Keep in sync with `rustledger_validate::ErrorCode::is_advisory_only`.
+fn is_advisory_only_code(code: &str) -> bool {
+    // E1004 = AccountCloseNotEmpty (close with a residual balance). Python
+    // beancount does not flag this.
+    code == "E1004"
+}
 #[cfg(feature = "python-plugin-wasm")]
 use rustledger_plugin::PluginManager;
 #[cfg(feature = "python-plugin-wasm")]
@@ -508,6 +517,13 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
     // Convert process errors to diagnostics, using the phase field to
     // split into parse/validate/plugin categories.
     for err in &ledger.errors {
+        // Advisory-only diagnostics are not surfaced by `check`, which mirrors
+        // `bean-check`: Python beancount does not flag closing an account with a
+        // residual balance (E1004). They are reported by `rledger lint
+        // closed-nonempty` instead.
+        if is_advisory_only_code(&err.code) {
+            continue;
+        }
         let severity_str = match err.severity {
             rustledger_loader::ErrorSeverity::Error => "error",
             rustledger_loader::ErrorSeverity::Warning => "warning",
@@ -567,7 +583,10 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
     let warning_count = ledger
         .errors
         .iter()
-        .filter(|e| matches!(e.severity, rustledger_loader::ErrorSeverity::Warning))
+        .filter(|e| {
+            matches!(e.severity, rustledger_loader::ErrorSeverity::Warning)
+                && !is_advisory_only_code(&e.code)
+        })
         .count();
     #[cfg(feature = "python-plugin-wasm")]
     let mut warning_count = warning_count;

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -6,19 +6,14 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use rustledger_core::Directive;
 use rustledger_loader::LoadError;
-
-/// True for validate codes that are advisory-only: produced by validation and
-/// reported by `rledger lint`, but NOT surfaced by `check` (which mirrors
-/// `bean-check`). Keep in sync with `rustledger_validate::ErrorCode::is_advisory_only`.
-fn is_advisory_only_code(code: &str) -> bool {
-    // E1004 = AccountCloseNotEmpty (close with a residual balance). Python
-    // beancount does not flag this.
-    code == "E1004"
-}
 #[cfg(feature = "python-plugin-wasm")]
 use rustledger_plugin::PluginManager;
 #[cfg(feature = "python-plugin-wasm")]
 use rustledger_plugin::{PluginInput, PluginOptions};
+// The canonical advisory-only predicate lives in `rustledger-validate` so that
+// `check` (which hides these, mirroring bean-check) and `lint` share one source
+// of truth for which codes are advisory.
+use rustledger_validate::is_advisory_only_code;
 use serde::Serialize;
 use std::io::{self, Write};
 use std::path::PathBuf;

--- a/crates/rustledger/src/cmd/lint/closed_nonempty.rs
+++ b/crates/rustledger/src/cmd/lint/closed_nonempty.rs
@@ -17,13 +17,14 @@
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use rustledger_loader::{LoadOptions, Loader};
+use rustledger_validate::ErrorCode;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-/// Validate code for "account closed with a non-zero balance"
-/// (`rustledger_validate::ErrorCode::AccountCloseNotEmpty`).
-const CLOSE_NONEMPTY_CODE: &str = "E1004";
+/// Validate code for "account closed with a non-zero balance", sourced from the
+/// canonical [`ErrorCode`] so it can't drift from the enum.
+const CLOSE_NONEMPTY_CODE: &str = ErrorCode::AccountCloseNotEmpty.code();
 
 /// Output format for the report.
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -91,11 +92,25 @@ pub fn run_with_writer<W: std::io::Write>(args: &Args, out: &mut W) -> Result<Ex
         ..Default::default()
     };
     for path in &args.files {
-        let mut load_result = Loader::new()
+        let load_result = Loader::new()
             .load(path)
             .with_context(|| format!("failed to load {}", path.display()))?;
-        // `process` re-reports load errors; we only want the validate advisory.
-        load_result.errors.clear();
+        // The Loader surfaces parse/include errors in `errors` rather than
+        // returning `Err`. We can't reliably analyze account closes in a file
+        // that didn't parse, so fail loudly instead of reporting a misleading
+        // "no accounts closed with a non-zero balance" for invalid input.
+        if !load_result.errors.is_empty() {
+            let joined = load_result
+                .errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("; ");
+            anyhow::bail!(
+                "{}: cannot lint a file with load errors: {joined}",
+                path.display()
+            );
+        }
         let ledger = rustledger_loader::process(load_result, &options)
             .with_context(|| format!("failed to process {}", path.display()))?;
         for err in &ledger.errors {
@@ -193,6 +208,27 @@ mod tests {
         assert!(
             out.contains("No accounts closed with a non-zero balance"),
             "expected no findings for a zero-balance close, got: {out}"
+        );
+    }
+
+    #[test]
+    fn errors_on_file_with_load_errors() {
+        // A missing include surfaces as a load error; the lint must fail loudly
+        // rather than silently report "no accounts" on a file it couldn't load.
+        let mut file = tempfile::Builder::new()
+            .suffix(".beancount")
+            .tempfile()
+            .unwrap();
+        file.write_all(b"include \"definitely-missing-xyz.beancount\"\n")
+            .unwrap();
+        let args = Args {
+            files: vec![file.path().to_path_buf()],
+            format: OutputFormat::Text,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(
+            run_with_writer(&args, &mut buf).is_err(),
+            "expected a hard error when the file has load errors"
         );
     }
 }

--- a/crates/rustledger/src/cmd/lint/closed_nonempty.rs
+++ b/crates/rustledger/src/cmd/lint/closed_nonempty.rs
@@ -1,0 +1,198 @@
+//! `rledger lint closed-nonempty` — report accounts that are closed while
+//! still holding a non-zero balance.
+//!
+//! Python beancount's `bean-check` does NOT flag this: closing an account
+//! merely records that it is inactive from that date and does not require a
+//! zero balance. So `rledger check` stays silent to match it (the underlying
+//! validate diagnostic `E1004` / `AccountCloseNotEmpty` is marked
+//! `rustledger_validate::ErrorCode::is_advisory_only`). This lint surfaces the
+//! same advisory for users who want it — closing an account with a residual
+//! balance is frequently a bookkeeping mistake (the balance is usually
+//! transferred out first).
+//!
+//! This is a lint, not a check: finding accounts is not a failure, so the exit
+//! code is `0` whether or not any are reported. Hard errors (missing file,
+//! parse failure) propagate via `anyhow::Error`.
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use rustledger_loader::{LoadOptions, Loader};
+use serde::Serialize;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+/// Validate code for "account closed with a non-zero balance"
+/// (`rustledger_validate::ErrorCode::AccountCloseNotEmpty`).
+const CLOSE_NONEMPTY_CODE: &str = "E1004";
+
+/// Output format for the report.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable text (default).
+    #[default]
+    Text,
+    /// JSON: a single object with a `findings` array.
+    Json,
+}
+
+/// Report accounts that are closed while still holding a non-zero balance.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Beancount files to scan. At least one is required.
+    #[arg(value_name = "FILE", required = true)]
+    pub files: Vec<PathBuf>,
+
+    /// Output format.
+    #[arg(long, short = 'f', value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+/// One reported account close with a residual balance.
+#[derive(Serialize)]
+struct Finding {
+    /// Source file the `close` directive lives in, if known.
+    file: Option<String>,
+    /// 1-based line of the `close` directive, if known.
+    line: Option<usize>,
+    /// The advisory message (account + residual positions).
+    message: String,
+}
+
+/// The JSON report shape.
+#[derive(Serialize)]
+struct Report {
+    findings: Vec<Finding>,
+}
+
+/// Run the lint, writing its report to stdout.
+///
+/// # Errors
+/// Fails if any input file does not exist or cannot be parsed/processed.
+pub fn run(args: &Args) -> Result<ExitCode> {
+    let mut stdout = std::io::stdout().lock();
+    run_with_writer(args, &mut stdout)
+}
+
+/// Run the lint, writing the text/JSON report to `out`.
+///
+/// Reuses the canonical load+book+validate pipeline (`process` with
+/// `validate: true`) so detection stays identical to what `check` computes —
+/// the only difference is that `check` filters this advisory out while this
+/// lint keeps only it.
+///
+/// # Errors
+/// Fails if any input file does not exist or cannot be parsed/processed.
+pub fn run_with_writer<W: std::io::Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
+    let mut findings = Vec::new();
+    let options = LoadOptions {
+        run_plugins: true,
+        validate: true,
+        ..Default::default()
+    };
+    for path in &args.files {
+        let mut load_result = Loader::new()
+            .load(path)
+            .with_context(|| format!("failed to load {}", path.display()))?;
+        // `process` re-reports load errors; we only want the validate advisory.
+        load_result.errors.clear();
+        let ledger = rustledger_loader::process(load_result, &options)
+            .with_context(|| format!("failed to process {}", path.display()))?;
+        for err in &ledger.errors {
+            if err.code == CLOSE_NONEMPTY_CODE {
+                findings.push(Finding {
+                    file: err.location.as_ref().map(|l| l.file.display().to_string()),
+                    line: err.location.as_ref().map(|l| l.line),
+                    message: err.message.clone(),
+                });
+            }
+        }
+    }
+
+    match args.format {
+        OutputFormat::Text => {
+            if findings.is_empty() {
+                writeln!(out, "No accounts closed with a non-zero balance.")?;
+            } else {
+                for f in &findings {
+                    let loc = match (&f.file, f.line) {
+                        (Some(file), Some(line)) => format!("{file}:{line}"),
+                        (Some(file), None) => file.clone(),
+                        _ => "<unknown>".to_string(),
+                    };
+                    writeln!(out, "{loc}: {}", f.message)?;
+                }
+                writeln!(
+                    out,
+                    "\n{} account(s) closed with a non-zero balance.",
+                    findings.len()
+                )?;
+            }
+        }
+        OutputFormat::Json => {
+            let report = Report { findings };
+            writeln!(out, "{}", serde_json::to_string_pretty(&report)?)?;
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn lint_text(content: &str) -> String {
+        let mut file = tempfile::Builder::new()
+            .suffix(".beancount")
+            .tempfile()
+            .unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        let args = Args {
+            files: vec![file.path().to_path_buf()],
+            format: OutputFormat::Text,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        run_with_writer(&args, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn reports_account_closed_with_balance() {
+        let out = lint_text(concat!(
+            "2024-01-01 open Assets:Cash\n",
+            "2024-01-01 open Equity:Opening-Balances\n",
+            "2024-01-02 * \"deposit\"\n",
+            "  Assets:Cash   100.00 USD\n",
+            "  Equity:Opening-Balances\n",
+            "2024-12-31 close Assets:Cash\n",
+        ));
+        assert!(
+            out.contains("Assets:Cash"),
+            "expected the closed account to be reported, got: {out}"
+        );
+        assert!(
+            out.contains("1 account(s)"),
+            "expected a one-account summary, got: {out}"
+        );
+    }
+
+    #[test]
+    fn silent_when_account_closed_empty() {
+        let out = lint_text(concat!(
+            "2024-01-01 open Assets:Cash\n",
+            "2024-01-01 open Equity:Opening-Balances\n",
+            "2024-01-02 * \"deposit\"\n",
+            "  Assets:Cash   100.00 USD\n",
+            "  Equity:Opening-Balances\n",
+            "2024-06-01 * \"withdraw all\"\n",
+            "  Assets:Cash  -100.00 USD\n",
+            "  Equity:Opening-Balances\n",
+            "2024-12-31 close Assets:Cash\n",
+        ));
+        assert!(
+            out.contains("No accounts closed with a non-zero balance"),
+            "expected no findings for a zero-balance close, got: {out}"
+        );
+    }
+}

--- a/crates/rustledger/src/cmd/lint/mod.rs
+++ b/crates/rustledger/src/cmd/lint/mod.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 
+pub mod closed_nonempty;
 pub mod transfers;
 
 /// Run non-fatal advisory passes over one or more beancount files.
@@ -25,6 +26,11 @@ pub struct Args {
 pub enum LintKind {
     /// Detect inter-account transfer pairs.
     Transfers(transfers::Args),
+    /// Report accounts closed while still holding a non-zero balance.
+    ///
+    /// `check` stays silent on this to match `bean-check`; this lint is the
+    /// place the advisory lives.
+    ClosedNonempty(closed_nonempty::Args),
 }
 
 /// Dispatch to the requested lint, writing its report to stdout.
@@ -34,6 +40,7 @@ pub enum LintKind {
 pub fn run(args: &Args) -> Result<ExitCode> {
     match &args.lint {
         LintKind::Transfers(t_args) => transfers::run(t_args),
+        LintKind::ClosedNonempty(c_args) => closed_nonempty::run(c_args),
     }
 }
 
@@ -47,5 +54,6 @@ pub fn run(args: &Args) -> Result<ExitCode> {
 pub fn run_with_writer<W: std::io::Write>(args: &Args, out: &mut W) -> Result<ExitCode> {
     match &args.lint {
         LintKind::Transfers(t_args) => transfers::run_with_writer(t_args, out),
+        LintKind::ClosedNonempty(c_args) => closed_nonempty::run_with_writer(c_args, out),
     }
 }

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_json.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_json.snap
@@ -3,21 +3,9 @@ source: crates/rustledger/tests/cli_snapshot_test.rs
 expression: pretty
 ---
 {
-  "diagnostics": [
-    {
-      "code": "E1004",
-      "column": 1,
-      "end_column": 1,
-      "end_line": 79,
-      "file": "<fixtures>/valid-ledger.beancount",
-      "line": 78,
-      "message": "Cannot close account Assets:Bank:Savings with non-zero balance",
-      "phase": "validate",
-      "severity": "warning"
-    }
-  ],
+  "diagnostics": [],
   "error_count": 0,
   "parse_error_count": 0,
   "validate_error_count": 0,
-  "warning_count": 1
+  "warning_count": 0
 }

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_text.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_clean_text.snap
@@ -2,13 +2,4 @@
 source: crates/rustledger/tests/cli_snapshot_test.rs
 expression: normalized.trim()
 ---
-E1004
-
-  ! Cannot close account Assets:Bank:Savings with non-zero balance
-    ,-[<fixtures>/valid-ledger.beancount:78:1]
- 77 | ; Close an account
- 78 | 2020-12-31 close Assets:Bank:Savings
-    : ^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^
-    :                   `-- here
-    `----
-⚠ 1 warning
+✓ No errors found


### PR DESCRIPTION
## What

`rledger check` emitted **E1004 / AccountCloseNotEmpty** when an account was closed while still holding a non-zero balance. Python beancount's `bean-check` (3.2.3) never emits this — `close` records that an account is inactive from a date; it does not require a zero balance. So `check` was stricter than beancount on valid input, including our own `valid-ledger.beancount` fixture (which the `check_clean` snapshot test was asserting *with* a warning).

Per the **Python Compatibility Policy** (`check` mirrors `bean-check`), this moves the advisory out of `check` into a dedicated lint rather than dropping it — the "you closed an account with money still in it" nudge is genuinely useful, just not a `check`-level concern.

## How

- `ErrorCode::is_advisory_only()` marks **E1004** as advisory-only.
- `check` skips advisory-only codes in both its rendered report and its warning count (`is_advisory_only_code`), so `valid-ledger.beancount` now checks clean — matching `bean-check`.
- The detection is **unchanged** in `rustledger-validate`, so the LSP/editor still surfaces the advisory.
- New **`rledger lint closed-nonempty`** reuses the canonical `process(validate: true)` pipeline and keeps only E1004, with text and JSON output.

## Verify

```
# before: E1004 warning; after: clean (matches bean-check)
rledger check valid-ledger.beancount

# the advisory now lives here
rledger lint closed-nonempty ledger.beancount
# -> ledger.beancount:7: Cannot close account Assets:Cash with non-zero balance
#    1 account(s) closed with a non-zero balance.
```

- `check_clean_{text,json}` snapshots updated → "✓ No errors found", `warning_count: 0`.
- Regression tests in `closed_nonempty.rs`: reports a balance-bearing close; silent on a zero-balance close.
- `cargo test -p rustledger -p rustledger-validate`, clippy, and fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
