### PR TITLE
fix(lsp): reply ContentModified for edit-invalidated async requests

### DIFF
--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -358,7 +358,9 @@ impl MainLoopState {
                     lsp_server::Response::new_err(
                         task_result.request_id,
                         CONTENT_MODIFIED,
-                        "content modified".to_string(),
+                        "document changed while the request was in flight; \
+                         re-request for up-to-date results"
+                            .to_string(),
                     )
                 } else {
                     match task_result.result {
@@ -449,9 +451,12 @@ impl MainLoopState {
                     "Result for request {:?} is stale (revision changed); replying ContentModified",
                     request_id
                 );
+                // `result` is unused on the `content_modified` path (the
+                // consumer emits a ContentModified error), but use `Err` so the
+                // value never reads as a success if future code forgets the flag.
                 let _ = task_sender.send(TaskResult {
                     request_id,
-                    result: Ok(serde_json::Value::Null),
+                    result: Err("stale result (content modified)".to_string()),
                     content_modified: true,
                 });
                 return;

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -105,7 +105,16 @@ pub struct TaskResult {
     pub request_id: lsp_server::RequestId,
     /// The result of the task, or an error message.
     pub result: Result<serde_json::Value, String>,
+    /// Set when the world changed (revision bumped) between dispatch and
+    /// completion: the result is stale and is reported to the client as
+    /// `ContentModified` instead of being silently dropped (which would leave a
+    /// strict client waiting forever for a response that never comes).
+    pub content_modified: bool,
 }
+
+/// LSP `ContentModified` error code (the document changed while the request was
+/// in flight). Defined in LSP but not exposed by `lsp_server::ErrorCode`.
+const CONTENT_MODIFIED: i32 = -32801;
 
 /// A job to be executed on the background worker thread.
 type BackgroundJob = Box<dyn FnOnce() + Send>;
@@ -345,13 +354,21 @@ impl MainLoopState {
         match event {
             Event::Message(msg) => self.handle_message(msg),
             Event::Task(task_result) => {
-                let response = match task_result.result {
-                    Ok(value) => lsp_server::Response::new_ok(task_result.request_id, value),
-                    Err(msg) => lsp_server::Response::new_err(
+                let response = if task_result.content_modified {
+                    lsp_server::Response::new_err(
                         task_result.request_id,
-                        lsp_server::ErrorCode::InternalError as i32,
-                        msg,
-                    ),
+                        CONTENT_MODIFIED,
+                        "content modified".to_string(),
+                    )
+                } else {
+                    match task_result.result {
+                        Ok(value) => lsp_server::Response::new_ok(task_result.request_id, value),
+                        Err(msg) => lsp_server::Response::new_err(
+                            task_result.request_id,
+                            lsp_server::ErrorCode::InternalError as i32,
+                            msg,
+                        ),
+                    }
                 };
                 self.send(lsp_server::Message::Response(response));
             }
@@ -420,21 +437,32 @@ impl MainLoopState {
         let _ = self.job_sender.send(Box::new(move || {
             let result = handler();
 
-            // Drop stale results - if the world changed since dispatch,
-            // the client will have sent a new request for fresh data.
+            // If the world changed since dispatch, the result is stale.
+            // Report ContentModified rather than dropping it: a strict client
+            // tracking pending requests would otherwise wait forever for a
+            // response that never arrives. It re-requests on the next edit.
             // Skipped for unconditional dispatch (stateless handlers).
             if let Some(rev) = dispatch_revision
                 && revision_arc.load(std::sync::atomic::Ordering::SeqCst) != rev
             {
                 tracing::debug!(
-                    "Dropping stale result for request {:?} (revision changed)",
+                    "Result for request {:?} is stale (revision changed); replying ContentModified",
                     request_id
                 );
+                let _ = task_sender.send(TaskResult {
+                    request_id,
+                    result: Ok(serde_json::Value::Null),
+                    content_modified: true,
+                });
                 return;
             }
 
             // Ignore send errors - the main loop may have shut down
-            let _ = task_sender.send(TaskResult { request_id, result });
+            let _ = task_sender.send(TaskResult {
+                request_id,
+                result,
+                content_modified: false,
+            });
         }));
     }
 

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1129,6 +1129,10 @@ fn async_request_invalidated_by_edit_still_gets_a_response() {
     let deadline = Instant::now() + Duration::from_secs(15);
     let resp = loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "timed out waiting for a response to the async request — it was likely dropped (the bug)"
+        );
         let msg = client
             .recv_with_timeout(remaining)
             .expect("no response for the async request — it was dropped (the bug)");

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1074,3 +1074,75 @@ fn included_file_diagnostics_are_cleared_when_fixed() {
         "expected bad.beancount diagnostics to be cleared (empty publish) after the fix"
     );
 }
+
+/// An async-dispatched request (`semanticTokens/full`) invalidated by a
+/// concurrent edit must still receive a response — previously the stale result
+/// was silently dropped, leaving a strict client waiting forever. The response
+/// is either the (raced-in) tokens or a `ContentModified` (-32801) error.
+#[test]
+fn async_request_invalidated_by_edit_still_gets_a_response() {
+    let mut client = LspTestClient::spawn();
+    client.initialize();
+
+    let uri = test_uri("async_stale.beancount");
+    // A large document so `semanticTokens/full` takes long enough to be
+    // invalidated by the edit we send immediately after.
+    let mut big = String::new();
+    for i in 0..4000 {
+        big.push_str(&format!("2024-01-01 open Assets:A{i} USD\n"));
+    }
+    client.open_document(&uri, &big);
+
+    let id = client.next_request_id();
+    let req = lsp_server::Request {
+        id: id.clone(),
+        method: <SemanticTokensFullRequest as lsp_types::request::Request>::METHOD.to_string(),
+        params: serde_json::to_value(SemanticTokensParams {
+            text_document: TextDocumentIdentifier {
+                uri: uri.parse().unwrap(),
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+        .unwrap(),
+    };
+    client
+        .raw_send_request(req)
+        .expect("send semanticTokens/full");
+
+    // Immediately invalidate the world with an edit (bumps the revision).
+    client.notify::<lsp_types::notification::DidChangeTextDocument>(
+        lsp_types::DidChangeTextDocumentParams {
+            text_document: lsp_types::VersionedTextDocumentIdentifier {
+                uri: uri.parse().unwrap(),
+                version: 2,
+            },
+            content_changes: vec![lsp_types::TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "2024-01-01 open Assets:Edited USD\n".to_string(),
+            }],
+        },
+    );
+
+    // The request MUST get a response (pre-fix it was dropped → client hang).
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let resp = loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let msg = client
+            .recv_with_timeout(remaining)
+            .expect("no response for the async request — it was dropped (the bug)");
+        if let lsp_server::Message::Response(r) = msg
+            && r.id == id
+        {
+            break r;
+        }
+    };
+    // If the result raced in as stale, it must be reported as ContentModified.
+    if let Some(err) = resp.error {
+        assert_eq!(
+            err.code, -32801,
+            "a stale async result must be reported as ContentModified, got {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What

LSP: an async-dispatched request (today `semanticTokens/full`) that was **invalidated by a concurrent edit** sent **no response at all** — the stale result was silently dropped. A strict client that tracks pending requests waits forever (leaked promise / hang). Found by LSP dogfounding (round 4).

## How

When the revision changes between dispatch and completion, the worker now replies with a `ContentModified` (`-32801`) error instead of returning without sending — the conventional LSP signal for "the document changed, re-request" (what rust-analyzer does). `TaskResult` gains a `content_modified` flag that the main loop maps to the `-32801` error response.

## Tests

`async_request_invalidated_by_edit_still_gets_a_response`: opens a large document, fires `semanticTokens/full`, immediately sends a `didChange`, and asserts a response arrives for that request id (pre-fix: none → the loop times out) — and that if it's an error, the code is `-32801`. Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
