### PR TITLE
refactor(ffi): route stateless convert::clamp through clamp_indexed (BR6 step 2)

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1094,7 +1094,14 @@ fn loaded_directive_to_input(d: &wit::Directive) -> ffi::InputEntry {
 }
 
 /// `entry.clamp` — clamp loaded directives to `[begin, end)` via the typed
-/// `rustledger_ops::clamp`. Round-trips WIT -> core -> ops -> WIT.
+/// [`rustledger_ops::clamp::clamp_indexed`].
+///
+/// In-window entries and carried-forward prices are handed back as their
+/// **original** WIT directive (full fidelity + provenance) via the source index;
+/// only the synthesized opening-balance / earnings summaries are built fresh
+/// (with the `<clamped>` sentinel). This matches `SessionState::clamp` so the
+/// stateless and session clamp paths produce the same result — the divergence
+/// that the JSON `clamp_entries` workaround left open (#1425).
 pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::Directive> {
     let (Ok(begin_date), Ok(end_date)) = (
         begin.parse::<rustledger_core::NaiveDate>(),
@@ -1104,132 +1111,29 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         return entries;
     };
 
-    // Route through the shared, meta-preserving `commands::clamp` (the path the
-    // JSON-RPC surface uses) so in-window entries keep their original
-    // `filename`/`lineno`. We index the inputs by location and feed JSON
-    // entries carrying that meta; in-window outputs are then matched back to the
-    // original WIT directive (full fidelity + provenance), and only the
-    // synthesized boundary transactions are built from JSON. (#1425)
-    let mut by_loc: std::collections::HashMap<(String, u32), wit::Directive> =
-        std::collections::HashMap::new();
-    let mut json_entries: Vec<serde_json::Value> = Vec::new();
-    for d in &entries {
-        let (file, line) = wit_directive_location(d);
-        if let Ok(core) = ffi::input_entry_to_directive(&loaded_directive_to_input(d))
-            && let Ok(value) =
-                serde_json::to_value(ffi::convert::directive_to_json(&core, line, &file))
-        {
-            json_entries.push(value);
+    // Convert inputs to core directives, remembering each one's position in
+    // `entries` so a `clamp_indexed` source index can map an output back to the
+    // exact original WIT directive. Inputs that fail to convert are skipped (they
+    // can't participate in summarization); `orig_index` keeps the surviving cores
+    // aligned to their WIT source.
+    let mut core: Vec<rustledger_core::Directive> = Vec::new();
+    let mut orig_index: Vec<usize> = Vec::new();
+    for (i, d) in entries.iter().enumerate() {
+        if let Ok(c) = ffi::input_entry_to_directive(&loaded_directive_to_input(d)) {
+            core.push(c);
+            orig_index.push(i);
         }
-        by_loc.insert((file, line), d.clone());
     }
 
-    let result = ffi::commands::clamp::clamp_entries(json_entries, begin_date, end_date);
-    result
-        .entries
-        .iter()
-        .map(|entry| {
-            let file = entry
-                .pointer("/meta/filename")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default();
-            let line = entry
-                .pointer("/meta/lineno")
-                .and_then(serde_json::Value::as_u64)
-                .and_then(|n| u32::try_from(n).ok())
-                .unwrap_or(0);
-            by_loc
-                .get(&(file.to_string(), line))
-                .cloned()
-                .unwrap_or_else(|| synthesized_transaction_to_wit(entry))
+    rustledger_ops::clamp::clamp_indexed(&core, begin_date, end_date)
+        .into_iter()
+        .map(|(d, src)| match src.and_then(|j| orig_index.get(j)) {
+            // Pass-through: hand back the original WIT directive untouched.
+            Some(&i) => entries[i].clone(),
+            // Synthesized summary: build from core with the `<clamped>` source.
+            None => directive(ffi::convert::directive_to_json(&d, 0, "<clamped>")),
         })
         .collect()
-}
-
-/// The source location (`filename`, `lineno`) of a loaded WIT directive.
-fn wit_directive_location(d: &wit::Directive) -> (String, u32) {
-    let m = match d {
-        wit::Directive::Transaction(x) => &x.meta,
-        wit::Directive::Open(x) => &x.meta,
-        wit::Directive::Close(x) => &x.meta,
-        wit::Directive::Balance(x) => &x.meta,
-        wit::Directive::Pad(x) => &x.meta,
-        wit::Directive::Commodity(x) => &x.meta,
-        wit::Directive::Price(x) => &x.meta,
-        wit::Directive::Event(x) => &x.meta,
-        wit::Directive::Note(x) => &x.meta,
-        wit::Directive::Document(x) => &x.meta,
-        wit::Directive::Query(x) => &x.meta,
-        wit::Directive::Custom(x) => &x.meta,
-    };
-    (m.filename.clone(), m.lineno)
-}
-
-/// Build a WIT transaction from a synthesized clamp boundary entry. These are
-/// opening-balance transactions (`<summarization>`, simple `account` + `units`
-/// postings) — the only directive kind `commands::clamp` synthesizes.
-fn synthesized_transaction_to_wit(entry: &serde_json::Value) -> wit::Directive {
-    let s = |k: &str| {
-        entry
-            .get(k)
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .to_string()
-    };
-    let postings = entry
-        .get("postings")
-        .and_then(serde_json::Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .map(|p| wit::Posting {
-                    account: p
-                        .get("account")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or_default()
-                        .to_string(),
-                    units: p.get("units").and_then(|u| {
-                        Some(wit::Amount {
-                            number: u.get("number")?.as_str()?.to_string(),
-                            currency: u.get("currency")?.as_str()?.to_string(),
-                        })
-                    }),
-                    cost: None,
-                    price: None,
-                    flag: p
-                        .get("flag")
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_string),
-                    meta: vec![],
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    wit::Directive::Transaction(wit::Transaction {
-        date: s("date"),
-        flag: s("flag"),
-        payee: None,
-        narration: entry
-            .get("narration")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string),
-        tags: vec![],
-        links: vec![],
-        postings,
-        meta: wit::Meta {
-            filename: entry
-                .pointer("/meta/filename")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("<summarization>")
-                .to_string(),
-            lineno: 0,
-            hash: entry
-                .pointer("/meta/hash")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
-            user: vec![],
-        },
-    })
 }
 
 /// Run a BQL query against an already-loaded directive set (#1423).

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1113,11 +1113,13 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
 
     // Convert inputs to core directives, remembering each one's position in
     // `entries` so a `clamp_indexed` source index can map an output back to the
-    // exact original WIT directive. Inputs that fail to convert are skipped (they
-    // can't participate in summarization); `orig_index` keeps the surviving cores
-    // aligned to their WIT source.
-    let mut core: Vec<rustledger_core::Directive> = Vec::new();
-    let mut orig_index: Vec<usize> = Vec::new();
+    // exact original WIT directive. These are already-loaded WIT directives, so
+    // conversion is not expected to fail; if one ever does it is skipped — this
+    // surface returns `Vec<wit::Directive>` with no error channel (matching the
+    // unparsable-bounds early return above) — and `orig_index` keeps the
+    // surviving cores aligned to their WIT source.
+    let mut core: Vec<rustledger_core::Directive> = Vec::with_capacity(entries.len());
+    let mut orig_index: Vec<usize> = Vec::with_capacity(entries.len());
     for (i, d) in entries.iter().enumerate() {
         if let Ok(c) = ffi::input_entry_to_directive(&loaded_directive_to_input(d)) {
             core.push(c);


### PR DESCRIPTION
## What

Architecture-roadmap [L/BR6] — **step 2** of unifying on the typed clamp engine. Stacked on #1552 (now merged).

The stateless `entry.clamp` (the free `convert::clamp`) still went through the 846-line JSON `clamp_entries` — the #1425 provenance workaround — while `SessionState::clamp` used the typed `ops::clamp`. So **identical input could yield different clamped ledgers** depending on which embedding entry point you called.

## How

Rewrites `convert::clamp` to:
1. Convert the WIT inputs to core directives once, remembering each one's index in the input vector.
2. Call `rustledger_ops::clamp::clamp_indexed` (added in #1552).
3. For each output, hand back the **original** WIT directive for pass-throughs (by source index — full fidelity + provenance), and build only the synthesized opening-balance / earnings summaries fresh with the `<clamped>` sentinel.

This is exactly what `SessionState::clamp` does, so the stateless and session clamp paths now produce the same result. Deletes the now-dead `wit_directive_location` and `synthesized_transaction_to_wit` helpers.

## Scope

`clamp_entries` itself is **not** deleted here — it still backs the `ffi-wasi` JSON-RPC `clamp` command. That deletion is **step 3**, gated on routing (or removing) that surface (#1419). After this PR, `ffi-component` no longer calls `clamp_entries` at all.

## Tests

No clamp tests asserted the old JSON-synthetic WIT form, so none needed updating. `rustledger-ffi-component` suite passes; clippy `--all-features --all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
