### PR TITLE
feat(import): native OFX parser, dropping ofxy and chrono (#1457)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,6 @@
 [default.extend-words]
+# OFX tag name: currency exchange rate (<CURRATE>)
+CURRATE = "CURRATE"
 # Financial term: Profit and Loss
 Pn = "Pn"
 pnl = "pnl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,20 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "chumsky"
 version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,16 +1858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "isolang"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe50d48c77760c55188549098b9a7f6e37ae980c586a24693d6b01c3b2010c3c"
-dependencies = [
- "phf",
- "serde",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,12 +2196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,16 +2255,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2385,21 +2345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ofxy"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df077a0a0329dfc1933af32ff36f1fcf1ad36a639c1efb9f5c9564438cb153d9"
-dependencies = [
- "chrono",
- "isolang",
- "rust_decimal",
- "serde",
- "sgmlish",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,24 +2431,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3345,11 +3272,9 @@ name = "rustledger-importer"
 version = "0.16.5"
 dependencies = [
  "anyhow",
- "chrono",
  "csv",
  "format_num_pattern",
  "jiff",
- "ofxy",
  "proptest",
  "regex",
  "rmp-serde",
@@ -3805,18 +3730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sgmlish"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c08068b26a7f424e587d529b6b075e3cb4f346c2154063d235c4dd679cbf97"
-dependencies = [
- "log",
- "nom",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3906,12 +3819,6 @@ checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ tempfile = "3"
 
 # Data formats
 csv = "1"
-ofxy = "0.2"
 
 # HTTP
 ureq = { version = "3", features = ["json"] }

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -40,7 +40,6 @@ regex.workspace = true
 anyhow.workspace = true
 format_num_pattern.workspace = true
 csv.workspace = true
-ofxy.workspace = true
 # WASM importer loader (wave 2.3b). Mirrors the sandboxing model used by
 # rustledger-plugin's directive-plugin runtime. We depend on
 # rustledger-plugin (not just -plugin-types) for `convert::wrapper_to_directive`
@@ -50,13 +49,6 @@ wasmtime = { workspace = true, optional = true }
 rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
-# `ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`, so
-# we need chrono in the dep tree to call its inherent `.format()` method.
-# IMPORTANT: chrono types must NOT leak into this crate's public API — they
-# are converted to `jiff::civil::Date` inside ofx_importer.rs at the boundary.
-# When v1.0 ships, dropping ofxy or replacing it with a jiff-native OFX
-# parser would let us remove chrono entirely.
-chrono = "0.4"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/rustledger-importer/src/ofx_importer.rs
+++ b/crates/rustledger-importer/src/ofx_importer.rs
@@ -58,25 +58,23 @@ impl OfxImporter {
             )
         })?;
 
-        let statements = parse_ofx(content).with_context(|| "Failed to parse OFX content")?;
+        let transactions = parse_ofx(content).with_context(|| "Failed to parse OFX content")?;
 
         let mut directives = Vec::new();
         let mut warnings = Vec::new();
 
-        // Bank and credit-card statements are imported identically: every
+        // Bank and credit-card transactions are imported identically: every
         // transaction posts to `config.account`.
-        for statement in &statements {
-            let statement_currency = statement.currency.as_deref().unwrap_or("");
-            for txn in &statement.transactions {
-                match Self::build_transaction(
-                    txn,
-                    statement_currency,
-                    &config.account,
-                    default_currency,
-                ) {
-                    Ok(t) => directives.push(Directive::Transaction(t)),
-                    Err(e) => warnings.push(format!("Skipped transaction: {e}")),
-                }
+        for txn in &transactions {
+            let statement_currency = txn.statement_currency.as_deref().unwrap_or("");
+            match Self::build_transaction(
+                txn,
+                statement_currency,
+                &config.account,
+                default_currency,
+            ) {
+                Ok(t) => directives.push(Directive::Transaction(t)),
+                Err(e) => warnings.push(format!("Skipped transaction: {e}")),
             }
         }
 
@@ -183,93 +181,98 @@ impl OfxImporter {
 // ============================================================================
 // Native OFX parser
 //
-// OFX 1.x SGML and OFX 2.x XML differ only in whether leaf elements are closed:
-// SGML writes `<TAG>value` (the value runs to the next `<`), XML writes
-// `<TAG>value</TAG>`. Reading each leaf as "text up to the next `<`" parses both
-// dialects uniformly, with no dependency on header conformance or OFX version.
-// This replaces the `ofxy` crate (and its `chrono` dependency).
+// OFX 1.x SGML and OFX 2.x XML differ only in whether elements are closed: SGML
+// writes `<TAG>value` (the value runs to the next `<`) and may omit end tags on
+// aggregates too, while XML writes `<TAG>value</TAG>`. Reading each leaf as
+// "text up to the next `<`", and bounding each `STMTTRN` by the next sibling /
+// list-close / end-of-input rather than requiring `</STMTTRN>`, parses both
+// dialects (and end-tag-less SGML) with no dependency on header conformance or
+// OFX version. This replaces the `ofxy` crate (and its `chrono` dependency).
+//
+// Dates use the bank-stated civil date (the `YYYYMMDD` prefix of `DTPOSTED`),
+// not a UTC-shifted date — a transaction stamped late evening with a timezone
+// offset stays on the date the statement shows it, which is what an accounting
+// import wants. (`ofxy` converted to UTC, which could move it a day.)
 // ============================================================================
 
-/// One bank or credit-card statement: its declared currency (`CURDEF`) and the
-/// transactions in its `BANKTRANLIST`.
-struct OfxStatement {
-    currency: Option<String>,
-    transactions: Vec<OfxTransaction>,
-}
-
-/// A single `STMTTRN` aggregate, reduced to the fields we import. `date_posted`
-/// and `amount` are kept raw and validated in [`OfxImporter::build_transaction`]
-/// so a malformed value becomes a per-transaction warning, not a hard failure.
+/// A single `STMTTRN`, reduced to the fields we import, plus the statement
+/// currency (nearest preceding `CURDEF`) it belongs to. `date_posted` and
+/// `amount` are kept raw and validated in [`OfxImporter::build_transaction`] so
+/// a malformed or absent value becomes a per-transaction warning, not a silent
+/// drop or a hard failure of the whole import.
 struct OfxTransaction {
     date_posted: String,
     amount: String,
     name: Option<String>,
     memo: Option<String>,
     currency: Option<String>,
+    statement_currency: Option<String>,
 }
 
-/// Parse OFX content (1.x SGML or 2.x XML) into statements. Errors only if the
+/// Parse OFX content (1.x SGML or 2.x XML) into transactions. Errors only if the
 /// input isn't an OFX document at all; a well-formed file with no transactions
 /// yields an empty list.
-fn parse_ofx(content: &str) -> Result<Vec<OfxStatement>> {
+fn parse_ofx(content: &str) -> Result<Vec<OfxTransaction>> {
     if !content.contains("<OFX>") && !content.contains("<OFX ") {
         anyhow::bail!("not an OFX document (no <OFX> element)");
     }
 
-    let mut statements = Vec::new();
-    for (open, close) in [("<STMTRS>", "</STMTRS>"), ("<CCSTMTRS>", "</CCSTMTRS>")] {
-        for region in find_blocks(content, open, close) {
-            statements.push(OfxStatement {
-                currency: leaf(region, "CURDEF"),
-                transactions: parse_transactions(region),
-            });
+    // `CURDEF` positions in document order, so each transaction can take the
+    // currency of the statement it sits in (single forward pass — no per-txn
+    // rescan, keeping the parser linear).
+    let mut curdefs: Vec<(usize, String)> = Vec::new();
+    let mut scan = 0;
+    while let Some(rel) = content[scan..].find("<CURDEF>") {
+        let i = scan + rel;
+        if let Some(v) = leaf(&content[i..], "CURDEF") {
+            curdefs.push((i, v));
         }
+        scan = i + "<CURDEF>".len();
     }
 
-    // Fallback for files carrying STMTTRN aggregates without a recognized
-    // statement wrapper.
-    if statements.is_empty() {
-        let transactions = parse_transactions(content);
-        if !transactions.is_empty() {
-            statements.push(OfxStatement {
-                currency: leaf(content, "CURDEF"),
-                transactions,
-            });
+    let mut transactions = Vec::new();
+    let mut cd = 0;
+    let mut statement_currency: Option<String> = None;
+    let mut scan = 0;
+    while let Some(rel) = content[scan..].find("<STMTTRN>") {
+        let start = scan + rel;
+        let after = start + "<STMTTRN>".len();
+        // Advance the statement currency to the last CURDEF before this txn.
+        while cd < curdefs.len() && curdefs[cd].0 < start {
+            statement_currency = Some(curdefs[cd].1.clone());
+            cd += 1;
         }
+        // The block runs to the next STMTTRN open, the txn-list close, or end —
+        // whichever comes first — so a missing/whitespaced `</STMTTRN>` is fine.
+        let rest = &content[after..];
+        let end = ["<STMTTRN>", "</STMTTRN>", "</BANKTRANLIST>"]
+            .iter()
+            .filter_map(|m| rest.find(m))
+            .min()
+            .unwrap_or(rest.len());
+        let block = &rest[..end];
+        transactions.push(OfxTransaction {
+            date_posted: leaf(block, "DTPOSTED").unwrap_or_default(),
+            amount: leaf(block, "TRNAMT").unwrap_or_default(),
+            name: leaf(block, "NAME"),
+            memo: leaf(block, "MEMO"),
+            currency: transaction_currency(block),
+            statement_currency: statement_currency.clone(),
+        });
+        scan = after;
     }
 
-    Ok(statements)
+    Ok(transactions)
 }
 
-/// Parse every `STMTTRN` block in `region`. A block missing the required
-/// `DTPOSTED`/`TRNAMT` leaves isn't importable and is skipped.
-fn parse_transactions(region: &str) -> Vec<OfxTransaction> {
-    find_blocks(region, "<STMTTRN>", "</STMTTRN>")
-        .into_iter()
-        .filter_map(|block| {
-            Some(OfxTransaction {
-                date_posted: leaf(block, "DTPOSTED")?,
-                amount: leaf(block, "TRNAMT")?,
-                name: leaf(block, "NAME"),
-                memo: leaf(block, "MEMO"),
-                currency: leaf(block, "CURSYM"),
-            })
-        })
-        .collect()
-}
-
-/// Return the slices between each `open`..`close` pair in `s` (non-overlapping;
-/// OFX's STMTTRN/STMTRS aggregates don't self-nest, so this is sufficient).
-fn find_blocks<'a>(s: &'a str, open: &str, close: &str) -> Vec<&'a str> {
-    let mut blocks = Vec::new();
-    let mut rest = s;
-    while let Some(i) = rest.find(open) {
-        let after = &rest[i + open.len()..];
-        let Some(j) = after.find(close) else { break };
-        blocks.push(&after[..j]);
-        rest = &after[j + close.len()..];
-    }
-    blocks
+/// A transaction's own currency: the `<CURSYM>` inside its `<CURRENCY>`
+/// aggregate. Deliberately ignores `<ORIGCURRENCY>` (the pre-conversion
+/// currency), whose `CURSYM` must not be mistaken for the posted amount's.
+fn transaction_currency(block: &str) -> Option<String> {
+    // `<ORIGCURRENCY>` does not contain the literal `<CURRENCY>`, so this only
+    // matches the real `<CURRENCY>` aggregate.
+    let i = block.find("<CURRENCY>")?;
+    leaf(&block[i..], "CURSYM")
 }
 
 /// Extract leaf element `tag`'s value from `block`: the text after `<tag>` up to
@@ -463,17 +466,9 @@ NEWFILEUID:NONE
         let result =
             OfxImporter.extract_from_string(ofx_content, &ofx_cfg("Assets:Bank:Checking", "USD"));
 
-        match &result {
-            Ok(import_result) => {
-                assert_eq!(import_result.directives.len(), 2);
-                assert!(import_result.warnings.is_empty());
-            }
-            Err(e) => {
-                // Some OFX parsers may be strict about format
-                // Just verify we handled the error gracefully
-                println!("OFX parse error (expected with minimal test data): {e}");
-            }
-        }
+        let import_result = result.expect("OFX content should parse");
+        assert_eq!(import_result.directives.len(), 2);
+        assert!(import_result.warnings.is_empty());
     }
 
     #[test]
@@ -535,14 +530,8 @@ NEWFILEUID:NONE
         let result =
             OfxImporter.extract_from_string(ofx_content, &ofx_cfg("Liabilities:CreditCard", "USD"));
 
-        match &result {
-            Ok(import_result) => {
-                assert_eq!(import_result.directives.len(), 1);
-            }
-            Err(e) => {
-                println!("OFX parse error (expected with minimal test data): {e}");
-            }
-        }
+        let import_result = result.expect("OFX content should parse");
+        assert_eq!(import_result.directives.len(), 1);
     }
 
     #[test]
@@ -595,14 +584,8 @@ NEWFILEUID:NONE
         let result =
             OfxImporter.extract_from_string(ofx_content, &ofx_cfg("Assets:Bank:Checking", "USD"));
 
-        match &result {
-            Ok(import_result) => {
-                assert!(import_result.directives.is_empty());
-            }
-            Err(e) => {
-                println!("OFX parse error: {e}");
-            }
-        }
+        let import_result = result.expect("OFX content should parse");
+        assert!(import_result.directives.is_empty());
     }
 
     #[test]
@@ -686,14 +669,8 @@ NEWFILEUID:NONE
         let result =
             OfxImporter.extract_from_string(ofx_content, &ofx_cfg("Assets:Bank:Checking", "USD"));
 
-        match &result {
-            Ok(import_result) => {
-                assert_eq!(import_result.directives.len(), 1);
-            }
-            Err(e) => {
-                println!("OFX parse error: {e}");
-            }
-        }
+        let import_result = result.expect("OFX content should parse");
+        assert_eq!(import_result.directives.len(), 1);
     }
 
     #[test]
@@ -757,14 +734,8 @@ NEWFILEUID:NONE
         let result =
             OfxImporter.extract_from_string(ofx_content, &ofx_cfg("Assets:Bank:Checking", "USD"));
 
-        match &result {
-            Ok(import_result) => {
-                assert_eq!(import_result.directives.len(), 1);
-            }
-            Err(e) => {
-                println!("OFX parse error: {e}");
-            }
-        }
+        let import_result = result.expect("OFX content should parse");
+        assert_eq!(import_result.directives.len(), 1);
     }
 
     #[test]
@@ -828,14 +799,8 @@ NEWFILEUID:NONE
         let result =
             OfxImporter.extract_from_string(ofx_content, &ofx_cfg("Assets:Bank:Checking", "USD"));
 
-        match &result {
-            Ok(import_result) => {
-                assert_eq!(import_result.directives.len(), 1);
-            }
-            Err(e) => {
-                println!("OFX parse error: {e}");
-            }
-        }
+        let import_result = result.expect("OFX content should parse");
+        assert_eq!(import_result.directives.len(), 1);
     }
 
     #[test]
@@ -935,5 +900,117 @@ NEWFILEUID:NONE
             rustledger_core::naive_date(2024, 1, 15).unwrap()
         );
         assert!(ofx_date_to_naive("2024").is_err());
+    }
+
+    /// Helper: the currency of the first extracted transaction's primary posting.
+    fn first_posting_currency(r: &ImportResult) -> String {
+        match &r.directives[0] {
+            Directive::Transaction(t) => t.postings[0].amount().unwrap().currency.to_string(),
+            _ => panic!("expected transaction"),
+        }
+    }
+
+    /// A transaction-level `<CURRENCY><CURSYM>` overrides the statement `CURDEF`.
+    #[test]
+    fn test_native_transaction_cursym_overrides_statement() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240115<TRNAMT>-50.00<NAME>X\n\
+<CURRENCY><CURRATE>1.1<CURSYM>EUR</CURRENCY></STMTTRN></BANKTRANLIST>\n\
+</STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("must parse");
+        assert_eq!(first_posting_currency(&r), "EUR");
+    }
+
+    /// `<ORIGCURRENCY>` (pre-conversion currency) must NOT be used for the posted
+    /// amount — it stays the statement currency. Regression for the review bug
+    /// where `CURSYM` was captured from anywhere in the block.
+    #[test]
+    fn test_native_origcurrency_does_not_override() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240115<TRNAMT>-50.00<NAME>FOREIGN\n\
+<ORIGCURRENCY><CURRATE>0.8<CURSYM>GBP</ORIGCURRENCY></STMTTRN></BANKTRANLIST>\n\
+</STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("must parse");
+        assert_eq!(first_posting_currency(&r), "USD");
+    }
+
+    /// OFX 1.x SGML that omits the `</STMTTRN>` aggregate close tags must still
+    /// yield every transaction (bounded by the next `<STMTTRN>` / list close).
+    #[test]
+    fn test_native_sgml_without_aggregate_close_tags() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST>\n\
+<STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20240115<TRNAMT>-50.00<NAME>A\n\
+<STMTTRN><TRNTYPE>CREDIT<DTPOSTED>20240116<TRNAMT>60.00<NAME>B\n\
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("end-tag-less SGML must parse");
+        assert_eq!(r.directives.len(), 2);
+    }
+
+    /// OFX 2.x (XML) credit-card statement (`<CCSTMTRS>`, closed tags).
+    #[test]
+    fn test_native_2x_credit_card() {
+        let ofx = "<?xml version=\"1.0\"?><?OFX OFXHEADER=\"200\" VERSION=\"200\"?>\n\
+<OFX><CREDITCARDMSGSRSV1><CCSTMTTRNRS><CCSTMTRS><CURDEF>USD</CURDEF>\n\
+<BANKTRANLIST><STMTTRN><TRNTYPE>DEBIT</TRNTYPE><DTPOSTED>20240110</DTPOSTED><TRNAMT>-25.50</TRNAMT><NAME>SHOP</NAME></STMTTRN></BANKTRANLIST>\n\
+</CCSTMTRS></CCSTMTTRNRS></CREDITCARDMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Liabilities:Card", "USD"))
+            .expect("2.x credit card must parse");
+        assert_eq!(r.directives.len(), 1);
+    }
+
+    /// A transaction with neither NAME nor MEMO gets an empty narration.
+    #[test]
+    fn test_native_no_name_no_memo() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240115<TRNAMT>-50.00</STMTTRN></BANKTRANLIST>\n\
+</STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("must parse");
+        assert_eq!(r.directives.len(), 1);
+        let Directive::Transaction(t) = &r.directives[0] else {
+            panic!("expected transaction");
+        };
+        assert_eq!(t.narration.as_str(), "");
+    }
+
+    /// A malformed/absent amount is skipped with a warning, not a hard failure
+    /// or a silent drop.
+    #[test]
+    fn test_native_malformed_amount_warns() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240115<TRNAMT>not-a-number<NAME>X</STMTTRN></BANKTRANLIST>\n\
+</STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("parse succeeds; the bad txn is skipped");
+        assert!(r.directives.is_empty());
+        assert_eq!(r.warnings.len(), 1);
+        assert!(r.warnings[0].contains("invalid amount"));
+    }
+
+    /// The civil date is the bank-stated date, not a UTC-shifted one: a late
+    /// timestamp with an offset that would cross midnight in UTC stays put.
+    #[test]
+    fn test_native_date_is_local_not_utc() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240115230000[-5:EST]<TRNAMT>-50.00<NAME>LATE</STMTTRN></BANKTRANLIST>\n\
+</STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("must parse");
+        let Directive::Transaction(t) = &r.directives[0] else {
+            panic!("expected transaction");
+        };
+        // 23:00 EST is 04:00 UTC next day; we keep the stated 2024-01-15.
+        assert_eq!(t.date, rustledger_core::naive_date(2024, 1, 15).unwrap());
     }
 }

--- a/crates/rustledger-importer/src/ofx_importer.rs
+++ b/crates/rustledger-importer/src/ofx_importer.rs
@@ -213,7 +213,15 @@ struct OfxTransaction {
 /// input isn't an OFX document at all; a well-formed file with no transactions
 /// yields an empty list.
 fn parse_ofx(content: &str) -> Result<Vec<OfxTransaction>> {
-    if !content.contains("<OFX>") && !content.contains("<OFX ") {
+    // The `<OFX>` root may carry attributes or wrap onto the next line, so match
+    // `<OFX` followed by `>` or any whitespace rather than the two literal forms.
+    let has_ofx_root = content.match_indices("<OFX").any(|(i, _)| {
+        content[i + 4..]
+            .chars()
+            .next()
+            .is_some_and(|c| c == '>' || c.is_whitespace())
+    });
+    if !has_ofx_root {
         anyhow::bail!("not an OFX document (no <OFX> element)");
     }
 
@@ -275,20 +283,40 @@ fn transaction_currency(block: &str) -> Option<String> {
     leaf(&block[i..], "CURSYM")
 }
 
-/// Extract leaf element `tag`'s value from `block`: the text after `<tag>` up to
-/// the next `<` (handles SGML `<TAG>v` and XML `<TAG>v</TAG>` alike),
-/// entity-decoded and trimmed. `<tag/>` yields `Some("")`; absence yields `None`.
+/// Extract leaf element `tag`'s value from `block`: the text after the start tag
+/// up to the next `<` (handles SGML `<TAG>v` and XML `<TAG>v</TAG>` alike),
+/// entity-decoded and trimmed. All start-tag forms are recognized — `<TAG>`,
+/// `<TAG/>`, `<TAG />`, and `<TAG attr="…">` / `<TAG attr="…"/>` — with the
+/// self-closing forms yielding `Some("")`. Absence yields `None`. The next
+/// character after `<tag` must be `>`, `/`, or whitespace, so `<TAG>` never
+/// matches a longer sibling like `<TAGEXTRA>`.
 fn leaf(block: &str, tag: &str) -> Option<String> {
-    let open = format!("<{tag}>");
-    if let Some(i) = block.find(&open) {
-        let after = &block[i + open.len()..];
-        let end = after.find('<').unwrap_or(after.len());
-        return Some(decode_entities(after[..end].trim()));
+    let prefix = format!("<{tag}");
+    let mut from = 0;
+    loop {
+        let i = from + block[from..].find(&prefix)?;
+        let rest = &block[i + prefix.len()..];
+        match rest.chars().next() {
+            // `<TAG>value…`
+            Some('>') => {
+                let after = &rest['>'.len_utf8()..];
+                let end = after.find('<').unwrap_or(after.len());
+                return Some(decode_entities(after[..end].trim()));
+            }
+            // `<TAG/>`, `<TAG />`, `<TAG attr=…>`, `<TAG attr=…/>`
+            Some('/' | ' ' | '\t' | '\r' | '\n') => {
+                let gt = rest.find('>')?;
+                if rest[..gt].ends_with('/') {
+                    return Some(String::new()); // self-closing
+                }
+                let after = &rest[gt + 1..];
+                let end = after.find('<').unwrap_or(after.len());
+                return Some(decode_entities(after[..end].trim()));
+            }
+            // Not this tag (e.g. `<TAGEXTRA>`); keep searching.
+            _ => from = i + prefix.len(),
+        }
     }
-    if block.contains(&format!("<{tag}/>")) {
-        return Some(String::new());
-    }
-    None
 }
 
 /// Decode the five predefined XML entities (OFX rarely uses numeric refs).
@@ -307,11 +335,13 @@ fn decode_entities(s: &str) -> String {
 /// Convert an OFX datetime (`YYYYMMDD`, optionally followed by `HHMMSS[.fff][tz]`)
 /// to a civil date by taking the `YYYYMMDD` prefix.
 fn ofx_date_to_naive(s: &str) -> Result<NaiveDate> {
-    let digits: String = s.trim().chars().take_while(char::is_ascii_digit).collect();
-    if digits.len() < 8 {
+    let s = s.trim();
+    // The civil date is the leading `YYYYMMDD`; slice it directly (the bytes are
+    // ASCII, so byte and char indices coincide) rather than allocating.
+    if s.len() < 8 || !s.as_bytes()[..8].iter().all(u8::is_ascii_digit) {
         anyhow::bail!("invalid OFX date: {s:?}");
     }
-    format!("{}-{}-{}", &digits[0..4], &digits[4..6], &digits[6..8])
+    format!("{}-{}-{}", &s[0..4], &s[4..6], &s[6..8])
         .parse()
         .with_context(|| format!("invalid OFX date: {s:?}"))
 }
@@ -894,6 +924,15 @@ NEWFILEUID:NONE
         assert_eq!(leaf("<NAME>Foo</NAME>", "NAME").as_deref(), Some("Foo"));
         assert_eq!(leaf("<MEMO/>", "MEMO").as_deref(), Some(""));
         assert_eq!(leaf("<NAME>x", "MEMO"), None);
+        // All XML start-tag forms (whitespace self-close, attributes).
+        assert_eq!(leaf("<MEMO />", "MEMO").as_deref(), Some(""));
+        assert_eq!(leaf("<MEMO x=\"1\"/>", "MEMO").as_deref(), Some(""));
+        assert_eq!(leaf("<NAME id=\"1\">Foo<", "NAME").as_deref(), Some("Foo"));
+        // A longer sibling must not be matched by a shorter tag.
+        assert_eq!(
+            leaf("<NAMEEXTRA>Z<NAME>Foo", "NAME").as_deref(),
+            Some("Foo")
+        );
         assert_eq!(decode_entities("a &amp; b &lt;c&gt;"), "a & b <c>");
         assert_eq!(
             ofx_date_to_naive("20240115120000[-5:EST]").unwrap(),

--- a/crates/rustledger-importer/src/ofx_importer.rs
+++ b/crates/rustledger-importer/src/ofx_importer.rs
@@ -3,14 +3,16 @@
 //! This module implements importing transactions from OFX (Open Financial Exchange)
 //! and QFX (Quicken Financial Exchange) files commonly exported by banks.
 //!
-//! # Chrono boundary
+//! # Native parser
 //!
-//! `ofxy::body::Transaction::date_posted` returns `chrono::DateTime<Utc>`, but
-//! the rest of the workspace uses `jiff::civil::Date`. The chrono → jiff
-//! conversion happens inside `extract_transaction` via a `format("%Y-%m-%d")
-//! .parse()` round-trip. No `chrono` type appears in any `pub` signature in
-//! this crate — `chrono` is an internal, ofxy-only seal. If we ever drop or
-//! replace ofxy, the chrono dependency can go away with it.
+//! Parsing is done by a small dependency-free reader (see the "Native OFX
+//! parser" section below) rather than an external crate. OFX 1.x (SGML) and OFX
+//! 2.x (XML) differ only in whether leaf elements are closed, so reading each
+//! leaf's value as "the text up to the next `<`" handles both dialects, with no
+//! dependency on header conformance or OFX version — sparse 1.x headers and 2.x
+//! files both parse (see #1457). Dates are produced directly as
+//! [`rustledger_core::NaiveDate`] (jiff), so this crate needs neither `ofxy`
+//! nor `chrono`.
 
 use crate::config::ImporterConfig;
 use crate::{EnrichedImportResult, ImportResult, Importer};
@@ -56,41 +58,24 @@ impl OfxImporter {
             )
         })?;
 
-        let ofx: ofxy::Ofx = content
-            .parse()
-            .with_context(|| "Failed to parse OFX content")?;
+        let statements = parse_ofx(content).with_context(|| "Failed to parse OFX content")?;
 
         let mut directives = Vec::new();
         let mut warnings = Vec::new();
 
-        // Process bank accounts
-        if let Some(bank_msg) = &ofx.body.bank {
-            let stmt = &bank_msg.transaction_response.statement;
-            let currency = &stmt.currency;
-
-            if let Some(txn_list) = &stmt.bank_transactions {
-                for txn in &txn_list.transactions {
-                    match Self::parse_transaction(txn, currency, &config.account, default_currency)
-                    {
-                        Ok(t) => directives.push(Directive::Transaction(t)),
-                        Err(e) => warnings.push(format!("Skipped transaction: {e}")),
-                    }
-                }
-            }
-        }
-
-        // Process credit card accounts
-        if let Some(cc_msg) = &ofx.body.credit_card {
-            let stmt = &cc_msg.transaction_response.statement;
-            let currency = &stmt.currency;
-
-            if let Some(txn_list) = &stmt.bank_transactions {
-                for txn in &txn_list.transactions {
-                    match Self::parse_transaction(txn, currency, &config.account, default_currency)
-                    {
-                        Ok(t) => directives.push(Directive::Transaction(t)),
-                        Err(e) => warnings.push(format!("Skipped transaction: {e}")),
-                    }
+        // Bank and credit-card statements are imported identically: every
+        // transaction posts to `config.account`.
+        for statement in &statements {
+            let statement_currency = statement.currency.as_deref().unwrap_or("");
+            for txn in &statement.transactions {
+                match Self::build_transaction(
+                    txn,
+                    statement_currency,
+                    &config.account,
+                    default_currency,
+                ) {
+                    Ok(t) => directives.push(Directive::Transaction(t)),
+                    Err(e) => warnings.push(format!("Skipped transaction: {e}")),
                 }
             }
         }
@@ -138,23 +123,17 @@ impl OfxImporter {
         Ok(enriched)
     }
 
-    fn parse_transaction(
-        txn: &ofxy::body::Transaction,
+    fn build_transaction(
+        txn: &OfxTransaction,
         statement_currency: &str,
         account: &str,
         default_currency: &str,
     ) -> Result<Transaction> {
-        // Get date from ofxy's DateTime<Utc> via formatted string roundtrip.
-        // See module docstring re: the chrono boundary.
-        let date: NaiveDate = txn
-            .date_posted
-            .format("%Y-%m-%d")
-            .to_string()
+        let date = ofx_date_to_naive(&txn.date_posted)?;
+        let amount: rust_decimal::Decimal = txn
+            .amount
             .parse()
-            .with_context(|| "Invalid date")?;
-
-        // Get amount
-        let amount = txn.amount;
+            .with_context(|| format!("invalid amount: {:?}", txn.amount))?;
 
         // Build narration from name and memo
         let name = txn.name.as_deref().unwrap_or("");
@@ -168,16 +147,11 @@ impl OfxImporter {
         };
 
         // Currency precedence: transaction → statement → config default.
-        let curr = txn.currency.as_ref().map_or_else(
-            || {
-                if statement_currency.is_empty() {
-                    default_currency.to_string()
-                } else {
-                    statement_currency.to_string()
-                }
-            },
-            |c| c.symbol.clone(),
-        );
+        let curr = match txn.currency.as_deref().filter(|c| !c.is_empty()) {
+            Some(c) => c.to_string(),
+            None if statement_currency.is_empty() => default_currency.to_string(),
+            None => statement_currency.to_string(),
+        };
 
         // Create posting
         let units = Amount::new(amount, &curr);
@@ -204,6 +178,139 @@ impl OfxImporter {
 
         Ok(txn_builder)
     }
+}
+
+// ============================================================================
+// Native OFX parser
+//
+// OFX 1.x SGML and OFX 2.x XML differ only in whether leaf elements are closed:
+// SGML writes `<TAG>value` (the value runs to the next `<`), XML writes
+// `<TAG>value</TAG>`. Reading each leaf as "text up to the next `<`" parses both
+// dialects uniformly, with no dependency on header conformance or OFX version.
+// This replaces the `ofxy` crate (and its `chrono` dependency).
+// ============================================================================
+
+/// One bank or credit-card statement: its declared currency (`CURDEF`) and the
+/// transactions in its `BANKTRANLIST`.
+struct OfxStatement {
+    currency: Option<String>,
+    transactions: Vec<OfxTransaction>,
+}
+
+/// A single `STMTTRN` aggregate, reduced to the fields we import. `date_posted`
+/// and `amount` are kept raw and validated in [`OfxImporter::build_transaction`]
+/// so a malformed value becomes a per-transaction warning, not a hard failure.
+struct OfxTransaction {
+    date_posted: String,
+    amount: String,
+    name: Option<String>,
+    memo: Option<String>,
+    currency: Option<String>,
+}
+
+/// Parse OFX content (1.x SGML or 2.x XML) into statements. Errors only if the
+/// input isn't an OFX document at all; a well-formed file with no transactions
+/// yields an empty list.
+fn parse_ofx(content: &str) -> Result<Vec<OfxStatement>> {
+    if !content.contains("<OFX>") && !content.contains("<OFX ") {
+        anyhow::bail!("not an OFX document (no <OFX> element)");
+    }
+
+    let mut statements = Vec::new();
+    for (open, close) in [("<STMTRS>", "</STMTRS>"), ("<CCSTMTRS>", "</CCSTMTRS>")] {
+        for region in find_blocks(content, open, close) {
+            statements.push(OfxStatement {
+                currency: leaf(region, "CURDEF"),
+                transactions: parse_transactions(region),
+            });
+        }
+    }
+
+    // Fallback for files carrying STMTTRN aggregates without a recognized
+    // statement wrapper.
+    if statements.is_empty() {
+        let transactions = parse_transactions(content);
+        if !transactions.is_empty() {
+            statements.push(OfxStatement {
+                currency: leaf(content, "CURDEF"),
+                transactions,
+            });
+        }
+    }
+
+    Ok(statements)
+}
+
+/// Parse every `STMTTRN` block in `region`. A block missing the required
+/// `DTPOSTED`/`TRNAMT` leaves isn't importable and is skipped.
+fn parse_transactions(region: &str) -> Vec<OfxTransaction> {
+    find_blocks(region, "<STMTTRN>", "</STMTTRN>")
+        .into_iter()
+        .filter_map(|block| {
+            Some(OfxTransaction {
+                date_posted: leaf(block, "DTPOSTED")?,
+                amount: leaf(block, "TRNAMT")?,
+                name: leaf(block, "NAME"),
+                memo: leaf(block, "MEMO"),
+                currency: leaf(block, "CURSYM"),
+            })
+        })
+        .collect()
+}
+
+/// Return the slices between each `open`..`close` pair in `s` (non-overlapping;
+/// OFX's STMTTRN/STMTRS aggregates don't self-nest, so this is sufficient).
+fn find_blocks<'a>(s: &'a str, open: &str, close: &str) -> Vec<&'a str> {
+    let mut blocks = Vec::new();
+    let mut rest = s;
+    while let Some(i) = rest.find(open) {
+        let after = &rest[i + open.len()..];
+        let Some(j) = after.find(close) else { break };
+        blocks.push(&after[..j]);
+        rest = &after[j + close.len()..];
+    }
+    blocks
+}
+
+/// Extract leaf element `tag`'s value from `block`: the text after `<tag>` up to
+/// the next `<` (handles SGML `<TAG>v` and XML `<TAG>v</TAG>` alike),
+/// entity-decoded and trimmed. `<tag/>` yields `Some("")`; absence yields `None`.
+fn leaf(block: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    if let Some(i) = block.find(&open) {
+        let after = &block[i + open.len()..];
+        let end = after.find('<').unwrap_or(after.len());
+        return Some(decode_entities(after[..end].trim()));
+    }
+    if block.contains(&format!("<{tag}/>")) {
+        return Some(String::new());
+    }
+    None
+}
+
+/// Decode the five predefined XML entities (OFX rarely uses numeric refs).
+/// `&amp;` is decoded last so `&amp;lt;` becomes `&lt;`, not `<`.
+fn decode_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+}
+
+/// Convert an OFX datetime (`YYYYMMDD`, optionally followed by `HHMMSS[.fff][tz]`)
+/// to a civil date by taking the `YYYYMMDD` prefix.
+fn ofx_date_to_naive(s: &str) -> Result<NaiveDate> {
+    let digits: String = s.trim().chars().take_while(char::is_ascii_digit).collect();
+    if digits.len() < 8 {
+        anyhow::bail!("invalid OFX date: {s:?}");
+    }
+    format!("{}-{}-{}", &digits[0..4], &digits[4..6], &digits[6..8])
+        .parse()
+        .with_context(|| format!("invalid OFX date: {s:?}"))
 }
 
 impl Importer for OfxImporter {
@@ -748,5 +855,85 @@ NEWFILEUID:NONE
             msg.contains("requires a default currency"),
             "expected currency error, got: {msg}"
         );
+    }
+
+    // ===== Native parser: #1457 cases + robustness =====
+
+    /// OFX 1.x SGML that omits CHARSET/COMPRESSION/OLDFILEUID/NEWFILEUID — the
+    /// header-strictness case from #1457. Must parse, and read fields correctly.
+    #[test]
+    fn test_native_1x_sparse_headers() {
+        let ofx = "OFXHEADER:100\nDATA:OFXSGML\nVERSION:102\nSECURITY:NONE\nENCODING:USASCII\n\n\
+<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD<BANKACCTFROM><ACCTID>1</BANKACCTFROM>\n\
+<BANKTRANLIST>\n\
+<STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20240115<TRNAMT>-50.00<FITID>t1<NAME>COFFEE SHOP</STMTTRN>\n\
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("sparse 1.x headers must parse");
+        assert_eq!(r.directives.len(), 1);
+        let Directive::Transaction(txn) = &r.directives[0] else {
+            panic!("expected transaction");
+        };
+        assert_eq!(txn.narration.as_str(), "COFFEE SHOP");
+        assert_eq!(txn.postings[0].account.as_str(), "Assets:Bank");
+    }
+
+    /// OFX 2.x (XML): version 200, `<?xml?>`/`<?OFX?>` prolog, closed tags, an
+    /// XML entity in `<NAME>`, and a self-closing `<MEMO/>`. The #1457 hard case.
+    #[test]
+    fn test_native_2x_xml_with_entities_and_self_closing() {
+        let ofx = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<?OFX OFXHEADER=\"200\" VERSION=\"200\" SECURITY=\"NONE\" OLDFILEUID=\"NONE\" NEWFILEUID=\"NONE\"?>\n\
+<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD</CURDEF>\n\
+<BANKTRANLIST>\n\
+<STMTTRN><TRNTYPE>DEBIT</TRNTYPE><DTPOSTED>20240115120000.000[-5:EST]</DTPOSTED><TRNAMT>-50.00</TRNAMT><FITID>t1</FITID><NAME>Johnson &amp; Co</NAME><MEMO/></STMTTRN>\n\
+</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("2.x XML must parse");
+        assert_eq!(r.directives.len(), 1);
+        let Directive::Transaction(txn) = &r.directives[0] else {
+            panic!("expected transaction");
+        };
+        // Entity decoded; timezone date reduced to the civil date; MEMO empty.
+        assert_eq!(txn.narration.as_str(), "Johnson & Co");
+        assert_eq!(txn.date, rustledger_core::naive_date(2024, 1, 15).unwrap());
+    }
+
+    /// Bank + credit-card statements with different `CURDEF` values: each
+    /// statement's transactions must use its own currency.
+    #[test]
+    fn test_native_multi_statement_currency() {
+        let ofx = "<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS><CURDEF>USD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240101<TRNAMT>-1.00<NAME>A</STMTTRN></BANKTRANLIST>\n\
+</STMTRS></STMTTRNRS></BANKMSGSRSV1>\n\
+<CREDITCARDMSGSRSV1><CCSTMTTRNRS><CCSTMTRS><CURDEF>CAD\n\
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240102<TRNAMT>-2.00<NAME>B</STMTTRN></BANKTRANLIST>\n\
+</CCSTMTRS></CCSTMTTRNRS></CREDITCARDMSGSRSV1></OFX>";
+        let r = OfxImporter
+            .extract_from_string(ofx, &ofx_cfg("Assets:Bank", "USD"))
+            .expect("multi-statement must parse");
+        assert_eq!(r.directives.len(), 2);
+        let curr = |d: &Directive| match d {
+            Directive::Transaction(t) => t.postings[0].amount().unwrap().currency.to_string(),
+            _ => panic!("expected transaction"),
+        };
+        assert_eq!(curr(&r.directives[0]), "USD");
+        assert_eq!(curr(&r.directives[1]), "CAD");
+    }
+
+    #[test]
+    fn test_native_leaf_and_helpers() {
+        assert_eq!(leaf("<NAME>Foo<MEMO>Bar", "NAME").as_deref(), Some("Foo"));
+        assert_eq!(leaf("<NAME>Foo</NAME>", "NAME").as_deref(), Some("Foo"));
+        assert_eq!(leaf("<MEMO/>", "MEMO").as_deref(), Some(""));
+        assert_eq!(leaf("<NAME>x", "MEMO"), None);
+        assert_eq!(decode_entities("a &amp; b &lt;c&gt;"), "a & b <c>");
+        assert_eq!(
+            ofx_date_to_naive("20240115120000[-5:EST]").unwrap(),
+            rustledger_core::naive_date(2024, 1, 15).unwrap()
+        );
+        assert!(ofx_date_to_naive("2024").is_err());
     }
 }

--- a/crates/rustledger-importer/tests/ofx_amount_fixtures.rs
+++ b/crates/rustledger-importer/tests/ofx_amount_fixtures.rs
@@ -1,9 +1,9 @@
 //! Differential tests for OFX amount parsing.
 //!
-//! The OFX importer delegates number parsing to the third-party `ofxy` crate. These tests
+//! The OFX importer parses `<TRNAMT>` values into `rust_decimal::Decimal`. These tests
 //! construct OFX content with known amounts (sub-cent, negative, large) and assert that
 //! every posting carries the exact `Decimal` value from the source — so that any silent
-//! corruption by `ofxy` would surface here, the same way #972 surfaced for CSV.
+//! corruption in amount parsing would surface here, the same way #972 surfaced for CSV.
 
 use rust_decimal::Decimal;
 use rustledger_importer::{
@@ -93,7 +93,7 @@ fn ofx_preserves_normal_amounts() {
 
 #[test]
 fn ofx_preserves_sub_cent_amounts() {
-    // The bug class from #972: any silent precision loss in `ofxy`'s amount parser
+    // The bug class from #972: any silent precision loss in OFX amount parsing
     // would corrupt these.
     assert_ofx_amounts(&["0.01", "-0.01", "0.05", "-0.05", "0.001", "-0.001"]);
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -171,10 +171,6 @@ criteria = "safe-to-deploy"
 version = "1.2.64"
 criteria = "safe-to-deploy"
 
-[[exemptions.chrono]]
-version = "0.4.45"
-criteria = "safe-to-deploy"
-
 [[exemptions.chumsky]]
 version = "1.0.0-alpha.8"
 criteria = "safe-to-deploy"
@@ -459,10 +455,6 @@ criteria = "safe-to-deploy"
 version = "1.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.isolang]]
-version = "2.4.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.itertools]]
 version = "0.14.0"
 criteria = "safe-to-deploy"
@@ -547,10 +539,6 @@ criteria = "safe-to-deploy"
 version = "0.3.8"
 criteria = "safe-to-run"
 
-[[exemptions.minimal-lexical]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.mio]]
 version = "1.2.1"
 criteria = "safe-to-deploy"
@@ -583,10 +571,6 @@ criteria = "safe-to-deploy"
 version = "0.7.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.ofxy]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.once_cell]]
 version = "1.21.3"
 criteria = "safe-to-deploy"
@@ -609,14 +593,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.petgraph]]
 version = "0.6.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.phf]]
-version = "0.11.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.phf_shared]]
-version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkg-config]]
@@ -831,10 +807,6 @@ criteria = "safe-to-deploy"
 version = "0.29.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.sgmlish]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.sha1]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
@@ -861,10 +833,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.simdutf8]]
 version = "0.1.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.siphasher]]
-version = "1.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.stable_deref_trait]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2205,15 +2205,6 @@ delta = "1.4.0 -> 1.5.0"
 notes = "Unsafe review notes: https://crrev.com/c/5650836"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.nom]]
-who = "danakj@chromium.org"
-criteria = "safe-to-deploy"
-version = "7.1.3"
-notes = """
-Reviewed in https://chromium-review.googlesource.com/c/chromium/src/+/5046153
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.num-integer]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## What

Replaces the `ofxy` crate with a small **dependency-free** OFX parser, resolving **both** halves of #1457 and removing the `chrono` dependency this module carried solely for `ofxy`. This is the durable alternative to the header shim (#1458, which this supersedes).

## Why not the shim / a different crate

- The shim (#1458) worked but leaned on `ofxy`'s *undocumented* tolerance of XML in an SGML body.
- The one maintained alternative crate (`ofx-rs`) swaps `chrono` for `time` (still not jiff) and is less adopted — lateral motion, not an upgrade.
- A native reader fixes 2.x robustly, removes a dependency *and* the `chrono` seal (the module's stated goal), and gives full control over header leniency.

## How

OFX 1.x SGML and 2.x XML differ only in whether leaf elements are closed (`<TAG>v` vs `<TAG>v</TAG>`). Reading each leaf as **"text up to the next `<`"** parses both uniformly, ignoring header conformance and OFX version — so sparse 1.x headers and 2.x files just work. The reader also decodes the five XML entities and tolerates self-closing tags (`<MEMO/>`). Dates come straight from the `YYYYMMDD` prefix as `NaiveDate` (jiff) → no `chrono`.

Behavior preserved exactly: bank + credit-card statements, name/memo narration, payee, currency precedence (txn `CURSYM` → statement `CURDEF` → config default), sign-based `Expenses/Income:Unknown` contra.

## Verify

```
1.x sparse headers          -> 3 txns   (was: "headers missing 'CHARSET'")
2.x XML                     -> 1 txn    (was: "does not yet support OFX version: 200")
2.x XML w/ &amp; + <MEMO/>  -> payee "Johnson & Co"
full-header 1.x             -> 2 txns   (unchanged)
non-OFX input               -> error, exit 1
```

145 importer tests pass (all existing OFX tests + new: sparse 1.x, 2.x-with-entities, multi-statement currency, leaf/date/entity helpers). `ofxy` removed from the workspace; clippy + fmt green.

Closes #1457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
