### PR TITLE
fix(query): date_add with an out-of-range day offset errors instead of panicking

### DIFF
--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -280,13 +280,13 @@ impl Executor<'_> {
 
         let second_arg = self.evaluate_expr(&func.args[1], ctx)?;
         let result = match second_arg {
-            Value::Integer(days) => date.checked_add(jiff::ToSpan::days(days)).unwrap(),
+            Value::Integer(days) => add_days(date, days)?,
             Value::Number(n) => {
                 use rust_decimal::prelude::ToPrimitive;
                 let days = n.to_i64().ok_or_else(|| {
                     QueryError::Type("DATE_ADD: days must be an integer".to_string())
                 })?;
-                date.checked_add(jiff::ToSpan::days(days)).unwrap()
+                add_days(date, days)?
             }
             Value::Interval(interval) => interval
                 .add_to_date(date)
@@ -558,4 +558,20 @@ impl Executor<'_> {
 
         Ok(Value::Date(binned))
     }
+}
+
+/// Add `days` to `date`, returning a graceful error instead of panicking when
+/// `days` is out of range.
+///
+/// `jiff::ToSpan::days` panics while *constructing* the span if the count is
+/// outside jiff's representable range (≈ ±7.3M days), so the previous
+/// `date.checked_add(days.days()).unwrap()` aborted the process on a large
+/// offset. Build the span fallibly and propagate overflow as a `QueryError`
+/// (beanquery raises a catchable `OverflowError` here).
+fn add_days(date: NaiveDate, days: i64) -> Result<NaiveDate, QueryError> {
+    let span = jiff::Span::new()
+        .try_days(days)
+        .map_err(|_| QueryError::Evaluation("DATE_ADD: day offset out of range".to_string()))?;
+    date.checked_add(span)
+        .map_err(|_| QueryError::Evaluation("DATE_ADD: resulting date out of range".to_string()))
 }

--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -565,13 +565,16 @@ impl Executor<'_> {
 ///
 /// `jiff::ToSpan::days` panics while *constructing* the span if the count is
 /// outside jiff's representable range (≈ ±7.3M days), so the previous
-/// `date.checked_add(days.days()).unwrap()` aborted the process on a large
-/// offset. Build the span fallibly and propagate overflow as a `QueryError`
-/// (beanquery raises a catchable `OverflowError` here).
+/// `date.checked_add(jiff::ToSpan::days(days)).unwrap()` aborted the process on
+/// a large offset. Build the span fallibly and propagate overflow as a
+/// `QueryError` (beanquery raises a catchable `OverflowError` here).
 fn add_days(date: NaiveDate, days: i64) -> Result<NaiveDate, QueryError> {
     let span = jiff::Span::new()
         .try_days(days)
-        .map_err(|_| QueryError::Evaluation("DATE_ADD: day offset out of range".to_string()))?;
-    date.checked_add(span)
-        .map_err(|_| QueryError::Evaluation("DATE_ADD: resulting date out of range".to_string()))
+        .map_err(|_| QueryError::Evaluation(format!("DATE_ADD: day offset {days} out of range")))?;
+    date.checked_add(span).map_err(|_| {
+        QueryError::Evaluation(format!(
+            "DATE_ADD: resulting date out of range (adding {days} days)"
+        ))
+    })
 }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -10036,9 +10036,18 @@ fn test_getprice_two_arg_returns_latest_price() {
 fn test_date_add_large_offset_errors_gracefully() {
     let directives = make_test_directives();
     // A day offset beyond jiff's representable range must produce a graceful
-    // QueryError, not panic the process (was: ToSpan::days().unwrap() aborted).
-    let _err = execute_query_err("SELECT date_add(date, 99999999999)", &directives);
-    let _err = execute_query_err("SELECT date_add(date, -99999999999)", &directives);
+    // overflow QueryError, not panic the process (was: ToSpan::days().unwrap()
+    // aborted). Assert the specific message so unrelated errors don't pass.
+    for q in [
+        "SELECT date_add(date, 99999999999)",
+        "SELECT date_add(date, -99999999999)",
+    ] {
+        let err = execute_query_err(q, &directives);
+        assert!(
+            err.to_string().contains("out of range"),
+            "{q}: expected an out-of-range error, got {err:?}"
+        );
+    }
     // Ordinary offsets still compute a date.
     let result = execute_query("SELECT date_add(date, 5)", &directives);
     assert!(matches!(result.rows[0][0], Value::Date(_)));

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -10031,3 +10031,15 @@ fn test_getprice_two_arg_returns_latest_price() {
         );
     }
 }
+
+#[test]
+fn test_date_add_large_offset_errors_gracefully() {
+    let directives = make_test_directives();
+    // A day offset beyond jiff's representable range must produce a graceful
+    // QueryError, not panic the process (was: ToSpan::days().unwrap() aborted).
+    let _err = execute_query_err("SELECT date_add(date, 99999999999)", &directives);
+    let _err = execute_query_err("SELECT date_add(date, -99999999999)", &directives);
+    // Ordinary offsets still compute a date.
+    let result = execute_query("SELECT date_add(date, 5)", &directives);
+    assert!(matches!(result.rows[0][0], Value::Date(_)));
+}


### PR DESCRIPTION
## What

A BQL `date_add(date, <large integer>)` **panicked the whole process**:

```
$ rledger query ledger.beancount "SELECT date_add(date, 99999999999)"
thread 'main' panicked at jiff-0.2.28/src/span.rs: value for days is out of bounds: ... range -7304484..=7304484
```

Found by differential dogfounding (round 3). beanquery raises a catchable `OverflowError` here; rledger aborted. Reproduces for `|days| > 7_304_484` (positive or negative), including in nested/aggregate contexts. A panic in the query engine is denial-of-service-class for embeddings (LSP/WASM/FFI) that run user queries.

## How

`jiff::ToSpan::days(n)` panics while *constructing* the span when `n` is outside jiff's representable range — so the old `date.checked_add(n.days()).unwrap()` never reached `checked_add`. New `add_days` helper builds the span fallibly (`Span::new().try_days(n)`) and propagates both span-range and date-overflow as a graceful `QueryError`. Both the integer and decimal-day arms of `date_add` route through it.

## Tests

`test_date_add_large_offset_errors_gracefully`: `date_add(date, ±99999999999)` returns a `QueryError` (no panic); `date_add(date, 5)` still computes a date. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
