### PR TITLE
feat(extract): make the merchant dictionary reachable via --use-merchant-dict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "jiff",
  "ofxy",
  "proptest",
+ "regex",
  "rmp-serde",
  "rust_decimal",
  "rustledger-core",

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -36,6 +36,7 @@ rustledger-plugin = { workspace = true, features = ["wasm-runtime"], optional = 
 rustledger-plugin-types.workspace = true
 jiff.workspace = true
 rust_decimal.workspace = true
+regex.workspace = true
 anyhow.workspace = true
 format_num_pattern.workspace = true
 csv.workspace = true

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -29,6 +29,27 @@ use std::path::Path;
 #[derive(Debug, Default, Clone)]
 pub struct CsvImporter;
 
+/// Precompiled merchant-dictionary regexes, built once on first use. Patterns
+/// that fail to compile are skipped, mirroring
+/// [`rustledger_ops::categorize::RulesEngine::load_merchant_dict`]. Each entry
+/// pairs a case-insensitive, unanchored regex with its `&'static` account.
+fn merchant_regexes() -> &'static [(regex::Regex, &'static str)] {
+    use std::sync::LazyLock;
+    static REGEXES: LazyLock<Vec<(regex::Regex, &'static str)>> = LazyLock::new(|| {
+        rustledger_ops::merchants::MERCHANT_PATTERNS
+            .iter()
+            .filter_map(|entry| {
+                regex::RegexBuilder::new(entry.pattern)
+                    .case_insensitive(true)
+                    .build()
+                    .ok()
+                    .map(|re| (re, entry.account))
+            })
+            .collect()
+    });
+    &REGEXES
+}
+
 impl Importer for CsvImporter {
     fn name(&self) -> &'static str {
         "CSV"
@@ -319,32 +340,35 @@ impl CsvImporter {
         payee: Option<&str>,
         narration: &str,
     ) -> Option<&'a str> {
-        let payee_lower = payee.map(str::to_lowercase);
-        let narration_lower = narration.to_lowercase();
-
         // User-supplied mappings take priority over the built-in dictionary.
-        for (pattern, account) in &csv_config.mappings {
-            // Match against payee first, then narration
-            if let Some(ref p) = payee_lower
-                && p.contains(pattern.as_str())
-            {
-                return Some(account);
-            }
-            if narration_lower.contains(pattern.as_str()) {
-                return Some(account);
+        // Only pay for the lowercasing when there are mappings to check.
+        if !csv_config.mappings.is_empty() {
+            let payee_lower = payee.map(str::to_lowercase);
+            let narration_lower = narration.to_lowercase();
+            for (pattern, account) in &csv_config.mappings {
+                // Match against payee first, then narration
+                if let Some(ref p) = payee_lower
+                    && p.contains(pattern.as_str())
+                {
+                    return Some(account);
+                }
+                if narration_lower.contains(pattern.as_str()) {
+                    return Some(account);
+                }
             }
         }
 
         // Then the built-in merchant dictionary, when enabled — so
         // `extract --use-merchant-dict` actually categorizes NETFLIX, AMAZON,
         // SHELL, … instead of leaving them at the default expense account.
+        // The dictionary patterns are regexes (e.g. `AMAZON|AMZN`), matched
+        // case-insensitively and unanchored, exactly as the enriched path's
+        // `RulesEngine::load_merchant_dict` does — a plain substring match
+        // would silently miss every alternation/character-class pattern.
         if csv_config.use_merchant_dict {
-            for entry in rustledger_ops::merchants::MERCHANT_PATTERNS {
-                let pat = entry.pattern.to_lowercase();
-                if payee_lower.as_deref().is_some_and(|p| p.contains(&pat))
-                    || narration_lower.contains(&pat)
-                {
-                    return Some(entry.account);
+            for (regex, account) in merchant_regexes() {
+                if payee.is_some_and(|p| regex.is_match(p)) || regex.is_match(narration) {
+                    return Some(account);
                 }
             }
         }
@@ -1254,7 +1278,7 @@ not-a-date,Coffee,-5.00
         // Regression for OUTSTANDING #20: with use_merchant_dict, the regular
         // extract path (used by the CLI) must apply the dictionary's account,
         // not leave a known merchant at the default expense account.
-        let account_for = |enable: bool| -> String {
+        let account_for = |description: &str, enable: bool| -> String {
             let config = ImporterConfig::csv()
                 .account("Assets:Bank")
                 .currency("USD")
@@ -1264,22 +1288,29 @@ not-a-date,Coffee,-5.00
                 .use_merchant_dict(enable)
                 .build()
                 .unwrap();
-            let csv = "Date,Description,Amount\n2024-03-08,NETFLIX.COM,-15.99\n";
-            let result = CsvImporter.extract_string(csv, &config).unwrap();
+            let csv = format!("Date,Description,Amount\n2024-03-08,{description},-15.99\n");
+            let result = CsvImporter.extract_string(&csv, &config).unwrap();
             match &result.directives[0] {
                 Directive::Transaction(txn) => txn.postings[1].account.as_str().to_string(),
                 _ => panic!("expected transaction"),
             }
         };
         assert_eq!(
-            account_for(false),
+            account_for("NETFLIX.COM", false),
             "Expenses:Unknown",
             "disabled stays default"
         );
         assert_eq!(
-            account_for(true),
+            account_for("NETFLIX.COM", true),
             "Expenses:Subscriptions:Streaming",
             "enabled: NETFLIX maps to the merchant-dict account"
+        );
+        // An `AMAZON|AMZN`-style alternation pattern must match too — a plain
+        // substring match would miss the second alternative entirely.
+        assert_eq!(
+            account_for("AMZN MKTP US", true),
+            "Expenses:Shopping:Amazon",
+            "enabled: AMZN matches the AMAZON|AMZN alternation pattern"
         );
     }
 

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -325,13 +325,10 @@ impl CsvImporter {
         payee: Option<&str>,
         narration: &str,
     ) -> Option<&'a str> {
-        if csv_config.mappings.is_empty() {
-            return None;
-        }
-
         let payee_lower = payee.map(str::to_lowercase);
         let narration_lower = narration.to_lowercase();
 
+        // User-supplied mappings take priority over the built-in dictionary.
         for (pattern, account) in &csv_config.mappings {
             // Match against payee first, then narration
             if let Some(ref p) = payee_lower
@@ -341,6 +338,20 @@ impl CsvImporter {
             }
             if narration_lower.contains(pattern.as_str()) {
                 return Some(account);
+            }
+        }
+
+        // Then the built-in merchant dictionary, when enabled — so
+        // `extract --use-merchant-dict` actually categorizes NETFLIX, AMAZON,
+        // SHELL, … instead of leaving them at the default expense account.
+        if csv_config.use_merchant_dict {
+            for entry in rustledger_ops::merchants::MERCHANT_PATTERNS {
+                let pat = entry.pattern.to_lowercase();
+                if payee_lower.as_deref().is_some_and(|p| p.contains(&pat))
+                    || narration_lower.contains(&pat)
+                {
+                    return Some(entry.account);
+                }
             }
         }
 
@@ -1234,6 +1245,40 @@ not-a-date,Coffee,-5.00
         } else {
             panic!("Expected transaction");
         }
+    }
+
+    #[test]
+    fn test_merchant_dict_categorizes_account_when_enabled() {
+        // Regression for OUTSTANDING #20: with use_merchant_dict, the regular
+        // extract path (used by the CLI) must apply the dictionary's account,
+        // not leave a known merchant at the default expense account.
+        let account_for = |enable: bool| -> String {
+            let config = ImporterConfig::csv()
+                .account("Assets:Bank")
+                .currency("USD")
+                .date_column("Date")
+                .narration_column("Description")
+                .amount_column("Amount")
+                .use_merchant_dict(enable)
+                .build()
+                .unwrap();
+            let csv = "Date,Description,Amount\n2024-03-08,NETFLIX.COM,-15.99\n";
+            let result = CsvImporter.extract_string(csv, &config).unwrap();
+            match &result.directives[0] {
+                Directive::Transaction(txn) => txn.postings[1].account.as_str().to_string(),
+                _ => panic!("expected transaction"),
+            }
+        };
+        assert_eq!(
+            account_for(false),
+            "Expenses:Unknown",
+            "disabled stays default"
+        );
+        assert_eq!(
+            account_for(true),
+            "Expenses:Subscriptions:Streaming",
+            "enabled: NETFLIX maps to the merchant-dict account"
+        );
     }
 
     #[test]

--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -781,6 +781,7 @@ fn build_extract_args(
         include_zero_amounts: bool_flag(req, "include-zero-amounts", None),
         auto: bool_flag(req, "auto", None),
         no_header: bool_flag(req, "no-header", None),
+        use_merchant_dict: bool_flag(req, "use-merchant-dict", None),
         output: path_flag(req, "output", Some("o")),
         existing: path_flag(req, "existing", None),
         suggest_categories: bool_flag(req, "suggest-categories", None),

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -121,6 +121,8 @@ pub(super) struct ImporterEntry {
     /// Account mappings: pattern → account.
     #[serde(default)]
     pub(super) mappings: HashMap<String, String>,
+    /// Categorize via the built-in merchant dictionary (off by default).
+    pub(super) use_merchant_dict: Option<bool>,
 }
 
 /// Apply a CSV column flag that may be a header name or a bare 0-based index.
@@ -284,6 +286,10 @@ pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterC
             .collect();
         mappings.sort_by_key(|a| std::cmp::Reverse(a.0.len()));
         builder = builder.mappings(mappings);
+    }
+
+    if let Some(enable) = entry.use_merchant_dict {
+        builder = builder.use_merchant_dict(enable);
     }
 
     builder.build()

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -181,9 +181,9 @@ pub struct Args {
     pub no_header: bool,
 
     /// Categorize transactions using the built-in merchant dictionary
-    /// (NETFLIX → Expenses:Subscriptions, SHELL → Expenses:Transportation:Gas,
-    /// …) instead of leaving unmatched rows at Expenses:Unknown. Can also be
-    /// set per-importer in importers.toml via `use_merchant_dict = true`.
+    /// (e.g. NETFLIX → Expenses:Subscriptions:Streaming) instead of leaving
+    /// unmatched rows at Expenses:Unknown. Can also be set per-importer in
+    /// importers.toml via `use_merchant_dict = true`.
     #[arg(long)]
     pub use_merchant_dict: bool,
 

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -180,6 +180,13 @@ pub struct Args {
     #[arg(long)]
     pub no_header: bool,
 
+    /// Categorize transactions using the built-in merchant dictionary
+    /// (NETFLIX → Expenses:Subscriptions, SHELL → Expenses:Transportation:Gas,
+    /// …) instead of leaving unmatched rows at Expenses:Unknown. Can also be
+    /// set per-importer in importers.toml via `use_merchant_dict = true`.
+    #[arg(long)]
+    pub use_merchant_dict: bool,
+
     /// Write output to a file instead of stdout
     #[arg(short, long, value_name = "FILE")]
     pub output: Option<PathBuf>,
@@ -638,6 +645,9 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             if args.include_zero_amounts {
                 csv_config.skip_zero_amounts = false;
             }
+            if args.use_merchant_dict {
+                csv_config.use_merchant_dict = true;
+            }
             // An explicit --amount-locale / --amount-format overrides the
             // separator locale inferred from the data. Report the *effective*
             // locale (override if given, otherwise the inferred one) so the
@@ -667,7 +677,8 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
                 .skip_rows(args.skip_rows)
                 .invert_sign(args.invert_sign)
                 .skip_zero_amounts(!args.include_zero_amounts)
-                .has_header(!args.no_header);
+                .has_header(!args.no_header)
+                .use_merchant_dict(args.use_merchant_dict);
 
             // Column flags accept either a header name or a 0-based index (see
             // `apply_column`), so headerless CSVs can be imported positionally.
@@ -1021,6 +1032,7 @@ narration_column = 1
             default_income: None,
             mappings: HashMap::new(),
             filename_pattern: None,
+            use_merchant_dict: None,
         };
 
         let config = build_config_from_entry(&entry).unwrap();
@@ -1055,6 +1067,7 @@ narration_column = 1
             default_income: None,
             mappings,
             filename_pattern: None,
+            use_merchant_dict: None,
         };
 
         let config = build_config_from_entry(&entry).unwrap();
@@ -1088,6 +1101,7 @@ narration_column = 1
             default_income: Some("Income:Other".to_string()),
             mappings: HashMap::new(),
             filename_pattern: None,
+            use_merchant_dict: None,
         };
 
         let config = build_config_from_entry(&entry).unwrap();
@@ -1122,6 +1136,7 @@ narration_column = 1
             default_income: None,
             mappings: HashMap::new(),
             filename_pattern: None,
+            use_merchant_dict: None,
         };
 
         let config = build_config_from_entry(&entry).unwrap();


### PR DESCRIPTION
## What

rledger ships a 76-pattern merchant dictionary (`rustledger-ops::merchants`) that maps known merchants to expense categories, but it was **unreachable from the CLI**: `use_merchant_dict` defaulted false and was only settable via the library `CsvConfigBuilder`. So every documented merchant (NETFLIX, AMAZON, SHELL, …) stayed at `Expenses:Unknown`:

```
$ printf 'Date,Description,Amount\n2024-03-08,NETFLIX.COM,-15.99\n' > m.csv
$ rledger extract m.csv -a Assets:Bank --date-column Date --narration-column Description --amount-column Amount
  Expenses:Unknown
```

(Worse: even with `use_merchant_dict` on, the regular extract path only produced enrichment *metadata* — it never applied the matched account.)

## How

- **`match_mapping`** (the regular path's account assignment) now consults `MERCHANT_PATTERNS` (case-insensitive substring), **after** user mappings, when `use_merchant_dict` is set — so the dictionary's account is actually assigned.
- A new **`--use-merchant-dict`** flag (wired into the CLI-flags and `--auto` paths) and an **`importers.toml` `use_merchant_dict`** field expose it.

```
$ rledger extract m.csv -a Assets:Bank --use-merchant-dict --date-column Date --narration-column Description --amount-column Amount
  Expenses:Subscriptions:Streaming
```

## Verify

Regression test `test_merchant_dict_categorizes_account_when_enabled` asserts NETFLIX → `Expenses:Subscriptions:Streaming` with the flag, `Expenses:Unknown` without. Full importer suite (138), clippy, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
