### PR TITLE
fix(extract): fail loudly when no transactions are extracted

### DIFF
--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -827,6 +827,21 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     let formatted = canonicalize_directives(directives.iter(), &fmt_config)
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
+    // Fail loudly on an empty result instead of printing "Extracted 0
+    // transactions" and exiting 0. A garbage / wrong-type / empty file
+    // otherwise makes a scripted `extract … >> ledger.beancount` silently
+    // append nothing.
+    if directives.is_empty() {
+        anyhow::bail!(
+            "no transactions were extracted from {}\n  \
+             the file may not match a recognized importer format, be empty, or \
+             use unexpected columns\n  \
+             try: --auto, an explicit importer (--importer), or column flags \
+             (--date-column, --amount-column, …)",
+            file.display()
+        );
+    }
+
     if let Some(ref output_path) = args.output {
         let mut out_file = fs::File::create(output_path)
             .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1511,3 +1511,39 @@ fn test_native_plugin_preferred_over_python_fallback() {
         "native plugins should not produce plugin-not-found errors: {combined}"
     );
 }
+
+/// Regression for OUTSTANDING #18: `extract` on a file that yields no
+/// transactions (garbage / wrong type / empty) must fail loudly instead of
+/// printing "Extracted 0 transactions" and exiting 0 — otherwise a scripted
+/// `extract … >> ledger.beancount` silently appends nothing.
+#[test]
+fn test_extract_empty_result_exits_nonzero() {
+    let bin = require_rledger!();
+
+    let file = tempfile::Builder::new()
+        .suffix(".txt")
+        .tempfile()
+        .expect("tempfile");
+    std::fs::write(file.path(), "garbage not a csv\nsecond line\n").expect("write");
+
+    let output = Command::new(&bin)
+        .args([
+            "extract",
+            file.path().to_str().unwrap(),
+            "-a",
+            "Assets:Bank",
+        ])
+        .output()
+        .expect("run extract");
+
+    assert!(
+        !output.status.success(),
+        "extract on a non-importable file should exit non-zero, got {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no transactions were extracted"),
+        "should explain why nothing was extracted; stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## What

`extract` printed `Extracted 0 transactions` and exited **0** regardless of the result, so a garbage / wrong-type / empty file silently produced nothing:

```
$ printf 'garbage not a csv\nsecond line\n' > foo.txt
$ rledger extract foo.txt -a Assets:Bank; echo $?
Extracted 0 transactions from foo.txt
0
```

A scripted `extract … >> ledger.beancount` therefore appends nothing **silently** on a malformed or wrong-path-but-existing file (only a *nonexistent* path exited non-zero).

## How

Bail with an actionable message when the result is empty (before writing output), so the exit code is non-zero:

```
error: no transactions were extracted from foo.txt
  the file may not match a recognized importer format, be empty, or use unexpected columns
  try: --auto, an explicit importer (--importer), or column flags (--date-column, --amount-column, …)
```

## Verify

```
printf 'garbage not a csv\n' > foo.txt
rledger extract foo.txt -a Assets:Bank; echo $?   # before: exit 0 | after: error + non-zero
```

A valid CSV still extracts normally (regression guarded). Regression test `test_extract_empty_result_exits_nonzero` asserts a non-importable file exits non-zero with the explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
