### PR TITLE
fix(completion): offer a currency inside cost specs and after @/@@

### DIFF
--- a/crates/rustledger-completion/src/lib.rs
+++ b/crates/rustledger-completion/src/lib.rs
@@ -198,11 +198,16 @@ pub fn classify_context(before_cursor: &str) -> CompletionContext {
         if posting_content.contains(':') && posting_content.contains(' ') {
             // After account, might be expecting amount or currency
             let parts: Vec<&str> = posting_content.split_whitespace().collect();
-            if parts.len() >= 2 {
-                // Check if last part looks like a number
-                if let Some(last) = parts.last()
-                    && (last.parse::<f64>().is_ok() || last.ends_with('.'))
-                {
+            if parts.len() >= 2
+                && let Some(last) = parts.last()
+            {
+                // A currency is expected after: the units amount (`100`), a
+                // cost-spec amount (`{100.00`/`{{100.00`), or a price-annotation
+                // amount (`@ 1.20`/`@@1.20` — including the bare `@`/`@@`/`{`
+                // marker before the amount is typed). Strip any leading `@`/`{`
+                // so the amount underneath is recognized.
+                let amount = last.trim_start_matches('@').trim_start_matches('{');
+                if amount.is_empty() || amount.parse::<f64>().is_ok() || amount.ends_with('.') {
                     return CompletionContext::ExpectingCurrency;
                 }
             }
@@ -623,6 +628,33 @@ mod tests {
     fn classify_expecting_currency() {
         assert_eq!(
             ctx("  Assets:Bank  100.00 "),
+            CompletionContext::ExpectingCurrency
+        );
+    }
+
+    #[test]
+    fn classify_expecting_currency_in_cost_and_price() {
+        // After a price annotation `@`/`@@` (with or without the amount typed).
+        assert_eq!(
+            ctx("  Assets:Stock  10 HOOL @ "),
+            CompletionContext::ExpectingCurrency
+        );
+        assert_eq!(
+            ctx("  Assets:Stock  10 HOOL @ 1.20 "),
+            CompletionContext::ExpectingCurrency
+        );
+        assert_eq!(
+            ctx("  Assets:Stock  10 HOOL @@1500 "),
+            CompletionContext::ExpectingCurrency
+        );
+        // Inside a cost spec `{...}` (amount typed, currency expected next).
+        assert_eq!(
+            ctx("  Assets:Stock  10 HOOL {100.00 "),
+            CompletionContext::ExpectingCurrency
+        );
+        // A fully-typed currency should NOT keep offering currency completion.
+        assert_ne!(
+            ctx("  Assets:Bank  100 USD "),
             CompletionContext::ExpectingCurrency
         );
     }


### PR DESCRIPTION
## What

Completion offered **nothing** inside a cost spec `{...}` or after a price annotation `@`/`@@`, where a **currency** is expected. Found by LSP dogfounding (round 5). `ExpectingCurrency` was only returned when the posting's last whitespace token parsed as a bare number — so after `{100.00 `, `@ `, or `@@1.20 ` the token (`{100.00`, `@`, `@@1.20`) didn't parse and completion fell through to empty.

## How

In the posting currency-context check (`rustledger-completion`), strip a leading `@`/`{` from the last token before the number test, and also treat the bare `@`/`@@`/`{`/`{{` marker (amount not yet typed) as expecting a currency. A fully-typed currency token still falls through (no re-offer).

This is the shared completion crate, so the fix benefits both the LSP and the WASM build.

## Tests

`classify_expecting_currency_in_cost_and_price`: `@`, `@ 1.20`, `@@1500`, and `{100.00` all classify as `ExpectingCurrency`; a complete `100 USD` does not. Full `rustledger-completion` suite passes; `rustledger-wasm` check + clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
