### PR TITLE
fix(completion): make payee/narration completion reachable

### DIFF
--- a/crates/rustledger-completion/src/lib.rs
+++ b/crates/rustledger-completion/src/lib.rs
@@ -246,6 +246,15 @@ pub fn classify_context(before_cursor: &str) -> CompletionContext {
         return CompletionContext::LineStart;
     }
 
+    // Inside an open quoted string → payee/narration completion. Checked
+    // before the date-prefix logic below: a transaction header
+    // (`2024-01-01 * "Pay…`) starts with a date, which otherwise
+    // short-circuits to `AfterDate` and leaves this context (and
+    // `complete_payee`) unreachable.
+    if before_cursor.chars().filter(|&c| c == '"').count() % 2 == 1 {
+        return CompletionContext::InsideString;
+    }
+
     // Check for date at line start (YYYY-MM-DD pattern). Guard the
     // 10-byte split on a char boundary: a `YYYY-MM-DD` prefix is all
     // ASCII, so if byte 10 lands mid-character the line can't be a
@@ -279,12 +288,6 @@ pub fn classify_context(before_cursor: &str) -> CompletionContext {
 
         // After date but no recognized directive yet
         return CompletionContext::AfterDate;
-    }
-
-    // Check if inside a quoted string
-    let quote_count = before_cursor.chars().filter(|&c| c == '"').count();
-    if quote_count % 2 == 1 {
-        return CompletionContext::InsideString;
     }
 
     CompletionContext::Unknown
@@ -598,6 +601,27 @@ mod tests {
     #[test]
     fn classify_inside_string() {
         assert_eq!(ctx("text \"inside"), CompletionContext::InsideString);
+    }
+
+    #[test]
+    fn classify_inside_string_in_transaction_header() {
+        // Regression: a transaction header starts with a date, which used to
+        // short-circuit to `AfterDate` before the open-quote check, leaving
+        // payee/narration completion unreachable.
+        assert_eq!(
+            ctx("2024-01-01 * \"Whole F"),
+            CompletionContext::InsideString
+        );
+        // Second string (narration) after a complete payee.
+        assert_eq!(
+            ctx("2024-01-01 * \"Payee\" \"Groc"),
+            CompletionContext::InsideString
+        );
+        // A complete (balanced) payee string is not "inside" a string.
+        assert_ne!(
+            ctx("2024-01-01 * \"Payee\" "),
+            CompletionContext::InsideString
+        );
     }
 
     #[test]

--- a/crates/rustledger-completion/src/lib.rs
+++ b/crates/rustledger-completion/src/lib.rs
@@ -250,8 +250,9 @@ pub fn classify_context(before_cursor: &str) -> CompletionContext {
     // before the date-prefix logic below: a transaction header
     // (`2024-01-01 * "Pay…`) starts with a date, which otherwise
     // short-circuits to `AfterDate` and leaves this context (and
-    // `complete_payee`) unreachable.
-    if before_cursor.chars().filter(|&c| c == '"').count() % 2 == 1 {
+    // `complete_payee`) unreachable. Uses lexer-aligned scanning so escaped
+    // quotes and quotes inside comments don't misclassify.
+    if ends_in_open_string(before_cursor) {
         return CompletionContext::InsideString;
     }
 
@@ -319,6 +320,34 @@ fn in_code_position(before: &str) -> bool {
         }
     }
     !in_string
+}
+
+/// Whether the cursor (end of `before`) sits inside an *open* string literal
+/// (a payee/narration being typed). Uses the same lexer-aligned scan as
+/// [`in_code_position`]: a backslash-escaped `\"` does not close the string,
+/// and an unescaped, unquoted `;` starts a comment (after which the cursor is
+/// in a comment, not a string). This is stricter than a raw `"`-parity count,
+/// which would miscount escaped quotes and quotes inside comments.
+fn ends_in_open_string(before: &str) -> bool {
+    let mut in_string = false;
+    let mut escaped = false;
+    for ch in before.chars() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+        } else if ch == '"' {
+            in_string = true;
+        } else if ch == ';' {
+            // Comment outside any string: cursor is in a comment, not a string.
+            return false;
+        }
+    }
+    in_string
 }
 
 /// Check if a string looks like a date (YYYY-MM-DD).
@@ -620,6 +649,26 @@ mod tests {
         // A complete (balanced) payee string is not "inside" a string.
         assert_ne!(
             ctx("2024-01-01 * \"Payee\" "),
+            CompletionContext::InsideString
+        );
+    }
+
+    #[test]
+    fn classify_inside_string_handles_escapes_and_comments() {
+        // An escaped quote does not close the string → still inside.
+        assert_eq!(
+            ctx("2024-01-01 * \"She said \\\"hi"),
+            CompletionContext::InsideString
+        );
+        // A balanced string that *contains* an escaped quote is not "inside".
+        assert_ne!(
+            ctx("2024-01-01 * \"a \\\" b\" "),
+            CompletionContext::InsideString
+        );
+        // A quote that appears inside a comment must not trigger payee
+        // completion (the `;` ends code/string scanning).
+        assert_ne!(
+            ctx("2024-01-01 open Assets:Bank ; \"note"),
             CompletionContext::InsideString
         );
     }


### PR DESCRIPTION
## What

LSP/completion: **payee & narration completion never fired**. Found by LSP dogfooding. Typing a transaction header like `2024-01-01 * "Whole F` and requesting completion returned 0 items at every cursor position — the advertised payee/narration completion was effectively dead.

## Root cause

`classify_context` (in `rustledger-completion`, shared by the LSP and WASM) checks the `YYYY-MM-DD` date prefix *before* the open-quote check. Since every transaction header starts with a date, the date branch always returned `AfterDate` (or an account context) and short-circuited before the `InsideString` quote-count check was ever reached — so `complete_payee` was unreachable for the normal case.

## How

Move the open-quote (`InsideString`) check **above** the date-prefix logic: an odd number of `"` before the cursor means the cursor is inside a payee/narration string, which takes precedence over the positional date logic. Removed the now-dead duplicate check at the end.

## Tests

`classify_inside_string_in_transaction_header`: `2024-01-01 * "Whole F` and `… "Payee" "Groc` → `InsideString`; a balanced `… "Payee" ` is not. Existing completion tests still pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
