### PR TITLE
fix(ffi): preserve warning severity + robust include handling in load_source

### DIFF
--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -109,12 +109,6 @@ pub fn load_source(source: &str) -> LoadResult {
     // (booking errors surface; semantic validation is `ledger.validate`'s job).
     let mut vfs = rustledger_loader::VirtualFileSystem::new();
     vfs.add_file("<source>", source);
-    for inc in &includes {
-        // Empty stub: include resolution becomes a no-op, so a bare source with
-        // `include` directives lists them (above) without emitting a parse-phase
-        // "file not found" error that would suppress `ledger.validate`.
-        vfs.add_file(inc.path.as_str(), "");
-    }
     let load_opts = rustledger_loader::LoadOptions {
         validate: false,
         ..Default::default()
@@ -128,13 +122,16 @@ pub fn load_source(source: &str) -> LoadResult {
         Ok(ledger) => ledger,
         Err(e) => {
             // Fatal load/process failure is unexpected for an in-memory source,
-            // but surface it rather than panicking.
+            // but surface it rather than panicking. Tag it `validate` (not the
+            // default `parse`): a fatal process/plugin failure must not be
+            // wrongly classified as a parse error, which would make the
+            // `ledger.validate`/`query` handlers suppress validation entirely.
             return LoadResult {
                 directives: Vec::new(),
                 spanned_directives: Vec::new(),
                 directive_lines: Vec::new(),
                 line_lookup: lookup,
-                errors: vec![Error::new(e)],
+                errors: vec![Error::new(e).validate_phase()],
                 options: LedgerOptions::default(),
                 plugins: Vec::new(),
                 includes,
@@ -198,7 +195,25 @@ pub fn load_source(source: &str) -> LoadResult {
         directives.push(spanned.value.clone());
     }
 
-    let errors: Vec<Error> = ledger.errors.iter().map(ledger_error_to_ffi).collect();
+    // The string surface has no filesystem, so declared `include` paths cannot
+    // be resolved. Drop the resulting resolution failures (file-not-found /
+    // glob no-match) for declared includes, preserving the "list includes,
+    // don't resolve, don't error" contract uniformly for literal AND glob
+    // paths (a literal VFS stub can't match a glob pattern). The includes stay
+    // listed in the DTO; only their resolution errors are suppressed. The
+    // filter is targeted — a parse-phase error that both names a declared
+    // include path and reports a resolution failure — so it never masks a real
+    // syntax error in the source itself.
+    let errors: Vec<Error> = ledger
+        .errors
+        .iter()
+        .filter(|e| {
+            !(e.phase == "parse"
+                && includes.iter().any(|inc| e.message.contains(&inc.path))
+                && (e.message.contains("not found") || e.message.contains("does not match")))
+        })
+        .map(ledger_error_to_ffi)
+        .collect();
 
     let mut options = build_ledger_options(&ledger.options);
     let mut commodity_list: Vec<_> = commodities.into_iter().collect();
@@ -378,6 +393,13 @@ fn ledger_error_to_ffi(e: &rustledger_loader::LedgerError) -> Error {
     // "parse", or it would wrongly suppress validation.
     if e.phase != "parse" {
         err = err.validate_phase();
+    }
+    // Preserve severity: the canonical pipeline emits warnings (e.g. the
+    // `unrealized` plugin's gain/loss notices) as `LedgerError`s with
+    // `Warning` severity. Now that the load surface routes through the full
+    // pipeline, these must surface to FFI consumers as warnings, not errors.
+    if matches!(e.severity, rustledger_loader::ErrorSeverity::Warning) {
+        err.severity = "warning".to_string();
     }
     err
 }

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -203,14 +203,22 @@ pub fn load_source(source: &str) -> LoadResult {
     // listed in the DTO; only their resolution errors are suppressed. The
     // filter is targeted — a parse-phase error that both names a declared
     // include path and reports a resolution failure — so it never masks a real
-    // syntax error in the source itself.
+    // syntax error in the source itself. Path separators are normalized to `/`
+    // on both sides: the loader renders paths via `Path::display()`, which uses
+    // `\` on Windows, while declared include paths use `/`.
+    let normalized_includes: Vec<String> =
+        includes.iter().map(|i| i.path.replace('\\', "/")).collect();
     let errors: Vec<Error> = ledger
         .errors
         .iter()
         .filter(|e| {
-            !(e.phase == "parse"
-                && includes.iter().any(|inc| e.message.contains(&inc.path))
-                && (e.message.contains("not found") || e.message.contains("does not match")))
+            if e.phase != "parse"
+                || !(e.message.contains("not found") || e.message.contains("does not match"))
+            {
+                return true;
+            }
+            let msg = e.message.replace('\\', "/");
+            !normalized_includes.iter().any(|p| msg.contains(p))
         })
         .map(ledger_error_to_ffi)
         .collect();

--- a/crates/rustledger-ffi-wasi/tests/load_regular_plugins.rs
+++ b/crates/rustledger-ffi-wasi/tests/load_regular_plugins.rs
@@ -79,3 +79,48 @@ fn load_source_lists_includes_without_resolution_error() {
         r.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+/// Plugin *warnings* (e.g. `unrealized`'s gain/loss notices), which now flow
+/// through the full pipeline, must surface to FFI consumers as warnings — not
+/// errors.
+#[test]
+fn load_source_preserves_warning_severity() {
+    let src = "plugin \"unrealized\" \"Equity:Unrealized\"\n\
+               2020-01-01 open Assets:Stock\n2020-01-01 open Assets:Cash\n\
+               2020-01-01 open Equity:Unrealized\n\
+               2020-01-02 * \"buy\"\n  Assets:Stock  10 AAPL {100.00 USD}\n  Assets:Cash  -1000.00 USD\n\
+               2020-06-01 price AAPL 150.00 USD\n";
+    let r = load_source(src);
+    assert!(
+        r.errors.iter().any(|e| e.severity == "warning"),
+        "unrealized gain must surface as a warning; got {:?}",
+        r.errors
+            .iter()
+            .map(|e| (&e.severity, &e.message))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !r.errors.iter().any(|e| e.severity == "error"),
+        "the unrealized notice must not be reported as an error; got {:?}",
+        r.errors
+            .iter()
+            .map(|e| (&e.severity, &e.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// A glob `include` path that cannot be resolved on the string surface must not
+/// error either (the literal-stub approach could not match a glob pattern).
+#[test]
+fn load_source_glob_include_does_not_error() {
+    let src = "include \"[ab].beancount\"\n\
+               2020-01-02 * \"x\"\n  Assets:Cash  -10.00 USD\n  Expenses:Food  10.00 USD\n";
+    let r = load_source(src);
+    assert!(
+        !r.errors
+            .iter()
+            .any(|e| e.message.contains("does not match") || e.message.contains("not found")),
+        "unresolved glob include must not produce an error; got {:?}",
+        r.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## What

Follow-up to #1462 (the `load_source` pipeline collapse), addressing Copilot's review — its comments landed just after the auto-merge, so they're handled here.

1. **Warning severity dropped (most impactful).** `ledger_error_to_ffi` hardcoded `severity: "error"`. With `load_source` now routing through the full pipeline, plugin **warnings** — e.g. the `unrealized` plugin's gain/loss notices — flow through `ledger.errors` and were surfacing to FFI consumers as **errors**. Now maps `ErrorSeverity::Warning` → wire `"warning"`.

2. **Glob include paths errored.** The empty-VFS-stub approach keyed on the literal include path, which can't match a glob (`[ab].bean` ≠ literal file `[ab].bean`) → `GlobNoMatch` parse error, breaking the "list, don't resolve, don't error" contract. Replaced stubbing with a **targeted filter** that drops parse-phase resolution failures (file-not-found / glob-no-match) for *declared* include paths — uniform for literal and glob, and narrow enough never to mask a real syntax error.

3. **Fatal-fallback error mis-tagged.** The fatal load/process fallback built a default (parse-phase) `Error`; a fatal process/plugin failure would then suppress `ledger.validate`/`query`. Now tagged `validate`.

## Tests

`tests/load_regular_plugins.rs` (now 5 tests):
- `load_source_preserves_warning_severity` — `unrealized` notice surfaces as `warning`, not `error`.
- `load_source_glob_include_does_not_error` — unresolved glob include produces no error.

## Verify

All 8 `rustledger-ffi-wasi` suites + `rustledger-ffi-component` pass; `cargo clippy --all-features --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
