### PR TITLE
fix(lsp): find-references spans included files

### DIFF
--- a/crates/rustledger-lsp/src/handlers/references.rs
+++ b/crates/rustledger-lsp/src/handlers/references.rs
@@ -11,13 +11,26 @@ use super::utils::{
 };
 use lsp_types::{Location, Position, Range, ReferenceParams, Uri};
 use rustledger_core::Directive;
-use rustledger_parser::ParseResult;
+use rustledger_parser::{ParseResult, parse};
+
+/// Which kind of symbol references are being collected.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RefKind {
+    Account,
+    Currency,
+    Payee,
+}
 
 /// Handle a find references request.
 pub fn handle_references(
     params: &ReferenceParams,
     source: &str,
     parse_result: &ParseResult,
+    // Other ledger files reachable via `include` (everything except the current
+    // buffer), as `(uri, source)` with live content for open buffers. Gathered
+    // by the caller under the state lock so parsing here holds no locks. So
+    // "find references" spans the whole ledger, not just the open file.
+    other_files: &[(Uri, String)],
     uri: &Uri,
     encoding: PositionEncoding,
 ) -> Option<Vec<Location>> {
@@ -31,44 +44,71 @@ pub fn handle_references(
     // Get the word at the cursor position
     let (word, _, _) = get_word_at_position(line, position.character as usize, encoding)?;
 
-    let mut locations = Vec::new();
-    // Build the line index once and share it across collectors —
-    // otherwise each posting/directive lookup is an O(n) scan.
-    let line_index = LineIndex::new(source, encoding);
+    // Classify the symbol kind from the cursor's file (account / currency /
+    // payee), then collect that kind's occurrences across every ledger file.
+    let kind = if is_account_like(&word) {
+        RefKind::Account
+    } else if is_currency_like(&word, parse_result) {
+        RefKind::Currency
+    } else if is_in_quotes(line, position.character as usize) {
+        RefKind::Payee
+    } else {
+        return None;
+    };
 
-    // Check if it's an account
-    if is_account_like(&word) {
-        collect_account_references(
-            parse_result,
-            &line_index,
-            &word,
-            uri,
-            include_declaration,
-            &mut locations,
-        );
+    // Collect references from a single file into its own vec (each collector
+    // sorts/dedups within the file). Returns the file's locations.
+    let collect_file = |src: &str, pr: &ParseResult, file_uri: &Uri| -> Vec<Location> {
+        let line_index = LineIndex::new(src, encoding);
+        let mut out = Vec::new();
+        match kind {
+            RefKind::Account => {
+                collect_account_references(
+                    pr,
+                    &line_index,
+                    &word,
+                    file_uri,
+                    include_declaration,
+                    &mut out,
+                );
+            }
+            RefKind::Currency => {
+                collect_currency_references(
+                    pr,
+                    &line_index,
+                    &word,
+                    file_uri,
+                    include_declaration,
+                    &mut out,
+                );
+            }
+            RefKind::Payee => {
+                collect_payee_references(src, pr, &line_index, &word, file_uri, &mut out);
+            }
+        }
+        out
+    };
+
+    let mut locations = collect_file(source, parse_result, uri);
+    for (f_uri, f_source) in other_files {
+        if f_uri == uri {
+            continue; // current file already collected from its live source
+        }
+        let f_parse = parse(f_source);
+        locations.extend(collect_file(f_source, &f_parse, f_uri));
     }
-    // Check if it's a currency
-    else if is_currency_like(&word, parse_result) {
-        collect_currency_references(
-            parse_result,
-            &line_index,
-            &word,
-            uri,
-            include_declaration,
-            &mut locations,
-        );
-    }
-    // Check if it's a payee (inside quotes on a transaction line)
-    else if is_in_quotes(line, position.character as usize) {
-        collect_payee_references(
-            source,
-            parse_result,
-            &line_index,
-            &word,
-            uri,
-            &mut locations,
-        );
-    }
+
+    // Final cross-file dedup keyed by (uri, range) — the per-file collectors
+    // only dedup by range, so two files with a same-positioned occurrence must
+    // not collapse into one.
+    locations.sort_by(|a, b| {
+        a.uri
+            .as_str()
+            .cmp(b.uri.as_str())
+            .then(a.range.start.line.cmp(&b.range.start.line))
+            .then(a.range.start.character.cmp(&b.range.start.character))
+    });
+    locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
 
     if locations.is_empty() {
         None
@@ -271,7 +311,7 @@ mod tests {
             },
         };
 
-        let refs = handle_references(&params, source, &result, &uri, PositionEncoding::Utf16);
+        let refs = handle_references(&params, source, &result, &[], &uri, PositionEncoding::Utf16);
         assert!(refs.is_some());
 
         let refs = refs.unwrap();
@@ -301,7 +341,7 @@ mod tests {
             },
         };
 
-        let refs = handle_references(&params, source, &result, &uri, PositionEncoding::Utf16);
+        let refs = handle_references(&params, source, &result, &[], &uri, PositionEncoding::Utf16);
         assert!(refs.is_some());
 
         let refs = refs.unwrap();
@@ -343,7 +383,7 @@ mod tests {
             },
         };
 
-        let refs = handle_references(&params, source, &result, &uri, PositionEncoding::Utf16)
+        let refs = handle_references(&params, source, &result, &[], &uri, PositionEncoding::Utf16)
             .expect("references returns Some");
 
         // Expected: 3 references — `commodity USD`, `-100 USD`,
@@ -368,6 +408,7 @@ mod tests {
             &params_no_decl,
             source,
             &result,
+            &[],
             &uri,
             PositionEncoding::Utf16,
         )
@@ -417,7 +458,7 @@ mod tests {
                 include_declaration: true,
             },
         };
-        let refs = handle_references(&params, source, &result, &uri, PositionEncoding::Utf16)
+        let refs = handle_references(&params, source, &result, &[], &uri, PositionEncoding::Utf16)
             .expect("references returns Some");
         // Expected: 2 references - the open's ACCOUNT token and
         // the posting's ACCOUNT token. The substring-search shape
@@ -460,6 +501,7 @@ mod tests {
             &params_no_decl,
             source,
             &result,
+            &[],
             &uri,
             PositionEncoding::Utf16,
         )
@@ -522,7 +564,7 @@ mod tests {
             },
         };
 
-        let refs = handle_references(&params, source, &result, &uri, PositionEncoding::Utf16)
+        let refs = handle_references(&params, source, &result, &[], &uri, PositionEncoding::Utf16)
             .expect("references returns Some");
 
         // Expected: 2 non-declaration references — the metadata
@@ -574,7 +616,7 @@ mod tests {
             },
         };
 
-        let refs = handle_references(&params, source, &result, &uri, PositionEncoding::Utf16)
+        let refs = handle_references(&params, source, &result, &[], &uri, PositionEncoding::Utf16)
             .expect("at least the Open definition + 1 posting reference");
 
         let metadata_lines = [3u32, 5u32];

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -723,8 +723,20 @@ impl MainLoopState {
         let uri = &params.text_document_position.text_document.uri;
         let (text, parse_result) = self.get_document_data(uri);
 
-        let response =
-            handle_references(&params, &text, &parse_result, uri, self.position_encoding);
+        // Other ledger files so "find references" spans every `include`d file,
+        // not just the open buffer. Collected under the locks (live content for
+        // open buffers); the handler then parses lock-free.
+        let current_canonical = uri_to_path(uri).and_then(|p| p.canonicalize().ok());
+        let other_files = self.other_ledger_files(current_canonical.as_deref());
+
+        let response = handle_references(
+            &params,
+            &text,
+            &parse_result,
+            &other_files,
+            uri,
+            self.position_encoding,
+        );
 
         serde_json::to_value(response).map_err(|e| e.to_string())
     }

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1268,3 +1268,67 @@ fn rename_account_spans_included_files() {
         "rename must also edit the included file (cross-file usage); edited: {edited_uris:?}"
     );
 }
+
+/// Regression: find-references on an account used across `include`d files must
+/// return locations in ALL files, not just the open one.
+#[cfg(unix)]
+#[test]
+fn references_span_included_files() {
+    use lsp_types::request::References;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let main_path = tmp.path().join("main.beancount");
+    let inc_path = tmp.path().join("inc.beancount");
+    std::fs::write(&main_path, "2024-01-01 open Assets:Bank USD\n").expect("write main");
+    std::fs::write(
+        &inc_path,
+        "2024-01-01 open Expenses:Food USD\n\
+         2024-02-01 * \"x\"\n  Assets:Bank  -5 USD\n  Expenses:Food  5 USD\n",
+    )
+    .expect("write inc");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            main_path.display(),
+            inc_path.display()
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+    let main_uri = format!("file://{}", main_path.display());
+    client.open_document(
+        &main_uri,
+        &std::fs::read_to_string(&main_path).expect("read main"),
+    );
+
+    // References on `Assets:Bank` (col 16, line 0 of main), include declaration.
+    let locations: Option<Vec<lsp_types::Location>> =
+        client.request::<References>(lsp_types::ReferenceParams {
+            text_document_position: lsp_types::TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: main_uri.parse().unwrap(),
+                },
+                position: lsp_types::Position::new(0, 16),
+            },
+            context: lsp_types::ReferenceContext {
+                include_declaration: true,
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        });
+    let locations = locations.unwrap_or_default();
+    let inc_uri = format!("file://{}", inc_path.display());
+    let uris: Vec<&str> = locations.iter().map(|l| l.uri.as_str()).collect();
+    assert!(
+        locations.iter().any(|l| l.uri.as_str() == main_uri),
+        "references must include the open file's open directive; got: {uris:?}"
+    );
+    assert!(
+        locations.iter().any(|l| l.uri.as_str() == inc_uri),
+        "references must include the usage in the included file; got: {uris:?}"
+    );
+}


### PR DESCRIPTION
## What

LSP `textDocument/references` ("find all references") on an account/currency/payee used across `include`d files returned only the occurrences in the **open** file. Documented as the phase-5.5 follow-up in `rename.rs` and confirmed by LSP dogfounding. Now that **rename** is cross-file (#1490), references was the remaining single-file sibling — leaving "find references" misleadingly incomplete on multi-file ledgers.

(Note: `documentHighlight` is intentionally left single-file — per the LSP spec it highlights occurrences within the *open document* only.)

## How

Thread the ledger's other files into `handle_references` (reusing `main_loop::other_ledger_files`, already added for rename — live buffer content for open includes, on-disk for the rest, collected under the lock and parsed lock-free). Classify the symbol kind once from the cursor's file, then run the matching token-precise collector (`account_occurrences` / `currency_occurrences` / payee) over every ledger file, each with its own URI + line index. A final dedup keyed by `(uri, range)` prevents two files with a same-positioned occurrence from collapsing.

## Tests

`references_span_included_files` (integration): a journal includes `main` (opens `Assets:Bank`) + `inc` (uses it in a posting); references from `main` return locations in **both** files. Existing single-file reference tests still pass. Full `rustledger-lsp` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
