### PR TITLE
refactor(core): single canonical MetaValue<->JSON wire codec

### DIFF
--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod identifiers;
 pub mod implicit_prices;
 pub mod intern;
 pub mod inventory;
+pub mod meta_json;
 pub mod position;
 pub mod shift_spans_impls;
 pub mod span;
@@ -86,6 +87,7 @@ pub use intern::{InternedStr, StringInterner};
 pub use inventory::{
     AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,
 };
+pub use meta_json::{json_to_meta_value, meta_value_to_json, meta_value_type_tag};
 pub use position::Position;
 pub use span::{SYNTHESIZED_FILE_ID, ShiftSpans, Span, Spanned};
 pub use visit::{visit_accounts, visit_currencies};

--- a/crates/rustledger-core/src/meta_json.rs
+++ b/crates/rustledger-core/src/meta_json.rs
@@ -82,10 +82,11 @@ pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 MetaValue::Int(i)
-            } else if let Some(f) = n.as_f64() {
-                Decimal::from_str_exact(&f.to_string()).map_or(MetaValue::None, MetaValue::Number)
             } else {
-                MetaValue::None
+                // Parse the number's exact textual form rather than round-tripping
+                // through f64 — that preserves `u64` values above `i64::MAX` and
+                // high-precision decimals (within `Decimal`'s range).
+                Decimal::from_str_exact(&n.to_string()).map_or(MetaValue::None, MetaValue::Number)
             }
         }
         serde_json::Value::Object(obj) => {
@@ -177,5 +178,10 @@ mod tests {
         );
         // A real JSON integer (e.g. from a plugin) parses as Int.
         assert_eq!(json_to_meta_value(&serde_json::json!(7)), MetaValue::Int(7));
+        // A u64 above i64::MAX is preserved exactly (not lost via an f64 hop).
+        assert_eq!(
+            json_to_meta_value(&serde_json::json!(18_446_744_073_709_551_615_u64)),
+            MetaValue::Number(dec!(18446744073709551615))
+        );
     }
 }

--- a/crates/rustledger-core/src/meta_json.rs
+++ b/crates/rustledger-core/src/meta_json.rs
@@ -1,0 +1,181 @@
+//! Canonical JSON wire codec for [`MetaValue`].
+//!
+//! Metadata values cross several wire boundaries — the CLI `query --format json`
+//! output and the WASI FFI JSON-RPC surface. Each used to re-implement the same
+//! `MetaValue` ↔ JSON match, so adding a variant meant editing every copy and
+//! the copies could silently drift (the type tag in particular). This module is
+//! the single source of that mapping.
+//!
+//! The WASM binding deliberately keeps `serde_json` a host-only dev-dependency
+//! (it emits a typed enum instead), so it cannot call [`meta_value_to_json`] —
+//! but it shares [`meta_value_type_tag`], which is `serde_json`-free, so the
+//! drift-prone type tag stays single-sourced across *every* surface.
+//!
+//! The plugin (`MetaValueData`, `MessagePack`) and the Component-Model WIT
+//! `meta-value` are separate, narrower wire contracts and are intentionally not
+//! routed through this JSON codec.
+
+use crate::MetaValue;
+
+/// Canonical JSON form of a metadata value.
+///
+/// Numeric values are stringified (lossless for `Decimal`, and uniform with
+/// `Int`). Typed references (`Account`/`Currency`/`Tag`/`Link`) lower to their
+/// string form — matching bean-query, which has no first-class type for them on
+/// the SQL/JSON surface.
+#[must_use]
+pub fn meta_value_to_json(value: &MetaValue) -> serde_json::Value {
+    match value {
+        MetaValue::String(s) => serde_json::Value::String(s.clone()),
+        MetaValue::Account(a) => serde_json::Value::String(a.to_string()),
+        MetaValue::Currency(c) => serde_json::Value::String(c.to_string()),
+        MetaValue::Tag(t) => serde_json::Value::String(t.to_string()),
+        MetaValue::Link(l) => serde_json::Value::String(l.to_string()),
+        MetaValue::Date(d) => serde_json::Value::String(d.to_string()),
+        MetaValue::Number(n) => serde_json::Value::String(n.to_string()),
+        MetaValue::Int(i) => serde_json::Value::String(i.to_string()),
+        MetaValue::Bool(b) => serde_json::Value::Bool(*b),
+        MetaValue::Amount(a) => serde_json::json!({
+            "number": a.number.to_string(),
+            "currency": a.currency.to_string(),
+        }),
+        MetaValue::None => serde_json::Value::Null,
+    }
+}
+
+/// The wire type tag for a metadata value (`"string"`, `"int"`, `"amount"`, …).
+///
+/// Single source for the `type`/`value_type` discriminator emitted by the FFI
+/// and WASM "typed value" forms. `serde_json`-free, so the WASM binding (which
+/// avoids `serde_json`) shares it too.
+#[must_use]
+pub const fn meta_value_type_tag(value: &MetaValue) -> &'static str {
+    match value {
+        MetaValue::String(_) => "string",
+        MetaValue::Account(_) => "account",
+        MetaValue::Currency(_) => "currency",
+        MetaValue::Tag(_) => "tag",
+        MetaValue::Link(_) => "link",
+        MetaValue::Date(_) => "date",
+        MetaValue::Number(_) => "number",
+        MetaValue::Int(_) => "int",
+        MetaValue::Bool(_) => "bool",
+        MetaValue::Amount(_) => "amount",
+        MetaValue::None => "null",
+    }
+}
+
+/// Parse a metadata value from its canonical JSON form (the inverse of
+/// [`meta_value_to_json`] for the round-trippable cases).
+///
+/// A JSON integer becomes `Int`; an `{number, currency}` object becomes
+/// `Amount`. Unparsable numbers and unrecognized shapes (arrays, foreign
+/// objects) become `None` rather than coercing to zero or panicking — metadata
+/// is informational, so "I saw something but couldn't interpret it" is the
+/// honest result.
+#[must_use]
+pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
+    use rust_decimal::Decimal;
+    match value {
+        serde_json::Value::String(s) => MetaValue::String(s.clone()),
+        serde_json::Value::Bool(b) => MetaValue::Bool(*b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                MetaValue::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                Decimal::from_str_exact(&f.to_string()).map_or(MetaValue::None, MetaValue::Number)
+            } else {
+                MetaValue::None
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            if let (Some(number), Some(currency)) = (obj.get("number"), obj.get("currency"))
+                && let (Some(n), Some(c)) = (number.as_str(), currency.as_str())
+                && let Ok(number) = Decimal::from_str_exact(n)
+            {
+                return MetaValue::Amount(crate::Amount {
+                    number,
+                    currency: c.into(),
+                });
+            }
+            MetaValue::None
+        }
+        serde_json::Value::Null | serde_json::Value::Array(_) => MetaValue::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    /// Every variant maps to a non-degenerate tag + JSON, and the
+    /// round-trippable ones survive `to_json -> json_to`. This is the fitness
+    /// function: a new `MetaValue` variant forces a new arm in all three
+    /// functions above (exhaustive match) and must be added here.
+    #[test]
+    fn codec_covers_every_variant() {
+        let cases = [
+            MetaValue::String("hi".into()),
+            MetaValue::Account("Assets:Cash".into()),
+            MetaValue::Currency("USD".into()),
+            MetaValue::Tag("trip".into()),
+            MetaValue::Link("inv-1".into()),
+            MetaValue::Date(crate::naive_date(2024, 6, 15).unwrap()),
+            MetaValue::Number(dec!(123.456)),
+            MetaValue::Int(42),
+            MetaValue::Bool(true),
+            MetaValue::Amount(crate::Amount::new(dec!(99.99), "EUR")),
+            MetaValue::None,
+        ];
+        for mv in &cases {
+            // tag is non-empty for every variant
+            assert!(!meta_value_type_tag(mv).is_empty());
+            // to_json never panics and is well-formed
+            let _ = meta_value_to_json(mv);
+        }
+        // Tags are exhaustive + distinct (one per variant).
+        let tags: Vec<&str> = cases.iter().map(meta_value_type_tag).collect();
+        let mut uniq = tags.clone();
+        uniq.sort_unstable();
+        uniq.dedup();
+        assert_eq!(
+            uniq.len(),
+            tags.len(),
+            "type tags must be distinct: {tags:?}"
+        );
+    }
+
+    #[test]
+    fn json_round_trip() {
+        // Cases whose JSON form is faithfully invertible.
+        assert_eq!(
+            json_to_meta_value(&meta_value_to_json(&MetaValue::String("x".into()))),
+            MetaValue::String("x".into())
+        );
+        assert_eq!(
+            json_to_meta_value(&meta_value_to_json(&MetaValue::Bool(true))),
+            MetaValue::Bool(true)
+        );
+        assert_eq!(
+            json_to_meta_value(&meta_value_to_json(&MetaValue::None)),
+            MetaValue::None
+        );
+        assert_eq!(
+            json_to_meta_value(&meta_value_to_json(&MetaValue::Amount(crate::Amount::new(
+                dec!(1.50),
+                "USD"
+            )))),
+            MetaValue::Amount(crate::Amount::new(dec!(1.50), "USD"))
+        );
+        // Numbers are stringified on the wire, so they round-trip back as a
+        // String (the wire form is intentionally lossy on numeric type — the
+        // typed `meta_value_type_tag` carries the original type).
+        assert_eq!(
+            json_to_meta_value(&meta_value_to_json(&MetaValue::Int(7))),
+            MetaValue::String("7".into())
+        );
+        // A real JSON integer (e.g. from a plugin) parses as Int.
+        assert_eq!(json_to_meta_value(&serde_json::json!(7)), MetaValue::Int(7));
+    }
+}

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -223,49 +223,13 @@ fn default_flag() -> String {
     "*".to_string()
 }
 
-/// Convert JSON metadata value to core `MetaValue`.
+/// Convert a JSON metadata value to a core `MetaValue`.
 ///
-/// Unparsable numeric values become `MetaValue::None` (review B-4.1)
-/// rather than silently coercing to zero. Metadata is informational
-/// so a typed `MetaValue::None` is the right "I saw something but
-/// couldn't interpret it as a number" signal — preferable to either
-/// silently substituting zero (loses the original value) or panicking
-/// (heavyweight for a metadata field).
+/// Thin wrapper over the single source [`rustledger_core::json_to_meta_value`];
+/// kept so call sites read in ffi-wasi terms. Unparsable numbers / unrecognized
+/// shapes become `MetaValue::None` (informational metadata, no coercion/panic).
 pub fn json_to_meta_value(value: &serde_json::Value) -> MetaValue {
-    match value {
-        serde_json::Value::String(s) => MetaValue::String(s.clone()),
-        serde_json::Value::Bool(b) => MetaValue::Bool(*b),
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                // A JSON integer round-trips as an integer metadata value.
-                MetaValue::Int(i)
-            } else if let Some(f) = n.as_f64() {
-                match rustledger_core::Decimal::from_str_exact(&f.to_string()) {
-                    Ok(d) => MetaValue::Number(d),
-                    Err(_) => MetaValue::None,
-                }
-            } else {
-                MetaValue::None
-            }
-        }
-        serde_json::Value::Null => MetaValue::None,
-        serde_json::Value::Object(obj) => {
-            // Handle Amount objects
-            if let (Some(number), Some(currency)) = (obj.get("number"), obj.get("currency"))
-                && let (Some(n), Some(c)) = (number.as_str(), currency.as_str())
-            {
-                return match rustledger_core::Decimal::from_str_exact(n) {
-                    Ok(number) => MetaValue::Amount(rustledger_core::Amount {
-                        number,
-                        currency: c.into(),
-                    }),
-                    Err(_) => MetaValue::None,
-                };
-            }
-            MetaValue::None
-        }
-        serde_json::Value::Array(_) => MetaValue::None,
-    }
+    rustledger_core::json_to_meta_value(value)
 }
 
 /// Convert `HashMap<String, Value>` to core Metadata.

--- a/crates/rustledger-ffi-wasi/src/types/output.rs
+++ b/crates/rustledger-ffi-wasi/src/types/output.rs
@@ -31,27 +31,12 @@ impl Meta {
     }
 }
 
-/// Convert `MetaValue` to JSON, extracting raw values without extra formatting.
+/// Convert `MetaValue` to its canonical JSON form.
+///
+/// Thin wrapper over the single source [`rustledger_core::meta_value_to_json`];
+/// kept so call sites and the `types` module API read in ffi-wasi terms.
 pub fn meta_value_to_json(value: &MetaValue) -> serde_json::Value {
-    match value {
-        MetaValue::String(s) => serde_json::Value::String(s.clone()),
-        MetaValue::Account(a) => serde_json::Value::String(a.to_string()),
-        MetaValue::Currency(c) => serde_json::Value::String(c.to_string()),
-        MetaValue::Tag(t) => serde_json::Value::String(t.to_string()),
-        MetaValue::Link(l) => serde_json::Value::String(l.to_string()),
-        MetaValue::Date(d) => serde_json::Value::String(d.to_string()),
-        MetaValue::Number(n) => serde_json::json!(n.to_string()),
-        MetaValue::Bool(b) => serde_json::Value::Bool(*b),
-        MetaValue::Amount(a) => serde_json::json!({
-            "number": a.number.to_string(),
-            "currency": a.currency.to_string()
-        }),
-        MetaValue::None => serde_json::Value::Null,
-        // Stringified like `Number`, keeping numeric metadata uniform on the
-        // wire and identical to the WASM binding (the equivalence harness pins
-        // ffi-wasi == wasm).
-        MetaValue::Int(i) => serde_json::json!(i.to_string()),
-    }
+    rustledger_core::meta_value_to_json(value)
 }
 
 #[derive(Serialize, Clone)]
@@ -159,54 +144,11 @@ pub struct TypedValue {
 
 impl TypedValue {
     pub fn from_meta_value(mv: &MetaValue) -> Self {
-        match mv {
-            MetaValue::String(s) => Self {
-                value_type: "string",
-                value: serde_json::Value::String(s.clone()),
-            },
-            MetaValue::Account(a) => Self {
-                value_type: "account",
-                value: serde_json::Value::String(a.to_string()),
-            },
-            MetaValue::Currency(c) => Self {
-                value_type: "currency",
-                value: serde_json::Value::String(c.to_string()),
-            },
-            MetaValue::Tag(t) => Self {
-                value_type: "tag",
-                value: serde_json::Value::String(t.to_string()),
-            },
-            MetaValue::Link(l) => Self {
-                value_type: "link",
-                value: serde_json::Value::String(l.to_string()),
-            },
-            MetaValue::Date(d) => Self {
-                value_type: "date",
-                value: serde_json::Value::String(d.to_string()),
-            },
-            MetaValue::Number(n) => Self {
-                value_type: "number",
-                value: serde_json::Value::String(n.to_string()),
-            },
-            MetaValue::Bool(b) => Self {
-                value_type: "bool",
-                value: serde_json::Value::Bool(*b),
-            },
-            MetaValue::Amount(a) => Self {
-                value_type: "amount",
-                value: serde_json::json!({
-                    "number": a.number.to_string(),
-                    "currency": a.currency.to_string()
-                }),
-            },
-            MetaValue::None => Self {
-                value_type: "null",
-                value: serde_json::Value::Null,
-            },
-            MetaValue::Int(i) => Self {
-                value_type: "int",
-                value: serde_json::Value::String(i.to_string()),
-            },
+        // The `type` tag and the JSON `value` are both single-sourced in core,
+        // so the tagged form can never drift from the plain `meta` map form.
+        Self {
+            value_type: rustledger_core::meta_value_type_tag(mv),
+            value: rustledger_core::meta_value_to_json(mv),
         }
     }
 }

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -61,54 +61,13 @@ fn metadata_to_json(meta: &Metadata) -> HashMap<String, MetaValueJson> {
 /// Stringified-decimal handling matches [`meta_value_to_json`] — JSON
 /// numbers can't represent `rust_decimal::Decimal` losslessly.
 fn meta_value_to_typed_json(value: &MetaValue) -> TypedValueJson {
-    match value {
-        MetaValue::String(s) => TypedValueJson {
-            value_type: "string".into(),
-            value: MetaValueJson::String(s.clone()),
-        },
-        MetaValue::Account(a) => TypedValueJson {
-            value_type: "account".into(),
-            value: MetaValueJson::String(a.to_string()),
-        },
-        MetaValue::Currency(c) => TypedValueJson {
-            value_type: "currency".into(),
-            value: MetaValueJson::String(c.to_string()),
-        },
-        MetaValue::Tag(t) => TypedValueJson {
-            value_type: "tag".into(),
-            value: MetaValueJson::String(t.to_string()),
-        },
-        MetaValue::Link(l) => TypedValueJson {
-            value_type: "link".into(),
-            value: MetaValueJson::String(l.to_string()),
-        },
-        MetaValue::Date(d) => TypedValueJson {
-            value_type: "date".into(),
-            value: MetaValueJson::String(d.to_string()),
-        },
-        MetaValue::Number(n) => TypedValueJson {
-            value_type: "number".into(),
-            value: MetaValueJson::String(n.to_string()),
-        },
-        MetaValue::Bool(b) => TypedValueJson {
-            value_type: "bool".into(),
-            value: MetaValueJson::Bool(*b),
-        },
-        MetaValue::Amount(a) => TypedValueJson {
-            value_type: "amount".into(),
-            value: MetaValueJson::Amount {
-                number: a.number.to_string(),
-                currency: a.currency.to_string(),
-            },
-        },
-        MetaValue::None => TypedValueJson {
-            value_type: "null".into(),
-            value: MetaValueJson::Null,
-        },
-        MetaValue::Int(i) => TypedValueJson {
-            value_type: "int".into(),
-            value: MetaValueJson::String(i.to_string()),
-        },
+    // The type tag is single-sourced in core (`serde_json`-free, so this crate
+    // can share it); the typed `value` reuses this crate's own `meta_value_to_json`
+    // (the WASM binding keeps `serde_json` a dev-only dep, so it emits the typed
+    // `MetaValueJson` enum rather than `serde_json::Value`).
+    TypedValueJson {
+        value_type: rustledger_core::meta_value_type_tag(value).into(),
+        value: meta_value_to_json(value),
     }
 }
 

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -603,29 +603,12 @@ pub(super) fn format_value(value: &Value, numberify: bool, ctx: &DisplayContext)
     }
 }
 
-/// Convert a metadata value to a typed JSON value, mirroring `value_to_json`'s
-/// conventions (decimals as strings to preserve precision). Without this the
-/// JSON output leaked the Rust Debug form (e.g. `"String(\"good\")"`).
+/// Convert a metadata value to its canonical JSON form (decimals as strings to
+/// preserve precision). Thin wrapper over the single source
+/// [`rustledger_core::meta_value_to_json`]; without it the JSON output leaked
+/// the Rust Debug form (e.g. `"String(\"good\")"`).
 fn meta_value_to_json(v: &rustledger_core::MetaValue) -> serde_json::Value {
-    use rustledger_core::MetaValue;
-    match v {
-        MetaValue::String(s) => serde_json::Value::String(s.clone()),
-        MetaValue::Number(n) => serde_json::json!(n.to_string()),
-        MetaValue::Bool(b) => serde_json::Value::Bool(*b),
-        MetaValue::Date(d) => serde_json::Value::String(d.to_string()),
-        MetaValue::Amount(a) => serde_json::json!({
-            "number": a.number.to_string(),
-            "currency": a.currency,
-        }),
-        MetaValue::Account(a) => serde_json::Value::String(a.to_string()),
-        MetaValue::Currency(c) => serde_json::Value::String(c.to_string()),
-        MetaValue::Tag(t) => serde_json::Value::String(t.to_string()),
-        MetaValue::Link(l) => serde_json::Value::String(l.to_string()),
-        MetaValue::None => serde_json::Value::Null,
-        // Stringified like `Number`, keeping all numeric metadata uniform on the
-        // JSON wire (and identical across the FFI bindings).
-        MetaValue::Int(i) => serde_json::json!(i.to_string()),
-    }
+    rustledger_core::meta_value_to_json(v)
 }
 
 fn value_to_json(value: &Value) -> serde_json::Value {


### PR DESCRIPTION
## What

First PR from the architecture-validation roadmap (item: *one canonical MetaValue↔wire codec*). Introduces a single source for the `MetaValue` JSON wire mapping in `rustledger-core` and routes the duplicated copies through it.

Adding `MetaValue::Int` recently required hand-editing the same `MetaValue → JSON` match at multiple wire surfaces (ffi-wasi plain + typed, CLI query, wasm typed), and the copies could silently drift — the type tag especially (I added `"int"` in two places). The audit flagged this as the highest change-amplification surface.

## How

New `rustledger_core::meta_json`:
- `meta_value_to_json(&MetaValue) -> serde_json::Value` — the canonical JSON form.
- `meta_value_type_tag(&MetaValue) -> &'static str` — the `type`/`value_type` discriminator, **`serde_json`-free** so the wasm binding can share it.
- `json_to_meta_value(&serde_json::Value) -> MetaValue` — the inverse.

Routed through it:
- **ffi-wasi** `meta_value_to_json` / `json_to_meta_value` → thin wrappers; `TypedValue::from_meta_value` collapses a 48-line match to `{ tag, json }`.
- **CLI** `query --format json` `meta_value_to_json` → core (also fixes a latent inconsistency: CLI serialized `Amount.currency` via serde while ffi-wasi/wasm used `.to_string()`; now unified).
- **wasm** `meta_value_to_typed_json` collapses to `{ core type-tag, this-crate value }`.

**Respecting a deliberate deviation:** the wasm crate intentionally keeps `serde_json` a host-only dev-dependency (it emits the typed `MetaValueJson` enum), so it can't call the `serde_json` codec — but it now shares the `serde_json`-free type tag, single-sourcing the drift-prone part across *every* surface. The plugin `MetaValueData` (MessagePack) and the WIT `meta-value` are separate, narrower wire contracts, intentionally left out of the JSON codec (documented).

## Fitness function

`codec_covers_every_variant` + `json_round_trip` in core, plus the existing ffi-wasi==wasm wire-format equivalence harness (unchanged → confirms byte-identical output). A new `MetaValue` variant now fails to compile in **one** module (three exhaustive matches in `meta_json`) instead of being silently missable across surfaces.

## Verification

`cargo build --all-features --all-targets` clean; rustledger-core/ffi-wasi/wasm/wire-format-tests/cli suites pass (the equivalence harness proves no wire-format change); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
