### PR TITLE
fix(cli): exit cleanly when query/format output pipe is closed early

### DIFF
--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -343,6 +343,9 @@ fn main() -> ExitCode {
             }
             match rustledger::cmd::query::run(&args) {
                 Ok(()) => ExitCode::SUCCESS,
+                // A downstream reader (e.g. `| head`) closing the pipe is not an
+                // error — exit cleanly, matching the Report arm and git.
+                Err(e) if rustledger::pager::is_broken_pipe(&e) => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("error: {e:#}");
                     ExitCode::from(1)
@@ -359,6 +362,9 @@ fn main() -> ExitCode {
             }
             match rustledger::cmd::format::run(&args) {
                 Ok(code) => code,
+                // A downstream reader (e.g. `| head`) closing the pipe is not an
+                // error — exit cleanly, matching the Report arm and git.
+                Err(e) if rustledger::pager::is_broken_pipe(&e) => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("error: {e:#}");
                     ExitCode::from(2)

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1511,3 +1511,74 @@ fn test_native_plugin_preferred_over_python_fallback() {
         "native plugins should not produce plugin-not-found errors: {combined}"
     );
 }
+
+/// Regression for OUTSTANDING #11: piping streaming output (`query`/`format`)
+/// to a reader that closes the pipe early — e.g. `| head` — must exit cleanly
+/// instead of printing `Broken pipe` and exiting non-zero. The `report` arm
+/// already handled this; `query` and `format` now match it.
+#[test]
+fn test_query_and_format_handle_broken_pipe() {
+    use std::io::Read as _;
+    use std::process::Stdio;
+
+    let bin = require_rledger!();
+
+    // Build a ledger whose output comfortably exceeds the OS pipe buffer
+    // (~64 KiB) so the writer is still producing output when we close the read
+    // end; otherwise it would finish before the pipe breaks and never exercise
+    // the EPIPE path. Same-date entries keep the ledger valid without date math.
+    let mut ledger = String::from(
+        "option \"operating_currency\" \"USD\"\n\
+         2020-01-01 open Assets:Cash\n\
+         2020-01-01 open Expenses:Food\n",
+    );
+    for i in 0..6000 {
+        ledger.push_str(&format!(
+            "2020-01-01 * \"payee {i}\" \"a deliberately long narration number {i} to inflate output\"\n  \
+             Expenses:Food  {}.50 USD\n  Assets:Cash\n",
+            i % 100
+        ));
+    }
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(tmp.path(), &ledger).expect("write ledger");
+    let path = tmp.path().to_str().expect("path");
+
+    // Run the command, read one chunk, then drop the read end to break the pipe.
+    let run_and_close = |args: &[&str]| -> (std::process::ExitStatus, String) {
+        let mut child = Command::new(&bin)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn rledger");
+        let mut out = child.stdout.take().expect("stdout");
+        let mut buf = [0u8; 256];
+        let _ = out.read(&mut buf);
+        drop(out); // close read end → writer hits EPIPE on its next write
+        let mut errbuf = String::new();
+        let _ = child
+            .stderr
+            .take()
+            .expect("stderr")
+            .read_to_string(&mut errbuf);
+        let status = child.wait().expect("wait");
+        (status, errbuf)
+    };
+
+    for args in [
+        vec!["query", path, "SELECT date, account, position, narration"],
+        vec!["format", path],
+    ] {
+        let (status, stderr) = run_and_close(&args);
+        assert!(
+            status.success(),
+            "`rledger {}` piped to an early-closing reader should exit 0, got {status:?}; stderr: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            !stderr.contains("Broken pipe"),
+            "`rledger {}` should not print a broken-pipe error; stderr: {stderr}",
+            args.join(" ")
+        );
+    }
+}


### PR DESCRIPTION
## What

Piping streaming output to a reader that closes the pipe early (e.g. `| head`) printed a broken-pipe error and exited non-zero:

```
$ rledger query big.beancount "SELECT date, account, position, narration" | head -5
... error: Broken pipe (os error 32)      # exit 1
$ rledger format big.beancount | head -1
... failed to write to stdout: Broken pipe  # exit 2
```

The `report` arm already maps a broken pipe to `ExitCode::SUCCESS` via `pager::is_broken_pipe` (the helper is documented to be silently ignored, matching git), but the `query` and `format` arms in `bin/rledger.rs` didn't.

## How

Add the same `Err(e) if pager::is_broken_pipe(&e) => ExitCode::SUCCESS` guard to the `Query` and `Format` arms. `is_broken_pipe` walks `err.chain()`, so it catches both the bare `io::Error` (query) and the context-wrapped error (format's "failed to write to stdout").

## Verify

```
rledger query big.beancount "SELECT date, account, position, narration" | head -5   # now: exit 0, no stderr
rledger format big.beancount | head -1                                              # now: exit 0, no stderr
```

Regression test `test_query_and_format_handle_broken_pipe`: spawns rledger against a ledger whose output exceeds the pipe buffer, reads one chunk, drops the read end to break the pipe, and asserts a clean exit with no broken-pipe message — for both `query` and `format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
