### PR TITLE
refactor(booking): route interpolate through the shared cost-weight engine

### DIFF
--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -194,45 +194,12 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                 }
 
                 // Determine the "weight" of this posting for balance purposes.
-                // This must match the logic in calculate_residual().
-                //
-                // Rules:
-                // - If there's a cost spec, weight is in cost currency (not units)
-                // - If there's a price annotation (no cost), weight is in price currency
-                // - Otherwise, weight is the units themselves
-
-                // Check if cost spec has determinable values.
-                // If cost has number but no currency, try to infer currency from:
-                // 1. Price annotation
-                // 2. Other postings in the transaction
-                let cost_contribution = posting.cost.as_ref().and_then(|cost_spec| {
-                    // Try to get cost currency, falling back to price currency, then other postings
-                    let inferred_currency = cost_spec
-                        .currency
-                        .clone()
-                        .or_else(|| crate::price_currency_of(posting))
-                        .or_else(|| get_inferred_currency(&mut inferred_cost_currency));
-
-                    let cost_curr = inferred_currency.as_ref()?;
-                    match cost_spec.number {
-                        Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => {
-                            let cost_amount = amount.number * per_unit;
-                            Some((cost_curr.clone(), cost_amount))
-                        }
-                        Some(rustledger_core::CostNumber::Total { value: total }) => {
-                            // Sign depends on units sign — the spec
-                            // names the total magnitude, not the
-                            // direction.
-                            Some((cost_curr.clone(), total * amount.number.signum()))
-                        }
-                        Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
-                            // Use the preserved total for precision
-                            // (same rationale as the residual block
-                            // above).
-                            Some((cost_curr.clone(), b.total * amount.number.signum()))
-                        }
-                        None => None, // empty `{}`
-                    }
+                // The cost weight goes through the shared `cost_weight` engine —
+                // the SAME `CostNumber` ladder `calculate_residual` uses — so
+                // interpolation and the balance residual can no longer disagree
+                // (the rule: cost beats price; else price; else units).
+                let cost_contribution = crate::cost_weight::<Decimal>(posting, amount, || {
+                    get_inferred_currency(&mut inferred_cost_currency)
                 });
 
                 if let Some((currency, cost_amount)) = cost_contribution {
@@ -254,12 +221,9 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                     // Track this as one unknown for the cost currency. The
                     // post-loop check then enforces the "at most one unknown
                     // per currency group" rule that bean-check enforces.
-                    let cost_currency = posting
-                        .cost
-                        .as_ref()
-                        .and_then(|c| c.currency.clone())
-                        .or_else(|| crate::price_currency_of(posting))
-                        .or_else(|| get_inferred_currency(&mut inferred_cost_currency));
+                    let cost_currency = crate::cost_currency_of(posting, || {
+                        get_inferred_currency(&mut inferred_cost_currency)
+                    });
                     if let Some(curr) = cost_currency {
                         *cost_unknowns_by_currency.entry(curr).or_default() += 1;
                     }
@@ -763,6 +727,44 @@ mod tests {
             !result.residuals.contains_key("HOOL"),
             "should not have HOOL residual"
         );
+    }
+
+    /// Agreement fitness function: interpolation and balance-checking now share
+    /// the `cost_weight` engine, so after interpolation the *independent* public
+    /// [`crate::calculate_residual`] must see the result as balanced — across
+    /// cost AND price weights. If interpolation computed a posting using a
+    /// different weight than the residual does, this would surface a non-zero
+    /// residual.
+    #[test]
+    fn test_interpolated_weights_agree_with_calculate_residual() {
+        // Total-cost stock + unit-priced FX leg, both weighing in USD; the auto
+        // cash posting must absorb the USD residual exactly.
+        let txn = Transaction::new(date(2015, 10, 2), "Mixed cost and price")
+            .with_synthesized_posting(
+                Posting::new("Assets:Stock", Amount::new(dec!(10), "HOOL")).with_cost(
+                    rustledger_core::CostSpec::empty()
+                        .with_number(rustledger_core::CostNumber::Total {
+                            value: dec!(1500.00),
+                        })
+                        .with_currency("USD"),
+                ),
+            )
+            .with_synthesized_posting(
+                Posting::new("Assets:EUR", Amount::new(dec!(-200.00), "EUR")).with_price(
+                    rustledger_core::PriceAnnotation::unit(Amount::new(dec!(1.10), "USD")),
+                ),
+            )
+            .with_synthesized_posting(Posting::auto("Assets:Cash"));
+
+        let result = interpolate(&txn).expect("interpolation should succeed");
+
+        // The independent residual engine (sharing cost_weight) sees balance.
+        for (currency, value) in crate::calculate_residual(&result.transaction) {
+            assert!(
+                value.abs() < dec!(0.0001),
+                "interpolated result not balanced per calculate_residual: {value} {currency}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -157,6 +157,57 @@ impl WeightNum for BigDecimal {
     }
 }
 
+/// Resolve the currency a posting's cost weight is denominated in: the explicit
+/// cost currency, else the price currency, else `infer_currency()` (called
+/// lazily — only when the first two are absent). Returns `None` if the posting
+/// has no cost spec or no currency can be determined.
+pub(crate) fn cost_currency_of(
+    posting: &rustledger_core::Posting,
+    infer_currency: impl FnOnce() -> Option<Currency>,
+) -> Option<Currency> {
+    let cost_spec = posting.cost.as_ref()?;
+    cost_spec
+        .currency
+        .clone()
+        .or_else(|| price_currency_of(posting))
+        .or_else(infer_currency)
+}
+
+/// The canonical per-posting **cost** weight contribution — the single
+/// `CostNumber` ladder shared by [`residual_weight`] and `interpolate` (so the
+/// "cost beats price" weight rule and a future `CostNumber` variant live in one
+/// place rather than drifting between balance-checking and interpolation).
+///
+/// Returns `None` for a posting with no cost spec, an empty `{}` spec (no
+/// determinable number), or when no cost currency resolves. `interpolate`
+/// instantiates this at `Decimal`.
+fn cost_weight<D: WeightNum>(
+    posting: &rustledger_core::Posting,
+    units: &Amount,
+    infer_currency: impl FnOnce() -> Option<Currency>,
+) -> Option<(Currency, D)> {
+    let cost_spec = posting.cost.as_ref()?;
+    let cost_curr = cost_currency_of(posting, infer_currency)?;
+    let signum = units.number.signum();
+    // `PerUnitFromTotal` and `Total` both carry a preserved total — using it
+    // avoids the division-then-multiplication precision loss of recomputing from
+    // `per_unit`. `PerUnit` goes through multiplication.
+    match cost_spec.number {
+        Some(rustledger_core::CostNumber::Total { value: total }) => {
+            Some((cost_curr, D::from_decimal(total) * D::from_decimal(signum)))
+        }
+        Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => Some((
+            cost_curr,
+            D::from_decimal(b.total) * D::from_decimal(signum),
+        )),
+        Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => Some((
+            cost_curr,
+            D::from_decimal(units.number) * D::from_decimal(per_unit),
+        )),
+        None => None, // empty `{}`
+    }
+}
+
 /// The canonical per-posting balance weight, summed per currency, generic over
 /// the numeric backend. Single source of truth for [`calculate_residual`] and
 /// [`calculate_residual_precise`].
@@ -185,34 +236,8 @@ fn residual_weight<D: WeightNum>(transaction: &Transaction) -> HashMap<Currency,
         let signum = units.number.signum();
 
         // Determine the "weight" of this posting for balance purposes.
-        // If cost has a number but no currency, infer the currency from the
-        // price annotation, then from the other postings.
-        let cost_contribution = posting.cost.as_ref().and_then(|cost_spec| {
-            let inferred_currency = cost_spec
-                .currency
-                .clone()
-                .or_else(|| price_currency_of(posting))
-                .or_else(|| get_inferred_currency(&mut inferred_cost_currency));
-
-            // `PerUnitFromTotal` and `Total` both carry a preserved total —
-            // using it avoids the division-then-multiplication precision loss of
-            // recomputing from `per_unit`. `PerUnit` goes through multiplication.
-            let cost_curr = inferred_currency.as_ref()?;
-            match cost_spec.number {
-                Some(rustledger_core::CostNumber::Total { value: total }) => Some((
-                    cost_curr.clone(),
-                    D::from_decimal(total) * D::from_decimal(signum),
-                )),
-                Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => Some((
-                    cost_curr.clone(),
-                    D::from_decimal(b.total) * D::from_decimal(signum),
-                )),
-                Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => Some((
-                    cost_curr.clone(),
-                    D::from_decimal(units.number) * D::from_decimal(per_unit),
-                )),
-                None => None, // empty `{}`
-            }
+        let cost_contribution = cost_weight::<D>(posting, units, || {
+            get_inferred_currency(&mut inferred_cost_currency)
         });
 
         if let Some((currency, amount)) = cost_contribution {

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -161,6 +161,7 @@ impl WeightNum for BigDecimal {
 /// cost currency, else the price currency, else `infer_currency()` (called
 /// lazily — only when the first two are absent). Returns `None` if the posting
 /// has no cost spec or no currency can be determined.
+#[must_use]
 pub(crate) fn cost_currency_of(
     posting: &rustledger_core::Posting,
     infer_currency: impl FnOnce() -> Option<Currency>,
@@ -187,25 +188,26 @@ fn cost_weight<D: WeightNum>(
     infer_currency: impl FnOnce() -> Option<Currency>,
 ) -> Option<(Currency, D)> {
     let cost_spec = posting.cost.as_ref()?;
-    let cost_curr = cost_currency_of(posting, infer_currency)?;
     let signum = units.number.signum();
     // `PerUnitFromTotal` and `Total` both carry a preserved total — using it
     // avoids the division-then-multiplication precision loss of recomputing from
-    // `per_unit`. `PerUnit` goes through multiplication.
-    match cost_spec.number {
+    // `per_unit`. `PerUnit` goes through multiplication. Match the number FIRST
+    // so an empty `{}` spec short-circuits without resolving (and possibly
+    // inferring) the cost currency.
+    let weight = match cost_spec.number {
         Some(rustledger_core::CostNumber::Total { value: total }) => {
-            Some((cost_curr, D::from_decimal(total) * D::from_decimal(signum)))
+            D::from_decimal(total) * D::from_decimal(signum)
         }
-        Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => Some((
-            cost_curr,
-            D::from_decimal(b.total) * D::from_decimal(signum),
-        )),
-        Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => Some((
-            cost_curr,
-            D::from_decimal(units.number) * D::from_decimal(per_unit),
-        )),
-        None => None, // empty `{}`
-    }
+        Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
+            D::from_decimal(b.total) * D::from_decimal(signum)
+        }
+        Some(rustledger_core::CostNumber::PerUnit { value: per_unit }) => {
+            D::from_decimal(units.number) * D::from_decimal(per_unit)
+        }
+        None => return None, // empty `{}`
+    };
+    let cost_curr = cost_currency_of(posting, infer_currency)?;
+    Some((cost_curr, weight))
 }
 
 /// The canonical per-posting balance weight, summed per currency, generic over


### PR DESCRIPTION
## What

Architecture-roadmap item (slice 2 of the posting-weight consolidation, after #1528). `interpolate` carried a hand-replicated copy of the cost-weight `CostNumber` ladder with a comment-only invariant — `interpolate.rs:197` literally said *"This must match the logic in calculate_residual()"*. A future `CostNumber` variant or sign fix applied to the residual ladder but not interpolation's copy would make a transaction that interpolates "balanced" while the residual check sees "unbalanced" (or vice versa).

## How

- Extract two shared helpers in `lib.rs` (alongside the #1528 `WeightNum`/`residual_weight` engine):
  - `cost_currency_of(posting, infer)` — the cost-currency resolution (explicit → price → inferred), used in 3 places before.
  - `cost_weight<D: WeightNum>(posting, units, infer)` — the canonical `CostNumber` ladder, generic over the numeric backend.
- Route `residual_weight`'s cost branch, `interpolate`'s cost contribution, and `interpolate`'s empty-cost-spec currency lookup through them. **Delete** the "This must match calculate_residual()" comment — it is now the *same function*.

Byte-identical: the Decimal arms are unchanged; only the call site moved.

## Tests

- All existing interpolate-with-cost tests (per-unit/total/negative cost, stock sale with cost+price) and the TLA balance proptest pass unchanged.
- New `test_interpolated_weights_agree_with_calculate_residual`: interpolate a total-cost + unit-price transaction, then assert the **independent** public `calculate_residual` sees the interpolated result as balanced — the audit's requested "interpolated weights and residual weights agree" check. A drift between the two engines would surface here as a non-zero residual.

Verification: rustledger-booking + rustledger-validate suites green; `clippy --all-features --all-targets -D warnings` + fmt clean.

## Remaining follow-up (tracked)

`Position::from_posting` shared by `book::apply` / `pad` / `validate` (with the zero-units guard in one place) — the last slice of the BR7 consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
