### PR TITLE
fix(importer): drop doubled Row N: prefix in extract date warnings

### DIFF
--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -111,14 +111,7 @@ impl CsvImporter {
                 }
             };
 
-            match self.parse_row(
-                &record,
-                config,
-                csv_config,
-                &amount_format,
-                &header_map,
-                row_num,
-            ) {
+            match self.parse_row(&record, config, csv_config, &amount_format, &header_map) {
                 Ok(Some(txn)) => directives.push(Directive::Transaction(txn)),
                 Ok(None) => {} // Skip empty rows
                 Err(e) => {
@@ -226,12 +219,14 @@ impl CsvImporter {
         csv_config: &CsvConfig,
         amount_format: &AmountFormat,
         header_map: &HashMap<String, usize>,
-        row_num: usize,
     ) -> Result<Option<Transaction>> {
-        // Get date
+        // Get date. No `Row N:` prefix on these errors: the sole caller
+        // (`extract`) already wraps every `parse_row` error with
+        // `Row {row_num}: {e}`, so prefixing here too produced a doubled
+        // `Row 1: Row 1: ...`.
         let date_str = self
             .get_column(record, &csv_config.date_column, header_map)
-            .with_context(|| format!("Row {row_num}: missing date column"))?;
+            .with_context(|| "missing date column".to_string())?;
 
         if date_str.trim().is_empty() {
             return Ok(None); // Skip empty rows
@@ -241,8 +236,8 @@ impl CsvImporter {
             .and_then(|tm| tm.to_date())
             .with_context(|| {
                 format!(
-                    "Row {}: failed to parse date '{}' with format '{}'",
-                    row_num, date_str, csv_config.date_format
+                    "failed to parse date '{}' with format '{}'",
+                    date_str, csv_config.date_format
                 )
             })?;
 
@@ -1030,6 +1025,14 @@ not-a-date,Coffee,-5.00
         assert_eq!(result.warnings.len(), 1);
         // The error propagates the "missing date column" context
         assert!(result.warnings[0].contains("missing date column"));
+        // ...with exactly one `Row N:` prefix, not the doubled
+        // `Row 1: Row 1: ...` the inner+outer prefixes used to produce.
+        assert_eq!(
+            result.warnings[0].matches("Row ").count(),
+            1,
+            "row prefix must not be doubled: {:?}",
+            result.warnings[0]
+        );
     }
 
     #[test]

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -220,10 +220,9 @@ impl CsvImporter {
         amount_format: &AmountFormat,
         header_map: &HashMap<String, usize>,
     ) -> Result<Option<Transaction>> {
-        // Get date. No `Row N:` prefix on these errors: the sole caller
-        // (`extract`) already wraps every `parse_row` error with
-        // `Row {row_num}: {e}`, so prefixing here too produced a doubled
-        // `Row 1: Row 1: ...`.
+        // Get date. No `Row N:` prefix on these errors: `parse_row`'s caller
+        // already wraps every error it returns with `Row {row_num}: {e}`, so
+        // prefixing here too produced a doubled `Row 1: Row 1: ...`.
         let date_str = self
             .get_column(record, &csv_config.date_column, header_map)
             .with_context(|| "missing date column".to_string())?;


### PR DESCRIPTION
## What

Per-row extract warnings for the two date errors carried a **doubled** `Row N:` prefix:

```
$ rledger extract h.csv -a Assets:Bank --date-column NoSuchCol ...
warning: Row 1: Row 1: missing date column
```

`csv_importer::parse_row` pre-attached `Row {n}: ...` to its date errors (missing date column, failed-to-parse date), and its **sole caller** `extract` then wrapped *every* `parse_row` error again with `Row {row_num}: {e}`.

## How

Drop the inner prefixes; the outer wrap already supplies exactly one `Row N:` for every parse_row error. The now-unused `row_num` parameter is removed from `parse_row`.

## Verify

```
printf 'date,desc,amt\n2024-01-01,Coffee,-4.50\n' > h.csv
rledger extract h.csv -a Assets:Bank --date-column NoSuchCol --narration-column desc --amount-column amt
# before: warning: Row 1: Row 1: missing date column | after: warning: Row 1: missing date column
```

`test_csv_import_missing_column_error` now asserts the warning carries exactly one `Row ` prefix; full importer lib suite (137) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
