### PR TITLE
fix(lsp): pluralize transaction/posting/amount counts in codeLens and hover

### DIFF
--- a/crates/rustledger-lsp/src/handlers/code_lens.rs
+++ b/crates/rustledger-lsp/src/handlers/code_lens.rs
@@ -45,7 +45,7 @@ use rustledger_validate::ErrorCode;
 use std::collections::HashMap;
 
 use super::diagnostics::validation_would_run;
-use super::utils::{LineIndex, PositionEncoding};
+use super::utils::{LineIndex, PositionEncoding, count_noun};
 
 /// Handle a code lens request.
 ///
@@ -102,10 +102,11 @@ pub fn handle_code_lens(
                     open.currencies.iter().map(|c| c.to_string()).collect();
 
                 let title = if txn_count > 0 {
+                    let counted = count_noun(txn_count, "transaction");
                     if currencies.is_empty() {
-                        format!("{} transactions", txn_count)
+                        counted
                     } else {
-                        format!("{} transactions | {}", txn_count, currencies.join(", "))
+                        format!("{} | {}", counted, currencies.join(", "))
                     }
                 } else if !currencies.is_empty() {
                     currencies.join(", ")
@@ -140,10 +141,11 @@ pub fn handle_code_lens(
                     .into_iter()
                     .collect();
 
+                let counted = count_noun(posting_count, "posting");
                 let title = if currencies.is_empty() {
-                    format!("{} postings", posting_count)
+                    counted
                 } else {
-                    format!("{} postings | {}", posting_count, currencies.join(", "))
+                    format!("{} | {}", counted, currencies.join(", "))
                 };
 
                 lenses.push(CodeLens {

--- a/crates/rustledger-lsp/src/handlers/hover.rs
+++ b/crates/rustledger-lsp/src/handlers/hover.rs
@@ -12,8 +12,8 @@ use rustledger_parser::{ParseResult, Spanned};
 use crate::ledger_state::LedgerState;
 
 use super::utils::{
-    PositionEncoding, commodity_declaration_spans, get_word_at_source_position, is_account_type,
-    is_currency_like_simple,
+    PositionEncoding, commodity_declaration_spans, count_noun, get_word_at_source_position,
+    is_account_type, is_currency_like_simple,
 };
 
 /// Handle a hover request.
@@ -111,14 +111,18 @@ fn get_account_info(
             let currencies: Vec<String> = open.currencies.iter().map(|c| c.to_string()).collect();
             info.push_str(&format!("**Currencies:** {}\n\n", currencies.join(", ")));
         }
-        info.push_str(&format!("**Used in:** {usage_count} postings"));
+        info.push_str(&format!(
+            "**Used in:** {}",
+            count_noun(usage_count, "posting")
+        ));
         return Some(info);
     }
 
     // No open found anywhere, but still provide usage info if it's referenced.
     if usage_count > 0 {
         return Some(format!(
-            "## Account: `{account}`\n\n**Note:** No `open` directive found\n\n**Used in:** {usage_count} postings"
+            "## Account: `{account}`\n\n**Note:** No `open` directive found\n\n**Used in:** {}",
+            count_noun(usage_count, "posting")
         ));
     }
 
@@ -152,7 +156,10 @@ fn get_currency_info(currency: &str, parse_result: &ParseResult) -> Option<Strin
 
             // Count usages
             let usage_count = count_currency_usages(currency, parse_result);
-            info.push_str(&format!("\n**Used in:** {} amounts", usage_count));
+            info.push_str(&format!(
+                "\n**Used in:** {}",
+                count_noun(usage_count, "amount")
+            ));
 
             return Some(info);
         }
@@ -162,8 +169,9 @@ fn get_currency_info(currency: &str, parse_result: &ParseResult) -> Option<Strin
     let usage_count = count_currency_usages(currency, parse_result);
     if usage_count > 0 {
         return Some(format!(
-            "## Currency: `{}`\n\n**Note:** No `commodity` directive found\n\n**Used in:** {} amounts",
-            currency, usage_count
+            "## Currency: `{}`\n\n**Note:** No `commodity` directive found\n\n**Used in:** {}",
+            currency,
+            count_noun(usage_count, "amount")
         ));
     }
 

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -20,6 +20,18 @@ pub(crate) fn trim_span_end(source: &str, end: usize) -> usize {
         .map_or(clamped, |s| s.trim_end().len())
 }
 
+/// Format a count with a noun, pluralizing with a trailing `s` unless the count
+/// is exactly 1 (so hover/code-lens show "1 posting", not "1 postings"). Only
+/// handles regular `+s` plurals, which is all the LSP surface needs
+/// (transaction, posting, amount).
+pub(crate) fn count_noun(count: usize, singular: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {singular}s")
+    }
+}
+
 /// Whether two LSP `Range`s overlap, using LSP half-open semantics
 /// (`Range.end` is EXCLUSIVE per the spec).
 ///
@@ -635,6 +647,15 @@ pub fn is_currency_like(s: &str, parse_result: &ParseResult) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_count_noun_pluralization() {
+        assert_eq!(count_noun(0, "posting"), "0 postings");
+        assert_eq!(count_noun(1, "posting"), "1 posting");
+        assert_eq!(count_noun(2, "posting"), "2 postings");
+        assert_eq!(count_noun(1, "transaction"), "1 transaction");
+        assert_eq!(count_noun(3, "amount"), "3 amounts");
+    }
 
     #[test]
     fn test_line_index_basic() {


### PR DESCRIPTION
## What

LSP count displays were hardcoded plural, producing ungrammatical singular output found by LSP dogfounding (round 3):
- codeLens above an `open` with one transaction: **"1 transactions"**
- codeLens above a transaction with one posting: **"1 postings"**
- hover on an account/currency used once: **"Used in: 1 postings"** / **"1 amounts"**

## How

Add a small `count_noun(count, singular)` helper in `handlers/utils.rs` (regular `+s` plural unless count is exactly 1 — covers transaction/posting/amount) and use it in `code_lens.rs` (both the `open` and transaction lenses) and `hover.rs` (account postings + currency amounts, both the found and not-found branches).

## Tests

`test_count_noun_pluralization` pins 0→"0 postings", 1→"1 posting", 2→"2 postings", etc. Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
