### PR TITLE
refactor(plugin): single-source the python file-vs-module classifier across crates

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1644,20 +1644,15 @@ fn is_python_module_name(resolved: &std::path::Path, raw_name: &str) -> bool {
 }
 
 /// Classify a Python plugin reference as a FILE path (vs a dotted module name):
-/// a file when it resolves to an existing path, ends in `.py` (case-insensitive),
-/// or contains a path separator. Forward `/` counts even on Windows (where
-/// `MAIN_SEPARATOR` is `\`), so `plugins/foo.py` is never mistaken for a module.
-///
-/// Single source for the up-front #1432 rejection (via `is_python_module_name`)
-/// and the runtime file-vs-module dispatch, which previously used non-equivalent
-/// criteria (the dispatch omitted the forward slash) and could disagree.
+/// a file when it resolves to an existing path, or its name is file-like by the
+/// shared [`rustledger_plugin::python::is_python_plugin_file_ref`] criterion
+/// (`.py` extension or a path separator). That shared classifier is the single
+/// source for the up-front #1432 rejection, the runtime dispatch here, and the
+/// `discover_module_source` routing inside `rustledger-plugin` — they previously
+/// used non-equivalent criteria and could disagree about the same reference.
 #[cfg(feature = "python-plugins")]
 fn is_python_plugin_file(resolved: &std::path::Path, raw_name: &str) -> bool {
-    resolved.exists()
-        || std::path::Path::new(raw_name)
-            .extension()
-            .is_some_and(|e| e.eq_ignore_ascii_case("py"))
-        || raw_name.contains(['/', std::path::MAIN_SEPARATOR])
+    resolved.exists() || rustledger_plugin::python::is_python_plugin_file_ref(raw_name)
 }
 
 /// Actionable error for a Python plugin referenced by module name. `file` is the

--- a/crates/rustledger-plugin/src/python/mod.rs
+++ b/crates/rustledger-plugin/src/python/mod.rs
@@ -35,7 +35,9 @@ mod download;
 mod runtime;
 
 pub use compat::BEANCOUNT_COMPAT_PY;
-pub use runtime::{PythonRuntime, is_python_available, suggest_module_path};
+pub use runtime::{
+    PythonRuntime, is_python_available, is_python_plugin_file_ref, suggest_module_path,
+};
 
 /// Python plugin error types.
 #[derive(Debug, thiserror::Error)]

--- a/crates/rustledger-plugin/src/python/runtime.rs
+++ b/crates/rustledger-plugin/src/python/runtime.rs
@@ -456,6 +456,23 @@ fn engine_config() -> Config {
 
 /// Discover and read a Python plugin's source code.
 ///
+/// Classify a Python plugin reference as a FILE path (vs a dotted module name):
+/// a file when it ends in `.py` (case-insensitive) or contains a path separator.
+/// Forward `/` counts even on Windows (where `MAIN_SEPARATOR` is `\`), so
+/// `plugins/foo.py` is never mistaken for a module.
+///
+/// Single source for the file-vs-module decision across the loader's up-front
+/// `#1432` rejection, the loader's runtime dispatch, and `discover_module_source`
+/// below — these previously used three non-equivalent criteria (some omitted
+/// the forward slash) and could disagree about the same reference.
+#[must_use]
+pub fn is_python_plugin_file_ref(name: &str) -> bool {
+    std::path::Path::new(name)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
+        || name.contains(['/', std::path::MAIN_SEPARATOR])
+}
+
 /// For file-based plugins (`.py` files or paths), reads the file directly.
 /// For module-based plugins, returns `ModuleNotFound` error - the caller should
 /// use `suggest_module_path()` to provide a helpful hint to the user.
@@ -470,10 +487,7 @@ fn discover_module_source(
     use std::path::PathBuf;
 
     // Handle file-based plugins first
-    let is_py_file = std::path::Path::new(module_name)
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"));
-    if is_py_file || module_name.contains(std::path::MAIN_SEPARATOR) {
+    if is_python_plugin_file_ref(module_name) {
         let path = if let Some(dir) = beancount_dir {
             dir.join(module_name)
         } else {

--- a/crates/rustledger-plugin/src/python/runtime.rs
+++ b/crates/rustledger-plugin/src/python/runtime.rs
@@ -454,8 +454,9 @@ fn engine_config() -> Config {
     config
 }
 
-/// Classify a Python plugin reference as a FILE path (vs a dotted module name):
-/// a file when it ends in `.py` (case-insensitive) or contains a path separator.
+/// Classify a Python plugin reference as a FILE path vs a dotted module name.
+///
+/// A file when it ends in `.py` (case-insensitive) or contains a path separator.
 /// Forward `/` counts even on Windows (where `MAIN_SEPARATOR` is `\`), so
 /// `plugins/foo.py` is never mistaken for a module.
 ///

--- a/crates/rustledger-plugin/src/python/runtime.rs
+++ b/crates/rustledger-plugin/src/python/runtime.rs
@@ -454,8 +454,6 @@ fn engine_config() -> Config {
     config
 }
 
-/// Discover and read a Python plugin's source code.
-///
 /// Classify a Python plugin reference as a FILE path (vs a dotted module name):
 /// a file when it ends in `.py` (case-insensitive) or contains a path separator.
 /// Forward `/` counts even on Windows (where `MAIN_SEPARATOR` is `\`), so
@@ -473,6 +471,8 @@ pub fn is_python_plugin_file_ref(name: &str) -> bool {
         || name.contains(['/', std::path::MAIN_SEPARATOR])
 }
 
+/// Discover and read a Python plugin's source code.
+///
 /// For file-based plugins (`.py` files or paths), reads the file directly.
 /// For module-based plugins, returns `ModuleNotFound` error - the caller should
 /// use `suggest_module_path()` to provide a helpful hint to the user.


### PR DESCRIPTION
## What

Architecture-roadmap [M/BR4], follow-on to #1548. Finishes single-sourcing the Python plugin **file-vs-module classifier** by unifying the *fourth* copy — `rustledger_plugin::python::discover_module_source`, the one that actually performs the runtime routing (the point Copilot raised on #1548).

`discover_module_source` keyed file-vs-module on `.py || contains(MAIN_SEPARATOR)`, omitting the forward slash — so on Windows a ref like `plugins/foo` was classified inconsistently with the loader's (already-fixed) up-front rejection.

## How

- New `rustledger_plugin::python::is_python_plugin_file_ref(name)` — the single string-criterion (`.py` extension, or a path separator including `/`).
- `discover_module_source` calls it.
- The loader's `is_python_plugin_file` (added in #1548) now delegates its string check to it (keeping its own `exists()` test).

All four classification sites — loader up-front rejection, loader dispatch, and `discover_module_source` — now share **one** criterion and can no longer disagree about the same reference.

## Behavior

Linux-identical (`MAIN_SEPARATOR == '/'`, so the added `/` is a no-op); the only change is the Windows forward-slash case, which now agrees everywhere.

## Tests

`rustledger-plugin` + `rustledger-loader` suites (with `python-plugins`) pass; clippy `--all-features --all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
