### PR TITLE
fix(price): skip self-referential (base == quote) fetch jobs

### DIFF
--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -357,6 +357,15 @@ pub fn run_with_writer<W: Write>(
             );
 
         for (effective_currency, per_spec_mapping) in per_quote_jobs {
+            // A commodity is never priced in itself. Skip self-referential
+            // (base == quote) jobs — these arise when `--undeclared` picks up
+            // the operating/quote currency (e.g. USD held as cash, or seen as a
+            // cost currency) as a base candidate, whose resolved quote is then
+            // itself. bean-price never fetches a currency against itself; left
+            // unfiltered this emits a nonsensical `price USD … USD` directive.
+            if &effective_currency == symbol {
+                continue;
+            }
             // --clobber: pre-fetch skip when an explicit `price` directive for
             // (symbol, effective_currency, requested_date) already exists. Avoids
             // round-tripping through the source for the common case where the
@@ -630,6 +639,12 @@ fn dump_fetch_plan(
             );
 
         for (currency, per_spec_mapping) in per_quote_jobs {
+            // Skip self-referential (base == quote) jobs so `--dry-run` matches
+            // the fetch path: a commodity is never priced in itself. See the
+            // identical guard in the fetch loop above.
+            if &currency == symbol {
+                continue;
+            }
             // Apply the per-spec mapping override so describe_attempts shows
             // the source/ticker that *this* quote will actually use, not
             // whatever happened to win first-spec precedence in
@@ -803,6 +818,14 @@ fn run_with_external_command<W: Write>(
             );
 
         for effective_currency in per_quote_currencies {
+            // Skip self-referential (base == quote) jobs, same as the network
+            // fetch and --dry-run paths: a commodity is never priced in itself
+            // (guards against `--undeclared` picking up the operating/quote
+            // currency as a base, which would emit a nonsensical `price USD …
+            // USD` directive).
+            if &effective_currency == symbol {
+                continue;
+            }
             // --clobber: skip when an existing price for this (symbol, currency, date)
             // is already in the file. Same rule as the network fetch path.
             if !args.clobber {

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1686,6 +1686,10 @@ fn test_query_and_format_handle_broken_pipe() {
 /// currency) as a base candidate; resolving its quote yields itself. A
 /// commodity is never priced in itself — bean-price never fetches a currency
 /// against itself. Exercises the `--source-cmd` fetch path (offline).
+///
+/// Unix-only: the stub source uses `echo`, which is a shell builtin without a
+/// standalone executable on Windows.
+#[cfg(unix)]
 #[test]
 fn test_price_no_self_quote_directive() {
     let rledger = require_rledger!();
@@ -1711,17 +1715,36 @@ fn test_price_no_self_quote_directive() {
         .output()
         .expect("Failed to run rledger price");
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    if !output.status.success() && stdout.is_empty() {
-        eprintln!("Skipping: price/--source-cmd not supported in this build");
+    // Skip only when the build genuinely lacks the flag (don't mask real
+    // failures behind an empty-stdout heuristic).
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success()
+        && (stderr.contains("--source-cmd") || stderr.contains("unexpected argument"))
+    {
+        eprintln!("Skipping: --source-cmd not supported in this build");
         return;
     }
+
+    // Parse the emitted `<date> price <SYMBOL> <num> <CURRENCY>` directives and
+    // assert on the (symbol, currency) tokens — precise, not substring matching
+    // (which would treat `price USDX …` as a hit).
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut saw_aapl = false;
+    for line in stdout.lines() {
+        let toks: Vec<&str> = line.split_whitespace().collect();
+        if toks.len() >= 5 && toks[1] == "price" {
+            let (symbol, currency) = (toks[2], toks[toks.len() - 1]);
+            assert_ne!(
+                symbol, currency,
+                "self-referential price directive emitted: {line}"
+            );
+            if symbol == "AAPL" {
+                saw_aapl = true;
+            }
+        }
+    }
     assert!(
-        stdout.contains("price AAPL"),
-        "should fetch the held AAPL; got: {stdout}"
-    );
-    assert!(
-        !stdout.contains("price USD"),
-        "must not emit a self-referential `price USD … USD`; got: {stdout}"
+        saw_aapl,
+        "expected a `price AAPL … USD` directive; got: {stdout}"
     );
 }

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1679,3 +1679,49 @@ fn test_query_and_format_handle_broken_pipe() {
         );
     }
 }
+
+/// Regression: `rledger price --undeclared` must not emit a self-referential
+/// `price USD … USD` directive. The `--undeclared` ticker-shape heuristic picks
+/// up the operating/quote currency (USD, held as cash / seen as a cost
+/// currency) as a base candidate; resolving its quote yields itself. A
+/// commodity is never priced in itself — bean-price never fetches a currency
+/// against itself. Exercises the `--source-cmd` fetch path (offline).
+#[test]
+fn test_price_no_self_quote_directive() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    std::fs::write(
+        tmp.path(),
+        "option \"operating_currency\" \"USD\"\n\
+         2024-01-01 open Assets:Stock\n2024-01-01 open Assets:Cash\n\
+         2024-01-02 * \"buy\"\n  Assets:Stock  10 AAPL {100.00 USD}\n  Assets:Cash  -1000.00 USD\n",
+    )
+    .expect("write");
+
+    let output = Command::new(&rledger)
+        .args(["price", "-f"])
+        .arg(tmp.path())
+        .args([
+            "--undeclared",
+            "-b",
+            "--no-cache",
+            "--source-cmd",
+            "echo 150.00 USD",
+        ])
+        .output()
+        .expect("Failed to run rledger price");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !output.status.success() && stdout.is_empty() {
+        eprintln!("Skipping: price/--source-cmd not supported in this build");
+        return;
+    }
+    assert!(
+        stdout.contains("price AAPL"),
+        "should fetch the held AAPL; got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("price USD"),
+        "must not emit a self-referential `price USD … USD`; got: {stdout}"
+    );
+}


### PR DESCRIPTION
## What

Found by dogfooding (pass 13): `rledger price --undeclared` emits a **nonsensical `price USD <n> USD`** directive — a currency priced in itself — which would pollute the user's price DB.

```
$ rledger price -f ledger.beancount --undeclared -b --source-cmd '…'
2024-06-01 price AAPL 150.00 USD
2024-06-01 price USD 150.00 USD   ← bogus: USD priced in USD
```

The `--undeclared` ticker-shape heuristic walks transactions and picks up the operating/quote currency (USD, held as cash or seen as a cost currency) as a **base** candidate. Resolving its quote yields the operating currency — itself — producing a self-referential `(USD, USD)` job. bean-price never fetches a currency against itself.

## How

Skip any job whose quote currency equals its base symbol. The price command has **three** independent job-iterating paths, so the guard is applied in each to keep them consistent:
- the network fetch loop,
- the `--dry-run` plan (`dump_fetch_plan`),
- the `--source-cmd` external path (`run_with_external_command`).

The per-job `base == quote` check (rather than excluding the currency entirely) preserves legitimate foreign-currency fetches: EUR held in a USD ledger still produces `(EUR, USD)`.

## Tests

`cli_commands_test::test_price_no_self_quote_directive` — a ledger holding AAPL in USD, via `--source-cmd`, fetches `price AAPL` but emits no `price USD … USD`.

## Verify

New test + 9 existing `price` tests pass; `cargo clippy --all-features --all-targets` and `cargo fmt --check` clean. Confirmed across `-n`, network, and `--source-cmd` paths; `(EUR, USD)` still fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
