### PR TITLE
fix(loader): close fail-open hole in plugin path-security (BR4)

### DIFF
--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -869,6 +869,49 @@ struct PluginInvocation {
     force_python: bool,
 }
 
+/// Lexically resolve `.` / `..` in `p` WITHOUT touching the filesystem,
+/// preserving the root/prefix. Unlike `Path::canonicalize` this works on paths
+/// that don't exist yet, so a `..` traversal is still collapsed (e.g.
+/// `/ledger/../../etc` → `/etc`). A `..` at the root is clamped (it can't escape
+/// above the root).
+#[cfg(feature = "plugins")]
+fn lexically_normalize(p: &Path) -> std::path::PathBuf {
+    let mut out = std::path::PathBuf::new();
+    for component in p.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Whether a `resolved` plugin path stays within `base_dir` under path-security.
+///
+/// When the plugin file exists, both sides are `canonicalize`d so symlinks are
+/// resolved (symlink-safe). When it does NOT (a not-yet-created path, a typo, a
+/// permission error), both sides fall back to [`lexically_normalize`] in the
+/// SAME namespace, so a `..` escape is still caught. This closes the fail-OPEN
+/// hole in the previous `let (Ok, Ok) = (canonicalize, canonicalize)` guard,
+/// which skipped the check entirely whenever either `canonicalize` returned
+/// `Err` — and which, even on success, string-prefix-matched an unresolved
+/// absolute `/base/../../etc` past `/base` because `..` was never collapsed.
+#[cfg(feature = "plugins")]
+fn plugin_path_within_base(resolved: &Path, base_dir: &Path) -> bool {
+    match resolved.canonicalize() {
+        Ok(canon_plugin) => match base_dir.canonicalize() {
+            Ok(canon_base) => canon_plugin.starts_with(&canon_base),
+            // Plugin canonicalized but base didn't — cannot compare in one
+            // namespace, so fail closed.
+            Err(_) => false,
+        },
+        Err(_) => lexically_normalize(resolved).starts_with(lexically_normalize(base_dir)),
+    }
+}
+
 /// `pass` selects which subset of plugins to run — see [`PluginPass`].
 /// The loader pipeline calls this twice (synth pass before Early,
 /// regular pass after booking).
@@ -1055,12 +1098,12 @@ pub fn run_plugins(
                     base_dir.join(name)
                 };
 
-                // Path security: prevent plugins from outside the ledger directory
-                if options.path_security
-                    && let (Ok(canon_base), Ok(canon_plugin)) =
-                        (base_dir.canonicalize(), resolved.canonicalize())
-                    && !canon_plugin.starts_with(&canon_base)
-                {
+                // Path security: prevent plugins from outside the ledger
+                // directory. `plugin_path_within_base` canonicalizes when the
+                // file exists (symlink-safe) and otherwise normalizes `..`
+                // lexically — so it fails CLOSED instead of skipping the check
+                // when canonicalize errors (the old fail-open hole).
+                if options.path_security && !plugin_path_within_base(&resolved, base_dir) {
                     return Err(format!(
                         "plugin path '{name}' is outside the ledger directory"
                     ));
@@ -1853,6 +1896,50 @@ mod sanitize_tests {
         });
         sanitize_inner_posting_spans(&mut d, &sm); // no panic, no change
         assert!(matches!(d, Directive::Open(_)));
+    }
+}
+
+#[cfg(all(test, feature = "plugins"))]
+mod plugin_path_security_tests {
+    use super::{lexically_normalize, plugin_path_within_base};
+    use std::path::Path;
+
+    #[test]
+    fn lexically_normalize_resolves_dotdot_for_nonexistent_paths() {
+        // The whole point: it works without the path existing on disk.
+        assert_eq!(
+            lexically_normalize(Path::new("/ledger/../../etc/passwd")),
+            Path::new("/etc/passwd"),
+        );
+        // `..` at the root is clamped — can't escape above root.
+        assert_eq!(lexically_normalize(Path::new("/../../x")), Path::new("/x"));
+        // `.` segments dropped, structure preserved.
+        assert_eq!(
+            lexically_normalize(Path::new("/ledger/./plugins/p.py")),
+            Path::new("/ledger/plugins/p.py"),
+        );
+    }
+
+    #[test]
+    fn plugin_path_within_base_rejects_traversal_even_when_path_absent() {
+        let base = Path::new("/ledger");
+        // A `..` escape on a path that does NOT exist (canonicalize fails, so the
+        // old `(Ok, Ok)` guard skipped the check entirely) must still be rejected.
+        assert!(!plugin_path_within_base(
+            Path::new("/ledger/../../etc/passwd"),
+            base
+        ));
+        // An in-bounds (also non-existent) path is allowed.
+        assert!(plugin_path_within_base(
+            Path::new("/ledger/plugins/p.py"),
+            base
+        ));
+        // A sibling that merely shares a string prefix is NOT within (component
+        // comparison, not string prefix).
+        assert!(!plugin_path_within_base(
+            Path::new("/ledger-evil/p.py"),
+            base
+        ));
     }
 }
 

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -892,13 +892,15 @@ fn lexically_normalize(p: &Path) -> std::path::PathBuf {
 /// Whether a `resolved` plugin path stays within `base_dir` under path-security.
 ///
 /// When the plugin file exists, both sides are `canonicalize`d so symlinks are
-/// resolved (symlink-safe). When it does NOT (a not-yet-created path, a typo, a
-/// permission error), both sides fall back to [`lexically_normalize`] in the
-/// SAME namespace, so a `..` escape is still caught. This closes the fail-OPEN
-/// hole in the previous `let (Ok, Ok) = (canonicalize, canonicalize)` guard,
-/// which skipped the check entirely whenever either `canonicalize` returned
-/// `Err` — and which, even on success, string-prefix-matched an unresolved
-/// absolute `/base/../../etc` past `/base` because `..` was never collapsed.
+/// resolved (symlink-safe). When it does NOT *yet* exist (`NotFound`), both sides
+/// fall back to [`lexically_normalize`] in the SAME namespace, so a `..` escape
+/// is still caught. Any OTHER canonicalize error (permission denied, I/O) is
+/// genuinely unverifiable and is REJECTED — fail closed. This closes the
+/// fail-OPEN hole in the previous `let (Ok, Ok) = (canonicalize, canonicalize)`
+/// guard, which skipped the check entirely whenever either `canonicalize`
+/// returned `Err` — and which, even on success, string-prefix-matched an
+/// unresolved absolute `/base/../../etc` past `/base` because `..` was never
+/// collapsed.
 #[cfg(feature = "plugins")]
 fn plugin_path_within_base(resolved: &Path, base_dir: &Path) -> bool {
     match resolved.canonicalize() {
@@ -908,7 +910,12 @@ fn plugin_path_within_base(resolved: &Path, base_dir: &Path) -> bool {
             // namespace, so fail closed.
             Err(_) => false,
         },
-        Err(_) => lexically_normalize(resolved).starts_with(lexically_normalize(base_dir)),
+        // Only a not-yet-existing path falls back to the lexical `..` check; a
+        // permission/I/O error is unverifiable, so reject rather than guess.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            lexically_normalize(resolved).starts_with(lexically_normalize(base_dir))
+        }
+        Err(_) => false,
     }
 }
 


### PR DESCRIPTION
## What

Architecture-roadmap [M/4] (plugin-dispatch) — **fix the fail-open hole in the plugin path-security check** and single-source the traversal logic into one helper.

The `run_plugins` god-function had a third inline copy of plugin path-security (`process.rs:1062`) that was **bypassed on a `canonicalize` error**:

```rust
if options.path_security
    && let (Ok(canon_base), Ok(canon_plugin)) =
        (base_dir.canonicalize(), resolved.canonicalize())   // <- Err short-circuits
    && !canon_plugin.starts_with(&canon_base)
{ return Err(...); }
```

A plugin path that **can't be canonicalized** (doesn't exist yet, a typo, a permission error) makes the `let (Ok, Ok)` pattern fail, so the whole check is **skipped** and the path is allowed — a fail-OPEN path-traversal hole. Unlike the `include` traversal guard (which normalizes via the injected filesystem and never skips), this copy fails open.

## Fix

Extract two helpers:
- **`lexically_normalize`** — resolves `.`/`..` *without* touching the filesystem (preserving the root, clamping `..` at root), so a traversal is collapsed even for a non-existent path (`/ledger/../../etc` → `/etc`).
- **`plugin_path_within_base`** — `canonicalize`s both sides when the plugin file exists (symlink-safe), and otherwise falls back to `lexically_normalize` in the **same namespace**. It **fails CLOSED**: an unverifiable path is rejected, not allowed.

The inline check becomes `if options.path_security && !plugin_path_within_base(&resolved, base_dir)`.

## Scope note

The audit also flagged a "triplicated, non-equivalent file-vs-module classifier" — two of those three are **already unified** onto `rustledger_plugin::python::is_python_plugin_file_ref` by prior work (#1548/#1549 + follow-ups), so this PR targets the remaining concrete defect: the path-security copy. The larger `run_plugins` god-function extraction (moving native/wasm/python dispatch into `rustledger-plugin` behind one entry point) remains as a separate, bigger refactor.

## Tests

New `plugin_path_security_tests`: `..`-resolution for non-existent paths, traversal rejected even when `canonicalize` fails (the bug), in-bounds allowed, and a string-prefix sibling (`/ledger-evil`) correctly rejected. Full `rustledger-loader --features plugins` suite unchanged; clippy `--all-features --all-targets -D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
