### PR TITLE
refactor(query): single-source source-location columns; fix unchecked lineno cast (BR8 step 2)

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -381,17 +381,15 @@ impl Executor<'_> {
             )))),
             // Source location columns — resolved from the posting's own span
             // (falling back to the enclosing directive's location).
-            "filename" => Ok(self
-                .resolved_source_location(ctx)
-                .map_or(Value::Null, |loc| Value::String(loc.filename))),
-            "lineno" => Ok(self
-                .resolved_source_location(ctx)
-                .map_or(Value::Null, |loc| Value::Integer(loc.lineno as i64))),
-            "location" => Ok(self
-                .resolved_source_location(ctx)
-                .map_or(Value::Null, |loc| {
-                    Value::String(format!("{}:{}", loc.filename, loc.lineno))
-                })),
+            "filename" => Ok(Self::source_filename_value(
+                self.resolved_source_location(ctx).as_ref(),
+            )),
+            "lineno" => Ok(Self::source_lineno_value(
+                self.resolved_source_location(ctx).as_ref(),
+            )),
+            "location" => Ok(Self::source_location_value(
+                self.resolved_source_location(ctx).as_ref(),
+            )),
             // has_cost - check if posting has cost specification
             "has_cost" => Ok(Value::Boolean(posting.cost.is_some())),
             // entry - parent transaction as structured object

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -75,6 +75,29 @@ impl Executor<'_> {
         }
     }
 
+    /// The synthetic `filename` source-location column value.
+    pub(crate) fn source_filename_value(loc: Option<&SourceLocation>) -> Value {
+        loc.map_or(Value::Null, |l| Value::String(l.filename.clone()))
+    }
+
+    /// The synthetic `lineno` source-location column value, as an `Integer`.
+    ///
+    /// Saturates to `i64::MAX` only on the practically-impossible case of a line
+    /// number exceeding `i64` — the single, overflow-checked replacement for the
+    /// unchecked `loc.lineno as i64` casts the column paths used (bug #4).
+    pub(crate) fn source_lineno_value(loc: Option<&SourceLocation>) -> Value {
+        loc.map_or(Value::Null, |l| {
+            Value::Integer(i64::try_from(l.lineno).unwrap_or(i64::MAX))
+        })
+    }
+
+    /// The synthetic `location` source-location column value (`filename:lineno`).
+    pub(crate) fn source_location_value(loc: Option<&SourceLocation>) -> Value {
+        loc.map_or(Value::Null, |l| {
+            Value::String(format!("{}:{}", l.filename, l.lineno))
+        })
+    }
+
     /// Look up a single metadata key, falling back to the synthetic
     /// source-location keys (`filename`/`lineno`) when absent from `raw`.
     fn meta_lookup(raw: &Metadata, loc: Option<&SourceLocation>, key: &str) -> Option<MetaValue> {
@@ -218,5 +241,53 @@ impl Executor<'_> {
             }
         }
         Ok(Value::Null)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::Executor;
+    use super::super::super::types::{SourceLocation, Value};
+
+    fn loc(lineno: usize) -> SourceLocation {
+        SourceLocation {
+            filename: "f.bean".to_string(),
+            lineno,
+        }
+    }
+
+    #[test]
+    fn source_lineno_value_basics() {
+        assert_eq!(
+            Executor::source_lineno_value(Some(&loc(42))),
+            Value::Integer(42)
+        );
+        assert_eq!(Executor::source_lineno_value(None), Value::Null);
+    }
+
+    // bug #4: a line number exceeding `i64` must saturate to `i64::MAX`, not wrap
+    // negative as the old unchecked `loc.lineno as i64` cast did. Only reachable
+    // where `usize` is wider than `i64`.
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn source_lineno_value_saturates_on_overflow() {
+        assert_eq!(
+            Executor::source_lineno_value(Some(&loc(usize::MAX))),
+            Value::Integer(i64::MAX)
+        );
+    }
+
+    #[test]
+    fn source_filename_and_location_values() {
+        assert_eq!(
+            Executor::source_filename_value(Some(&loc(7))),
+            Value::String("f.bean".to_string())
+        );
+        assert_eq!(
+            Executor::source_location_value(Some(&loc(7))),
+            Value::String("f.bean:7".to_string())
+        );
+        assert_eq!(Executor::source_filename_value(None), Value::Null);
+        assert_eq!(Executor::source_location_value(None), Value::Null);
     }
 }

--- a/crates/rustledger-query/src/executor/functions/util.rs
+++ b/crates/rustledger-query/src/executor/functions/util.rs
@@ -80,21 +80,25 @@ impl Executor<'_> {
         loc.map_or(Value::Null, |l| Value::String(l.filename.clone()))
     }
 
-    /// The synthetic `lineno` source-location column value, as an `Integer`.
-    ///
-    /// Saturates to `i64::MAX` only on the practically-impossible case of a line
-    /// number exceeding `i64` — the single, overflow-checked replacement for the
-    /// unchecked `loc.lineno as i64` casts the column paths used (bug #4).
-    pub(crate) fn source_lineno_value(loc: Option<&SourceLocation>) -> Value {
-        loc.map_or(Value::Null, |l| {
-            Value::Integer(i64::try_from(l.lineno).unwrap_or(i64::MAX))
-        })
+    /// The line number as an `i64`, saturating to `i64::MAX` only on the
+    /// practically-impossible case of a line number exceeding `i64` — the single,
+    /// overflow-checked replacement for the unchecked `loc.lineno as i64` casts
+    /// (bug #4). Shared by the `lineno` and `location` columns so they can never
+    /// disagree on the same posting.
+    fn lineno_i64(loc: &SourceLocation) -> i64 {
+        i64::try_from(loc.lineno).unwrap_or(i64::MAX)
     }
 
-    /// The synthetic `location` source-location column value (`filename:lineno`).
+    /// The synthetic `lineno` source-location column value, as an `Integer`.
+    pub(crate) fn source_lineno_value(loc: Option<&SourceLocation>) -> Value {
+        loc.map_or(Value::Null, |l| Value::Integer(Self::lineno_i64(l)))
+    }
+
+    /// The synthetic `location` source-location column value (`filename:lineno`),
+    /// using the same saturated line number as [`Self::source_lineno_value`].
     pub(crate) fn source_location_value(loc: Option<&SourceLocation>) -> Value {
         loc.map_or(Value::Null, |l| {
-            Value::String(format!("{}:{}", l.filename, l.lineno))
+            Value::String(format!("{}:{}", l.filename, Self::lineno_i64(l)))
         })
     }
 
@@ -274,6 +278,11 @@ mod tests {
         assert_eq!(
             Executor::source_lineno_value(Some(&loc(usize::MAX))),
             Value::Integer(i64::MAX)
+        );
+        // `location` must use the same saturated value so the two columns agree.
+        assert_eq!(
+            Executor::source_location_value(Some(&loc(usize::MAX))),
+            Value::String(format!("f.bean:{}", i64::MAX))
         );
     }
 

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -523,8 +523,8 @@ impl Executor<'_> {
                 )
             };
 
-        let filename = source_loc.map_or(Value::Null, |loc| Value::String(loc.filename.clone()));
-        let lineno = source_loc.map_or(Value::Null, |loc| Value::Integer(loc.lineno as i64));
+        let filename = Self::source_filename_value(source_loc);
+        let lineno = Self::source_lineno_value(source_loc);
 
         vec![
             Value::Integer(idx as i64), // id
@@ -648,14 +648,12 @@ impl Executor<'_> {
                 let posting_loc = self
                     .span_source_location(posting.file_id, posting.span.start)
                     .or_else(|| source_loc.cloned());
-                let (filename, lineno, location) = match posting_loc.as_ref() {
-                    Some(loc) => (
-                        Value::String(loc.filename.clone()),
-                        Value::Integer(loc.lineno as i64),
-                        Value::String(format!("{}:{}", loc.filename, loc.lineno)),
-                    ),
-                    None => (Value::Null, Value::Null, Value::Null),
-                };
+                let loc = posting_loc.as_ref();
+                let (filename, lineno, location) = (
+                    Self::source_filename_value(loc),
+                    Self::source_lineno_value(loc),
+                    Self::source_location_value(loc),
+                );
 
                 // Update running balances (per-account and cumulative).
                 if let Some(units) = posting.amount() {


### PR DESCRIPTION
## What

Architecture-roadmap [XL/BR8] — **step 2** of the PostingContext-stream unification. Single-sources the **source-location column** leaf (`filename`/`lineno`/`location`), and fixes **bug #4** along the way.

These three synthetic columns were built in ~3 places, two of which used an **unchecked `loc.lineno as i64`** cast (`lineno` is `usize`) — bug #4: on a hypothetical line number exceeding `i64`, the cast wraps to a negative `lineno`. The META path already guarded this (`source_location_meta_key` uses `try_from`); the *column* paths did not.

## How

Adds three shared helpers next to the existing `source_location_meta_key`:
- `source_filename_value`, `source_lineno_value`, `source_location_value` — each `Option<&SourceLocation> -> Value`.
- `source_lineno_value` is the single overflow-checked conversion (`i64::try_from(...).unwrap_or(i64::MAX)`), replacing every `as i64` cast.

Routes all column sites through them:
- `executor/evaluation.rs` — the `filename`/`lineno`/`location` posting-function arms
- `executor/system_tables.rs` — the standalone `filename`/`lineno` pair and the `(filename, lineno, location)` `#postings` tuple

Behavior is unchanged for every real ledger (linenos fit in `i64`); only the pathological overflow now saturates instead of wrapping.

## Tests

Added unit tests: `source_lineno_value` saturates `usize::MAX` to `i64::MAX` on 64-bit (bug #4 pin), basic lineno/filename/location values, and `None` handling. Full `rustledger-query` suite passes; clippy `--all-features --all-targets -D warnings` + fmt clean.

Follow-up (step 3): fold these leaves + the cost-resolve (step 1, #1555) into one posting-source iterator consumed by `build_postings_table`, `build_balances_with_filter`, and aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
