### PR TITLE
fix(loader): cache display_precision + 2 dropped option fields (field-parity guard)

### DIFF
--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -84,11 +84,17 @@ pub struct CachedOptions {
     pub infer_tolerance_from_cost: bool,
     pub use_legacy_fixed_tolerances: bool,
     pub experiment_explicit_tolerances: bool,
+    pub use_precise_interpolation: bool,
     pub booking_method: String,
     pub render_commas: bool,
+    /// `option "display_precision" "USD:4"` overrides, stored as
+    /// (currency, digits) pairs. Dropping this on a cache hit silently reverted
+    /// number formatting to inferred precision (the bug this field fixes).
+    pub display_precision: Vec<(String, u32)>,
     pub allow_pipe_separator: bool,
     pub long_string_maxlines: u32,
     pub documents: Vec<String>,
+    pub plugin_processing_mode: String,
     pub custom: Vec<(String, String)>,
     /// Names of options the source explicitly set (e.g.
     /// `"booking_method"`). Restored so downstream resolution that
@@ -125,11 +131,18 @@ impl From<&Options> for CachedOptions {
             infer_tolerance_from_cost: opts.infer_tolerance_from_cost,
             use_legacy_fixed_tolerances: opts.use_legacy_fixed_tolerances,
             experiment_explicit_tolerances: opts.experiment_explicit_tolerances,
+            use_precise_interpolation: opts.use_precise_interpolation,
             booking_method: opts.booking_method.clone(),
             render_commas: opts.render_commas,
+            display_precision: opts
+                .display_precision
+                .iter()
+                .map(|(k, v)| (k.clone(), *v))
+                .collect(),
             allow_pipe_separator: opts.allow_pipe_separator,
             long_string_maxlines: opts.long_string_maxlines,
             documents: opts.documents.clone(),
+            plugin_processing_mode: opts.plugin_processing_mode.clone(),
             custom: opts
                 .custom
                 .iter()
@@ -170,11 +183,14 @@ impl From<CachedOptions> for Options {
         opts.infer_tolerance_from_cost = cached.infer_tolerance_from_cost;
         opts.use_legacy_fixed_tolerances = cached.use_legacy_fixed_tolerances;
         opts.experiment_explicit_tolerances = cached.experiment_explicit_tolerances;
+        opts.use_precise_interpolation = cached.use_precise_interpolation;
         opts.booking_method = cached.booking_method;
         opts.render_commas = cached.render_commas;
+        opts.display_precision = cached.display_precision.into_iter().collect();
         opts.allow_pipe_separator = cached.allow_pipe_separator;
         opts.long_string_maxlines = cached.long_string_maxlines;
         opts.documents = cached.documents;
+        opts.plugin_processing_mode = cached.plugin_processing_mode;
         opts.custom = cached.custom.into_iter().collect();
         opts.set_options = cached.set_options.into_iter().collect();
         opts
@@ -321,7 +337,12 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     metadata literals (`key: 42`) now archive as `Int` rather than
 ///     `Number`, and the new discriminant changes the enum's archived
 ///     layout, so old bytes must be regenerated.
-const CACHE_VERSION: u32 = 11;
+/// v12: `CachedOptions` gained `display_precision`, `use_precise_interpolation`,
+///     and `plugin_processing_mode` — previously dropped, so a cache hit
+///     silently ignored `option "display_precision" "USD:4"` (formatting fell
+///     back to inferred precision) and the other two settings. New fields change
+///     the archived layout, so old bytes must be regenerated.
+const CACHE_VERSION: u32 = 12;
 
 /// Cache header stored at the start of cache files.
 #[derive(Debug, Clone)]
@@ -1016,11 +1037,11 @@ mod tests {
         // the developer to also update the fixtures (or remove this
         // tripwire if v9's contract is identical to v8 for CostNumber
         // — which is unusual but possible).
-        // v9 (#1340), v10 (string escape-decoding), and v11 (`MetaValue::Int`)
-        // all bumped CACHE_VERSION without touching the `CostNumber` archived
-        // layout these fixtures pin, so the byte arrays below are still valid
-        // and only FIXTURE_VERSION moves.
-        const FIXTURE_VERSION: u32 = 11;
+        // v9 (#1340), v10 (string escape-decoding), v11 (`MetaValue::Int`), and
+        // v12 (`CachedOptions` field-parity) all bumped CACHE_VERSION without
+        // touching the `CostNumber` archived layout these fixtures pin, so the
+        // byte arrays below are still valid and only FIXTURE_VERSION moves.
+        const FIXTURE_VERSION: u32 = 12;
         assert_eq!(
             CACHE_VERSION, FIXTURE_VERSION,
             "CACHE_VERSION advanced past the fixture version; regenerate \
@@ -1110,6 +1131,64 @@ mod tests {
         assert_eq!(restored.title, Some("Test Ledger".to_string()));
         assert_eq!(restored.operating_currency, vec!["USD", "EUR"]);
         assert!(restored.render_commas);
+    }
+
+    /// Structural guard (fitness function): populate EVERY non-transient
+    /// `Options` field with a non-default value, round-trip through
+    /// `CachedOptions`, and assert nothing was dropped. A new `Options` field
+    /// that `CachedOptions` forgets to carry fails here — the bug class that
+    /// silently dropped `display_precision` / `use_precise_interpolation` /
+    /// `plugin_processing_mode` (and `set_options` before #1340).
+    ///
+    /// `warnings` is intentionally transient (re-derived, not cached), so it is
+    /// left default on both sides. **When you add a field to `Options`, set it
+    /// here too.**
+    #[test]
+    fn cached_options_field_parity() {
+        use rust_decimal_macros::dec;
+
+        let mut opts = Options::new();
+        opts.title = Some("T".into());
+        opts.filename = Some("f.beancount".into());
+        opts.operating_currency = vec!["USD".into(), "EUR".into()];
+        opts.name_assets = "A".into();
+        opts.name_liabilities = "L".into();
+        opts.name_equity = "Q".into();
+        opts.name_income = "I".into();
+        opts.name_expenses = "X".into();
+        opts.account_rounding = Some("Equity:Round".into());
+        opts.account_previous_balances = "Opening".into();
+        opts.account_previous_earnings = "Earn".into();
+        opts.account_previous_conversions = "Conv".into();
+        opts.account_current_earnings = "CurEarn".into();
+        opts.account_current_conversions = Some("CurConv".into());
+        opts.account_unrealized_gains = Some("Unreal".into());
+        opts.conversion_currency = Some("NOTHING".into());
+        opts.inferred_tolerance_default =
+            std::iter::once(("USD".to_string(), dec!(0.005))).collect();
+        opts.inferred_tolerance_multiplier = dec!(1.5);
+        opts.infer_tolerance_from_cost = true;
+        opts.use_legacy_fixed_tolerances = true;
+        opts.experiment_explicit_tolerances = true;
+        opts.use_precise_interpolation = true;
+        opts.booking_method = "FIFO".into();
+        opts.render_commas = true;
+        opts.display_precision = [("USD".to_string(), 4u32), ("JPY".to_string(), 0)]
+            .into_iter()
+            .collect();
+        opts.allow_pipe_separator = true;
+        opts.long_string_maxlines = 99;
+        opts.documents = vec!["docs".into()];
+        opts.plugin_processing_mode = "raw".into();
+        opts.custom = std::iter::once(("k".to_string(), "v".to_string())).collect();
+        opts.set_options = std::iter::once("booking_method".to_string()).collect();
+        // `warnings` left default (transient — not cached).
+
+        let restored: Options = CachedOptions::from(&opts).into();
+        assert_eq!(
+            restored, opts,
+            "a CachedOptions field was dropped on the cache round-trip"
+        );
     }
 
     /// Regression for #1340: `set_options` must survive the cache

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -87,7 +87,8 @@ pub struct CachedOptions {
     pub use_precise_interpolation: bool,
     pub booking_method: String,
     pub render_commas: bool,
-    /// `option "display_precision" "USD:4"` overrides, stored as
+    /// `option "display_precision" "USD:0.0001"` overrides (the digit count is
+    /// the example number's decimal scale, so `0.0001` → 4), stored as
     /// (currency, digits) pairs. Dropping this on a cache hit silently reverted
     /// number formatting to inferred precision (the bug this field fixes).
     pub display_precision: Vec<(String, u32)>,
@@ -323,7 +324,7 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     positionally) — verified against rkyv 0.8.16 — so this change
 ///     does NOT require a separate version bump. If a future rkyv
 ///     version changes that encoding, OR if `CostNumber` gains
-///     additional fields, bump to the next version (v12).
+///     additional fields, bump `CACHE_VERSION` to the next value.
 /// v9: `CachedOptions` gained a `set_options: Vec<String>` field
 ///     (#1340). It was previously dropped, so a cache hit lost the
 ///     record of which options the file explicitly set — making
@@ -339,9 +340,9 @@ const CACHE_MAGIC: &[u8; 8] = b"RLEDGER\0";
 ///     layout, so old bytes must be regenerated.
 /// v12: `CachedOptions` gained `display_precision`, `use_precise_interpolation`,
 ///     and `plugin_processing_mode` — previously dropped, so a cache hit
-///     silently ignored `option "display_precision" "USD:4"` (formatting fell
-///     back to inferred precision) and the other two settings. New fields change
-///     the archived layout, so old bytes must be regenerated.
+///     silently ignored `option "display_precision" "USD:0.0001"` (formatting
+///     fell back to inferred precision) and the other two settings. New fields
+///     change the archived layout, so old bytes must be regenerated.
 const CACHE_VERSION: u32 = 12;
 
 /// Cache header stored at the start of cache files.

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -53,7 +53,7 @@ const REPEATABLE_OPTIONS: &[&str] = &[
 const READONLY_OPTIONS: &[&str] = &["filename"];
 
 /// Option validation warning.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptionWarning {
     /// Warning code (E7001 through E7006).
     pub code: &'static str,
@@ -68,7 +68,7 @@ pub struct OptionWarning {
 /// Beancount file options.
 ///
 /// These correspond to the `option` directives in beancount files.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Options {
     /// Title for the ledger.
     pub title: Option<String>,


### PR DESCRIPTION
## What

Architecture-roadmap item (cheap risk-reducer): `CachedOptions` — the hand-maintained rkyv mirror of `Options` — silently dropped three behavior-affecting fields, so a **cache hit produced different results than a fresh load**:

- `display_precision` → `option "display_precision" "USD:4"` was ignored; number formatting reverted to inferred precision.
- `use_precise_interpolation` → interpolation behavior changed.
- `plugin_processing_mode` → plugin processing changed.

This is the same bug class fixed once for `set_options` (#1340) without closing the structural gap.

## How

- Add the three fields to `CachedOptions` + both `From` impls (`display_precision` stored as `Vec<(String, u32)>`, matching the existing pair-encoding convention).
- Bump `CACHE_VERSION` 11 → 12 (the new fields change the archived layout; old caches auto-invalidate and rebuild). `FIXTURE_VERSION` tripwire moved to 12 (`CostNumber` bytes unchanged).

## Fitness function (the structural fix)

`cached_options_field_parity`: populates **every** non-transient `Options` field with a non-default value, round-trips through `CachedOptions`, and asserts whole-struct equality — so a future field that `CachedOptions` forgets to carry fails the test. Enabled by deriving `PartialEq`/`Eq` on `Options` + `OptionWarning`. (`warnings` is intentionally transient — re-derived, not cached — and is excluded.)

## Verification

`cargo build --all-features --all-targets` clean; rustledger-loader suite passes (field-parity + the v12 fixture tripwire); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
