### PR TITLE
fix(importer): parse DR/CR accounting suffix with correct sign

### DIFF
--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -188,6 +188,23 @@ impl AmountFormat {
     pub fn parse(&self, amount: &str) -> Result<Decimal> {
         let trimmed = amount.trim();
 
+        // DR/CR accounting suffix (e.g. "5.00 DR" debit → negative, "5.00 CR"
+        // credit → positive), used by some bank exports. Without this the
+        // numeric parser silently drops the letters, so a debit would import
+        // with the wrong (positive) sign. Case-insensitive; strip the marker
+        // and force the sign on the magnitude, reusing the normal number
+        // parsing (locale, parens, trailing-minus) for the remainder.
+        let upper = trimmed.to_ascii_uppercase();
+        for (suffix, negative) in [("DR", true), ("CR", false)] {
+            if let Some(stripped) = upper.strip_suffix(suffix)
+                && !stripped.trim_end().is_empty()
+            {
+                let body = &trimmed[..trimmed.len() - suffix.len()];
+                let magnitude = self.parse(body)?.abs();
+                return Ok(if negative { -magnitude } else { magnitude });
+            }
+        }
+
         // Trailing-minus negative convention ("50.00-"), emitted by some bank
         // and mainframe CSV exports. Strip the trailing sign and negate after
         // parsing, since the underlying numeric parsers reject a trailing '-'.
@@ -849,6 +866,36 @@ mod tests {
         // Accountancy convention: (123.45) means -123.45.
         let v = AmountFormat::default().parse("(0.01)").unwrap();
         assert_eq!(v, Decimal::from_str("-0.01").unwrap());
+    }
+
+    #[test]
+    fn parse_default_dr_cr_suffix() {
+        // DR (debit) → negative, CR (credit) → positive; case-insensitive,
+        // with or without a space. Used by some bank/mainframe exports.
+        let f = AmountFormat::default();
+        assert_eq!(
+            f.parse("5.00 DR").unwrap(),
+            Decimal::from_str("-5.00").unwrap()
+        );
+        assert_eq!(
+            f.parse("5.00 CR").unwrap(),
+            Decimal::from_str("5.00").unwrap()
+        );
+        assert_eq!(f.parse("100CR").unwrap(), Decimal::from(100));
+        assert_eq!(f.parse("100dr").unwrap(), Decimal::from(-100));
+        assert_eq!(
+            f.parse("1,234.56 DR").unwrap(),
+            Decimal::from_str("-1234.56").unwrap()
+        );
+        // DR forces negative even if the magnitude is written negative.
+        assert_eq!(
+            f.parse("-5.00 DR").unwrap(),
+            Decimal::from_str("-5.00").unwrap()
+        );
+        // A trailing currency-like token that merely ends in "CR"/"DR" letters
+        // but isn't the marker still parses its numeric part; bare markers fail.
+        assert!(f.parse("DR").is_err());
+        assert!(f.parse("CR").is_err());
     }
 
     #[test]

--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -196,8 +196,15 @@ impl AmountFormat {
         // parsing (locale, parens, trailing-minus) for the remainder.
         let upper = trimmed.to_ascii_uppercase();
         for (suffix, negative) in [("DR", true), ("CR", false)] {
+            // Only treat DR/CR as the accounting marker when it stands alone —
+            // i.e. the char before it is a digit or whitespace. This avoids
+            // misreading a currency code that happens to end in those letters
+            // (e.g. "100 XDR", "100 SCR") as a debit/credit and flipping its sign.
             if let Some(stripped) = upper.strip_suffix(suffix)
-                && !stripped.trim_end().is_empty()
+                && stripped
+                    .chars()
+                    .last()
+                    .is_some_and(|c| c.is_ascii_digit() || c.is_whitespace())
             {
                 let body = &trimmed[..trimmed.len() - suffix.len()];
                 let magnitude = self.parse(body)?.abs();
@@ -892,8 +899,12 @@ mod tests {
             f.parse("-5.00 DR").unwrap(),
             Decimal::from_str("-5.00").unwrap()
         );
-        // A trailing currency-like token that merely ends in "CR"/"DR" letters
-        // but isn't the marker still parses its numeric part; bare markers fail.
+        // A currency code that merely ends in DR/CR letters (preceded by a
+        // letter, not a digit/space) is NOT the marker — it parses positive,
+        // not sign-flipped. e.g. XDR (IMF SDR), SCR (Seychelles rupee).
+        assert_eq!(f.parse("100 XDR").unwrap(), Decimal::from(100));
+        assert_eq!(f.parse("100 SCR").unwrap(), Decimal::from(100));
+        // Bare markers (no number) fail.
         assert!(f.parse("DR").is_err());
         assert!(f.parse("CR").is_err());
     }


### PR DESCRIPTION
## What

CSV import: the **DR/CR accounting suffix** (`5.00 DR` = debit, `5.00 CR` = credit) was mis-handled — the numeric parser silently dropped the `DR`/`CR` letters and imported every such row as **positive**, so a debit got the wrong sign. Found during importer dogfooding.

```
Date,Description,Amount
2024-01-02,Coffee,5.00 DR    before: +5.00 (wrong)   after: -5.00
2024-01-05,Salary,2000.00 CR before: +2000.00         after: +2000.00
```

## How

`AmountFormat::parse` now recognizes a trailing `DR`/`CR` marker (case-insensitive, with or without a space): strip it and force the sign on the magnitude (DR → negative, CR → positive), reusing the normal number parsing (locale, parens, trailing-minus) for the remainder. Bare `DR`/`CR` with no number still errors.

## Tests

`parse_default_dr_cr_suffix`: `5.00 DR`→-5.00, `5.00 CR`→5.00, `100CR`→100, `100dr`→-100, `1,234.56 DR`→-1234.56, `-5.00 DR`→-5.00 (DR forces negative), bare `DR`/`CR` error. All 156 importer tests pass.

## Verify

`rledger extract --auto drcr.csv`: DR rows import negative, CR positive. Build/clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
