### PR TITLE
fix(query): aggregate over subqueries; COUNT(col) non-NULL in table path

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -689,14 +689,29 @@ impl<'a> Executor<'a> {
             Expr::Function(func) => {
                 match func.name.to_uppercase().as_str() {
                     "COUNT" => {
-                        // COUNT(*) or COUNT(col) — validate argument count
                         if func.args.len() > 1 {
                             return Err(QueryError::InvalidArguments(
                                 "COUNT".to_string(),
                                 "expected 0 or 1 argument".to_string(),
                             ));
                         }
-                        Ok(Value::Integer(group.len() as i64))
+                        // SQL semantics (matching beanquery): COUNT(*) counts
+                        // every row; COUNT(col) counts only non-NULL values.
+                        // Mirrors the posting-stream path in `evaluate_aggregate_row`.
+                        let count = match func.args.first() {
+                            None | Some(Expr::Wildcard) => group.len(),
+                            Some(arg) => {
+                                let mut c = 0usize;
+                                for row in group {
+                                    let v = self.evaluate_subquery_expr(arg, row, column_map)?;
+                                    if !matches!(v, Value::Null) {
+                                        c += 1;
+                                    }
+                                }
+                                c
+                            }
+                        };
+                        Ok(Value::Integer(count as i64))
                     }
                     "SUM" => {
                         if func.args.len() != 1 {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -331,6 +331,24 @@ impl Executor<'_> {
             .map(|(i, name)| (name.to_lowercase(), i))
             .collect();
 
+        // Aggregate queries over a subquery must group/aggregate, exactly like
+        // the table-source path (`execute_select_from_table`). Without this,
+        // `SELECT count(*) FROM (SELECT ...)` was evaluated per inner row,
+        // yielding one (empty) row per row instead of a single aggregated value.
+        let is_aggregate = outer_query
+            .targets
+            .iter()
+            .any(|t| Self::is_aggregate_expr(&t.expr))
+            || outer_query.group_by.is_some()
+            || outer_query.having.is_some();
+        if is_aggregate {
+            let table = Table {
+                columns: inner_result.columns,
+                rows: inner_result.rows,
+            };
+            return self.execute_aggregate_from_table(outer_query, &table, &inner_column_map);
+        }
+
         // Determine outer column names
         let outer_column_names =
             self.resolve_subquery_column_names(&outer_query.targets, &inner_result.columns)?;

--- a/crates/rustledger-query/tests/subquery_aggregate_test.rs
+++ b/crates/rustledger-query/tests/subquery_aggregate_test.rs
@@ -55,4 +55,11 @@ fn aggregate_over_subquery_collapses_to_one_row() {
         Value::Integer(2),
         "COUNT(payee) over a subquery excludes NULLs"
     );
+    // SUM was affected by the same per-row dispatch bug — exercise it too.
+    // The 4 postings net to zero (-1/+1 per transaction).
+    assert_eq!(
+        one("SELECT sum(number) FROM (SELECT number)"),
+        Value::Number(dec!(0)),
+        "SUM(number) over a subquery aggregates to one row"
+    );
 }

--- a/crates/rustledger-query/tests/subquery_aggregate_test.rs
+++ b/crates/rustledger-query/tests/subquery_aggregate_test.rs
@@ -1,0 +1,58 @@
+//! Regression: aggregates over a subquery (`SELECT agg() FROM (SELECT ...)`)
+//! must aggregate to a single value, not evaluate per inner row — and
+//! `COUNT(col)` in that path must exclude NULLs.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+fn dirs() -> Vec<Directive> {
+    let txn = |d: u32, payee: Option<&str>, narr: &str| {
+        let mut t = Transaction::new(date(2024, 1, d), narr);
+        if let Some(p) = payee {
+            t = t.with_payee(p);
+        }
+        Directive::Transaction(
+            t.with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1), "USD")))
+                .with_synthesized_posting(Posting::new("Expenses:X", Amount::new(dec!(1), "USD"))),
+        )
+    };
+    vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:X")),
+        txn(2, Some("Alpha"), "a"),
+        txn(3, None, "no payee"),
+    ]
+}
+
+fn one(query_str: &str) -> Value {
+    let q = parse(query_str).expect("parse");
+    let d = dirs();
+    let mut ex = Executor::new(&d);
+    let r = ex.execute(&q).expect("execute");
+    assert_eq!(
+        r.rows.len(),
+        1,
+        "aggregate must produce exactly one row: {query_str}"
+    );
+    r.rows[0][0].clone()
+}
+
+#[test]
+fn aggregate_over_subquery_collapses_to_one_row() {
+    // 4 postings; 2 have a payee.
+    assert_eq!(
+        one("SELECT count(*) FROM (SELECT account)"),
+        Value::Integer(4),
+        "COUNT(*) over a subquery aggregates to one row"
+    );
+    assert_eq!(
+        one("SELECT count(payee) FROM (SELECT payee)"),
+        Value::Integer(2),
+        "COUNT(payee) over a subquery excludes NULLs"
+    );
+}


### PR DESCRIPTION
## What

Found by pass #21 (BQL differential): **aggregates over a subquery don't aggregate**.

```
ledger with a payee-less txn (4 postings)        rledger        beanquery
SELECT count(*)  FROM (SELECT payee)      6 empty rows (!)        6
SELECT count(payee) FROM (SELECT payee)   6 empty rows (!)        4
SELECT sum(number)  FROM (SELECT number)  6 empty rows (!)        0
```

`execute_select_from_subquery` evaluated the outer SELECT once per inner row and never grouped/aggregated — the table-source path (`execute_select_from_table`) has the `is_aggregate` dispatch, but the subquery path was missing it. (Non-aggregate subqueries already worked.)

## How

- Add the same `is_aggregate` check to `execute_select_from_subquery`: wrap the inner result as a `Table` and route through `execute_aggregate_from_table` when the outer query aggregates / has GROUP BY / HAVING.
- That path's `COUNT` arm also returned `group.len()` (counting NULLs); now reachable, fix it to count only non-NULL values for `COUNT(col)` — same as the posting-stream path (companion to #1468).

## Tests

`subquery_aggregate_test`: `count(*) FROM (SELECT account)` → 4 (one row); `count(payee) FROM (SELECT payee)` → 2 (excludes NULLs).

## Verify

`count(*)`/`count(payee)`/`sum()` over a subquery now match bean-query; full `rustledger-query` suite passes (0 regressions); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
