### PR TITLE
fix(query): balance in #postings is a post-WHERE running total

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -3,7 +3,7 @@
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use rustledger_core::{Amount, Directive, NaiveDate, Position};
+use rustledger_core::{Amount, Directive, Inventory, NaiveDate, Position};
 
 /// Threshold for parallel row evaluation. Below this, sequential is faster.
 const PARALLEL_THRESHOLD: usize = 1000;
@@ -469,6 +469,23 @@ impl Executor<'_> {
             FxHashSet::default()
         };
 
+        // `balance` is a running total over the post-WHERE output stream, in
+        // table (entry) order — a streaming window column, not a property of a
+        // posting. The materialized table carries an UNFILTERED snapshot, which
+        // is wrong the moment WHERE drops rows that carry other commodities
+        // (e.g. `... WHERE account = "Assets:Bank"` must not see the AAPL leg of
+        // a stock purchase). Recompute it here over the surviving rows, in entry
+        // order, before ORDER BY — mirroring the default path's `collect_postings`.
+        // Gated so non-balance queries pay nothing (the per-row Inventory clone
+        // was the #1080 hot path). `account_balance` is intentionally NOT
+        // recomputed: it is the account's true ledger balance across all postings.
+        let balance_idx = column_map.get("balance").copied();
+        let position_idx = column_map.get("position").copied();
+        let track_balance = balance_idx.is_some()
+            && position_idx.is_some()
+            && super::query_references_column(query, "balance");
+        let mut running_balance = Inventory::default();
+
         // Process each row from the table
         for row in &table.rows {
             // Apply WHERE clause if present
@@ -477,6 +494,22 @@ impl Executor<'_> {
             {
                 continue;
             }
+
+            // Recompute the running `balance` cell over WHERE-surviving rows.
+            let overridden_row;
+            let row = if track_balance {
+                if let Some(Value::Position(pos)) = position_idx.map(|i| &row[i]) {
+                    running_balance.add((**pos).clone());
+                }
+                let mut r = row.clone();
+                if let Some(i) = balance_idx {
+                    r[i] = Value::Inventory(Box::new(running_balance.clone()));
+                }
+                overridden_row = r;
+                &overridden_row
+            } else {
+                row
+            };
 
             // Evaluate targets (including hidden columns)
             let result_row = self.evaluate_subquery_row(&extended_targets, row, &column_map)?;

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -481,9 +481,17 @@ impl Executor<'_> {
         // recomputed: it is the account's true ledger balance across all postings.
         let balance_idx = column_map.get("balance").copied();
         let position_idx = column_map.get("position").copied();
+        // `SELECT *` expands to every table column (including `balance`), but
+        // `query_references_column` doesn't see through the wildcard — so treat a
+        // wildcard target as referencing `balance`, else `SELECT * FROM #postings
+        // WHERE ...` would still emit the pre-WHERE snapshot.
+        let selects_all = query
+            .targets
+            .iter()
+            .any(|t| matches!(t.expr, Expr::Wildcard));
         let track_balance = balance_idx.is_some()
             && position_idx.is_some()
-            && super::query_references_column(query, "balance");
+            && (selects_all || super::query_references_column(query, "balance"));
         let mut running_balance = Inventory::default();
 
         // Process each row from the table

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -4275,6 +4275,30 @@ mod tests {
         assert_eq!(result.rows[0][1], Value::Null);
         assert_eq!(result.rows[1][1], Value::Null);
         assert_eq!(result.rows[2][1], Value::Null);
+
+        // `SELECT *` expands to the `balance` column too — it must be recomputed
+        // the same way (wildcard doesn't name `balance` explicitly).
+        let result = executor
+            .execute(
+                &parse("SELECT * FROM #postings WHERE account = 'Assets:Bank' ORDER BY date")
+                    .unwrap(),
+            )
+            .unwrap();
+        let bal_col = result
+            .columns
+            .iter()
+            .position(|c| c == "balance")
+            .expect("balance column present");
+        for row in &result.rows {
+            if let Value::Inventory(inv) = &row[bal_col] {
+                assert!(
+                    inv.units("AAPL").is_zero(),
+                    "SELECT * balance must not leak the filtered AAPL leg"
+                );
+            } else {
+                panic!("expected an Inventory in the balance column");
+            }
+        }
     }
 
     #[test]

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -4211,6 +4211,73 @@ mod tests {
     }
 
     #[test]
+    fn test_postings_balance_excludes_filtered_commodities() {
+        // Regression: `balance` in the #postings path accumulated over ALL
+        // postings (pre-WHERE), so a stock leg leaked into a cash-account
+        // balance. It must be a running total over WHERE-surviving rows only,
+        // in entry order.
+        let p = |account: &str, n, currency: &str| {
+            rustledger_core::Spanned::synthesized(Posting::new(account, Amount::new(n, currency)))
+        };
+        let txn = |d, postings| {
+            Directive::Transaction(Transaction {
+                date: d,
+                flag: '*',
+                payee: None,
+                narration: "t".into(),
+                tags: vec![],
+                links: vec![],
+                meta: Metadata::default(),
+                postings,
+                trailing_comments: Vec::new(),
+            })
+        };
+        let directives = vec![
+            txn(
+                date(2020, 1, 2),
+                vec![
+                    p("Assets:Bank", dec!(5000), "USD"),
+                    p("Income:Salary", dec!(-5000), "USD"),
+                ],
+            ),
+            txn(
+                date(2020, 1, 3),
+                vec![
+                    p("Assets:Stock", dec!(10), "AAPL"),
+                    p("Assets:Bank", dec!(-1000), "USD"),
+                ],
+            ),
+            txn(
+                date(2020, 1, 4),
+                vec![
+                    p("Assets:Bank", dec!(2000), "USD"),
+                    p("Income:Salary", dec!(-2000), "USD"),
+                ],
+            ),
+        ];
+        let mut executor = Executor::new(&directives);
+        let result = executor
+            .execute(
+                &parse(
+                    "SELECT getitem(balance, 'USD'), getitem(balance, 'AAPL') \
+                     FROM #postings WHERE account = 'Assets:Bank' ORDER BY date",
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(result.rows.len(), 3);
+        let usd = |n| Value::Amount(Amount::new(n, "USD"));
+        assert_eq!(result.rows[0][0], usd(dec!(5000)));
+        assert_eq!(result.rows[1][0], usd(dec!(4000)));
+        assert_eq!(result.rows[2][0], usd(dec!(6000)));
+        // The AAPL leg (Assets:Stock, filtered out by WHERE) must NOT leak into
+        // the cash balance — getitem returns NULL for a zero/absent commodity.
+        assert_eq!(result.rows[0][1], Value::Null);
+        assert_eq!(result.rows[1][1], Value::Null);
+        assert_eq!(result.rows[2][1], Value::Null);
+    }
+
+    #[test]
     fn test_interval_function() {
         let directives = sample_directives();
         let mut executor = Executor::new(&directives);


### PR DESCRIPTION
## What

`balance` in the `FROM #postings` path leaked filtered-out commodities. A cash-account balance picked up a stock leg:

```
SELECT date, balance FROM #postings WHERE account = "Assets:Bank" ORDER BY date
rledger (before):  5000 USD ; 10 AAPL {100 USD} -1000 USD ; ...   ← AAPL leaked
bean-query:        5000 USD ; 4000 USD ; 6000 USD
```

Found in round-4 BQL dogfounding.

## Root cause

`balance` is a **running total over the post-WHERE output stream**, in entry order — a streaming window column, not a property of a posting. The default path (`collect_postings`) gets this right: it applies WHERE *inline* and accumulates only over surviving postings. But `FROM #postings` goes through `build_postings_table`, which precomputes `balance` over **all** postings, and `execute_select_from_table` applies WHERE *afterward* — so the precomputed snapshot already included the filtered-out legs.

## Oracle-confirmed semantics

- `balance` accumulates over WHERE-surviving rows only;
- in **entry (table) order**, computed **before** ORDER BY (ORDER BY then just reorders rows carrying their entry-order balance);
- a cumulative multi-commodity `Inventory` with cost basis preserved.

## How

Recompute `balance` in the streaming consumer (`execute_select_from_table`), over the WHERE-surviving rows in entry order, overriding the table's unfiltered snapshot — mirroring `collect_postings`. Keyed on the table having both `balance` and `position` columns (general "postings-like running balance", not a `#postings` string check) and gated on the query referencing `balance` (the #1080 per-row `Inventory`-clone hot path). `account_balance` is intentionally left as-is — it is the account's true ledger balance across all postings. Subqueries over `#postings` are fixed for free (the inner SELECT runs the same path).

Architecture note: full unification (route `#postings` through `collect_postings`) is the longer-term ideal, but `#postings` is a materialized table also used by aggregate/subquery/join paths, so computing the running column in the streaming consumer is the correct, lower-risk altitude.

## Tests

`test_postings_balance_excludes_filtered_commodities`: a cash + stock ledger; `balance` over `Assets:Bank` is `5000/4000/6000 USD` with the AAPL leg NULL (no leak). Oracle-verified against bean-query (post-WHERE, ORDER BY, multi-commodity). Full `rustledger-query` suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
