### PR TITLE
fix(query): reconcile #postings vs default-SELECT type + cost_date with the oracle (BR8 step 3)

### DIFF
--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -329,11 +329,19 @@ impl Executor<'_> {
                 .as_ref()
                 .and_then(|c| c.currency.as_ref())
                 .map_or(Value::Null, |c| Value::String(c.to_string()))),
-            // Cost date
+            // Cost date — the *resolved* cost date, not the raw spec date: an
+            // undated cost (`{150 USD}`) inherits the transaction date when
+            // booked, which is what bean-query and the `#postings` table report.
+            // Reading the raw `CostSpec.date` (often `None`) was the divergence.
             "cost_date" => Ok(posting
-                .cost
-                .as_ref()
-                .and_then(|c| c.date)
+                .amount()
+                .and_then(|units| {
+                    posting
+                        .cost
+                        .as_ref()
+                        .and_then(|cs| cs.resolve(units.number, ctx.transaction.date))
+                })
+                .and_then(|cost| cost.date)
                 .map_or(Value::Null, Value::Date)),
             // Cost label
             "cost_label" => Ok(posting
@@ -421,9 +429,11 @@ impl Executor<'_> {
                 obj.insert("meta".to_string(), Value::Object(Box::new(meta_obj)));
                 Ok(Value::Object(Box::new(obj)))
             }
-            // type - directive type (matches Python beancount's type column)
-            // For SELECT FROM (default), this is always "Transaction"
-            "type" => Ok(Value::String("Transaction".to_string())),
+            // type - directive type. bean-query lowercases it (`transaction`),
+            // and the `#postings` table already emits lowercase; the default
+            // posting source is always a transaction. (Confirmed against the
+            // bean-query oracle.)
+            "type" => Ok(Value::String("transaction".to_string())),
             // id - directive index (matches Python beancount's id column)
             "id" => Ok(ctx
                 .directive_index

--- a/crates/rustledger-query/tests/postings_parity_test.rs
+++ b/crates/rustledger-query/tests/postings_parity_test.rs
@@ -130,3 +130,78 @@ fn default_select_matches_postings_table() {
          posting-source implementations have drifted"
     );
 }
+
+/// Every `#postings` column the default path also computes, EXCEPT the two that
+/// are known to diverge today (see [`KNOWN_DIVERGENT_COLUMNS`]). The two paths
+/// must agree on all of these — the bulk of the projection.
+const AGREEING_COLUMNS: &str = "id, date, year, month, day, flag, payee, narration, \
+     description, tags, links, posting_flag, account, other_accounts, number, currency, \
+     cost_number, cost_currency, cost_label, position, price, weight, balance, account_balance";
+
+/// The columns where the default `SELECT` path and `#postings` currently produce
+/// different values for the same posting — the BR8 step-3 reconciliation work-list:
+///
+/// - `type`: default emits `"Transaction"` (capitalized), `#postings` emits
+///   `"transaction"` (lowercase) — a casing mismatch.
+/// - `cost_date`: default reads the raw `CostSpec.date` (`None` for `{150 USD}`),
+///   `#postings` reads the *resolved* cost date (filled to the txn date).
+///
+/// Pinned here so the eventual single-posting-source unification has an explicit
+/// list to reconcile (each to the bean-query-correct value), and so a NEW
+/// divergence appearing on any other column fails this test loudly.
+const KNOWN_DIVERGENT_COLUMNS: &[&str] = &["type", "cost_date"];
+
+fn columns_that_diverge(dirs: &[Directive]) -> Vec<String> {
+    let mut executor = Executor::new(dirs);
+    let all = format!("{AGREEING_COLUMNS}, type, cost_date");
+    all.split(',')
+        .map(str::trim)
+        .filter(|col| {
+            let direct = executor
+                .execute(&parse(&format!("SELECT {col}")).unwrap())
+                .unwrap();
+            let table = executor
+                .execute(&parse(&format!("SELECT {col} FROM #postings")).unwrap())
+                .unwrap();
+            direct.rows != table.rows
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+/// The default `SELECT` path and `#postings` agree on every column except the
+/// two documented ones — proven per-column so the failure message names any new
+/// drift. This is the regression net for the upcoming iterator unification.
+#[test]
+fn divergence_is_exactly_the_known_two_columns() {
+    let mut diverge = columns_that_diverge(&fixture());
+    diverge.sort();
+    let mut known: Vec<String> = KNOWN_DIVERGENT_COLUMNS
+        .iter()
+        .copied()
+        .map(str::to_string)
+        .collect();
+    known.sort();
+    assert_eq!(
+        diverge, known,
+        "the set of diverging #postings columns changed — reconcile or update KNOWN_DIVERGENT_COLUMNS"
+    );
+}
+
+/// Full row-for-row parity on the agreeing columns (the bulk of the table).
+#[test]
+fn agreeing_columns_match_row_for_row() {
+    let dirs = fixture();
+    let mut executor = Executor::new(&dirs);
+    let direct = executor
+        .execute(&parse(&format!("SELECT {AGREEING_COLUMNS}")).unwrap())
+        .unwrap();
+    let table = executor
+        .execute(&parse(&format!("SELECT {AGREEING_COLUMNS} FROM #postings")).unwrap())
+        .unwrap();
+    assert_eq!(direct.columns, table.columns, "headers diverge");
+    assert_eq!(
+        direct.rows, table.rows,
+        "default SELECT and #postings diverge on an agreeing column"
+    );
+}

--- a/crates/rustledger-query/tests/postings_parity_test.rs
+++ b/crates/rustledger-query/tests/postings_parity_test.rs
@@ -131,30 +131,18 @@ fn default_select_matches_postings_table() {
     );
 }
 
-/// Every `#postings` column the default path also computes, EXCEPT the two that
-/// are known to diverge today (see [`KNOWN_DIVERGENT_COLUMNS`]). The two paths
-/// must agree on all of these — the bulk of the projection.
-const AGREEING_COLUMNS: &str = "id, date, year, month, day, flag, payee, narration, \
+/// Every `#postings` column the default `SELECT` path also computes. After the
+/// `type`/`cost_date` reconciliation (both were the default path being wrong vs
+/// the bean-query oracle), the two paths agree on ALL of these.
+const ALL_COLUMNS: &str = "type, id, date, year, month, day, flag, payee, narration, \
      description, tags, links, posting_flag, account, other_accounts, number, currency, \
-     cost_number, cost_currency, cost_label, position, price, weight, balance, account_balance";
-
-/// The columns where the default `SELECT` path and `#postings` currently produce
-/// different values for the same posting — the BR8 step-3 reconciliation work-list:
-///
-/// - `type`: default emits `"Transaction"` (capitalized), `#postings` emits
-///   `"transaction"` (lowercase) — a casing mismatch.
-/// - `cost_date`: default reads the raw `CostSpec.date` (`None` for `{150 USD}`),
-///   `#postings` reads the *resolved* cost date (filled to the txn date).
-///
-/// Pinned here so the eventual single-posting-source unification has an explicit
-/// list to reconcile (each to the bean-query-correct value), and so a NEW
-/// divergence appearing on any other column fails this test loudly.
-const KNOWN_DIVERGENT_COLUMNS: &[&str] = &["type", "cost_date"];
+     cost_number, cost_currency, cost_date, cost_label, position, price, weight, balance, \
+     account_balance";
 
 fn columns_that_diverge(dirs: &[Directive]) -> Vec<String> {
     let mut executor = Executor::new(dirs);
-    let all = format!("{AGREEING_COLUMNS}, type, cost_date");
-    all.split(',')
+    ALL_COLUMNS
+        .split(',')
         .map(str::trim)
         .filter(|col| {
             let direct = executor
@@ -169,39 +157,32 @@ fn columns_that_diverge(dirs: &[Directive]) -> Vec<String> {
         .collect()
 }
 
-/// The default `SELECT` path and `#postings` agree on every column except the
-/// two documented ones — proven per-column so the failure message names any new
-/// drift. This is the regression net for the upcoming iterator unification.
+/// No `#postings` column may diverge from the default `SELECT` path — proven
+/// per-column so a failure names exactly which column drifted. This is the
+/// regression net for the upcoming single-posting-source iterator unification.
 #[test]
-fn divergence_is_exactly_the_known_two_columns() {
-    let mut diverge = columns_that_diverge(&fixture());
-    diverge.sort();
-    let mut known: Vec<String> = KNOWN_DIVERGENT_COLUMNS
-        .iter()
-        .copied()
-        .map(str::to_string)
-        .collect();
-    known.sort();
-    assert_eq!(
-        diverge, known,
-        "the set of diverging #postings columns changed — reconcile or update KNOWN_DIVERGENT_COLUMNS"
+fn no_columns_diverge_from_default_select() {
+    let diverge = columns_that_diverge(&fixture());
+    assert!(
+        diverge.is_empty(),
+        "columns where default SELECT and #postings diverge: {diverge:?}"
     );
 }
 
-/// Full row-for-row parity on the agreeing columns (the bulk of the table).
+/// Full row-for-row parity across the entire projectable column set.
 #[test]
-fn agreeing_columns_match_row_for_row() {
+fn all_columns_match_row_for_row() {
     let dirs = fixture();
     let mut executor = Executor::new(&dirs);
     let direct = executor
-        .execute(&parse(&format!("SELECT {AGREEING_COLUMNS}")).unwrap())
+        .execute(&parse(&format!("SELECT {ALL_COLUMNS}")).unwrap())
         .unwrap();
     let table = executor
-        .execute(&parse(&format!("SELECT {AGREEING_COLUMNS} FROM #postings")).unwrap())
+        .execute(&parse(&format!("SELECT {ALL_COLUMNS} FROM #postings")).unwrap())
         .unwrap();
     assert_eq!(direct.columns, table.columns, "headers diverge");
     assert_eq!(
         direct.rows, table.rows,
-        "default SELECT and #postings diverge on an agreeing column"
+        "default SELECT and #postings diverge on a column value"
     );
 }


### PR DESCRIPTION
## What

Architecture-roadmap [XL/BR8] — **step 3: find AND reconcile the posting-source divergences.** Using the parity harness, I mapped exactly where the default `SELECT` path (`collect_postings` + per-column evaluation) and the `#postings` table (`build_postings_table`) disagree, checked each against the **bean-query oracle**, and fixed the two that were wrong.

## Finding → fix

Per-column comparison across all 26 projectable columns: **24 agreed; 2 diverged.** Checked against bean-query (`bean-query <ledger> "SELECT type, cost_date"`):

| Column | Default (was) | `#postings` | bean-query oracle | Fix |
|--------|---------------|-------------|-------------------|-----|
| **`type`** | `"Transaction"` | `"transaction"` | **`transaction`** | default path → lowercase |
| **`cost_date`** | raw `CostSpec.date` (`None`) | resolved txn date | **`2024-01-14`** (resolved) | default path → resolve the cost |

In both cases the **default path was wrong** and `#postings` already matched the oracle. The fixes are in `executor/evaluation.rs`:
- `type` → `"transaction"`.
- `cost_date` → resolve the cost (`cs.resolve(units, txn.date)`) so an undated `{150 USD}` cost reports the booked txn date, exactly as `#postings` and beancount do.

The full `rustledger-query` suite passes unchanged — no test depended on the old (wrong) values.

## Net

The two posting-source paths now produce **identical values on every column** (sorted input). The parity test is upgraded to assert full per-column agreement, so it's the regression net proving the upcoming iterator unification behavior-preserving. The one remaining step-3 item is the **iteration order** on *unsorted* input (`build_postings_table` sorts by date; `collect_postings` doesn't) — moot in practice (loaded ledgers are pre-sorted) and resolved when the two iterations actually merge onto one stream.

## Tests

Parity harness (full-column agreement, per-column drift detector) + full `rustledger-query` suite pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
