### PR TITLE
fix(lsp): anchor inlay hint before a trailing inline comment

### DIFF
--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -172,7 +172,7 @@ pub fn handle_inlay_hints(
             // amount before the comment, so the first `;` unambiguously starts
             // it. Without this the hint anchors *past* the comment instead of at
             // the account end.
-            let content = line.split(';').next().unwrap_or(line);
+            let content = line.split_once(';').map_or(line, |(before, _)| before);
             let trimmed = content.trim();
             let indent_bytes = line.len() - line.trim_start().len();
             let end_col_bytes = indent_bytes + trimmed.len();

--- a/crates/rustledger-lsp/src/handlers/inlay_hints.rs
+++ b/crates/rustledger-lsp/src/handlers/inlay_hints.rs
@@ -167,7 +167,13 @@ pub fn handle_inlay_hints(
             // A well-formed fully-missing posting line is
             // `[indent][flag ]account[trailing ws]`, so the end of the
             // trimmed content lands right after the account.
-            let trimmed = line.trim();
+            // Strip a trailing inline comment first: a fully-elided posting line
+            // is `[indent][flag ]account[ws][; comment]` with no string or
+            // amount before the comment, so the first `;` unambiguously starts
+            // it. Without this the hint anchors *past* the comment instead of at
+            // the account end.
+            let content = line.split(';').next().unwrap_or(line);
+            let trimmed = content.trim();
             let indent_bytes = line.len() - line.trim_start().len();
             let end_col_bytes = indent_bytes + trimmed.len();
             let indent_chars = line[..indent_bytes].chars().count();
@@ -823,6 +829,43 @@ mod tests {
             "hint number should be right-justified at the formatter column; label={label:?}"
         );
         assert_eq!(label.trim_start(), "50.00 USD");
+    }
+
+    #[test]
+    fn test_inlay_hint_anchors_before_inline_comment() {
+        // The elided posting carries a trailing inline comment. The hint must
+        // anchor at the account end (col 13, after `Assets:Cash`), NOT past the
+        // `; note here` comment (which the old `line.trim()` swallowed).
+        let source = "\
+2024-01-15 * \"Test\"
+  Expenses:Food  -5.00 USD
+  Assets:Cash  ; note here
+";
+        let result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let params = InlayHintParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: "file:///t.beancount".parse().unwrap(),
+            },
+            range: lsp_types::Range {
+                start: Position::new(0, 0),
+                end: Position::new(10, 0),
+            },
+            work_done_progress_params: Default::default(),
+        };
+        let hints = handle_inlay_hints(&params, source, &result, PositionEncoding::Utf16)
+            .unwrap_or_default();
+        assert_eq!(hints.len(), 1, "one inferred-amount hint expected");
+        let h = &hints[0];
+        assert_eq!(h.position.line, 2);
+        assert_eq!(
+            h.position.character, 13,
+            "hint must anchor at the account end (col 13), not past the inline comment"
+        );
     }
 
     /// #1346 regression for the byte-vs-encoding bugs the deep review


### PR DESCRIPTION
## What

LSP `textDocument/inlayHint`: the inferred-amount hint on an elided posting that has a trailing inline comment was anchored **past the comment**, rendering `  Expenses:Food  ; note here   5.00 USD` instead of aligning the greyed amount with the explicit amount above. Found by LSP dogfounding (round 6).

## How

`inlay_hints.rs` computed the anchor as `indent + line.trim().len()`, which counts a trailing `; comment` as part of the account region. A fully-elided posting line is `[indent][flag ]account[ws][; comment]` with no string or amount before the comment, so the first `;` unambiguously starts the comment — strip it before computing the anchor.

## Tests

`test_inlay_hint_anchors_before_inline_comment`: an elided `  Assets:Cash  ; note here` anchors the hint at col 13 (account end), not past the comment. Existing inlay tests (alignment, non-ASCII, clamp) still pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
