### PR TITLE
refactor(ops): port reconcile to core::Directive, drop the round-trip (L/4)

### DIFF
--- a/crates/rustledger-ops/src/reconcile.rs
+++ b/crates/rustledger-ops/src/reconcile.rs
@@ -80,7 +80,7 @@ pub fn reconcile(
 
 /// Create a core balance-assertion [`Directive`] from a statement balance.
 ///
-/// Returns a `core::Directive` directly so the CLI can append it without a
+/// Returns a [`Directive`] directly so the CLI can append it without a
 /// `DirectiveWrapper` round-trip (it previously built a wrapper here only to call
 /// `wrapper_to_directive` on it one line later).
 #[must_use]

--- a/crates/rustledger-ops/src/reconcile.rs
+++ b/crates/rustledger-ops/src/reconcile.rs
@@ -5,16 +5,13 @@
 //! balance assertion directives for the ledger.
 
 use rust_decimal::Decimal;
-use rustledger_plugin_types::{
-    AmountData, BalanceData, DirectiveData, DirectiveWrapper, MetaValueData,
-};
-use std::str::FromStr;
+use rustledger_core::{Amount, Balance, Directive, MetaValue, Metadata, NaiveDate};
 
 /// A balance point extracted from a bank statement.
 #[derive(Debug, Clone)]
 pub struct StatementBalance {
     /// Date of the balance (usually end of statement period).
-    pub date: String,
+    pub date: NaiveDate,
     /// Account this balance applies to.
     pub account: String,
     /// The balance amount.
@@ -35,7 +32,7 @@ pub struct ReconciliationResult {
     /// The difference (expected - computed).
     pub difference: Decimal,
     /// A balance assertion directive to add to the ledger.
-    pub balance_directive: DirectiveWrapper,
+    pub balance_directive: Directive,
 }
 
 /// Reconcile imported transactions against a statement ending balance.
@@ -48,21 +45,20 @@ pub struct ReconciliationResult {
 /// (if known). If `None`, only the transaction total is compared.
 #[must_use]
 pub fn reconcile(
-    directives: &[DirectiveWrapper],
+    directives: &[Directive],
     ending_balance: &StatementBalance,
     opening_balance: Option<Decimal>,
 ) -> ReconciliationResult {
     let mut total = opening_balance.unwrap_or(Decimal::ZERO);
 
     for d in directives {
-        if let DirectiveData::Transaction(txn) = &d.data {
+        if let Directive::Transaction(txn) = d {
             for posting in &txn.postings {
-                if posting.account == ending_balance.account
-                    && let Some(units) = &posting.units
-                    && units.currency == ending_balance.currency
-                    && let Ok(amount) = Decimal::from_str(&units.number)
+                if posting.account.as_str() == ending_balance.account
+                    && let Some(units) = posting.amount()
+                    && units.currency.as_str() == ending_balance.currency
                 {
-                    total += amount;
+                    total += units.number;
                 }
             }
         }
@@ -82,69 +78,32 @@ pub fn reconcile(
     }
 }
 
-/// Create a balance assertion directive from a statement balance.
+/// Create a core balance-assertion [`Directive`] from a statement balance.
+///
+/// Returns a `core::Directive` directly so the CLI can append it without a
+/// `DirectiveWrapper` round-trip (it previously built a wrapper here only to call
+/// `wrapper_to_directive` on it one line later).
 #[must_use]
-pub fn create_balance_directive(balance: &StatementBalance) -> DirectiveWrapper {
-    DirectiveWrapper {
-        directive_type: "balance".to_string(),
-        date: balance.date.clone(),
-        filename: Some("<import-reconcile>".to_string()),
-        lineno: None,
-        data: DirectiveData::Balance(BalanceData {
-            account: balance.account.clone(),
-            amount: AmountData {
-                number: balance.number.to_string(),
-                currency: balance.currency.clone(),
-            },
-            tolerance: None,
-            metadata: vec![("import-reconcile".to_string(), MetaValueData::Bool(true))],
-        }),
-    }
+pub fn create_balance_directive(balance: &StatementBalance) -> Directive {
+    let amount = Amount::new(balance.number, balance.currency.as_str());
+    let mut meta = Metadata::default();
+    meta.insert("import-reconcile".to_string(), MetaValue::Bool(true));
+    Directive::Balance(Balance::new(balance.date, balance.account.as_str(), amount).with_meta(meta))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustledger_plugin_types::{PostingData, TransactionData};
+    use rustledger_core::{Posting, Transaction};
 
-    fn make_txn(date: &str, account: &str, amount: &str, currency: &str) -> DirectiveWrapper {
-        DirectiveWrapper {
-            directive_type: "transaction".to_string(),
-            date: date.to_string(),
-            filename: None,
-            lineno: None,
-            data: DirectiveData::Transaction(TransactionData {
-                flag: "*".to_string(),
-                payee: None,
-                narration: "Test".to_string(),
-                tags: vec![],
-                links: vec![],
-                metadata: vec![],
-                postings: vec![
-                    PostingData {
-                        account: account.to_string(),
-                        units: Some(AmountData {
-                            number: amount.to_string(),
-                            currency: currency.to_string(),
-                        }),
-                        cost: None,
-                        price: None,
-                        flag: None,
-                        metadata: vec![],
-                        span: None,
-                    },
-                    PostingData {
-                        account: "Expenses:Unknown".to_string(),
-                        units: None,
-                        cost: None,
-                        price: None,
-                        flag: None,
-                        metadata: vec![],
-                        span: None,
-                    },
-                ],
-            }),
-        }
+    fn make_txn(date: &str, account: &str, amount: &str, currency: &str) -> Directive {
+        let txn = Transaction::new(date.parse::<NaiveDate>().unwrap(), "Test")
+            .with_synthesized_posting(Posting::new(
+                account,
+                Amount::new(amount.parse::<Decimal>().unwrap(), currency),
+            ))
+            .with_synthesized_posting(Posting::auto("Expenses:Unknown"));
+        Directive::Transaction(txn)
     }
 
     #[test]
@@ -155,7 +114,7 @@ mod tests {
             make_txn("2024-01-17", "Assets:Checking", "100.00", "USD"),
         ];
         let balance = StatementBalance {
-            date: "2024-01-31".to_string(),
+            date: "2024-01-31".parse().unwrap(),
             account: "Assets:Checking".to_string(),
             number: Decimal::new(102_000, 2), // 1020.00 (opening 1000 + 20 net)
             currency: "USD".to_string(),
@@ -169,7 +128,7 @@ mod tests {
     fn reconcile_mismatch() {
         let directives = vec![make_txn("2024-01-15", "Assets:Checking", "-50.00", "USD")];
         let balance = StatementBalance {
-            date: "2024-01-31".to_string(),
+            date: "2024-01-31".parse().unwrap(),
             account: "Assets:Checking".to_string(),
             number: Decimal::new(100_000, 2), // 1000.00
             currency: "USD".to_string(),
@@ -187,7 +146,7 @@ mod tests {
             make_txn("2024-01-16", "Assets:Checking", "100.00", "USD"),
         ];
         let balance = StatementBalance {
-            date: "2024-01-31".to_string(),
+            date: "2024-01-31".parse().unwrap(),
             account: "Assets:Checking".to_string(),
             number: Decimal::new(5000, 2), // 50.00
             currency: "USD".to_string(),
@@ -203,7 +162,7 @@ mod tests {
             make_txn("2024-01-15", "Assets:Savings", "50.00", "USD"),
         ];
         let balance = StatementBalance {
-            date: "2024-01-31".to_string(),
+            date: "2024-01-31".parse().unwrap(),
             account: "Assets:Checking".to_string(),
             number: Decimal::new(-5000, 2), // -50.00
             currency: "USD".to_string(),
@@ -215,17 +174,17 @@ mod tests {
     #[test]
     fn balance_directive_created() {
         let balance = StatementBalance {
-            date: "2024-01-31".to_string(),
+            date: "2024-01-31".parse().unwrap(),
             account: "Assets:Checking".to_string(),
             number: Decimal::new(100_000, 2),
             currency: "USD".to_string(),
         };
         let directive = create_balance_directive(&balance);
-        assert_eq!(directive.date, "2024-01-31");
-        if let DirectiveData::Balance(b) = &directive.data {
-            assert_eq!(b.account, "Assets:Checking");
-            assert_eq!(b.amount.number, "1000.00");
-            assert_eq!(b.amount.currency, "USD");
+        if let Directive::Balance(b) = &directive {
+            assert_eq!(b.date, "2024-01-31".parse::<NaiveDate>().unwrap());
+            assert_eq!(b.account.as_str(), "Assets:Checking");
+            assert_eq!(b.amount.number, Decimal::new(100_000, 2));
+            assert_eq!(b.amount.currency.as_str(), "USD");
         } else {
             panic!("Expected Balance directive");
         }
@@ -234,14 +193,16 @@ mod tests {
     #[test]
     fn balance_directive_has_metadata() {
         let balance = StatementBalance {
-            date: "2024-01-31".to_string(),
+            date: "2024-01-31".parse().unwrap(),
             account: "Assets:Checking".to_string(),
             number: Decimal::new(100_000, 2),
             currency: "USD".to_string(),
         };
         let directive = create_balance_directive(&balance);
-        if let DirectiveData::Balance(b) = &directive.data {
-            assert!(b.metadata.iter().any(|(k, _)| k == "import-reconcile"));
+        if let Directive::Balance(b) = &directive {
+            assert!(b.meta.contains_key("import-reconcile"));
+        } else {
+            panic!("Expected Balance directive");
         }
     }
 }

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -841,10 +841,13 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
 
         let amount = Decimal::from_str(balance_amount)
             .with_context(|| format!("Invalid balance amount: {balance_amount}"))?;
-        let date = args
+        let date_str = args
             .balance_date
             .clone()
             .unwrap_or_else(|| jiff::Zoned::now().date().to_string());
+        let date = date_str
+            .parse::<rustledger_core::NaiveDate>()
+            .with_context(|| format!("Invalid balance date: {date_str}"))?;
 
         let balance = rustledger_ops::reconcile::StatementBalance {
             date,
@@ -852,11 +855,9 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
             number: amount,
             currency: args.currency.clone(),
         };
-        let balance_wrapper = rustledger_ops::reconcile::create_balance_directive(&balance);
-
-        // Convert DirectiveWrapper to core Directive
-        let balance_directive = rustledger_plugin::convert::wrapper_to_directive(&balance_wrapper)
-            .map_err(|e| anyhow!("Failed to create balance directive: {e:?}"))?;
+        // `create_balance_directive` returns a core `Directive` directly now — no
+        // `DirectiveWrapper` round-trip through `wrapper_to_directive`.
+        let balance_directive = rustledger_ops::reconcile::create_balance_directive(&balance);
 
         let mut with_balance = directives;
         with_balance.push(balance_directive);


### PR DESCRIPTION
## What

Architecture-roadmap [L/4] (ops core-typed — reconcile slice) — **port `rustledger_ops::reconcile` to `core::Directive`, eliminating the audit's named `DirectiveWrapper` round-trip.**

`ops` promises "pure operations on core directives," but `reconcile` operated on the plugin **wire type** `DirectiveWrapper`. The audit's pointed example: `extract --balance` built a wrapper via `create_balance_directive` *only to convert it straight back* to a core `Directive` one line later via `wrapper_to_directive`.

## Change

- `create_balance_directive` now returns a `core::Directive::Balance` directly (built with `Balance::new(...).with_meta(...)`), so the CLI appends it with **no wrapper round-trip**. The wire-only synthetic `filename` is dropped (core directives carry source location via spans, not a field); the `import-reconcile` metadata is preserved.
- `reconcile` takes `&[Directive]` and reads typed core postings (`posting.amount()` → no `Decimal::from_str` on a wire string).
- `StatementBalance.date` is now a `NaiveDate` (parsed once at the CLI input boundary) instead of a `String`, keeping `create_balance_directive`/`reconcile` infallible.
- The `extract --balance` call site drops `wrapper_to_directive` and parses the balance date up front.

`reconcile()` itself has no production callers (tests only), so this is also a consistency/correctness alignment — but `create_balance_directive` is live, and its round-trip is now gone.

## Tests

The reconcile unit tests build core `Directive`s (instead of `DirectiveWrapper`s) and assert on the typed `Directive::Balance` (`Decimal` amount, `Account`, `meta`). Full `rustledger-ops` + `rledger extract` suites pass; clippy `--all-features --all-targets -D warnings` + fmt clean.

## Scope note

This is the **reconcile** slice of the L/4 ops core-typing (dedup landed in #1565). `transfer` and `ml` remain on `DirectiveWrapper` — `transfer` in particular carries a real per-call deep clone on the `rledger check` hot path (`find_transfers_in_ledger(&wrappers)`) and is the next, higher-impact slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
