### PR TITLE
docs(check): document E7003 duplicate-option strictness as a deliberate deviation

### DIFF
--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -244,7 +244,12 @@ impl Options {
             return; // Don't apply the value
         }
 
-        // Check for duplicate non-repeatable options (E7003)
+        // Check for duplicate non-repeatable options (E7003).
+        //
+        // Stricter than beancount: `bean-check` silently lets the last value
+        // win (exit 0). We flag the duplicate so the CLI can surface it as an
+        // error (a repeated non-repeatable option is almost always a mistake) —
+        // a DELIBERATE deviation. See `cmd::check` E7003 handling.
         let is_repeatable = REPEATABLE_OPTIONS.contains(&key);
         if is_known && !is_repeatable && self.set_options.contains(key) {
             self.warnings.push(OptionWarning {

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -438,8 +438,9 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
         }
     }
 
-    // Report option warnings (E7001 unknown option, E7002 invalid value,
-    // E7003 duplicate non-repeatable option) as hard errors.
+    // All option warnings collected by `Options::set` (E7001 unknown option,
+    // E7002 invalid value, E7003 duplicate non-repeatable, E7004/E7005/E7006
+    // read-only and related) are surfaced here as hard errors.
     //
     // E7001/E7002 match beancount: `bean-check` exits non-zero on an unknown
     // option or an invalid option value.

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -438,8 +438,18 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
         }
     }
 
-    // Report option errors (E7001, E7002, E7003)
-    // In Python beancount, invalid options are errors, not warnings
+    // Report option warnings (E7001 unknown option, E7002 invalid value,
+    // E7003 duplicate non-repeatable option) as hard errors.
+    //
+    // E7001/E7002 match beancount: `bean-check` exits non-zero on an unknown
+    // option or an invalid option value.
+    //
+    // E7003 is a DELIBERATE deviation, stricter than beancount (Python
+    // compatibility policy bucket 1): `bean-check` silently accepts a repeated
+    // non-repeatable option (last value wins, exit 0), but a duplicated
+    // `option "title"` / `option "name_*"` is almost always a copy-paste
+    // mistake, so we surface it as an error. Pinned by
+    // `cli_commands_test::test_check_duplicate_option_is_error`.
     let main_file_str = file.display().to_string();
     let option_error_count = load_result.options.warnings.len();
     for warning in &load_result.options.warnings {

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1748,3 +1748,63 @@ fn test_price_no_self_quote_directive() {
         "expected a `price AAPL … USD` directive; got: {stdout}"
     );
 }
+
+/// `rledger check` rejects a repeated non-repeatable option (E7003) as an
+/// error. This is a DELIBERATE deviation, stricter than beancount: `bean-check`
+/// silently accepts the duplicate (last value wins, exit 0). A duplicated
+/// non-repeatable `option` is almost always a copy-paste mistake, so we surface
+/// it. See the E7003 handling in `cmd::check`.
+#[test]
+fn test_check_duplicate_option_is_error() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(
+        tmp.path(),
+        "option \"title\" \"First\"\noption \"title\" \"Second\"\n2024-01-01 open Assets:Cash\n",
+    )
+    .expect("write");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--no-cache"])
+        .arg(tmp.path())
+        .output()
+        .expect("Failed to run rledger check");
+
+    assert!(
+        !output.status.success(),
+        "duplicate non-repeatable option should fail check (stricter than beancount)"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("E7003"),
+        "output should cite E7003; got: {combined}"
+    );
+}
+
+/// Conversely, a single non-repeatable option must NOT be flagged (no false
+/// positive on the deliberate E7003 strictness).
+#[test]
+fn test_check_single_option_ok() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(
+        tmp.path(),
+        "option \"title\" \"Only Once\"\n2024-01-01 open Assets:Cash\n",
+    )
+    .expect("write");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--no-cache"])
+        .arg(tmp.path())
+        .output()
+        .expect("Failed to run rledger check");
+
+    assert!(
+        output.status.success(),
+        "a single non-repeatable option must pass check"
+    );
+}


### PR DESCRIPTION
## What

Surfaced by a cross-surface warning audit (pass 12): `rledger check` reports a repeated **non-repeatable** option — E7003, e.g. `option "title"` declared twice — as a **hard error** (exit 1), while beancount's `bean-check` silently accepts it (last value wins, exit 0).

Mapping rledger vs beancount across the option-warning codes:

| Code | Case | beancount | rledger |
|---|---|---|---|
| E7001 | unknown option | exit 1 | exit 1 ✓ |
| E7002 | invalid value | exit 1 | exit 1 ✓ |
| E7005 | read-only option | exit 0 | exit 0 ✓ |
| **E7003** | **duplicate non-repeatable** | **exit 0** | **exit 1** (stricter) |

The existing comment (*"In Python beancount, invalid options are errors, not warnings"*) is accurate for E7001/E7002 but was applied uniformly, sweeping in E7003.

## Decision

Keep the stricter behavior — a duplicated non-repeatable option is almost always a copy-paste mistake worth surfacing — but make it a **deliberate, documented deviation** per the CLAUDE.md Python-compatibility checklist (bucket 1), rather than an undocumented divergence.

## How

- Expand the `cmd::check` comment to distinguish E7001/E7002 (match beancount) from E7003 (deliberate deviation), with the rationale.
- Add a rationale note at the E7003 generation site in `options.rs`.
- Pin the behavior with CLI regression tests.

No behavior change.

## Tests

- `cli_commands_test::test_check_duplicate_option_is_error` — duplicate option fails check, output cites E7003.
- `cli_commands_test::test_check_single_option_ok` — a single non-repeatable option passes (no false positive).

## Verify

New CLI tests pass; `rustledger-loader` option tests (31) pass; `cargo clippy --all-features --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
