### PR TITLE
fix(importer): unify CSV categorization on RulesEngine (honor regex_mappings on the plain path)

### DIFF
--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -29,27 +29,6 @@ use std::path::Path;
 #[derive(Debug, Default, Clone)]
 pub struct CsvImporter;
 
-/// Precompiled merchant-dictionary regexes, built once on first use. Patterns
-/// that fail to compile are skipped, mirroring
-/// [`rustledger_ops::categorize::RulesEngine::load_merchant_dict`]. Each entry
-/// pairs a case-insensitive, unanchored regex with its `&'static` account.
-fn merchant_regexes() -> &'static [(regex::Regex, &'static str)] {
-    use std::sync::LazyLock;
-    static REGEXES: LazyLock<Vec<(regex::Regex, &'static str)>> = LazyLock::new(|| {
-        rustledger_ops::merchants::MERCHANT_PATTERNS
-            .iter()
-            .filter_map(|entry| {
-                regex::RegexBuilder::new(entry.pattern)
-                    .case_insensitive(true)
-                    .build()
-                    .ok()
-                    .map(|re| (re, entry.account))
-            })
-            .collect()
-    });
-    &REGEXES
-}
-
 impl Importer for CsvImporter {
     fn name(&self) -> &'static str {
         "CSV"
@@ -101,6 +80,12 @@ impl CsvImporter {
         // compile thousands of times if we did it inside the loop.
         let amount_format = csv_config.compile_amount_format()?;
 
+        // Build the categorization engine once for the whole file — the single
+        // source shared with the enriched path (config mappings, regex mappings,
+        // and the merchant dictionary). The plain path previously consulted a
+        // bespoke matcher that ignored `regex_mappings` entirely.
+        let engine = Self::build_rules_engine(csv_config);
+
         let mut reader = csv::ReaderBuilder::new()
             .has_headers(csv_config.has_header)
             .delimiter(csv_config.delimiter as u8)
@@ -132,7 +117,14 @@ impl CsvImporter {
                 }
             };
 
-            match self.parse_row(&record, config, csv_config, &amount_format, &header_map) {
+            match self.parse_row(
+                &record,
+                config,
+                csv_config,
+                &amount_format,
+                &header_map,
+                &engine,
+            ) {
                 Ok(Some(txn)) => directives.push(Directive::Transaction(txn)),
                 Ok(None) => {} // Skip empty rows
                 Err(e) => {
@@ -178,15 +170,9 @@ impl CsvImporter {
         let ImporterType::Csv(csv_config) = &config.importer_type;
         let result = self.extract_string(content, config)?;
 
-        // Build the rules engine once for all directives
-        let mut engine = rustledger_ops::categorize::RulesEngine::new();
-        engine.load_from_mappings(&csv_config.mappings);
-        if !csv_config.regex_mappings.is_empty() {
-            engine.load_from_regex_mappings(&csv_config.regex_mappings);
-        }
-        if csv_config.use_merchant_dict {
-            engine.load_merchant_dict();
-        }
+        // Build the rules engine once for all directives — shared with the
+        // plain path via `build_rules_engine`.
+        let engine = Self::build_rules_engine(csv_config);
 
         let entries = result
             .directives
@@ -240,6 +226,7 @@ impl CsvImporter {
         csv_config: &CsvConfig,
         amount_format: &AmountFormat,
         header_map: &HashMap<String, usize>,
+        engine: &rustledger_ops::categorize::RulesEngine,
     ) -> Result<Option<Transaction>> {
         // Get date. No `Row N:` prefix on these errors: `parse_row`'s caller
         // already wraps every error it returns with `Row {row_num}: {e}`, so
@@ -331,10 +318,10 @@ impl CsvImporter {
                 .as_deref()
                 .unwrap_or("Income:Unknown")
         };
-        let contra_account = self
-            .match_mapping(csv_config, payee.as_deref(), &narration)
-            .unwrap_or(default_contra);
-        let contra_posting = Posting::auto(contra_account);
+        let contra_account = engine
+            .categorize(payee.as_deref(), &narration)
+            .map_or_else(|| default_contra.to_string(), |m| m.account);
+        let contra_posting = Posting::auto(&contra_account);
 
         // Build the transaction
         let mut txn = Transaction::new(date, &narration)
@@ -349,50 +336,23 @@ impl CsvImporter {
         Ok(Some(txn))
     }
 
-    /// Match payee/narration against configured mappings.
-    /// Returns the mapped account name if a pattern matches, or None.
-    /// Patterns are pre-lowercased at build time, so only the input fields
-    /// need to be lowercased here.
-    fn match_mapping<'a>(
-        &self,
-        csv_config: &'a CsvConfig,
-        payee: Option<&str>,
-        narration: &str,
-    ) -> Option<&'a str> {
-        // User-supplied mappings take priority over the built-in dictionary.
-        // Only pay for the lowercasing when there are mappings to check.
-        if !csv_config.mappings.is_empty() {
-            let payee_lower = payee.map(str::to_lowercase);
-            let narration_lower = narration.to_lowercase();
-            for (pattern, account) in &csv_config.mappings {
-                // Match against payee first, then narration
-                if let Some(ref p) = payee_lower
-                    && p.contains(pattern.as_str())
-                {
-                    return Some(account);
-                }
-                if narration_lower.contains(pattern.as_str()) {
-                    return Some(account);
-                }
-            }
+    /// Build the categorization [`rustledger_ops::categorize::RulesEngine`] from
+    /// a CSV config — the single source consulted by BOTH the plain
+    /// (`extract`/`extract_string`) and enriched (`extract_string_enriched`)
+    /// paths. Loads, in priority order: the config's exact mappings (substring,
+    /// lowercased), its regex mappings, and the built-in merchant dictionary
+    /// (when `use_merchant_dict`). Previously the plain path used a bespoke
+    /// matcher that silently skipped `regex_mappings`.
+    fn build_rules_engine(csv_config: &CsvConfig) -> rustledger_ops::categorize::RulesEngine {
+        let mut engine = rustledger_ops::categorize::RulesEngine::new();
+        engine.load_from_mappings(&csv_config.mappings);
+        if !csv_config.regex_mappings.is_empty() {
+            engine.load_from_regex_mappings(&csv_config.regex_mappings);
         }
-
-        // Then the built-in merchant dictionary, when enabled — so
-        // `extract --use-merchant-dict` actually categorizes NETFLIX, AMAZON,
-        // SHELL, … instead of leaving them at the default expense account.
-        // The dictionary patterns are regexes (e.g. `AMAZON|AMZN`), matched
-        // case-insensitively and unanchored, exactly as the enriched path's
-        // `RulesEngine::load_merchant_dict` does — a plain substring match
-        // would silently miss every alternation/character-class pattern.
         if csv_config.use_merchant_dict {
-            for (regex, account) in merchant_regexes() {
-                if payee.is_some_and(|p| regex.is_match(p)) || regex.is_match(narration) {
-                    return Some(account);
-                }
-            }
+            engine.load_merchant_dict();
         }
-
-        None
+        engine
     }
 
     fn get_column<'a>(
@@ -1388,6 +1348,50 @@ not-a-date,Coffee,-5.00
             account_for("AMZN MKTP US", true),
             "Expenses:Shopping:Amazon",
             "enabled: AMZN matches the AMAZON|AMZN alternation pattern"
+        );
+    }
+
+    #[test]
+    fn test_regex_mappings_categorize_on_plain_path_and_match_enriched() {
+        // Regression: the plain `extract`/`extract_string` path (used by the
+        // CLI) previously ignored `regex_mappings` entirely — a regex-matched
+        // row landed at the default account instead of its mapped one — while
+        // the enriched path honored them. Both now share one RulesEngine and
+        // must agree.
+        let config = ImporterConfig::csv()
+            .account("Assets:Bank")
+            .currency("USD")
+            .date_column("Date")
+            .narration_column("Description")
+            .amount_column("Amount")
+            .regex_mappings(vec![(
+                "STARBUCKS|SBUX".to_string(),
+                "Expenses:Coffee".to_string(),
+            )])
+            .build()
+            .unwrap();
+        // "SBUX" matches only the regex alternation, not a plain substring of
+        // "STARBUCKS" — the exact case the plain path used to drop.
+        let csv = "Date,Description,Amount\n2024-03-08,SBUX STORE #123,-4.50\n";
+
+        let plain = CsvImporter.extract_string(csv, &config).unwrap();
+        let plain_account = match &plain.directives[0] {
+            Directive::Transaction(txn) => txn.postings[1].account.as_str().to_string(),
+            _ => panic!("expected transaction"),
+        };
+        assert_eq!(
+            plain_account, "Expenses:Coffee",
+            "plain path must honor regex_mappings (SBUX -> Expenses:Coffee)"
+        );
+
+        let enriched = CsvImporter.extract_string_enriched(csv, &config).unwrap();
+        let enriched_account = match &enriched.entries[0].0 {
+            Directive::Transaction(txn) => txn.postings[1].account.as_str().to_string(),
+            _ => panic!("expected transaction"),
+        };
+        assert_eq!(
+            plain_account, enriched_account,
+            "plain and enriched contra-accounts must agree"
         );
     }
 

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -69,6 +69,24 @@ impl CsvImporter {
 
     /// Extract transactions from string content using the given importer config.
     pub fn extract_string(&self, content: &str, config: &ImporterConfig) -> Result<ImportResult> {
+        let ImporterType::Csv(csv_config) = &config.importer_type;
+        // Build the categorization engine once and share it with the row loop —
+        // the single source also used by the enriched path. `extract_string_enriched`
+        // builds it once and reuses it for enrichment too, so the engine (which
+        // compiles the merchant regexes) is never constructed twice per call.
+        let engine = Self::build_rules_engine(csv_config);
+        self.extract_string_with_engine(content, config, &engine)
+    }
+
+    /// Row-extraction core shared by [`Self::extract_string`] and
+    /// [`Self::extract_string_enriched`], parameterized on a pre-built rules
+    /// engine so it is constructed exactly once per extract call.
+    fn extract_string_with_engine(
+        &self,
+        content: &str,
+        config: &ImporterConfig,
+        engine: &rustledger_ops::categorize::RulesEngine,
+    ) -> Result<ImportResult> {
         // Irrefutable today because `ImporterType` has a single variant.
         // If a new variant is added the compiler will catch this as
         // refutable — that's intentional load-bearing safety; do NOT
@@ -79,12 +97,6 @@ impl CsvImporter {
         // is non-trivial and parse_row runs per row, so we'd repeat the
         // compile thousands of times if we did it inside the loop.
         let amount_format = csv_config.compile_amount_format()?;
-
-        // Build the categorization engine once for the whole file — the single
-        // source shared with the enriched path (config mappings, regex mappings,
-        // and the merchant dictionary). The plain path previously consulted a
-        // bespoke matcher that ignored `regex_mappings` entirely.
-        let engine = Self::build_rules_engine(csv_config);
 
         let mut reader = csv::ReaderBuilder::new()
             .has_headers(csv_config.has_header)
@@ -123,7 +135,7 @@ impl CsvImporter {
                 csv_config,
                 &amount_format,
                 &header_map,
-                &engine,
+                engine,
             ) {
                 Ok(Some(txn)) => directives.push(Directive::Transaction(txn)),
                 Ok(None) => {} // Skip empty rows
@@ -168,11 +180,12 @@ impl CsvImporter {
         config: &ImporterConfig,
     ) -> Result<EnrichedImportResult> {
         let ImporterType::Csv(csv_config) = &config.importer_type;
-        let result = self.extract_string(content, config)?;
 
-        // Build the rules engine once for all directives — shared with the
-        // plain path via `build_rules_engine`.
+        // Build the rules engine ONCE and use it for both row extraction and
+        // enrichment, instead of building it inside `extract_string` and again
+        // here (the engine compiles the merchant regexes).
         let engine = Self::build_rules_engine(csv_config);
+        let result = self.extract_string_with_engine(content, config, &engine)?;
 
         let entries = result
             .directives
@@ -318,10 +331,13 @@ impl CsvImporter {
                 .as_deref()
                 .unwrap_or("Income:Unknown")
         };
-        let contra_account = engine
-            .categorize(payee.as_deref(), &narration)
-            .map_or_else(|| default_contra.to_string(), |m| m.account);
-        let contra_posting = Posting::auto(&contra_account);
+        // Borrow the matched account (or the default) as `&str` — no per-row
+        // `String` allocation when a rule doesn't match.
+        let rule_match = engine.categorize(payee.as_deref(), &narration);
+        let contra_account = rule_match
+            .as_ref()
+            .map_or(default_contra, |m| m.account.as_str());
+        let contra_posting = Posting::auto(contra_account);
 
         // Build the transaction
         let mut txn = Transaction::new(date, &narration)

--- a/crates/rustledger-ops/src/categorize.rs
+++ b/crates/rustledger-ops/src/categorize.rs
@@ -10,6 +10,24 @@
 
 use crate::enrichment::CategorizationMethod;
 use regex::Regex;
+use std::sync::LazyLock;
+
+/// Built-in merchant-dictionary regexes, compiled once on first use. Patterns
+/// that fail to compile are skipped. Each entry pairs a case-insensitive,
+/// unanchored regex with its `&'static` category and account; the `Regex` is
+/// cheaply `Arc`-cloned into per-engine rules by [`RulesEngine::load_merchant_dict`].
+static MERCHANT_REGEXES: LazyLock<Vec<(Regex, &'static str, &'static str)>> = LazyLock::new(|| {
+    crate::merchants::MERCHANT_PATTERNS
+        .iter()
+        .filter_map(|entry| {
+            regex::RegexBuilder::new(entry.pattern)
+                .case_insensitive(true)
+                .build()
+                .ok()
+                .map(|re| (re, entry.category, entry.account))
+        })
+        .collect()
+});
 
 /// A categorization rule.
 #[derive(Debug)]
@@ -125,18 +143,18 @@ impl RulesEngine {
 
     /// Load the built-in merchant dictionary as low-priority rules.
     pub fn load_merchant_dict(&mut self) {
-        for entry in crate::merchants::MERCHANT_PATTERNS {
-            if let Ok(regex) = regex::RegexBuilder::new(entry.pattern)
-                .case_insensitive(true)
-                .build()
-            {
-                self.rules.push(Rule {
-                    name: Some(entry.category.to_string()),
-                    pattern: RulePattern::Regex(regex),
-                    account: entry.account.to_string(),
-                    priority: -1000, // Below all user rules
-                });
-            }
+        // Merchant regexes are compiled once process-wide (see `MERCHANT_REGEXES`)
+        // and cheaply `Arc`-cloned per engine. Recompiling them on every
+        // `build_rules_engine` call — one per imported file — was a real cost;
+        // this restores the cache the plain CSV path had before unification,
+        // now shared by both the plain and enriched paths.
+        for (regex, category, account) in MERCHANT_REGEXES.iter() {
+            self.rules.push(Rule {
+                name: Some((*category).to_string()),
+                pattern: RulePattern::Regex(regex.clone()),
+                account: (*account).to_string(),
+                priority: -1000, // Below all user rules
+            });
         }
         self.rules.sort_by_key(|r| std::cmp::Reverse(r.priority));
     }


### PR DESCRIPTION
## What

Architecture-roadmap [M/BR4] — unify `CsvImporter` categorization on `RulesEngine` for both extraction paths. **Fixes a real CLI bug.**

The plain `extract`/`extract_string` path (what the CLI uses) categorized via a bespoke `match_mapping` matcher that checked exact `mappings` and the merchant dictionary but **never consulted `regex_mappings`** — so a row matched only by a regex rule landed at the *default* account instead of its mapped one. The enriched path used `RulesEngine` (which loads all three). The two were kept in sync only by an "exactly as RulesEngine does" comment, and silently diverged.

## How

- New `build_rules_engine(csv_config)` — the single engine builder (exact mappings + regex mappings + merchant dict), used by **both** paths.
- The plain path builds it once per file and `parse_row` categorizes via `engine.categorize(...)`.
- Deleted the bespoke `match_mapping` and `merchant_regexes()` (their logic is `RulesEngine`'s `load_from_mappings` (substring) + `load_merchant_dict`, which is exactly what the plain path duplicated).

`load_from_mappings` uses the same case-insensitive substring match as the old `match_mapping`, so exact-mapping and merchant-dict behavior is unchanged — the only behavior change is that `regex_mappings` now apply on the plain path too.

## Tests

The audit noted **no test covered `regex_mappings` on the plain path**. Added `test_regex_mappings_categorize_on_plain_path_and_match_enriched`: a `SBUX`-only-regex row now categorizes to `Expenses:Coffee` on the plain path and matches the enriched path. Full `rustledger-importer` suite passes (158 existing tests unchanged); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
