### PR TITLE
refactor(core): inventory unify (1+2) — single-source reduction gate + pad sub-account sum (BR6)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -467,18 +467,11 @@ impl BookingEngine {
                 let method = self.method_for(&posting.account);
                 let inv = self.inventories.entry(posting.account.clone()).or_default();
 
-                // Determine if this is a reduction: units reduce inventory when
-                // signs differ for the same currency. Only cost-bearing positions
-                // are considered, so simple (no-cost) positions don't trigger
-                // false reduction detection.
-                //
-                // NONE booking (issue #1182) treats every posting as an
-                // augmentation. Mixed-sign positions accumulate in the
-                // inventory — Python beancount's semantic for the NONE
-                // method, which the parallel guard in `book()` mirrors.
-                let is_reduction = method != BookingMethod::None
-                    && posting.cost.is_some()
-                    && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
+                // Reduction vs augmentation — the single source for this decision
+                // (`Inventory::is_booking_reduction`), shared with the Late
+                // validator so the two can't drift (including the #1182 NONE gate
+                // that previously had to be maintained in both crates).
+                let is_reduction = inv.is_booking_reduction(units, posting.cost.as_ref(), method);
 
                 if is_reduction {
                     // Reduce from inventory. `reduce` only errors when the lot

--- a/crates/rustledger-booking/src/pad.rs
+++ b/crates/rustledger-booking/src/pad.rs
@@ -188,10 +188,17 @@ pub fn process_pads(directives: &[Directive]) -> PadResult {
                         continue;
                     }
 
-                    // Calculate padding amount
-                    let current = inventories
-                        .get(&bal.account)
-                        .map_or(Decimal::ZERO, |inv| inv.units(&bal.amount.currency));
+                    // Calculate padding amount. The balance assertion this pad
+                    // targets sums the account AND its sub-accounts (beancount
+                    // semantic, verified against bean-check), so the pad
+                    // difference must be measured the same way — using only the
+                    // leaf account here under-/over-padded a non-leaf target and
+                    // then tripped the (sub-account-summing) Late validator.
+                    let current = rustledger_core::sum_account_and_subaccounts(
+                        inventories.iter(),
+                        bal.account.as_str(),
+                        &bal.amount.currency,
+                    );
 
                     let difference = bal.amount.number - current;
 
@@ -462,6 +469,50 @@ mod tests {
         assert_eq!(
             txn.postings[0].amount(),
             Some(&Amount::new(dec!(500.00), "USD"))
+        );
+    }
+
+    #[test]
+    fn test_process_pads_sums_subaccounts_for_nonleaf_target() {
+        // A pad targeting a NON-LEAF account must measure the current balance the
+        // same way the balance assertion does — summing the account AND its
+        // sub-accounts (beancount semantic, verified against bean-check). Here the
+        // balance lives entirely in the sub-account `Assets:Bank:Checking`, so the
+        // pad to `Assets:Bank` must be 100 - 50 = 50, NOT 100 (the old leaf-only
+        // bug, which then tripped the sub-account-summing Late validator).
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank:Checking")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Equity:Opening")),
+            Directive::Open(Open::new(date(2024, 1, 1), "Income:Salary")),
+            Directive::Transaction(
+                Transaction::new(date(2024, 1, 5), "Deposit into sub-account")
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Bank:Checking",
+                        Amount::new(dec!(50.00), "USD"),
+                    ))
+                    .with_synthesized_posting(Posting::new(
+                        "Income:Salary",
+                        Amount::new(dec!(-50.00), "USD"),
+                    )),
+            ),
+            Directive::Pad(Pad::new(date(2024, 1, 10), "Assets:Bank", "Equity:Opening")),
+            Directive::Balance(Balance::new(
+                date(2024, 1, 15),
+                "Assets:Bank",
+                Amount::new(dec!(100.00), "USD"),
+            )),
+        ];
+
+        let result = process_pads(&directives);
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.padding_transactions.len(), 1);
+        // 100 target - 50 already held in the sub-account = 50.
+        assert_eq!(
+            result.padding_transactions[0].postings[0].amount(),
+            Some(&Amount::new(dec!(50.00), "USD")),
+            "pad on a non-leaf account must sum sub-accounts (was leaf-only)"
         );
     }
 

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -458,6 +458,29 @@ impl Inventory {
         })
     }
 
+    /// Whether a posting of `units` carrying `cost` would REDUCE this inventory
+    /// under `method` — the single source for the reduction-vs-augmentation
+    /// decision shared by the booking engine (`BookingEngine::apply`) and the
+    /// Late validator's inventory pass.
+    ///
+    /// A posting reduces only when it carries a cost, the booking method isn't
+    /// `NONE` (issue #1182 — `NONE` accumulates every posting as an augmentation,
+    /// with no lot matching), and the inventory holds a cost-bearing position of
+    /// the opposite sign in the same currency ([`Self::is_reduced_by`] with
+    /// [`ReductionScope::CostBearingOnly`]). This gate was previously written
+    /// byte-for-byte in both crates and the #1182 fix had to be applied twice.
+    #[must_use]
+    pub fn is_booking_reduction(
+        &self,
+        units: &Amount,
+        cost: Option<&CostSpec>,
+        method: BookingMethod,
+    ) -> bool {
+        method != BookingMethod::None
+            && cost.is_some()
+            && self.is_reduced_by(units, ReductionScope::CostBearingOnly)
+    }
+
     /// Get the total book value (cost basis) for a currency.
     ///
     /// Returns the sum of all cost bases for positions of the given currency.

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -2327,6 +2327,52 @@ mod tests {
     }
 
     #[test]
+    fn is_booking_reduction_gates_on_method_cost_and_sign() {
+        // A cost-bearing long position.
+        let mut inv = Inventory::new();
+        inv.add(Position::with_cost(
+            Amount::new(dec!(10), "AAPL"),
+            Cost::new(dec!(150), "USD").with_date(date(2024, 1, 1)),
+        ));
+
+        let sell = Amount::new(dec!(-5), "AAPL"); // opposite sign of the held lot
+        let buy = Amount::new(dec!(5), "AAPL"); // same sign
+        let spec = CostSpec::empty(); // only spec *presence* (is_some) matters here
+
+        // Opposite-sign units carrying a cost spec under a lot-matching method
+        // is the one combination that reduces.
+        assert!(inv.is_booking_reduction(&sell, Some(&spec), BookingMethod::Strict));
+        // NONE never reduces — every posting accumulates (#1182).
+        assert!(!inv.is_booking_reduction(&sell, Some(&spec), BookingMethod::None));
+        // No cost spec -> augmentation.
+        assert!(!inv.is_booking_reduction(&sell, None, BookingMethod::Strict));
+        // Same sign as the held lot -> augmentation.
+        assert!(!inv.is_booking_reduction(&buy, Some(&spec), BookingMethod::Strict));
+    }
+
+    #[test]
+    fn sum_account_and_subaccounts_sums_children_not_prefix_siblings() {
+        let mut bank = Inventory::new();
+        bank.add(Position::simple(Amount::new(dec!(10), "USD")));
+        let mut checking = Inventory::new(); // sub-account: included
+        checking.add(Position::simple(Amount::new(dec!(40), "USD")));
+        let mut alias = Inventory::new(); // prefix sibling: excluded
+        alias.add(Position::simple(Amount::new(dec!(99), "USD")));
+
+        let mut map: FxHashMap<Account, Inventory> = FxHashMap::default();
+        map.insert(Account::from("Assets:Bank"), bank);
+        map.insert(Account::from("Assets:Bank:Checking"), checking);
+        map.insert(Account::from("Assets:BankAlias"), alias);
+
+        let total = sum_account_and_subaccounts(map.iter(), "Assets:Bank", &Currency::from("USD"));
+        assert_eq!(
+            total,
+            dec!(50),
+            "parent (10) + sub-account (40), excluding the Assets:BankAlias prefix sibling"
+        );
+    }
+
+    #[test]
     fn test_accounted_error_display_insufficient_units() {
         let err = BookingError::InsufficientUnits {
             currency: "AAPL".into(),

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -13,7 +13,7 @@ use smallvec::SmallVec;
 use std::fmt;
 use std::str::FromStr;
 
-use crate::{Amount, CostSpec, Position};
+use crate::{Account, Amount, CostSpec, Currency, Position, is_subaccount_or_equal};
 
 /// Inline storage for `BookingResult::matched`.
 ///
@@ -463,12 +463,14 @@ impl Inventory {
     /// decision shared by the booking engine (`BookingEngine::apply`) and the
     /// Late validator's inventory pass.
     ///
-    /// A posting reduces only when it carries a cost, the booking method isn't
-    /// `NONE` (issue #1182 — `NONE` accumulates every posting as an augmentation,
-    /// with no lot matching), and the inventory holds a cost-bearing position of
-    /// the opposite sign in the same currency ([`Self::is_reduced_by`] with
-    /// [`ReductionScope::CostBearingOnly`]). This gate was previously written
-    /// byte-for-byte in both crates and the #1182 fix had to be applied twice.
+    /// A posting reduces only when it carries a cost spec (`cost.is_some()` —
+    /// presence of the spec, which includes an empty/unresolved one like `{}`),
+    /// the booking method isn't `NONE` (issue #1182 — `NONE` accumulates every
+    /// posting as an augmentation, with no lot matching), and the inventory holds
+    /// a cost-bearing position of the opposite sign in the same currency
+    /// ([`Self::is_reduced_by`] with [`ReductionScope::CostBearingOnly`]). This
+    /// gate was previously written byte-for-byte in both crates and the #1182 fix
+    /// had to be applied twice.
     #[must_use]
     pub fn is_booking_reduction(
         &self,
@@ -682,6 +684,36 @@ impl Inventory {
 
         result
     }
+}
+
+/// Sum the units of `currency` across `account` AND all of its sub-accounts,
+/// over a map of per-account inventories.
+///
+/// Beancount's `balance Assets:Bank` assertion — and the pad math that targets
+/// it — includes `Assets:Bank:Checking`, `Assets:Bank:Savings`, etc. (verified
+/// against `bean-check`: an assertion on a parent passes when the balance is held
+/// in a sub-account). Sub-account membership uses [`is_subaccount_or_equal`], so
+/// the segment-boundary rule (`Assets:BankAlias` does NOT match `Assets:Bank`)
+/// is shared.
+///
+/// This is the single source for that sum, used by both the booking pad engine
+/// and the Late balance validator. They previously computed the pad/assertion
+/// difference differently — booking summed only the leaf account
+/// (`Inventory::units`) while the validator summed sub-accounts — so a pad
+/// targeting a non-leaf account inserted the wrong synthetic amount.
+pub fn sum_account_and_subaccounts<'a, I>(
+    inventories: I,
+    account: &str,
+    currency: &Currency,
+) -> Decimal
+where
+    I: IntoIterator<Item = (&'a Account, &'a Inventory)>,
+{
+    inventories
+        .into_iter()
+        .filter(|(inv_account, _)| is_subaccount_or_equal(inv_account.as_str(), account))
+        .map(|(_, inv)| inv.units(currency))
+        .sum()
 }
 
 impl fmt::Display for Inventory {

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -86,6 +86,7 @@ pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};
 pub use inventory::{
     AccountedBookingError, BookingError, BookingMethod, BookingResult, Inventory, ReductionScope,
+    sum_account_and_subaccounts,
 };
 pub use meta_json::{json_to_meta_value, meta_value_to_json, meta_value_type_tag};
 pub use position::Position;

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -2,14 +2,11 @@
 
 // ratchet: fxhash-only — hot path; use FxHashMap/FxHashSet, not std SipHash collections (#1237).
 use rust_decimal::{Decimal, MathematicalOps};
-use rustledger_core::{Amount, Balance, Pad, Position, is_subaccount_or_equal};
+use rustledger_core::{Amount, Balance, Pad, Position};
 
 use super::helpers::require_account_open;
 use crate::error::{ErrorCode, ValidationError};
 use crate::{LedgerState, PendingPad};
-
-use rustc_hash::FxHashMap;
-use rustledger_core::Inventory;
 
 /// Multiplier for balance assertion tolerance (matches Python beancount).
 /// Balance assertions use 2x the `tolerance_multiplier` option.
@@ -48,28 +45,6 @@ pub fn balance_tolerance(
     } else {
         Decimal::ZERO
     }
-}
-
-/// Sum the units of a given currency across an account and all its sub-accounts.
-///
-/// In beancount, `balance Assets:Bank` includes `Assets:Bank:Checking`,
-/// `Assets:Bank:Savings`, etc. Account membership is delegated to
-/// [`is_subaccount_or_equal`] so the segment-boundary rule
-/// (`Assets:BankAlias` does NOT match `Assets:Bank`) lives in one
-/// definition shared with the LSP code-lens path.
-fn sum_account_and_subaccounts(
-    inventories: &FxHashMap<rustledger_core::Account, Inventory>,
-    account: &rustledger_core::Account,
-    currency: &rustledger_core::Currency,
-) -> Decimal {
-    let account_str = account.as_str();
-    let mut total = Decimal::ZERO;
-    for (inv_account, inv) in inventories {
-        if is_subaccount_or_equal(inv_account.as_str(), account_str) {
-            total += inv.units(currency);
-        }
-    }
-    total
 }
 
 /// Base 10 for tolerance scale calculation.
@@ -201,8 +176,11 @@ pub fn validate_balance_late(
         if let Some(pending_pad) = effective_idx.last().and_then(|&i| pending_pads.get_mut(i)) {
             // Apply padding: calculate difference and add to both accounts
             // Balance assertions include sub-accounts, so sum them all up
-            let actual =
-                sum_account_and_subaccounts(&state.inventories, &bal.account, &bal.amount.currency);
+            let actual = rustledger_core::sum_account_and_subaccounts(
+                state.inventories.iter(),
+                bal.account.as_str(),
+                &bal.amount.currency,
+            );
             {
                 let expected = bal.amount.number;
                 let difference = expected - actual;
@@ -244,8 +222,11 @@ pub fn validate_balance_late(
     // Get inventory and check balance (no padding case).
     // In beancount, balance assertions include sub-accounts
     // e.g., balance Assets:Checking includes Assets:Checking:Sub1, etc.
-    let actual =
-        sum_account_and_subaccounts(&state.inventories, &bal.account, &bal.amount.currency);
+    let actual = rustledger_core::sum_account_and_subaccounts(
+        state.inventories.iter(),
+        bal.account.as_str(),
+        &bal.amount.currency,
+    );
 
     // Always check balance assertions, even for accounts with no transactions.
     // This matches Python beancount behavior where `balance Account 1 USD` fails

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -2,7 +2,7 @@
 
 use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;
-use rustledger_core::{Amount, BookingMethod, Inventory, Posting, ReductionScope, Transaction};
+use rustledger_core::{Amount, BookingMethod, Inventory, Posting, Transaction};
 use std::collections::HashMap;
 
 use super::helpers::push_account_not_open;
@@ -490,22 +490,13 @@ pub fn update_inventories(
             .map(|a| a.booking)
             .unwrap_or_default();
 
-        // Use the same reduction detection as the booking engine: a posting
-        // reduces inventory when the inventory has cost-bearing positions with
-        // the opposite sign for the same currency. Simple (no-cost) positions
-        // are ignored. This correctly handles sell-to-open (selling into empty
-        // inventory) as an augmentation, not a reduction.
-        //
-        // Under `option "booking_method" "NONE"` (issue #1182), every
-        // posting is an augmentation — NONE accumulates positions
-        // without lot matching. Mirrors the parallel guards in
-        // `rustledger-booking::book::book` and `BookingEngine::apply`.
-        // Without this gate, the validator's independent lot-matching
-        // pass would re-raise the ambiguous/no-matching-lot errors
-        // the booker just decided to skip.
-        let is_reduction = booking_method != BookingMethod::None
-            && posting.cost.is_some()
-            && inv.is_reduced_by(units, ReductionScope::CostBearingOnly);
+        // Reduction vs augmentation — the SAME decision the booking engine makes,
+        // now via the single `Inventory::is_booking_reduction` source: a cost-bearing
+        // opposite-sign position reduces, and under `option "booking_method" "NONE"`
+        // (issue #1182) every posting is an augmentation. Sharing it means this
+        // validator pass and `BookingEngine::apply` can't drift, and the #1182 gate
+        // lives in one place instead of being maintained in both crates.
+        let is_reduction = inv.is_booking_reduction(units, posting.cost.as_ref(), booking_method);
 
         if is_reduction {
             process_inventory_reduction(inv, posting, units, booking_method, txn, errors);


### PR DESCRIPTION
## What

Architecture-roadmap [L/BR6] — **inventory/lot-matching unify, parts 1 & 2.** Two duplications between the booking engine and the Late validator collapsed onto shared core sources.

### Part 1 — the reduction gate (`Inventory::is_booking_reduction`)

`BookingEngine::apply` and the validator's `update_inventories` made a **byte-identical** reduction decision in two crates:

```rust
method != BookingMethod::None && posting.cost.is_some()
    && inv.is_reduced_by(units, ReductionScope::CostBearingOnly)
```

This is the #1182 NONE-method gate — written twice, so the #1182 fix had to be applied twice and the two could drift. Now one core method (`Inventory::is_booking_reduction`) that both share. Only the identical 3-condition gate is unified; `book.rs` has two *other* `is_reduced_by` sites with deliberately different guards (one omits `cost.is_some()`), left untouched.

### Part 2 — the pad sub-account difference (a real bug)

A balance assertion sums an account **and its sub-accounts** (beancount semantic). The Late validator did this (`sum_account_and_subaccounts`); the booking **pad engine did not** — it measured `current` from the leaf account only (`inv.units()`). So a `pad` targeting a **non-leaf** account inserted the wrong synthetic amount, which then tripped the (sub-account-summing) validator.

**Oracle-verified** against `bean-check`/`bean-query`:
- `balance Assets:Bank 50 USD` with the 50 held in `Assets:Bank:Checking` → **passes** (sums sub-accounts); asserting `0 USD` fails with "accumulated 50 USD".
- `pad Assets:Bank` before `balance Assets:Bank 100 USD` (50 in the sub-account) → beancount pads **50**, and `Assets:Bank` totals **100**. Booking's leaf-only path padded 100 → the validator then saw 150 → spurious failure.

Fix: one `rustledger_core::sum_account_and_subaccounts` (built on the existing `is_subaccount_or_equal`), used by **both** the booking pad engine and the validator, so the pad amount and the validated amount are computed identically. New regression test (`test_process_pads_sums_subaccounts_for_nonleaf_target`) pins the oracle-confirmed value (50) — it fails on the old leaf-only code.

## Remaining

Part 3 of this audit item — have Late validation **consume** the booked inventory map instead of rebuilding it (the larger data-flow change) — follows as its own PR.

## Tests

New pad regression test + full `rustledger-core`/`-booking`/`-validate` suites pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
