### PR TITLE
fix(lsp): workspace/symbol searches the whole ledger + anchors ranges at symbol names

### DIFF
--- a/crates/rustledger-lsp/src/handlers/workspace_symbols.rs
+++ b/crates/rustledger-lsp/src/handlers/workspace_symbols.rs
@@ -47,6 +47,34 @@ pub fn handle_workspace_symbols(
     }
 }
 
+/// Find the exact source range of a symbol via the parser's token-occurrence
+/// index (`account_occurrences` / `currency_occurrences`), restricted to the
+/// directive's span. This is token-precise: unlike a substring search, it won't
+/// anchor a currency `USD` to the `USD` inside an account like `Assets:USD:Bank`.
+/// Returns `None` when no matching token occurrence falls inside the directive
+/// (e.g. payees, which have no occurrence index), so the caller can fall back.
+fn token_location<T: AsRef<str>>(
+    occurrences: &[rustledger_parser::Spanned<T>],
+    name: &str,
+    dir_start: usize,
+    dir_end: usize,
+    line_index: &LineIndex,
+    uri: &Uri,
+) -> Option<Location> {
+    let occ = occurrences
+        .iter()
+        .find(|o| o.value.as_ref() == name && o.span.start >= dir_start && o.span.end <= dir_end)?;
+    let (sl, sc) = line_index.offset_to_position(occ.span.start);
+    let (el, ec) = line_index.offset_to_position(occ.span.end);
+    Some(Location {
+        uri: uri.clone(),
+        range: Range {
+            start: Position::new(sl, sc),
+            end: Position::new(el, ec),
+        },
+    })
+}
+
 /// Collect symbols from a single document.
 #[allow(deprecated)] // SymbolInformation::deprecated field is deprecated but required
 #[allow(clippy::too_many_arguments)]
@@ -93,7 +121,15 @@ fn collect_symbols_from_document(
                         kind: SymbolKind::CLASS,
                         tags: None,
                         deprecated: None,
-                        location: locate(&account),
+                        location: token_location(
+                            &parse_result.account_occurrences,
+                            &account,
+                            dir_span.start,
+                            dir_span.end,
+                            &line_index,
+                            uri,
+                        )
+                        .unwrap_or_else(|| locate(&account)),
                         container_name: Some("Accounts".to_string()),
                     });
                     seen_accounts.insert(account);
@@ -110,7 +146,15 @@ fn collect_symbols_from_document(
                             kind: SymbolKind::CONSTANT,
                             tags: None,
                             deprecated: None,
-                            location: locate(&curr_str),
+                            location: token_location(
+                                &parse_result.currency_occurrences,
+                                &curr_str,
+                                dir_span.start,
+                                dir_span.end,
+                                &line_index,
+                                uri,
+                            )
+                            .unwrap_or_else(|| locate(&curr_str)),
                             container_name: Some("Currencies".to_string()),
                         });
                         seen_currencies.insert(curr_str);
@@ -128,7 +172,15 @@ fn collect_symbols_from_document(
                         kind: SymbolKind::CONSTANT,
                         tags: None,
                         deprecated: None,
-                        location: locate(&curr),
+                        location: token_location(
+                            &parse_result.currency_occurrences,
+                            &curr,
+                            dir_span.start,
+                            dir_span.end,
+                            &line_index,
+                            uri,
+                        )
+                        .unwrap_or_else(|| locate(&curr)),
                         container_name: Some("Currencies".to_string()),
                     });
                     seen_currencies.insert(curr);

--- a/crates/rustledger-lsp/src/handlers/workspace_symbols.rs
+++ b/crates/rustledger-lsp/src/handlers/workspace_symbols.rs
@@ -62,13 +62,24 @@ fn collect_symbols_from_document(
 ) {
     let line_index = LineIndex::new(source, encoding);
     for spanned in &parse_result.directives {
-        let (line, col) = line_index.offset_to_position(spanned.span.start);
-        let location = Location {
-            uri: uri.clone(),
-            range: Range {
-                start: Position::new(line, col),
-                end: Position::new(line, col + 10),
-            },
+        let dir_span = spanned.span;
+        // Locate a symbol by its name within the directive's source span, so the
+        // result jumps to the symbol token (e.g. the account name) rather than a
+        // hardcoded 10-column window anchored at the directive's date.
+        let locate = |name: &str| -> Location {
+            let dir_text = source.get(dir_span.start..dir_span.end).unwrap_or("");
+            let off = dir_text
+                .find(name)
+                .map_or(dir_span.start, |rel| dir_span.start + rel);
+            let (sl, sc) = line_index.offset_to_position(off);
+            let (el, ec) = line_index.offset_to_position(off + name.len());
+            Location {
+                uri: uri.clone(),
+                range: Range {
+                    start: Position::new(sl, sc),
+                    end: Position::new(el, ec),
+                },
+            }
         };
 
         match &spanned.value {
@@ -82,7 +93,7 @@ fn collect_symbols_from_document(
                         kind: SymbolKind::CLASS,
                         tags: None,
                         deprecated: None,
-                        location: location.clone(),
+                        location: locate(&account),
                         container_name: Some("Accounts".to_string()),
                     });
                     seen_accounts.insert(account);
@@ -99,7 +110,7 @@ fn collect_symbols_from_document(
                             kind: SymbolKind::CONSTANT,
                             tags: None,
                             deprecated: None,
-                            location: location.clone(),
+                            location: locate(&curr_str),
                             container_name: Some("Currencies".to_string()),
                         });
                         seen_currencies.insert(curr_str);
@@ -117,7 +128,7 @@ fn collect_symbols_from_document(
                         kind: SymbolKind::CONSTANT,
                         tags: None,
                         deprecated: None,
-                        location,
+                        location: locate(&curr),
                         container_name: Some("Currencies".to_string()),
                     });
                     seen_currencies.insert(curr);
@@ -130,11 +141,11 @@ fn collect_symbols_from_document(
                     let payee_str = payee.to_string();
                     if query.is_empty() || payee_str.to_lowercase().contains(query) {
                         symbols.push(SymbolInformation {
-                            name: payee_str,
+                            name: payee_str.clone(),
                             kind: SymbolKind::STRING,
                             tags: None,
                             deprecated: None,
-                            location: location.clone(),
+                            location: locate(&payee_str),
                             container_name: Some("Payees".to_string()),
                         });
                     }
@@ -187,6 +198,20 @@ mod tests {
         assert!(symbols.iter().any(|s| s.name == "Assets:Bank"));
         assert!(symbols.iter().any(|s| s.name == "USD"));
         assert!(symbols.iter().any(|s| s.name == "EUR"));
+
+        // The location must point at the account *name*, not the directive's
+        // date (the old `col + 10` window). On line 1, `Assets:Bank` starts at
+        // column 16 (after `2024-01-01 open `).
+        let bank = symbols.iter().find(|s| s.name == "Assets:Bank").unwrap();
+        assert_eq!(bank.location.range.start.line, 1);
+        assert_eq!(
+            bank.location.range.start.character, 16,
+            "symbol range must anchor at the account name, not the date"
+        );
+        assert_eq!(
+            bank.location.range.end.character,
+            16 + "Assets:Bank".len() as u32
+        );
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -863,18 +863,48 @@ impl MainLoopState {
         let params: WorkspaceSymbolParams =
             serde_json::from_value(req.params).map_err(|e| e.to_string())?;
 
-        // Collect all open documents with cached parse results
-        let mut vfs = self.vfs.write();
-        let documents: Vec<_> = vfs
-            .iter_with_parse()
-            .map(|(path, content, parse_result)| {
-                let uri_str = format!("file://{}", path.display());
-                let uri: Uri = uri_str
-                    .parse()
-                    .unwrap_or_else(|_| "file:///".parse().unwrap());
-                (uri, content, parse_result)
-            })
+        // Collect all open documents with cached parse results.
+        let mut documents: Vec<(Uri, String, Arc<ParseResult>)> = {
+            let mut vfs = self.vfs.write();
+            vfs.iter_with_parse()
+                .map(|(path, content, parse_result)| {
+                    let uri_str = format!("file://{}", path.display());
+                    let uri: Uri = uri_str
+                        .parse()
+                        .unwrap_or_else(|_| "file:///".parse().unwrap());
+                    (uri, content, parse_result)
+                })
+                .collect()
+        };
+
+        // Add ledger files reachable via `include` that aren't open, so
+        // workspace symbol search spans the whole project — not just the
+        // buffers the user happens to have open. Open buffers are listed first
+        // (and the handler dedups by name), so their live edits take precedence
+        // over the ledger snapshot.
+        let open_canonical: std::collections::HashSet<PathBuf> = self
+            .vfs
+            .read()
+            .paths()
+            .filter_map(|p| p.canonicalize().ok())
             .collect();
+        let ledger_guard = self.ledger_state.read();
+        if let Some(ledger) = ledger_guard.ledger() {
+            for f in ledger.source_map.files() {
+                if let Ok(c) = f.path.canonicalize()
+                    && open_canonical.contains(&c)
+                {
+                    continue;
+                }
+                let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
+                    continue;
+                };
+                let source = f.source.to_string();
+                let parsed = Arc::new(parse(&source));
+                documents.push((uri, source, parsed));
+            }
+        }
+        drop(ledger_guard);
 
         let response = handle_workspace_symbols(&params, &documents, self.position_encoding);
 

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -888,23 +888,41 @@ impl MainLoopState {
             .paths()
             .filter_map(|p| p.canonicalize().ok())
             .collect();
-        let ledger_guard = self.ledger_state.read();
-        if let Some(ledger) = ledger_guard.ledger() {
-            for f in ledger.source_map.files() {
-                if let Ok(c) = f.path.canonicalize()
-                    && open_canonical.contains(&c)
-                {
-                    continue;
-                }
-                let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
-                    continue;
-                };
-                let source = f.source.to_string();
-                let parsed = Arc::new(parse(&source));
-                documents.push((uri, source, parsed));
-            }
+        // Collect the unopened ledger files' (uri, source) UNDER the lock, then
+        // drop the guard before parsing — re-parsing a large ledger while
+        // holding the state read-lock would block journal reloads.
+        let unopened: Vec<(Uri, String)> = {
+            let ledger_guard = self.ledger_state.read();
+            ledger_guard.ledger().map_or_else(Vec::new, |ledger| {
+                ledger
+                    .source_map
+                    .files()
+                    .iter()
+                    .filter(|f| {
+                        f.path
+                            .canonicalize()
+                            .ok()
+                            .is_none_or(|c| !open_canonical.contains(&c))
+                    })
+                    .filter_map(|f| {
+                        match format!("file://{}", f.path.display()).parse::<Uri>() {
+                            Ok(uri) => Some((uri, f.source.to_string())),
+                            Err(_) => {
+                                tracing::warn!(
+                                    "workspace/symbol: skipping ledger file with a non-file:// URI: {}",
+                                    f.path.display()
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .collect()
+            })
+        };
+        for (uri, source) in unopened {
+            let parsed = Arc::new(parse(&source));
+            documents.push((uri, source, parsed));
         }
-        drop(ledger_guard);
 
         let response = handle_workspace_symbols(&params, &documents, self.position_encoding);
 

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1150,3 +1150,53 @@ fn async_request_invalidated_by_edit_still_gets_a_response() {
         );
     }
 }
+
+/// Regression: `workspace/symbol` must search the whole loaded ledger, not just
+/// open buffers — an account declared in an unopened `include`d file must be
+/// findable. Pre-fix the search only consulted open documents.
+#[cfg(unix)]
+#[test]
+fn workspace_symbol_finds_symbols_in_unopened_included_files() {
+    use lsp_types::request::WorkspaceSymbolRequest;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let main_path = tmp.path().join("main.beancount");
+    let inc_path = tmp.path().join("inc.beancount");
+    std::fs::write(&main_path, "2024-01-01 open Assets:Bank USD\n").expect("write main");
+    std::fs::write(&inc_path, "2024-01-01 open Expenses:CrossFileOnly USD\n").expect("write inc");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            main_path.display(),
+            inc_path.display()
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+    // Open only main.beancount; inc.beancount stays unopened.
+    let main_uri = format!("file://{}", main_path.display());
+    client.open_document(
+        &main_uri,
+        &std::fs::read_to_string(&main_path).expect("read main"),
+    );
+
+    let resp: Option<lsp_types::WorkspaceSymbolResponse> = client
+        .request::<WorkspaceSymbolRequest>(lsp_types::WorkspaceSymbolParams {
+            query: "CrossFileOnly".to_string(),
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        });
+    let symbols = match resp {
+        Some(lsp_types::WorkspaceSymbolResponse::Flat(v)) => v,
+        other => panic!("expected a flat workspace-symbol response, got {other:?}"),
+    };
+    assert!(
+        symbols.iter().any(|s| s.name == "Expenses:CrossFileOnly"),
+        "workspace/symbol must find an account from an unopened included file; got: {:?}",
+        symbols.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## What

Two `workspace/symbol` bugs found by LSP dogfounding (round 4):

1. **Ignored the loaded ledger** — project-wide symbol search only looked at *open* buffers, so an account/currency declared in an unopened `include`d file was unfindable.
2. **Wrong location range** — each result's range was a hardcoded 10-column window anchored at the directive's **date** (`col + 10`), so jumping to a result landed mid-`open` instead of on the symbol name.

## How

1. The dispatch (`handle_workspace_symbol_request`) now appends every ledger file reachable via `include` that isn't already open (parsed from the loaded `source_map`), so search spans the whole project. Open buffers are listed first and the handler dedups by name, so live edits win over the snapshot.
2. `collect_symbols_from_document` now locates each symbol by its **name** within the directive's source span (a `locate(name)` helper) instead of `col + 10`, so the range points at the account/currency/payee token.

## Tests

- `workspace_symbol_finds_symbols_in_unopened_included_files` (integration): opening only `main`, a query finds `Expenses:CrossFileOnly` declared in an unopened include.
- `test_workspace_symbols` extended: asserts `Assets:Bank`'s range anchors at the account name (col 16), not the date.

Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
