### PR TITLE
fix(extract): route --existing dedup through the loader pipeline (M/5)

### DIFF
--- a/crates/rustledger/src/cmd/extract_cmd/duplicate.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/duplicate.rs
@@ -2,19 +2,36 @@
 
 use anyhow::{Context, Result};
 use rustledger_core::{Directive, Transaction};
-use std::fs;
 use std::path::Path;
 
 /// Load existing transactions from a beancount file for duplicate detection.
+///
+/// Runs the file through the loader pipeline (`rustledger_loader::load`) rather
+/// than a raw parse, so dedup sees the SAME transactions the user does:
+///
+/// - `include`d files are resolved — a raw parse only saw the top file, so
+///   transactions in included ledgers were invisible at dedup time and genuine
+///   duplicates got re-imported into the user's real ledger.
+/// - Elided amounts are interpolated by booking — a raw parse leaves them `None`,
+///   so `first_posting_amount` returned `None` and the amount comparison broke.
+///
+/// Plugins and validation are intentionally skipped: dedup only needs the booked
+/// transaction set, and the existing ledger's own diagnostics aren't this
+/// command's concern (and would add overhead / failure modes to every import).
 pub(super) fn load_existing_transactions(path: &Path) -> Result<Vec<Transaction>> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read existing ledger: {}", path.display()))?;
-    let parse_result = rustledger_parser::parse(&content);
-    let mut transactions = Vec::new();
-    for directive in parse_result.directives {
-        if let Directive::Transaction(txn) = directive.value {
-            transactions.push(txn);
-        }
-    }
-    Ok(transactions)
+    let options = rustledger_loader::LoadOptions {
+        run_plugins: false,
+        validate: false,
+        ..Default::default()
+    };
+    let ledger = rustledger_loader::load(path, &options)
+        .with_context(|| format!("Failed to load existing ledger: {}", path.display()))?;
+    Ok(ledger
+        .directives
+        .into_iter()
+        .filter_map(|spanned| match spanned.value {
+            Directive::Transaction(txn) => Some(txn),
+            _ => None,
+        })
+        .collect())
 }

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -1508,6 +1508,48 @@ default_expense = "Expenses:Uncategorized"
     }
 
     #[test]
+    fn test_load_existing_resolves_includes_and_interpolates() {
+        // Regression: a raw parse only saw the top file and left elided amounts
+        // as None. Routing through the loader pipeline makes `include`d
+        // transactions visible AND fills the interpolated amount — both needed so
+        // dedup compares against the user's real (resolved, booked) ledger.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("sub.beancount"),
+            "2024-02-01 * \"PHONE BILL\" \"Monthly\"\n  \
+             Assets:Bank:Checking  -40.00 USD\n  Expenses:Phone\n",
+        )
+        .unwrap();
+        let main_path = dir.path().join("main.beancount");
+        std::fs::write(
+            &main_path,
+            "include \"sub.beancount\"\n\n2024-01-15 * \"GROCERY STORE\" \"Weekly\"\n  \
+             Assets:Bank:Checking  -50.00 USD\n  Expenses:Food          50.00 USD\n",
+        )
+        .unwrap();
+
+        let txns = load_existing_transactions(&main_path).unwrap();
+        // The INCLUDED transaction is visible (a raw parse missed it entirely).
+        assert_eq!(txns.len(), 2, "included transaction must be loaded");
+        let phone = txns
+            .iter()
+            .find(|t| t.narration.as_str() == "Monthly")
+            .expect("included PHONE BILL transaction must be present");
+        // Its elided `Expenses:Phone` posting was interpolated (raw parse: None).
+        let amount = phone
+            .postings
+            .iter()
+            .find(|p| p.account.as_str() == "Expenses:Phone")
+            .and_then(|p| p.units.as_ref())
+            .and_then(rustledger_core::IncompleteAmount::number);
+        assert_eq!(
+            amount,
+            Some("40.00".parse::<rust_decimal::Decimal>().unwrap()),
+            "elided posting must be interpolated by booking",
+        );
+    }
+
+    #[test]
     fn test_end_to_end_output_file() {
         let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## What

Architecture-roadmap [M/5] (extract half) — **route `extract --existing` duplicate detection through the loader pipeline instead of a raw parse.**

`load_existing_transactions` loaded the user's existing ledger with a raw `rustledger_parser::parse`, which **skips include resolution and booking**. Two real consequences for dedup against the user's *real* ledger:

- **`include`d transactions were invisible.** A raw parse only sees the top file, so any transaction in an included ledger was never compared — genuine duplicates got **re-imported into the user's ledger**.
- **Interpolated amounts read as `None`.** A raw parse leaves elided posting amounts unfilled, so `first_posting_amount` returned `None` and the amount comparison silently failed to match.

## Change

`load_existing_transactions` now calls `rustledger_loader::load(path, &opts)` (the canonical pipeline `check`/`query`/`report` already use), so includes are resolved and booking fills interpolated amounts before dedup. Plugins and validation are intentionally **off** (`run_plugins: false, validate: false`): dedup only needs the booked transaction set, and the existing ledger's own diagnostics aren't this import command's concern — a documented "book + resolve includes" projection of the pipeline.

## Tests

New `test_load_existing_resolves_includes_and_interpolates`: a `main.beancount` that `include`s a `sub.beancount` whose transaction has an elided posting — asserts the included transaction is loaded (was invisible) **and** its elided amount was interpolated (was `None`). Existing `extract` suite unchanged; clippy `--all-features --all-targets -D warnings` + fmt clean.

## Scope note

The other half of this audit item — routing the **WASM `parse_multi_file`** surface through `process()` (so its JS-visible stream matches `validateMultiFile`/`queryMultiFile`: sorted, synth-augmented, booked) — is a JS-API-contract change and is left as a separate, focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
