### PR TITLE
fix(format): read files with lossy UTF-8, matching the loader

### DIFF
--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -100,8 +100,12 @@ fn format_file<W: Write>(file: &PathBuf, args: &Args, out: &mut W) -> Result<Exi
         anyhow::bail!("file not found: {}", file.display());
     }
 
-    let original_content =
-        fs::read_to_string(file).with_context(|| format!("failed to read {}", file.display()))?;
+    // Read tolerantly to match the loader/cache (rustledger-loader `vfs.rs`,
+    // `cache.rs`), which decode with `from_utf8_lossy`. Otherwise a ledger that
+    // `rledger check` accepts — e.g. one with stray invalid-UTF-8 bytes, which
+    // beancount also accepts — would fail to `format` with a hard read error.
+    let bytes = fs::read(file).with_context(|| format!("failed to read {}", file.display()))?;
+    let original_content = String::from_utf8_lossy(&bytes).into_owned();
 
     let formatted = match try_format_source(&original_content) {
         Ok(out) => out,

--- a/crates/rustledger/src/cmd/format.rs
+++ b/crates/rustledger/src/cmd/format.rs
@@ -105,6 +105,11 @@ fn format_file<W: Write>(file: &PathBuf, args: &Args, out: &mut W) -> Result<Exi
     // `rledger check` accepts — e.g. one with stray invalid-UTF-8 bytes, which
     // beancount also accepts — would fail to `format` with a hard read error.
     let bytes = fs::read(file).with_context(|| format!("failed to read {}", file.display()))?;
+    // Track whether the input was valid UTF-8. If not, `from_utf8_lossy`
+    // replaced bytes with U+FFFD, so writing the formatted output would rewrite
+    // the file even if the formatted text equals the lossy-decoded original —
+    // `--check` must report that as "needs formatting" (see below).
+    let had_invalid_utf8 = std::str::from_utf8(&bytes).is_err();
     let original_content = String::from_utf8_lossy(&bytes).into_owned();
 
     let formatted = match try_format_source(&original_content) {
@@ -124,7 +129,10 @@ fn format_file<W: Write>(file: &PathBuf, args: &Args, out: &mut W) -> Result<Exi
         // that the canonical form rewrites — exactly the kind of
         // change the new formatter introduces (one trailing newline,
         // exactly one blank between directives).
-        if formatted == original_content {
+        // Invalid UTF-8 always counts as "needs formatting": `--in-place`
+        // would rewrite the offending bytes to U+FFFD, so reporting "already
+        // formatted" here would let CI miss a real rewrite.
+        if formatted == original_content && !had_invalid_utf8 {
             if args.verbose {
                 eprintln!("File is already formatted: {}", file.display());
             }

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1841,3 +1841,31 @@ fn test_format_accepts_invalid_utf8() {
         "formatted output should contain the directive: {stdout}"
     );
 }
+
+/// Companion to `test_format_accepts_invalid_utf8`: `format --check` must report
+/// a file with invalid UTF-8 as needing formatting (exit 1), because
+/// `--in-place` would rewrite the invalid bytes to U+FFFD.
+#[test]
+fn test_format_check_flags_invalid_utf8() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    let mut bytes = b"2024-01-01 open Assets:Cash\n;".to_vec();
+    bytes.push(0xC2);
+    bytes.push(0xC2);
+    bytes.extend_from_slice(b"\n");
+    std::fs::write(tmp.path(), &bytes).expect("write");
+
+    let output = Command::new(&rledger)
+        .args(["format", "--check"])
+        .arg(tmp.path())
+        .output()
+        .expect("Failed to run rledger format --check");
+
+    // exit 1 == "needs formatting"; must NOT be reported as already-formatted.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "format --check should flag invalid-UTF-8 input as needing formatting: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1808,3 +1808,36 @@ fn test_check_single_option_ok() {
         "a single non-repeatable option must pass check"
     );
 }
+
+/// Regression: `rledger format` must read files tolerantly (lossy UTF-8), the
+/// same way the loader (`rledger check`) does. A ledger with stray invalid
+/// UTF-8 bytes — which `check` and beancount both accept — previously failed
+/// to `format` with a hard "stream did not contain valid UTF-8" read error.
+#[test]
+fn test_format_accepts_invalid_utf8() {
+    let rledger = require_rledger!();
+    let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+    // Valid ledger plus a comment containing invalid UTF-8 (lone 0xC2 bytes).
+    let mut bytes = b"2024-01-01 open Assets:Cash\n;".to_vec();
+    bytes.push(0xC2);
+    bytes.push(0xC2);
+    bytes.extend_from_slice(b"\n");
+    std::fs::write(tmp.path(), &bytes).expect("write");
+
+    let output = Command::new(&rledger)
+        .arg("format")
+        .arg(tmp.path())
+        .output()
+        .expect("Failed to run rledger format");
+
+    assert!(
+        output.status.success(),
+        "format should succeed on invalid-UTF-8 input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Assets:Cash"),
+        "formatted output should contain the directive: {stdout}"
+    );
+}


### PR DESCRIPTION
## What

Found by a format round-trip pass over the 714-file real-world compat corpus: one file (`fava/tests_data_invalid-unicode.beancount`) that `rledger check` accepts but `rledger format` rejects with a hard read error:

```
error: failed to read ...: stream did not contain valid UTF-8
```

The file has stray invalid UTF-8 bytes (a `;\xc2\xc2` comment). `bean-check` accepts it; `rledger check` accepts it; only `rledger format` failed.

## Root cause

`format` read the file with `fs::read_to_string` (strict UTF-8), while the loader path used by `check` reads tolerantly:
- `rustledger-loader/src/vfs.rs` → `String::from_utf8_lossy` on decode error
- `rustledger-loader/src/cache.rs` → same, with a comment that `read_to_string` "would error"

So a ledger you can `check` could not be `format`ted — an internal inconsistency.

## How

`format_file` now reads bytes and decodes with `from_utf8_lossy`, matching the loader/cache. Invalid bytes become U+FFFD (the formatted output is valid UTF-8), consistent with how `check` already sees the file.

## Tests

`test_format_accepts_invalid_utf8` (cli_commands_test): writes a ledger with lone `0xC2` bytes, asserts `rledger format` succeeds and emits the directive.

## Verify

Round-trip pass re-run: 0 format failures on valid files; format remains idempotent, re-parse-safe, and balance-preserving across the corpus. Build/clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
