### PR TITLE
docs: record long-lived reference branches as do-not-delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,20 @@ cd /path/to/main/rustledger
 - **Clean state**: Each worktree is isolated, no cross-contamination
 - **Faster CI feedback**: Work on fixes while waiting for CI on another branch
 
+### Long-lived reference branches — do NOT delete
+
+A few remote branches are kept intentionally and are **not** cleanup targets,
+even when they have no open PR. Run `git log <branch>` for full context before
+touching any of them.
+
+| Branch | Why it's kept |
+|--------|---------------|
+| `spike/ffi-wit-component` | WIT / Component-Model FFI design spike for #1384. Reference if the `rustledger:ledger` component contract (the typed WIT API) changes. |
+| `spike/ledger-resource` | Stateful `resource session` "A+B boundary" redesign spike for #173. Reference for a future stateful embedding API. |
+| `benchmarks`, `compatibility` | CI-managed data branches (nightly benchmark / compatibility results). Written by automation — never hand-delete. |
+
+When pruning merged/closed PR branches, skip the rows above.
+
 ______________________________________________________________________
 
 ## Project Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,9 @@ cd /path/to/main/rustledger
 ### Long-lived reference branches — do NOT delete
 
 A few remote branches are kept intentionally and are **not** cleanup targets,
-even when they have no open PR. Run `git log <branch>` for full context before
-touching any of them.
+even when they have no open PR. Run `git log origin/<branch>` for full context
+before touching any of them (they are remote-only — a bare `<branch>` ref won't
+resolve unless you've fetched it locally).
 
 | Branch | Why it's kept |
 |--------|---------------|


### PR DESCRIPTION
## What

Documents the long-lived reference branches so they aren't accidentally deleted during branch cleanup.

During a branch-cleanup pass we removed two dead **closed-PR** branches (`docs/roadmap-accuracy` #1372, `fix/ofx-header-shim` #1458) but intentionally kept:

- `spike/ffi-wit-component` — WIT/Component-Model FFI design spike for #1384
- `spike/ledger-resource` — stateful `resource session` boundary redesign for #173
- `benchmarks`, `compatibility` — CI-managed data branches

These have no open PR, so a naive "delete branches without an open PR" sweep would remove them. This adds a "do NOT delete" table to the CLAUDE.md worktree section so the rule is explicit.

## How

Docs-only: a new subsection under **⚠️ Always Use Worktrees → Why Worktrees?** in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
