### PR TITLE
fix(query): name trailing tokens instead of mislabeling as EOF

### DIFF
--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -1082,13 +1082,16 @@ mod tests {
         ] {
             let err = parse(q).expect_err("should be a parse error");
             assert_eq!(err.position, pos, "span should point at the token in {q:?}");
-            match err.kind {
-                ParseErrorKind::SyntaxError(ref m) => assert!(
-                    m.contains(token),
-                    "error should name {token:?}, got {m:?} for {q:?}"
-                ),
-                other => panic!("expected SyntaxError naming {token:?}, got {other:?} for {q:?}"),
-            }
+            let ParseErrorKind::SyntaxError(ref m) = err.kind else {
+                panic!(
+                    "expected SyntaxError naming {token:?}, got {:?} for {q:?}",
+                    err.kind
+                );
+            };
+            assert!(
+                m.contains(token),
+                "error should name {token:?}, got {m:?} for {q:?}"
+            );
         }
     }
 

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -99,12 +99,23 @@ pub fn parse(source: &str) -> Result<Query, ParseError> {
         Ok(query)
     } else {
         let err = errs.first().map(|e| {
-            let kind = if e.found().is_none() {
+            let start = e.span().start;
+            // chumsky reports `found() == None` both for a genuine premature
+            // EOF *and* for the `end()` combinator rejecting leftover tokens
+            // after a valid prefix — so `found()` can't tell them apart. The
+            // error span, however, points at the real offending position.
+            // Treat only a position at/past the end of input as EOF; otherwise
+            // name the unexpected (often trailing) token instead of
+            // mislabeling it "unexpected end of input".
+            let kind = if start >= source.len() {
                 ParseErrorKind::UnexpectedEof
+            } else if let Some(rest) = source.get(start..) {
+                let token = rest.split_whitespace().next().unwrap_or(rest);
+                ParseErrorKind::SyntaxError(format!("unexpected token '{token}'"))
             } else {
                 ParseErrorKind::SyntaxError(e.to_string())
             };
-            ParseError::new(kind, e.span().start)
+            ParseError::new(kind, start)
         });
         Err(err.unwrap_or_else(|| ParseError::new(ParseErrorKind::UnexpectedEof, 0)))
     }
@@ -1054,6 +1065,32 @@ fn integer<'a>() -> impl Parser<'a, ParserInput<'a>, i64, ParserExtra<'a>> + Clo
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
+
+    #[test]
+    fn trailing_tokens_are_named_not_mislabeled_eof() {
+        // Regression for OUTSTANDING #16: leftover tokens after a valid prefix
+        // were reported as "unexpected end of input" (because `end()` rejects
+        // them with `found() == None`), even though the span points at the real
+        // token. They must now be named.
+        for (q, token, pos) in [
+            ("SELECT account FOOBAR", "FOOBAR", 15usize),
+            (
+                "SELECT account, sum(position) GROUP BY account WHERE number > 0",
+                "WHERE",
+                47,
+            ),
+        ] {
+            let err = parse(q).expect_err("should be a parse error");
+            assert_eq!(err.position, pos, "span should point at the token in {q:?}");
+            match err.kind {
+                ParseErrorKind::SyntaxError(ref m) => assert!(
+                    m.contains(token),
+                    "error should name {token:?}, got {m:?} for {q:?}"
+                ),
+                other => panic!("expected SyntaxError naming {token:?}, got {other:?} for {q:?}"),
+            }
+        }
+    }
 
     #[test]
     fn test_simple_select() {

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -100,16 +100,18 @@ pub fn parse(source: &str) -> Result<Query, ParseError> {
     } else {
         let err = errs.first().map(|e| {
             let start = e.span().start;
-            // chumsky reports `found() == None` both for a genuine premature
-            // EOF *and* for the `end()` combinator rejecting leftover tokens
-            // after a valid prefix — so `found()` can't tell them apart. The
-            // error span, however, points at the real offending position.
-            // Treat only a position at/past the end of input as EOF; otherwise
-            // name the unexpected (often trailing) token instead of
-            // mislabeling it "unexpected end of input".
-            let kind = if start >= source.len() {
+            let kind = if e.found().is_some() {
+                // chumsky found a concrete unexpected token: keep its rich
+                // message ("expected keyword …", "invalid number", …).
+                ParseErrorKind::SyntaxError(e.to_string())
+            } else if start >= source.len() {
+                // `found() == None` at/past the end is a genuine premature EOF.
                 ParseErrorKind::UnexpectedEof
             } else if let Some(rest) = source.get(start..) {
+                // `found() == None` mid-input is the `end()` combinator
+                // rejecting leftover tokens after a valid prefix. The span
+                // points at the real token; name it instead of mislabeling it
+                // "unexpected end of input".
                 let token = rest.split_whitespace().next().unwrap_or(rest);
                 ParseErrorKind::SyntaxError(format!("unexpected token '{token}'"))
             } else {
@@ -1067,7 +1069,7 @@ mod tests {
     use rust_decimal_macros::dec;
 
     #[test]
-    fn trailing_tokens_are_named_not_mislabeled_eof() {
+    fn test_trailing_tokens_are_named_not_mislabeled_eof() {
         // Regression for OUTSTANDING #16: leftover tokens after a valid prefix
         // were reported as "unexpected end of input" (because `end()` rejects
         // them with `found() == None`), even though the span points at the real


### PR DESCRIPTION
## What

The query parser reported **"unexpected end of input"** for *any* trailing tokens after a valid prefix:

```
$ rledger query main.beancount "SELECT account, sum(position) GROUP BY account WHERE number > 0"
syntax error at position 47: unexpected end of input        # 47 is the WHERE token
$ rledger query main.beancount "SELECT account FOOBAR"
syntax error: unexpected end of input                       # at FOOBAR
```

The classifier used `e.found().is_none()` to mean EOF — but chumsky's `end()` combinator (which rejects leftover tokens) *also* reports `found() == None`, so trailing tokens were mislabeled even though the error span pointed straight at them.

## How

Classify by the **error span position** instead: a position at or past the end of the input is a genuine EOF; otherwise name the unexpected token at that position.

```
syntax error at position 47: unexpected token 'WHERE'
syntax error at position 15: unexpected token 'FOOBAR'
```

## Verify

```
rledger query f.beancount "SELECT account, sum(position) GROUP BY account WHERE number > 0"   # names WHERE@47
rledger query f.beancount "SELECT account FOOBAR"                                              # names FOOBAR@15
```

Test `trailing_tokens_are_named_not_mislabeled_eof`; full `rustledger-query` suite, clippy, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
