### PR TITLE
fix(validate): defer explicit-posting open check past account-rewriting plugins

### DIFF
--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -2134,7 +2134,7 @@ fn test_open_check_deferred_past_account_rewriting_plugins() {
     );
 }
 
-/// The deferred E1001 dedup is keyed per-posting (file_id, span), not per
+/// The deferred E1001 dedup is keyed per-posting (`file_id`, span), not per
 /// (account, date): two transactions on the SAME date posting to the SAME
 /// unopened account — one elided (reported early), one explicit (reported
 /// late) — must BOTH be flagged, not silently deduped to one.

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -2088,3 +2088,48 @@ fn test_booking_failure_partitioned_from_late_validation() {
         "all three transactions should appear in final Ledger output (including the failed one); got {txn_count}"
     );
 }
+
+/// Account-rewriting regular plugins (e.g. `rename_accounts`, `split_expenses`)
+/// run AFTER the early validation phase, so the open-existence check (E1001)
+/// for *explicit* postings must be deferred to the late phase — otherwise the
+/// pre-rewrite account name is falsely flagged "never opened". The genuine
+/// unopened case must still be caught.
+#[test]
+fn test_open_check_deferred_past_account_rewriting_plugins() {
+    use rustledger_loader::{LoadOptions, load};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // rename_accounts: post to `Expenses:Old`, open only the target `Expenses:New`.
+    let rename = dir.path().join("rename.beancount");
+    std::fs::write(
+        &rename,
+        "plugin \"rename_accounts\" \"{'Expenses:Old': 'Expenses:New'}\"\n\
+         2020-01-01 open Assets:Cash\n\
+         2020-01-01 open Expenses:New\n\
+         2020-01-02 * \"x\"\n  Assets:Cash  -10.00 USD\n  Expenses:Old  10.00 USD\n",
+    )
+    .expect("write rename ledger");
+    let ledger = load(&rename, &LoadOptions::default()).expect("load rename ledger");
+    let e1001: Vec<_> = ledger.errors.iter().filter(|e| e.code == "E1001").collect();
+    assert!(
+        e1001.is_empty(),
+        "rename_accounts must not trip E1001 on the pre-rewrite account; got: {e1001:?}"
+    );
+
+    // Regression guard: a genuine explicit posting to an unopened account
+    // (no plugin) is still reported.
+    let unopened = dir.path().join("unopened.beancount");
+    std::fs::write(
+        &unopened,
+        "2020-01-01 open Assets:Cash\n\
+         2020-01-02 * \"x\"\n  Assets:Cash  -10.00 USD\n  Expenses:NeverOpened  10.00 USD\n",
+    )
+    .expect("write unopened ledger");
+    let ledger2 = load(&unopened, &LoadOptions::default()).expect("load unopened ledger");
+    assert!(
+        ledger2.errors.iter().any(|e| e.code == "E1001"),
+        "a genuine unopened account must still be flagged E1001; got: {:?}",
+        ledger2.errors
+    );
+}

--- a/crates/rustledger-loader/tests/loader_test.rs
+++ b/crates/rustledger-loader/tests/loader_test.rs
@@ -2133,3 +2133,33 @@ fn test_open_check_deferred_past_account_rewriting_plugins() {
         ledger2.errors
     );
 }
+
+/// The deferred E1001 dedup is keyed per-posting (file_id, span), not per
+/// (account, date): two transactions on the SAME date posting to the SAME
+/// unopened account — one elided (reported early), one explicit (reported
+/// late) — must BOTH be flagged, not silently deduped to one.
+#[test]
+fn test_e1001_dedup_is_per_posting_not_account_date() {
+    use rustledger_loader::{LoadOptions, load};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("samedate.beancount");
+    std::fs::write(
+        &path,
+        "2020-01-01 open Assets:Cash\n\
+         2020-01-01 * \"elided\"\n  Assets:Cash  -5.00 USD\n  Expenses:Same\n\
+         2020-01-01 * \"explicit\"\n  Assets:Cash  -7.00 USD\n  Expenses:Same  7.00 USD\n",
+    )
+    .expect("write ledger");
+    let ledger = load(&path, &LoadOptions::default()).expect("load ledger");
+    let same_acct_e1001 = ledger
+        .errors
+        .iter()
+        .filter(|e| e.code == "E1001" && e.message.contains("Expenses:Same"))
+        .count();
+    assert_eq!(
+        same_acct_e1001, 2,
+        "both same-date postings to the unopened account must be reported; got: {:?}",
+        ledger.errors
+    );
+}

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -88,9 +88,9 @@ pub enum Phase {
 }
 
 use validators::{
-    validate_balance_early, validate_balance_late, validate_close, validate_close_late,
-    validate_document, validate_note, validate_open, validate_pad, validate_transaction_early,
-    validate_transaction_late,
+    register_open_late, validate_balance_early, validate_balance_late, validate_close,
+    validate_close_late, validate_document, validate_note, validate_open, validate_pad,
+    validate_transaction_early, validate_transaction_late,
 };
 
 use rayon::prelude::*;
@@ -537,6 +537,12 @@ fn validate_phase_inner<D: ValidatableDirective>(
             // ── Early-only kinds (state setup, structural / presence checks) ──
             (Phase::Early, Directive::Open(open)) => {
                 validate_open(state, open, &mut errors);
+            }
+            // Late sees plugin-generated Opens (regular plugins run after early),
+            // so the deferred account-presence check on plugin-added postings
+            // recognizes them. No-op for originals already in state from early.
+            (Phase::Late, Directive::Open(open)) => {
+                register_open_late(state, open);
             }
             (Phase::Early, Directive::Close(close)) => {
                 validate_close(state, close, &mut errors);

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -320,6 +320,16 @@ pub struct LedgerState {
     /// reopen-after-close is ever supported, a legitimate later close on
     /// the same account still runs the inventory check.
     pub(crate) late_close_processed: FxHashSet<(rustledger_core::Account, NaiveDate)>,
+    /// `(account, date)` pairs for which the early phase already emitted
+    /// `AccountNotOpen` (E1001) on an *elided* posting to an unopened account.
+    /// Elided postings must be checked early — booking interpolates them, so the
+    /// account has to exist before booking (the Python #877-equivalent case).
+    /// Explicit postings are deferred to the late phase so account-rewriting
+    /// regular plugins (e.g. `rename_accounts`, `split_expenses`), which run
+    /// after early, aren't falsely flagged on their pre-rewrite account name.
+    /// The late phase consults this set to avoid double-reporting an elided
+    /// posting that is still unopened after the plugin pass.
+    pub(crate) account_not_open_early: FxHashSet<(rustledger_core::Account, NaiveDate)>,
 }
 
 impl LedgerState {
@@ -2818,9 +2828,9 @@ mod tests {
         );
     }
 
-    /// `validate_late` must NOT re-emit account-presence errors that the
-    /// early phase already produced — otherwise the loader pipeline
-    /// would surface duplicate E1001 diagnostics per posting.
+    /// An *explicit* posting to an unopened account is reported in the LATE
+    /// phase (deferred from early so account-rewriting plugins run first) —
+    /// exactly once across phases, never duplicated.
     #[test]
     fn test_validate_late_does_not_duplicate_e1001() {
         let directives = vec![
@@ -2851,10 +2861,13 @@ mod tests {
             .filter(|e| e.code == ErrorCode::AccountNotOpen)
             .count();
 
-        assert_eq!(early_e1001, 1, "early phase should emit E1001 once");
         assert_eq!(
-            late_e1001, 0,
-            "late phase must not re-emit account-presence errors; got: {late:?}"
+            early_e1001, 0,
+            "explicit posting: early phase defers E1001 to late; got: {early:?}"
+        );
+        assert_eq!(
+            late_e1001, 1,
+            "explicit posting: late phase emits E1001 exactly once; got: {late:?}"
         );
     }
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -320,16 +320,18 @@ pub struct LedgerState {
     /// reopen-after-close is ever supported, a legitimate later close on
     /// the same account still runs the inventory check.
     pub(crate) late_close_processed: FxHashSet<(rustledger_core::Account, NaiveDate)>,
-    /// `(account, date)` pairs for which the early phase already emitted
-    /// `AccountNotOpen` (E1001) on an *elided* posting to an unopened account.
-    /// Elided postings must be checked early — booking interpolates them, so the
-    /// account has to exist before booking (the Python #877-equivalent case).
-    /// Explicit postings are deferred to the late phase so account-rewriting
-    /// regular plugins (e.g. `rename_accounts`, `split_expenses`), which run
-    /// after early, aren't falsely flagged on their pre-rewrite account name.
-    /// The late phase consults this set to avoid double-reporting an elided
-    /// posting that is still unopened after the plugin pass.
-    pub(crate) account_not_open_early: FxHashSet<(rustledger_core::Account, NaiveDate)>,
+    /// Per-posting identities `(file_id, span)` for which the early phase already
+    /// emitted `AccountNotOpen` (E1001) on an *elided* posting to an unopened
+    /// account. Elided postings must be checked early — booking interpolates
+    /// them, so the account has to exist before booking (the Python
+    /// #877-equivalent case). Explicit postings are deferred to the late phase
+    /// so account-rewriting regular plugins (e.g. `rename_accounts`,
+    /// `split_expenses`), which run after early, aren't falsely flagged on their
+    /// pre-rewrite account name. The late phase consults this set to skip the
+    /// *same* posting (a booked-from-elided one still unopened after plugins),
+    /// keyed by source identity so a different posting that merely shares an
+    /// account/date is still reported.
+    pub(crate) account_not_open_early: FxHashSet<(u16, rustledger_core::Span)>,
 }
 
 impl LedgerState {

--- a/crates/rustledger-validate/src/validators/account.rs
+++ b/crates/rustledger-validate/src/validators/account.rs
@@ -62,6 +62,35 @@ pub fn validate_open(state: &mut LedgerState, open: &Open, errors: &mut Vec<Vali
         .insert(open.account.clone(), Inventory::new());
 }
 
+/// Late-phase: reflect an `Open` in account/inventory state without re-running
+/// the early-phase name/duplicate checks. Regular plugins (e.g.
+/// `currency_accounts`) run *after* the early phase and may generate both an
+/// Open and a posting for the same account; this lets the late-phase
+/// account-presence check on plugin-added postings see those generated Opens
+/// (originals are already in state from early, so this is a no-op for them).
+pub fn register_open_late(state: &mut LedgerState, open: &Open) {
+    if state.accounts.contains_key(&open.account) {
+        return;
+    }
+    let booking = open
+        .booking
+        .as_ref()
+        .and_then(|b| b.parse::<BookingMethod>().ok())
+        .unwrap_or(state.options.default_booking_method);
+    state.accounts.insert(
+        open.account.clone(),
+        AccountState {
+            opened: open.date,
+            closed: None,
+            currencies: open.currencies.iter().cloned().collect(),
+            booking,
+        },
+    );
+    state
+        .inventories
+        .insert(open.account.clone(), Inventory::new());
+}
+
 /// Early-phase Close validation — runs on pre-booking directives.
 ///
 /// Checks that the account being closed exists and isn't already

--- a/crates/rustledger-validate/src/validators/mod.rs
+++ b/crates/rustledger-validate/src/validators/mod.rs
@@ -7,7 +7,7 @@ pub mod helpers;
 pub mod transaction;
 
 // Re-export validator functions for use in lib.rs
-pub use account::{validate_close, validate_close_late, validate_open};
+pub use account::{register_open_late, validate_close, validate_close_late, validate_open};
 pub use balance::{validate_balance_early, validate_balance_late, validate_pad};
 pub use document::{validate_document, validate_note};
 pub use transaction::{validate_transaction_early, validate_transaction_late};

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -19,7 +19,7 @@ use crate::{AccountState, LedgerState, ValidationOptions};
 /// deliberately deferred to the late phase, since elided postings have
 /// `units: None` here.
 pub fn validate_transaction_early(
-    state: &LedgerState,
+    state: &mut LedgerState,
     txn: &Transaction,
     errors: &mut Vec<ValidationError>,
 ) {
@@ -30,17 +30,26 @@ pub fn validate_transaction_early(
     // here — we don't want to run the currency check yet (deferred to late
     // phase so it sees filled units).
     for posting in &txn.postings {
-        match state.accounts.get(&posting.account) {
-            Some(account_state) => {
-                validate_account_lifecycle(txn, posting, account_state, errors);
-            }
-            None => {
-                errors.push(ValidationError::new(
-                    ErrorCode::AccountNotOpen,
-                    format!("Account {} was never opened", posting.account),
-                    txn.date,
-                ));
-            }
+        if let Some(account_state) = state.accounts.get(&posting.account) {
+            validate_account_lifecycle(txn, posting, account_state, errors);
+            continue;
+        }
+        // Account not opened. Only flag *elided* postings here: booking
+        // interpolates them, so the account must exist before booking (the
+        // Python #877-equivalent case). Explicit postings are deferred to the
+        // late phase so account-rewriting regular plugins (`rename_accounts`,
+        // `split_expenses`, …) — which run after early — aren't falsely flagged
+        // on their pre-rewrite account name. The recorded key lets the late
+        // phase skip re-reporting an elided posting that is still unopened.
+        if posting.units.is_none() {
+            errors.push(ValidationError::new(
+                ErrorCode::AccountNotOpen,
+                format!("Account {} was never opened", posting.account),
+                txn.date,
+            ));
+            state
+                .account_not_open_early
+                .insert((posting.account.clone(), txn.date));
         }
     }
 }
@@ -55,17 +64,26 @@ pub fn validate_transaction_late(
     txn: &Transaction,
     errors: &mut Vec<ValidationError>,
 ) {
-    // Currency-constraint checks on filled postings. These need to run
-    // late because they call `posting.amount()`, which is `None` for
-    // elided postings until booking fills them in.
+    // Currency-constraint checks on filled postings (they call
+    // `posting.amount()`, `None` for elided postings until booking fills them).
     //
-    // Account-presence (E1001) already ran in the early phase; we
-    // deliberately don't re-emit here, but we still need the account
-    // state to enforce currency constraints — so skip the check rather
-    // than re-flagging unopened accounts.
+    // Account-presence (E1001) for *explicit* postings is also emitted here —
+    // deferred from the early phase so account-rewriting regular plugins have
+    // already run and we see the final account names. Elided postings were
+    // checked early (booking needs the account); `account_not_open_early`
+    // guards against double-reporting one that is still unopened.
     for posting in &txn.postings {
         if let Some(account_state) = state.accounts.get(&posting.account) {
             validate_posting_currency(state, txn, posting, account_state, errors);
+        } else if !state
+            .account_not_open_early
+            .contains(&(posting.account.clone(), txn.date))
+        {
+            errors.push(ValidationError::new(
+                ErrorCode::AccountNotOpen,
+                format!("Account {} was never opened", posting.account),
+                txn.date,
+            ));
         }
     }
 

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -47,9 +47,12 @@ pub fn validate_transaction_early(
                 format!("Account {} was never opened", posting.account),
                 txn.date,
             ));
+            // Key by the posting's source identity (not account/date) so the
+            // late phase skips *this* posting only — a different posting that
+            // merely shares the account on the same date is still reported.
             state
                 .account_not_open_early
-                .insert((posting.account.clone(), txn.date));
+                .insert((posting.file_id, posting.span));
         }
     }
 }
@@ -77,7 +80,7 @@ pub fn validate_transaction_late(
             validate_posting_currency(state, txn, posting, account_state, errors);
         } else if !state
             .account_not_open_early
-            .contains(&(posting.account.clone(), txn.date))
+            .contains(&(posting.file_id, posting.span))
         {
             errors.push(ValidationError::new(
                 ErrorCode::AccountNotOpen,

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_json.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_json.snap
@@ -8,6 +8,17 @@ expression: pretty
       "code": "E1001",
       "column": 1,
       "end_column": 1,
+      "end_line": 11,
+      "file": "<fixtures>/validation-errors.beancount",
+      "line": 10,
+      "message": "Account Assets:Cash was never opened",
+      "phase": "validate",
+      "severity": "error"
+    },
+    {
+      "code": "E1001",
+      "column": 1,
+      "end_column": 1,
       "end_line": 10,
       "file": "<fixtures>/validation-errors.beancount",
       "line": 5,
@@ -22,17 +33,6 @@ expression: pretty
       "end_line": 10,
       "file": "<fixtures>/validation-errors.beancount",
       "line": 5,
-      "message": "Account Assets:Cash was never opened",
-      "phase": "validate",
-      "severity": "error"
-    },
-    {
-      "code": "E1001",
-      "column": 1,
-      "end_column": 1,
-      "end_line": 11,
-      "file": "<fixtures>/validation-errors.beancount",
-      "line": 10,
       "message": "Account Assets:Cash was never opened",
       "phase": "validate",
       "severity": "error"

--- a/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_text.snap
+++ b/crates/rustledger/tests/snapshots/cli_snapshot_test__check_validation_errors_text.snap
@@ -4,6 +4,15 @@ expression: normalized.trim()
 ---
 E1001
 
+  x Account Assets:Cash was never opened
+    ,-[<fixtures>/validation-errors.beancount:10:1]
+  9 | ; Balance assertion that will fail (no opens, so balance is 0)
+ 10 | 2024-01-16 balance Assets:Cash 100 USD
+    : ^^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^^
+    :                    `-- here
+    `----
+E1001
+
   x Account Expenses:Food was never opened
     ,-[<fixtures>/validation-errors.beancount:5:1]
   4 |     ; Transaction referencing accounts that were never opened
@@ -27,14 +36,5 @@ E1001
   9 | |-> ; Balance assertion that will fail (no opens, so balance is 0)
     : `---- here
  10 |     2024-01-16 balance Assets:Cash 100 USD
-    `----
-E1001
-
-  x Account Assets:Cash was never opened
-    ,-[<fixtures>/validation-errors.beancount:10:1]
-  9 | ; Balance assertion that will fail (no opens, so balance is 0)
- 10 | 2024-01-16 balance Assets:Cash 100 USD
-    : ^^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^^
-    :                    `-- here
     `----
 ✗ 3 errors


### PR DESCRIPTION
## What

Account-rewriting regular plugins (`rename_accounts`, `split_expenses`, …) run **after** the early validation phase, so rledger's open-existence check (`E1001`) fired on the **pre-rewrite** account name — an account that doesn't exist in the final ledger:

```
plugin "rename_accounts" "{'Expenses:Old': 'Expenses:New'}"
2020-01-01 open Assets:Cash
2020-01-01 open Expenses:New
2020-01-02 * "x"
  Assets:Cash  -10.00 USD
  Expenses:Old  10.00 USD     ; renamed to Expenses:New by the plugin
→ error: Account Expenses:Old was never opened   ❌
```

Found by dogfooding (pass #5).

## How

The pipeline is `sort → synth-plugins → Early → book → regular-plugins → Late → finalize`. The open-existence check for a posting to an unopened account was emitted entirely in **Early**, before regular plugins rewrite accounts.

- **Early** now emits E1001 only for **elided** postings to unopened accounts. This case *must* stay early: booking prunes zero-interpolated postings, which would otherwise hide the error (the documented Python #877 invariant — `interpolate.rs:532`).
- **Explicit** postings' open check is **deferred to Late**, which runs after the regular plugin pass, so it sees the final account names.
- A new `account_not_open_early` set on `LedgerState` dedups, so an elided posting that's *still* unopened after plugins isn't double-reported in Late.

## Scope

Fixes account-rewriting plugins for **explicit** postings (`rename_accounts`; `split_expenses` with explicit amounts). The **elided-shorthand** source case (`split_expenses` with an elided `Expenses:Accommodation` posting) stays tied to the early zero-pruning invariant and is left as a known limitation.

## Verify

- `rename_accounts` + explicit posting → loads clean (was E1001). ✓
- Genuine unopened account (no plugin), explicit or elided → still E1001. ✓
- `#877` elided-zero pruned posting → still caught early. ✓
- Full `rustledger-validate` (89+ tests) + `rustledger-loader` suites pass; new `test_open_check_deferred_past_account_rewriting_plugins`; clippy + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
