### PR TITLE
fix(lsp): trim trailing whitespace from folding + document-symbol ranges

### DIFF
--- a/crates/rustledger-lsp/src/handlers/folding.rs
+++ b/crates/rustledger-lsp/src/handlers/folding.rs
@@ -9,7 +9,7 @@ use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams};
 use rustledger_core::Directive;
 use rustledger_parser::ParseResult;
 
-use super::utils::{LineIndex, PositionEncoding};
+use super::utils::{LineIndex, PositionEncoding, trim_span_end};
 
 /// Handle a folding range request.
 pub fn handle_folding_ranges(
@@ -29,7 +29,10 @@ pub fn handle_folding_ranges(
             && !txn.postings.is_empty()
         {
             let (start_line, _) = line_index.offset_to_position(spanned.span.start);
-            let (end_line, _) = line_index.offset_to_position(spanned.span.end);
+            // Trim the span end so the fold doesn't swallow trailing blank
+            // lines and the next directive's header (which made folds overlap).
+            let (end_line, _) =
+                line_index.offset_to_position(trim_span_end(source, spanned.span.end));
 
             // Only fold if spans multiple lines
             if end_line > start_line {
@@ -230,6 +233,30 @@ mod tests {
         // Transaction should fold from line 0 to line 2
         let txn_fold = ranges.iter().find(|r| r.start_line == 0);
         assert!(txn_fold.is_some());
+    }
+
+    #[test]
+    fn test_folding_does_not_overshoot_into_next_directive() {
+        // Two transactions separated by blank lines. The first fold must end at
+        // its last posting (line 2), NOT extend across the blanks into T2's
+        // header (line 5) — which would make folds overlap and hide T2.
+        let source = "2024-01-15 * \"T1\"\n  Assets:Bank  -5 USD\n  Expenses:Food  5 USD\n\n\n2024-01-20 * \"T2\"\n  Assets:Bank  -3 USD\n  Expenses:Food  3 USD\n";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "no parse errors");
+        let params = FoldingRangeParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        let ranges =
+            handle_folding_ranges(&params, source, &result, PositionEncoding::Utf16).unwrap();
+        let t1 = ranges.iter().find(|r| r.start_line == 0).expect("T1 fold");
+        assert_eq!(
+            t1.end_line, 2,
+            "T1 fold must end at its last posting, not overshoot"
+        );
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/symbols.rs
+++ b/crates/rustledger-lsp/src/handlers/symbols.rs
@@ -12,7 +12,7 @@ use lsp_types::{
 use rustledger_core::{Directive, SYNTHESIZED_FILE_ID};
 use rustledger_parser::ParseResult;
 
-use super::utils::{LineIndex, PositionEncoding};
+use super::utils::{LineIndex, PositionEncoding, trim_span_end};
 
 /// Handle a document symbols request.
 pub fn handle_document_symbols(
@@ -31,7 +31,10 @@ pub fn handle_document_symbols(
             directive_to_symbol(
                 &spanned.value,
                 spanned.span.start,
-                spanned.span.end,
+                // Trim trailing whitespace so a symbol's range ends at its own
+                // content, not at the next directive (which made sibling symbol
+                // ranges overlap and broke editor breadcrumb/enclosing logic).
+                trim_span_end(source, spanned.span.end),
                 &line_index,
             )
         })
@@ -297,5 +300,36 @@ mod tests {
         if let Some(DocumentSymbolResponse::Nested(symbols)) = response {
             assert_eq!(symbols.len(), 2); // open + transaction
         }
+    }
+
+    #[test]
+    fn test_document_symbol_ranges_do_not_overlap() {
+        // Two transactions separated by blank lines. Each symbol's range must
+        // end at its own content, not extend into the next directive — else
+        // sibling ranges overlap and break editor breadcrumb/enclosing logic.
+        let source = "2024-01-15 * \"T1\"\n  Assets:Bank  -5 USD\n  Expenses:Food  5 USD\n\n\n2024-01-20 * \"T2\"\n  Assets:Bank  -3 USD\n  Expenses:Food  3 USD\n";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "no parse errors");
+        let params = DocumentSymbolParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///test.beancount".parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        let Some(DocumentSymbolResponse::Nested(symbols)) =
+            handle_document_symbols(&params, source, &result, PositionEncoding::Utf16)
+        else {
+            panic!("expected nested symbols");
+        };
+        assert_eq!(symbols.len(), 2);
+        // T1's range must end before T2's range starts (line 5 is T2's header).
+        assert!(
+            symbols[0].range.end.line < symbols[1].range.start.line,
+            "T1 symbol range {:?} overlaps T2 {:?}",
+            symbols[0].range,
+            symbols[1].range
+        );
+        assert_eq!(symbols[0].range.end.line, 2, "T1 ends at its last posting");
     }
 }

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -6,6 +6,20 @@
 use lsp_types::{Position, Range};
 use rustledger_parser::ParseResult;
 
+/// Trim a directive span's end offset back over trailing whitespace.
+///
+/// A directive's parser span runs up to the *start of the next directive*, so
+/// it swallows any trailing blank lines. Mapping that raw end to a `Position`
+/// makes ranges (folding, document symbols, …) overshoot into the following
+/// directive. This returns the offset just past the directive's last
+/// non-whitespace byte, so the range ends at the directive's real content.
+pub(crate) fn trim_span_end(source: &str, end: usize) -> usize {
+    let clamped = end.min(source.len());
+    source
+        .get(..clamped)
+        .map_or(clamped, |s| s.trim_end().len())
+}
+
 /// Whether two LSP `Range`s overlap, using LSP half-open semantics
 /// (`Range.end` is EXCLUSIVE per the spec).
 ///


### PR DESCRIPTION
## What

Two LSP capabilities mapped a directive's raw `span.end` straight to a `Position`, but a directive's parser span runs up to the *start of the next directive* (it includes trailing blank lines). So both **overshot** into the following directive:

- **Folding ranges** — a transaction's fold swallowed trailing blanks and the next transaction's header line; adjacent folds overlapped, so collapsing one hid the next.
- **Document symbols** — a transaction's symbol `range` engulfed the next transaction's header; sibling symbol ranges overlapped, breaking editor breadcrumb / enclosing-symbol logic.

Found by LSP dogfounding (round 2). Same family as the diagnostic-range overshoot fixed in #1479, here in two more surfaces.

## How

Add a shared `trim_span_end(source, end)` helper in `handlers/utils.rs` that trims the span end back over trailing whitespace to the directive's last content byte, and use it in `folding.rs` and `symbols.rs`.

## Tests

- `test_folding_does_not_overshoot_into_next_directive`: T1's fold ends at its last posting (line 2), not T2's header.
- `test_document_symbol_ranges_do_not_overlap`: T1's symbol range ends before T2's starts.

Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
