### PR TITLE
fix(query): BQL NULL/TRUE/FALSE literals usable in expression position

### DIFF
--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -814,11 +814,16 @@ fn primary_expr<'a>(
             .then_ignore(ws())
             .then_ignore(just(')'))
             .map(|e| Expr::Paren(Box::new(e))),
+        // Literals MUST come before the column/function branch: a bare
+        // identifier otherwise greedily parses `TRUE`/`FALSE`/`NULL` as a column
+        // name, so those literals were unreachable in expression position. The
+        // literal parser only matches the reserved keywords plus number/string/
+        // date literals, so ordinary column and function names still fall
+        // through to `function_call_or_column`.
+        literal().map(Expr::Literal),
         // Function call or column reference (must come before wildcard check)
         // Pass expr to allow nested function calls like units(sum(position))
         function_call_or_column(expr),
-        // Literals
-        literal().map(Expr::Literal),
         // Wildcard (fallback if nothing else matched)
         just('*').to(Expr::Wildcard),
     ))

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -10103,3 +10103,28 @@ fn test_quarter_returns_year_quarter_string() {
     let result = execute_query("SELECT quarter(max(date))", &directives);
     assert_eq!(result.rows[0][0], Value::String("2020-Q4".to_string()));
 }
+
+#[test]
+fn test_boolean_and_null_literals_in_expressions() {
+    let directives = make_test_directives();
+    // TRUE/FALSE/NULL must parse as literals in expression position; the bare
+    // column parser used to shadow them, yielding "column not found".
+    let total = match execute_query("SELECT count(*)", &directives).rows[0][0] {
+        Value::Integer(n) => n,
+        ref v => panic!("expected integer count, got {v:?}"),
+    };
+    assert_eq!(
+        execute_query("SELECT count(*) WHERE TRUE", &directives).rows[0][0],
+        Value::Integer(total),
+        "WHERE TRUE should match all rows"
+    );
+    assert_eq!(
+        execute_query("SELECT count(*) WHERE FALSE", &directives).rows[0][0],
+        Value::Integer(0),
+        "WHERE FALSE should match no rows"
+    );
+    assert!(matches!(
+        execute_query("SELECT NULL", &directives).rows[0][0],
+        Value::Null
+    ));
+}

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -10109,9 +10109,9 @@ fn test_boolean_and_null_literals_in_expressions() {
     let directives = make_test_directives();
     // TRUE/FALSE/NULL must parse as literals in expression position; the bare
     // column parser used to shadow them, yielding "column not found".
-    let total = match execute_query("SELECT count(*)", &directives).rows[0][0] {
-        Value::Integer(n) => n,
-        ref v => panic!("expected integer count, got {v:?}"),
+    let total = match &execute_query("SELECT count(*)", &directives).rows[0][0] {
+        Value::Integer(n) => *n,
+        v => panic!("expected integer count, got {v:?}"),
     };
     assert_eq!(
         execute_query("SELECT count(*) WHERE TRUE", &directives).rows[0][0],


### PR DESCRIPTION
## What

BQL `NULL`, `TRUE`, and `FALSE` literals were unusable in expression position — e.g. `SELECT count(*) WHERE TRUE` failed with `column 'TRUE' not found`. Found by differential dogfounding (round 3); beanquery accepts them. They worked only in the postfix `IS NULL` form.

## How

In `parser.rs::primary_expr`, the `function_call_or_column` branch ran **before** `literal()`, so a bare `TRUE`/`FALSE`/`NULL` was consumed as a column name and never reached the literal parser. Reorder `literal()` ahead of `function_call_or_column`. The literal parser only matches the reserved keywords plus number/string/date literals, so ordinary column and function names still fall through to `function_call_or_column` — confirmed by the full unchanged parser/executor suite.

## Tests

`test_boolean_and_null_literals_in_expressions`: `WHERE TRUE` matches all rows, `WHERE FALSE` matches none, `SELECT NULL` yields NULL. Full `rustledger-query` suite passes unchanged (no parser regressions); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
