### PR TITLE
test(cache): generalize rkyv layout tripwire to MetaValue (M/3)

### DIFF
--- a/crates/rustledger-core/src/directive.rs
+++ b/crates/rustledger-core/src/directive.rs
@@ -1498,6 +1498,65 @@ mod tests {
         crate::naive_date(year, month, day).unwrap()
     }
 
+    /// Layout/distinctness snapshot for [`MetaValue`] — the rkyv companion to
+    /// `CostNumber`'s `cost_number_archived_bytes_snapshot`.
+    ///
+    /// The cache archives the whole `Directive` graph, including metadata, but the
+    /// only frozen-byte tripwire pinned `CostNumber`. A `MetaValue` variant
+    /// reorder or discriminant collision changes the on-disk bytes while
+    /// `CostNumber` stays identical, so a stale cache would deserialize old bytes
+    /// into the new layout. This pins that every variant archives non-empty and
+    /// PAIRWISE-DISTINCT — including same-payload pairs like `Number(42)`/`Int(42)`
+    /// and `String("USD")`/`Currency("USD")` whose only difference is the
+    /// discriminant. A collision or reorder trips here; the exact frozen bytes
+    /// that also catch a *uniform* encoding shift live in `rustledger-loader::cache`.
+    #[cfg(feature = "rkyv")]
+    #[test]
+    fn meta_value_archived_bytes_snapshot() {
+        let archive = |mv: &MetaValue| rkyv::to_bytes::<rkyv::rancor::Error>(mv).unwrap().to_vec();
+
+        // Same-payload pairs are deliberate so pairwise distinctness exercises the
+        // discriminant, not the payload.
+        let cases: &[(&str, MetaValue)] = &[
+            ("String", MetaValue::String("USD".to_string())),
+            (
+                "Account",
+                MetaValue::Account(crate::Account::from("Assets:Bank")),
+            ),
+            (
+                "Currency",
+                MetaValue::Currency(crate::Currency::from("USD")),
+            ),
+            ("Tag", MetaValue::Tag(crate::Tag::from("t"))),
+            ("Link", MetaValue::Link(crate::Link::from("t"))),
+            ("Date", MetaValue::Date(date(2024, 1, 15))),
+            ("Number", MetaValue::Number(dec!(42))),
+            ("Bool", MetaValue::Bool(true)),
+            ("Amount", MetaValue::Amount(Amount::new(dec!(10), "USD"))),
+            ("None", MetaValue::None),
+            ("Int", MetaValue::Int(42)),
+        ];
+
+        let archived: Vec<(&str, Vec<u8>)> =
+            cases.iter().map(|(n, mv)| (*n, archive(mv))).collect();
+
+        for (name, bytes) in &archived {
+            assert!(
+                !bytes.is_empty(),
+                "MetaValue::{name} archived to empty bytes"
+            );
+        }
+        for (i, (na, a)) in archived.iter().enumerate() {
+            for (nb, b) in archived.iter().skip(i + 1) {
+                assert_ne!(
+                    a, b,
+                    "MetaValue::{na} and MetaValue::{nb} archive identically — a \
+                     discriminant collision (variant reorder?) the cache can't tell apart"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_transaction() {
         let txn = Transaction::new(date(2024, 1, 15), "Grocery shopping")

--- a/crates/rustledger-loader/src/cache.rs
+++ b/crates/rustledger-loader/src/cache.rs
@@ -1092,6 +1092,74 @@ mod tests {
         );
     }
 
+    /// Layout-hash tripwire for [`rustledger_core::MetaValue`] — generalizes the
+    /// `CostNumber` frozen-byte fixtures above to the metadata value type the
+    /// cache also archives.
+    ///
+    /// The `CostNumber` fixtures only catch drift in cost numbers. A `MetaValue`
+    /// variant reorder, or an rkyv encoding shift in how `InternedStr` / `String`
+    /// / `Decimal` / `Amount` pack, changes the on-disk metadata bytes while
+    /// `CostNumber` stays byte-identical — and `MetaValue::Int` (v11) was
+    /// previously guarded only by a code comment, not a test. This hashes the
+    /// archived bytes of one of every `MetaValue` variant (declaration order,
+    /// length-prefixed) and pins the digest. Any archived-layout drift trips this,
+    /// forcing the developer to bump `CACHE_VERSION` (so stale on-disk caches
+    /// short-circuit at the header check) and regenerate the hash.
+    ///
+    /// Little-endian only, like the `CostNumber` fixtures — `rkyv::to_bytes` uses
+    /// native endianness, and `CACHE_VERSION` guards same-machine reads.
+    #[cfg(target_endian = "little")]
+    #[test]
+    fn meta_value_archived_layout_hash_matches() {
+        use rustledger_core::{Account, Currency, Link, MetaValue, Tag};
+
+        // Tripwire: regenerating the hash without bumping CACHE_VERSION leaves
+        // users with rotten metadata caches.
+        const FIXTURE_VERSION: u32 = 12;
+        const META_VALUE_LAYOUT_HASH: &str =
+            "43e3c258fe376cede6a6c2c975100bcf67ddda0ab84b21566b123c01e0a54b25";
+        assert_eq!(
+            CACHE_VERSION, FIXTURE_VERSION,
+            "CACHE_VERSION advanced past the MetaValue layout-hash fixture; if the \
+             MetaValue archived layout changed, bump CACHE_VERSION and regenerate \
+             META_VALUE_LAYOUT_HASH below in the same commit, else just bump \
+             FIXTURE_VERSION.",
+        );
+
+        // One value of every variant in declaration order. Each is archived alone
+        // (no metadata map), so the bytes are deterministic.
+        let variants: &[MetaValue] = &[
+            MetaValue::String("USD".to_string()),
+            MetaValue::Account(Account::from("Assets:Bank")),
+            MetaValue::Currency(Currency::from("USD")),
+            MetaValue::Tag(Tag::from("t")),
+            MetaValue::Link(Link::from("t")),
+            MetaValue::Date(rustledger_core::naive_date(2024, 1, 15).unwrap()),
+            MetaValue::Number(dec!(42)),
+            MetaValue::Bool(true),
+            MetaValue::Amount(Amount::new(dec!(10), "USD")),
+            MetaValue::None,
+            MetaValue::Int(42),
+        ];
+
+        let mut hasher = Hasher::new();
+        for mv in variants {
+            let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(mv).unwrap();
+            // Length-prefix so a byte moving across a variant boundary can't be
+            // masked by a compensating change in the neighbour.
+            hasher.update(&(bytes.len() as u64).to_le_bytes());
+            hasher.update(&bytes);
+        }
+        let digest = hasher.finalize().to_hex();
+
+        assert_eq!(
+            digest.as_str(),
+            META_VALUE_LAYOUT_HASH,
+            "MetaValue archived layout changed. If intentional, bump CACHE_VERSION \
+             and set META_VALUE_LAYOUT_HASH to: {digest}",
+        );
+    }
+
     #[test]
     fn test_reintern_directives_deduplication() {
         let date = rustledger_core::naive_date(2024, 1, 15).unwrap();


### PR DESCRIPTION
## What

Architecture-roadmap [M/3] — **generalize the rkyv on-disk layout tripwire from `CostNumber` to `MetaValue`.**

`CacheEntry` archives the whole `Directive` graph (Directive, MetaValue, Amount, Spanned, Options), but the only frozen-byte tripwire pinned `CostNumber`. A non-`CostNumber` layout change — a `MetaValue` variant reorder, or an rkyv encoding shift in how `InternedStr`/`String`/`Decimal`/`Amount` pack — changes the archived bytes while `CostNumber` stays byte-identical, passing the tripwire. If `CACHE_VERSION` isn't manually bumped, stale on-disk caches deserialize old bytes into the new layout. The `MetaValue::Int` (v11) addition was enforced only by a **code comment**, not a test.

## Change — two complementary guards, mirroring the `CostNumber` pair

**Core (`rustledger-core::directive`) — `meta_value_archived_bytes_snapshot`:** archives one of every `MetaValue` variant and asserts they're non-empty and **pairwise-distinct**, including same-payload pairs (`Number(42)`/`Int(42)`, `String("USD")`/`Currency("USD")`) whose only difference is the discriminant. Catches a variant reorder or discriminant collision — the rkyv companion to the existing `cost_number_archived_bytes_snapshot`.

**Loader (`rustledger-loader::cache`) — `meta_value_archived_layout_hash_matches`:** BLAKE3-hashes the archived bytes of every variant (declaration order, length-prefixed) and pins the digest next to a `FIXTURE_VERSION == CACHE_VERSION` assertion. This catches the **uniform encoding shift** the distinctness snapshot can't (every variant moving together). Any archived-layout drift trips it, forcing a `CACHE_VERSION` bump + hash regeneration in the same commit — exactly the enforcement `MetaValue::Int` lacked.

A compact layout *hash* (not frozen byte arrays) is used because each variant is archived alone — no metadata `FxHashMap` in the fixture, so the bytes are deterministic — and one digest is far less brittle than 11 byte literals. Little-endian-gated like the `CostNumber` fixtures (`rkyv::to_bytes` is native-endian; `CACHE_VERSION` guards same-machine reads).

## Tests

Both tripwires pass; full `rustledger-core` (`--features rkyv`) and `rustledger-loader` (`--features cache`) suites unchanged; clippy `--all-features --all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
