### PR TITLE
fix(query): sort NULL as smallest, matching beanquery

### DIFF
--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -492,9 +492,13 @@ impl Executor<'_> {
         right: &Value,
     ) -> std::cmp::Ordering {
         match (left, right) {
+            // NULL sorts as the smallest value, matching beanquery: ORDER BY ...
+            // ASC places NULLs first, DESC (via the caller's `.reverse()`) places
+            // them last. (`SELECT payee ORDER BY payee` on a payee-less txn now
+            // matches bean-query.)
             (Value::Null, Value::Null) => std::cmp::Ordering::Equal,
-            (Value::Null, _) => std::cmp::Ordering::Greater, // Nulls sort last
-            (_, Value::Null) => std::cmp::Ordering::Less,
+            (Value::Null, _) => std::cmp::Ordering::Less,
+            (_, Value::Null) => std::cmp::Ordering::Greater,
             (Value::Number(a), Value::Number(b)) => a.cmp(b),
             (Value::Integer(a), Value::Integer(b)) => a.cmp(b),
             (Value::Number(a), Value::Integer(b)) => a.cmp(&Decimal::from(*b)),

--- a/crates/rustledger-query/tests/sort_null_order_test.rs
+++ b/crates/rustledger-query/tests/sort_null_order_test.rs
@@ -1,0 +1,80 @@
+//! Regression: NULL sorts as the smallest value (matching beanquery) — ORDER BY
+//! ASC places NULLs first, DESC places them last.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    rustledger_core::naive_date(year, month, day).unwrap()
+}
+
+fn dirs() -> Vec<Directive> {
+    let txn = |d: u32, payee: Option<&str>, narr: &str| {
+        let mut t = Transaction::new(date(2024, 1, d), narr);
+        if let Some(p) = payee {
+            t = t.with_payee(p);
+        }
+        Directive::Transaction(
+            t.with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1), "USD")))
+                .with_synthesized_posting(Posting::new("Expenses:X", Amount::new(dec!(1), "USD"))),
+        )
+    };
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:X")),
+        txn(2, Some("Alpha"), "a"),
+        txn(3, None, "no payee"),
+        txn(4, Some("Beta"), "b"),
+    ]
+}
+
+/// The payee column, one entry per result row (`None` = NULL).
+fn payee_order(query_str: &str) -> Vec<Option<String>> {
+    let query = parse(query_str).expect("parse");
+    let directives = dirs();
+    let mut ex = Executor::new(&directives);
+    let result = ex.execute(&query).expect("execute");
+    result
+        .rows
+        .iter()
+        .map(|row| match row.first() {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn order_by_asc_puts_nulls_first() {
+    let order = payee_order("SELECT payee ORDER BY payee");
+    assert_eq!(
+        order,
+        vec![
+            None,
+            None,
+            Some("Alpha".into()),
+            Some("Alpha".into()),
+            Some("Beta".into()),
+            Some("Beta".into()),
+        ],
+        "ASC: NULLs first, then ascending"
+    );
+}
+
+#[test]
+fn order_by_desc_puts_nulls_last() {
+    let order = payee_order("SELECT payee ORDER BY payee DESC");
+    assert_eq!(
+        order,
+        vec![
+            Some("Beta".into()),
+            Some("Beta".into()),
+            Some("Alpha".into()),
+            Some("Alpha".into()),
+            None,
+            None,
+        ],
+        "DESC: descending, then NULLs last"
+    );
+}


### PR DESCRIPTION
## What

Found by the pass-20 NULL-edge differential: `ORDER BY` places NULLs opposite to beanquery.

```
ledger with a payee-less txn, SELECT payee ORDER BY payee
        rledger              beanquery
ASC :   Alpha,Beta,<null>    <null>,Alpha,Beta
DESC:   <null>,Beta,Alpha    Beta,Alpha,<null>
```

rledger ranked NULL as the **largest** value; beanquery ranks it the **smallest** (NULL sorts before everything; DESC flips it to last). Both are internally consistent, but they diverge — a portability surprise.

## How

Rank `NULL` below all other values in `compare_values_for_sort` (one match arm). ASC then yields nulls-first, DESC (via the caller's `.reverse()`) yields nulls-last — matching beanquery. No test pinned the prior nulls-last order.

## Tests

`sort_null_order_test`: `ORDER BY payee` ASC → NULLs first; `DESC` → NULLs last.

## Verify

ASC/DESC now match bean-query; full `rustledger-query` suite passes (0 regressions); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
