### PR TITLE
fix(validate): anchor E2003 (unused pad) to the pad source line

### DIFF
--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -988,6 +988,37 @@ fn test_relative_document_in_included_file_resolves_against_that_file() {
 }
 
 #[test]
+fn test_unused_pad_error_has_source_location() {
+    // Regression: E2003 (Unused Pad) must be anchored to the pad's own line,
+    // not rendered as `<unknown>:`. The pad below is never consumed by a
+    // following balance assertion.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ledger.beancount");
+    std::fs::write(
+        &path,
+        "2024-01-01 open Assets:Checking USD\n\
+         2024-01-01 open Equity:Opening USD\n\
+         2024-03-15 pad Assets:Checking Equity:Opening\n",
+    )
+    .unwrap();
+
+    let ledger = load(&path, &LoadOptions::default()).expect("should load");
+    let e2003 = ledger
+        .errors
+        .iter()
+        .find(|e| e.code == "E2003")
+        .expect("expected an E2003 unused-pad error");
+    let loc = e2003
+        .location
+        .as_ref()
+        .expect("E2003 must carry a source location, not <unknown>");
+    assert_eq!(
+        loc.line, 3,
+        "E2003 should point at the pad's line; got {loc:?}"
+    );
+}
+
+#[test]
 fn test_document_discovery_no_option() {
     // Test that document discovery doesn't happen when option "documents" is not set
     let path = fixtures_path("simple.beancount");

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -576,14 +576,7 @@ fn validate_phase_inner<D: ValidatableDirective>(
                     error.file_id = Some(file_id);
                 }
                 if error.note.is_none() && file_id == SYNTHESIZED_FILE_ID {
-                    error.note = Some(
-                        "directive was synthesized by a plugin (no source location \
-                         in your files); the responsible plugin is either an \
-                         enabled auto-plugin (e.g. `auto_accounts`, or document \
-                         discovery via `option \"documents\"`) or one of your \
-                         `plugin \"…\"` declarations"
-                            .to_string(),
-                    );
+                    error.note = Some(SYNTHESIZED_DIRECTIVE_NOTE.to_string());
                 }
             }
         }
@@ -595,6 +588,16 @@ fn validate_phase_inner<D: ValidatableDirective>(
 /// Collect unused-pad errors (E2003). Called once after both phases
 /// have run — pads can be marked `used` by either phase's balance
 /// applications.
+/// Advisory note attached to errors anchored to a plugin-synthesized directive
+/// (`file_id == SYNTHESIZED_FILE_ID`), so the user can trace an error that maps
+/// to nothing in their source files back to a plugin. Shared by the
+/// per-directive patching loop and the deferred [`check_unused_pads`].
+const SYNTHESIZED_DIRECTIVE_NOTE: &str = "directive was synthesized by a plugin (no source location \
+     in your files); the responsible plugin is either an \
+     enabled auto-plugin (e.g. `auto_accounts`, or document \
+     discovery via `option \"documents\"`) or one of your \
+     `plugin \"…\"` declarations";
+
 fn check_unused_pads(state: &LedgerState) -> Vec<ValidationError> {
     let mut errors = Vec::new();
     for (target_account, pads) in &state.pending_pads {
@@ -610,10 +613,16 @@ fn check_unused_pads(state: &LedgerState) -> Vec<ValidationError> {
                     pad.date, target_account, pad.source_account
                 ));
                 // Anchor the deferred error to the pad's own line (when known)
-                // so it renders with a location instead of `<unknown>:`.
+                // so it renders with a location instead of `<unknown>:`. A pad
+                // synthesized by a plugin gets the same advisory note the
+                // per-directive patching loop attaches to in-phase errors, so
+                // deferred and in-phase errors stay consistent.
                 if let Some((span, file_id)) = pad.location {
                     error.span = Some(span);
                     error.file_id = Some(file_id);
+                    if file_id == SYNTHESIZED_FILE_ID {
+                        error.note = Some(SYNTHESIZED_DIRECTIVE_NOTE.to_string());
+                    }
                 }
                 errors.push(error);
             }

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -288,6 +288,10 @@ struct PendingPad {
     /// `used` flag. Empty set = no balance has consumed this pad yet
     /// (drives E2003 in `check_unused_pads`).
     padded_currencies: FxHashSet<rustledger_core::Currency>,
+    /// Source span + file id of the `pad` directive, when validating
+    /// `Spanned` directives. Carried so `check_unused_pads` can anchor the
+    /// deferred E2003 to the pad's own line instead of `<unknown>`.
+    location: Option<(rustledger_parser::Span, u16)>,
 }
 
 /// Ledger state for validation.
@@ -533,7 +537,7 @@ fn validate_phase_inner<D: ValidatableDirective>(
                 validate_commodity_precision_meta(comm, &mut errors);
             }
             (Phase::Early, Directive::Pad(pad)) => {
-                validate_pad(state, pad, &mut errors);
+                validate_pad(state, pad, d.span_info(), &mut errors);
             }
             (Phase::Early, Directive::Document(doc)) => {
                 let file_id = d.span_info().map(|(_, fid)| fid);
@@ -596,17 +600,22 @@ fn check_unused_pads(state: &LedgerState) -> Vec<ValidationError> {
     for (target_account, pads) in &state.pending_pads {
         for pad in pads {
             if pad.padded_currencies.is_empty() {
-                errors.push(
-                    ValidationError::new(
-                        ErrorCode::PadWithoutBalance,
-                        "Unused Pad entry".to_string(),
-                        pad.date,
-                    )
-                    .with_context(format!(
-                        "   {} pad {} {}",
-                        pad.date, target_account, pad.source_account
-                    )),
-                );
+                let mut error = ValidationError::new(
+                    ErrorCode::PadWithoutBalance,
+                    "Unused Pad entry".to_string(),
+                    pad.date,
+                )
+                .with_context(format!(
+                    "   {} pad {} {}",
+                    pad.date, target_account, pad.source_account
+                ));
+                // Anchor the deferred error to the pad's own line (when known)
+                // so it renders with a location instead of `<unknown>:`.
+                if let Some((span, file_id)) = pad.location {
+                    error.span = Some(span);
+                    error.file_id = Some(file_id);
+                }
+                errors.push(error);
             }
         }
     }

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -75,7 +75,12 @@ fn sum_account_and_subaccounts(
 const DECIMAL_TEN: Decimal = Decimal::TEN;
 
 /// Validate a Pad directive.
-pub fn validate_pad(state: &mut LedgerState, pad: &Pad, errors: &mut Vec<ValidationError>) {
+pub fn validate_pad(
+    state: &mut LedgerState,
+    pad: &Pad,
+    location: Option<(rustledger_parser::Span, u16)>,
+    errors: &mut Vec<ValidationError>,
+) {
     // Check that the target account exists
     if !state.accounts.contains_key(&pad.account) {
         errors.push(ValidationError::new(
@@ -101,6 +106,7 @@ pub fn validate_pad(state: &mut LedgerState, pad: &Pad, errors: &mut Vec<Validat
         source_account: pad.source_account.clone(),
         date: pad.date,
         padded_currencies: rustc_hash::FxHashSet::default(),
+        location,
     };
     state
         .pending_pads


### PR DESCRIPTION
## What

An unconsumed `pad` directive emitted its E2003 with **no source location**:

```
$ rledger check t.beancount
<unknown>: error[E2003]: Unused Pad entry
```

while sibling errors (E2001, etc.) render a full miette report with file/line and carets. The project's own self-review checklist requires file-location context on errors.

## Why

E2003 is **deferred** — `check_unused_pads` runs after both validation phases, walking leftover `PendingPad`s. But `PendingPad` kept only the pad's account/date/currencies, never its span or `file_id`, so the deferred error had nothing to anchor to.

## How

- `PendingPad` now carries `location: Option<(Span, u16)>`.
- `validate_pad` takes the pad's `span_info()` from the dispatch and stores it.
- `check_unused_pads` sets `span`/`file_id` on the E2003 from the `PendingPad`.

It now renders with the pad's own line:

```
E2003
  x Unused Pad entry
   ,-[t.beancount:3:1]
```

## Verify

```
printf '2024-01-01 open Assets:Checking USD\n2024-01-01 open Equity:Opening USD\n2024-03-15 pad Assets:Checking Equity:Opening\n' > t.beancount
rledger check t.beancount   # before: <unknown>: ... | after: t.beancount:3:1
```

Regression test `test_unused_pad_error_has_source_location` asserts the E2003 `LedgerError` carries a location pointing at the pad's line. `rustledger-validate` + `rustledger-loader` suites, clippy, fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
