### PR TITLE
test(query): add an executor fuzz target (fuzz_query_execute)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,6 +32,7 @@ on:
           - fuzz_parse
           - fuzz_parse_line
           - fuzz_query_parse
+          - fuzz_query_execute
           - fuzz_booking
 permissions:
   contents: read
@@ -157,16 +158,20 @@ jobs:
           tail -20 crates/rustledger-parser/fuzz-output.txt >> $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
   fuzz-query:
-    name: Fuzz Query (fuzz_query_parse)
+    name: Fuzz Query (${{ matrix.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [fuzz_query_parse, fuzz_query_execute]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check if target should run
         id: check
         run: |
           INPUT_TARGET="${{ github.event.inputs.target || 'all' }}"
-          if [ "$INPUT_TARGET" = "all" ] || [ "$INPUT_TARGET" = "fuzz_query_parse" ]; then
+          if [ "$INPUT_TARGET" = "all" ] || [ "$INPUT_TARGET" = "${{ matrix.target }}" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
@@ -182,10 +187,10 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: crates/rustledger-query/fuzz/corpus/fuzz_query_parse
-          key: fuzz-corpus-query-${{ github.sha }}
+          path: crates/rustledger-query/fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
-            fuzz-corpus-query-
+            fuzz-corpus-${{ matrix.target }}-
       - name: Determine fuzz duration
         if: steps.check.outputs.should_run == 'true'
         id: duration
@@ -204,8 +209,8 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         run: |
           cd crates/rustledger-query
-          echo "Running fuzz_query_parse for ${{ steps.duration.outputs.seconds }} seconds..."
-          cargo +nightly fuzz run fuzz_query_parse -- \
+          echo "Running ${{ matrix.target }} for ${{ steps.duration.outputs.seconds }} seconds..."
+          cargo +nightly fuzz run ${{ matrix.target }} -- \
             -max_total_time=${{ steps.duration.outputs.seconds }} \
             -max_len=2048 \
             -print_final_stats=1 \
@@ -214,7 +219,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         run: |
           cd crates/rustledger-query
-          dir="fuzz/artifacts/fuzz_query_parse"
+          dir="fuzz/artifacts/${{ matrix.target }}"
           # Fail on ANY artifact that is not a benign `slow-unit-*`. This is
           # the safe superset of libFuzzer's real-failure prefixes
           # (crash-/oom-/timeout-/leak-/mismatch-), so an unknown or future
@@ -242,19 +247,19 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: crashes-fuzz_query_parse
-          path: crates/rustledger-query/fuzz/artifacts/fuzz_query_parse/
+          name: crashes-${{ matrix.target }}
+          path: crates/rustledger-query/fuzz/artifacts/${{ matrix.target }}/
       - name: Upload corpus
         if: steps.check.outputs.should_run == 'true' && github.event_name == 'schedule'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: corpus-fuzz_query_parse
-          path: crates/rustledger-query/fuzz/corpus/fuzz_query_parse/
+          name: corpus-${{ matrix.target }}
+          path: crates/rustledger-query/fuzz/corpus/${{ matrix.target }}/
           retention-days: 7
       - name: Summary
         if: steps.check.outputs.should_run == 'true'
         run: |
-          echo "## Fuzz Results: fuzz_query_parse" >> $GITHUB_STEP_SUMMARY
+          echo "## Fuzz Results: ${{ matrix.target }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Duration: ${{ steps.duration.outputs.seconds }} seconds" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/crates/rustledger-query/fuzz/Cargo.toml
+++ b/crates/rustledger-query/fuzz/Cargo.toml
@@ -15,6 +15,12 @@ arbitrary = { version = "1", features = ["derive"] }
 [dependencies.rustledger-query]
 path = ".."
 
+[dependencies.rustledger-core]
+path = "../../rustledger-core"
+
+[dependencies.rustledger-parser]
+path = "../../rustledger-parser"
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
@@ -22,6 +28,13 @@ members = ["."]
 [[bin]]
 name = "fuzz_query_parse"
 path = "fuzz_targets/fuzz_query_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_query_execute"
+path = "fuzz_targets/fuzz_query_execute.rs"
 test = false
 doc = false
 bench = false

--- a/crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_execute.rs
+++ b/crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_execute.rs
@@ -38,8 +38,20 @@ const LEDGER: &str = "\
 
 /// Parse the fixed ledger once; every fuzz iteration borrows these directives.
 static DIRECTIVES: LazyLock<Vec<Directive>> = LazyLock::new(|| {
-    let (spanned, _errors) = rustledger_parser::parse_directives(LEDGER);
-    spanned.into_iter().map(|s| s.value).collect()
+    let (spanned, errors) = rustledger_parser::parse_directives(LEDGER);
+    // Fail fast if the baseline fixture ever stops parsing cleanly — otherwise
+    // the fuzzer would silently run against a partial/empty ledger and quietly
+    // lose most of its coverage.
+    assert!(
+        errors.is_empty(),
+        "fuzz_query_execute baseline LEDGER failed to parse: {errors:?}"
+    );
+    let directives: Vec<Directive> = spanned.into_iter().map(|s| s.value).collect();
+    assert!(
+        !directives.is_empty(),
+        "fuzz_query_execute baseline LEDGER parsed to zero directives"
+    );
+    directives
 });
 
 fuzz_target!(|data: &[u8]| {

--- a/crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_execute.rs
+++ b/crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_execute.rs
@@ -1,0 +1,55 @@
+#![no_main]
+//! Fuzz target for the BQL query **executor**.
+//!
+//! Parses arbitrary input as a BQL query and, when it parses, *executes* it
+//! against a small fixed ledger. The executor must never panic on any query
+//! the parser accepts. This guards the panic bug class found repeatedly by
+//! hand — e.g. a divide-by-zero in `DATE_BIN`, an out-of-range integer cast,
+//! an unchecked slice index in a function argument. It complements
+//! `fuzz_query_parse`, which exercises only the parser.
+
+use std::sync::LazyLock;
+
+use libfuzzer_sys::fuzz_target;
+use rustledger_core::Directive;
+use rustledger_query::{parse, Executor};
+
+/// A small but varied ledger so fuzzed queries reach every system table
+/// (`#postings`, `#balances`, `#prices`, `#events`, `#notes`, …) and exercise
+/// functions over real amounts, costs, accounts, dates, and metadata.
+const LEDGER: &str = "\
+2024-01-01 open Assets:Bank:Checking USD
+2024-01-01 open Expenses:Food
+2024-01-01 open Income:Salary
+2024-01-01 commodity USD
+  name: \"US Dollar\"
+2024-01-15 * \"Coffee Shop\" \"Coffee\"
+  category: \"food\"
+  Expenses:Food         5.00 USD
+  Assets:Bank:Checking  -5.00 USD
+2024-01-16 price USD 1.10 EUR
+2024-01-18 * \"Acme\" \"Salary\"
+  Assets:Bank:Checking  1000.00 USD
+  Income:Salary        -1000.00 USD
+2024-01-20 balance Assets:Bank:Checking  995.00 USD
+2024-01-21 note Assets:Bank:Checking \"a note\"
+2024-01-22 event \"location\" \"office\"
+";
+
+/// Parse the fixed ledger once; every fuzz iteration borrows these directives.
+static DIRECTIVES: LazyLock<Vec<Directive>> = LazyLock::new(|| {
+    let (spanned, _errors) = rustledger_parser::parse_directives(LEDGER);
+    spanned.into_iter().map(|s| s.value).collect()
+});
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        // Any input the parser accepts must execute without panicking. Parse
+        // errors are expected and ignored — the parser robustness is covered
+        // by `fuzz_query_parse`.
+        if let Ok(query) = parse(input) {
+            let mut executor = Executor::new(&DIRECTIVES);
+            let _ = executor.execute(&query);
+        }
+    }
+});


### PR DESCRIPTION
## What

Architecture-roadmap fitness item [L/BR4]. Adds an **executor fuzz target** (`fuzz_query_execute`) that parses arbitrary input as a BQL query and, when it parses, **executes** it against a small fixed ledger. The executor must never panic on any query the parser accepts.

## Why

This session's dual-eval work alone uncovered several latent executor panics by hand — a divide-by-zero in `DATE_BIN`, out-of-range integer casts in `DATE`/`MAXWIDTH`, an unguarded slice. The existing `fuzz_query_parse` only exercises the **parser**; nothing fuzzed query **execution**. This target makes CI find that bug class instead of a human.

## How

- `crates/rustledger-query/fuzz/fuzz_targets/fuzz_query_execute.rs` — parses via `rustledger_query::parse`, builds an `Executor` over a fixed ledger (parsed once via `parse_directives`, covering `#postings`/`#balances`/`#prices`/`#events`/`#notes` and amounts/costs/dates/metadata), and runs `execute`. Parse failures are ignored (parser robustness is `fuzz_query_parse`'s job).
- `fuzz/Cargo.toml` — new `[[bin]]` + `rustledger-core`/`rustledger-parser` dev paths.
- `.github/workflows/fuzz.yml` — the `fuzz-query` job becomes a matrix `[fuzz_query_parse, fuzz_query_execute]` (mirroring the parser job), with per-target corpus cache; added to the `workflow_dispatch` choices.

## Verification

- Target type-checks (0 rustc errors; the libfuzzer link runs under cargo-fuzz in CI).
- End-to-end smoke test: the fixed ledger parses to 4 postings, and `SELECT date_add(date, 1), maxwidth(narration, 8) FROM #postings` executes correctly.
- The workflow triggers on `crates/rustledger-query/**`, so this PR's CI **builds and fuzzes the new target** (10 min on PRs, 30 min nightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
