### PR TITLE
fix(add): name the missing-currency error in quick mode

### DIFF
--- a/crates/rustledger/src/cmd/add_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/add_cmd/mod.rs
@@ -74,6 +74,13 @@ pub struct Args {
     pub yes: bool,
 
     /// Quick mode: payee narration account amount \[account \[amount\]\]...
+    ///
+    /// Each amount needs an explicit currency and must be a SINGLE argument, so
+    /// quote it: `'5.00 USD'` (otherwise the shell splits it into `5.00` and
+    /// `USD`). Because `--quick` is variadic it consumes every following
+    /// argument, so pass the FILE before `--quick`, or end the quick args with
+    /// `--`. Example:
+    ///   `rledger add ledger.beancount -y --quick 'Store' 'Lunch' Expenses:Food '5.00 USD' Assets:Cash`
     #[arg(short, long, num_args = 4.., value_name = "ARGS")]
     pub quick: Option<Vec<String>>,
 
@@ -195,6 +202,18 @@ fn canonical_format_directive(directive: &Directive, config: &FormatConfig) -> R
         .map_err(|e| anyhow::anyhow!(e.to_string()))
 }
 
+/// Heuristic: does `token` look like a mistyped amount rather than an
+/// account name? Account names start with an uppercase letter; an amount-like
+/// token starts with a digit, or a sign / decimal point followed by a digit.
+fn looks_like_amount(token: &str) -> bool {
+    let mut chars = token.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_digit() => true,
+        Some('-' | '+' | '.') => chars.next().is_some_and(|c| c.is_ascii_digit()),
+        _ => false,
+    }
+}
+
 /// Run the add command in quick mode (writes to stdout).
 fn run_quick_mode(args: &Args, file: &PathBuf, date: NaiveDate) -> Result<()> {
     let mut stdout = std::io::stdout().lock();
@@ -258,6 +277,21 @@ fn run_quick_mode_with_writer<W: std::io::Write>(
     while i < quick_args.len() {
         let account = &quick_args[i];
         i += 1;
+
+        // A token in the account position that looks like a number is almost
+        // always a misparsed amount: either it lacks a currency (`5.00` instead
+        // of `5.00 USD`) or a `5.00 USD` amount got split by the shell into two
+        // arguments. Without this, such a token is silently taken as a phantom
+        // account and the user sees a confusing "N postings lack amounts".
+        if looks_like_amount(account) {
+            bail!(
+                "'{account}' looks like an amount but appears where an account \
+                 name is expected.\n  Amounts need an explicit currency \
+                 (e.g. '{account} USD') and must be a single argument — quote \
+                 amounts that contain a space (e.g. '5.00 USD') so the shell \
+                 does not split them."
+            );
+        }
 
         if i < quick_args.len() {
             // Try to parse as amount
@@ -708,6 +742,22 @@ pub fn run(args: &Args, file: &PathBuf) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn looks_like_amount_distinguishes_amounts_from_accounts() {
+        // Amount-like tokens that, in the account position, used to become
+        // phantom accounts and trigger a confusing "N postings lack amounts".
+        for t in ["5.00", "-45.00", "+10", ".5", "0", "1234.56"] {
+            assert!(looks_like_amount(t), "{t:?} should look like an amount");
+        }
+        // Real account names and bare currencies are not amount-like.
+        for t in ["Assets:Cash", "Expenses:Food", "USD", "Equity:Opening", "-"] {
+            assert!(
+                !looks_like_amount(t),
+                "{t:?} should NOT look like an amount"
+            );
+        }
+    }
 
     #[test]
     fn test_parse_date_today() {

--- a/crates/rustledger/src/cmd/add_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/add_cmd/mod.rs
@@ -76,11 +76,11 @@ pub struct Args {
     /// Quick mode: payee narration account amount \[account \[amount\]\]...
     ///
     /// Each amount needs an explicit currency and must be a SINGLE argument, so
-    /// quote it: `'5.00 USD'` (otherwise the shell splits it into `5.00` and
+    /// quote it: `"5.00 USD"` (otherwise the shell splits it into `5.00` and
     /// `USD`). Because `--quick` is variadic it consumes every following
     /// argument, so pass the FILE before `--quick`, or end the quick args with
     /// `--`. Example:
-    ///   `rledger add ledger.beancount -y --quick 'Store' 'Lunch' Expenses:Food '5.00 USD' Assets:Cash`
+    ///   `rledger add ledger.beancount -y --quick "Store" "Lunch" Expenses:Food "5.00 USD" Assets:Cash`
     #[arg(short, long, num_args = 4.., value_name = "ARGS")]
     pub quick: Option<Vec<String>>,
 
@@ -202,14 +202,16 @@ fn canonical_format_directive(directive: &Directive, config: &FormatConfig) -> R
         .map_err(|e| anyhow::anyhow!(e.to_string()))
 }
 
-/// Heuristic: does `token` look like a mistyped amount rather than an
-/// account name? Account names start with an uppercase letter; an amount-like
-/// token starts with a digit, or a sign / decimal point followed by a digit.
+/// Heuristic: does `token` look like a mistyped amount rather than an account
+/// name? It's amount-like if, after an optional leading sign, it starts with a
+/// digit or a decimal point followed by a digit (`5`, `-45.00`, `.5`, `-.5`).
+/// Account names never start that way, so this distinguishes the two.
 fn looks_like_amount(token: &str) -> bool {
-    let mut chars = token.chars();
+    let rest = token.strip_prefix(['-', '+']).unwrap_or(token);
+    let mut chars = rest.chars();
     match chars.next() {
         Some(c) if c.is_ascii_digit() => true,
-        Some('-' | '+' | '.') => chars.next().is_some_and(|c| c.is_ascii_digit()),
+        Some('.') => chars.next().is_some_and(|c| c.is_ascii_digit()),
         _ => false,
     }
 }
@@ -286,10 +288,9 @@ fn run_quick_mode_with_writer<W: std::io::Write>(
         if looks_like_amount(account) {
             bail!(
                 "'{account}' looks like an amount but appears where an account \
-                 name is expected.\n  Amounts need an explicit currency \
-                 (e.g. '{account} USD') and must be a single argument — quote \
-                 amounts that contain a space (e.g. '5.00 USD') so the shell \
-                 does not split them."
+                 name is expected.\n  Amounts need an explicit currency and must \
+                 be a single argument — quote amounts that contain a space \
+                 (e.g. \"5.00 USD\") so the shell does not split them."
             );
         }
 
@@ -747,7 +748,7 @@ mod tests {
     fn looks_like_amount_distinguishes_amounts_from_accounts() {
         // Amount-like tokens that, in the account position, used to become
         // phantom accounts and trigger a confusing "N postings lack amounts".
-        for t in ["5.00", "-45.00", "+10", ".5", "0", "1234.56"] {
+        for t in ["5.00", "-45.00", "+10", ".5", "-.5", "+.5", "0", "1234.56"] {
             assert!(looks_like_amount(t), "{t:?} should look like an amount");
         }
         // Real account names and bare currencies are not amount-like.


### PR DESCRIPTION
## What

In `add` quick mode, a bare or split amount became a phantom **account** and produced a misleading error:

```
$ rledger add t.beancount -y --quick 'Store' 'Lunch' Expenses:Food 5.00 Assets:Cash
error: Quick mode supports at most one posting without an explicit amount, but 3 postings lack amounts.
```

The account/amount loop calls `parse_amount` on each post-account token and, on failure, silently treats it as the next account. `parse_amount` rejects a currency-less number, so a bare `5.00` (or a `5.00 USD` amount the shell split into two args) slipped through as an account.

## How

Detect an amount-looking token in the account position (`looks_like_amount`) and bail with a message that names the real cause:

```
error: '5.00' looks like an amount but appears where an account name is expected.
  Amounts need an explicit currency (e.g. '5.00 USD') and must be a single argument —
  quote amounts that contain a space (e.g. '5.00 USD') so the shell does not split them.
```

The `--quick` help text now documents the quoting and FILE-before-`--quick` / `--` requirements.

## Verify

```
rledger add t.beancount -y --quick 'Store' 'Lunch' Expenses:Food 5.00 Assets:Cash       # clear error
rledger add t.beancount -n --quick 'Store' 'Lunch' Expenses:Food '5.00 USD' Assets:Cash  # works
```

Test `looks_like_amount_distinguishes_amounts_from_accounts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
