### PR TITLE
ci(compat): block on BQL query regressions

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -154,6 +154,9 @@ jobs:
           mkdir -p .github/badges
           curl -sSf https://raw.githubusercontent.com/${{ github.repository }}/compatibility/.github/badges/compat-check-results.jsonl \
             -o .github/badges/previous-check-results.jsonl 2>/dev/null || echo "" > .github/badges/previous-check-results.jsonl
+          # BQL baseline (main's per-query results) for the regression gate below.
+          curl -sSf https://raw.githubusercontent.com/${{ github.repository }}/compatibility/.github/badges/compat-bql-results.jsonl \
+            -o .github/badges/previous-bql-results.jsonl 2>/dev/null || echo "" > .github/badges/previous-bql-results.jsonl
       - name: Run comprehensive compatibility test
         id: compat_test
         run: |
@@ -625,11 +628,15 @@ jobs:
         id: bql_compat
         run: |
           echo "=== BQL Compatibility Test ==="
+          # --baseline makes this step EXIT NON-ZERO (fail the job) if any
+          # (file, query) pair that matched on main now fails — i.e. a BQL
+          # regression. This is what blocks a JOURNAL-style drop from merging.
           python3 scripts/compat-bql-test.py \
             --corpus tests/compatibility/bql-queries.toml \
             --files-from compat-check-results.jsonl \
             --rledger ./target/release/rledger \
             --output compat-bql-results.jsonl \
+            --baseline .github/badges/previous-bql-results.jsonl \
             --github-output
       - name: Generate YAML summary
         run: |

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -549,6 +549,16 @@ def main() -> int:
         default=MAX_FILES,
         help="Test against at most this many files",
     )
+    ap.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Baseline JSONL (a previous run's --output) to gate against. "
+            "Exit non-zero if any (file, query) pair that matched in the "
+            "baseline now fails — i.e. a regression."
+        ),
+    )
     args = ap.parse_args()
 
     queries = load_corpus(args.corpus)
@@ -759,6 +769,45 @@ def main() -> int:
                 f.write(f"bql_known_rust={known_rs}\n")
                 f.write(f"bql_pct={pct}\n")
                 f.write(f"bql_weak_queries={len(weak)}\n")
+
+    # Regression gate. Compare against a baseline run (e.g. main's results from
+    # the `compatibility` branch) and FAIL if any (file, query) pair that
+    # *matched* in the baseline now fails. Comparing per-pair — not the overall
+    # percentage — is robust to corpus/coverage changes: a pair that simply drops
+    # out of the run (its file no longer qualifies) is NOT counted, only a real
+    # true→false flip is. This is the gate that would have caught the JOURNAL
+    # regression (90→12 matches) that previously merged unblocked.
+    if args.baseline and args.baseline.exists():
+        baseline_passing = set()
+        with open(args.baseline) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                b = json.loads(line)
+                if b.get("match"):
+                    baseline_passing.add((b.get("file"), b.get("query_name")))
+
+        regressed = [
+            r
+            for r in results
+            if not r.match and (r.file, r.query_name) in baseline_passing
+        ]
+        if regressed:
+            print()
+            print(
+                f"::error::BQL compat regression: {len(regressed)} (file, query) "
+                f"pair(s) that matched on the baseline now fail"
+            )
+            for r in sorted(regressed, key=lambda r: (r.query_name, r.file))[:30]:
+                print(f"  REGRESSED: {r.query_name} | {r.file}")
+            if len(regressed) > 30:
+                print(f"  ... and {len(regressed) - 30} more")
+            return 1
+        print(
+            f"\nNo BQL regressions vs baseline "
+            f"({len(baseline_passing)} baseline-passing pairs checked)."
+        )
 
     return 0
 

--- a/scripts/compat-bql-test.py
+++ b/scripts/compat-bql-test.py
@@ -784,7 +784,14 @@ def main() -> int:
                 line = line.strip()
                 if not line:
                     continue
-                b = json.loads(line)
+                try:
+                    b = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate a truncated/corrupt baseline line rather than
+                    # crashing with a traceback that obscures the real result.
+                    # A wholly unparsable baseline yields an empty set → no gate
+                    # this run (safer than a spurious block).
+                    continue
                 if b.get("match"):
                     baseline_passing.add((b.get("file"), b.get("query_name")))
 


### PR DESCRIPTION
## What

Makes the **Compatibility** check **block on BQL query regressions**. Today the compat job records results but never exits non-zero — which is how #1506 dropped BQL `JOURNAL` from 90/90 → 12/90 (BQL compat 93%→77%) and still merged.

## How

- `scripts/compat-bql-test.py` gains `--baseline <prev-results.jsonl>`. After the run it compares against the baseline and **exits non-zero if any `(file, query)` pair that *matched* in the baseline now fails** — a true→false regression. The CI annotation lists exactly what regressed (`REGRESSED: <query> | <file>`).
- `compat.yml` fetches main's `compat-bql-results.jsonl` from the `compatibility` branch and passes it as `--baseline`.

**Why per-pair, not percentage:** comparing the overall % is fragile when the corpus or the eligible-file set changes. Per-`(file, query)` only flags an actual result flip — a pair that drops out of the run (coverage change) or a brand-new failure (never passed before) is **not** counted. Verified with a standalone test (catches the flip; ignores coverage-drops and new failures).

## Safety / ordering

- On **PRs**: a regression fails the BQL step → red check → blocks merge. The baseline-commit step is already `if: github.event_name != 'pull_request'`, so PRs never write the baseline.
- On **main / nightly**: a regression fails the job *before* the later "Commit results to compatibility branch" step, so a regression is **not** blessed into the baseline (the next run still compares against the last-good baseline).
- First run after merge: main is at ~93% (post-JOURNAL-fix) vs a ≤93% baseline → only improvements (false→true), no regressions → gate passes and the baseline advances.

## Scope note

This gates **BQL query** regressions (the JOURNAL class). The file-level `regression_count` is also computed but is intentionally **not** gated here — synthetic test files are regenerated each run, so a hard file gate needs determinism handling first. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
