### PR TITLE
fix(loader): one path-normalization namespace for include traversal guard

### DIFF
--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -73,48 +73,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use thiserror::Error;
 
-/// Try to canonicalize a path, falling back to making it absolute if canonicalize
-/// is not supported (e.g., on WASI).
-///
-/// This function:
-/// 1. First tries `fs::canonicalize()` which resolves symlinks and returns absolute path
-/// 2. If that fails (e.g., WASI doesn't support it), tries to make an absolute path manually
-/// 3. As a last resort, returns the original path
-fn normalize_path(path: &Path) -> PathBuf {
-    // Try canonicalize first (works on most platforms, resolves symlinks)
-    if let Ok(canonical) = path.canonicalize() {
-        return canonical;
-    }
-
-    // Fallback: make absolute without resolving symlinks (WASI-compatible)
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else if let Ok(cwd) = std::env::current_dir() {
-        // Join with current directory and clean up the path
-        let mut result = cwd;
-        for component in path.components() {
-            match component {
-                std::path::Component::ParentDir => {
-                    result.pop();
-                }
-                std::path::Component::Normal(s) => {
-                    result.push(s);
-                }
-                std::path::Component::CurDir => {}
-                std::path::Component::RootDir => {
-                    result = PathBuf::from("/");
-                }
-                std::path::Component::Prefix(p) => {
-                    result = PathBuf::from(p.as_os_str());
-                }
-            }
-        }
-        result
-    } else {
-        // Last resort: just return the path as-is
-        path.to_path_buf()
-    }
-}
+// Path normalization lives in a single place: `FileSystem::normalize`
+// (`DiskFileSystem::normalize` is the disk implementation, `VirtualFileSystem`
+// the in-memory one). The free `normalize_path` that used to duplicate the disk
+// body was removed — all callers go through the injected filesystem so the
+// include path-traversal guard normalizes consistently in one namespace.
 
 /// Errors that can occur during loading.
 #[derive(Debug, Error)]
@@ -531,9 +494,15 @@ impl Loader {
                     } else {
                         base_dir.to_path_buf()
                     };
-                    normalize_path(&prefix_path)
+                    // Normalize via the injected filesystem (not a hardcoded
+                    // disk path fn), so this pre-glob traversal guard and the
+                    // per-matched-file guard below resolve in the SAME namespace
+                    // — under a `VirtualFileSystem` the disk `normalize_path`
+                    // would have compared a disk-canonicalized prefix against a
+                    // pure-string root.
+                    self.fs.normalize(&prefix_path)
                 } else {
-                    normalize_path(&full_path)
+                    self.fs.normalize(&full_path)
                 };
 
                 if !path_to_check.starts_with(root) {
@@ -1126,6 +1095,43 @@ include "./transactions/*.beancount"
         assert!(
             has_glob_error,
             "expected GlobNoMatch error, got: {:?}",
+            result.errors
+        );
+    }
+
+    /// Regression: with path security under a `VirtualFileSystem`, the pre-glob
+    /// traversal guard used the disk `normalize_path` while the per-file guard
+    /// used `self.fs.normalize` — different namespaces. So a LEGITIMATE glob
+    /// include within the root got its prefix disk-normalized to a real-CWD path
+    /// that didn't `starts_with` the VFS root, and was falsely rejected as a
+    /// path traversal. Both guards now normalize through the injected filesystem.
+    #[test]
+    fn test_vfs_glob_include_within_root_not_flagged_as_traversal() {
+        let mut vfs = VirtualFileSystem::new();
+        vfs.add_file("ledger/main.beancount", r#"include "sub/*.beancount""#);
+        vfs.add_file(
+            "ledger/sub/a.beancount",
+            "2024-01-01 open Assets:Cash USD\n",
+        );
+
+        let result = Loader::new()
+            .with_filesystem(Box::new(vfs))
+            .with_root_dir(PathBuf::from("ledger")) // enables path security
+            .load(Path::new("ledger/main.beancount"))
+            .unwrap();
+
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| matches!(e, LoadError::PathTraversal { .. })),
+            "legit in-root VFS glob include wrongly flagged as traversal: {:?}",
+            result.errors
+        );
+        // The included file actually loaded (its `open` is present).
+        assert!(
+            !result.directives.is_empty(),
+            "the in-root include should have loaded; errors: {:?}",
             result.errors
         );
     }

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -336,6 +336,16 @@ impl Loader {
         if self.enforce_path_security && self.root_dir.is_none() {
             self.root_dir = canonical.parent().map(Path::to_path_buf);
         }
+        // Normalize the root through the SAME filesystem namespace as the paths
+        // it is compared against. An explicit `with_root_dir(...)` may be
+        // relative/un-normalized, and on disk `normalize` makes paths absolute —
+        // so without this, a relative root never `starts_with` a normalized path
+        // and every include would be falsely rejected as a traversal. (The
+        // default-derived root is already normalized, so re-normalizing is a
+        // no-op there.)
+        if let Some(root) = self.root_dir.take() {
+            self.root_dir = Some(self.fs.normalize(&root));
+        }
 
         // Phase 1: Parse the root file to discover includes.
         // The root file is typically small (just includes + options).


### PR DESCRIPTION
## What

Architecture-roadmap item (security boundary): the include path-traversal guard used **two different path-normalization implementations in different namespaces**.

- The pre-glob prefix check used the free `normalize_path` (hardcoded disk `canonicalize`-or-lexical), while the per-matched-file check used `self.fs.normalize`.
- Under a `VirtualFileSystem`, the pre-check disk-normalized the prefix to a real-CWD path that didn't `starts_with` the VFS root — so a **legitimate in-root glob include was falsely rejected as a path traversal** (and the disk vs VFS copies could also drift on a future `..`/symlink edge).
- `normalize_path` (lib.rs) and `DiskFileSystem::normalize` (vfs.rs) were byte-identical copies.

## How

- Route **both** include checks (the pre-glob prefix and the per-file) through `self.fs.normalize`, so the security boundary normalizes consistently in one namespace and respects the injected `FileSystem`. On disk this is behaviorally identical (`DiskFileSystem::normalize` == the old `normalize_path`); under VFS it's the fix.
- Delete the now-dead free `normalize_path` — the disk normalization body now lives in exactly one place (`DiskFileSystem::normalize`).

## Tests

`test_vfs_glob_include_within_root_not_flagged_as_traversal`: a legit in-root glob include under a `VirtualFileSystem` with path security enabled must load (no `PathTraversal`). Fails on the old code (disk-normalized prefix), passes now. Existing path-traversal/include tests unchanged.

## Scope note (follow-up)

A third bespoke copy of this check exists in `run_plugins` (process.rs, plugin path security) using bare `canonicalize()` gated on `(Ok, Ok)` — silently skipped when `canonicalize` fails. It's a free function with no `FileSystem` in scope, and a naive "reject on normalize failure" interacts subtly with a symlinked base dir + a not-yet-existing plugin file (false positives). Left as a separate, carefully-scoped follow-up rather than rushed into this security PR.

Verification: rustledger-loader suite passes; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
