### PR TITLE
refactor(query): route posting cost-resolve through Position::from_posting (BR8 step 1)

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -238,16 +238,11 @@ impl Executor<'_> {
                 // Position includes both units and cost.
                 // Uses resolve() to handle both per-unit and total cost syntax.
                 if let Some(units) = posting.amount() {
-                    if let Some(cost_spec) = &posting.cost
-                        && let Some(cost) = cost_spec.resolve(units.number, ctx.transaction.date)
-                    {
-                        Ok(Value::Position(Box::new(Position::with_cost(
-                            units.clone(),
-                            cost,
-                        ))))
-                    } else {
-                        Ok(Value::Position(Box::new(Position::simple(units.clone()))))
-                    }
+                    Ok(Value::Position(Box::new(Position::from_posting(
+                        units,
+                        posting.cost.as_ref(),
+                        ctx.transaction.date,
+                    ))))
                 } else {
                     Ok(Value::Null)
                 }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -907,13 +907,7 @@ impl Executor<'_> {
                         // posting carries a cost annotation; bare units
                         // otherwise.
                         let pos = posting.amount().map(|units| {
-                            if let Some(cost_spec) = &posting.cost
-                                && let Some(cost) = cost_spec.resolve(units.number, txn.date)
-                            {
-                                Position::with_cost(units.clone(), cost)
-                            } else {
-                                Position::simple(units.clone())
-                            }
+                            Position::from_posting(units, posting.cost.as_ref(), txn.date)
                         });
 
                         if let Some(ref p) = pos {

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -402,15 +402,7 @@ impl<'a> Executor<'a> {
                     if let Some(units) = posting.amount() {
                         let balance = balances.entry(posting.account.clone()).or_default();
 
-                        let pos = if let Some(cost_spec) = &posting.cost {
-                            if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
-                                Position::with_cost(units.clone(), cost)
-                            } else {
-                                Position::simple(units.clone())
-                            }
-                        } else {
-                            Position::simple(units.clone())
-                        };
+                        let pos = Position::from_posting(units, posting.cost.as_ref(), txn.date);
                         balance.add(pos);
                     }
                 }
@@ -471,18 +463,13 @@ impl<'a> Executor<'a> {
             self.resolved_directives().enumerate().collect();
 
         // Resolve a posting to a Position that preserves cost basis when present.
-        // Other balance accumulators in this crate (`build_balances_with_filter`,
-        // `build_postings_table`) use this same shape; running `balance` /
-        // `account_balance` need to match so lot details aren't dropped.
+        // The single cost-resolve lives in `Position::from_posting`, shared with
+        // every other balance accumulator in this crate so lot details can't be
+        // dropped by a divergent copy.
         let resolve_position = |posting: &rustledger_core::Posting, txn_date: NaiveDate| {
-            posting.amount().map(|units| {
-                if let Some(cost_spec) = &posting.cost
-                    && let Some(cost) = cost_spec.resolve(units.number, txn_date)
-                {
-                    return Position::with_cost(units.clone(), cost);
-                }
-                Position::simple(units.clone())
-            })
+            posting
+                .amount()
+                .map(|units| Position::from_posting(units, posting.cost.as_ref(), txn_date))
         };
 
         for (directive_index, directive) in directive_iter {

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -659,15 +659,7 @@ impl Executor<'_> {
 
                 // Update running balances (per-account and cumulative).
                 if let Some(units) = posting.amount() {
-                    let pos = if let Some(cost_spec) = &posting.cost {
-                        if let Some(cost) = cost_spec.resolve(units.number, txn.date) {
-                            Position::with_cost(units.clone(), cost)
-                        } else {
-                            Position::simple(units.clone())
-                        }
-                    } else {
-                        Position::simple(units.clone())
-                    };
+                    let pos = Position::from_posting(units, posting.cost.as_ref(), txn.date);
                     account_balances
                         .entry(posting.account.clone())
                         .or_default()
@@ -704,13 +696,11 @@ impl Executor<'_> {
                 };
 
                 let position_val = if let Some(units) = posting.amount() {
-                    if let Some(cost_spec) = &posting.cost
-                        && let Some(cost) = cost_spec.resolve(units.number, txn.date)
-                    {
-                        Value::Position(Box::new(Position::with_cost(units.clone(), cost)))
-                    } else {
-                        Value::Position(Box::new(Position::simple(units.clone())))
-                    }
+                    Value::Position(Box::new(Position::from_posting(
+                        units,
+                        posting.cost.as_ref(),
+                        txn.date,
+                    )))
                 } else {
                     Value::Null
                 };


### PR DESCRIPTION
## What

Architecture-roadmap [XL/BR8] — **step 1** of unifying the four copies of "iterate postings, resolve cost→Position, accumulate Inventory, derive columns" onto one stream. This first slice single-sources the **cost-resolve leaf**, the most-duplicated piece.

The idiom `if cost_spec.resolve(units, date) { Position::with_cost } else { Position::simple }` (also guarding the no-cost case) was hand-written at 5 Position-building sites across the query executor. The canonical version already exists as `rustledger_core::Position::from_posting` (extracted in the L/7 work) — these sites just hadn't been routed through it.

## How

Routes all 6 query-executor Position-building cost-resolves through `Position::from_posting(units, posting.cost.as_ref(), date)`:
- `executor/mod.rs` — `build_balances_with_filter` accumulator + the `resolve_position` closure (running `balance`/`account_balance`)
- `executor/system_tables.rs` — `#postings` running-balance `pos` + the `position` column
- `executor/evaluation.rs` — the `position` posting-function

`Position::from_posting` is byte-for-byte equivalent to each replaced block (`cs.resolve(...)` → `with_cost`, else `simple`; outer `None` → `simple`), so query results are unchanged. The cost-*field*-extraction at system_tables (which reads the resolved cost's number/currency/date/label) and the units×cost weight in mod.rs are different idioms and are left alone.

## Why

Removes the "running balance / account_balance need to match so lot details aren't dropped" convention-only invariant (its comment is replaced by the shared call). A future `CostNumber` variant or cost-resolve fix now lands in one place.

## Tests

Full `rustledger-query` suite passes (these are result-producing paths); clippy `--all-features --all-targets -D warnings` + fmt clean. Follow-ups: the source-location-columns leaf (fixes bug #4's unchecked `as i64`), then the unified posting iterator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

