### PR TITLE
feat(core): add MetaValue::Int(i64) variant (lineno -> Integer)

### DIFF
--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -53,6 +53,12 @@ pub enum MetaValue {
     Amount(Amount),
     /// Null/None value
     None,
+    /// Integer value (e.g. beancount `key: 42`, distinct from `42.0`).
+    ///
+    /// MUST remain the LAST variant: rkyv encodes enum discriminants by
+    /// declaration order, so appending keeps the existing variants' discriminants
+    /// stable. `CACHE_VERSION` (rustledger-loader) was bumped when this was added.
+    Int(i64),
 }
 
 impl fmt::Display for MetaValue {
@@ -68,6 +74,7 @@ impl fmt::Display for MetaValue {
             Self::Bool(b) => write!(f, "{b}"),
             Self::Amount(a) => write!(f, "{a}"),
             Self::None => write!(f, "None"),
+            Self::Int(i) => write!(f, "{i}"),
         }
     }
 }
@@ -90,24 +97,38 @@ pub type Metadata = FxHashMap<String, MetaValue>;
 #[must_use = "ignoring the result silently drops invalid `precision:` metadata; the loader expects to skip invalid values, the validator expects to surface them"]
 pub fn parse_precision_meta(value: &MetaValue) -> Result<u32, String> {
     use rust_decimal::prelude::ToPrimitive;
-    let MetaValue::Number(n) = value else {
-        return Err(format!(
+    match value {
+        // `precision: 2` now parses as an integer metadata value.
+        MetaValue::Int(i) => u32::try_from(*i).map_err(|_| {
+            if *i < 0 {
+                format!("expected a non-negative integer, got {i}")
+            } else {
+                format!(
+                    "value {i} exceeds the maximum supported precision ({})",
+                    u32::MAX
+                )
+            }
+        }),
+        // `precision: 2.0` (an explicit decimal) is still accepted if integral.
+        MetaValue::Number(n) => {
+            if n.is_sign_negative() {
+                return Err(format!("expected a non-negative integer, got {n}"));
+            }
+            if !n.fract().is_zero() {
+                return Err(format!("expected an integer, got {n}"));
+            }
+            n.to_u32().ok_or_else(|| {
+                format!(
+                    "value {n} exceeds the maximum supported precision ({})",
+                    u32::MAX
+                )
+            })
+        }
+        _ => Err(format!(
             "expected a non-negative integer, got {} value",
             meta_value_kind(value)
-        ));
-    };
-    if n.is_sign_negative() {
-        return Err(format!("expected a non-negative integer, got {n}"));
+        )),
     }
-    if !n.fract().is_zero() {
-        return Err(format!("expected an integer, got {n}"));
-    }
-    n.to_u32().ok_or_else(|| {
-        format!(
-            "value {n} exceeds the maximum supported precision ({})",
-            u32::MAX
-        )
-    })
 }
 
 const fn meta_value_kind(v: &MetaValue) -> &'static str {
@@ -122,6 +143,7 @@ const fn meta_value_kind(v: &MetaValue) -> &'static str {
         MetaValue::Bool(_) => "bool",
         MetaValue::Amount(_) => "amount",
         MetaValue::None => "none",
+        MetaValue::Int(_) => "int",
     }
 }
 
@@ -1842,6 +1864,11 @@ mod tests {
 
     #[test]
     fn parse_precision_meta_accepts_non_negative_integers() {
+        // `precision: 2` parses as `Int`; `precision: 2.0` as `Number`. Both
+        // must validate identically.
+        assert_eq!(parse_precision_meta(&MetaValue::Int(0)), Ok(0));
+        assert_eq!(parse_precision_meta(&MetaValue::Int(2)), Ok(2));
+        assert_eq!(parse_precision_meta(&MetaValue::Int(28)), Ok(28));
         assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(0))), Ok(0));
         assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(2))), Ok(2));
         assert_eq!(parse_precision_meta(&MetaValue::Number(dec!(28))), Ok(28));
@@ -1856,6 +1883,8 @@ mod tests {
     fn parse_precision_meta_rejects_negatives() {
         let err = parse_precision_meta(&MetaValue::Number(dec!(-1))).unwrap_err();
         assert!(err.contains("non-negative"), "got: {err}");
+        let err = parse_precision_meta(&MetaValue::Int(-1)).unwrap_err();
+        assert!(err.contains("non-negative"), "got: {err}");
     }
 
     #[test]
@@ -1869,6 +1898,16 @@ mod tests {
         // 2^33 — out of u32 range.
         let err = parse_precision_meta(&MetaValue::Number(dec!(8589934592))).unwrap_err();
         assert!(err.contains("exceeds"), "got: {err}");
+        let err = parse_precision_meta(&MetaValue::Int(8_589_934_592)).unwrap_err();
+        assert!(err.contains("exceeds"), "got: {err}");
+    }
+
+    #[test]
+    fn meta_value_int_display_and_kind() {
+        assert_eq!(MetaValue::Int(42).to_string(), "42");
+        assert_eq!(MetaValue::Int(-7).to_string(), "-7");
+        assert_eq!(crate::format::format_meta_value(&MetaValue::Int(42)), "42");
+        assert_eq!(meta_value_kind(&MetaValue::Int(0)), "int");
     }
 
     #[test]

--- a/crates/rustledger-core/src/format/helpers.rs
+++ b/crates/rustledger-core/src/format/helpers.rs
@@ -16,6 +16,7 @@ pub fn format_meta_value(value: &MetaValue) -> String {
         MetaValue::Amount(a) => format_amount(a),
         MetaValue::Bool(b) => if *b { "TRUE" } else { "FALSE" }.to_string(),
         MetaValue::None => String::new(),
+        MetaValue::Int(i) => i.to_string(),
     }
 }
 

--- a/crates/rustledger-core/src/shift_spans_impls.rs
+++ b/crates/rustledger-core/src/shift_spans_impls.rs
@@ -204,6 +204,7 @@ impl ShiftSpans for MetaValue {
             Self::Bool(b) => b.shift_spans(shift),
             Self::Amount(a) => a.shift_spans(shift),
             Self::None => {}
+            Self::Int(i) => i.shift_spans(shift),
         }
     }
 }

--- a/crates/rustledger-core/src/visit.rs
+++ b/crates/rustledger-core/src/visit.rs
@@ -306,6 +306,7 @@ fn visit_meta_value_currency<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a st
         | MetaValue::Date(_)
         | MetaValue::Number(_)
         | MetaValue::Bool(_)
+        | MetaValue::Int(_)
         | MetaValue::None => {}
     }
 }
@@ -324,6 +325,7 @@ fn visit_meta_value_account<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a str
         | MetaValue::Number(_)
         | MetaValue::Bool(_)
         | MetaValue::Amount(_)
+        | MetaValue::Int(_)
         | MetaValue::None => {}
     }
 }
@@ -342,6 +344,7 @@ fn visit_meta_value_tag<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a str)) {
         | MetaValue::Number(_)
         | MetaValue::Bool(_)
         | MetaValue::Amount(_)
+        | MetaValue::Int(_)
         | MetaValue::None => {}
     }
 }
@@ -360,6 +363,7 @@ fn visit_meta_value_link<'a>(v: &'a MetaValue, visit: &mut impl FnMut(&'a str)) 
         | MetaValue::Number(_)
         | MetaValue::Bool(_)
         | MetaValue::Amount(_)
+        | MetaValue::Int(_)
         | MetaValue::None => {}
     }
 }

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -237,7 +237,8 @@ pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
         serde_json::Value::Bool(b) => MetaValue::Bool(*b),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                MetaValue::Number(rustledger_core::Decimal::from(i))
+                // A JSON integer round-trips as an integer metadata value.
+                MetaValue::Int(i)
             } else if let Some(f) = n.as_f64() {
                 match rustledger_core::Decimal::from_str_exact(&f.to_string()) {
                     Ok(d) => MetaValue::Number(d),

--- a/crates/rustledger-ffi-wasi/src/types/output.rs
+++ b/crates/rustledger-ffi-wasi/src/types/output.rs
@@ -47,6 +47,10 @@ pub fn meta_value_to_json(value: &MetaValue) -> serde_json::Value {
             "currency": a.currency.to_string()
         }),
         MetaValue::None => serde_json::Value::Null,
+        // Stringified like `Number`, keeping numeric metadata uniform on the
+        // wire and identical to the WASM binding (the equivalence harness pins
+        // ffi-wasi == wasm).
+        MetaValue::Int(i) => serde_json::json!(i.to_string()),
     }
 }
 
@@ -198,6 +202,10 @@ impl TypedValue {
             MetaValue::None => Self {
                 value_type: "null",
                 value: serde_json::Value::Null,
+            },
+            MetaValue::Int(i) => Self {
+                value_type: "int",
+                value: serde_json::Value::String(i.to_string()),
             },
         }
     }

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -317,7 +317,11 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 /// v10: String literals are now escape-decoded at parse (`\"`->`"`, etc.);
 ///     the stored narration/payee/meta/etc. bytes differ from the old raw
 ///     form, so a cache hit would serve stale, still-escaped strings.
-const CACHE_VERSION: u32 = 10;
+/// v11: `MetaValue` gained an `Int(i64)` variant (appended last). Integer
+///     metadata literals (`key: 42`) now archive as `Int` rather than
+///     `Number`, and the new discriminant changes the enum's archived
+///     layout, so old bytes must be regenerated.
+const CACHE_VERSION: u32 = 11;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -1012,11 +1016,11 @@ mod tests {
         // the developer to also update the fixtures (or remove this
         // tripwire if v9's contract is identical to v8 for CostNumber
         // — which is unusual but possible).
-        // v9 (#1340) and v10 (string escape-decoding) both bumped
-        // CACHE_VERSION without touching the `CostNumber` archived layout
-        // these fixtures pin, so the byte arrays below are still valid and
-        // only FIXTURE_VERSION moves.
-        const FIXTURE_VERSION: u32 = 10;
+        // v9 (#1340), v10 (string escape-decoding), and v11 (`MetaValue::Int`)
+        // all bumped CACHE_VERSION without touching the `CostNumber` archived
+        // layout these fixtures pin, so the byte arrays below are still valid
+        // and only FIXTURE_VERSION moves.
+        const FIXTURE_VERSION: u32 = 11;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -307,7 +307,7 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     positionally) — verified against rkyv 0.8.16 — so this change
 ///     does NOT require a separate version bump. If a future rkyv
 ///     version changes that encoding, OR if `CostNumber` gains
-///     additional fields, bump to the next version (v11).
+///     additional fields, bump to the next version (v12).
 /// v9: `CachedOptions` gained a `set_options: Vec<String>` field
 ///     (#1340). It was previously dropped, so a cache hit lost the
 ///     record of which options the file explicitly set — making

--- a/crates/rustledger-loader/src/dedup.rs
+++ b/crates/rustledger-loader/src/dedup.rs
@@ -128,6 +128,7 @@ fn intern_meta(meta: &mut Metadata, interner: &mut StringInterner, dedup_count: 
             }
             MetaValue::String(_)
             | MetaValue::Number(_)
+            | MetaValue::Int(_)
             | MetaValue::Date(_)
             | MetaValue::Bool(_)
             | MetaValue::None => {}

--- a/crates/rustledger-plugin/src/convert/to_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/to_wrapper.rs
@@ -146,6 +146,9 @@ pub(super) fn meta_value_to_data(value: &MetaValue) -> MetaValueData {
         MetaValue::Amount(a) => MetaValueData::Amount(amount_to_data(a)),
         MetaValue::Bool(b) => MetaValueData::Bool(*b),
         MetaValue::None => MetaValueData::String(String::new()),
+        // The plugin wire has no integer case; carry it as a numeric string
+        // (plugins already see `Number` the same way).
+        MetaValue::Int(i) => MetaValueData::Number(i.to_string()),
     }
 }
 

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -64,9 +64,13 @@ impl Executor<'_> {
         let loc = loc?;
         match key {
             "filename" => Some(MetaValue::String(loc.filename.clone())),
-            // There is no integer `MetaValue`; `Number(Decimal)` renders as `4`
-            // and compares numerically, matching beanquery's integer lineno.
-            "lineno" => Some(MetaValue::Number(Decimal::from(loc.lineno as u64))),
+            // beanquery's lineno is an integer; emit a true `Int` (the `lineno`
+            // column is also `Integer`). Falls back to `Number` only on the
+            // practically-impossible case of a line number exceeding i64.
+            "lineno" => Some(i64::try_from(loc.lineno).map_or_else(
+                |_| MetaValue::Number(Decimal::from(loc.lineno as u64)),
+                MetaValue::Int,
+            )),
             _ => None,
         }
     }
@@ -103,6 +107,7 @@ impl Executor<'_> {
             None => Value::Null,
             Some(MetaValue::String(s)) => Value::String(s.clone()),
             Some(MetaValue::Number(n)) => Value::Number(*n),
+            Some(MetaValue::Int(i)) => Value::Integer(*i),
             Some(MetaValue::Date(d)) => Value::Date(*d),
             Some(MetaValue::Bool(b)) => Value::Boolean(*b),
             Some(MetaValue::Amount(a)) => Value::Amount(a.clone()),

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -4180,20 +4180,20 @@ mod tests {
         let mut executor = Executor::new_with_sources(&spanned, &source_map);
 
         // meta() exposes synthetic filename/lineno per posting. (lineno is a
-        // Number — there is no integer MetaValue; the dedicated `lineno` column
-        // is Integer.)
+        // true Integer — matching the dedicated `lineno` column and beanquery's
+        // integer lineno.)
         let r = executor
             .execute(&parse("SELECT meta('filename'), meta('lineno')").unwrap())
             .unwrap();
         assert_eq!(r.rows[0][0], Value::String("test.beancount".to_string()));
-        assert_eq!(r.rows[0][1], Value::Number(dec!(2)));
-        assert_eq!(r.rows[1][1], Value::Number(dec!(3)));
+        assert_eq!(r.rows[0][1], Value::Integer(2));
+        assert_eq!(r.rows[1][1], Value::Integer(3));
 
         // entry_meta uses the ENTRY (directive) line, not the posting's.
         let r = executor
             .execute(&parse("SELECT entry_meta('lineno')").unwrap())
             .unwrap();
-        assert_eq!(r.rows[0][0], Value::Number(dec!(1)));
+        assert_eq!(r.rows[0][0], Value::Integer(1));
 
         // A user meta key still resolves and takes precedence.
         let r = executor
@@ -4202,12 +4202,12 @@ mod tests {
         assert_eq!(r.rows[0][0], Value::String("food".to_string()));
 
         // The full meta column is augmented; getitem over it (and via #postings)
-        // sees the synthetic keys.
+        // sees the synthetic keys as integers.
         let r = executor
             .execute(&parse("SELECT getitem(meta, 'lineno') FROM #postings").unwrap())
             .unwrap();
-        assert_eq!(r.rows[0][0], Value::Number(dec!(2)));
-        assert_eq!(r.rows[1][0], Value::Number(dec!(3)));
+        assert_eq!(r.rows[0][0], Value::Integer(2));
+        assert_eq!(r.rows[1][0], Value::Integer(3));
     }
 
     #[test]

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -36,6 +36,9 @@ fn meta_value_to_json(value: &MetaValue) -> MetaValueJson {
             currency: a.currency.to_string(),
         },
         MetaValue::None => MetaValueJson::Null,
+        // Stringified like `Number` (MetaValueJson has no numeric case); the
+        // typed variant below carries the "int" type tag.
+        MetaValue::Int(i) => MetaValueJson::String(i.to_string()),
     }
 }
 
@@ -101,6 +104,10 @@ fn meta_value_to_typed_json(value: &MetaValue) -> TypedValueJson {
         MetaValue::None => TypedValueJson {
             value_type: "null".into(),
             value: MetaValueJson::Null,
+        },
+        MetaValue::Int(i) => TypedValueJson {
+            value_type: "int".into(),
+            value: MetaValueJson::String(i.to_string()),
         },
     }
 }

--- a/crates/rustledger-wire-format-tests/tests/equivalence.rs
+++ b/crates/rustledger-wire-format-tests/tests/equivalence.rs
@@ -253,6 +253,7 @@ fn fixture_metadata_all_variants() -> Metadata {
         MetaValue::Date(naive_date(2024, 6, 15).unwrap()),
     );
     m.insert("number-key".to_string(), MetaValue::Number(dec!(123.456)));
+    m.insert("int-key".to_string(), MetaValue::Int(42));
     m.insert("bool-key".to_string(), MetaValue::Bool(true));
     m.insert(
         "amount-key".to_string(),

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -622,6 +622,9 @@ fn meta_value_to_json(v: &rustledger_core::MetaValue) -> serde_json::Value {
         MetaValue::Tag(t) => serde_json::Value::String(t.to_string()),
         MetaValue::Link(l) => serde_json::Value::String(l.to_string()),
         MetaValue::None => serde_json::Value::Null,
+        // Stringified like `Number`, keeping all numeric metadata uniform on the
+        // JSON wire (and identical across the FFI bindings).
+        MetaValue::Int(i) => serde_json::json!(i.to_string()),
     }
 }
 


### PR DESCRIPTION
## What

Add a first-class `MetaValue::Int(i64)` variant. This is **PR 1 of 2**: it introduces the variant, wires it through every match site and wire boundary, and switches the synthetic BQL `lineno` metadata key to it — but does **not** yet change the parser (PR 2 makes `key: 42` parse as `Int`). After PR 1, `meta('lineno')` / `getitem(meta,'lineno')` are true `Integer`s, matching the dedicated `lineno` column.

## Why

`MetaValue` had only `Number(Decimal)`, so #5b (#1511) had to synthesize `lineno` as a `Number` — a type inconsistency vs the `Integer` `lineno` column. More broadly, beancount distinguishes integer (`key: 42`) from decimal (`key: 42.0`) metadata; rledger conflated them. `Int(i64)` fixes the modeling.

## How

- **Core** (`directive.rs`): `Int(i64)` appended as the **last** `MetaValue` variant (keeps rkyv discriminants stable; `i64` is natively rkyv-archivable). Arms added to `Display`, `meta_value_kind` (`"int"`), `parse_precision_meta` (accepts `Int` like `Number`), `shift_spans`, the four `visit.rs` extractors, and `format_meta_value`.
- **Cache** (`rustledger-loader/cache.rs`): `CACHE_VERSION` 10 → 11 (the new discriminant changes the archived layout; old caches auto-invalidate and rebuild — no data loss). `FIXTURE_VERSION` tripwire bumped (CostNumber bytes unchanged). `dedup.rs intern_meta`: no-op arm.
- **Query** (`functions/util.rs`): synthetic `lineno` → `Int`; `meta_value_to_value` maps `Int → Value::Integer`.
- **Wire** (CLI query JSON, ffi-wasi in/out, wasm, plugin): `Int` stringified like `Number` to keep numeric metadata uniform on the JSON wire and **identical across the ffi-wasi/wasm bindings** (the equivalence harness pins `ffi-wasi == wasm`). ffi-component needs no change (no exhaustive `MetaValue` match; the JSON flows through unchanged).

## Tests

- `executor/mod.rs::test_meta_includes_source_location` updated: `lineno` via `meta()`/`entry_meta()`/`getitem` now asserts `Integer` (was `Number`).
- `parse_precision_meta` Int cases (accept / negative / overflow); `Display`/`meta_value_kind` Int test.
- Wire-format `fixture_metadata_all_variants` gains an `Int` key (ffi-wasi == wasm equivalence holds).
- Oracle-verified: `getitem(meta,'lineno') + 100` → `104`/`105` (true integer arithmetic).

Full workspace builds `--all-features --all-targets`; rustledger-core/query/loader/wire-format/cli/plugin suites pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
