### PR TITLE
fix(query): BQL length() counts chars; substr() uses Python slice semantics

### DIFF
--- a/crates/rustledger-query/src/executor/functions/mod.rs
+++ b/crates/rustledger-query/src/executor/functions/mod.rs
@@ -6,7 +6,7 @@ mod account;
 mod date;
 mod math;
 mod position;
-mod string;
+pub(in crate::executor) mod string;
 mod util;
 
 /// Three-letter English weekday abbreviation (`Mon`..`Sun`) for a Monday-zero

--- a/crates/rustledger-query/src/executor/functions/string.rs
+++ b/crates/rustledger-query/src/executor/functions/string.rs
@@ -385,9 +385,17 @@ impl Executor<'_> {
 /// Matches `CPython` (and thus beanquery) semantics: negative indices count from
 /// the end, both bounds are clamped into `0..=len`, and `start >= end` yields an
 /// empty string. `end == None` slices to the end (`chars[start:]`).
-fn py_slice(chars: &[char], start: i64, end: Option<i64>) -> String {
+pub(in crate::executor) fn py_slice(chars: &[char], start: i64, end: Option<i64>) -> String {
     let n = chars.len() as i64;
-    let normalize = |i: i64| -> i64 { if i < 0 { (n + i).max(0) } else { i.min(n) } };
+    // `saturating_add` so a very negative index (e.g. `i64::MIN`) clamps to 0
+    // instead of overflowing and panicking in debug builds.
+    let normalize = |i: i64| -> i64 {
+        if i < 0 {
+            n.saturating_add(i).max(0)
+        } else {
+            i.min(n)
+        }
+    };
     let s = normalize(start);
     let e = end.map_or(n, normalize);
     if s >= e {

--- a/crates/rustledger-query/src/executor/functions/string.rs
+++ b/crates/rustledger-query/src/executor/functions/string.rs
@@ -21,7 +21,9 @@ impl Executor<'_> {
                 Self::require_args(name, func, 1)?;
                 let val = self.evaluate_expr(&func.args[0], ctx)?;
                 match val {
-                    Value::String(s) => Ok(Value::Integer(s.len() as i64)),
+                    // Count Unicode characters, not UTF-8 bytes (matches
+                    // beanquery / Python `len(str)`).
+                    Value::String(s) => Ok(Value::Integer(s.chars().count() as i64)),
                     Value::StringSet(s) => Ok(Value::Integer(s.len() as i64)),
                     _ => Err(QueryError::Type(
                         "LENGTH expects a string or set".to_string(),
@@ -359,20 +361,38 @@ impl Executor<'_> {
         };
 
         match (val, start, len) {
-            (Value::String(s), Value::Integer(start), None) => {
-                let start = start.max(0) as usize;
-                let result: String = s.chars().skip(start).collect();
-                Ok(Value::String(result))
-            }
-            (Value::String(s), Value::Integer(start), Some(Value::Integer(len))) => {
-                let start = start.max(0) as usize;
-                let len = len.max(0) as usize;
-                let result: String = s.chars().skip(start).take(len).collect();
-                Ok(Value::String(result))
-            }
+            // SUBSTR(s, start, end) follows Python slicing `s[start:end]`
+            // (beanquery semantics): the third argument is the END index, NOT a
+            // length, and negative indices count from the end. The 2-arg form
+            // `s[start:]` is a rledger extension (beanquery requires 3 args).
+            (Value::String(s), Value::Integer(start), None) => Ok(Value::String(py_slice(
+                &s.chars().collect::<Vec<_>>(),
+                start,
+                None,
+            ))),
+            (Value::String(s), Value::Integer(start), Some(Value::Integer(end))) => Ok(
+                Value::String(py_slice(&s.chars().collect::<Vec<_>>(), start, Some(end))),
+            ),
             _ => Err(QueryError::Type(
                 "SUBSTR expects (string, int, [int])".to_string(),
             )),
         }
+    }
+}
+
+/// Python-style slice `chars[start:end]` over a character vector.
+///
+/// Matches `CPython` (and thus beanquery) semantics: negative indices count from
+/// the end, both bounds are clamped into `0..=len`, and `start >= end` yields an
+/// empty string. `end == None` slices to the end (`chars[start:]`).
+fn py_slice(chars: &[char], start: i64, end: Option<i64>) -> String {
+    let n = chars.len() as i64;
+    let normalize = |i: i64| -> i64 { if i < 0 { (n + i).max(0) } else { i.min(n) } };
+    let s = normalize(start);
+    let e = end.map_or(n, normalize);
+    if s >= e {
+        String::new()
+    } else {
+        chars[s as usize..e as usize].iter().collect()
     }
 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -643,7 +643,8 @@ impl<'a> Executor<'a> {
             "LENGTH" => {
                 Self::require_args_count(&name_upper, args, 1)?;
                 match &args[0] {
-                    Value::String(s) => Ok(Value::Integer(s.len() as i64)),
+                    // Count Unicode characters, not UTF-8 bytes (matches beanquery).
+                    Value::String(s) => Ok(Value::Integer(s.chars().count() as i64)),
                     _ => Err(QueryError::Type("LENGTH expects a string".to_string())),
                 }
             }
@@ -1295,17 +1296,18 @@ impl<'a> Executor<'a> {
                         "expected 2 or 3 arguments".to_string(),
                     ));
                 }
+                // Python slice semantics s[start:end] — see `py_slice` /
+                // `eval_substr`. arg3 is the END index, not a length.
                 match (&args[0], &args[1], args.get(2)) {
-                    (Value::String(s), Value::Integer(start), None) => {
-                        let start = (*start).max(0) as usize;
-                        let result: String = s.chars().skip(start).collect();
-                        Ok(Value::String(result))
-                    }
-                    (Value::String(s), Value::Integer(start), Some(Value::Integer(len))) => {
-                        let start = (*start).max(0) as usize;
-                        let len = (*len).max(0) as usize;
-                        let result: String = s.chars().skip(start).take(len).collect();
-                        Ok(Value::String(result))
+                    (Value::String(s), Value::Integer(start), None) => Ok(Value::String(
+                        functions::string::py_slice(&s.chars().collect::<Vec<_>>(), *start, None),
+                    )),
+                    (Value::String(s), Value::Integer(start), Some(Value::Integer(end))) => {
+                        Ok(Value::String(functions::string::py_slice(
+                            &s.chars().collect::<Vec<_>>(),
+                            *start,
+                            Some(*end),
+                        )))
                     }
                     _ => Err(QueryError::Type(
                         "SUBSTR expects (string, int, [int])".to_string(),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -270,6 +270,40 @@ fn test_division_by_zero_returns_null_not_panic() {
 }
 
 #[test]
+fn test_length_counts_chars_not_bytes() {
+    let directives = make_test_directives();
+    // LENGTH must count Unicode characters, not UTF-8 bytes (matches beanquery).
+    let result = execute_query(r#"SELECT length("Café")"#, &directives);
+    assert_eq!(result.rows[0][0], Value::Integer(4));
+    let result = execute_query(r#"SELECT length("Coffee ☕ unicode")"#, &directives);
+    assert_eq!(result.rows[0][0], Value::Integer(16));
+}
+
+#[test]
+fn test_substr_python_slice_semantics() {
+    let directives = make_test_directives();
+    // SUBSTR(s, start, end) == Python s[start:end] (beanquery): arg3 is the END
+    // index, not a length; negatives count from the end; bounds clamp.
+    let cases = [
+        (r#"substr("hello", 1, 3)"#, "el"),
+        (r#"substr("hello", 1, -1)"#, "ell"),
+        (r#"substr("hello", -10, 5)"#, "hello"), // negative start clamps to 0
+        (r#"substr("hello", 10, 20)"#, ""),
+        (r#"substr("hello", 3, 1)"#, ""),
+        (r#"substr("Café", 1, 3)"#, "af"),
+        (r#"substr("hello", 1)"#, "ello"), // 2-arg rledger extension: s[start:]
+    ];
+    for (expr, expected) in cases {
+        let result = execute_query(&format!("SELECT {expr}"), &directives);
+        assert_eq!(
+            result.rows[0][0],
+            Value::String(expected.to_string()),
+            "for {expr}"
+        );
+    }
+}
+
+#[test]
 fn test_execute_select_with_date_filter() {
     let directives = make_test_directives();
     let result = execute_query(

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -280,6 +280,29 @@ fn test_length_counts_chars_not_bytes() {
 }
 
 #[test]
+fn test_string_funcs_in_aggregate_context_use_char_semantics() {
+    // length()/substr() wrapping an aggregate route through the separate
+    // `evaluate_function_on_values` path — it must use the same char-based /
+    // Python-slice semantics as the normal path (Copilot review on #1498).
+    let directives = vec![
+        Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2024, 1, 1), "Equity:O")),
+        Directive::Transaction(
+            Transaction::new(date(2024, 1, 15), "Café ☕")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(5), "USD")))
+                .with_synthesized_posting(Posting::new("Equity:O", Amount::new(dec!(-5), "USD"))),
+        ),
+    ];
+    // "Café ☕" is 6 chars (more bytes); length must count chars.
+    let result = execute_query("SELECT length(max(narration))", &directives);
+    assert_eq!(result.rows[0][0], Value::Integer(6));
+    // substr arg3 is the END index: [1:4] of "Café ☕" = "afé" (length-semantics
+    // would have returned "afé " with the trailing space).
+    let result = execute_query("SELECT substr(max(narration), 1, 4)", &directives);
+    assert_eq!(result.rows[0][0], Value::String("afé".to_string()));
+}
+
+#[test]
 fn test_substr_python_slice_semantics() {
     let directives = make_test_directives();
     // SUBSTR(s, start, end) == Python s[start:end] (beanquery): arg3 is the END


### PR DESCRIPTION
## What

Two BQL string-function correctness bugs found by differential testing against Python beanquery:

1. **`length()` counted UTF-8 bytes, not characters.** `length("Café")` → `5` (should be `4`); `length("Coffee ☕ unicode")` → `18` (should be `16`).
2. **`substr(s, start, end)` treated the 3rd argument as a LENGTH, not an END index.** beanquery/Python semantics are `s[start:end]`: `substr("Café", 1, 3)` → rledger `afé`, should be `af`; and negative indices weren't supported (`substr("Buy stock", 0, -1)` → empty, should be `Buy stoc`).

## How

- `length()`: `s.chars().count()` instead of `s.len()` for the `String` case (the `StringSet` arm correctly stays set-cardinality).
- `substr()`: new `py_slice` helper implementing CPython slice semantics (`s[start:end]`) over a char vector — negative indices count from the end, both bounds clamp into `0..=len`, `start >= end` → empty. The 2-arg form `s[start:]` is kept as a rledger extension (beanquery requires 3 args). Oracle-verified across negative/clamp/out-of-range cases.

## Tests

`test_length_counts_chars_not_bytes` and `test_substr_python_slice_semantics` (incl. negative end, negative/over-range start, `start >= end`, non-ASCII). Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
