### PR TITLE
fix(query): PRINT falls back to spanned_directives (was empty in CLI)

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -1019,7 +1019,18 @@ impl Executor<'_> {
         let columns = vec!["directive".to_string()];
         let mut result = QueryResult::new(columns);
 
-        for directive in self.directives {
+        // Iterate whichever directive source is populated: when the Executor is
+        // built via `new_with_sources` (e.g. the CLI, source-mapped queries),
+        // `self.directives` is empty and the data lives in `spanned_directives`
+        // — same fallback as the system-table builders. Without this, PRINT
+        // returned zero rows in the CLI.
+        let all_directives: Vec<&Directive> = if let Some(spanned) = self.spanned_directives {
+            spanned.iter().map(|s| &s.value).collect()
+        } else {
+            self.directives.iter().collect()
+        };
+
+        for directive in all_directives {
             // Apply FROM clause filter if present
             if let Some(from) = &query.from
                 && let Some(filter) = &from.filter

--- a/crates/rustledger/tests/integration_test.rs
+++ b/crates/rustledger/tests/integration_test.rs
@@ -800,12 +800,16 @@ fn test_query_print_outputs_directives() {
                    2020-02-01 * \"p\"\n  \
                      Assets:Cash  10.00 USD\n  \
                      Equity:O\n";
-    let temp_file = std::env::temp_dir().join("query-print-test.beancount");
-    std::fs::write(&temp_file, content).expect("write temp file");
+    // Unique temp file (auto-removed on drop) to avoid cross-run collisions.
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".beancount")
+        .tempfile()
+        .expect("create temp file");
+    std::io::Write::write_all(&mut tmp, content.as_bytes()).expect("write temp file");
 
     let output = Command::new(binary)
         .arg("query")
-        .arg(&temp_file)
+        .arg(tmp.path())
         .arg("PRINT")
         .output()
         .expect("run rledger query PRINT");
@@ -821,6 +825,4 @@ fn test_query_print_outputs_directives() {
         stdout.contains("open Assets:Cash"),
         "PRINT should emit directives, got:\n{stdout}"
     );
-
-    std::fs::remove_file(&temp_file).ok();
 }

--- a/crates/rustledger/tests/integration_test.rs
+++ b/crates/rustledger/tests/integration_test.rs
@@ -786,3 +786,41 @@ fn test_query_filename_lineno_columns_resolve() {
 
     std::fs::remove_file(&temp_file).ok();
 }
+
+#[test]
+fn test_query_print_outputs_directives() {
+    // Regression: PRINT returned 0 rows from the CLI after the executor switched
+    // to new_with_sources (execute_print didn't fall back to spanned_directives).
+    let Some(binary) = rledger_binary() else {
+        eprintln!("Skipping: rledger binary not found");
+        return;
+    };
+    let content = "2020-01-01 open Assets:Cash USD\n\
+                   2020-01-01 open Equity:O USD\n\
+                   2020-02-01 * \"p\"\n  \
+                     Assets:Cash  10.00 USD\n  \
+                     Equity:O\n";
+    let temp_file = std::env::temp_dir().join("query-print-test.beancount");
+    std::fs::write(&temp_file, content).expect("write temp file");
+
+    let output = Command::new(binary)
+        .arg("query")
+        .arg(&temp_file)
+        .arg("PRINT")
+        .output()
+        .expect("run rledger query PRINT");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "PRINT should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // PRINT must emit the directives (was empty before the fix).
+    assert!(
+        stdout.contains("open Assets:Cash"),
+        "PRINT should emit directives, got:\n{stdout}"
+    );
+
+    std::fs::remove_file(&temp_file).ok();
+}


### PR DESCRIPTION
## What

`PRINT` (and `PRINT FROM …`) returned **0 rows** from `rledger query` — it emitted only a `directive` header. bean-query prints all directives.

## Root cause (regression from #1506)

`execute_print` iterates `self.directives`, but the CLI builds the executor via `Executor::new_with_sources` (added in #1506 for the `filename`/`lineno` columns), which stores directives in `spanned_directives` and leaves `self.directives` empty. The system-table builders and other shorthands already fall back to `spanned_directives`; `execute_print` was the one path that didn't, so it saw an empty slice.

## How

Add the same `spanned_directives` fallback the sibling methods use, so `execute_print` iterates whichever source is populated.

## Tests

`test_query_print_outputs_directives` (CLI e2e): `PRINT` emits the directives (was empty). Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
