### PR TITLE
fix(query): resolve filename/lineno columns in the CLI

### DIFF
--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -33,7 +33,7 @@ pub use book::{
 pub use interpolate::{InterpolationError, InterpolationResult, interpolate};
 pub use pad::{
     PadError, PadResult, SYNTH_PAD_NARRATION_PREFIX, is_synthesized_pad, merge_with_padding,
-    process_pads,
+    merge_with_padding_spanned, process_pads,
 };
 
 use bigdecimal::BigDecimal;

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -24,7 +24,7 @@
 
 use rust_decimal::Decimal;
 use rustledger_core::{
-    Amount, Currency, Directive, Inventory, NaiveDate, Pad, Position, Posting, Transaction,
+    Amount, Currency, Directive, Inventory, NaiveDate, Pad, Position, Posting, Spanned, Transaction,
 };
 use std::collections::HashMap;
 use std::ops::Neg;
@@ -342,6 +342,47 @@ pub fn merge_with_padding(directives: &[Directive]) -> Vec<Directive> {
     merged.extend(directives.iter().cloned());
 
     merged.sort_by_key(rustledger_core::Directive::date);
+
+    merged
+}
+
+/// Span-preserving variant of [`merge_with_padding`].
+///
+/// Identical merge behavior, but the input/output keep each directive's
+/// [`Spanned`] wrapper so downstream consumers (e.g. BQL's `filename`/`lineno`
+/// columns) can resolve real source locations. Pad-synthesized transactions
+/// have no source representation, so they are wrapped with
+/// [`Spanned::synthesized`] ([`Span::ZERO`](rustledger_core::Span) +
+/// [`SYNTHESIZED_FILE_ID`](rustledger_core::SYNTHESIZED_FILE_ID)) — exactly how
+/// other synthesized directives (plugin output, etc.) are marked.
+///
+/// # Not idempotent
+///
+/// Same caveat as [`merge_with_padding`]: re-running on its own output
+/// double-counts pad effects.
+#[must_use]
+pub fn merge_with_padding_spanned(directives: &[Spanned<Directive>]) -> Vec<Spanned<Directive>> {
+    let plain: Vec<Directive> = directives.iter().map(|s| s.value.clone()).collect();
+    debug_assert!(
+        !plain
+            .iter()
+            .any(|d| matches!(d, Directive::Transaction(t) if is_synthesized_pad(t))),
+        "merge_with_padding_spanned called on input that already contains synth pad transactions; \
+         re-running would double-count pad effects",
+    );
+
+    let result = process_pads(&plain);
+
+    // Prepend synth transactions (same ordering rationale as the plain variant)
+    // and mark them as synthesized so they resolve to no source location.
+    let mut merged: Vec<Spanned<Directive>> =
+        Vec::with_capacity(directives.len() + result.padding_transactions.len());
+    for txn in result.padding_transactions {
+        merged.push(Spanned::synthesized(Directive::Transaction(txn)));
+    }
+    merged.extend(directives.iter().cloned());
+
+    merged.sort_by_key(|s| s.value.date());
 
     merged
 }

--- a/crates/rustledger/src/cmd/query/interactive.rs
+++ b/crates/rustledger/src/cmd/query/interactive.rs
@@ -3,7 +3,8 @@
 use super::output::execute_query;
 use super::{Args, OutputFormat, SYSTEM_TABLES, ShellSettings};
 use anyhow::Result;
-use rustledger_core::{Directive, DisplayContext};
+use rustledger_core::{Directive, DisplayContext, Spanned};
+use rustledger_loader::SourceMap;
 use rustledger_query::parse as parse_query;
 use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
@@ -23,12 +24,12 @@ fn get_init_path() -> Option<PathBuf> {
 }
 
 /// Count statistics about directives.
-fn count_statistics(directives: &[Directive]) -> (usize, usize, usize) {
+fn count_statistics(directives: &[Spanned<Directive>]) -> (usize, usize, usize) {
     let mut num_transactions = 0;
     let mut num_postings = 0;
 
     for directive in directives {
-        if let Directive::Transaction(txn) = directive {
+        if let Directive::Transaction(txn) = &directive.value {
             num_transactions += 1;
             num_postings += txn.postings.len();
         }
@@ -39,7 +40,8 @@ fn count_statistics(directives: &[Directive]) -> (usize, usize, usize) {
 
 pub(super) fn run_interactive(
     file: &PathBuf,
-    directives: &[Directive],
+    directives: &[Spanned<Directive>],
+    source_map: &SourceMap,
     display_context: &DisplayContext,
     args: &Args,
 ) -> Result<()> {
@@ -90,7 +92,7 @@ pub(super) fn run_interactive(
 
                 // Handle dot-commands
                 if let Some(cmd) = line.strip_prefix('.') {
-                    if handle_dot_command(cmd, &mut settings, directives) {
+                    if handle_dot_command(cmd, &mut settings, directives, source_map) {
                         break;
                     }
                     continue;
@@ -106,7 +108,7 @@ pub(super) fn run_interactive(
                         "warning: commands without \".\" prefix are deprecated. use \".{lower}\" instead"
                     );
 
-                    if handle_dot_command(&lower, &mut settings, directives) {
+                    if handle_dot_command(&lower, &mut settings, directives, source_map) {
                         break;
                     }
                     continue;
@@ -115,7 +117,9 @@ pub(super) fn run_interactive(
                 // Execute as BQL query
                 let result = if let Some(ref output_path) = settings.output_file {
                     match fs::File::create(output_path) {
-                        Ok(mut file) => execute_query(line, directives, &settings, &mut file),
+                        Ok(mut file) => {
+                            execute_query(line, directives, source_map, &settings, &mut file)
+                        }
                         Err(e) => {
                             eprintln!("error: failed to open {}: {}", output_path.display(), e);
                             continue;
@@ -123,7 +127,7 @@ pub(super) fn run_interactive(
                     }
                 } else {
                     let mut stdout = io::stdout();
-                    execute_query(line, directives, &settings, &mut stdout)
+                    execute_query(line, directives, source_map, &settings, &mut stdout)
                 };
                 match result {
                     Ok(()) => {}
@@ -154,7 +158,12 @@ pub(super) fn run_interactive(
 }
 
 /// Returns `true` if the REPL should exit.
-fn handle_dot_command(cmd: &str, settings: &mut ShellSettings, directives: &[Directive]) -> bool {
+fn handle_dot_command(
+    cmd: &str,
+    settings: &mut ShellSettings,
+    directives: &[Spanned<Directive>],
+    source_map: &SourceMap,
+) -> bool {
     let parts: Vec<&str> = cmd.split_whitespace().collect();
     let command = parts.first().map(|s| s.to_lowercase()).unwrap_or_default();
     let args: Vec<&str> = parts.into_iter().skip(1).collect();
@@ -366,9 +375,9 @@ fn handle_dot_command(cmd: &str, settings: &mut ShellSettings, directives: &[Dir
                         println!("Running: {query}");
                         let result = if let Some(ref output_path) = settings.output_file {
                             match fs::File::create(output_path) {
-                                Ok(mut file) => {
-                                    execute_query(query, directives, settings, &mut file)
-                                }
+                                Ok(mut file) => execute_query(
+                                    query, directives, source_map, settings, &mut file,
+                                ),
                                 Err(e) => {
                                     eprintln!(
                                         "error: failed to open {}: {}",
@@ -380,7 +389,7 @@ fn handle_dot_command(cmd: &str, settings: &mut ShellSettings, directives: &[Dir
                             }
                         } else {
                             let mut stdout = io::stdout();
-                            execute_query(query, directives, settings, &mut stdout)
+                            execute_query(query, directives, source_map, settings, &mut stdout)
                         };
                         if let Err(e) = result {
                             eprintln!("error: {e:#}");

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -17,7 +17,7 @@ mod output;
 use crate::cmd::completions::ShellType;
 use anyhow::{Context, Result};
 use clap::Parser;
-use rustledger_booking::merge_with_padding;
+use rustledger_booking::merge_with_padding_spanned;
 use rustledger_core::DisplayContext;
 use rustledger_loader::LoadOptions;
 use std::fs;
@@ -165,18 +165,19 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
         eprintln!();
     }
 
-    // Get directives (already booked and plugins applied)
-    let booked_directives: Vec<_> = ledger.directives.into_iter().map(|s| s.value).collect();
-
     // Merge pad-synthesized transactions into the directive stream
-    // (BQL is a balance-computing consumer). `merge_with_padding`
-    // preserves the original Pad directives in the output so
-    // `FROM #entries WHERE type = 'pad'` audits still enumerate them,
-    // AND handles multi-pad shadowing (#1300) correctly by
-    // construction via `process_pads`.
-    let directives = merge_with_padding(&booked_directives);
+    // (BQL is a balance-computing consumer). The span-preserving variant keeps
+    // each directive's source `Spanned` wrapper so the query engine can resolve
+    // the `filename`/`lineno` columns (pad-synth transactions are marked
+    // synthesized → no source location). `merge_with_padding_spanned` preserves
+    // the original Pad directives in the output so `FROM #entries WHERE type =
+    // 'pad'` audits still enumerate them, AND handles multi-pad shadowing
+    // (#1300) correctly by construction via `process_pads`.
+    let directives = merge_with_padding_spanned(&ledger.directives);
 
-    // Use display context from the loaded ledger
+    // Source map + display context from the loaded ledger (used for source-
+    // location columns and number formatting respectively).
+    let source_map = ledger.source_map;
     let display_context = ledger.display_context;
 
     if args.verbose {
@@ -208,7 +209,13 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
             .with_context(|| format!("failed to read query file {}", query_file.display()))?
     } else {
         // Interactive mode
-        return interactive::run_interactive(file, &directives, &display_context, args);
+        return interactive::run_interactive(
+            file,
+            &directives,
+            &source_map,
+            &display_context,
+            args,
+        );
     };
 
     // Batch query: no pager (matching Python bean-query behavior).
@@ -217,9 +224,9 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
     if let Some(ref output_path) = settings.output_file {
         let mut file = fs::File::create(output_path)
             .with_context(|| format!("failed to create output file {}", output_path.display()))?;
-        output::execute_query(&query_str, &directives, &settings, &mut file)
+        output::execute_query(&query_str, &directives, &source_map, &settings, &mut file)
     } else {
-        output::execute_query(&query_str, &directives, &settings, out)
+        output::execute_query(&query_str, &directives, &source_map, &settings, out)
     }
 }
 

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -2,7 +2,8 @@
 
 use super::ShellSettings;
 use anyhow::{Context, Result};
-use rustledger_core::{Directive, DisplayContext};
+use rustledger_core::{Directive, DisplayContext, Spanned};
+use rustledger_loader::SourceMap;
 use rustledger_query::{Executor, Value, parse as parse_query};
 use std::io::Write;
 
@@ -18,15 +19,18 @@ const MAX_COLUMN_WIDTH: usize = u16::MAX as usize;
 
 pub(super) fn execute_query<W: Write>(
     query_str: &str,
-    directives: &[Directive],
+    directives: &[Spanned<Directive>],
+    source_map: &SourceMap,
     settings: &ShellSettings,
     writer: &mut W,
 ) -> Result<()> {
     // Parse the query
     let query = parse_query(query_str).with_context(|| "failed to parse query")?;
 
-    // Execute
-    let mut executor = Executor::new(directives);
+    // Execute. Use the source-map-aware constructor so the `filename`/`lineno`
+    // columns (and `meta`-derived location lookups) resolve to real source
+    // positions instead of NULL.
+    let mut executor = Executor::new_with_sources(directives, source_map);
     let result = executor
         .execute(&query)
         .with_context(|| "failed to execute query")?;

--- a/crates/rustledger/tests/integration_test.rs
+++ b/crates/rustledger/tests/integration_test.rs
@@ -740,3 +740,49 @@ fn test_beancount_canonical_example_matches_python() {
         "Rust should match Python on example.beancount: {rs_output}"
     );
 }
+
+#[test]
+fn test_query_filename_lineno_columns_resolve() {
+    // Regression: `SELECT filename, lineno` used to return NULL from the CLI
+    // because the query command built the executor without a source map.
+    let Some(binary) = rledger_binary() else {
+        eprintln!("Skipping: rledger binary not found");
+        return;
+    };
+    // Transaction is on line 3 (two opens precede it).
+    let content = "2020-01-01 open Assets:Cash USD\n\
+                   2020-01-01 open Equity:O USD\n\
+                   2020-02-01 * \"p\"\n  \
+                     Assets:Cash  10.00 USD\n  \
+                     Equity:O\n";
+    let temp_file = std::env::temp_dir().join("query-filename-lineno-test.beancount");
+    std::fs::write(&temp_file, content).expect("write temp file");
+
+    let output = Command::new(binary)
+        .arg("query")
+        .arg(&temp_file)
+        .arg("SELECT filename, lineno WHERE flag = \"*\"")
+        .output()
+        .expect("run rledger query");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "query should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // filename resolves to the real path (was empty/NULL before the fix).
+    assert!(
+        stdout.contains("query-filename-lineno-test.beancount"),
+        "expected the source filename in output, got:\n{stdout}"
+    );
+    // lineno resolves to 3 (the transaction's line).
+    assert!(
+        stdout
+            .lines()
+            .any(|l| l.contains(".beancount") && l.trim_end().ends_with('3')),
+        "expected lineno 3 on the directive's row, got:\n{stdout}"
+    );
+
+    std::fs::remove_file(&temp_file).ok();
+}


### PR DESCRIPTION
## What

BQL `SELECT filename, lineno` (and `location`, `getitem(meta,'lineno')`) returned **NULL** from `rledger query`; bean-query returns the real source path + line number. Found by BQL dogfounding (round 3).

## Root cause

The query *engine* supports source locations via `Executor::new_with_sources(spanned_directives, source_map)`, but the CLI never used it: `cmd/query/mod.rs` stripped the `Spanned` wrappers (`ledger.directives.into_iter().map(|s| s.value)`) before booking and called `Executor::new` (no source map), so the location columns had nothing to resolve.

## How

- New span-preserving `merge_with_padding_spanned` in `rustledger-booking`: same merge behavior as `merge_with_padding`, but keeps each directive's `Spanned` wrapper; pad-synthesized transactions (no source) are marked with `Spanned::synthesized` (`Span::ZERO` + `SYNTHESIZED_FILE_ID`) → they resolve to no location, exactly like other synthesized directives.
- CLI `query`: keep `ledger.directives` (spanned) + `ledger.source_map`, merge via the spanned variant, and thread both through `execute_query` → `Executor::new_with_sources`. Updated `run_interactive`, `handle_dot_command`, and `count_statistics` accordingly (all 6 `execute_query` call sites).

## Tests

`test_query_filename_lineno_columns_resolve` (CLI e2e): `SELECT filename, lineno` returns the real path + line 3 for the transaction (was empty). `rustledger-booking` and `rustledger-query` suites pass unchanged; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
