### PR TITLE
refactor(loader): single-source the python plugin file-vs-module classifier

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1640,15 +1640,24 @@ fn run_wasm_plugin(
 /// file-vs-module test used by the Python runtime (case-insensitive extension).
 #[cfg(feature = "python-plugins")]
 fn is_python_module_name(resolved: &std::path::Path, raw_name: &str) -> bool {
-    // Treat both `/` and the platform separator as path markers: forward
-    // slashes are common (and accepted) even on Windows, where
-    // `MAIN_SEPARATOR` is `\`, so a `plugins/foo.py` ref must not be mistaken
-    // for a module name.
-    !resolved.exists()
-        && !std::path::Path::new(raw_name)
+    !is_python_plugin_file(resolved, raw_name)
+}
+
+/// Classify a Python plugin reference as a FILE path (vs a dotted module name):
+/// a file when it resolves to an existing path, ends in `.py` (case-insensitive),
+/// or contains a path separator. Forward `/` counts even on Windows (where
+/// `MAIN_SEPARATOR` is `\`), so `plugins/foo.py` is never mistaken for a module.
+///
+/// Single source for the up-front #1432 rejection (via `is_python_module_name`)
+/// and the runtime file-vs-module dispatch, which previously used non-equivalent
+/// criteria (the dispatch omitted the forward slash) and could disagree.
+#[cfg(feature = "python-plugins")]
+fn is_python_plugin_file(resolved: &std::path::Path, raw_name: &str) -> bool {
+    resolved.exists()
+        || std::path::Path::new(raw_name)
             .extension()
             .is_some_and(|e| e.eq_ignore_ascii_case("py"))
-        && !raw_name.contains(['/', std::path::MAIN_SEPARATOR])
+        || raw_name.contains(['/', std::path::MAIN_SEPARATOR])
 }
 
 /// Actionable error for a Python plugin referenced by module name. `file` is the
@@ -1691,12 +1700,9 @@ fn run_python_plugin(
         config: config.clone(),
     };
 
-    // Try file-based execution first, then module-based
-    let is_file = resolved_path.exists()
-        || std::path::Path::new(module_name)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
-        || module_name.contains(std::path::MAIN_SEPARATOR);
+    // Try file-based execution first, then module-based. Same file-vs-module
+    // classifier as the up-front #1432 rejection — see `is_python_plugin_file`.
+    let is_file = is_python_plugin_file(resolved_path, module_name);
 
     let output = if is_file {
         runtime


### PR DESCRIPTION
## What

Architecture-roadmap [M/BR4], first slice — **single-source the Python plugin file-vs-module classifier**. The classifier was duplicated across two sites in `process.rs` with **non-equivalent criteria**:

- `is_python_module_name` (up-front #1432 rejection): module iff `!exists && !.py && !contains(['/', MAIN_SEPARATOR])`
- the runtime dispatch (`is_file`): file iff `exists || .py || contains(MAIN_SEPARATOR)` — **omitting the forward slash**

So on Windows (where `MAIN_SEPARATOR` is `\`), a ref like `plugins/foo` classifies as a *file* by the up-front check but a *module* by the dispatch — they can disagree about the same ref.

## How

Extracted one canonical `is_python_plugin_file(resolved, raw_name)` — file iff resolves to an existing path, ends in `.py` (case-insensitive), or contains a path separator (`/` counts even on Windows). `is_python_module_name` is now its negation, and the runtime dispatch calls it directly. The two can no longer diverge.

(The separate "is this a Python plugin at all" gate — which uses `contains('.')` to catch dotted module names like `beancount.plugins.foo` — is a *different* decision and is intentionally left as-is; it is not the file-vs-module classifier. The remaining god-function extraction is a follow-up.)

## Behavior

Linux-identical (`MAIN_SEPARATOR == '/'`, so the added `/` is a no-op); the only change is the Windows forward-slash case, which now agrees with the up-front check.

## Tests

Full `rustledger-loader` suite (with `python-plugins`) passes; clippy `--all-features --all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
