### PR TITLE
fix(query): BQL 2-arg getprice returns the latest price

### DIFF
--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -378,22 +378,25 @@ impl Executor<'_> {
             }
         };
 
-        // Get date (optional, defaults to context date)
-        let date = if func.args.len() == 3 {
-            match self.evaluate_expr(&func.args[2], ctx)? {
+        // With an explicit date, look up the price as of that date. Without one,
+        // return the LATEST price — beanquery's `getprice(base, quote)` passes
+        // `date=None`, which resolves to the most recent price, NOT the price as
+        // of the current transaction's date.
+        let price = if func.args.len() == 3 {
+            let date = match self.evaluate_expr(&func.args[2], ctx)? {
                 Value::Date(d) => d,
                 _ => {
                     return Err(QueryError::Type(
                         "GETPRICE: third argument must be a date".to_string(),
                     ));
                 }
-            }
+            };
+            self.price_db.get_price(&base, &quote, date)
         } else {
-            ctx.transaction.date
+            self.price_db.get_latest_price(&base, &quote)
         };
 
-        // Look up the price
-        match self.price_db.get_price(&base, &quote, date) {
+        match price {
             Some(price) => Ok(Value::Number(price)),
             None => Ok(Value::Null),
         }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -9985,3 +9985,49 @@ fn test_safediv_accepts_mixed_int_and_decimal() {
     let result = execute_query("SELECT safediv(max(number), 0)", &directives);
     assert_eq!(result.rows[0][0], Value::Number(dec!(0)));
 }
+
+#[test]
+fn test_getprice_two_arg_returns_latest_price() {
+    use rustledger_core::Price;
+    // Two-arg getprice(base, quote) must return the LATEST price (beanquery
+    // date=None semantics), NOT the price as of the transaction date.
+    let directives = vec![
+        Directive::Open(Open::new(date(2020, 1, 1), "Assets:Stock")),
+        Directive::Open(Open::new(date(2020, 1, 1), "Equity:O")),
+        Directive::Price(Price {
+            date: date(2020, 1, 15),
+            currency: "AAPL".into(),
+            amount: Amount::new(dec!(150.00), "USD"),
+            meta: Default::default(),
+        }),
+        Directive::Price(Price {
+            date: date(2020, 4, 1),
+            currency: "AAPL".into(),
+            amount: Amount::new(dec!(160.00), "USD"),
+            meta: Default::default(),
+        }),
+        Directive::Transaction(
+            Transaction::new(date(2020, 2, 1), "buy")
+                .with_synthesized_posting(Posting::new(
+                    "Assets:Stock",
+                    Amount::new(dec!(10), "AAPL"),
+                ))
+                .with_synthesized_posting(Posting::new(
+                    "Equity:O",
+                    Amount::new(dec!(-1500), "USD"),
+                )),
+        ),
+    ];
+    let result = execute_query(r#"SELECT getprice("AAPL", "USD")"#, &directives);
+    assert!(!result.rows.is_empty(), "query returned no rows");
+    for row in &result.rows {
+        // The mid-range transaction is 2020-02-01, but the latest price (160.00,
+        // 2020-04-01) is what beanquery returns for the dateless form.
+        assert_eq!(
+            row[0],
+            Value::Number(dec!(160.00)),
+            "expected the latest price 160.00, got {:?}",
+            row[0]
+        );
+    }
+}


### PR DESCRIPTION
## What

BQL `getprice(base, quote)` (the 2-argument, dateless form) returned the price **as of each row's transaction date** instead of the **latest** price. Found by differential testing against beanquery, whose `getprice(base, quote)` passes `date=None` and resolves to the most recent price (documented in `beancount/core/prices.py`).

Example — with `price AAPL 150 USD` (Jan) and `price AAPL 160 USD` (Apr), `SELECT getprice("AAPL","USD")`:
- beanquery → `160.00` for every row
- rledger → `NULL`/`150`/`160` depending on each posting's transaction date

## How

In `eval_getprice`, the no-date branch now calls the existing `PriceDatabase::get_latest_price(base, quote)` instead of `get_price(base, quote, transaction.date)`. The 3-argument form (explicit date) is unchanged.

## Tests

`test_getprice_two_arg_returns_latest_price`: a ledger with two AAPL prices and a transaction dated *between* them — the dateless `getprice` returns the latest (160.00) for all rows. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
