### PR TITLE
refactor: deny unwrap/expect on wasm + loader never-panic surfaces (L/4)

### DIFF
--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -27,6 +27,12 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+// Never-panic surface: the loader resolves attacker-controlled `include` paths
+// and parser output, so production code must not `unwrap`/`expect`. `not(test)`
+// scopes the deny so test code (incl. `#[cfg(all(test, feature = ...))]` modules)
+// may unwrap/expect freely. Proven-safe production sites carry an audited
+// `#[allow]` with a justification.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 #[cfg(feature = "cache")]
 pub mod cache;

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -29,9 +29,11 @@
 #![warn(missing_docs)]
 // Never-panic surface: the loader resolves attacker-controlled `include` paths
 // and parser output, so production code must not `unwrap`/`expect`. `not(test)`
-// scopes the deny so test code (incl. `#[cfg(all(test, feature = ...))]` modules)
-// may unwrap/expect freely. Proven-safe production sites carry an audited
-// `#[allow]` with a justification.
+// scopes the deny to non-test builds, so this crate's own `#[cfg(test)]` /
+// `#[test]` code (incl. `#[cfg(all(test, feature = ...))]` modules) is exempt — it
+// compiles with `cfg(test)`. (Integration tests under `tests/` are separate crates
+// and aren't governed by this attribute either way.) Proven-safe production sites
+// carry an audited `#[allow]` with a justification.
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 #[cfg(feature = "cache")]

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -70,7 +70,9 @@ fn strip_header(bytes: &[u8], expected_magic: [u8; 8]) -> Result<&[u8], String> 
     if header[..8] != expected_magic {
         return Err("Invalid cache: wrong payload type or unrecognized magic bytes".to_string());
     }
-    let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
+    // `header` is exactly `HEADER_SIZE` (12) bytes — the length was checked
+    // above — so bytes 8..12 are always present (no panic, no unwrap).
+    let version = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
     if version != CACHE_VERSION {
         return Err(format!(
             "Cache version mismatch: expected {CACHE_VERSION}, got {version}. Re-parse the ledger."

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -140,6 +140,8 @@ pub fn run_validation(load: &ProcessedLedger) -> Vec<Error> {
     // future-date warnings — WASM has no reliable wall clock and the
     // legacy `validate()` shortcut also didn't fire these warnings
     // unless `warn_future_dates` was explicitly enabled (it isn't here).
+    // 2999-12-31 is a valid Gregorian date, so `naive_date` is always `Some`.
+    #[allow(clippy::unwrap_used)]
     let today = rustledger_core::naive_date(2999, 12, 31).unwrap();
     let session = ValidationSession::new(ValidationOptions::default());
     let (session, mut errors) = session.run_early(&load.directives, today);

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -36,9 +36,12 @@
 #![warn(missing_docs)]
 // Never-panic surface: WASM is the sandboxed, attacker-facing boundary and ships
 // with `panic = "abort"` in release, so a stray `unwrap`/`expect` is a hard crash
-// of the embedder. Deny both in production code; `not(test)` scopes it so test
-// code (incl. `#[cfg(all(test, feature = ...))]` modules) may unwrap/expect
-// freely. Proven-safe production sites carry an audited `#[allow]` with reason.
+// of the embedder. Deny both in production code. `not(test)` scopes it to
+// non-test builds, so this crate's own `#[cfg(test)]` / `#[test]` code (incl.
+// `#[cfg(all(test, feature = ...))]` modules) is exempt — it compiles with
+// `cfg(test)`. (Integration tests under `tests/` are separate crates and aren't
+// governed by this attribute either way.) Proven-safe production sites carry an
+// audited `#[allow]` with a justification.
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // wasm_bindgen doesn't support const fn on exported methods
 #![allow(clippy::missing_const_for_fn)]

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -34,6 +34,12 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+// Never-panic surface: WASM is the sandboxed, attacker-facing boundary and ships
+// with `panic = "abort"` in release, so a stray `unwrap`/`expect` is a hard crash
+// of the embedder. Deny both in production code; `not(test)` scopes it so test
+// code (incl. `#[cfg(all(test, feature = ...))]` modules) may unwrap/expect
+// freely. Proven-safe production sites carry an audited `#[allow]` with reason.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 // wasm_bindgen doesn't support const fn on exported methods
 #![allow(clippy::missing_const_for_fn)]
 


### PR DESCRIPTION
## What

Architecture-roadmap [L/4] (deny-panic slice) — **enable `clippy::unwrap_used` + `clippy::expect_used` as `deny` on the two never-panic surfaces with the fewest production sites: `rustledger-wasm` and `rustledger-loader`.** A stray `unwrap`/`expect` on these paths is a real crash vector (WASM ships `panic = "abort"`; the loader handles attacker-controlled `include` paths and parser output), and the lints were previously not enabled, so a new one would compile and ship.

## Change

- Both crate roots gain `#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]`. The `not(test)` scopes the deny to **production** code and exempts all test code — including `#[cfg(all(test, feature = ...))]` modules, which clippy's `allow-unwrap-in-tests` config does *not* recognize as test context (that was my first attempt; `cfg_attr(not(test))` is the robust, cfg-shape-agnostic fix).
- Audited the production sites the lint flagged:
  - `wasm/cache.rs`: `header[8..12].try_into().unwrap()` → rewritten to `from_le_bytes([header[8], header[9], header[10], header[11]])`. `header` is exactly `HEADER_SIZE` (12) bytes (length-checked above), so the indices are always present — **no unwrap, no panic.**
  - `wasm/helpers.rs`: `naive_date(2999, 12, 31).unwrap()` — a known-valid calendar date, so an **audited `#[allow(clippy::unwrap_used)]`** with a justification comment.
  - `loader`: 0 production sites — the deny just locks the invariant going forward.

## Verification

Clippy `-D warnings` clean on **both** the default and `--all-features --all-targets` configs (the all-features build is what surfaced the feature-gated test-helper sites that drove the `cfg_attr(not(test))` decision); `rustledger-wasm` + `rustledger-loader` suites pass; fmt clean.

## Scope

This is the wasm+loader slice of the deny-panic item. The **parser** (~19 production `unwrap`/`expect` sites — the CLAUDE.md "must handle malformed input gracefully" surface) and **`clippy::indexing_slicing`** (the noisy one, needing many audited `#[allow]`s) are the larger follow-ups. The other three parts of the original roadmap item (CI bench job, `fuzz_query_execute` target, parallel-threshold brackets) are independent and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
