### PR TITLE
test(query): finish the dual-eval collapse — pin the subquery path (dual-eval PR 6)

### DIFF
--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -818,6 +818,35 @@ fn test_getitem_meta_eager_path_postings() {
     assert_eq!(result.rows[0][0], Value::String("food".to_string()));
 }
 
+/// After the dual-eval-path collapse, the `#postings` / subquery front-end
+/// (`evaluate_subquery_expr`) routes function calls through the same registry
+/// as top-level queries, so it inherits the extended-date functions (previously
+/// `UnknownFunction` there) and the reconciled function bodies. The META
+/// interception must still run first (covered by the getitem-meta test above).
+#[test]
+fn test_unified_registry_reaches_postings_subquery_path() {
+    let directives = sample_directives();
+    let mut executor = Executor::new(&directives);
+
+    // Extended-date function (DATE + DATE_ADD) in the #postings path — errored
+    // `UnknownFunction` here before the registry was unified.
+    let result = executor
+        .execute(&parse("SELECT date_add(DATE('2024-01-15'), 1) FROM #postings").unwrap())
+        .unwrap();
+    assert!(!result.rows.is_empty(), "#postings produced no rows");
+    assert_eq!(
+        result.rows[0][0],
+        Value::Date(rustledger_core::naive_date(2024, 1, 16).unwrap())
+    );
+
+    // Reconciled MAXWIDTH (Python textwrap.shorten) in the #postings path —
+    // the eager registry previously did naive truncation here.
+    let result = executor
+        .execute(&parse("SELECT maxwidth('hello world', 8) FROM #postings").unwrap())
+        .unwrap();
+    assert_eq!(result.rows[0][0], Value::String("[...]".to_string()));
+}
+
 #[test]
 fn test_integer_modulo_floored_sign() {
     // Integer `%` uses Python floored modulo (sign follows the divisor);

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -834,16 +834,14 @@ fn test_unified_registry_reaches_postings_subquery_path() {
         .execute(&parse("SELECT date_add(DATE('2024-01-15'), 1) FROM #postings").unwrap())
         .unwrap();
     assert!(!result.rows.is_empty(), "#postings produced no rows");
-    assert_eq!(
-        result.rows[0][0],
-        Value::Date(rustledger_core::naive_date(2024, 1, 16).unwrap())
-    );
+    assert_eq!(result.rows[0][0], Value::Date(date(2024, 1, 16)));
 
     // Reconciled MAXWIDTH (Python textwrap.shorten) in the #postings path —
     // the eager registry previously did naive truncation here.
     let result = executor
         .execute(&parse("SELECT maxwidth('hello world', 8) FROM #postings").unwrap())
         .unwrap();
+    assert!(!result.rows.is_empty(), "#postings produced no rows");
     assert_eq!(result.rows[0][0], Value::String("[...]".to_string()));
 }
 


### PR DESCRIPTION
## What

**PR 6 — the finisher of the dual-eval-path registry collapse** [XL/BR9]. The earlier PRs unified the function-evaluation logic; this one locks the third dispatch front-end — `evaluate_subquery_expr` (the `#postings` / aggregate / subquery path) — with regression tests proving it inherited the unification.

## Why it's just tests

`evaluate_subquery_expr` already delegates function calls to `evaluate_function_on_values` (with the META-family interception correctly ordered *before* the registry, for row-context metadata). So once PRs 3–5 made that registry the single, correct implementation, this front-end automatically gained:
- the 7 extended-date functions (previously `UnknownFunction` in `#postings`/subqueries),
- the 6 reconciled function bodies (MAXWIDTH, ROUND, JOINSTR, POSSIGN, LENGTH, CONVERT).

No production change was needed here — the collapse did the work. This PR adds `test_unified_registry_reaches_postings_subquery_path` to pin it: `DATE_ADD(DATE(...), 1)` and `MAXWIDTH(...)` now evaluate correctly through `FROM #postings`.

`KNOWN_RUST_DIVERGENCES` needs no new entries — the BQL compat suite stayed at 100% through the entire collapse, so none of the reconciliations introduced a deliberate Python deviation.

## Tests

New `#postings` regression test green; full `rustledger-query` suite + clippy + fmt clean.

This completes the dual-eval-path registry unification: **one implementation per BQL function**, reached identically by the lazy per-row path, the `#postings`/subquery path, and aggregates — guarded by the differential parity harness (PR 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
