### PR TITLE
fix(lsp): do not discover a journal from the process cwd when a workspace is set

### DIFF
--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -95,7 +95,7 @@ impl Server {
         // when there is no workspace folder. Otherwise a stray journal in the
         // editor's launch directory silently contaminates an unrelated
         // workspace's state.
-        let discovered = Self::discovery_dir(workspace_root, std::env::current_dir().ok())
+        let discovered = Self::discovery_dir(workspace_root, || std::env::current_dir().ok())
             .and_then(|dir| discover_journal_file(&dir));
         if discovered.is_none() {
             tracing::debug!("No journal file configured or discovered");
@@ -107,12 +107,14 @@ impl Server {
     /// folder when set, otherwise the process cwd. The cwd is deliberately
     /// *not* consulted when a workspace folder exists, so a journal that
     /// happens to sit in the editor's launch directory cannot leak into an
-    /// unrelated workspace.
+    /// unrelated workspace. `cwd` is computed lazily so the `current_dir`
+    /// syscall is skipped entirely (and its failure ignored) when a workspace
+    /// folder is set.
     fn discovery_dir(
         workspace_root: Option<std::path::PathBuf>,
-        cwd: Option<std::path::PathBuf>,
+        cwd: impl FnOnce() -> Option<std::path::PathBuf>,
     ) -> Option<std::path::PathBuf> {
-        workspace_root.or(cwd)
+        workspace_root.or_else(cwd)
     }
 
     /// Get the workspace root path from init params.
@@ -351,13 +353,20 @@ mod tests {
         let ws = PathBuf::from("/work/space");
         let cwd = PathBuf::from("/tmp/launch");
         // Workspace set → search the workspace, never the cwd (no contamination).
-        assert_eq!(
-            Server::discovery_dir(Some(ws.clone()), Some(cwd.clone())),
-            Some(ws)
+        // The cwd closure must not even be invoked in this case.
+        let mut cwd_called = false;
+        let got = Server::discovery_dir(Some(ws.clone()), || {
+            cwd_called = true;
+            Some(cwd.clone())
+        });
+        assert_eq!(got, Some(ws));
+        assert!(
+            !cwd_called,
+            "cwd must not be consulted when a workspace is set"
         );
         // No workspace → fall back to the cwd.
-        assert_eq!(Server::discovery_dir(None, Some(cwd.clone())), Some(cwd));
+        assert_eq!(Server::discovery_dir(None, || Some(cwd.clone())), Some(cwd));
         // Neither → nothing to discover.
-        assert_eq!(Server::discovery_dir(None, None), None);
+        assert_eq!(Server::discovery_dir(None, || None), None);
     }
 }

--- a/crates/rustledger-lsp/src/server.rs
+++ b/crates/rustledger-lsp/src/server.rs
@@ -90,22 +90,29 @@ impl Server {
             return self.resolve_explicit_journal(journal, workspace_root.as_deref());
         }
 
-        // No explicit config - try auto-discovery in workspace root
-        if let Some(root) = workspace_root
-            && let Some(discovered) = discover_journal_file(&root)
-        {
-            return Some(discovered);
+        // No explicit config - auto-discover, but only in the right directory:
+        // a set workspace folder is authoritative; the process cwd is used ONLY
+        // when there is no workspace folder. Otherwise a stray journal in the
+        // editor's launch directory silently contaminates an unrelated
+        // workspace's state.
+        let discovered = Self::discovery_dir(workspace_root, std::env::current_dir().ok())
+            .and_then(|dir| discover_journal_file(&dir));
+        if discovered.is_none() {
+            tracing::debug!("No journal file configured or discovered");
         }
+        discovered
+    }
 
-        // Also try current directory as fallback for discovery
-        if let Ok(cwd) = std::env::current_dir()
-            && let Some(discovered) = discover_journal_file(&cwd)
-        {
-            return Some(discovered);
-        }
-
-        tracing::debug!("No journal file configured or discovered");
-        None
+    /// Directory to search for a journal during auto-discovery: the workspace
+    /// folder when set, otherwise the process cwd. The cwd is deliberately
+    /// *not* consulted when a workspace folder exists, so a journal that
+    /// happens to sit in the editor's launch directory cannot leak into an
+    /// unrelated workspace.
+    fn discovery_dir(
+        workspace_root: Option<std::path::PathBuf>,
+        cwd: Option<std::path::PathBuf>,
+    ) -> Option<std::path::PathBuf> {
+        workspace_root.or(cwd)
     }
 
     /// Get the workspace root path from init params.
@@ -332,4 +339,25 @@ pub fn start_stdio() -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
     io_threads.join()?;
 
     Ok(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Server;
+    use std::path::PathBuf;
+
+    #[test]
+    fn discovery_dir_prefers_workspace_and_ignores_cwd() {
+        let ws = PathBuf::from("/work/space");
+        let cwd = PathBuf::from("/tmp/launch");
+        // Workspace set → search the workspace, never the cwd (no contamination).
+        assert_eq!(
+            Server::discovery_dir(Some(ws.clone()), Some(cwd.clone())),
+            Some(ws)
+        );
+        // No workspace → fall back to the cwd.
+        assert_eq!(Server::discovery_dir(None, Some(cwd.clone())), Some(cwd));
+        // Neither → nothing to discover.
+        assert_eq!(Server::discovery_dir(None, None), None);
+    }
 }


### PR DESCRIPTION
## What

LSP: when a workspace folder is open but contains **no** journal, the server fell back to discovering a journal in the **process's current working directory** (the editor's launch dir). A stray `main.beancount`/`ledger.beancount` there was silently loaded and merged into an unrelated file's state — phantom accounts in completion, wrong hover, and (potentially) cross-ledger diagnostics. Found by LSP dogfooding.

## How

`resolve_journal_path` now only consults the process cwd for auto-discovery when there is **no workspace folder at all**. When a workspace folder is set, only its own journal counts (extracted as the pure `discovery_dir` helper: `workspace_root.or(cwd)`). Explicit `journal_file` config is unaffected.

## Tests

`discovery_dir_prefers_workspace_and_ignores_cwd`: workspace set → workspace dir (cwd ignored); no workspace → cwd; neither → none. Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
