### PR TITLE
fix(core): guard zero-units Total cost; share Position::from_posting

### DIFF
--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -158,15 +158,8 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
                     if let Some(units) = posting.amount()
                         && let Some(inv) = inventories.get_mut(&posting.account)
                     {
-                        let position = if let Some(cost_spec) = &posting.cost {
-                            if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
-                                Position::with_cost(units.clone(), cost)
-                            } else {
-                                Position::simple(units.clone())
-                            }
-                        } else {
-                            Position::simple(units.clone())
-                        };
+                        let position =
+                            Position::from_posting(units, posting.cost.as_ref(), txn.date);
                         inv.add(position);
                     }
                 }

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -815,7 +815,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_total_cost_with_zero_units_returns_none_not_panic() {
+    fn test_resolve_total_cost_zero_units_returns_none() {
         // `0 X {{100 USD}}`: a Total cost over zero units. Before the guard,
         // `total / units.abs()` was `100 / 0`, which PANICKED in `validate`/`pad`
         // (which call `resolve`). It must now resolve to `None` (uncosted).

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -721,8 +721,18 @@ impl CostSpec {
         let number = match self.number? {
             // User-specified per-unit cost.
             CostNumber::PerUnit { value: per } => per,
-            // Calculated from total — preserve full precision.
-            CostNumber::Total { value: total } => total / units.abs(),
+            // Calculated from total — preserve full precision. Zero units make
+            // the per-unit cost undefined, and `total / 0` panics, so there is
+            // no cost to resolve: return `None` and let the caller book an
+            // uncosted position. Matches the zero-units guard in
+            // `BookingEngine::apply`; before this, `validate`/`pad` (which call
+            // `resolve`) panicked on `0 X {{n CUR}}`.
+            CostNumber::Total { value: total } => {
+                if units.is_zero() {
+                    return None;
+                }
+                total / units.abs()
+            }
             // Already booked: `b.per_unit == b.total / |units|` by
             // `BookedCost::new`'s invariant, so this is identical to
             // the `Total` arm above but without the redivision.
@@ -802,6 +812,22 @@ mod tests {
         let total = cost.total_cost(dec!(10));
         assert_eq!(total.number, dec!(1500.00));
         assert_eq!(total.currency, "USD");
+    }
+
+    #[test]
+    fn resolve_total_cost_with_zero_units_returns_none_not_panic() {
+        // `0 X {{100 USD}}`: a Total cost over zero units. Before the guard,
+        // `total / units.abs()` was `100 / 0`, which PANICKED in `validate`/`pad`
+        // (which call `resolve`). It must now resolve to `None` (uncosted).
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::Total {
+                value: dec!(100.00),
+            })
+            .with_currency("USD");
+        assert_eq!(spec.resolve(Decimal::ZERO, date(2024, 1, 15)), None);
+        // Non-zero units still resolve to the per-unit cost.
+        let cost = spec.resolve(dec!(4), date(2024, 1, 15)).unwrap();
+        assert_eq!(cost.number, dec!(25)); // 100 / 4
     }
 
     #[test]

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -230,7 +230,7 @@ mod tests {
     }
 
     #[test]
-    fn from_posting_resolves_cost_else_simple_and_survives_zero_units() {
+    fn test_from_posting_resolves_cost_or_simple() {
         use crate::{CostNumber, CostSpec};
         use rust_decimal::Decimal;
 

--- a/crates/rustledger-core/src/position.rs
+++ b/crates/rustledger-core/src/position.rs
@@ -69,6 +69,27 @@ impl Position {
         }
     }
 
+    /// Build the booked position for a posting's `units` and optional cost
+    /// spec: [`Self::with_cost`] when the cost spec resolves to a [`Cost`],
+    /// otherwise [`Self::simple`].
+    ///
+    /// Single source for the validator's inventory-addition path and the pad
+    /// engine, which had byte-identical copies (mirrors the cost-bearing add
+    /// branch of `BookingEngine::apply`). [`CostSpec::resolve`] returns `None`
+    /// for an empty `{}` spec or a zero-units `Total` cost, so those book as a
+    /// simple (uncosted) position rather than panicking.
+    #[must_use]
+    pub fn from_posting(
+        units: &Amount,
+        cost_spec: Option<&CostSpec>,
+        date: crate::NaiveDate,
+    ) -> Self {
+        match cost_spec.and_then(|cs| cs.resolve(units.number, date)) {
+            Some(cost) => Self::with_cost(units.clone(), cost),
+            None => Self::simple(units.clone()),
+        }
+    }
+
     /// Check if this position is empty (zero units).
     #[must_use]
     pub const fn is_empty(&self) -> bool {
@@ -206,6 +227,33 @@ mod tests {
         assert_eq!(pos.units.number, dec!(10));
         assert_eq!(pos.currency(), "AAPL");
         assert_eq!(pos.cost_currency(), Some("USD"));
+    }
+
+    #[test]
+    fn from_posting_resolves_cost_else_simple_and_survives_zero_units() {
+        use crate::{CostNumber, CostSpec};
+        use rust_decimal::Decimal;
+
+        let units = Amount::new(dec!(10), "AAPL");
+        // Resolvable cost spec → with_cost.
+        let spec = CostSpec::empty()
+            .with_number(CostNumber::PerUnit { value: dec!(150) })
+            .with_currency("USD");
+        let pos = Position::from_posting(&units, Some(&spec), date(2024, 1, 15));
+        assert_eq!(pos.cost_currency(), Some("USD"));
+        // No cost spec → simple.
+        let pos = Position::from_posting(&units, None, date(2024, 1, 15));
+        assert!(pos.cost.is_none());
+        // Zero-units Total cost → simple (no cost), NOT a divide-by-zero panic.
+        let zero = Amount::new(Decimal::ZERO, "AAPL");
+        let total = CostSpec::empty()
+            .with_number(CostNumber::Total { value: dec!(100) })
+            .with_currency("USD");
+        let pos = Position::from_posting(&zero, Some(&total), date(2024, 1, 15));
+        assert!(
+            pos.cost.is_none(),
+            "zero-units Total cost must book uncosted, not panic"
+        );
     }
 
     #[test]

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -594,15 +594,7 @@ pub fn process_inventory_addition(
     units: &Amount,
     txn: &Transaction,
 ) {
-    let position = if let Some(cost_spec) = &posting.cost {
-        if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
-            rustledger_core::Position::with_cost(units.clone(), cost)
-        } else {
-            rustledger_core::Position::simple(units.clone())
-        }
-    } else {
-        rustledger_core::Position::simple(units.clone())
-    };
+    let position = rustledger_core::Position::from_posting(units, posting.cost.as_ref(), txn.date);
 
     inv.add(position);
 }


### PR DESCRIPTION
## What

Architecture-roadmap item (final posting-weight slice). Two issues with posting → `Position` construction:

1. **Live panic.** `CostSpec::resolve` computed `total / units.abs()` for a `Total` cost spec — **divide-by-zero panic** on zero units (`0 X {{n CUR}}`). `validate` and `pad` call `resolve`, so they panicked; `BookingEngine::apply` guards it (`if !units.is_zero()` → uncosted). `Loader`/validation must never panic on input.
2. **Duplication.** `validate` and `pad` had byte-identical `resolve → with_cost / else simple` blocks.

## How

- **`CostSpec::resolve`**: the `Total` arm returns `None` when units are zero (no divisor), matching apply's guard. Those postings now book an **uncosted** position instead of panicking.
- **`Position::from_posting(units, cost_spec, date)`**: one helper for the resolve→`with_cost`/`simple` pattern. `validate` and `pad` route through it.

## Tests

- `resolve_total_cost_with_zero_units_returns_none_not_panic` — the regression (`100 / 0` used to panic); non-zero units still resolve.
- `from_posting_resolves_cost_else_simple_and_survives_zero_units` — cost / no-cost / zero-units-Total paths.

Verification: core + booking + validate suites green; `clippy --all-features --all-targets -D warnings` + fmt clean. Behavior matches apply (no compat change).

## Scope note

`apply` keeps its own construction — it additionally **infers** the cost currency (price / other postings) which `resolve` does not, and the inference lives in `rustledger-booking` while `Position`/`resolve` live in `rustledger-core`. Unifying apply requires threading that inference across the crate boundary (it would *add* inference to validate/pad — a behavior change needing compat verification). Tracked as a follow-up; this PR fixes the live panic and de-dups the two identical sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
