### PR TITLE
fix(lsp): publish diagnostics for unopened included files

### DIFF
--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1784,10 +1784,16 @@ impl MainLoopState {
         };
 
         // Overlay applied when validating an unopened file: every open buffer's
-        // fresh parse (current file first, then the others).
+        // fresh parse (current file first, then the others). The current
+        // buffer is overlaid only when its fresh parse is clean — overlaying a
+        // partial/invalid parse would corrupt the validation input for the
+        // other files (matching the parse-error skip applied to the `other`
+        // buffers in `publish_diagnostics`).
         let mut overlay_all: Vec<(u16, &[Spanned<Directive>])> =
             Vec::with_capacity(1 + other_buffer_overlays.len());
-        if let Some(fid) = current_file_id {
+        if let Some(fid) = current_file_id
+            && current_parse.errors.is_empty()
+        {
             overlay_all.push((fid, current_parse.directives.as_slice()));
         }
         overlay_all.extend_from_slice(other_buffer_overlays);
@@ -1804,7 +1810,18 @@ impl MainLoopState {
             {
                 continue;
             }
+            // NOTE: this `file://{path}` assembly matches the crate-wide
+            // convention (see `revalidate_open_documents`, `document_links`,
+            // and `uri_to_path`, which strips a plain `file://` prefix without
+            // percent-decoding). A path with characters that aren't URI-safe
+            // (spaces, `#`, `%`) would fail to parse; warn rather than drop it
+            // silently. A proper percent-encoding `path_to_uri` helper applied
+            // consistently across the crate is the broader fix.
             let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
+                tracing::warn!(
+                    "skipping cross-file diagnostics for {}: path is not a valid file:// URI",
+                    f.path.display()
+                );
                 continue;
             };
             let parsed = parse(&f.source);
@@ -1822,27 +1839,51 @@ impl MainLoopState {
         out
     }
 
-    /// Publish or clear diagnostics for unopened included files. A non-empty
-    /// set is published and the URI tracked; an empty set clears (and untracks)
-    /// a URI we had previously reported errors for. URIs are tracked in
-    /// [`MainLoopState::cross_file_diag_uris`] because, unlike open buffers,
-    /// these files have no `on_did_close` to drive the LSP-required explicit
-    /// clear.
+    /// Publish or clear diagnostics for unopened included files.
+    ///
+    /// Non-empty sets are published and their URIs tracked in
+    /// [`MainLoopState::cross_file_diag_uris`]. Any previously-tracked URI that
+    /// is NOT erroring this round is then explicitly cleared (empty publish) and
+    /// untracked — this covers a fixed error, an include-graph change, the
+    /// ledger becoming single-file/unavailable (so `cross_file` is empty), all
+    /// of which would otherwise leave stale errors in the client. URIs of files
+    /// currently open in a buffer are left alone: those buffers publish (and
+    /// clear) their own diagnostics via didOpen/didChange/didClose.
+    #[allow(clippy::mutable_key_type)] // Uri has interior mutability but is safe as a set key here
     fn publish_cross_file_diagnostics(
         &mut self,
         cross_file: Vec<(Uri, Vec<lsp_types::Diagnostic>)>,
     ) {
+        // Publish the files that have errors this round.
+        let mut erroring: std::collections::HashSet<Uri> = std::collections::HashSet::new();
         for (uri, diags) in cross_file {
             if diags.is_empty() {
-                if self.cross_file_diag_uris.remove(&uri) {
-                    self.diagnostics.remove(&uri);
-                    self.send_diagnostics(&uri, vec![]);
-                }
-            } else {
-                self.cross_file_diag_uris.insert(uri.clone());
-                self.diagnostics.insert(uri.clone(), diags.clone());
-                self.send_diagnostics(&uri, diags);
+                continue;
             }
+            erroring.insert(uri.clone());
+            self.cross_file_diag_uris.insert(uri.clone());
+            self.diagnostics.insert(uri.clone(), diags.clone());
+            self.send_diagnostics(&uri, diags);
+        }
+
+        // Clear any previously-tracked URI that is no longer erroring and is not
+        // currently open (open buffers manage their own diagnostics).
+        let open_uris: std::collections::HashSet<Uri> = self
+            .vfs
+            .read()
+            .paths()
+            .filter_map(|p| format!("file://{}", p.display()).parse::<Uri>().ok())
+            .collect();
+        let stale: Vec<Uri> = self
+            .cross_file_diag_uris
+            .iter()
+            .filter(|u| !erroring.contains(*u) && !open_uris.contains(*u))
+            .cloned()
+            .collect();
+        for uri in stale {
+            self.cross_file_diag_uris.remove(&uri);
+            self.diagnostics.remove(&uri);
+            self.send_diagnostics(&uri, vec![]);
         }
     }
 

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -172,6 +172,12 @@ pub struct MainLoopState {
     pub sender: Sender<lsp_server::Message>,
     /// Cached diagnostics per file.
     pub diagnostics: HashMap<Uri, Vec<lsp_types::Diagnostic>>,
+    /// URIs of *unopened* ledger files (reachable via `include`) that we last
+    /// published non-empty diagnostics for. Tracked so that, when their errors
+    /// are fixed, we send an explicit empty diagnostic set to clear them — the
+    /// LSP spec has no implicit "clear", and these files have no open buffer of
+    /// their own to drive a clear via `on_did_close`.
+    pub cross_file_diag_uris: std::collections::HashSet<Uri>,
     /// Whether shutdown was requested.
     pub shutdown_requested: bool,
     /// Set by the `exit` notification handler. The main loop checks
@@ -262,6 +268,7 @@ impl MainLoopState {
 
         Self {
             vfs: Arc::new(RwLock::new(Vfs::new())),
+            cross_file_diag_uris: std::collections::HashSet::new(),
             sender,
             diagnostics: HashMap::new(),
             shutdown_requested: false,
@@ -1711,6 +1718,19 @@ impl MainLoopState {
             &other_buffer_overlays,
             self.position_encoding,
         );
+
+        // Compute diagnostics for ledger files reachable via `include` that are
+        // NOT open in any buffer — otherwise validation errors that live in an
+        // unopened included file (e.g. an unbalanced transaction) never surface
+        // anywhere. Open files publish their own diagnostics via didOpen/
+        // didChange, so they're skipped here.
+        let cross_file = self.compute_unopened_ledger_diagnostics(
+            ledger_state,
+            current_canonical_path.as_deref(),
+            current_file_id,
+            &result,
+            &other_buffer_overlays,
+        );
         drop(ledger_guard); // Release lock before sending
 
         tracing::debug!(
@@ -1723,6 +1743,107 @@ impl MainLoopState {
         // Cache and send
         self.diagnostics.insert(uri.clone(), diagnostics.clone());
         self.send_diagnostics(uri, diagnostics);
+
+        // Publish (or clear) diagnostics for unopened included files.
+        self.publish_cross_file_diagnostics(cross_file);
+    }
+
+    /// Compute diagnostics for every ledger file reachable via `include` that
+    /// is NOT currently open in a buffer. Each unopened file is validated
+    /// against the full ledger (reusing [`all_diagnostics`], filtered to that
+    /// file's id and mapped against that file's own source), with the open
+    /// buffers' fresh parses overlaid so unsaved edits are reflected.
+    ///
+    /// Returns one `(uri, diagnostics)` per unopened ledger file (diagnostics
+    /// may be empty — the caller clears those it had previously reported).
+    /// Cost is O(unopened ledger files) validations; real-world ledgers have
+    /// few files, and this only runs when the ledger spans more than one file.
+    fn compute_unopened_ledger_diagnostics(
+        &self,
+        ledger_state: Option<&crate::ledger_state::LedgerState>,
+        current_canonical: Option<&std::path::Path>,
+        current_file_id: Option<u16>,
+        current_parse: &ParseResult,
+        other_buffer_overlays: &[(u16, &[Spanned<Directive>])],
+    ) -> Vec<(Uri, Vec<lsp_types::Diagnostic>)> {
+        let Some(ls) = ledger_state else {
+            return Vec::new();
+        };
+        let Some(ledger) = ls.ledger() else {
+            return Vec::new();
+        };
+        if ledger.source_map.files().len() <= 1 {
+            return Vec::new();
+        }
+
+        // Canonical paths of all open buffers (so we skip files that
+        // self-publish).
+        let open_canonical: std::collections::HashSet<PathBuf> = {
+            let vfs = self.vfs.read();
+            vfs.paths().filter_map(|p| p.canonicalize().ok()).collect()
+        };
+
+        // Overlay applied when validating an unopened file: every open buffer's
+        // fresh parse (current file first, then the others).
+        let mut overlay_all: Vec<(u16, &[Spanned<Directive>])> =
+            Vec::with_capacity(1 + other_buffer_overlays.len());
+        if let Some(fid) = current_file_id {
+            overlay_all.push((fid, current_parse.directives.as_slice()));
+        }
+        overlay_all.extend_from_slice(other_buffer_overlays);
+
+        let mut out = Vec::new();
+        for f in ledger.source_map.files() {
+            let canonical = f.path.canonicalize().ok();
+            // Skip the current file and any open buffer — those self-publish.
+            if canonical.as_deref() == current_canonical {
+                continue;
+            }
+            if let Some(c) = &canonical
+                && open_canonical.contains(c)
+            {
+                continue;
+            }
+            let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
+                continue;
+            };
+            let parsed = parse(&f.source);
+            let diags = all_diagnostics(
+                &parsed,
+                &f.source,
+                ledger_state,
+                Some(f.id as u16),
+                Some(f.path.as_path()),
+                &overlay_all,
+                self.position_encoding,
+            );
+            out.push((uri, diags));
+        }
+        out
+    }
+
+    /// Publish or clear diagnostics for unopened included files. A non-empty
+    /// set is published and the URI tracked; an empty set clears (and untracks)
+    /// a URI we had previously reported errors for. URIs are tracked in
+    /// [`MainLoopState::cross_file_diag_uris`] because, unlike open buffers,
+    /// these files have no `on_did_close` to drive the LSP-required explicit
+    /// clear.
+    fn publish_cross_file_diagnostics(
+        &mut self,
+        cross_file: Vec<(Uri, Vec<lsp_types::Diagnostic>)>,
+    ) {
+        for (uri, diags) in cross_file {
+            if diags.is_empty() {
+                if self.cross_file_diag_uris.remove(&uri) {
+                    self.diagnostics.remove(&uri);
+                    self.send_diagnostics(&uri, vec![]);
+                }
+            } else {
+                self.cross_file_diag_uris.insert(uri.clone());
+                self.diagnostics.insert(uri.clone(), diags.clone());
+                self.send_diagnostics(&uri, diags);
+            }
+        }
     }
 
     /// Send diagnostics to the client.

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -893,3 +893,92 @@ fn completion_resolve_returns_single_item_and_uses_journal() {
         "resolve should show the journal balance 5000-1500=3500; got:\n{doc}"
     );
 }
+
+/// Regression for #2: a validation error living in an `include`d file that the
+/// user has NOT opened must still be surfaced — the server publishes
+/// diagnostics for the included file's own URI. Pre-fix the error was filtered
+/// out (only the open file's errors were kept) and the included file, having no
+/// open buffer, never received a `publishDiagnostics`, so the problem was
+/// completely invisible.
+///
+/// `cfg(unix)`: the `file://{path}` URI assembly assumes a POSIX absolute path
+/// (see `multi_file_balance_lens_reflects_cross_file_aggregation`).
+#[cfg(unix)]
+#[test]
+fn included_file_validation_errors_are_published() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let good_path = tmp.path().join("good.beancount");
+    let bad_path = tmp.path().join("bad.beancount");
+
+    // good.beancount opens the accounts so the only error in bad.beancount is
+    // the unbalanced transaction (no unopened-account noise).
+    std::fs::write(
+        &good_path,
+        "2024-01-01 open Assets:Cash USD\n2024-01-01 open Expenses:Food USD\n",
+    )
+    .expect("write good");
+    // bad.beancount: an unbalanced transaction (-5 vs +3).
+    std::fs::write(
+        &bad_path,
+        "2024-02-01 * \"unbalanced in include\"\n  \
+           Assets:Cash   -5 USD\n  \
+           Expenses:Food   3 USD\n",
+    )
+    .expect("write bad");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            good_path.display(),
+            bad_path.display()
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+
+    // Open ONLY good.beancount; bad.beancount stays unopened.
+    let good_uri = format!("file://{}", good_path.display());
+    let good_src = std::fs::read_to_string(&good_path).expect("read good");
+    client.open_document(&good_uri, &good_src);
+
+    let bad_uri = format!("file://{}", bad_path.display());
+
+    // Drain publishDiagnostics until bad.beancount's (non-empty) arrive.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut seen: Vec<String> = Vec::new();
+    let bad_diags = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break None;
+        }
+        let Some(msg) = client.recv_with_timeout(remaining) else {
+            break None;
+        };
+        if let lsp_server::Message::Notification(n) = msg
+            && n.method == "textDocument/publishDiagnostics"
+        {
+            let p: lsp_types::PublishDiagnosticsParams =
+                serde_json::from_value(n.params).expect("valid publishDiagnostics");
+            seen.push(p.uri.as_str().to_string());
+            if p.uri.as_str() == bad_uri && !p.diagnostics.is_empty() {
+                break Some(p);
+            }
+        }
+    };
+
+    let bad_diags = bad_diags.unwrap_or_else(|| {
+        panic!("no non-empty publishDiagnostics for the unopened included file {bad_uri}; saw URIs: {seen:?}")
+    });
+    let has_unbalanced = bad_diags.diagnostics.iter().any(|d| {
+        d.severity == Some(lsp_types::DiagnosticSeverity::ERROR)
+            && matches!(&d.code, Some(lsp_types::NumberOrString::String(s)) if s == "E3001")
+    });
+    assert!(
+        has_unbalanced,
+        "expected an E3001 (unbalanced) diagnostic for the unopened included file {bad_uri}; got {:?}",
+        bad_diags.diagnostics
+    );
+}

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -982,3 +982,95 @@ fn included_file_validation_errors_are_published() {
         bad_diags.diagnostics
     );
 }
+
+/// Companion to the above: once the error in the unopened included file is
+/// fixed, its diagnostics must be explicitly CLEARED (an empty publish), not
+/// left lingering in the client. Exercises `publish_cross_file_diagnostics`'s
+/// stale-clearing path via a watched-file change that reloads the journal.
+#[cfg(unix)]
+#[test]
+fn included_file_diagnostics_are_cleared_when_fixed() {
+    use lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let good_path = tmp.path().join("good.beancount");
+    let bad_path = tmp.path().join("bad.beancount");
+    std::fs::write(
+        &good_path,
+        "2024-01-01 open Assets:Cash USD\n2024-01-01 open Expenses:Food USD\n",
+    )
+    .expect("write good");
+    // Start unbalanced (-5 vs +3).
+    std::fs::write(
+        &bad_path,
+        "2024-02-01 * \"x\"\n  Assets:Cash   -5 USD\n  Expenses:Food   3 USD\n",
+    )
+    .expect("write bad");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            good_path.display(),
+            bad_path.display()
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+    let good_uri = format!("file://{}", good_path.display());
+    client.open_document(
+        &good_uri,
+        &std::fs::read_to_string(&good_path).expect("read good"),
+    );
+    let bad_uri = format!("file://{}", bad_path.display());
+
+    // Drain publishDiagnostics until bad.beancount reaches the desired emptiness.
+    let drain = |client: &mut LspTestClient, want_empty: bool| -> bool {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let Some(msg) = client.recv_with_timeout(remaining) else {
+                return false;
+            };
+            if let lsp_server::Message::Notification(n) = msg
+                && n.method == "textDocument/publishDiagnostics"
+            {
+                let p: lsp_types::PublishDiagnosticsParams =
+                    serde_json::from_value(n.params).expect("valid publishDiagnostics");
+                if p.uri.as_str() == bad_uri && p.diagnostics.is_empty() == want_empty {
+                    return true;
+                }
+            }
+        }
+    };
+
+    assert!(
+        drain(&mut client, false),
+        "expected a non-empty diagnostic for the unopened included file first"
+    );
+
+    // Fix bad.beancount on disk and notify a watched-file change → the server
+    // reloads the journal and revalidates the open document, which recomputes
+    // (now-clean) cross-file diagnostics for bad.beancount.
+    std::fs::write(
+        &bad_path,
+        "2024-02-01 * \"x\"\n  Assets:Cash   -5 USD\n  Expenses:Food   5 USD\n",
+    )
+    .expect("rewrite bad balanced");
+    client.notify::<lsp_types::notification::DidChangeWatchedFiles>(DidChangeWatchedFilesParams {
+        changes: vec![FileEvent {
+            uri: bad_uri.parse().unwrap(),
+            typ: FileChangeType::CHANGED,
+        }],
+    });
+
+    assert!(
+        drain(&mut client, true),
+        "expected bad.beancount diagnostics to be cleared (empty publish) after the fix"
+    );
+}


### PR DESCRIPTION
## What

LSP: a validation error living in an **`include`d file that the user hasn't opened** was completely invisible. Found by LSP dogfounding (round 3).

Example — open `main.beancount` which does `include "bad.beancount"`, where `bad.beancount` has an unbalanced transaction. `bean-check` reports the imbalance; the LSP reported **nothing** (no diagnostic on `main`, and none on `bad` either).

Two causes:
1. `validation_errors_to_diagnostics` filters errors to the *open* file's id, dropping included-file errors.
2. `publish_diagnostics` only ever runs for an open buffer, so a file with no open buffer never receives a `publishDiagnostics` — and the LSP spec has no implicit "clear".

## How

When a ledger is loaded, after publishing the open buffer's diagnostics, also compute and publish diagnostics for every ledger file (reachable via `include`) that is **not** open in any buffer:

- `compute_unopened_ledger_diagnostics` validates each unopened file against the full ledger by reusing the existing, tested `all_diagnostics` — filtered to that file's id and **mapped against that file's own source** (so ranges are correct), with the open buffers' fresh parses overlaid so unsaved edits are reflected.
- `publish_cross_file_diagnostics` publishes non-empty sets and tracks their URIs in `cross_file_diag_uris`, so when the errors are fixed an explicit empty set is sent to clear them (these files have no `on_did_close` to do it).

Open files are skipped (they self-publish via didOpen/didChange). The work only runs for multi-file ledgers, and is O(unopened ledger files) validations — real-world ledgers have few files. (A single-pass distribution would remove the per-file re-validation; noted as a possible future optimization.)

## Tests

`included_file_validation_errors_are_published` (integration, via the LSP harness): a journal includes `good` + `bad`; opening only `good`, the client receives a `publishDiagnostics` for `bad.beancount`'s URI carrying the `E3001` (unbalanced) error. Full `rustledger-lsp` suite passes (249 + integration); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
