### PR TITLE
refactor: reconcile validate error-code catalog with spec + Display for Value::Metadata (S/3)

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -383,8 +383,8 @@ fn query_value(v: &Value) -> wit::QueryValue {
         Value::Inventory(inv) => Q::Inventory(inv.positions().map(position).collect()),
         Value::StringSet(set) => Q::StringSet(set.clone()),
         Value::Metadata(m) => Q::Metadata(
-            // `Display` (`foo`), matching the canonical CLI, not `Debug`
-            // (which leaked `String("foo")`).
+            // `Display`, matching the canonical CLI, not `Debug` (which leaked
+            // the Rust wrapper, e.g. `String("foo")`).
             m.iter()
                 .map(|(k, val)| (k.clone(), format!("{val}")))
                 .collect(),

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -383,8 +383,10 @@ fn query_value(v: &Value) -> wit::QueryValue {
         Value::Inventory(inv) => Q::Inventory(inv.positions().map(position).collect()),
         Value::StringSet(set) => Q::StringSet(set.clone()),
         Value::Metadata(m) => Q::Metadata(
+            // `Display` (`foo`), matching the canonical CLI, not `Debug`
+            // (which leaked `String("foo")`).
             m.iter()
-                .map(|(k, val)| (k.clone(), format!("{val:?}")))
+                .map(|(k, val)| (k.clone(), format!("{val}")))
                 .collect(),
         ),
         Value::Interval(iv) => Q::Interval(wit::Interval {

--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -395,9 +395,11 @@ pub fn value_to_json(value: &rustledger_query::Value) -> serde_json::Value {
             serde_json::Value::Object(map)
         }
         Value::Metadata(meta) => {
+            // `Display` (`foo`), matching the canonical CLI, not `Debug`
+            // (which leaked `String("foo")`).
             let obj: serde_json::Map<String, serde_json::Value> = meta
                 .iter()
-                .map(|(k, v)| (k.clone(), serde_json::json!(format!("{v:?}"))))
+                .map(|(k, v)| (k.clone(), serde_json::json!(format!("{v}"))))
                 .collect();
             serde_json::Value::Object(obj)
         }

--- a/crates/rustledger-ffi-wasi/src/convert.rs
+++ b/crates/rustledger-ffi-wasi/src/convert.rs
@@ -395,8 +395,8 @@ pub fn value_to_json(value: &rustledger_query::Value) -> serde_json::Value {
             serde_json::Value::Object(map)
         }
         Value::Metadata(meta) => {
-            // `Display` (`foo`), matching the canonical CLI, not `Debug`
-            // (which leaked `String("foo")`).
+            // `Display`, matching the canonical CLI, not `Debug` (which leaked
+            // the Rust wrapper, e.g. `String("foo")`).
             let obj: serde_json::Map<String, serde_json::Value> = meta
                 .iter()
                 .map(|(k, v)| (k.clone(), serde_json::json!(format!("{v}"))))

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -42,8 +42,9 @@ pub enum ErrorCode {
     ///
     /// Reserved for spec parity but **never emitted**: rledger skips validation
     /// of a posting-less transaction rather than flagging it (matching Python
-    /// beancount, which treats it as a structurally-valid no-op). See the
-    /// early return in `validate_transaction` and the `no_postings` test.
+    /// beancount, which treats it as a structurally-valid no-op). See the early
+    /// return in `validate_transaction_structure` and the
+    /// `test_validate_no_postings_allowed` test.
     NoPostings,
     /// E3004: Transaction has single posting (warning).
     SinglePosting,

--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -6,7 +6,9 @@ use thiserror::Error;
 
 /// Validation error codes.
 ///
-/// Error codes follow the spec in `spec/validation.md`.
+/// Error codes follow the spec in `spec/core/validation.md`. Every variant's
+/// [`ErrorCode::code`] is asserted to appear in that spec by
+/// `error_codes_documented_in_spec` (a drift guard).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ErrorCode {
     // === Account Errors (E1xxx) ===
@@ -37,6 +39,11 @@ pub enum ErrorCode {
     /// E3002: Multiple postings missing amounts for same currency.
     MultipleInterpolation,
     /// E3003: Transaction has no postings.
+    ///
+    /// Reserved for spec parity but **never emitted**: rledger skips validation
+    /// of a posting-less transaction rather than flagging it (matching Python
+    /// beancount, which treats it as a structurally-valid no-op). See the
+    /// early return in `validate_transaction` and the `no_postings` test.
     NoPostings,
     /// E3004: Transaction has single posting (warning).
     SinglePosting,
@@ -79,6 +86,39 @@ pub enum ErrorCode {
 }
 
 impl ErrorCode {
+    /// Every error-code variant. Used by the spec-drift guard test (and any
+    /// catalog enumeration). MUST list every variant — keep it in sync with the
+    /// enum; the exhaustive [`code`](Self::code) match is the compiler-enforced
+    /// source of truth for the code strings themselves.
+    pub const ALL: &'static [Self] = &[
+        Self::AccountNotOpen,
+        Self::AccountAlreadyOpen,
+        Self::AccountClosed,
+        Self::AccountCloseNotEmpty,
+        Self::InvalidAccountName,
+        Self::BalanceAssertionFailed,
+        Self::BalanceToleranceExceeded,
+        Self::PadWithoutBalance,
+        Self::MultiplePadForBalance,
+        Self::TransactionUnbalanced,
+        Self::MultipleInterpolation,
+        Self::NoPostings,
+        Self::SinglePosting,
+        Self::NoMatchingLot,
+        Self::InsufficientUnits,
+        Self::AmbiguousLotMatch,
+        Self::NegativeCost,
+        Self::UndeclaredCurrency,
+        Self::CurrencyNotAllowed,
+        Self::InvalidPrecisionMetadata,
+        Self::UnknownOption,
+        Self::InvalidOptionValue,
+        Self::DuplicateOption,
+        Self::DocumentNotFound,
+        Self::DateOutOfOrder,
+        Self::FutureDate,
+    ];
+
     /// Get the error code string (e.g., "E1001").
     #[must_use]
     pub const fn code(&self) -> &'static str {
@@ -295,6 +335,36 @@ impl ValidationError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn error_codes_documented_in_spec() {
+        // Drift guard: every `ErrorCode` must be documented in the validation
+        // spec. (The spec may also carry codes emitted by other crates — e.g.
+        // loader include errors E9001/E9002 — so this is a subset check, not
+        // strict equality.) Codes are backtick-wrapped in the spec (`**Code:**
+        // `E1001``), so the backtick delimiters keep `E1001` from matching
+        // inside `E10001`.
+        let spec = include_str!("../../../spec/core/validation.md");
+        let missing: Vec<&str> = ErrorCode::ALL
+            .iter()
+            .map(ErrorCode::code)
+            .filter(|code| !spec.contains(&format!("`{code}`")))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "error codes missing from spec/core/validation.md: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn all_lists_distinct_codes() {
+        // Cheap completeness/dup guard for `ALL`: every code string is unique.
+        let mut codes: Vec<&str> = ErrorCode::ALL.iter().map(ErrorCode::code).collect();
+        let n = codes.len();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), n, "duplicate code in ErrorCode::ALL");
+    }
 
     #[test]
     fn invalid_account_name_is_parse_phase() {

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! # Error Codes
 //!
-//! All error codes follow the spec in `spec/validation.md`:
+//! All error codes follow the spec in `spec/core/validation.md`:
 //!
 //! | Code | Description |
 //! |------|-------------|

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -270,10 +270,11 @@ pub fn value_to_cell(value: &rustledger_query::Value) -> CellValue {
             CellValue::Set(values.iter().map(|v| Box::new(value_to_cell(v))).collect())
         }
         Value::Metadata(meta) => {
-            // Convert metadata to a string representation
+            // Render values via `Display` (`foo`), matching the canonical CLI
+            // (`cmd/query/output.rs`), not `Debug` (which leaked `String("foo")`).
             let repr = meta
                 .iter()
-                .map(|(k, v)| format!("{k}: {v:?}"))
+                .map(|(k, v)| format!("{k}: {v}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             CellValue::String(repr)

--- a/crates/rustledger-wasm/src/convert.rs
+++ b/crates/rustledger-wasm/src/convert.rs
@@ -270,8 +270,9 @@ pub fn value_to_cell(value: &rustledger_query::Value) -> CellValue {
             CellValue::Set(values.iter().map(|v| Box::new(value_to_cell(v))).collect())
         }
         Value::Metadata(meta) => {
-            // Render values via `Display` (`foo`), matching the canonical CLI
-            // (`cmd/query/output.rs`), not `Debug` (which leaked `String("foo")`).
+            // Render values via `Display`, matching the canonical CLI
+            // (`cmd/query/output.rs`), not `Debug` (which leaked the Rust
+            // wrapper, e.g. `String("foo")`).
             let repr = meta
                 .iter()
                 .map(|(k, v)| format!("{k}: {v}"))

--- a/spec/core/validation.md
+++ b/spec/core/validation.md
@@ -256,6 +256,16 @@ This document catalogs all validation errors and warnings with their trigger con
   Assets:Cash
 ```
 
+### BOOKING_NEGATIVE_COST
+
+**Code:** `E4005`
+
+**Condition:** A posting's cost amount is negative (a cost must be non-negative).
+
+**Message:** `Cost is negative: {label} cost ({value} {cost_currency}) for {units} in posting to {account}`
+
+**Severity:** Error
+
 ## Currency Errors
 
 ### CURRENCY_NOT_DECLARED
@@ -285,6 +295,16 @@ This document catalogs all validation errors and warnings with their trigger con
   Assets:USDOnly   100 EUR  ; ERROR: Only USD allowed
   Income:Salary
 ```
+
+### COMMODITY_INVALID_PRECISION_META
+
+**Code:** `E5003`
+
+**Condition:** A `commodity` directive carries a `precision` metadata value that does not parse as a non-negative integer. The declaration is ignored (display precision falls back to `option "display_precision"`, otherwise to inference).
+
+**Message:** `invalid `precision` metadata on commodity {currency}: {reason}; this declaration is ignored — display precision falls back to `option "display_precision"` if set, otherwise to inference`
+
+**Severity:** Warning
 
 ## Option Errors
 

--- a/spec/core/validation.md
+++ b/spec/core/validation.md
@@ -302,7 +302,7 @@ This document catalogs all validation errors and warnings with their trigger con
 
 **Condition:** A `commodity` directive carries a `precision` metadata value that does not parse as a non-negative integer. The declaration is ignored (display precision falls back to `option "display_precision"`, otherwise to inference).
 
-**Message:** `invalid `precision` metadata on commodity {currency}: {reason}; this declaration is ignored — display precision falls back to `option "display_precision"` if set, otherwise to inference`
+**Message:** `invalid precision metadata on commodity {currency}: {reason}; this declaration is ignored — display precision falls back to option "display_precision" if set, otherwise to inference`
 
 **Severity:** Warning
 


### PR DESCRIPTION
## What

Architecture-roadmap [S/3] — **reconcile the validate error-code catalog with the spec, and stop the query bindings leaking `Debug` for `Value::Metadata`.** Three small, independent surface-accuracy fixes.

### (a) Catalog ↔ spec drift + a guard test
- The `ErrorCode` enum had **E4005** (negative cost) and **E5003** (invalid `precision` metadata) that were **missing from `spec/core/validation.md`** — added both sections (condition / message / severity, matching the emitted messages). (`E9001`/`E9002` in the spec are *loader* include-errors, correctly not in the validate enum.)
- The in-code doc path was the stale **`spec/validation.md`** (actual file: `spec/core/validation.md`) — fixed in `error.rs` + `lib.rs`.
- Added `ErrorCode::ALL` (the full variant catalog) + a **drift-guard test** `error_codes_documented_in_spec` (`include_str!`s the spec and asserts every code is documented — a subset check, since the spec also carries other crates' codes) so this can't silently drift again. Plus `all_lists_distinct_codes`.

### (b) E3003 documented as reserved-but-unreachable
`NoPostings` (E3003) is defined and counted but **never emitted** — rledger skips validation of a posting-less transaction (matching Python beancount), as a test already asserts. Documented that on the variant so it reads as intentional, not a gap.

### (c) `Value::Metadata` rendering: `Debug` → `Display`
The three bindings (`ffi-wasi`, `ffi-component`, `wasm`) rendered metadata values with `{v:?}` — leaking Rust `Debug` (`key: String("foo")`) — while the canonical CLI uses `{v}` (`key: foo`). Switched all three to `Display`, matching the CLI. (A user-visible output fix for embedders; codes/structure unchanged.)

## Tests

The new drift-guard test passes (proving the spec now contains every enum code); full `rustledger-validate` suite green; `wasm` / `ffi-wasi` / `ffi-component` build clean; clippy `-D warnings` + fmt clean.

## Scope

This is the validate-catalog item. The related, larger **L/7 canonical `MetaValue`↔wire codec** (collapsing the 4 independent wire types) remains a separate follow-up — (c) here only fixes the *rendering* (Display), not the type duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
