### PR TITLE
fix(query): BQL maxwidth uses textwrap.shorten; parse_date accepts 1 arg

### DIFF
--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -414,7 +414,14 @@ impl Executor<'_> {
         func: &FunctionCall,
         ctx: &PostingContext,
     ) -> Result<Value, QueryError> {
-        Self::require_args("PARSE_DATE", func, 2)?;
+        // beanquery accepts `parse_date(str)` (dateutil) and
+        // `parse_date(str, format)`.
+        if func.args.is_empty() || func.args.len() > 2 {
+            return Err(QueryError::InvalidArguments(
+                "PARSE_DATE".to_string(),
+                "expected 1 or 2 arguments".to_string(),
+            ));
+        }
 
         let string = match self.evaluate_expr(&func.args[0], ctx)? {
             Value::String(s) => s,
@@ -424,23 +431,45 @@ impl Executor<'_> {
                 ));
             }
         };
-        let format = match self.evaluate_expr(&func.args[1], ctx)? {
-            Value::String(s) => s,
-            _ => {
-                return Err(QueryError::Type(
-                    "PARSE_DATE: second argument must be a format string".to_string(),
-                ));
-            }
-        };
 
-        jiff::fmt::strtime::parse(&format, &string)
-            .and_then(|tm| tm.to_date())
-            .map(Value::Date)
-            .map_err(|e| {
-                QueryError::Type(format!(
-                    "PARSE_DATE: cannot parse '{string}' with format '{format}': {e}"
-                ))
-            })
+        // Two-arg form: explicit strftime format.
+        if func.args.len() == 2 {
+            let format = match self.evaluate_expr(&func.args[1], ctx)? {
+                Value::String(s) => s,
+                _ => {
+                    return Err(QueryError::Type(
+                        "PARSE_DATE: second argument must be a format string".to_string(),
+                    ));
+                }
+            };
+            return jiff::fmt::strtime::parse(&format, &string)
+                .and_then(|tm| tm.to_date())
+                .map(Value::Date)
+                .map_err(|e| {
+                    QueryError::Type(format!(
+                        "PARSE_DATE: cannot parse '{string}' with format '{format}': {e}"
+                    ))
+                });
+        }
+
+        // One-arg form: beanquery uses dateutil's flexible parser. We cover the
+        // common ISO / numeric / month-name shapes (including dateutil's
+        // month-first default for ambiguous `MM-DD-YYYY`); full natural-language
+        // parsing is not replicated.
+        if let Ok(d) = string.parse::<NaiveDate>() {
+            return Ok(Value::Date(d));
+        }
+        const FORMATS: &[&str] = &[
+            "%Y/%m/%d", "%m-%d-%Y", "%m/%d/%Y", "%B %d %Y", "%b %d %Y", "%d %B %Y", "%d %b %Y",
+        ];
+        for fmt in FORMATS {
+            if let Ok(d) = jiff::fmt::strtime::parse(fmt, &string).and_then(|tm| tm.to_date()) {
+                return Ok(Value::Date(d));
+            }
+        }
+        Err(QueryError::Type(format!(
+            "PARSE_DATE: cannot parse '{string}' (one-arg parse_date covers ISO/numeric/month-name formats)"
+        )))
     }
 
     /// Evaluate `DATE_BIN` function (bin dates into buckets).

--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -8,6 +8,13 @@ use crate::error::QueryError;
 use super::super::Executor;
 use super::super::types::{Interval, IntervalUnit, PostingContext, Value};
 
+/// strftime formats the one-arg `PARSE_DATE` tries (after ISO `FromStr`),
+/// covering numeric and month-name shapes — `%m-%d-%Y` first so ambiguous
+/// `MM-DD-YYYY` matches dateutil's month-first default.
+const PARSE_DATE_FORMATS: &[&str] = &[
+    "%Y/%m/%d", "%m-%d-%Y", "%m/%d/%Y", "%B %d %Y", "%b %d %Y", "%d %B %Y", "%d %b %Y",
+];
+
 impl Executor<'_> {
     /// Evaluate date functions: `YEAR`, `MONTH`, `DAY`, `WEEKDAY`, `QUARTER`, `YMONTH`, `TODAY`.
     pub(crate) fn eval_date_function(
@@ -459,10 +466,7 @@ impl Executor<'_> {
         if let Ok(d) = string.parse::<NaiveDate>() {
             return Ok(Value::Date(d));
         }
-        const FORMATS: &[&str] = &[
-            "%Y/%m/%d", "%m-%d-%Y", "%m/%d/%Y", "%B %d %Y", "%b %d %Y", "%d %B %Y", "%d %b %Y",
-        ];
-        for fmt in FORMATS {
+        for fmt in PARSE_DATE_FORMATS {
             if let Ok(d) = jiff::fmt::strtime::parse(fmt, &string).and_then(|tm| tm.to_date()) {
                 return Ok(Value::Date(d));
             }

--- a/crates/rustledger-query/src/executor/functions/string.rs
+++ b/crates/rustledger-query/src/executor/functions/string.rs
@@ -8,6 +8,10 @@ use crate::error::QueryError;
 use super::super::Executor;
 use super::super::types::{PostingContext, Value};
 
+/// Ellipsis marker `MAXWIDTH` appends when it shortens text (Python
+/// `textwrap.shorten`'s default `placeholder`, sans the leading space).
+const MAXWIDTH_PLACEHOLDER: &str = "[...]";
+
 impl Executor<'_> {
     /// Evaluate string functions: `LENGTH`, `UPPER`, `LOWER`, `SUBSTR`, `TRIM`, `STARTSWITH`, `ENDSWITH`.
     pub(crate) fn eval_string_function(
@@ -334,13 +338,12 @@ impl Executor<'_> {
         // drop whole trailing words and append the placeholder ` [...]`. A
         // single over-long word collapses to `[...]`. A width too small for the
         // placeholder itself is an error (textwrap raises ValueError).
-        const PLACEHOLDER: &str = "[...]";
         let words: Vec<&str> = string.split_whitespace().collect();
         let collapsed = words.join(" ");
         if collapsed.chars().count() <= n {
             return Ok(Value::String(collapsed));
         }
-        let placeholder_len = PLACEHOLDER.chars().count();
+        let placeholder_len = MAXWIDTH_PLACEHOLDER.chars().count();
         if placeholder_len > n {
             return Err(QueryError::Evaluation(
                 "MAXWIDTH: placeholder too large for max width".to_string(),
@@ -368,9 +371,9 @@ impl Executor<'_> {
             }
         }
         if kept.is_empty() {
-            Ok(Value::String(PLACEHOLDER.to_string()))
+            Ok(Value::String(MAXWIDTH_PLACEHOLDER.to_string()))
         } else {
-            Ok(Value::String(format!("{kept} {PLACEHOLDER}")))
+            Ok(Value::String(format!("{kept} {MAXWIDTH_PLACEHOLDER}")))
         }
     }
 

--- a/crates/rustledger-query/src/executor/functions/string.rs
+++ b/crates/rustledger-query/src/executor/functions/string.rs
@@ -329,13 +329,48 @@ impl Executor<'_> {
             }
         };
 
-        if string.chars().count() <= n {
-            Ok(Value::String(string))
-        } else if n <= 3 {
-            Ok(Value::String(string.chars().take(n).collect()))
+        // Match Python `textwrap.shorten` (beanquery's MAXWIDTH): collapse
+        // runs of whitespace to single spaces, and if the result exceeds `n`,
+        // drop whole trailing words and append the placeholder ` [...]`. A
+        // single over-long word collapses to `[...]`. A width too small for the
+        // placeholder itself is an error (textwrap raises ValueError).
+        const PLACEHOLDER: &str = "[...]";
+        let words: Vec<&str> = string.split_whitespace().collect();
+        let collapsed = words.join(" ");
+        if collapsed.chars().count() <= n {
+            return Ok(Value::String(collapsed));
+        }
+        let placeholder_len = PLACEHOLDER.chars().count();
+        if placeholder_len > n {
+            return Err(QueryError::Evaluation(
+                "MAXWIDTH: placeholder too large for max width".to_string(),
+            ));
+        }
+        // Greedily keep words while "<kept> [...]" still fits in `n`.
+        let mut kept = String::new();
+        let mut kept_len = 0usize;
+        for word in &words {
+            let wlen = word.chars().count();
+            let candidate_len = if kept.is_empty() {
+                wlen
+            } else {
+                kept_len + 1 + wlen
+            };
+            // candidate + a leading-space placeholder (" [...]").
+            if candidate_len + 1 + placeholder_len <= n {
+                if !kept.is_empty() {
+                    kept.push(' ');
+                }
+                kept.push_str(word);
+                kept_len = candidate_len;
+            } else {
+                break;
+            }
+        }
+        if kept.is_empty() {
+            Ok(Value::String(PLACEHOLDER.to_string()))
         } else {
-            let truncated: String = string.chars().take(n - 3).collect();
-            Ok(Value::String(format!("{truncated}...")))
+            Ok(Value::String(format!("{kept} {PLACEHOLDER}")))
         }
     }
 

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -3676,10 +3676,11 @@ mod tests {
         let result = executor.execute(&query).unwrap();
         assert_eq!(result.rows[0][0], Value::String("hello".to_string()));
 
-        // Test MAXWIDTH - truncation with ellipsis
+        // Test MAXWIDTH - textwrap.shorten: neither word fits with the " [...]"
+        // placeholder in width 8, so it collapses to the placeholder alone.
         let query = parse("SELECT maxwidth('hello world', 8)").unwrap();
         let result = executor.execute(&query).unwrap();
-        assert_eq!(result.rows[0][0], Value::String("hello...".to_string()));
+        assert_eq!(result.rows[0][0], Value::String("[...]".to_string()));
     }
 
     #[test]

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -10128,3 +10128,42 @@ fn test_boolean_and_null_literals_in_expressions() {
         Value::Null
     ));
 }
+
+#[test]
+fn test_maxwidth_textwrap_shorten() {
+    let directives = make_test_directives();
+    // MAXWIDTH matches Python textwrap.shorten: collapse whitespace, drop whole
+    // trailing words, append " [...]"; a lone over-long word becomes "[...]".
+    let cases = [
+        (r#"maxwidth("hello world foo", 12)"#, "hello [...]"),
+        (r#"maxwidth("hello world foo", 20)"#, "hello world foo"),
+        (r#"maxwidth("abcdefghij", 5)"#, "[...]"),
+    ];
+    for (q, expected) in cases {
+        let result = execute_query(&format!("SELECT {q}"), &directives);
+        assert_eq!(
+            result.rows[0][0],
+            Value::String(expected.to_string()),
+            "for {q}"
+        );
+    }
+    // Width too small for the placeholder is an error (textwrap ValueError).
+    let _ = execute_query_err(r#"SELECT maxwidth("hello", 3)"#, &directives);
+}
+
+#[test]
+fn test_parse_date_one_arg() {
+    let directives = make_test_directives();
+    // One-arg parse_date covers ISO / numeric / month-name formats, including
+    // dateutil's month-first reading of ambiguous MM-DD-YYYY.
+    let cases = [
+        (r#"parse_date("2021-07-01")"#, (2021, 7, 1)),
+        (r#"parse_date("2021/07/01")"#, (2021, 7, 1)),
+        (r#"parse_date("01-07-2021")"#, (2021, 1, 7)),
+        (r#"parse_date("July 1 2021")"#, (2021, 7, 1)),
+    ];
+    for (q, (y, m, d)) in cases {
+        let result = execute_query(&format!("SELECT {q}"), &directives);
+        assert_eq!(result.rows[0][0], Value::Date(date(y, m, d)), "for {q}");
+    }
+}


### PR DESCRIPTION
## What

Two BQL function correctness bugs (round 3), both diverging from beanquery:

1. **`maxwidth(s, n)` char-truncated** with a trailing `...` instead of Python's `textwrap.shorten`. e.g. `maxwidth("hello world foo", 12)` → rledger `hello wor...`, beanquery `hello [...]`. This is the function behind JOURNAL's payee/narration columns, so long-text cells differed.
2. **`parse_date(s)` (1-arg) was rejected** — rledger required 2 args; beanquery accepts a single string (dateutil).

## How

- `maxwidth`: reimplement as `textwrap.shorten` — collapse whitespace, drop whole trailing words to fit `n`, append ` [...]`; a lone over-long word collapses to `[...]`; a width smaller than the placeholder is an error (textwrap's `ValueError`).
- `parse_date`: accept the 1-arg form, trying ISO (`%Y-%m-%d`), numeric (`%Y/%m/%d`, `%m-%d-%Y` — dateutil's month-first default for ambiguous input, `%m/%d/%Y`), and month-name shapes (`%B %d %Y`, etc.). Full dateutil natural-language parsing isn't replicated; documented in the code + error message.

## Tests

`test_maxwidth_textwrap_shorten` (word-drop, fits-unchanged, lone-word, too-small-error) and `test_parse_date_one_arg` (ISO, slash, ambiguous MM-DD-YYYY, `July 1 2021`). All oracle-verified against bean-query. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
