### PR TITLE
refactor(dedup): single-source fuzzy dedup on core types + fix threshold drift (BR4)

### DIFF
--- a/crates/rustledger-ops/src/dedup.rs
+++ b/crates/rustledger-ops/src/dedup.rs
@@ -15,7 +15,8 @@
 use std::collections::HashSet;
 
 use rust_decimal::Decimal;
-use rustledger_plugin_types::{DirectiveData, DirectiveWrapper, PluginError, TransactionData};
+use rustledger_core::{Directive, Transaction};
+use rustledger_plugin_types::{DirectiveData, DirectiveWrapper, PluginError};
 
 use crate::fingerprint::structural_hash;
 
@@ -103,68 +104,77 @@ pub struct FuzzyDuplicateMatch {
 /// probable duplicates of existing ones.
 #[must_use]
 pub fn find_fuzzy_duplicates(
-    new_directives: &[DirectiveWrapper],
-    existing_directives: &[DirectiveWrapper],
+    new_directives: &[Directive],
+    existing_directives: &[Directive],
     config: &FuzzyDedupConfig,
 ) -> Vec<FuzzyDuplicateMatch> {
-    let mut matches = Vec::new();
-
-    // Pre-compute existing transaction info for efficient comparison
-    let existing: Vec<(usize, &str, Option<Decimal>, String)> = existing_directives
+    // Pre-collect existing transactions (with their directive index) once.
+    let existing: Vec<(usize, &Transaction)> = existing_directives
         .iter()
         .enumerate()
-        .filter_map(|(i, w)| {
-            if let DirectiveData::Transaction(txn) = &w.data {
-                Some((i, w.date.as_str(), first_posting_amount(txn), txn_text(txn)))
-            } else {
-                None
-            }
+        .filter_map(|(i, d)| match d {
+            Directive::Transaction(txn) => Some((i, txn)),
+            _ => None,
         })
         .collect();
 
-    for (new_i, wrapper) in new_directives.iter().enumerate() {
-        if let DirectiveData::Transaction(txn) = &wrapper.data {
-            let new_amount = first_posting_amount(txn);
-            let new_text = txn_text(txn);
-
-            for &(existing_i, existing_date, ref existing_amount, ref existing_text) in &existing {
-                if wrapper.date != existing_date {
-                    continue;
-                }
-                if new_amount != *existing_amount {
-                    continue;
-                }
-                if fuzzy_text_match(&new_text, existing_text, config.text_similarity_threshold) {
-                    matches.push(FuzzyDuplicateMatch {
-                        new_index: new_i,
-                        existing_index: existing_i,
-                    });
-                    break; // One match is enough
-                }
-            }
+    let mut matches = Vec::new();
+    for (new_i, directive) in new_directives.iter().enumerate() {
+        if let Directive::Transaction(new_txn) = directive
+            && let Some(&(existing_i, _)) = existing.iter().find(|(_, existing_txn)| {
+                is_fuzzy_duplicate(new_txn, existing_txn, config.text_similarity_threshold)
+            })
+        {
+            matches.push(FuzzyDuplicateMatch {
+                new_index: new_i,
+                existing_index: existing_i,
+            });
         }
     }
-
     matches
 }
 
+/// Whether `new_txn` is a fuzzy duplicate of any transaction in `existing`.
+///
+/// Per-transaction convenience over the same matcher as [`find_fuzzy_duplicates`]
+/// — the single source for `rledger extract --existing` duplicate filtering,
+/// which previously had its own copy with a divergent `> 0.5` threshold (this
+/// uses `config.text_similarity_threshold`, default `>= 0.5`).
+#[must_use]
+pub fn is_duplicate(
+    new_txn: &Transaction,
+    existing: &[Transaction],
+    config: &FuzzyDedupConfig,
+) -> bool {
+    existing.iter().any(|existing_txn| {
+        is_fuzzy_duplicate(new_txn, existing_txn, config.text_similarity_threshold)
+    })
+}
+
+/// Same date, same first-posting amount, and a fuzzy payee/narration match.
+fn is_fuzzy_duplicate(new_txn: &Transaction, existing_txn: &Transaction, threshold: f64) -> bool {
+    new_txn.date == existing_txn.date
+        && first_posting_amount(new_txn) == first_posting_amount(existing_txn)
+        && fuzzy_text_match(&txn_text(new_txn), &txn_text(existing_txn), threshold)
+}
+
 /// Get the decimal amount from the first posting of a transaction.
-fn first_posting_amount(txn: &TransactionData) -> Option<Decimal> {
+fn first_posting_amount(txn: &Transaction) -> Option<Decimal> {
     txn.postings.first().and_then(|p| {
         p.units
             .as_ref()
-            .and_then(|u| u.number.parse::<Decimal>().ok())
+            .and_then(rustledger_core::IncompleteAmount::number)
     })
 }
 
 /// Build a lowercase string combining payee and narration for fuzzy matching.
-fn txn_text(txn: &TransactionData) -> String {
+fn txn_text(txn: &Transaction) -> String {
     let mut text = String::new();
     if let Some(ref payee) = txn.payee {
-        text.push_str(payee);
+        text.push_str(payee.as_str());
         text.push(' ');
     }
-    text.push_str(&txn.narration);
+    text.push_str(txn.narration.as_str());
     text.to_lowercase()
 }
 
@@ -201,7 +211,25 @@ mod tests {
     use super::*;
     use rustledger_plugin_types::{AmountData, DirectiveData, PostingData, TransactionData};
 
-    fn make_directive(
+    /// Core-typed transaction directive for the fuzzy-dedup tests (which now run
+    /// on `core::Directive`).
+    fn make_directive(date: &str, payee: Option<&str>, narration: &str, amount: &str) -> Directive {
+        use std::str::FromStr;
+        let date: rustledger_core::NaiveDate = date.parse().unwrap();
+        let mut txn = Transaction::new(date, narration);
+        if let Some(p) = payee {
+            txn = txn.with_payee(p);
+        }
+        txn = txn.with_synthesized_posting(rustledger_core::Posting::new(
+            "Assets:Bank",
+            rustledger_core::Amount::new(Decimal::from_str(amount).unwrap(), "USD"),
+        ));
+        Directive::Transaction(txn)
+    }
+
+    /// Wire-typed directive for the structural-dedup tests (which stay on
+    /// `DirectiveWrapper`, the plugin boundary).
+    fn make_wrapper(
         date: &str,
         payee: Option<&str>,
         narration: &str,
@@ -240,8 +268,8 @@ mod tests {
     #[test]
     fn structural_finds_exact_duplicates() {
         let directives = vec![
-            make_directive("2024-01-15", Some("Store"), "Groceries", "-50.00"),
-            make_directive("2024-01-15", Some("Store"), "Groceries", "-50.00"),
+            make_wrapper("2024-01-15", Some("Store"), "Groceries", "-50.00"),
+            make_wrapper("2024-01-15", Some("Store"), "Groceries", "-50.00"),
         ];
         let dups = find_structural_duplicates(&directives);
         assert_eq!(dups.len(), 1);
@@ -251,8 +279,8 @@ mod tests {
     #[test]
     fn structural_no_false_positives() {
         let directives = vec![
-            make_directive("2024-01-15", Some("Store"), "Groceries", "-50.00"),
-            make_directive("2024-01-15", Some("Store"), "Groceries", "-51.00"),
+            make_wrapper("2024-01-15", Some("Store"), "Groceries", "-50.00"),
+            make_wrapper("2024-01-15", Some("Store"), "Groceries", "-51.00"),
         ];
         let dups = find_structural_duplicates(&directives);
         assert!(dups.is_empty());
@@ -383,17 +411,10 @@ mod tests {
 
     #[test]
     fn fuzzy_non_transaction_directives_are_skipped() {
-        let note_directive = DirectiveWrapper {
-            directive_type: "note".to_string(),
-            date: "2024-01-15".to_string(),
-            filename: None,
-            lineno: None,
-            data: DirectiveData::Note(rustledger_plugin_types::NoteData {
-                account: "Assets:Bank".to_string(),
-                comment: "A note".to_string(),
-                metadata: vec![],
-            }),
-        };
+        let note_directive = Directive::Open(rustledger_core::Open::new(
+            "2024-01-15".parse().unwrap(),
+            "Assets:Bank",
+        ));
         let txn = make_directive("2024-01-15", Some("Store"), "Groceries", "-50.00");
 
         // Note in new directives - should be skipped
@@ -538,5 +559,33 @@ mod tests {
         let matches = find_fuzzy_duplicates(&new, &existing, &config);
         // "alpha beta" shares 1/2 words with "alpha gamma delta" → 50% < 90%
         assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_threshold_is_inclusive_at_exactly_half() {
+        // Exactly 50% word overlap counts as a duplicate (ratio >= 0.5) — the
+        // boundary the CLI's now-deleted `> 0.5` copy got wrong. Same date and
+        // amount; the two narrations share 1 of 2 words.
+        let new = vec![make_directive("2024-01-15", None, "alpha beta", "-50.00")];
+        let existing = vec![make_directive("2024-01-15", None, "alpha gamma", "-50.00")];
+        assert_eq!(
+            find_fuzzy_duplicates(&new, &existing, &FuzzyDedupConfig::default()).len(),
+            1,
+            "exactly 50% overlap must be a duplicate (>= 0.5)",
+        );
+
+        // The per-transaction `is_duplicate` entry point (used by `extract
+        // --existing`) agrees with the batch API.
+        let Directive::Transaction(new_txn) = &new[0] else {
+            unreachable!()
+        };
+        let Directive::Transaction(existing_txn) = &existing[0] else {
+            unreachable!()
+        };
+        assert!(is_duplicate(
+            new_txn,
+            std::slice::from_ref(existing_txn),
+            &FuzzyDedupConfig::default(),
+        ));
     }
 }

--- a/crates/rustledger-ops/src/dedup.rs
+++ b/crates/rustledger-ops/src/dedup.rs
@@ -108,27 +108,33 @@ pub fn find_fuzzy_duplicates(
     existing_directives: &[Directive],
     config: &FuzzyDedupConfig,
 ) -> Vec<FuzzyDuplicateMatch> {
-    // Pre-collect existing transactions (with their directive index) once.
-    let existing: Vec<(usize, &Transaction)> = existing_directives
+    let threshold = config.text_similarity_threshold;
+    // Pre-compute each existing transaction's comparison key ONCE (its
+    // date/amount/text), so the per-new scan below doesn't re-derive — and
+    // re-allocate — them for every candidate.
+    let existing: Vec<(usize, TxnKey)> = existing_directives
         .iter()
         .enumerate()
         .filter_map(|(i, d)| match d {
-            Directive::Transaction(txn) => Some((i, txn)),
+            Directive::Transaction(txn) => Some((i, TxnKey::of(txn))),
             _ => None,
         })
         .collect();
 
     let mut matches = Vec::new();
     for (new_i, directive) in new_directives.iter().enumerate() {
-        if let Directive::Transaction(new_txn) = directive
-            && let Some(&(existing_i, _)) = existing.iter().find(|(_, existing_txn)| {
-                is_fuzzy_duplicate(new_txn, existing_txn, config.text_similarity_threshold)
-            })
-        {
-            matches.push(FuzzyDuplicateMatch {
-                new_index: new_i,
-                existing_index: existing_i,
-            });
+        if let Directive::Transaction(new_txn) = directive {
+            // Compute the new transaction's key once per new transaction.
+            let key = TxnKey::of(new_txn);
+            if let Some((existing_i, _)) = existing
+                .iter()
+                .find(|(_, ek)| key.is_duplicate_of(ek, threshold))
+            {
+                matches.push(FuzzyDuplicateMatch {
+                    new_index: new_i,
+                    existing_index: *existing_i,
+                });
+            }
         }
     }
     matches
@@ -146,16 +152,37 @@ pub fn is_duplicate(
     existing: &[Transaction],
     config: &FuzzyDedupConfig,
 ) -> bool {
+    // Compute the new transaction's key once, not once per existing candidate.
+    let key = TxnKey::of(new_txn);
     existing.iter().any(|existing_txn| {
-        is_fuzzy_duplicate(new_txn, existing_txn, config.text_similarity_threshold)
+        key.is_duplicate_of(&TxnKey::of(existing_txn), config.text_similarity_threshold)
     })
 }
 
-/// Same date, same first-posting amount, and a fuzzy payee/narration match.
-fn is_fuzzy_duplicate(new_txn: &Transaction, existing_txn: &Transaction, threshold: f64) -> bool {
-    new_txn.date == existing_txn.date
-        && first_posting_amount(new_txn) == first_posting_amount(existing_txn)
-        && fuzzy_text_match(&txn_text(new_txn), &txn_text(existing_txn), threshold)
+/// A transaction's fuzzy-dedup comparison key: date, first-posting amount, and
+/// the lowercased payee/narration text. Computing this once and reusing it
+/// across a scan avoids recomputing (and reallocating) `txn_text` per candidate.
+struct TxnKey {
+    date: rustledger_core::NaiveDate,
+    amount: Option<Decimal>,
+    text: String,
+}
+
+impl TxnKey {
+    fn of(txn: &Transaction) -> Self {
+        Self {
+            date: txn.date,
+            amount: first_posting_amount(txn),
+            text: txn_text(txn),
+        }
+    }
+
+    /// Same date, same first-posting amount, and a fuzzy payee/narration match.
+    fn is_duplicate_of(&self, other: &TxnKey, threshold: f64) -> bool {
+        self.date == other.date
+            && self.amount == other.amount
+            && fuzzy_text_match(&self.text, &other.text, threshold)
+    }
 }
 
 /// Get the decimal amount from the first posting of a transaction.

--- a/crates/rustledger-ops/src/dedup.rs
+++ b/crates/rustledger-ops/src/dedup.rs
@@ -178,7 +178,7 @@ impl TxnKey {
     }
 
     /// Same date, same first-posting amount, and a fuzzy payee/narration match.
-    fn is_duplicate_of(&self, other: &TxnKey, threshold: f64) -> bool {
+    fn is_duplicate_of(&self, other: &Self, threshold: f64) -> bool {
         self.date == other.date
             && self.amount == other.amount
             && fuzzy_text_match(&self.text, &other.text, threshold)

--- a/crates/rustledger/src/cmd/extract_cmd/duplicate.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/duplicate.rs
@@ -1,7 +1,6 @@
 //! Duplicate transaction detection for extract command.
 
 use anyhow::{Context, Result};
-use rust_decimal::Decimal;
 use rustledger_core::{Directive, Transaction};
 use std::fs;
 use std::path::Path;
@@ -18,67 +17,4 @@ pub(super) fn load_existing_transactions(path: &Path) -> Result<Vec<Transaction>
         }
     }
     Ok(transactions)
-}
-
-/// Check if a new transaction is a duplicate of an existing one.
-///
-/// Matches on: same date, same first-posting amount, and fuzzy payee/narration match.
-pub(super) fn is_duplicate(new_txn: &Transaction, existing: &[Transaction]) -> bool {
-    let new_amount = first_posting_amount(new_txn);
-    let new_text = txn_match_text(new_txn);
-
-    existing.iter().any(|existing_txn| {
-        if new_txn.date != existing_txn.date {
-            return false;
-        }
-        let existing_amount = first_posting_amount(existing_txn);
-        if new_amount != existing_amount {
-            return false;
-        }
-        let existing_text = txn_match_text(existing_txn);
-        fuzzy_text_match(&new_text, &existing_text)
-    })
-}
-
-/// Get the amount from the first posting of a transaction (for comparison).
-pub(super) fn first_posting_amount(txn: &Transaction) -> Option<Decimal> {
-    txn.postings.first().and_then(|p| {
-        p.units
-            .as_ref()
-            .and_then(rustledger_core::IncompleteAmount::number)
-    })
-}
-
-/// Build a lowercase string combining payee and narration for fuzzy matching.
-pub(super) fn txn_match_text(txn: &Transaction) -> String {
-    let mut text = String::new();
-    if let Some(ref payee) = txn.payee {
-        text.push_str(payee.as_str());
-        text.push(' ');
-    }
-    text.push_str(txn.narration.as_str());
-    text.to_lowercase()
-}
-
-/// Fuzzy text match: returns true if either string contains the other,
-/// or if they share significant word overlap.
-pub(super) fn fuzzy_text_match(a: &str, b: &str) -> bool {
-    if a.is_empty() || b.is_empty() {
-        return false;
-    }
-    if a == b {
-        return true;
-    }
-    if a.contains(b) || b.contains(a) {
-        return true;
-    }
-    let a_words: Vec<&str> = a.split_whitespace().collect();
-    let b_words: Vec<&str> = b.split_whitespace().collect();
-    let (shorter, longer) = if a_words.len() <= b_words.len() {
-        (&a_words, &b_words)
-    } else {
-        (&b_words, &a_words)
-    };
-    let matches = shorter.iter().filter(|w| longer.contains(w)).count();
-    matches * 2 > shorter.len()
 }

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -69,7 +69,7 @@ use config::{
 // Used only by the WASM-importer-dir resolution path (gated below).
 #[cfg(feature = "python-plugin-wasm")]
 use config::expand_tilde;
-use duplicate::{is_duplicate, load_existing_transactions};
+use duplicate::load_existing_transactions;
 use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig};
 use rustledger_importer::config::CsvConfigBuilder;
@@ -810,7 +810,11 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             .into_iter()
             .filter(|d| {
                 if let Directive::Transaction(txn) = d {
-                    !is_duplicate(txn, &existing_txns)
+                    !rustledger_ops::dedup::is_duplicate(
+                        txn,
+                        &existing_txns,
+                        &rustledger_ops::dedup::FuzzyDedupConfig::default(),
+                    )
                 } else {
                     true
                 }
@@ -898,9 +902,7 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
 #[cfg(test)]
 mod tests {
     use super::config::{ImporterEntry, parse_column_value};
-    use super::duplicate::{first_posting_amount, fuzzy_text_match, txn_match_text};
     use super::*;
-    use rustledger_core::Transaction;
     use rustledger_importer::config::ImporterType;
     use std::collections::HashMap;
 
@@ -1479,102 +1481,6 @@ default_expense = "Expenses:Uncategorized"
     }
 
     #[test]
-    fn test_fuzzy_text_match_exact() {
-        assert!(fuzzy_text_match("grocery store", "grocery store"));
-    }
-
-    #[test]
-    fn test_fuzzy_text_match_contains() {
-        assert!(fuzzy_text_match("grocery store #123", "grocery store"));
-        assert!(fuzzy_text_match("grocery store", "grocery store #123"));
-    }
-
-    #[test]
-    fn test_fuzzy_text_match_word_overlap() {
-        assert!(fuzzy_text_match("whole foods market", "whole foods"));
-    }
-
-    #[test]
-    fn test_fuzzy_text_match_no_match() {
-        assert!(!fuzzy_text_match("amazon", "netflix"));
-    }
-
-    #[test]
-    fn test_fuzzy_text_match_empty() {
-        assert!(!fuzzy_text_match("", "something"));
-        assert!(!fuzzy_text_match("something", ""));
-    }
-
-    #[test]
-    fn test_is_duplicate_matching() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let new_txn = Transaction::new(date, "GROCERY STORE").with_synthesized_posting(
-            rustledger_core::Posting::new(
-                "Assets:Bank",
-                rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-            ),
-        );
-
-        let existing = vec![
-            Transaction::new(date, "GROCERY STORE #123").with_synthesized_posting(
-                rustledger_core::Posting::new(
-                    "Assets:Bank",
-                    rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-                ),
-            ),
-        ];
-
-        assert!(is_duplicate(&new_txn, &existing));
-    }
-
-    #[test]
-    fn test_is_duplicate_different_date() {
-        let new_txn = Transaction::new(
-            rustledger_core::naive_date(2024, 1, 15).unwrap(),
-            "GROCERY STORE",
-        )
-        .with_synthesized_posting(rustledger_core::Posting::new(
-            "Assets:Bank",
-            rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-        ));
-
-        let existing = vec![
-            Transaction::new(
-                rustledger_core::naive_date(2024, 1, 16).unwrap(),
-                "GROCERY STORE",
-            )
-            .with_synthesized_posting(rustledger_core::Posting::new(
-                "Assets:Bank",
-                rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-            )),
-        ];
-
-        assert!(!is_duplicate(&new_txn, &existing));
-    }
-
-    #[test]
-    fn test_is_duplicate_different_amount() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let new_txn = Transaction::new(date, "GROCERY STORE").with_synthesized_posting(
-            rustledger_core::Posting::new(
-                "Assets:Bank",
-                rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-            ),
-        );
-
-        let existing = vec![
-            Transaction::new(date, "GROCERY STORE").with_synthesized_posting(
-                rustledger_core::Posting::new(
-                    "Assets:Bank",
-                    rustledger_core::Amount::new(rust_decimal::Decimal::new(-7500, 2), "USD"),
-                ),
-            ),
-        ];
-
-        assert!(!is_duplicate(&new_txn, &existing));
-    }
-
-    #[test]
     fn test_load_existing_transactions() {
         let dir = tempfile::tempdir().unwrap();
         let ledger_path = dir.path().join("ledger.beancount");
@@ -1832,72 +1738,6 @@ amount_column = "Amount"
     }
 
     #[test]
-    fn test_first_posting_amount_no_postings() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let txn = Transaction::new(date, "Test");
-        assert_eq!(first_posting_amount(&txn), None);
-    }
-
-    #[test]
-    fn test_first_posting_amount_auto_posting() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let txn = Transaction::new(date, "Test")
-            .with_synthesized_posting(rustledger_core::Posting::auto("Expenses:Unknown"));
-        assert_eq!(first_posting_amount(&txn), None);
-    }
-
-    #[test]
-    fn test_txn_match_text_with_payee() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let txn = Transaction::new(date, "Weekly groceries").with_payee("Whole Foods");
-        let text = txn_match_text(&txn);
-        assert!(text.contains("whole foods"));
-        assert!(text.contains("weekly groceries"));
-    }
-
-    #[test]
-    fn test_txn_match_text_no_payee() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let txn = Transaction::new(date, "Coffee Shop");
-        let text = txn_match_text(&txn);
-        assert_eq!(text, "coffee shop");
-    }
-
-    #[test]
-    fn test_is_duplicate_no_existing() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let txn = Transaction::new(date, "Coffee").with_synthesized_posting(
-            rustledger_core::Posting::new(
-                "Assets:Bank",
-                rustledger_core::Amount::new(rust_decimal::Decimal::new(-500, 2), "USD"),
-            ),
-        );
-        assert!(!is_duplicate(&txn, &[]));
-    }
-
-    #[test]
-    fn test_is_duplicate_with_payee() {
-        let date = rustledger_core::naive_date(2024, 1, 15).unwrap();
-        let new_txn = Transaction::new(date, "Weekly groceries")
-            .with_payee("WHOLE FOODS")
-            .with_synthesized_posting(rustledger_core::Posting::new(
-                "Assets:Bank",
-                rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-            ));
-
-        let existing = vec![
-            Transaction::new(date, "Weekly groceries")
-                .with_payee("Whole Foods Market")
-                .with_synthesized_posting(rustledger_core::Posting::new(
-                    "Assets:Bank",
-                    rustledger_core::Amount::new(rust_decimal::Decimal::new(-5000, 2), "USD"),
-                )),
-        ];
-
-        assert!(is_duplicate(&new_txn, &existing));
-    }
-
-    #[test]
     fn test_load_existing_transactions_nonexistent_file() {
         let result = load_existing_transactions(Path::new("/nonexistent/ledger.beancount"));
         assert!(result.is_err());
@@ -2082,24 +1922,6 @@ NEWFILEUID:NONE
         let output = std::fs::read_to_string(&output_path).unwrap();
         assert!(output.contains("2024-01-15"));
         assert!(output.contains("GROCERY STORE"));
-    }
-
-    #[test]
-    fn test_fuzzy_text_match_word_overlap_threshold() {
-        // 1 out of 3 words match — below 50% threshold
-        assert!(!fuzzy_text_match("the big store", "the small shop"));
-        // 2 out of 2 words match — above 50% threshold
-        assert!(fuzzy_text_match("grocery store", "grocery store extra"));
-    }
-
-    #[test]
-    fn test_fuzzy_text_match_longer_a_than_b() {
-        // a has more words than b, and neither contains the other as a substring
-        // This forces the word-overlap path with the swap branch
-        assert!(fuzzy_text_match(
-            "whole foods market store location",
-            "whole foods burgers"
-        ));
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -805,16 +805,14 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
     let directives = if let Some(ref existing_path) = args.existing {
         let existing_txns = load_existing_transactions(existing_path)?;
         let before_count = result.directives.len();
+        // Build the dedup config once, not once per filtered directive.
+        let dedup_config = rustledger_ops::dedup::FuzzyDedupConfig::default();
         let mut filtered: Vec<_> = result
             .directives
             .into_iter()
             .filter(|d| {
                 if let Directive::Transaction(txn) = d {
-                    !rustledger_ops::dedup::is_duplicate(
-                        txn,
-                        &existing_txns,
-                        &rustledger_ops::dedup::FuzzyDedupConfig::default(),
-                    )
+                    !rustledger_ops::dedup::is_duplicate(txn, &existing_txns, &dedup_config)
                 } else {
                     true
                 }


### PR DESCRIPTION
## What

Architecture-roadmap [L/4] (ops-dedup) — **delete the duplicate CLI fuzzy-dedup; make `ops::dedup`'s fuzzy path core-typed; fix the threshold-boundary drift.**

Fuzzy duplicate detection was implemented **twice**, with a real bug:
- `rustledger_ops::dedup::find_fuzzy_duplicates` — maintained and tested, but on the wire type `DirectiveWrapper` and with **zero production callers**.
- `rledger extract`'s own `extract_cmd/duplicate.rs` — core-typed and **the live path**, but untested-by-ops and using a divergent threshold.

The two disagreed at exactly 50% word overlap: ops returns duplicate (`ratio >= 0.5`), the CLI copy did **not** (`matches*2 > shorter.len()`, i.e. `> 0.5`). The live path used the CLI copy, so the maintained/tested version's behavior never actually shipped.

## Change

- **Ported `find_fuzzy_duplicates` to `core::Directive`** (it had only test callers), and added a per-transaction `is_duplicate(new_txn, existing, config) -> bool` sharing one `is_fuzzy_duplicate` matcher. `find_structural_duplicates` stays on `DirectiveWrapper` — it has a real production caller (the `no_duplicates` native *plugin*), so it correctly lives at the plugin boundary (matching the audit's "confine `DirectiveWrapper` to the plugin boundary").
- **Deleted `extract_cmd/duplicate.rs`'s fuzzy logic** (`is_duplicate`, `first_posting_amount`, `txn_match_text`, `fuzzy_text_match`); `extract --existing` now calls `rustledger_ops::dedup::is_duplicate(...)`. Only the I/O helper `load_existing_transactions` remains.
- **Threshold single-sourced** on the ops config (`>= 0.5`, default). The CLI's divergent `> 0.5` is gone, pinned by a new boundary test: exactly 50% overlap is a duplicate, asserted through **both** `find_fuzzy_duplicates` and `is_duplicate`.

The CLI's now-redundant dedup unit tests were removed (the behavior is covered — and extended with the boundary case — by the ops tests).

## Tests

New `fuzzy_threshold_is_inclusive_at_exactly_half`; full `rustledger-ops` + `rledger extract` suites pass; clippy `--all-features --all-targets -D warnings` + fmt clean.

## Scope note

This is the fuzzy-dedup slice of the larger [L/4] item. Porting `transfer`/`ml`/`reconcile` off `DirectiveWrapper` (to drop their per-call core↔wrapper deep clones) remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
