### PR TITLE
fix(query): getitem(meta) in eager path; integer modulo floored sign

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1371,9 +1371,20 @@ impl<'a> Executor<'a> {
                             Ok(Value::Amount(Amount::new(amount, currency.as_str())))
                         }
                     }
+                    // Metadata / object lookup — mirror the per-row path
+                    // (`eval_getitem`). Previously only the lazy path handled
+                    // these, so `getitem(meta, key)` errored in the eager /
+                    // `#postings` evaluation path.
+                    (Value::Metadata(meta), Value::String(key)) => {
+                        Ok(Self::meta_value_to_value(meta.get(key)))
+                    }
+                    (Value::Object(obj), Value::String(key)) => {
+                        Ok(obj.get(key).cloned().unwrap_or(Value::Null))
+                    }
                     (Value::Null, _) => Ok(Value::Null),
                     _ => Err(QueryError::Type(
-                        "GETITEM expects (inventory, string)".to_string(),
+                        "GETITEM expects (inventory, string), (metadata, string), or (object, string)"
+                            .to_string(),
                     )),
                 }
             }
@@ -3533,6 +3544,81 @@ mod tests {
         let query = parse("SELECT meta('nonexistent') WHERE account ~ 'Expenses'").unwrap();
         let result = executor.execute(&query).unwrap();
         assert_eq!(result.rows[0][0], Value::Null);
+    }
+
+    #[test]
+    fn test_getitem_meta_eager_path_postings() {
+        // Regression: getitem(meta, key) errored in the eager / `#postings`
+        // path (only the per-row/lazy path handled metadata). `FROM #postings`
+        // routes the function through `evaluate_function_on_values`.
+        let mut posting_meta: Metadata = Metadata::default();
+        posting_meta.insert(
+            "category".to_string(),
+            MetaValue::String("food".to_string()),
+        );
+        let txn = Transaction {
+            date: date(2024, 1, 15),
+            flag: '*',
+            payee: None,
+            narration: "Coffee".into(),
+            tags: vec![],
+            links: vec![],
+            meta: Metadata::default(),
+            postings: vec![
+                rustledger_core::Spanned::synthesized(Posting {
+                    account: "Expenses:Food".into(),
+                    units: Some(rustledger_core::IncompleteAmount::Complete(Amount::new(
+                        dec!(5),
+                        "USD",
+                    ))),
+                    cost: None,
+                    price: None,
+                    flag: None,
+                    meta: posting_meta,
+                    comments: Vec::new(),
+                    trailing_comments: Vec::new(),
+                }),
+                rustledger_core::Spanned::synthesized(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-5), "USD"),
+                )),
+            ],
+            trailing_comments: Vec::new(),
+        };
+        let directives = vec![Directive::Transaction(txn)];
+        let mut executor = Executor::new(&directives);
+        let query =
+            parse("SELECT getitem(meta, 'category') FROM #postings WHERE account ~ 'Expenses'")
+                .unwrap();
+        let result = executor.execute(&query).unwrap();
+        assert_eq!(result.rows[0][0], Value::String("food".to_string()));
+    }
+
+    #[test]
+    fn test_integer_modulo_floored_sign() {
+        // Integer `%` uses Python floored modulo (sign follows the divisor);
+        // decimal `%` stays truncated (matching Python `Decimal`).
+        let directives = vec![Directive::Transaction(
+            Transaction::new(date(2024, 1, 1), "x")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(1), "USD"))),
+        )];
+        let mut executor = Executor::new(&directives);
+        for (q, expected) in [
+            ("-5 % 3", 1i64),
+            ("5 % -3", -1),
+            ("-7 % 4", 1),
+            ("7 % -4", -1),
+        ] {
+            let r = executor
+                .execute(&parse(&format!("SELECT {q}")).unwrap())
+                .unwrap();
+            assert_eq!(r.rows[0][0], Value::Integer(expected), "for {q}");
+        }
+        // Decimal modulo is unchanged (truncated).
+        let r = executor
+            .execute(&parse("SELECT -5.0 % 3").unwrap())
+            .unwrap();
+        assert_eq!(r.rows[0][0], Value::Number(dec!(-2)));
     }
 
     #[test]

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -184,7 +184,7 @@ impl Executor<'_> {
             }
             BinaryOperator::Mul => self.arithmetic_op(&left, &right, |a, b| Some(a * b)),
             BinaryOperator::Div => self.arithmetic_op(&left, &right, Decimal::checked_div),
-            BinaryOperator::Mod => self.arithmetic_op(&left, &right, Decimal::checked_rem),
+            BinaryOperator::Mod => self.modulo_op(&left, &right),
         }
     }
 
@@ -299,6 +299,24 @@ impl Executor<'_> {
         // beanquery, which produces NULL rather than raising — and crucially
         // avoid the underlying `rust_decimal` panic on `a / 0`.
         Ok(op(a, b).map_or(Value::Null, Value::Number))
+    }
+
+    /// Modulo (`%`) matching beanquery/Python semantics.
+    ///
+    /// Integers use Python's FLOORED modulo (the result's sign follows the
+    /// divisor): `-5 % 3 == 1`, `5 % -3 == -1`. Decimal operands keep truncated
+    /// remainder, which matches Python's `Decimal.__mod__`. A zero divisor
+    /// yields NULL (consistent with division). The previous code applied
+    /// `Decimal::checked_rem` to integers too, giving the truncated (wrong) sign.
+    pub(super) fn modulo_op(&self, left: &Value, right: &Value) -> Result<Value, QueryError> {
+        if let (Value::Integer(a), Value::Integer(b)) = (left, right) {
+            return Ok(if *b == 0 {
+                Value::Null
+            } else {
+                Value::Integer(((a % b) + b) % b)
+            });
+        }
+        self.arithmetic_op(left, right, Decimal::checked_rem)
     }
 
     /// Convert a value to boolean using SQL/beanquery truthiness rules.
@@ -485,7 +503,7 @@ impl Executor<'_> {
             }
             BinaryOperator::Mul => self.arithmetic_op(left, right, |a, b| Some(a * b)),
             BinaryOperator::Div => self.arithmetic_op(left, right, Decimal::checked_div),
-            BinaryOperator::Mod => self.arithmetic_op(left, right, Decimal::checked_rem),
+            BinaryOperator::Mod => self.modulo_op(left, right),
         }
     }
 

--- a/crates/rustledger-query/src/executor/operators.rs
+++ b/crates/rustledger-query/src/executor/operators.rs
@@ -310,11 +310,26 @@ impl Executor<'_> {
     /// `Decimal::checked_rem` to integers too, giving the truncated (wrong) sign.
     pub(super) fn modulo_op(&self, left: &Value, right: &Value) -> Result<Value, QueryError> {
         if let (Value::Integer(a), Value::Integer(b)) = (left, right) {
-            return Ok(if *b == 0 {
-                Value::Null
+            let (a, b) = (*a, *b);
+            if b == 0 {
+                return Ok(Value::Null);
+            }
+            // `i64::MIN % -1` overflows the truncated remainder but is
+            // mathematically 0 (every integer is divisible by -1), so map the
+            // overflow case to 0.
+            let Some(rem) = a.checked_rem(b) else {
+                return Ok(Value::Integer(0));
+            };
+            // Floored modulo: when the truncated remainder's sign differs from
+            // the divisor's, shift by the divisor. This `rem + b` cannot
+            // overflow — in the differing-sign branch `|rem| < |b|`, so the sum
+            // stays within range and takes the divisor's sign.
+            let result = if rem != 0 && (rem < 0) != (b < 0) {
+                rem + b
             } else {
-                Value::Integer(((a % b) + b) % b)
-            });
+                rem
+            };
+            return Ok(Value::Integer(result));
         }
         self.arithmetic_op(left, right, Decimal::checked_rem)
     }


### PR DESCRIPTION
## What

Two BQL correctness bugs found in round-4 differential dogfounding, both in the eager / aggregate / `#postings` evaluation path (`evaluate_function_on_values` / operators):

1. **`getitem(meta, key)` errored** in the eager path — `getitem(meta,'k') FROM #postings` → `type error: GETITEM expects (inventory, string)`. The per-row (lazy) path handles `Metadata`/`Object` (round-3 fix); the eager copy never got those arms.
2. **Integer `%` used truncated sign**, not Python's floored modulo. `-5 % 3` → `-2` (should be `1`); `5 % -3` → `2` (should be `-1`). beanquery (Python `int`) floors; `Decimal::checked_rem` truncates. (Decimal `%` correctly stays truncated — Python `Decimal` also truncates.)

## How

- `getitem`: add the `Metadata`/`Object` arms to the eager `GETITEM` (mirrors `eval_getitem`).
- `%`: new `modulo_op` — integer operands use floored modulo `((a % b) + b) % b` (zero divisor → NULL, like division); decimal operands keep `checked_rem`. Both `Mod` arms route through it.

## Tests

`test_getitem_meta_eager_path_postings` (getitem on posting metadata via `#postings`) and `test_integer_modulo_floored_sign` (`-5%3=1`, `5%-3=-1`, `-7%4=1`, `7%-4=-1`; decimal `-5.0%3=-2`). All oracle-verified against bean-query. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
