### PR TITLE
fix(query): WEEKDAY returns day-name string, matching beanquery

### DIFF
--- a/crates/rustledger-query/src/completions.rs
+++ b/crates/rustledger-query/src/completions.rs
@@ -532,7 +532,7 @@ fn function_completions() -> Vec<Completion> {
         function("MONTH(", "Extract month"),
         function("DAY(", "Extract day"),
         function("QUARTER(", "Extract quarter"),
-        function("WEEKDAY(", "Day of week (0=Mon)"),
+        function("WEEKDAY(", "Day-of-week name (Mon..Sun)"),
         function("YMONTH(", "Year-month format"),
         function("TODAY()", "Current date"),
         // String functions

--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -44,8 +44,8 @@ impl Executor<'_> {
             "YEAR" => Ok(Value::Integer(date.year().into())),
             "MONTH" => Ok(Value::Integer(date.month().into())),
             "DAY" => Ok(Value::Integer(date.day().into())),
-            "WEEKDAY" => Ok(Value::Integer(
-                (date.weekday().to_monday_zero_offset() as u32).into(),
+            "WEEKDAY" => Ok(Value::String(
+                super::weekday_abbrev(date.weekday().to_monday_zero_offset() as u32).to_string(),
             )),
             "QUARTER" => {
                 let quarter = (date.month() - 1) / 3 + 1;

--- a/crates/rustledger-query/src/executor/functions/mod.rs
+++ b/crates/rustledger-query/src/executor/functions/mod.rs
@@ -10,8 +10,8 @@ mod string;
 mod util;
 
 /// Three-letter English weekday abbreviation (`Mon`..`Sun`) for a Monday-zero
-/// offset (0=Mon … 6=Sun). `WEEKDAY()` returns this string, matching beanquery
-/// (whose `weekday()` yields a day name, not an integer).
+/// offset (0=Mon … 6=Sun). `WEEKDAY(date)` returns this string, matching
+/// beanquery (whose `weekday(date)` yields a day name, not an integer).
 pub(super) const fn weekday_abbrev(monday_zero_offset: u32) -> &'static str {
     match monday_zero_offset {
         0 => "Mon",

--- a/crates/rustledger-query/src/executor/functions/mod.rs
+++ b/crates/rustledger-query/src/executor/functions/mod.rs
@@ -8,3 +8,18 @@ mod math;
 mod position;
 mod string;
 mod util;
+
+/// Three-letter English weekday abbreviation (`Mon`..`Sun`) for a Monday-zero
+/// offset (0=Mon … 6=Sun). `WEEKDAY()` returns this string, matching beanquery
+/// (whose `weekday()` yields a day name, not an integer).
+pub(super) const fn weekday_abbrev(monday_zero_offset: u32) -> &'static str {
+    match monday_zero_offset {
+        0 => "Mon",
+        1 => "Tue",
+        2 => "Wed",
+        3 => "Thu",
+        4 => "Fri",
+        5 => "Sat",
+        _ => "Sun",
+    }
+}

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1271,8 +1271,9 @@ impl<'a> Executor<'a> {
             "WEEKDAY" => {
                 Self::require_args_count(&name_upper, args, 1)?;
                 match &args[0] {
-                    Value::Date(d) => Ok(Value::Integer(
-                        (d.weekday().to_monday_zero_offset() as u32).into(),
+                    Value::Date(d) => Ok(Value::String(
+                        functions::weekday_abbrev(d.weekday().to_monday_zero_offset() as u32)
+                            .to_string(),
                     )),
                     _ => Err(QueryError::Type("WEEKDAY expects a date".to_string())),
                 }

--- a/crates/rustledger-query/tests/weekday_string_test.rs
+++ b/crates/rustledger-query/tests/weekday_string_test.rs
@@ -1,0 +1,34 @@
+//! Regression: `WEEKDAY(date)` returns the day-name string (`Mon`..`Sun`),
+//! matching beanquery (whose `weekday()` yields a string, not an integer).
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+fn weekday_of(day: u32) -> Value {
+    // 2024-01-01 is a Monday, so day 1..7 covers Mon..Sun.
+    let dirs = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Expenses:X")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, day), "t")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1), "USD")))
+                .with_synthesized_posting(Posting::new("Expenses:X", Amount::new(dec!(1), "USD"))),
+        ),
+    ];
+    let q = parse("SELECT weekday(date) LIMIT 1").expect("parse");
+    let mut ex = Executor::new(&dirs);
+    let r = ex.execute(&q).expect("execute");
+    r.rows[0][0].clone()
+}
+
+#[test]
+fn weekday_returns_day_name_string() {
+    assert_eq!(weekday_of(1), Value::String("Mon".into()));
+    assert_eq!(weekday_of(3), Value::String("Wed".into()));
+    assert_eq!(weekday_of(7), Value::String("Sun".into()));
+}

--- a/docs/reference/bql.md
+++ b/docs/reference/bql.md
@@ -248,7 +248,7 @@ SELECT min(date), max(date)
 | `month(date)` | Extract month | `3` |
 | `day(date)` | Extract day | `15` |
 | `quarter(date)` | Extract quarter | `1` |
-| `weekday(date)` | Day of week (0=Mon) | `4` |
+| `weekday(date)` | Day-of-week name (`Mon`..`Sun`) | `Fri` |
 | `today()` | Current date | `2024-03-15` |
 
 ### Amount Functions

--- a/packages/mcp-server/src/docs/bql-functions.md
+++ b/packages/mcp-server/src/docs/bql-functions.md
@@ -19,7 +19,7 @@
 | `month(date)` | Extract month (1-12) |
 | `day(date)` | Extract day of month |
 | `quarter(date)` | Extract quarter (1-4) |
-| `weekday(date)` | Day of week (0=Monday) |
+| `weekday(date)` | Day-of-week name (`Mon`..`Sun`) |
 
 ## String Functions
 

--- a/spec/core/bql.md
+++ b/spec/core/bql.md
@@ -106,7 +106,7 @@ Functions transform positions into derived quantities:
 - `MONTH(date)` → Integer
 - `YEAR(date)` → Integer
 - `QUARTER(date)` → Integer
-- `WEEKDAY(date)` → Integer
+- `WEEKDAY(date)` → String (day name, `Mon`..`Sun`)
 
 ### String Functions
 


### PR DESCRIPTION
## What

`WEEKDAY(date)` returned an **integer** (0=Mon … 6=Sun), but beanquery's `weekday()` returns the **day-name string** (`Mon`..`Sun`). This is a portability divergence — a query written for beancount (`WHERE weekday(date) = "Mon"`) failed on rustledger, and vice versa. Found in the upstream-parity review.

```
SELECT weekday(date)   rledger before: 0   beanquery: Mon   →  rledger after: Mon
```

beanquery has only `weekday` (string); it has no integer `dow`, and no rustledger test pinned the integer form — so this is a safe compat fix.

## How

Both `WEEKDAY` evaluator paths (`functions/date.rs`, `executor/mod.rs`) now return `Value::String("Mon".."Sun")` via a shared `weekday_abbrev` helper. Completion hint updated.

## Tests

`weekday_string_test`: `weekday(date)` → `"Mon"`/`"Wed"`/`"Sun"` for Mon/Wed/Sun dates. Full `rustledger-query` suite passes; clippy + fmt clean.

## Verify

`rledger query "SELECT weekday(date)"` now yields `Mon`, matching `bean-query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
