### PR TITLE
fix(wasm): stop treating plugin warnings as fatal

### DIFF
--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -11,7 +11,7 @@ use rustledger_loader::{FileSystem, LoadError, LoadResult};
 use rustledger_parser::parse as parse_beancount;
 
 use crate::convert::{directive_to_json, value_to_cell};
-use crate::helpers::{extract_options, load_and_book, run_validation, to_js};
+use crate::helpers::{extract_options, has_fatal, load_and_book, run_validation, to_js};
 #[cfg(feature = "completions")]
 use crate::types::{CompletionJson, CompletionResultJson};
 use crate::types::{
@@ -102,7 +102,9 @@ pub fn validate_source(source: &str) -> Result<JsValue, JsError> {
     errors.extend(validation_errors);
 
     let result = ValidationResult {
-        valid: errors.is_empty(),
+        // Warnings do not invalidate a ledger (matching `rledger check`, which
+        // exits 0 on warning-only input); only actual errors do.
+        valid: !has_fatal(&errors),
         errors,
     };
     to_js(&result)
@@ -119,8 +121,9 @@ pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
 
     let load = load_and_book(source);
 
-    // Return early if there were parse/interpolation errors
-    if !load.errors.is_empty() {
+    // Return early only on actual errors (parse/booking); warnings must not
+    // abort processing.
+    if has_fatal(&load.errors) {
         let result = QueryResult {
             columns: Vec::new(),
             rows: Vec::new(),
@@ -227,8 +230,9 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
 
     let load = load_and_book(source);
 
-    // Return early if there were parse/interpolation errors
-    if !load.errors.is_empty() {
+    // Return early only on actual errors (parse/booking); warnings must not
+    // abort processing.
+    if has_fatal(&load.errors) {
         let result = PadResult {
             directives: Vec::new(),
             padding_transactions: Vec::new(),
@@ -297,8 +301,9 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
 
     let load = load_and_book(source);
 
-    // Return early if there were parse/interpolation errors
-    if !load.errors.is_empty() {
+    // Return early only on actual errors (parse/booking); warnings must not
+    // abort processing.
+    if has_fatal(&load.errors) {
         let result = PluginResult {
             directives: Vec::new(),
             errors: load.errors,
@@ -596,7 +601,8 @@ pub fn validate_multi_file(files: JsValue, entry_point: &str) -> Result<JsValue,
     let errors: Vec<Error> = ledger.errors.into_iter().map(Error::from).collect();
 
     let result = ValidationResult {
-        valid: errors.is_empty(),
+        // Warnings do not invalidate a ledger; only actual errors do.
+        valid: !has_fatal(&errors),
         errors,
     };
     to_js(&result)

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -132,14 +132,20 @@ pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
         return to_js(&result);
     }
 
+    // Carry any non-fatal load warnings through every result path so callers
+    // still see them alongside (or instead of) query output.
+    let warnings = load.errors;
+
     // Parse the query
     let query = match parse_query(query_str) {
         Ok(q) => q,
         Err(e) => {
+            let mut errors = warnings;
+            errors.push(Error::new(e.to_string()));
             let result = QueryResult {
                 columns: Vec::new(),
                 rows: Vec::new(),
-                errors: vec![Error::new(e.to_string())],
+                errors,
             };
             return to_js(&result);
         }
@@ -163,15 +169,17 @@ pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
             let query_result = QueryResult {
                 columns: result.columns,
                 rows,
-                errors: Vec::new(),
+                errors: warnings,
             };
             to_js(&query_result)
         }
         Err(e) => {
+            let mut errors = warnings;
+            errors.push(Error::new(format!("Query execution error: {e}")));
             let result = QueryResult {
                 columns: Vec::new(),
                 rows: Vec::new(),
-                errors: vec![Error::new(format!("Query execution error: {e}"))],
+                errors,
             };
             to_js(&result)
         }
@@ -241,8 +249,17 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
         return to_js(&result);
     }
 
+    // Carry non-fatal load warnings through to the result.
+    let mut errors = load.errors;
+
     // Process pads
     let pad_result = process_pads(&load.directives);
+    errors.extend(
+        pad_result
+            .errors
+            .iter()
+            .map(|e| Error::new(e.message.clone())),
+    );
 
     let result = PadResult {
         // The source stream, verbatim — `process_pads` no longer
@@ -254,11 +271,7 @@ pub fn expand_pads(source: &str) -> Result<JsValue, JsError> {
             .iter()
             .map(|txn| directive_to_json(&Directive::Transaction(txn.clone())))
             .collect(),
-        errors: pad_result
-            .errors
-            .iter()
-            .map(|e| Error::new(e.message.clone()))
-            .collect(),
+        errors,
     };
     to_js(&result)
 }
@@ -311,15 +324,20 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
         return to_js(&result);
     }
 
+    // Carry non-fatal load warnings through every result path.
+    let warnings = load.errors;
+
     // Find and run the plugin
     let registry = NativePluginRegistry::global();
     // External API runs plugins on already-booked input — synth
     // plugins are a loader-internal concern and would re-emit Opens
     // for accounts the booking pass already opened.
     let Some(plugin) = registry.find_regular(plugin_name) else {
+        let mut errors = warnings;
+        errors.push(Error::new(format!("Unknown plugin: {plugin_name}")));
         let result = PluginResult {
             directives: Vec::new(),
-            errors: vec![Error::new(format!("Unknown plugin: {plugin_name}"))],
+            errors,
         };
         return to_js(&result);
     };
@@ -340,26 +358,24 @@ pub fn run_plugin(source: &str, plugin_name: &str) -> Result<JsValue, JsError> {
     let output_directives = match wrappers_to_directives(&materialized_wrappers) {
         Ok(dirs) => dirs,
         Err(e) => {
+            let mut errors = warnings;
+            errors.push(Error::new(format!("Conversion error: {e}")));
             let result = PluginResult {
                 directives: Vec::new(),
-                errors: vec![Error::new(format!("Conversion error: {e}"))],
+                errors,
             };
             return to_js(&result);
         }
     };
 
+    let mut errors = warnings;
+    errors.extend(output.errors.iter().map(|e| match e.severity {
+        rustledger_plugin::PluginErrorSeverity::Warning => Error::warning(e.message.clone()),
+        rustledger_plugin::PluginErrorSeverity::Error => Error::new(e.message.clone()),
+    }));
     let result = PluginResult {
         directives: output_directives.iter().map(directive_to_json).collect(),
-        errors: output
-            .errors
-            .iter()
-            .map(|e| match e.severity {
-                rustledger_plugin::PluginErrorSeverity::Warning => {
-                    Error::warning(e.message.clone())
-                }
-                rustledger_plugin::PluginErrorSeverity::Error => Error::new(e.message.clone()),
-            })
-            .collect(),
+        errors,
     };
     to_js(&result)
 }

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -105,11 +105,25 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
     }
 }
 
+/// Whether any entry is an actual error (`Severity::Error`), as opposed to a
+/// warning. Warnings (e.g. the `unrealized` plugin's gain/loss notices) must
+/// not abort processing or mark a ledger invalid — matching `rledger check`,
+/// which exits 0 on warning-only ledgers.
+#[must_use]
+pub fn has_fatal(errors: &[Error]) -> bool {
+    errors.iter().any(|e| e.severity == Severity::Error)
+}
+
 /// Run validation on a loaded ledger and return validation errors.
 pub fn run_validation(load: &ProcessedLedger) -> Vec<Error> {
     use rustledger_validate::{ValidationOptions, ValidationSession};
 
-    if !load.errors.is_empty() {
+    // Skip validation only when loading produced a genuine *error* (parse or
+    // booking failure) — those make the directive stream unsound to validate.
+    // A warning must NOT skip validation, or real diagnostics (E1001, balance
+    // residuals, …) would be silently dropped for any ledger that also emits a
+    // plugin warning.
+    if has_fatal(&load.errors) {
         return Vec::new();
     }
 
@@ -181,5 +195,43 @@ fn extract_loader_options(options: &rustledger_loader::Options) -> LedgerOptions
     LedgerOptions {
         title: options.title.clone(),
         operating_currencies: options.operating_currency.clone(),
+    }
+}
+
+#[cfg(test)]
+mod warning_severity_tests {
+    use super::*;
+
+    #[test]
+    fn has_fatal_ignores_warnings() {
+        assert!(!has_fatal(&[Error::warning("w".to_string())]));
+        assert!(has_fatal(&[Error::new("e")]));
+        assert!(has_fatal(&[
+            Error::warning("w".to_string()),
+            Error::new("e")
+        ]));
+    }
+
+    /// A plugin warning must NOT cause validation to be skipped — otherwise a
+    /// genuine error on a ledger that also warns is silently dropped.
+    #[test]
+    fn run_validation_not_skipped_by_warning() {
+        let src = "plugin \"unrealized\" \"Equity:Unrealized\"\n\
+                   2020-01-01 open Assets:Stock\n2020-01-01 open Assets:Cash\n\
+                   2020-01-01 open Equity:Unrealized\n\
+                   2020-01-02 * \"buy\"\n  Assets:Stock  10 AAPL {100.00 USD}\n  Assets:Cash  -1000.00 USD\n\
+                   2020-06-01 price AAPL 150.00 USD\n\
+                   2020-07-01 * \"x\"\n  Assets:Cash  -5.00 USD\n  Expenses:NeverOpened  5.00 USD\n";
+        let load = load_and_book(src);
+        assert!(
+            load.errors.iter().any(|e| e.severity == Severity::Warning),
+            "expected an unrealized warning in load.errors"
+        );
+        assert!(!has_fatal(&load.errors), "a warning must not be fatal");
+        let validation = run_validation(&load);
+        assert!(
+            validation.iter().any(|e| e.message.contains("NeverOpened")),
+            "validation must run despite the warning and report E1001"
+        );
     }
 }


### PR DESCRIPTION
## What

The `rustledger-wasm` library correctly routes source through the canonical `process()` pipeline, so plugin **warnings** (e.g. the `unrealized` plugin's gain/loss notices) flow through `load.errors` with `Warning` severity. But several entry points treated *any* non-empty error list as fatal — so a warning behaved like an error:

- **`run_validation` skipped validation entirely** on a non-empty `load.errors`. A ledger that emits a warning had its real diagnostics (E1001, balance residuals, …) **silently dropped**. *(the serious bug)*
- **`validateSource` / `validateMultiFile`** computed `valid: errors.is_empty()`, so a **warning-only ledger reported `valid: false`**.
- **`query` / `expandPads` / `runPlugin`** returned early on any non-empty `load.errors`, refusing results for a ledger that merely warns.

Confirmed with `unrealized` + a posting to an unopened account: `load.errors` held the warning, `run_validation` returned 0 errors, and the genuine `E1001` was missed.

## How

Add a `has_fatal(&[Error])` helper (true iff any `Severity::Error`) and gate all of the above on it instead of emptiness — matching `rledger check`, which exits 0 on warning-only input. Warnings are still surfaced (validation results include them); they no longer abort processing or invalidate the ledger.

## Tests

`helpers.rs` unit tests:
- `has_fatal_ignores_warnings`
- `run_validation_not_skipped_by_warning` — validation runs and reports `E1001` even when the ledger also emits a plugin warning.

## Verify

86 `rustledger-wasm` tests pass; `cargo clippy --all-features --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
