### PR TITLE
refactor(validate): single account-presence helper for E1001

### DIFF
--- a/crates/rustledger-validate/src/validators/account.rs
+++ b/crates/rustledger-validate/src/validators/account.rs
@@ -5,7 +5,7 @@ use rustledger_core::{BookingMethod, Close, Inventory, Open};
 use crate::error::{ErrorCode, ValidationError};
 use crate::{AccountState, LedgerState};
 
-use super::helpers::validate_account_name;
+use super::helpers::{push_account_not_open, validate_account_name};
 
 /// Validate an Open directive.
 pub fn validate_open(state: &mut LedgerState, open: &Open, errors: &mut Vec<ValidationError>) {
@@ -113,13 +113,7 @@ pub fn validate_close(state: &mut LedgerState, close: &Close, errors: &mut Vec<V
                 account_state.closed = Some(close.date);
             }
         }
-        None => {
-            errors.push(ValidationError::new(
-                ErrorCode::AccountNotOpen,
-                format!("Account {} was never opened", close.account),
-                close.date,
-            ));
-        }
+        None => push_account_not_open(&close.account, close.date, "Account", errors),
     }
 }
 

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -4,6 +4,7 @@
 use rust_decimal::{Decimal, MathematicalOps};
 use rustledger_core::{Amount, Balance, Pad, Position, is_subaccount_or_equal};
 
+use super::helpers::require_account_open;
 use crate::error::{ErrorCode, ValidationError};
 use crate::{LedgerState, PendingPad};
 
@@ -82,22 +83,18 @@ pub fn validate_pad(
     errors: &mut Vec<ValidationError>,
 ) {
     // Check that the target account exists
-    if !state.accounts.contains_key(&pad.account) {
-        errors.push(ValidationError::new(
-            ErrorCode::AccountNotOpen,
-            format!("Pad target account {} was never opened", pad.account),
-            pad.date,
-        ));
+    if !require_account_open(state, &pad.account, pad.date, "Pad target account", errors) {
         return;
     }
 
     // Check that the source account exists
-    if !state.accounts.contains_key(&pad.source_account) {
-        errors.push(ValidationError::new(
-            ErrorCode::AccountNotOpen,
-            format!("Pad source account {} was never opened", pad.source_account),
-            pad.date,
-        ));
+    if !require_account_open(
+        state,
+        &pad.source_account,
+        pad.date,
+        "Pad source account",
+        errors,
+    ) {
         return;
     }
 
@@ -126,13 +123,7 @@ pub fn validate_balance_early(
     bal: &Balance,
     errors: &mut Vec<ValidationError>,
 ) {
-    if !state.accounts.contains_key(&bal.account) {
-        errors.push(ValidationError::new(
-            ErrorCode::AccountNotOpen,
-            format!("Account {} was never opened", bal.account),
-            bal.date,
-        ));
-    }
+    require_account_open(state, &bal.account, bal.date, "Account", errors);
 }
 
 /// Late-phase balance validation — runs after booking + plugins.

--- a/crates/rustledger-validate/src/validators/helpers.rs
+++ b/crates/rustledger-validate/src/validators/helpers.rs
@@ -1,5 +1,48 @@
 //! Helper functions for validation.
 
+use rustledger_core::{Account, NaiveDate};
+
+use crate::LedgerState;
+use crate::error::{ErrorCode, ValidationError};
+
+/// Push an `E1001` (`AccountNotOpen`) error for `account` at `date`. `subject`
+/// names the account's role in the message — `"Account"`, `"Pad target
+/// account"`, `"Pad source account"` — producing
+/// `"<subject> <account> was never opened"`. This is the single definition of
+/// the E1001 message and code, shared by every directive validator that reports
+/// an unopened account.
+pub fn push_account_not_open(
+    account: &Account,
+    date: NaiveDate,
+    subject: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    errors.push(ValidationError::new(
+        ErrorCode::AccountNotOpen,
+        format!("{subject} {account} was never opened"),
+        date,
+    ));
+}
+
+/// Account-presence check for E1001. `state.accounts` is populated in date
+/// order, so an account absent from it has not been opened on or before `date`.
+/// Returns `true` when the account is open; otherwise pushes the E1001 error
+/// (via [`push_account_not_open`]) and returns `false`. Callers that need to
+/// bail out on an unopened account branch on the returned `bool`.
+pub fn require_account_open(
+    state: &LedgerState,
+    account: &Account,
+    date: NaiveDate,
+    subject: &str,
+    errors: &mut Vec<ValidationError>,
+) -> bool {
+    if state.accounts.contains_key(account) {
+        return true;
+    }
+    push_account_not_open(account, date, subject, errors);
+    false
+}
+
 /// Validate an account name according to beancount rules.
 /// Returns None if valid, or Some(reason) if invalid.
 ///

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashMap;
 use rustledger_core::{Amount, BookingMethod, Inventory, Posting, ReductionScope, Transaction};
 use std::collections::HashMap;
 
+use super::helpers::push_account_not_open;
 use crate::error::{ErrorCode, ValidationError};
 use crate::{AccountState, LedgerState, ValidationOptions};
 
@@ -42,11 +43,7 @@ pub fn validate_transaction_early(
         // on their pre-rewrite account name. The recorded key lets the late
         // phase skip re-reporting an elided posting that is still unopened.
         if posting.units.is_none() {
-            errors.push(ValidationError::new(
-                ErrorCode::AccountNotOpen,
-                format!("Account {} was never opened", posting.account),
-                txn.date,
-            ));
+            push_account_not_open(&posting.account, txn.date, "Account", errors);
             // Key by the posting's source identity (not account/date) so the
             // late phase skips *this* posting only — a different posting that
             // merely shares the account on the same date is still reported.
@@ -82,11 +79,7 @@ pub fn validate_transaction_late(
             .account_not_open_early
             .contains(&(posting.file_id, posting.span))
         {
-            errors.push(ValidationError::new(
-                ErrorCode::AccountNotOpen,
-                format!("Account {} was never opened", posting.account),
-                txn.date,
-            ));
+            push_account_not_open(&posting.account, txn.date, "Account", errors);
         }
     }
 


### PR DESCRIPTION
## What

Architecture-roadmap [M/BR4] — a **single account-presence helper for E1001** (`AccountNotOpen`). The "account was never opened" check + error were duplicated across **6 sites** in three validators, each re-formatting the same message and re-naming the error code.

## How

Two helpers in `validators/helpers.rs`:
- **`push_account_not_open(account, date, subject, errors)`** — the single definition of the E1001 message (`"<subject> <account> was never opened"`) and code. Used by all 6 sites.
- **`require_account_open(state, account, date, subject, errors) -> bool`** — presence check (`state.accounts` is filled in date order) that pushes the E1001 error when absent and returns whether the account is open. Used by the simple sites that bail out on failure.

Routed every site through them:
- `balance.rs` — pad target, pad source, balance-early (3)
- `transaction.rs` — early elided posting, late explicit posting (2, via `push_account_not_open`, preserving the two-phase `account_not_open_early` dedup)
- `account.rs` — close on an unopened account (1)

The `subject` argument preserves each site's exact message ("Account", "Pad target account", "Pad source account").

## Tests

Behavior-preserving — the full `rustledger-validate` suite passes unchanged. Clippy `--all-features --all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
