### PR TITLE
fix(query): reconcile value-affecting dual-eval divergences (dual-eval PR 2)

### DIFF
--- a/crates/rustledger-query/src/executor/dual_eval_parity.rs
+++ b/crates/rustledger-query/src/executor/dual_eval_parity.rs
@@ -152,44 +152,43 @@ fn shared_pure_functions_agree_across_both_paths() {
 }
 
 // ---------------------------------------------------------------------------
-// Drift pins — these assert the CURRENT divergence between the paths. The
-// reconciliation steps will flip each (and update the corresponding pin),
-// proving the change is deliberate rather than an accidental behavior shift.
+// Reconciled divergences + remaining drift pins. A pin asserts the CURRENT
+// behavior of a known divergence; the reconciliation steps flip each to assert
+// AGREEMENT (renamed `reconciled_*`), so the change is deliberate rather than
+// an accidental behavior shift. The extended-date pin is still pending (it
+// flips when those functions are registered in the eager path).
 // ---------------------------------------------------------------------------
 
-/// `ROOT(account, n)` with a negative depth: the lazy path correctly errors,
-/// the eager path has a `*i as usize` bug that turns `-1` into `usize::MAX` and
-/// silently returns the whole account. Reconciliation ports the lazy guard.
+/// RECONCILED: `ROOT(account, -1)`. The eager path previously had a
+/// `*i as usize` bug that turned `-1` into `usize::MAX` and silently returned
+/// the whole account; the lazy guard was ported into the eager arm, so both
+/// paths now reject a negative depth.
 #[test]
-fn drift_root_negative_depth() {
+fn reconciled_root_negative_depth_both_error() {
     let (eager, lazy) = run_both("ROOT", &[s("Assets:Bank:Checking"), Value::Integer(-1)]);
     assert!(
         lazy.unwrap().is_err(),
-        "lazy ROOT(acct,-1) should error (depth guard)"
+        "lazy ROOT(acct,-1) errors (depth guard)"
     );
-    // The `*i as usize` cast turns -1 into usize::MAX, so `n >= parts.len()`
-    // and eager returns the WHOLE account verbatim. Assert that exact value so
-    // the pin can't be satisfied by some other accidental Ok result.
     assert!(
-        matches!(&eager, Ok(Value::String(a)) if a == "Assets:Bank:Checking"),
-        "eager ROOT(acct,-1) currently returns the whole account (the `*i as usize` bug), \
-         got {eager:?} — flip this pin when the lazy guard is ported into the eager arm"
+        eager.is_err(),
+        "eager ROOT(acct,-1) now errors (guard ported)"
     );
 }
 
-/// `GETITEM(NULL, key)`: the eager path returns `NULL`, the lazy path falls
-/// into a catch-all and errors. Reconciliation adds the `NULL` arm to lazy.
+/// RECONCILED: `GETITEM(NULL, key)`. The eager path returned `NULL`; the lazy
+/// path fell into a catch-all and errored. A `(NULL, _) => NULL` arm was added
+/// to the lazy path, so both paths now return `NULL`.
 #[test]
-fn drift_getitem_on_null() {
+fn reconciled_getitem_on_null_both_null() {
     let (eager, lazy) = run_both("GETITEM", &[Value::Null, s("k")]);
     assert!(
         matches!(eager, Ok(Value::Null)),
-        "eager GETITEM(NULL,k) returns NULL, got {eager:?}"
+        "eager GETITEM(NULL,k) is NULL, got {eager:?}"
     );
     assert!(
-        lazy.unwrap().is_err(),
-        "lazy GETITEM(NULL,k) currently errors — flip this pin when the NULL arm \
-         is added to the lazy path"
+        matches!(lazy.unwrap(), Ok(Value::Null)),
+        "lazy GETITEM(NULL,k) now returns NULL (NULL arm added)"
     );
 }
 
@@ -226,18 +225,14 @@ fn drift_extended_date_functions_missing_from_eager() {
     }
 }
 
-/// `TODAY` takes no arguments; the lazy path rejects extra args, the eager path
-/// ignores them. Reconciliation tightens the eager arm to match lazy.
+/// RECONCILED: `TODAY` takes no arguments. The eager path ignored extras; it
+/// now rejects them with a zero-arg guard, matching the lazy path.
 #[test]
-fn drift_today_extra_arg() {
+fn reconciled_today_extra_arg_both_error() {
     let (eager, lazy) = run_both("TODAY", &[Value::Integer(1)]);
     assert!(
         lazy.unwrap().is_err(),
-        "lazy TODAY(x) should reject the extra arg"
+        "lazy TODAY(x) rejects the extra arg"
     );
-    assert!(
-        eager.is_ok(),
-        "eager TODAY(x) currently ignores the extra arg — flip this pin when the \
-         eager arm gains the zero-arg guard"
-    );
+    assert!(eager.is_err(), "eager TODAY(x) now errors (zero-arg guard)");
 }

--- a/crates/rustledger-query/src/executor/functions/position.rs
+++ b/crates/rustledger-query/src/executor/functions/position.rs
@@ -168,6 +168,9 @@ impl Executor<'_> {
             (Value::Object(obj), Value::String(key)) => {
                 Ok(obj.get(&key).cloned().unwrap_or(Value::Null))
             }
+            // `getitem(NULL, _)` is NULL, not an error — mirrors the eager
+            // `evaluate_function_on_values` arm so both paths agree.
+            (Value::Null, _) => Ok(Value::Null),
             _ => Err(QueryError::Type(
                 "GETITEM expects (inventory, string), (metadata, string), or (object, string)"
                     .to_string(),

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -669,7 +669,11 @@ impl<'a> Executor<'a> {
         let name_upper = name.to_uppercase();
         match name_upper.as_str() {
             // Date functions
-            "TODAY" => Ok(Value::Date(jiff::Zoned::now().date())),
+            "TODAY" => {
+                // Takes no arguments; reject extras to match the lazy path.
+                Self::require_args_count(&name_upper, args, 0)?;
+                Ok(Value::Date(jiff::Zoned::now().date()))
+            }
             "YEAR" => {
                 Self::require_args_count(&name_upper, args, 1)?;
                 match &args[0] {
@@ -1005,10 +1009,22 @@ impl<'a> Executor<'a> {
                     ));
                 }
                 let n = if args.len() == 2 {
-                    match &args[1] {
-                        Value::Integer(i) => *i as usize,
-                        _ => 1,
-                    }
+                    let raw = match &args[1] {
+                        Value::Integer(i) => *i,
+                        _ => {
+                            return Err(QueryError::Type(
+                                "ROOT second arg must be integer".to_string(),
+                            ));
+                        }
+                    };
+                    // Reject negatives explicitly — `i as usize` would silently
+                    // turn -1 into `usize::MAX` and return the whole account.
+                    // Mirrors the lazy `eval_root` guard so both paths agree.
+                    usize::try_from(raw).map_err(|_| {
+                        QueryError::Type(format!(
+                            "ROOT second arg must be a non-negative integer, got {raw}"
+                        ))
+                    })?
                 } else {
                     1
                 };


### PR DESCRIPTION
## What

**PR 2 of the dual-eval-path registry collapse** [XL/BR9]. Reconciles the value-affecting divergences between the lazy (`evaluate_function`) and eager (`evaluate_function_on_values`) BQL dispatchers so their bodies agree — a prerequisite for collapsing them onto one registry without any behavior change. Each fix is gated by the parity harness from PR 1 (#1538).

## Changes

1. **`ROOT(account, n)` negative-depth bug (real latent bug).** The eager arm computed depth with `*i as usize`, turning `-1` into `usize::MAX` and **silently returning the whole account**; a non-Integer second arg was silently coerced to `1`. Ported the lazy `eval_root` guard verbatim — Integer-only, `usize::try_from` rejecting negatives — so both paths now error. (`mod.rs`)
2. **`GETITEM(NULL, key)`.** The eager path returned `NULL`; the lazy path fell into a catch-all and errored. Added the `(NULL, _) => NULL` arm to the lazy `eval_getitem` so both return `NULL`. (`functions/position.rs`)
3. **`TODAY` arity.** The eager arm ignored extra arguments; added a zero-arg guard so it errors like the lazy path. (`mod.rs`)

The three corresponding harness pins flip from asserting *divergence* to asserting *agreement* (`reconciled_*`), proving each change is deliberate.

Arity-*wording* differences (`require_args` vs `require_args_count`) are intentionally left for the delegation PR, where they first become user-visible — they're cosmetic here (both paths error; the harness treats both-error as parity).

## Tests

Parity harness green (5/5, including the 3 reconciled pins). Full `rustledger-query` suite + clippy + fmt clean. The BQL compat gate runs in CI (these are stricter-or-equal behaviors — no compat regression expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
