### PR TITLE
perf(validate): sub-account prefix index for balance assertions (M/2)

### DIFF
--- a/crates/rustledger-validate/benches/validate_bench.rs
+++ b/crates/rustledger-validate/benches/validate_bench.rs
@@ -208,10 +208,74 @@ fn bench_validate_balance_assertions(c: &mut Criterion) {
     group.finish();
 }
 
+/// Scale the (accounts × balance-assertions) product that
+/// `bench_validate_balance_assertions` fixes at 2×1. A parent balance assertion
+/// sums the whole subtree, so this is the dimension a quadratic
+/// `sum_account_and_subaccounts` regression would surface in — and the one the
+/// prefix index removes. Each `accounts` value runs `assertions` parent
+/// assertions, each summing every sub-account.
+fn bench_validate_subaccount_balance_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("validate_subaccount_balance_scaling");
+
+    let assertions = 50u32;
+    for accounts in [32u32, 64, 128] {
+        let mut directives = Vec::new();
+        directives.push(Directive::Open(Open::new(date(2024, 1, 1), "Assets:Bank")));
+        directives.push(Directive::Open(Open::new(
+            date(2024, 1, 1),
+            "Income:Salary",
+        )));
+        for a in 0..accounts {
+            directives.push(Directive::Open(Open::new(
+                date(2024, 1, 1),
+                format!("Assets:Bank:Sub{a}"),
+            )));
+        }
+
+        // Fund each sub-account once.
+        let per = dec!(10.00);
+        for a in 0..accounts {
+            let txn = Transaction::new(date(2024, 1, 2), format!("fund {a}"))
+                .with_flag('*')
+                .with_synthesized_posting(Posting::new(
+                    format!("Assets:Bank:Sub{a}"),
+                    Amount::new(per, "USD"),
+                ))
+                .with_synthesized_posting(Posting::new("Income:Salary", Amount::new(-per, "USD")));
+            directives.push(Directive::Transaction(txn));
+        }
+
+        // Many assertions on the PARENT — each sums all `accounts` sub-accounts.
+        let total = per * rust_decimal::Decimal::from(accounts);
+        for i in 0..assertions {
+            let day = 3 + (i % 27);
+            directives.push(Directive::Balance(Balance::new(
+                date(2024, 1, day),
+                "Assets:Bank",
+                Amount::new(total, "USD"),
+            )));
+        }
+
+        group.throughput(Throughput::Elements(
+            u64::from(accounts) * u64::from(assertions),
+        ));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(accounts),
+            &directives,
+            |b, directives| {
+                b.iter(|| std::hint::black_box(validate(std::hint::black_box(directives))));
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_validate_valid,
     bench_validate_with_errors,
     bench_validate_balance_assertions,
+    bench_validate_subaccount_balance_scaling,
 );
 criterion_main!(benches);

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -304,10 +304,10 @@ pub struct LedgerState {
     inventories: FxHashMap<rustledger_core::Account, Inventory>,
     /// Lexically-sorted view of the `inventories` keys — the sub-account prefix
     /// index. Kept in lockstep with `inventories` (both gain a key only in
-    /// `register_open`/`register_open_late`; keys are never removed). Lets
-    /// [`Self::sum_account_and_subaccounts`] answer a balance assertion with a
-    /// range query over just the target's subtree, instead of an O(all-accounts)
-    /// scan per assertion (`Account`'s `Ord`/`Borrow<str>` are lexical).
+    /// `validate_open`/`register_open_late`; keys are never removed). Lets
+    /// [`sum_account_subtree`] answer a balance assertion with a range query over
+    /// just the target's subtree, instead of an O(all-accounts) scan per
+    /// assertion (`Account`'s `Ord`/`Borrow<str>` are lexical).
     inventory_accounts: BTreeSet<Account>,
     /// Declared commodities.
     commodities: FxHashSet<rustledger_core::Currency>,
@@ -478,9 +478,14 @@ fn sum_account_subtree(
         .map_or(Decimal::ZERO, |inv| inv.units(currency));
     // Its sub-accounts: the contiguous `["A:", "A;")` range. The explicit
     // `Bound` tuple gives `RangeBounds<str>` (a `&str..&str` range would be
-    // `RangeBounds<&str>`, which `range::<str>` doesn't accept).
-    let lower = format!("{acct}:");
-    let upper = format!("{acct};");
+    // `RangeBounds<&str>`, which `range::<str>` doesn't accept). Build the two
+    // bound strings without `format!` — this runs per balance assertion.
+    let mut lower = String::with_capacity(acct.len() + 1);
+    lower.push_str(acct);
+    lower.push(':');
+    let mut upper = String::with_capacity(acct.len() + 1);
+    upper.push_str(acct);
+    upper.push(';');
     let bounds = (
         std::ops::Bound::Included(lower.as_str()),
         std::ops::Bound::Excluded(upper.as_str()),
@@ -1145,7 +1150,7 @@ mod tests {
 
     #[test]
     fn sum_account_subtree_matches_scan_and_excludes_prefix_siblings() {
-        // Build inventories + the prefix index exactly as `register_open` does.
+        // Build inventories + the prefix index exactly as `validate_open` does.
         let mut state = LedgerState::default();
         let fixture = [
             ("Assets:Bank", dec!(10)),

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -106,8 +106,9 @@ const PARALLEL_SORT_THRESHOLD: usize = 5000;
 const PARALLEL_DOC_EXISTS_THRESHOLD: usize = 64;
 use rust_decimal::Decimal;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustledger_core::{BookingMethod, Commodity, Directive, Inventory};
+use rustledger_core::{Account, BookingMethod, Commodity, Currency, Directive, Inventory};
 use rustledger_parser::{SYNTHESIZED_FILE_ID, Spanned};
+use std::collections::BTreeSet;
 
 /// Account state for tracking lifecycle.
 #[derive(Debug, Clone)]
@@ -301,6 +302,13 @@ pub struct LedgerState {
     accounts: FxHashMap<rustledger_core::Account, AccountState>,
     /// Account inventories.
     inventories: FxHashMap<rustledger_core::Account, Inventory>,
+    /// Lexically-sorted view of the `inventories` keys — the sub-account prefix
+    /// index. Kept in lockstep with `inventories` (both gain a key only in
+    /// `register_open`/`register_open_late`; keys are never removed). Lets
+    /// [`Self::sum_account_and_subaccounts`] answer a balance assertion with a
+    /// range query over just the target's subtree, instead of an O(all-accounts)
+    /// scan per assertion (`Account`'s `Ord`/`Borrow<str>` are lexical).
+    inventory_accounts: BTreeSet<Account>,
     /// Declared commodities.
     commodities: FxHashSet<rustledger_core::Currency>,
     /// Pending pad directives (account -> list of pads).
@@ -442,6 +450,47 @@ impl ValidatableDirective for Spanned<Directive> {
     fn span_info(&self) -> Option<(rustledger_parser::Span, u16)> {
         Some((self.span, self.file_id))
     }
+}
+
+/// Sum the units of `currency` across `account` and all of its sub-accounts —
+/// the value a `balance` assertion checks (beancount includes sub-accounts).
+///
+/// Uses the `inventory_accounts` prefix index instead of scanning every account:
+/// the subtree of `Assets:Bank` is `Assets:Bank` itself plus the keys in the
+/// half-open range `["Assets:Bank:", "Assets:Bank;")` (`;` is the byte after
+/// `:`), which captures every `Assets:Bank:*` and nothing else — equivalent to
+/// [`rustledger_core::is_subaccount_or_equal`], answered by a `BTreeSet` range
+/// query in O(log A + subtree) rather than O(A) per assertion. Equivalence to
+/// the unindexed [`rustledger_core::sum_account_and_subaccounts`] is pinned by a
+/// parity test. Takes the two fields directly (not `&self`) so callers can hold
+/// a disjoint `&mut` borrow of another `LedgerState` field (e.g. `pending_pads`)
+/// at the same time.
+fn sum_account_subtree(
+    inventories: &FxHashMap<Account, Inventory>,
+    index: &BTreeSet<Account>,
+    account: &Account,
+    currency: &Currency,
+) -> Decimal {
+    let acct = account.as_str();
+    // The account itself (the `== A` arm of `is_subaccount_or_equal`).
+    let mut total = inventories
+        .get(account)
+        .map_or(Decimal::ZERO, |inv| inv.units(currency));
+    // Its sub-accounts: the contiguous `["A:", "A;")` range. The explicit
+    // `Bound` tuple gives `RangeBounds<str>` (a `&str..&str` range would be
+    // `RangeBounds<&str>`, which `range::<str>` doesn't accept).
+    let lower = format!("{acct}:");
+    let upper = format!("{acct};");
+    let bounds = (
+        std::ops::Bound::Included(lower.as_str()),
+        std::ops::Bound::Excluded(upper.as_str()),
+    );
+    for sub in index.range::<str, _>(bounds) {
+        if let Some(inv) = inventories.get(sub) {
+            total += inv.units(currency);
+        }
+    }
+    total
 }
 
 /// Internal: run ONE validation phase over a sorted view of `directives`,
@@ -1092,6 +1141,56 @@ mod tests {
         errors.extend(late_errors);
         errors.extend(session.finalize());
         errors
+    }
+
+    #[test]
+    fn sum_account_subtree_matches_scan_and_excludes_prefix_siblings() {
+        // Build inventories + the prefix index exactly as `register_open` does.
+        let mut state = LedgerState::default();
+        let fixture = [
+            ("Assets:Bank", dec!(10)),
+            ("Assets:Bank:Checking", dec!(40)),
+            ("Assets:Bank:Savings", dec!(5)),
+            ("Assets:BankAlias", dec!(99)), // prefix sibling — must be excluded
+            ("Assets:Other", dec!(7)),
+        ];
+        for (name, amt) in fixture {
+            let acct = Account::from(name);
+            let mut inv = Inventory::new();
+            inv.add(rustledger_core::Position::simple(Amount::new(amt, "USD")));
+            state.inventories.insert(acct.clone(), inv);
+            state.inventory_accounts.insert(acct);
+        }
+
+        let cur = Currency::from("USD");
+        // The indexed sum must equal the unindexed core scan for every target.
+        for name in [
+            "Assets:Bank",
+            "Assets:Bank:Checking",
+            "Assets:BankAlias",
+            "Assets:Other",
+            "Assets:Missing",
+        ] {
+            let acct = Account::from(name);
+            let indexed =
+                sum_account_subtree(&state.inventories, &state.inventory_accounts, &acct, &cur);
+            let scan =
+                rustledger_core::sum_account_and_subaccounts(state.inventories.iter(), name, &cur);
+            assert_eq!(indexed, scan, "indexed vs scan disagree for {name}");
+        }
+
+        // Parent sums itself + sub-accounts (10 + 40 + 5 = 55), NOT BankAlias.
+        let bank = sum_account_subtree(
+            &state.inventories,
+            &state.inventory_accounts,
+            &Account::from("Assets:Bank"),
+            &cur,
+        );
+        assert_eq!(
+            bank,
+            dec!(55),
+            "Assets:Bank must sum its subtree, excluding the Assets:BankAlias prefix sibling"
+        );
     }
 
     #[test]

--- a/crates/rustledger-validate/src/validators/account.rs
+++ b/crates/rustledger-validate/src/validators/account.rs
@@ -60,6 +60,8 @@ pub fn validate_open(state: &mut LedgerState, open: &Open, errors: &mut Vec<Vali
     state
         .inventories
         .insert(open.account.clone(), Inventory::new());
+    // Keep the sub-account prefix index in lockstep with `inventories`.
+    state.inventory_accounts.insert(open.account.clone());
 }
 
 /// Late-phase: reflect an `Open` in account/inventory state without re-running
@@ -89,6 +91,8 @@ pub fn register_open_late(state: &mut LedgerState, open: &Open) {
     state
         .inventories
         .insert(open.account.clone(), Inventory::new());
+    // Keep the sub-account prefix index in lockstep with `inventories`.
+    state.inventory_accounts.insert(open.account.clone());
 }
 
 /// Early-phase Close validation — runs on pre-booking directives.

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -175,10 +175,13 @@ pub fn validate_balance_late(
         // Use the most recent effective pad
         if let Some(pending_pad) = effective_idx.last().and_then(|&i| pending_pads.get_mut(i)) {
             // Apply padding: calculate difference and add to both accounts
-            // Balance assertions include sub-accounts, so sum them all up
-            let actual = rustledger_core::sum_account_and_subaccounts(
-                state.inventories.iter(),
-                bal.account.as_str(),
+            // Balance assertions include sub-accounts; the prefix index answers
+            // this without scanning every account (disjoint borrow from the
+            // `pending_pad` mutable borrow held here).
+            let actual = crate::sum_account_subtree(
+                &state.inventories,
+                &state.inventory_accounts,
+                &bal.account,
                 &bal.amount.currency,
             );
             {
@@ -222,9 +225,10 @@ pub fn validate_balance_late(
     // Get inventory and check balance (no padding case).
     // In beancount, balance assertions include sub-accounts
     // e.g., balance Assets:Checking includes Assets:Checking:Sub1, etc.
-    let actual = rustledger_core::sum_account_and_subaccounts(
-        state.inventories.iter(),
-        bal.account.as_str(),
+    let actual = crate::sum_account_subtree(
+        &state.inventories,
+        &state.inventory_accounts,
+        &bal.account,
         &bal.amount.currency,
     );
 


### PR DESCRIPTION
## What

Architecture-roadmap [M/2] — **precompute a sub-account prefix index for balance assertions, eliminating the O(assertions × accounts) scan.**

`sum_account_and_subaccounts` scanned **every** entry of the inventories map per balance assertion (`is_subaccount_or_equal` against each) — O(A·B) for A accounts and B assertions, on a file annotated as a hot path. A ledger with many accounts and many parent assertions paid a quadratic cost.

## Change

`LedgerState` gains `inventory_accounts: BTreeSet<Account>` — a lexically-sorted view of the inventory keys, kept in lockstep with `inventories` (both gain a key only in `register_open`/`register_open_late`; keys are never removed). `Account`'s `Ord` and `Borrow<str>` are lexical (via `Arc<str>`), so the subtree of `Assets:Bank` is exactly:

- `Assets:Bank` itself, **plus**
- the half-open range `["Assets:Bank:", "Assets:Bank;")` (`;` is the byte after `:`)

which captures every `Assets:Bank:*` and **nothing** else (e.g. excludes the `Assets:BankAlias` prefix sibling) — provably equivalent to `is_subaccount_or_equal`, answered by a `BTreeSet` range query in **O(log A + subtree)** instead of O(A) per assertion.

Implemented as a free fn `sum_account_subtree(inventories, index, account, currency)` taking the two fields directly (not `&self`) so call site 1 can keep its disjoint `&mut pending_pads` borrow. Both validator call sites use it. The unindexed `rustledger_core::sum_account_and_subaccounts` stays for the booking pad engine (its own map, far fewer calls).

## Correctness

- New parity test: the indexed `sum_account_subtree` equals the unindexed core scan for parent / leaf / prefix-sibling / missing targets, and `Assets:Bank` sums its subtree (10+40+5=55) while excluding `Assets:BankAlias` (99).
- The full `rustledger-validate` suite is unchanged — the index is behavior-equivalent, only faster.

## Benchmark

New `validate_subaccount_balance_scaling` scales the **accounts × assertions** product (32/64/128 accounts × 50 parent assertions) that the existing balance benchmark fixed at 2×1 — the dimension a quadratic regression would surface in, now covered so a future crossover is caught.

## Tests

Parity test + full validate suite pass; new benchmark compiles; clippy `--all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
