### PR TITLE
fix(plugin,booking): reject multi-char wire flags; document apply() precondition

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -447,7 +447,18 @@ impl BookingEngine {
         })
     }
 
-    /// Apply a transaction to the inventories (update balances).
+    /// Apply a transaction's postings to the running inventories (update
+    /// balances).
+    ///
+    /// # Precondition
+    ///
+    /// The transaction MUST already be booked — postings filled with complete
+    /// units and resolved costs, as produced by [`Self::book_and_interpolate`]
+    /// or the free [`book`](crate::book) function. Applying an *unbooked*
+    /// transaction can silently over-sell an inventory: a reduction with no
+    /// matching lot yet is dropped (its `reduce` error is otherwise ignored).
+    /// The loader pipeline guarantees this ordering; the in-loop `debug_assert`
+    /// below catches a violating caller in debug builds.
     pub fn apply(&mut self, txn: &Transaction) {
         for posting in &txn.postings {
             if let Some(IncompleteAmount::Complete(units)) = &posting.units {
@@ -470,8 +481,22 @@ impl BookingEngine {
                     && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
 
                 if is_reduction {
-                    // Reduce from inventory
-                    let _ = inv.reduce(units, posting.cost.as_ref(), method);
+                    // Reduce from inventory. `reduce` only errors when the lot
+                    // it would match is missing — a "must book first" precondition
+                    // violation (see the fn-level doc). In release builds the
+                    // historical behavior (ignore) is kept; in debug builds we
+                    // surface the unbooked-apply bug instead of silently
+                    // over-selling.
+                    let reduced = inv.reduce(units, posting.cost.as_ref(), method);
+                    debug_assert!(
+                        reduced.is_ok(),
+                        "apply() reduction failed — the transaction must be booked \
+                         before apply() (postings filled, costs resolved); applying \
+                         an unbooked reduction silently over-sells inventory"
+                    );
+                    // `reduced` is consumed only by the debug assertion above;
+                    // release builds keep the historical ignore-the-Result behavior.
+                    let _ = reduced;
                 } else {
                     // Add to inventory
                     let position = if let Some(cost_spec) = &posting.cost {

--- a/crates/rustledger-plugin/src/convert/from_wrapper.rs
+++ b/crates/rustledger-plugin/src/convert/from_wrapper.rs
@@ -23,10 +23,14 @@ pub(super) fn data_to_transaction(
         "!" => '!',
         "P" => 'P',
         other => {
-            if let Some(c) = other.chars().next() {
-                c
-            } else {
-                return Err(ConversionError::InvalidFlag(other.to_string()));
+            // Reject empty AND multi-character flags rather than silently
+            // truncating (e.g. "txn" -> 't') — symmetric with the span/cost
+            // reject-don't-truncate discipline elsewhere in this module, and
+            // with the core flag being a single `char`.
+            let mut chars = other.chars();
+            match (chars.next(), chars.next()) {
+                (Some(c), None) => c,
+                _ => return Err(ConversionError::InvalidFlag(other.to_string())),
             }
         }
     };

--- a/crates/rustledger-plugin/src/convert/mod.rs
+++ b/crates/rustledger-plugin/src/convert/mod.rs
@@ -231,6 +231,39 @@ mod tests {
     }
 
     #[test]
+    fn test_multi_char_wire_flag_rejected_not_truncated() {
+        use rustledger_plugin_types::TransactionData;
+        let date = rustledger_core::naive_date(2024, 1, 1).unwrap();
+        let data = TransactionData {
+            flag: "txn".to_string(),
+            payee: None,
+            narration: "test".to_string(),
+            tags: vec![],
+            links: vec![],
+            metadata: vec![],
+            postings: vec![],
+        };
+        // A multi-char wire flag must be REJECTED, not silently truncated to
+        // its first char ("txn" -> 't').
+        let result = super::from_wrapper::data_to_transaction(&data, date);
+        assert!(
+            matches!(&result, Err(ConversionError::InvalidFlag(f)) if f == "txn"),
+            "multi-char flag must be rejected, got {result:?}"
+        );
+
+        // A single-char flag still converts.
+        let single = TransactionData {
+            flag: "x".to_string(),
+            ..data
+        };
+        let ok = super::from_wrapper::data_to_transaction(&single, date);
+        assert!(
+            matches!(ok, Ok(txn) if txn.flag == 'x'),
+            "single-char flag should convert"
+        );
+    }
+
+    #[test]
     fn test_roundtrip_transaction() {
         let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
         let txn = Transaction {


### PR DESCRIPTION
## What

Architecture-roadmap [S/3] — close two boundary failure-mode gaps where a precondition violation is currently silent.

**(1) Multi-char wire flag silently truncated.** `data_to_transaction` (`from_wrapper.rs`) converted a multi-character wire flag to its first char (`"txn"` -> `'t'`), even though the same module deliberately *rejects* span overflow and `PerUnitFromTotal` "rather than silently truncating/corrupting", and the empty-flag case already errors. Now a flag whose char-length != 1 is rejected with `ConversionError::InvalidFlag`, symmetric with the empty-flag rejection.

**(2) `BookingEngine::apply()` had an undocumented "must book first" precondition.** It discarded `inv.reduce(...)`'s `Result` and is `pub` with no documented precondition — a caller doing `apply(&original_txn)` on an *unbooked* transaction gets a silently over-sold inventory. Added a `# Precondition` doc and a `debug_assert!` that the reduction succeeded (the audit's minimal option — release behavior unchanged, debug builds catch a violating caller). Not the heavier `BookedTransaction` newtype.

## Tests

`test_multi_char_wire_flag_rejected_not_truncated`: `"txn"` -> `InvalidFlag`, single-char still converts. Full `rustledger-plugin` + `rustledger-booking` suites pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
