### PR TITLE
refactor(core): single-source the booking-order sort key

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -613,10 +613,7 @@ pub fn book(directives: &[Directive], method: BookingMethod) -> LedgerBookResult
     // file position)` — is already encoded in the input's positional order,
     // and a stable sort keeps that as the tiebreak.
     let mut order: Vec<usize> = (0..directives.len()).collect();
-    order.sort_by_key(|&i| {
-        let d = &directives[i];
-        (d.date(), d.priority(), d.has_cost_reduction())
-    });
+    order.sort_by_key(|&i| rustledger_core::booking_sort_key(&directives[i]));
 
     // Book in booking order, recording each transaction's outcome against
     // its original index so the result can be reassembled in input order.

--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -622,7 +622,23 @@ impl Directive {
 /// those that do reduce cost-basis lots. This ensures lots exist
 /// when they're matched, regardless of file ordering.
 pub fn sort_directives(directives: &mut [Directive]) {
-    directives.sort_by_cached_key(|d| (d.date(), d.priority(), d.has_cost_reduction()));
+    directives.sort_by_cached_key(booking_sort_key);
+}
+
+/// The canonical booking-order sort key: `(date, priority, has_cost_reduction)`.
+///
+/// Within a `(date, priority)` group, cost augmentations
+/// (`has_cost_reduction == false`) sort before the reductions that match
+/// against them, so lots exist when matched regardless of file ordering.
+///
+/// This is the SINGLE source of the booking order. [`sort_directives`] sorts a
+/// slice in place by it, and both `book()` (rustledger-booking) and
+/// `run_booking()` (rustledger-loader) key an index permutation through it
+/// (they preserve the input order for reassembly, so they cannot sort the slice
+/// directly). Change a booking-order tiebreak here only.
+#[must_use]
+pub fn booking_sort_key(d: &Directive) -> (NaiveDate, DirectivePriority, bool) {
+    (d.date(), d.priority(), d.has_cost_reduction())
 }
 
 /// A transaction directive.

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -67,7 +67,7 @@ pub use cost::{BookedCost, BookedCostInvariantError, Cost, CostNumber, CostSpec}
 pub use directive::{
     Balance, Close, Commodity, Custom, Directive, DirectivePriority, Document, Event, MetaValue,
     Metadata, Note, Open, Pad, Posting, Price, PriceAnnotation, PriceKind, Query, Transaction,
-    parse_precision_meta, sort_directives,
+    booking_sort_key, parse_precision_meta, sort_directives,
 };
 pub use display_context::{DEFAULT_CURRENCY, DisplayContext, Precision};
 pub use extract::{

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -783,10 +783,7 @@ fn run_booking(
     // file_id, span.start)` — is already encoded in the existing
     // positional order, and stable_sort preserves that as the tiebreak).
     let mut order: Vec<usize> = (0..directives.len()).collect();
-    order.sort_by_key(|&i| {
-        let d = &directives[i].value;
-        (d.date(), d.priority(), d.has_cost_reduction())
-    });
+    order.sort_by_key(|&i| rustledger_core::booking_sort_key(&directives[i].value));
 
     let mut failed_indices: Vec<usize> = Vec::new();
     for &i in &order {


### PR DESCRIPTION
## What

Architecture-roadmap [M/BR5], first slice — **single-source the booking-order sort key**. The key `(date, priority, has_cost_reduction)` was **triple-sourced**: `core::sort_directives` had it, but neither `book()` (rustledger-booking) nor `run_booking()` (rustledger-loader) called it — both re-inlined the identical tuple in their index sorts. A booking-order tiebreak change would have to be made in three places or silently diverge.

## How

- Added `rustledger_core::booking_sort_key(d) -> (NaiveDate, DirectivePriority, bool)` — the single definition of the booking order, with the rationale (augmentations before reductions within a `(date, priority)` group) documented once.
- `sort_directives` now sorts by it.
- `book()` and `run_booking()` key their index permutations through it (`order.sort_by_key(|&i| booking_sort_key(&directives[i]))`) instead of re-inlining the tuple. They keep their own index sort because both must preserve input order for reassembly — they can't sort the slice in place.

Byte-identical key, so booking order is unchanged.

## Tests

Behavior-preserving — the full `rustledger-core` + `rustledger-booking` + `rustledger-loader` suites pass unchanged. Clippy + fmt clean. (The shared book-loop body itself — the second half of the BR5 item — is a follow-up; this PR removes the silent-divergence risk in the sort key.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
