### PR TITLE
fix(query): expose filename/lineno as synthetic metadata keys

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -380,7 +380,10 @@ impl Executor<'_> {
                 ))
             }
             // Posting metadata as dictionary
-            "meta" => Ok(Value::Metadata(Box::new(posting.meta.clone()))),
+            "meta" => Ok(Value::Metadata(Box::new(Self::augmented_meta(
+                &posting.meta,
+                self.resolved_source_location(ctx).as_ref(),
+            )))),
             // Source location columns — resolved from the posting's own span
             // (falling back to the enclosing directive's location).
             "filename" => Ok(self

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -3,13 +3,13 @@
 //! This module includes metadata, conversion, casting, and helper functions.
 
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, Inventory, MetaValue, Position};
+use rustledger_core::{Amount, Inventory, MetaValue, Metadata, Position};
 
 use crate::ast::FunctionCall;
 use crate::error::QueryError;
 
 use super::super::Executor;
-use super::super::types::{PostingContext, Value};
+use super::super::types::{PostingContext, SourceLocation, Value};
 
 impl Executor<'_> {
     /// Evaluate metadata functions: `META`, `ENTRY_META`, `ANY_META`.
@@ -36,17 +36,65 @@ impl Executor<'_> {
 
         let posting = &ctx.transaction.postings[ctx.posting_index];
 
+        // beanquery exposes `filename`/`lineno` as members of a posting's /
+        // entry's metadata. Resolve them per scope: posting metadata carries
+        // the POSTING's location, entry metadata the enclosing directive's.
+        let posting_loc = self.resolved_source_location(ctx);
+        let entry_loc = ctx
+            .directive_index
+            .and_then(|i| self.get_source_location(i).cloned());
+
         let meta_value = match name {
-            "META" | "POSTING_META" => posting.meta.get(&key),
-            "ENTRY_META" => ctx.transaction.meta.get(&key),
-            "ANY_META" => posting
-                .meta
-                .get(&key)
-                .or_else(|| ctx.transaction.meta.get(&key)),
+            "META" | "POSTING_META" => Self::meta_lookup(&posting.meta, posting_loc.as_ref(), &key),
+            "ENTRY_META" => Self::meta_lookup(&ctx.transaction.meta, entry_loc.as_ref(), &key),
+            "ANY_META" => Self::meta_lookup(&posting.meta, posting_loc.as_ref(), &key)
+                .or_else(|| Self::meta_lookup(&ctx.transaction.meta, entry_loc.as_ref(), &key)),
             _ => unreachable!(),
         };
 
-        Ok(Self::meta_value_to_value(meta_value))
+        Ok(Self::meta_value_to_value(meta_value.as_ref()))
+    }
+
+    /// beanquery's parser injects `filename` and `lineno` into every posting's
+    /// and entry's metadata dict. rledger keeps source location in spans, not in
+    /// the meta map, so synthesize those two keys at the BQL boundary from the
+    /// resolved location. A user-defined key of the same name wins (callers
+    /// consult the raw map first).
+    fn source_location_meta_key(loc: Option<&SourceLocation>, key: &str) -> Option<MetaValue> {
+        let loc = loc?;
+        match key {
+            "filename" => Some(MetaValue::String(loc.filename.clone())),
+            // There is no integer `MetaValue`; `Number(Decimal)` renders as `4`
+            // and compares numerically, matching beanquery's integer lineno.
+            "lineno" => Some(MetaValue::Number(Decimal::from(loc.lineno as u64))),
+            _ => None,
+        }
+    }
+
+    /// Look up a single metadata key, falling back to the synthetic
+    /// source-location keys (`filename`/`lineno`) when absent from `raw`.
+    fn meta_lookup(raw: &Metadata, loc: Option<&SourceLocation>, key: &str) -> Option<MetaValue> {
+        raw.get(key)
+            .cloned()
+            .or_else(|| Self::source_location_meta_key(loc, key))
+    }
+
+    /// Return `raw` extended with beanquery's synthetic `filename`/`lineno`
+    /// metadata keys resolved from `loc` (existing user keys win). Used to
+    /// materialize the full `meta` column value.
+    pub(crate) fn augmented_meta(raw: &Metadata, loc: Option<&SourceLocation>) -> Metadata {
+        if loc.is_none() {
+            return raw.clone();
+        }
+        let mut meta = raw.clone();
+        for key in ["filename", "lineno"] {
+            if !meta.contains_key(key)
+                && let Some(value) = Self::source_location_meta_key(loc, key)
+            {
+                meta.insert(key.to_string(), value);
+            }
+        }
+        meta
     }
 
     /// Convert a `MetaValue` to a `Value`.

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2588,13 +2588,9 @@ impl<'a> Executor<'a> {
 
         for (dir_idx, txn) in &transactions {
             // Pre-compute transaction-level values shared across all postings
+            // Transaction-level location — used as the per-posting fallback
+            // below (for synthesized postings / no source map).
             let source_loc = self.get_source_location(*dir_idx);
-            let filename =
-                source_loc.map_or(Value::Null, |loc| Value::String(loc.filename.clone()));
-            let lineno = source_loc.map_or(Value::Null, |loc| Value::Integer(loc.lineno as i64));
-            let location = source_loc.map_or(Value::Null, |loc| {
-                Value::String(format!("{}:{}", loc.filename, loc.lineno))
-            });
 
             let tags: Vec<String> = txn.tags.iter().map(ToString::to_string).collect();
             let links: Vec<String> = txn.links.iter().map(ToString::to_string).collect();
@@ -2618,18 +2614,22 @@ impl<'a> Executor<'a> {
             let day = Value::Integer(i64::from(txn.date.day()));
 
             for posting in &txn.postings {
-                // Per-posting source location, falling back to the txn-level
-                // values when the posting has no real span (synthesized) or no
-                // source map is available. Shadows the txn-level bindings.
-                let (filename, lineno, location) =
-                    match self.span_source_location(posting.file_id, posting.span.start) {
-                        Some(loc) => (
-                            Value::String(loc.filename.clone()),
-                            Value::Integer(loc.lineno as i64),
-                            Value::String(format!("{}:{}", loc.filename, loc.lineno)),
-                        ),
-                        None => (filename.clone(), lineno.clone(), location.clone()),
-                    };
+                // Per-posting source location (the posting's own span), falling
+                // back to the transaction's when the posting has no real span
+                // (synthesized) or no source map is available. The single
+                // resolved location feeds both the location columns and the
+                // synthetic `filename`/`lineno` metadata keys below.
+                let posting_loc = self
+                    .span_source_location(posting.file_id, posting.span.start)
+                    .or_else(|| source_loc.cloned());
+                let (filename, lineno, location) = match posting_loc.as_ref() {
+                    Some(loc) => (
+                        Value::String(loc.filename.clone()),
+                        Value::Integer(loc.lineno as i64),
+                        Value::String(format!("{}:{}", loc.filename, loc.lineno)),
+                    ),
+                    None => (Value::Null, Value::Null, Value::Null),
+                };
 
                 // Update running balances (per-account and cumulative).
                 if let Some(units) = posting.amount() {
@@ -2753,7 +2753,10 @@ impl<'a> Executor<'a> {
                     balance_val,
                     account_balance_val,
                     // Metadata and collection
-                    Value::Metadata(Box::new(posting.meta.clone())),
+                    Value::Metadata(Box::new(Self::augmented_meta(
+                        &posting.meta,
+                        posting_loc.as_ref(),
+                    ))),
                     Value::StringSet(all_accounts.clone()),
                     // Hidden metadata columns
                     Self::metadata_to_value(&txn.meta),
@@ -4115,6 +4118,96 @@ mod tests {
             .unwrap();
         assert_eq!(result.rows[0][0], Value::Integer(2));
         assert_eq!(result.rows[1][0], Value::Integer(3));
+    }
+
+    #[test]
+    fn test_meta_includes_source_location() {
+        use rustledger_loader::SourceMap;
+        use rustledger_parser::{Span, Spanned};
+        use std::sync::Arc;
+
+        let source: Arc<str> =
+            "2024-01-15 * \"Test\"\n  Assets:Bank  100 USD\n  Expenses:Food  -100 USD".into();
+        let mut source_map = SourceMap::new();
+        let file_id = source_map.add_file("test.beancount".into(), source) as u16;
+
+        // Posting 1 (line 2) carries a user `category` key; posting 2 (line 3)
+        // has none.
+        let mut p1_meta = Metadata::default();
+        p1_meta.insert(
+            "category".to_string(),
+            MetaValue::String("food".to_string()),
+        );
+        let txn = Transaction {
+            date: rustledger_core::naive_date(2024, 1, 15).unwrap(),
+            flag: '*',
+            payee: Some("Test".into()),
+            narration: "Test".into(),
+            tags: vec![],
+            links: vec![],
+            meta: Metadata::default(),
+            postings: vec![
+                Spanned {
+                    value: Posting {
+                        account: "Assets:Bank".into(),
+                        units: Some(rustledger_core::IncompleteAmount::Complete(Amount::new(
+                            dec!(100),
+                            "USD",
+                        ))),
+                        cost: None,
+                        price: None,
+                        flag: None,
+                        meta: p1_meta,
+                        comments: Vec::new(),
+                        trailing_comments: Vec::new(),
+                    },
+                    span: Span { start: 20, end: 42 },
+                    file_id,
+                },
+                Spanned {
+                    value: Posting::new("Expenses:Food", Amount::new(dec!(-100), "USD")),
+                    span: Span { start: 43, end: 67 },
+                    file_id,
+                },
+            ],
+            trailing_comments: Vec::new(),
+        };
+        let spanned = vec![Spanned {
+            value: Directive::Transaction(txn),
+            span: Span { start: 0, end: 67 },
+            file_id,
+        }];
+        let mut executor = Executor::new_with_sources(&spanned, &source_map);
+
+        // meta() exposes synthetic filename/lineno per posting. (lineno is a
+        // Number — there is no integer MetaValue; the dedicated `lineno` column
+        // is Integer.)
+        let r = executor
+            .execute(&parse("SELECT meta('filename'), meta('lineno')").unwrap())
+            .unwrap();
+        assert_eq!(r.rows[0][0], Value::String("test.beancount".to_string()));
+        assert_eq!(r.rows[0][1], Value::Number(dec!(2)));
+        assert_eq!(r.rows[1][1], Value::Number(dec!(3)));
+
+        // entry_meta uses the ENTRY (directive) line, not the posting's.
+        let r = executor
+            .execute(&parse("SELECT entry_meta('lineno')").unwrap())
+            .unwrap();
+        assert_eq!(r.rows[0][0], Value::Number(dec!(1)));
+
+        // A user meta key still resolves and takes precedence.
+        let r = executor
+            .execute(&parse("SELECT meta('category') WHERE account ~ 'Bank'").unwrap())
+            .unwrap();
+        assert_eq!(r.rows[0][0], Value::String("food".to_string()));
+
+        // The full meta column is augmented; getitem over it (and via #postings)
+        // sees the synthetic keys.
+        let r = executor
+            .execute(&parse("SELECT getitem(meta, 'lineno') FROM #postings").unwrap())
+            .unwrap();
+        assert_eq!(r.rows[0][0], Value::Number(dec!(2)));
+        assert_eq!(r.rows[1][0], Value::Number(dec!(3)));
     }
 
     #[test]


### PR DESCRIPTION
## What

The `meta` column rendered `{}` for postings with no user metadata and omitted beanquery's `filename`/`lineno` keys; `meta('filename')`/`meta('lineno')` and `getitem(meta, …)` couldn't see them either. beanquery's parser injects `filename`/`lineno` into every posting's/entry's metadata, so `SELECT meta` shows `{'filename': …, 'lineno': N}`.

Found in round-4 BQL dogfounding (#5b). Builds on the per-posting source-location resolution from #1510.

## Design (why it's a shared view, not a 2-site patch)

rledger deliberately keeps source location in **spans** (`file_id` + offset), not in the meta map (beancount's per-entry filename-string model is exactly the memory cost rledger avoids). So `filename`/`lineno`-in-meta is a **compatibility view synthesized at the BQL boundary**, from a single resolver — not injected at load time, and not patched ad-hoc at each `Value::Metadata` site (which would leave `meta` the column augmented but `meta()`/`entry_meta()` reading raw maps — a split-brain).

One shared helper set, scope-aware:
- `source_location_meta_key(loc, key)` → the synthetic `filename`/`lineno` for a location.
- `meta_lookup(raw, loc, key)` — single-key access; **user keys win** (raw map consulted first).
- `augmented_meta(raw, loc)` — materializes the full `meta` column (user keys win).

Routed through **every** accessor with the correct scope:
- `META`/`POSTING_META`/`ANY_META` → posting location (the posting's own line).
- `ENTRY_META` → the entry/directive location (the transaction's line).
- `meta` column (default path **and** `#postings`) → `augmented_meta`.
- `getitem(meta, …)` rides on the (now augmented) column value — no separate change.

All derive from #1510's single location resolver, so values agree with the `filename`/`lineno` columns.

## Notes / deliberate choices

- `lineno` via the meta surface is a `Number` (there is no integer `MetaValue`); the dedicated `lineno` **column** stays `Integer`. `Number(Decimal)` renders `4` and compares numerically — beanquery-compatible.
- User-defined `filename`/`lineno` keys take precedence (raw map first). 

## Tests

`test_meta_includes_source_location`: `meta('filename')`/`meta('lineno')` per-posting; `entry_meta('lineno')` = entry line (scope); user key wins; `getitem(meta,'lineno')` augmented over `#postings`. Values verified against bean-query's `SELECT meta`. Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
