### PR TITLE
fix(importer): parse trailing-minus amounts (50.00-) as negative

### DIFF
--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -195,6 +195,18 @@ impl AmountFormat {
             amount
         };
 
+        // Reject a value carrying BOTH a leading and a trailing minus
+        // (e.g. "-50.00-"): the sign is ambiguous, and silently negating the
+        // already-negative magnitude to a positive would be surprising.
+        if trailing_neg {
+            let body = to_parse.trim_start();
+            if body.starts_with('-') || body.starts_with('\u{2212}') {
+                anyhow::bail!(
+                    "ambiguous amount sign (both leading and trailing minus): {amount:?}"
+                );
+            }
+        }
+
         let value: Decimal = match self {
             Self::Symbols(number_symbols) => parse_with_symbols(to_parse, number_symbols)
                 .with_context(|| format!("unable to parse using symbols: {number_symbols:?}"))?,
@@ -846,6 +858,10 @@ mod tests {
             f.parse("50.00").unwrap(),
             Decimal::from_str("50.00").unwrap()
         );
+        // Both leading and trailing minus is ambiguous → rejected, not flipped
+        // to positive.
+        assert!(f.parse("-50.00-").is_err());
+        assert!(f.parse("\u{2212}50.00-").is_err());
     }
 
     #[test]

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -181,14 +181,31 @@ fn parse_with_symbols(s: &str, sym: &NumberSymbols) -> Result<Decimal, rust_deci
 impl AmountFormat {
     /// Attempt to parse a string using the given format.
     pub fn parse(&self, amount: &str) -> Result<Decimal> {
+        let trimmed = amount.trim();
+
+        // Trailing-minus negative convention ("50.00-"), emitted by some bank
+        // and mainframe CSV exports. Strip the trailing sign and negate after
+        // parsing, since the underlying numeric parsers reject a trailing '-'.
+        // Parens negation (handled below) is mutually exclusive and takes
+        // precedence, so don't treat a ")-"-style string as trailing-minus.
+        let trailing_neg = trimmed.len() > 1 && trimmed.ends_with('-') && !trimmed.starts_with('(');
+        let to_parse = if trailing_neg {
+            &trimmed[..trimmed.len() - 1]
+        } else {
+            amount
+        };
+
         let value: Decimal = match self {
-            Self::Symbols(number_symbols) => parse_with_symbols(amount, number_symbols)
+            Self::Symbols(number_symbols) => parse_with_symbols(to_parse, number_symbols)
                 .with_context(|| format!("unable to parse using symbols: {number_symbols:?}"))?,
-            Self::Format(number_format) => parse_fmt(amount, number_format)
+            Self::Format(number_format) => parse_fmt(to_parse, number_format)
                 .with_context(|| format!("unable to parse using given format: {number_format}"))?,
         };
 
-        if amount.trim().starts_with('(') && amount.trim().ends_with(')') {
+        // Parens negation and trailing-minus are mutually exclusive (the latter
+        // excludes a leading '('), so either one negates the parsed magnitude.
+        let parens_neg = trimmed.starts_with('(') && trimmed.ends_with(')');
+        if parens_neg || trailing_neg {
             Ok(value.neg())
         } else {
             Ok(value)
@@ -803,6 +820,32 @@ mod tests {
         // Accountancy convention: (123.45) means -123.45.
         let v = AmountFormat::default().parse("(0.01)").unwrap();
         assert_eq!(v, Decimal::from_str("-0.01").unwrap());
+    }
+
+    #[test]
+    fn parse_default_trailing_minus_as_negative() {
+        // Trailing-minus convention ("50.00-") from some bank/mainframe exports.
+        let f = AmountFormat::default();
+        assert_eq!(
+            f.parse("50.00-").unwrap(),
+            Decimal::from_str("-50.00").unwrap()
+        );
+        assert_eq!(
+            f.parse("1,234.56-").unwrap(),
+            Decimal::from_str("-1234.56").unwrap()
+        );
+        // A lone "-" is not a number.
+        assert!(f.parse("-").is_err());
+        // Leading minus still works and isn't double-negated.
+        assert_eq!(
+            f.parse("-50.00").unwrap(),
+            Decimal::from_str("-50.00").unwrap()
+        );
+        // Plain positive unaffected.
+        assert_eq!(
+            f.parse("50.00").unwrap(),
+            Decimal::from_str("50.00").unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Found by importer dogfooding: `rledger extract --auto` fails to parse the **trailing-minus** negative convention (`50.00-`) used by many bank and mainframe CSV exports:

```
Date,Description,Amount
2024-01-02,Coffee,5.00-      ← warning: Row 1: Failed to parse amount
2024-01-05,Salary,2000.00
2024-01-08,Rent,1200.00-     ← warning: Row 3: Failed to parse amount
```

The importer already handles the other negative conventions — leading minus (`-50.00`), accounting parens (`(50.00)`), and separate debit/credit columns — so trailing-minus was an inconsistent gap. The two trailing-minus rows were silently dropped.

## How

`AmountFormat::parse` now strips a trailing `-` (when the string isn't a parens form) and negates after parsing, mirroring the existing parens handling. The underlying numeric parser rejects an embedded/trailing `-`, so the sign is handled explicitly. Parens and trailing-minus are mutually exclusive.

## Tests

- `parse_default_trailing_minus_as_negative` (unit): `50.00-` → `-50.00`, `1,234.56-` → `-1234.56`, lone `-` errors, leading `-50.00` not double-negated, plain `50.00` unaffected.
- All 159 existing importer tests still pass.

## Verify

`rledger extract --auto trailneg.csv` now imports `Coffee -5.00`, `Salary 2000.00`, `Rent -1200.00`. Build/clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
