### PR TITLE
fix(query): return NULL for BQL division/modulo by zero instead of panicking

### DIFF
--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -163,7 +163,7 @@ impl Executor<'_> {
                             .map(Value::Date)
                             .ok_or_else(|| QueryError::Evaluation("date overflow".to_string()))
                     }
-                    _ => self.arithmetic_op(&left, &right, |a, b| a + b),
+                    _ => self.arithmetic_op(&left, &right, |a, b| Some(a + b)),
                 }
             }
             BinaryOperator::Sub => {
@@ -179,12 +179,12 @@ impl Executor<'_> {
                             .map(Value::Date)
                             .ok_or_else(|| QueryError::Evaluation("date overflow".to_string()))
                     }
-                    _ => self.arithmetic_op(&left, &right, |a, b| a - b),
+                    _ => self.arithmetic_op(&left, &right, |a, b| Some(a - b)),
                 }
             }
-            BinaryOperator::Mul => self.arithmetic_op(&left, &right, |a, b| a * b),
-            BinaryOperator::Div => self.arithmetic_op(&left, &right, |a, b| a / b),
-            BinaryOperator::Mod => self.arithmetic_op(&left, &right, |a, b| a % b),
+            BinaryOperator::Mul => self.arithmetic_op(&left, &right, |a, b| Some(a * b)),
+            BinaryOperator::Div => self.arithmetic_op(&left, &right, Decimal::checked_div),
+            BinaryOperator::Mod => self.arithmetic_op(&left, &right, Decimal::checked_rem),
         }
     }
 
@@ -281,7 +281,7 @@ impl Executor<'_> {
         op: F,
     ) -> Result<Value, QueryError>
     where
-        F: FnOnce(Decimal, Decimal) -> Decimal,
+        F: FnOnce(Decimal, Decimal) -> Option<Decimal>,
     {
         let (a, b) = match (left, right) {
             (Value::Number(a), Value::Number(b)) => (*a, *b),
@@ -294,7 +294,11 @@ impl Executor<'_> {
                 ));
             }
         };
-        Ok(Value::Number(op(a, b)))
+        // `op` returns `None` for undefined results (e.g. division/modulo by
+        // zero, where `checked_div`/`checked_rem` yield `None`). Match
+        // beanquery, which produces NULL rather than raising — and crucially
+        // avoid the underlying `rust_decimal` panic on `a / 0`.
+        Ok(op(a, b).map_or(Value::Null, Value::Number))
     }
 
     /// Convert a value to boolean using SQL/beanquery truthiness rules.
@@ -460,7 +464,7 @@ impl Executor<'_> {
                             .map(Value::Date)
                             .ok_or_else(|| QueryError::Evaluation("date overflow".to_string()))
                     }
-                    _ => self.arithmetic_op(left, right, |a, b| a + b),
+                    _ => self.arithmetic_op(left, right, |a, b| Some(a + b)),
                 }
             }
             BinaryOperator::Sub => {
@@ -476,12 +480,12 @@ impl Executor<'_> {
                             .map(Value::Date)
                             .ok_or_else(|| QueryError::Evaluation("date overflow".to_string()))
                     }
-                    _ => self.arithmetic_op(left, right, |a, b| a - b),
+                    _ => self.arithmetic_op(left, right, |a, b| Some(a - b)),
                 }
             }
-            BinaryOperator::Mul => self.arithmetic_op(left, right, |a, b| a * b),
-            BinaryOperator::Div => self.arithmetic_op(left, right, |a, b| a / b),
-            BinaryOperator::Mod => self.arithmetic_op(left, right, |a, b| a % b),
+            BinaryOperator::Mul => self.arithmetic_op(left, right, |a, b| Some(a * b)),
+            BinaryOperator::Div => self.arithmetic_op(left, right, Decimal::checked_div),
+            BinaryOperator::Mod => self.arithmetic_op(left, right, Decimal::checked_rem),
         }
     }
 

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -244,6 +244,32 @@ fn test_execute_select_with_filter() {
 }
 
 #[test]
+fn test_division_by_zero_returns_null_not_panic() {
+    let directives = make_test_directives();
+    // Division / modulo by zero must yield NULL (matching beanquery), not panic
+    // the process via rust_decimal's `a / 0`.
+    for q in [
+        "SELECT 1 / 0",
+        "SELECT 5 % 0",
+        "SELECT 1.0 / 0",
+        "SELECT 7 % 0",
+    ] {
+        let result = execute_query(q, &directives);
+        assert!(!result.rows.is_empty(), "query {q} returned no rows");
+        for row in &result.rows {
+            assert!(
+                matches!(row[0], Value::Null),
+                "{q}: expected NULL, got {:?}",
+                row[0]
+            );
+        }
+    }
+    // Non-zero division still computes a value.
+    let result = execute_query("SELECT 10 / 4", &directives);
+    assert!(matches!(result.rows[0][0], Value::Number(_)));
+}
+
+#[test]
 fn test_execute_select_with_date_filter() {
     let directives = make_test_directives();
     let result = execute_query(


### PR DESCRIPTION
## What

A BQL query dividing (or taking modulo) by zero **panicked the whole process** instead of returning a value:

```
$ rledger query ledger.beancount "SELECT number / 0"
thread 'main' panicked at rust_decimal-1.42.1/.../arithmetic_impls.rs: Division by zero
```

Also affected `SELECT n % 0` and `SELECT 1.0 / 0`. Found by differential testing against Python beanquery, which returns **NULL** for these. A panic in the query engine is a denial-of-service-class bug for any embedding (LSP, WASM, FFI) that runs user queries.

## How

`executor::operators::arithmetic_op` applied its operator closure directly (`a / b`), so `rust_decimal`'s panicking `Div`/`Rem` ran on a zero divisor. The closure now returns `Option<Decimal>` — `Add`/`Sub`/`Mul` wrap `Some`, while `Div`/`Mod` use `Decimal::checked_div`/`checked_rem` (which yield `None` on a zero divisor) — and `arithmetic_op` maps `None` → `Value::Null`, matching beanquery. No behavior change for non-zero arithmetic.

## Tests

`test_division_by_zero_returns_null_not_panic`: `1 / 0`, `5 % 0`, `1.0 / 0`, `7 % 0` all return `Value::Null` (no panic); `10 / 4` still computes. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
