### PR TITLE
fix(cli): broken-pipe handling for check/completions + query flag-after-query hint

### DIFF
--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -324,6 +324,9 @@ fn main() -> ExitCode {
             }
             match rustledger::cmd::check::run(&args) {
                 Ok(code) => code,
+                // A downstream reader (e.g. `| head`) closing the pipe is not an
+                // error — exit cleanly, matching the Query/Format arms.
+                Err(e) if rustledger::pager::is_broken_pipe(&e) => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("error: {e:#}");
                     ExitCode::from(2)
@@ -497,8 +500,21 @@ fn main() -> ExitCode {
             }
         },
         Commands::Completions { shell } => {
-            clap_complete::generate(shell, &mut Cli::command(), "rledger", &mut io::stdout());
-            ExitCode::SUCCESS
+            // Generate into a buffer first: `clap_complete::generate` writes
+            // straight to the sink and panics on a write error, so writing to a
+            // pipe that a reader closed early (e.g. `| head`) would abort. We
+            // write the buffer ourselves and treat a broken pipe as success.
+            use std::io::Write as _;
+            let mut buf = Vec::new();
+            clap_complete::generate(shell, &mut Cli::command(), "rledger", &mut buf);
+            match io::stdout().write_all(&buf) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) if e.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::from(1)
+                }
+            }
         }
     }
 }

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -183,6 +183,22 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
         eprintln!("Loaded {} directives", directives.len());
     }
 
+    // The QUERY positional is `trailing_var_arg` (so an unquoted query works),
+    // which means a flag placed *after* the query is captured as a query token
+    // rather than parsed as a flag. Catch that early with an actionable error
+    // instead of a baffling "unexpected token"/"column not found" from the BQL
+    // parser. `--x` and `-x` (short flag) are never valid leading BQL tokens;
+    // `-5` (a negative number) is left alone.
+    if let Some(flag) = args.query.iter().find(|t| {
+        t.starts_with("--")
+            || (t.starts_with('-') && t.as_bytes().get(1).is_some_and(u8::is_ascii_alphabetic))
+    }) {
+        anyhow::bail!(
+            "'{flag}' looks like a command-line flag but was parsed as part of the query.\n  \
+             Flags must come before the query, e.g. `rledger query <file> {flag} … \"<query>\"`."
+        );
+    }
+
     // Determine query source
     let query_str = if !args.query.is_empty() {
         args.query.join(" ")

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -187,11 +187,12 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     // which means a flag placed *after* the query is captured as a query token
     // rather than parsed as a flag. Catch that early with an actionable error
     // instead of a baffling "unexpected token"/"column not found" from the BQL
-    // parser. `--x` and `-x` (short flag) are never valid leading BQL tokens;
-    // `-5` (a negative number) is left alone.
+    // parser. Only a long flag (`--format`) or a bare short flag (exactly `-`
+    // plus one letter, e.g. `-m`) is treated as misplaced; `-5` (a negative
+    // number) and `-number` (BQL unary negation of a column) are left alone.
     if let Some(flag) = args.query.iter().find(|t| {
         t.starts_with("--")
-            || (t.starts_with('-') && t.as_bytes().get(1).is_some_and(u8::is_ascii_alphabetic))
+            || (t.len() == 2 && t.starts_with('-') && t.as_bytes()[1].is_ascii_alphabetic())
     }) {
         anyhow::bail!(
             "'{flag}' looks like a command-line flag but was parsed as part of the query.\n  \

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -477,6 +477,44 @@ fn test_query_select_accounts() {
 }
 
 #[test]
+fn test_query_flag_after_query_is_rejected_with_hint() {
+    let path = test_fixtures_dir().join("valid-ledger.beancount");
+    if !path.exists() {
+        eprintln!("Skipping: valid-ledger.beancount not found");
+        return;
+    }
+
+    // A flag after the (trailing_var_arg) query is captured as a query token;
+    // we should fail with an actionable hint, not a cryptic BQL error.
+    let output = Command::new(require_rledger!())
+        .arg("query")
+        .arg(&path)
+        .arg("SELECT account")
+        .arg("--numberify")
+        .output()
+        .expect("Failed to run rledger query");
+    assert!(!output.status.success(), "misplaced flag should error");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("looks like a command-line flag"),
+        "expected a misplaced-flag hint, got: {stderr}"
+    );
+
+    // A negative number in the query must NOT be mistaken for a flag.
+    let ok = Command::new(require_rledger!())
+        .arg("query")
+        .arg(&path)
+        .arg("SELECT account WHERE number > -5")
+        .output()
+        .expect("Failed to run rledger query");
+    assert!(
+        ok.status.success(),
+        "negative number should not be flagged: {}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+}
+
+#[test]
 fn test_query_sum_positions() {
     let path = test_fixtures_dir().join("valid-ledger.beancount");
     if !path.exists() {
@@ -1598,9 +1636,21 @@ fn test_query_and_format_handle_broken_pipe() {
         (status, errbuf)
     };
 
+    // `completions` streams a large script regardless of any ledger; `check`
+    // only emits many lines when there are many errors, so give it one.
+    let mut errs = String::from("2020-01-01 open Assets:Cash\n");
+    for i in 0..2000 {
+        errs.push_str(&format!("2020-01-01 balance Assets:Cash {i}.00 USD\n"));
+    }
+    let errtmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(errtmp.path(), &errs).expect("write errors ledger");
+    let errpath = errtmp.path().to_str().expect("path");
+
     for args in [
         vec!["query", path, "SELECT date, account, position, narration"],
         vec!["format", path],
+        vec!["check", errpath],
+        vec!["completions", "bash"],
     ] {
         let (status, stderr) = run_and_close(&args);
         assert!(
@@ -1609,8 +1659,8 @@ fn test_query_and_format_handle_broken_pipe() {
             args.join(" ")
         );
         assert!(
-            !stderr.contains("Broken pipe"),
-            "`rledger {}` should not print a broken-pipe error; stderr: {stderr}",
+            !stderr.contains("Broken pipe") && !stderr.contains("panic"),
+            "`rledger {}` should not print a broken-pipe error or panic; stderr: {stderr}",
             args.join(" ")
         );
     }

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -512,6 +512,20 @@ fn test_query_flag_after_query_is_rejected_with_hint() {
         "negative number should not be flagged: {}",
         String::from_utf8_lossy(&ok.stderr)
     );
+
+    // Unary negation of a column (`-number`) is valid BQL, not a flag — it must
+    // never trip the misplaced-flag hint even when written unquoted.
+    let neg = Command::new(require_rledger!())
+        .arg("query")
+        .arg(&path)
+        .arg("SELECT")
+        .arg("-number")
+        .output()
+        .expect("Failed to run rledger query");
+    assert!(
+        !String::from_utf8_lossy(&neg.stderr).contains("looks like a command-line flag"),
+        "unary negation '-number' must not be flagged as a CLI flag"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Two CLI robustness papercuts found by dogfooding:

1. **Broken pipe on `check` / `completions`.** Piping their output to a reader that closes early (`| head`, or quitting a pager) produced `error: Broken pipe (os error 32)` (exit 2) for `check`, and a **panic (exit 101)** for `completions` — whereas `query`/`format`/`report` exit cleanly.
2. **`query` swallows flags placed after the query.** The `QUERY` positional is `trailing_var_arg` (to allow unquoted queries), so `rledger query f.bean "SELECT …" --numberify` captured `--numberify` as a query token and failed with a baffling `column 'numberify' not found`.

## How

- Add the existing `is_broken_pipe` guard to the **`check`** dispatch arm (matching query/format/report).
- **`completions`**: generate into a buffer, then write it ourselves and treat `BrokenPipe` as success — `clap_complete::generate` writes straight to the sink and panics on a write error.
- **`query`**: before running, detect a leading `--x` / `-x` (short flag) token in the query and bail with an actionable hint ("Flags must come before the query…"). Negative numbers (`-5`) are not flagged.

## Verify

```
rledger check big.beancount | head            # exit 0, no "Broken pipe"
rledger completions bash | head -c 30         # exit 0, no panic
rledger query f.bean "SELECT account" -m      # error: '-m' looks like a command-line flag …
rledger query f.bean "SELECT account WHERE number > -5"   # runs fine
```

Extended the broken-pipe integration test to cover `check` and `completions`; added a `query` flag-after-query test. clippy + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
