### PR TITLE
fix(query): BQL round() negative precision and quarter() string format

### DIFF
--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -48,8 +48,9 @@ impl Executor<'_> {
                 super::weekday_abbrev(date.weekday().to_monday_zero_offset() as u32).to_string(),
             )),
             "QUARTER" => {
+                // beanquery returns a `YYYY-Qn` string, not an integer.
                 let quarter = (date.month() - 1) / 3 + 1;
-                Ok(Value::Integer(quarter.into()))
+                Ok(Value::String(format!("{:04}-Q{}", date.year(), quarter)))
             }
             "YMONTH" => Ok(Value::String(format!(
                 "{:04}-{:02}",

--- a/crates/rustledger-query/src/executor/functions/math.rs
+++ b/crates/rustledger-query/src/executor/functions/math.rs
@@ -55,9 +55,9 @@ impl Executor<'_> {
         }
 
         let val = self.evaluate_expr(&func.args[0], ctx)?;
-        let decimals = if func.args.len() == 2 {
+        let decimals: i64 = if func.args.len() == 2 {
             match self.evaluate_expr(&func.args[1], ctx)? {
-                Value::Integer(i) => i as u32,
+                Value::Integer(i) => i,
                 _ => {
                     return Err(QueryError::Type(
                         "ROUND second arg must be integer".to_string(),
@@ -69,7 +69,7 @@ impl Executor<'_> {
         };
 
         match val {
-            Value::Number(n) => Ok(Value::Number(n.round_dp(decimals))),
+            Value::Number(n) => Ok(Value::Number(round_decimal(n, decimals))),
             Value::Integer(i) => Ok(Value::Integer(i)),
             _ => Err(QueryError::Type("ROUND expects a number".to_string())),
         }
@@ -123,4 +123,27 @@ impl Executor<'_> {
             _ => Err(QueryError::Type("SAFEDIV expects two numbers".to_string())),
         }
     }
+}
+
+/// Round `n` to `places` decimal places, matching Python's `round` (and thus
+/// beanquery): a NEGATIVE `places` rounds to the left of the decimal point
+/// (tens, hundreds, …). Uses banker's rounding (half-to-even), consistent with
+/// `Decimal::round_dp`.
+///
+/// The old code cast `places` to `u32`, so a negative value wrapped to a huge
+/// precision and `round_dp` became a silent no-op.
+fn round_decimal(n: Decimal, places: i64) -> Decimal {
+    if places >= 0 {
+        // `round_dp` caps at Decimal's 28-digit precision; clamp to avoid a
+        // needless huge argument.
+        return n.round_dp(u32::try_from(places).unwrap_or(u32::MAX).min(28));
+    }
+    let k = -places;
+    // 10^k stops fitting in Decimal beyond 28 digits; any representable number
+    // rounds to 0 at that magnitude.
+    if k > 28 {
+        return Decimal::ZERO;
+    }
+    let scale = Decimal::from_i128_with_scale(10i128.pow(k as u32), 0);
+    (n / scale).round() * scale
 }

--- a/crates/rustledger-query/src/executor/functions/math.rs
+++ b/crates/rustledger-query/src/executor/functions/math.rs
@@ -70,7 +70,19 @@ impl Executor<'_> {
 
         match val {
             Value::Number(n) => Ok(Value::Number(round_decimal(n, decimals))),
-            Value::Integer(i) => Ok(Value::Integer(i)),
+            Value::Integer(i) => {
+                // Rounding an integer to >= 0 places is a no-op; a negative
+                // precision rounds it to tens/hundreds (beanquery `round(1234,
+                // -2)` = 1200). The result is integral — keep it an integer when
+                // it still fits in i64, else fall back to a decimal.
+                if decimals >= 0 {
+                    Ok(Value::Integer(i))
+                } else {
+                    use rust_decimal::prelude::ToPrimitive;
+                    let r = round_decimal(Decimal::from(i), decimals);
+                    Ok(r.to_i64().map_or(Value::Number(r), Value::Integer))
+                }
+            }
             _ => Err(QueryError::Type("ROUND expects a number".to_string())),
         }
     }
@@ -138,9 +150,12 @@ fn round_decimal(n: Decimal, places: i64) -> Decimal {
         // needless huge argument.
         return n.round_dp(u32::try_from(places).unwrap_or(u32::MAX).min(28));
     }
-    let k = -places;
-    // 10^k stops fitting in Decimal beyond 28 digits; any representable number
-    // rounds to 0 at that magnitude.
+    // `checked_neg` guards `places == i64::MIN` (where `-places` would overflow).
+    // 10^k also stops fitting in Decimal beyond 28 digits; in either case any
+    // representable number rounds to 0 at that magnitude.
+    let Some(k) = places.checked_neg() else {
+        return Decimal::ZERO;
+    };
     if k > 28 {
         return Decimal::ZERO;
     }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1256,7 +1256,12 @@ impl<'a> Executor<'a> {
             "QUARTER" => {
                 Self::require_args_count(&name_upper, args, 1)?;
                 match &args[0] {
-                    Value::Date(d) => Ok(Value::Integer(((d.month() - 1) / 3 + 1).into())),
+                    // beanquery returns a `YYYY-Qn` string, not an integer.
+                    Value::Date(d) => Ok(Value::String(format!(
+                        "{:04}-Q{}",
+                        d.year(),
+                        (d.month() - 1) / 3 + 1
+                    ))),
                     _ => Err(QueryError::Type("QUARTER expects a date".to_string())),
                 }
             }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -7283,10 +7283,16 @@ fn test_aggregate_context_non_aggregate_function_short_circuit() {
     );
 
     assert_eq!(result.len(), 2, "should have 2 quarters");
-    // Verify quarter values are 1 and 2
+    // quarter() returns a `YYYY-Qn` string (matching beanquery), not an integer.
     let quarters: Vec<_> = result.rows.iter().map(|r| &r[0]).collect();
-    assert!(quarters.contains(&&Value::Integer(1)), "should contain Q1");
-    assert!(quarters.contains(&&Value::Integer(2)), "should contain Q2");
+    assert!(
+        quarters.contains(&&Value::String("2024-Q1".to_string())),
+        "should contain 2024-Q1, got {quarters:?}"
+    );
+    assert!(
+        quarters.contains(&&Value::String("2024-Q2".to_string())),
+        "should contain 2024-Q2, got {quarters:?}"
+    );
 }
 
 #[test]
@@ -10051,4 +10057,43 @@ fn test_date_add_large_offset_errors_gracefully() {
     // Ordinary offsets still compute a date.
     let result = execute_query("SELECT date_add(date, 5)", &directives);
     assert!(matches!(result.rows[0][0], Value::Date(_)));
+}
+
+#[test]
+fn test_round_negative_precision() {
+    let directives = make_test_directives();
+    // Negative precision rounds to the left of the decimal point (matching
+    // Python/beanquery); it used to be a silent no-op (cast to u32 wrapped).
+    let cases = [
+        ("round(1234.56, -2)", dec!(1200)),
+        ("round(123.45, -1)", dec!(120)),
+        ("round(1234.56, 0)", dec!(1235)),
+        ("round(2.5, 0)", dec!(2)), // banker's rounding (half-to-even)
+        ("round(1234.5, -100)", dec!(0)), // far beyond the magnitude → 0
+    ];
+    for (q, expected) in cases {
+        let result = execute_query(&format!("SELECT {q}"), &directives);
+        assert_eq!(result.rows[0][0], Value::Number(expected), "for {q}");
+    }
+}
+
+#[test]
+fn test_quarter_returns_year_quarter_string() {
+    use rustledger_core::{Open, Transaction};
+    // quarter() returns a `YYYY-Qn` string (beanquery), not an integer — in both
+    // the per-row and aggregate (wrapping max()) eval paths.
+    let directives = vec![
+        Directive::Open(Open::new(date(2020, 1, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2020, 1, 1), "Equity:O")),
+        Directive::Transaction(
+            Transaction::new(date(2020, 11, 5), "x")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(1), "USD")))
+                .with_synthesized_posting(Posting::new("Equity:O", Amount::new(dec!(-1), "USD"))),
+        ),
+    ];
+    let result = execute_query("SELECT quarter(date)", &directives);
+    assert_eq!(result.rows[0][0], Value::String("2020-Q4".to_string()));
+    // Aggregate path (quarter wrapping an aggregate).
+    let result = execute_query("SELECT quarter(max(date))", &directives);
+    assert_eq!(result.rows[0][0], Value::String("2020-Q4".to_string()));
 }

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -10075,6 +10075,12 @@ fn test_round_negative_precision() {
         let result = execute_query(&format!("SELECT {q}"), &directives);
         assert_eq!(result.rows[0][0], Value::Number(expected), "for {q}");
     }
+    // Integer arguments round too (beanquery round(1234,-2)=1200), staying
+    // integers; non-negative precision is a no-op.
+    let result = execute_query("SELECT round(1234, -2)", &directives);
+    assert_eq!(result.rows[0][0], Value::Integer(1200));
+    let result = execute_query("SELECT round(1234, 2)", &directives);
+    assert_eq!(result.rows[0][0], Value::Integer(1234));
 }
 
 #[test]


### PR DESCRIPTION
## What

Two BQL scalar-function correctness bugs found by differential dogfounding (round 3), both diverging from beanquery:

1. **`round(x, n)` with negative `n` was a silent no-op.** `round(1234.56, -2)` → `1234.56` (should be `1200`); `round(123.45, -1)` → unchanged (should be `120`). The second arg was cast to `u32`, so a negative value wrapped to a huge precision and `round_dp` did nothing.
2. **`quarter(date)` returned an integer instead of a `YYYY-Qn` string.** `quarter(2020-01-05)` → `1` (should be `"2020-Q1"`). Affected both the per-row and aggregate eval paths.

## How

- `round`: keep the precision as `i64`; new `round_decimal` helper rounds to the left of the decimal point for negative `n` (`(n / 10^k).round() * 10^k`, banker's rounding to match `round_dp`; magnitudes beyond Decimal's range → `0`).
- `quarter`: format as `"{:04}-Q{}"` in both `date.rs` (per-row) and `mod.rs` (aggregate path).

## Tests

`test_round_negative_precision` (incl. banker's `round(2.5,0)=2` and far-out `-100`→0) and `test_quarter_returns_year_quarter_string` (per-row + `quarter(max(date))`). Updated the existing `quarter()` GROUP BY test, which pinned the old integer values, to the `YYYY-Qn` strings. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
