### PR TITLE
refactor(ops): port ml train to core::Directive — completes ops core-typing (L/4)

### DIFF
--- a/crates/rustledger-ops/src/ml.rs
+++ b/crates/rustledger-ops/src/ml.rs
@@ -19,7 +19,7 @@
 //! // → [("Expenses:Groceries", 0.92), ("Expenses:Dining", 0.05), ...]
 //! ```
 
-use rustledger_plugin_types::{DirectiveData, DirectiveWrapper};
+use rustledger_core::Directive;
 use std::collections::HashMap;
 
 /// A trained categorization model.
@@ -71,30 +71,30 @@ impl CategorizationModel {
     ///
     /// Returns `MlError::InsufficientData` if there aren't enough transactions
     /// or distinct categories to train a useful model.
-    pub fn train(directives: &[DirectiveWrapper]) -> Result<Self, MlError> {
+    pub fn train(directives: &[Directive]) -> Result<Self, MlError> {
         // Extract training data: (text, account) pairs
         let mut samples: Vec<(String, String)> = Vec::new();
 
         for d in directives {
-            if let DirectiveData::Transaction(txn) = &d.data {
+            if let Directive::Transaction(txn) = d {
                 // Skip transactions with fewer than 2 postings
                 if txn.postings.len() < 2 {
                     continue;
                 }
 
                 // The target account is the second posting (contra-account)
-                let account = &txn.postings[1].account;
+                let account = txn.postings[1].account.as_str();
 
                 // Build text from payee + narration
                 let mut text = String::new();
-                if let Some(ref payee) = txn.payee {
-                    text.push_str(payee);
+                if let Some(payee) = &txn.payee {
+                    text.push_str(payee.as_str());
                     text.push(' ');
                 }
-                text.push_str(&txn.narration);
+                text.push_str(txn.narration.as_str());
 
                 if !text.trim().is_empty() {
-                    samples.push((text.to_lowercase(), account.clone()));
+                    samples.push((text.to_lowercase(), account.to_string()));
                 }
             }
         }
@@ -362,54 +362,30 @@ fn tfidf_row(tokens: &[String], vocab: &HashMap<String, usize>, idf: &[f64]) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustledger_plugin_types::{AmountData, PostingData, TransactionData};
+    use rust_decimal::Decimal;
+    use rustledger_core::{Amount, NaiveDate, Posting, Transaction};
 
     fn make_txn(
         payee: Option<&str>,
         narration: &str,
         from_account: &str,
         to_account: &str,
-    ) -> DirectiveWrapper {
-        DirectiveWrapper {
-            directive_type: "transaction".to_string(),
-            date: "2024-01-15".to_string(),
-            filename: None,
-            lineno: None,
-            data: DirectiveData::Transaction(TransactionData {
-                flag: "*".to_string(),
-                payee: payee.map(String::from),
-                narration: narration.to_string(),
-                tags: vec![],
-                links: vec![],
-                metadata: vec![],
-                postings: vec![
-                    PostingData {
-                        account: from_account.to_string(),
-                        units: Some(AmountData {
-                            number: "-50.00".to_string(),
-                            currency: "USD".to_string(),
-                        }),
-                        cost: None,
-                        price: None,
-                        flag: None,
-                        metadata: vec![],
-                        span: None,
-                    },
-                    PostingData {
-                        account: to_account.to_string(),
-                        units: None,
-                        cost: None,
-                        price: None,
-                        flag: None,
-                        metadata: vec![],
-                        span: None,
-                    },
-                ],
-            }),
+    ) -> Directive {
+        // First posting carries the amount; the second posting's account is the
+        // categorization target that `train` reads (`postings[1].account`).
+        let mut txn = Transaction::new("2024-01-15".parse::<NaiveDate>().unwrap(), narration)
+            .with_synthesized_posting(Posting::new(
+                from_account,
+                Amount::new("-50.00".parse::<Decimal>().unwrap(), "USD"),
+            ))
+            .with_synthesized_posting(Posting::auto(to_account));
+        if let Some(payee) = payee {
+            txn = txn.with_payee(payee);
         }
+        Directive::Transaction(txn)
     }
 
-    fn training_data() -> Vec<DirectiveWrapper> {
+    fn training_data() -> Vec<Directive> {
         vec![
             make_txn(
                 Some("Whole Foods"),

--- a/crates/rustledger/src/cmd/extract_cmd/suggest.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/suggest.rs
@@ -13,7 +13,6 @@
 use anyhow::{Context, Result, anyhow};
 use rustledger_core::{Directive, InternedStr, Transaction};
 use rustledger_ops::ml::CategorizationModel;
-use rustledger_plugin::convert::directives_to_wrappers;
 
 /// Outcome of running ML suggestion over a batch of imported directives.
 #[derive(Debug, Default)]
@@ -42,17 +41,17 @@ pub(super) fn apply_ml_suggestions(
     existing_txns: &[Transaction],
     fallback_accounts: &[String],
 ) -> Result<SuggestStats> {
-    // Wrap existing transactions as Directives for the wrapper-based ML API.
-    // Clone is unavoidable here — `existing_txns` is also used for duplicate
-    // detection in the calling path.
+    // Wrap existing transactions as core `Directive`s for the ML API (clone is
+    // unavoidable — `existing_txns` is also used for duplicate detection in the
+    // calling path). `train` now takes `&[Directive]` directly, so there is no
+    // longer a `DirectiveWrapper` conversion here.
     let training_directives: Vec<Directive> = existing_txns
         .iter()
         .cloned()
         .map(Directive::Transaction)
         .collect();
-    let training_wrappers = directives_to_wrappers(&training_directives);
 
-    let model = match CategorizationModel::train(&training_wrappers) {
+    let model = match CategorizationModel::train(&training_directives) {
         Ok(m) => m,
         Err(rustledger_ops::ml::MlError::InsufficientData(reason)) => {
             eprintln!(


### PR DESCRIPTION
## What

Architecture-roadmap [L/4] (ops core-typed — **final slice**) — **port `rustledger_ops::ml::CategorizationModel::train` off `DirectiveWrapper` onto `core::Directive`, eliminating the `extract --suggest-categories` deep clone.**

This is the audit's most blatant case: `apply_ml_suggestions` already had `training_directives: Vec<Directive>` (core), then `directives_to_wrappers(&training_directives)` deep-cloned every one into a `DirectiveWrapper` purely to satisfy `train`'s wire-typed signature.

## Change

- `train(directives: &[Directive])` reads core fields directly — `Directive::Transaction(txn)`, the second posting's account (`txn.postings[1].account.as_str()`, the categorization target), `txn.payee`/`txn.narration` via `as_str()`. The rest of the model (samples, label map, vocab, IDF) is unchanged — it operates on the extracted `(text, account)` `String` pairs.
- The caller (`extract_cmd/suggest.rs`) passes `&training_directives` straight to `train`; the `directives_to_wrappers` conversion (and its import) are gone.

The only remaining clone there is the pre-existing `existing_txns` (`&[Transaction]`) → `Vec<Directive>` wrap, which is unavoidable (`existing_txns` is also used for dedup in the same path) and far cheaper than the wire conversion this removes.

## Tests

The 7 `ml` unit tests build core `Directive`s via `Transaction::new(...).with_synthesized_posting(...)` (first posting carries the amount; the second posting's account is the `postings[1]` target `train` reads) instead of `DirectiveWrapper`s. `rustledger-ops` ml (7) + `rledger` suggest (4) suites pass; clippy `--all-features --all-targets -D warnings` + fmt clean.

## Scope

This **completes the L/4 ops core-typing item**: dedup (#1565), reconcile (#1568), transfer (#1569), and now ml are all on `core::Directive`. No `ops` module operates on the plugin wire type `DirectiveWrapper` anymore — the doc promise of "pure operations on core directives, no framework coupling" now holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
