### PR TITLE
fix(lsp): rename across included files (no more dangling references)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/rename.rs
+++ b/crates/rustledger-lsp/src/handlers/rename.rs
@@ -43,9 +43,6 @@ use lsp_types::{
 use rustledger_parser::{ParseResult, parse};
 use std::collections::HashMap;
 
-use crate::ledger_state::LedgerState;
-use crate::uri_to_path;
-
 use super::utils::{
     LineIndex, PositionEncoding, get_word_at_position, is_account_like, is_currency_like,
 };
@@ -117,7 +114,11 @@ pub fn handle_rename(
     params: &RenameParams,
     source: &str,
     parse_result: &ParseResult,
-    ledger_state: Option<&LedgerState>,
+    // Other ledger files reachable via `include` (everything except the current
+    // buffer), as `(uri, source)` — the source is the open buffer's live
+    // content when the file is open, else the loader's on-disk source. Gathered
+    // by the caller under the state lock so parsing here holds no locks.
+    other_files: &[(lsp_types::Uri, String)],
     encoding: PositionEncoding,
 ) -> Option<WorkspaceEdit> {
     let position = params.text_document_position.position;
@@ -175,34 +176,28 @@ pub fn handle_rename(
 
     let mut changes: HashMap<lsp_types::Uri, Vec<TextEdit>> = HashMap::new();
 
-    // Current buffer (live source — reflects unsaved edits).
+    // Current buffer (live source — reflects unsaved edits). If the cursor is
+    // NOT on a real occurrence in the current file (e.g. account-shaped text in
+    // a comment or string), there are no edits here — bail out rather than
+    // triggering a surprising cross-file rename from a non-symbol position.
     let current_edits = collect(parse_result, source);
-    if !current_edits.is_empty() {
-        changes.insert(uri.clone(), current_edits);
+    if current_edits.is_empty() {
+        return None;
     }
+    changes.insert(uri.clone(), current_edits);
 
     // Every OTHER file in the loaded ledger (reachable via `include`): rename
     // the symbol there too, so a multi-file ledger isn't left with dangling
     // references to the old name. Without this, renaming an account used across
     // includes corrupted the ledger.
-    if let Some(ls) = ledger_state
-        && let Some(ledger) = ls.ledger()
-    {
-        let current_canonical = uri_to_path(&uri).and_then(|p| p.canonicalize().ok());
-        for f in ledger.source_map.files() {
-            if let Ok(c) = f.path.canonicalize()
-                && current_canonical.as_deref() == Some(c.as_path())
-            {
-                continue; // current file already handled with its live source
-            }
-            let Ok(f_uri) = format!("file://{}", f.path.display()).parse::<lsp_types::Uri>() else {
-                continue;
-            };
-            let f_parse = parse(&f.source);
-            let f_edits = collect(&f_parse, &f.source);
-            if !f_edits.is_empty() {
-                changes.insert(f_uri, f_edits);
-            }
+    for (f_uri, f_source) in other_files {
+        if *f_uri == uri {
+            continue; // never overwrite the current buffer's live edits
+        }
+        let f_parse = parse(f_source);
+        let f_edits = collect(&f_parse, f_source);
+        if !f_edits.is_empty() {
+            changes.insert(f_uri.clone(), f_edits);
         }
     }
 
@@ -369,7 +364,7 @@ mod tests {
             work_done_progress_params: Default::default(),
         };
 
-        let edit = handle_rename(&params, source, &result, None, PositionEncoding::Utf16);
+        let edit = handle_rename(&params, source, &result, &[], PositionEncoding::Utf16);
         assert!(edit.is_some());
 
         let edit = edit.unwrap();
@@ -426,7 +421,7 @@ mod tests {
             work_done_progress_params: Default::default(),
         };
 
-        let edit = handle_rename(&params, source, &result, None, PositionEncoding::Utf16)
+        let edit = handle_rename(&params, source, &result, &[], PositionEncoding::Utf16)
             .expect("rename returns edit");
         let changes = edit.changes.expect("edit has changes");
         let edits = changes.values().next().expect("at least one file");
@@ -494,7 +489,7 @@ mod tests {
             new_name: "Assets:Checking".to_string(),
             work_done_progress_params: Default::default(),
         };
-        let edit = handle_rename(&params, source, &result, None, PositionEncoding::Utf16)
+        let edit = handle_rename(&params, source, &result, &[], PositionEncoding::Utf16)
             .expect("rename returns edit");
         let changes = edit.changes.expect("edit has changes");
         let edits = changes.values().next().expect("at least one file");

--- a/crates/rustledger-lsp/src/handlers/rename.rs
+++ b/crates/rustledger-lsp/src/handlers/rename.rs
@@ -40,12 +40,22 @@ use lsp_types::{
     Position, PrepareRenameResponse, Range, RenameParams, TextDocumentPositionParams, TextEdit,
     WorkspaceEdit,
 };
-use rustledger_parser::ParseResult;
+use rustledger_parser::{ParseResult, parse};
 use std::collections::HashMap;
+
+use crate::ledger_state::LedgerState;
+use crate::uri_to_path;
 
 use super::utils::{
     LineIndex, PositionEncoding, get_word_at_position, is_account_like, is_currency_like,
 };
+
+/// Which kind of symbol is being renamed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RenameKind {
+    Account,
+    Currency,
+}
 
 /// Handle a prepare rename request (check if rename is valid at position).
 ///
@@ -107,6 +117,7 @@ pub fn handle_rename(
     params: &RenameParams,
     source: &str,
     parse_result: &ParseResult,
+    ledger_state: Option<&LedgerState>,
     encoding: PositionEncoding,
 ) -> Option<WorkspaceEdit> {
     let position = params.text_document_position.position;
@@ -120,25 +131,12 @@ pub fn handle_rename(
     // Get the word at the cursor position
     let (old_name, _, _) = get_word_at_position(line, position.character as usize, encoding)?;
 
-    // Collect all edits
-    let mut edits = Vec::new();
-    // Build the line index once and share across collectors. The
-    // previous code went through `byte_offset_to_position`, which is
-    // O(n) per call (linear scan from byte 0); for a large ledger
-    // with many account / currency occurrences, that scaled
-    // quadratically with file size.
-    let line_index = LineIndex::new(source, encoding);
-
-    // Account vs currency dispatch via the parser's occurrence
-    // indices, not the legacy is_account_like hardcoded English
-    // root-name check. The index gate works for any account the
-    // lexer produced (including Unicode-prefix names like
-    // `Vermögen:Bank` when the user has
-    // `option "name_assets" "Vermögen"`), AND it's free - we walk
-    // the same index a second time inside collect_*_rename_edits
-    // anyway. The legacy is_account_like / is_currency_like
-    // helpers stay in place for prepare_rename which has no
-    // ParseResult at hand.
+    // Determine the symbol kind ONCE from the current file's occurrence
+    // indices (account vs currency), preserving the original precedence:
+    // known-account > known-currency > account-shaped > currency-shaped.
+    // The cursor sits on `old_name` in the current file, so its occurrence
+    // index classifies it. The legacy is_account_like / is_currency_like
+    // helpers stay in place for prepare_rename which has no ParseResult.
     let is_known_account = parse_result
         .account_occurrences
         .iter()
@@ -147,27 +145,70 @@ pub fn handle_rename(
         .currency_occurrences
         .iter()
         .any(|o| o.value == old_name);
-    if is_known_account {
-        collect_account_rename_edits(parse_result, &line_index, &old_name, new_name, &mut edits);
+    let kind = if is_known_account {
+        RenameKind::Account
     } else if is_known_currency {
-        collect_currency_rename_edits(parse_result, &line_index, &old_name, new_name, &mut edits);
+        RenameKind::Currency
     } else if is_account_like(&old_name) {
-        // Word looks account-shaped but the parser never produced
-        // an ACCOUNT token for it - probably a typo mid-edit, or
-        // a fragment from a broken directive. Walk the (empty)
-        // index anyway so a future contributor can drop this
-        // branch when prepare_rename's gate also uses the index.
-        collect_account_rename_edits(parse_result, &line_index, &old_name, new_name, &mut edits);
+        RenameKind::Account
     } else if is_currency_like(&old_name, parse_result) {
-        collect_currency_rename_edits(parse_result, &line_index, &old_name, new_name, &mut edits);
+        RenameKind::Currency
+    } else {
+        return None;
+    };
+
+    // Build the edits for ONE file (its own source + parse) — reused for the
+    // current buffer (live source) and for every other ledger file.
+    let collect = |pr: &ParseResult, src: &str| -> Vec<TextEdit> {
+        let idx = LineIndex::new(src, encoding);
+        let mut edits = Vec::new();
+        match kind {
+            RenameKind::Account => {
+                collect_account_rename_edits(pr, &idx, &old_name, new_name, &mut edits);
+            }
+            RenameKind::Currency => {
+                collect_currency_rename_edits(pr, &idx, &old_name, new_name, &mut edits);
+            }
+        }
+        edits
+    };
+
+    let mut changes: HashMap<lsp_types::Uri, Vec<TextEdit>> = HashMap::new();
+
+    // Current buffer (live source — reflects unsaved edits).
+    let current_edits = collect(parse_result, source);
+    if !current_edits.is_empty() {
+        changes.insert(uri.clone(), current_edits);
     }
 
-    if edits.is_empty() {
+    // Every OTHER file in the loaded ledger (reachable via `include`): rename
+    // the symbol there too, so a multi-file ledger isn't left with dangling
+    // references to the old name. Without this, renaming an account used across
+    // includes corrupted the ledger.
+    if let Some(ls) = ledger_state
+        && let Some(ledger) = ls.ledger()
+    {
+        let current_canonical = uri_to_path(&uri).and_then(|p| p.canonicalize().ok());
+        for f in ledger.source_map.files() {
+            if let Ok(c) = f.path.canonicalize()
+                && current_canonical.as_deref() == Some(c.as_path())
+            {
+                continue; // current file already handled with its live source
+            }
+            let Ok(f_uri) = format!("file://{}", f.path.display()).parse::<lsp_types::Uri>() else {
+                continue;
+            };
+            let f_parse = parse(&f.source);
+            let f_edits = collect(&f_parse, &f.source);
+            if !f_edits.is_empty() {
+                changes.insert(f_uri, f_edits);
+            }
+        }
+    }
+
+    if changes.is_empty() {
         return None;
     }
-
-    let mut changes = HashMap::new();
-    changes.insert(uri, edits);
 
     Some(WorkspaceEdit {
         changes: Some(changes),
@@ -328,7 +369,7 @@ mod tests {
             work_done_progress_params: Default::default(),
         };
 
-        let edit = handle_rename(&params, source, &result, PositionEncoding::Utf16);
+        let edit = handle_rename(&params, source, &result, None, PositionEncoding::Utf16);
         assert!(edit.is_some());
 
         let edit = edit.unwrap();
@@ -385,7 +426,7 @@ mod tests {
             work_done_progress_params: Default::default(),
         };
 
-        let edit = handle_rename(&params, source, &result, PositionEncoding::Utf16)
+        let edit = handle_rename(&params, source, &result, None, PositionEncoding::Utf16)
             .expect("rename returns edit");
         let changes = edit.changes.expect("edit has changes");
         let edits = changes.values().next().expect("at least one file");
@@ -453,7 +494,7 @@ mod tests {
             new_name: "Assets:Checking".to_string(),
             work_done_progress_params: Default::default(),
         };
-        let edit = handle_rename(&params, source, &result, PositionEncoding::Utf16)
+        let edit = handle_rename(&params, source, &result, None, PositionEncoding::Utf16)
             .expect("rename returns edit");
         let changes = edit.changes.expect("edit has changes");
         let edits = changes.values().next().expect("at least one file");

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -952,7 +952,22 @@ impl MainLoopState {
         let uri = &params.text_document_position.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        let response = handle_rename(&params, &text, &parse_result, self.position_encoding);
+        // Ledger state so the rename spans every `include`d file, not just the
+        // open buffer (otherwise references in other files are left dangling).
+        let ledger_guard = self.ledger_state.read();
+        let ledger_state = if ledger_guard.ledger().is_some() {
+            Some(&*ledger_guard)
+        } else {
+            None
+        };
+
+        let response = handle_rename(
+            &params,
+            &text,
+            &parse_result,
+            ledger_state,
+            self.position_encoding,
+        );
 
         serde_json::to_value(response).map_err(|e| e.to_string())
     }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -952,24 +952,67 @@ impl MainLoopState {
         let uri = &params.text_document_position.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        // Ledger state so the rename spans every `include`d file, not just the
-        // open buffer (otherwise references in other files are left dangling).
-        let ledger_guard = self.ledger_state.read();
-        let ledger_state = if ledger_guard.ledger().is_some() {
-            Some(&*ledger_guard)
-        } else {
-            None
-        };
+        // Gather the other ledger files (everything except the current buffer)
+        // so the rename spans every `include`d file — otherwise references in
+        // other files are left dangling. Collected under the locks here (with
+        // each file's live buffer content when open) so the handler parses with
+        // no locks held.
+        let current_canonical = uri_to_path(uri).and_then(|p| p.canonicalize().ok());
+        let other_files = self.other_ledger_files(current_canonical.as_deref());
 
         let response = handle_rename(
             &params,
             &text,
             &parse_result,
-            ledger_state,
+            &other_files,
             self.position_encoding,
         );
 
         serde_json::to_value(response).map_err(|e| e.to_string())
+    }
+
+    /// Collect the ledger's files reachable via `include`, EXCLUDING the file at
+    /// `current_canonical`, as `(uri, source)`. The source is the open buffer's
+    /// live content when the file is open (so edit ranges match the client),
+    /// else the loader's on-disk source. Locks are released before returning, so
+    /// callers can parse without holding them.
+    fn other_ledger_files(
+        &self,
+        current_canonical: Option<&std::path::Path>,
+    ) -> Vec<(Uri, String)> {
+        // Live content of every open buffer, keyed by canonical path.
+        let open: std::collections::HashMap<PathBuf, String> = {
+            let vfs = self.vfs.read();
+            vfs.paths()
+                .filter_map(|p| Some((p.canonicalize().ok()?, vfs.get_content(p)?)))
+                .collect()
+        };
+
+        let ledger_guard = self.ledger_state.read();
+        let mut out = Vec::new();
+        if let Some(ledger) = ledger_guard.ledger() {
+            for f in ledger.source_map.files() {
+                let canon = f.path.canonicalize().ok();
+                if canon.as_deref() == current_canonical {
+                    continue;
+                }
+                let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
+                    tracing::warn!(
+                        "rename: skipping ledger file with a non-file:// URI: {}",
+                        f.path.display()
+                    );
+                    continue;
+                };
+                // Prefer the open buffer's live content over the on-disk source
+                // so cross-file edit ranges line up with the client's buffer.
+                let source = canon
+                    .as_ref()
+                    .and_then(|c| open.get(c).cloned())
+                    .unwrap_or_else(|| f.source.to_string());
+                out.push((uri, source));
+            }
+        }
+        out
     }
 
     /// Handle the textDocument/formatting request.

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1200,3 +1200,71 @@ fn workspace_symbol_finds_symbols_in_unopened_included_files() {
         symbols.iter().map(|s| &s.name).collect::<Vec<_>>()
     );
 }
+
+/// Regression: renaming an account used across `include`d files must produce
+/// edits for ALL files, not just the open one — otherwise the rename leaves
+/// dangling references in the other files and corrupts the ledger.
+#[cfg(unix)]
+#[test]
+#[allow(clippy::mutable_key_type)] // Uri keys in the WorkspaceEdit changes map are safe to read
+fn rename_account_spans_included_files() {
+    use lsp_types::request::Rename;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let main_path = tmp.path().join("main.beancount");
+    let inc_path = tmp.path().join("inc.beancount");
+    // main opens Assets:Bank; inc uses it in a posting.
+    std::fs::write(&main_path, "2024-01-01 open Assets:Bank USD\n").expect("write main");
+    std::fs::write(
+        &inc_path,
+        "2024-01-01 open Expenses:Food USD\n\
+         2024-02-01 * \"x\"\n  Assets:Bank  -5 USD\n  Expenses:Food  5 USD\n",
+    )
+    .expect("write inc");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            main_path.display(),
+            inc_path.display()
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+    let main_uri = format!("file://{}", main_path.display());
+    client.open_document(
+        &main_uri,
+        &std::fs::read_to_string(&main_path).expect("read main"),
+    );
+
+    // Rename `Assets:Bank` (col 16 on line 0 of main) -> `Assets:Checking`.
+    let edit: Option<lsp_types::WorkspaceEdit> =
+        client.request::<Rename>(lsp_types::RenameParams {
+            text_document_position: lsp_types::TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: main_uri.parse().unwrap(),
+                },
+                position: lsp_types::Position::new(0, 16),
+            },
+            new_name: "Assets:Checking".to_string(),
+            work_done_progress_params: Default::default(),
+        });
+
+    let changes = edit
+        .expect("rename returned an edit")
+        .changes
+        .expect("workspace edit has per-file changes");
+    let inc_uri = format!("file://{}", inc_path.display());
+    let edited_uris: Vec<&str> = changes.keys().map(|u| u.as_str()).collect();
+    assert!(
+        changes.keys().any(|u| u.as_str() == main_uri),
+        "rename must edit the open file; edited: {edited_uris:?}"
+    );
+    assert!(
+        changes.keys().any(|u| u.as_str() == inc_uri),
+        "rename must also edit the included file (cross-file usage); edited: {edited_uris:?}"
+    );
+}


### PR DESCRIPTION
## What

LSP `textDocument/rename` on an account (or currency) used across `include`d files only edited the **currently-open file**, leaving every occurrence in the other ledger files pointing at the old name — actively corrupting a multi-file ledger (the renamed account becomes unopened; the old name elsewhere now references an absent account). Found by LSP dogfounding (round 4); the most severe finding (writes broken state).

## How

`handle_rename` now:
1. Determines the symbol kind (account vs currency) once from the current file's occurrence index (same precedence as before).
2. Collects edits for the current buffer from its **live** source (unsaved edits).
3. Collects edits for **every other file in the loaded ledger** (`source_map`), parsing each and walking its own occurrence index, mapped against its own `LineIndex`.
4. Returns a multi-URI `WorkspaceEdit` (`changes` keyed by each file's URI).

The per-file edit collection reuses the existing, token-precise `collect_account_rename_edits` / `collect_currency_rename_edits` (no comment/string false positives). `ledger_state` is threaded in from the main loop (mirroring hover/definition/diagnostics).

## Tests

`rename_account_spans_included_files` (integration): a journal includes `main` (opens `Assets:Bank`) + `inc` (uses it in a posting); renaming from `main` yields a `WorkspaceEdit` with edits for **both** files. Existing single-file rename unit tests still pass. Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
