### PR TITLE
refactor(parser): deny unwrap/expect on the parser never-panic surface (L/4)

### DIFF
--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -485,7 +485,11 @@ impl SourceFile {
     #[must_use]
     pub fn parse(source: &str) -> Self {
         let node = crate::cst::parser::parse_structured(source);
-        Self::cast(node).expect("parse_structured always returns a SOURCE_FILE")
+        // `parse_structured` always produces a SOURCE_FILE root, so this cast is
+        // infallible — a parser invariant, not an input-driven path.
+        #[allow(clippy::expect_used)]
+        let source_file = Self::cast(node).expect("parse_structured always returns a SOURCE_FILE");
+        source_file
     }
 
     /// All recognized directives, in source order.

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -715,19 +715,16 @@ fn convert_transaction(
     // narration-only; with 3+ -> ambiguous (typed-AST surface
     // returns None for both, matching the round-2 review fix).
     let strings: Vec<String> = node.strings().filter_map(|s| s.text_decoded()).collect();
-    let (payee_str, narration_str) = match strings.len() {
-        0 => (None, String::new()),
-        1 => (None, strings.into_iter().next().unwrap()),
-        2 => {
-            let mut it = strings.into_iter();
-            let p = it.next().unwrap();
-            let n = it.next().unwrap();
-            (Some(p), n)
-        }
-        // 3+ strings: surface only the last as narration; the
-        // middle ones are unreachable through this typed shape
-        // (matches the round-2 docstring).
-        _ => (None, strings.last().cloned().unwrap_or_default()),
+    // Consume via the iterator (no count-then-unwrap): 0 -> empty narration;
+    // 1 -> narration only; 2 -> payee + narration; 3+ -> surface only the last
+    // as narration (middles unreachable through this typed shape).
+    let last = strings.last().cloned().unwrap_or_default();
+    let mut it = strings.into_iter();
+    let (payee_str, narration_str) = match (it.next(), it.next(), it.next()) {
+        (None, _, _) => (None, String::new()),
+        (Some(n), None, _) => (None, n),
+        (Some(p), Some(n), None) => (Some(p), n),
+        (Some(_), Some(_), Some(_)) => (None, last),
     };
 
     let payee = payee_str.map(InternedStr::from);

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -718,13 +718,14 @@ fn convert_transaction(
     // Consume via the iterator (no count-then-unwrap): 0 -> empty narration;
     // 1 -> narration only; 2 -> payee + narration; 3+ -> surface only the last
     // as narration (middles unreachable through this typed shape).
-    let last = strings.last().cloned().unwrap_or_default();
     let mut it = strings.into_iter();
     let (payee_str, narration_str) = match (it.next(), it.next(), it.next()) {
         (None, _, _) => (None, String::new()),
         (Some(n), None, _) => (None, n),
         (Some(p), Some(n), None) => (Some(p), n),
-        (Some(_), Some(_), Some(_)) => (None, last),
+        // 3+: `c` is the 3rd string; if more follow, `it.last()` is the actual
+        // last (else it falls back to `c`). No clone in the common 0/1/2 cases.
+        (Some(_), Some(_), Some(c)) => (None, it.last().unwrap_or(c)),
     };
 
     let payee = payee_str.map(InternedStr::from);
@@ -2908,6 +2909,21 @@ mod tests {
         assert_eq!(t.flag, '!');
         assert!(t.payee.is_none());
         assert_eq!(t.narration.as_str(), "Pending");
+    }
+
+    #[test]
+    fn transaction_three_plus_header_strings_surface_last_as_narration() {
+        // A header with 3+ strings is ambiguous (the grammar caps payee+narration
+        // at two); the lossless CST still keeps all of them, so the typed surface
+        // drops the payee and surfaces only the LAST string as narration. Locks
+        // the `(Some, Some, Some(c)) => it.last().unwrap_or(c)` arm.
+        let src = "2024-01-15 * \"a\" \"b\" \"c\"\n  Assets:Cash  -5 USD\n";
+        let result = parse_via_cst(src);
+        let Directive::Transaction(t) = &result.directives[0].value else {
+            panic!("expected Transaction");
+        };
+        assert!(t.payee.is_none(), "3+ strings drop the payee");
+        assert_eq!(t.narration.as_str(), "c", "last string becomes narration");
     }
 
     #[test]

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -711,14 +711,11 @@ fn convert_transaction(
     // with no flag token; defaults to '*').
     let flag = node.flag().map_or('*', |f| flag_char_from_transaction(&f));
 
-    // Header strings: with 2 -> payee + narration; with 1 ->
-    // narration-only; with 3+ -> ambiguous (typed-AST surface
-    // returns None for both, matching the round-2 review fix).
-    let strings: Vec<String> = node.strings().filter_map(|s| s.text_decoded()).collect();
-    // Consume via the iterator (no count-then-unwrap): 0 -> empty narration;
-    // 1 -> narration only; 2 -> payee + narration; 3+ -> surface only the last
-    // as narration (middles unreachable through this typed shape).
-    let mut it = strings.into_iter();
+    // Header strings, consumed straight off the iterator (no intermediate Vec,
+    // no count-then-unwrap): 0 -> empty narration; 1 -> narration only;
+    // 2 -> payee + narration; 3+ -> surface only the last as narration (the
+    // middles are unreachable through this typed shape).
+    let mut it = node.strings().filter_map(|s| s.text_decoded());
     let (payee_str, narration_str) = match (it.next(), it.next(), it.next()) {
         (None, _, _) => (None, String::new()),
         (Some(n), None, _) => (None, n),

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -812,10 +812,9 @@ pub fn format_node_with_alignment(node: &crate::SyntaxNode, alignment: PostingAl
 /// `format_node_range_full_range_matches_format_node` in this
 /// file's test module.
 ///
-/// # Panics
-///
-/// Panics if `node`'s kind is not `SOURCE_FILE` — same precondition
-/// as [`format_node`].
+/// Returns `None` if `node`'s kind is not `SOURCE_FILE` (the precondition is
+/// still that callers pass the parse root) or if `range` intersects no top-level
+/// child.
 #[must_use]
 pub fn format_node_range(
     node: &crate::SyntaxNode,

--- a/crates/rustledger-parser/src/cst/format.rs
+++ b/crates/rustledger-parser/src/cst/format.rs
@@ -622,6 +622,9 @@ const fn advance_source_state(
 /// tests.
 #[must_use]
 pub fn format_node(node: &crate::SyntaxNode) -> String {
+    // Precondition: `node` is the SOURCE_FILE parse root (the only thing callers
+    // pass); a wrong node is a caller bug, not input-driven.
+    #[allow(clippy::expect_used)]
     let source_file =
         SourceFile::cast(node.clone()).expect("format_node called on non-SOURCE_FILE node");
     let alignment = compute_alignment(&source_file);
@@ -818,8 +821,9 @@ pub fn format_node_range(
     node: &crate::SyntaxNode,
     range: rowan::TextRange,
 ) -> Option<(rowan::TextRange, String)> {
-    let source_file =
-        SourceFile::cast(node.clone()).expect("format_node_range called on non-SOURCE_FILE node");
+    // This returns `Option`, so a non-SOURCE_FILE node is a clean `None` rather
+    // than a panic (the precondition is still that callers pass the parse root).
+    let source_file = SourceFile::cast(node.clone())?;
     // File-wide alignment pre-pass: see rustdoc above for the
     // rationale. The selected subset always uses the full file's
     // alignment columns. Hot paths with a precomputed `PostingAlignment`
@@ -904,7 +908,12 @@ pub fn format_node_range_with_alignment(
     if !any_included {
         return None;
     }
-    let snap = rowan::TextRange::new(snap_start.unwrap(), snap_end.unwrap());
+    // `any_included` guarantees both bounds were set in the loop above; bail
+    // (return `None`) rather than `unwrap` if somehow not.
+    let (Some(snap_start), Some(snap_end)) = (snap_start, snap_end) else {
+        return None;
+    };
+    let snap = rowan::TextRange::new(snap_start, snap_end);
 
     // ERROR_NODE intersection bail: if the snap range covers any
     // top-level ERROR_NODE byte, refuse to format and return None.

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -31,6 +31,13 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+// Never-panic surface: the parser must handle malformed input gracefully (no
+// panics — see CLAUDE.md), so production code must not `unwrap`/`expect`.
+// `not(test)` scopes the deny to non-test builds, exempting this crate's own
+// `#[cfg(test)]` code (it compiles with `cfg(test)`); integration tests under
+// `tests/` are separate crates. Proven-safe production sites (parser invariants
+// like "the root is always SOURCE_FILE") carry an audited `#[allow]` with reason.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod bom;
 pub mod cst;


### PR DESCRIPTION
## What

Architecture-roadmap [L/4] (deny-panic — parser slice) — **enable `clippy::unwrap_used` + `clippy::expect_used` as `deny` on `rustledger-parser`**, the most security-critical never-panic surface (CLAUDE.md: *"Parser: must handle malformed input gracefully (no panics)"*). Continues #1572 (wasm + loader) with the same `cfg_attr(not(test))` mechanism.

## Change

- `#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]` on the parser crate root.
- Audited every production site clippy flagged:
  - **Fixed (input-reachable)** — the transaction header-string match (`convert.rs`) no longer counts-then-`unwrap()`s; it consumes via `it.next()` (slice of `Option`s), preserving the exact 0/1/2/3+ behavior with no panic. The range-snapshot `unwrap`s (`format.rs`) became a `let-else` that returns `None`. `format_node_range` (which already returns `Option`) now `?`s the cast instead of `expect`ing.
  - **Audited `#[allow]` (proven-safe invariants)** — `SourceFile::parse` (the `parse_structured` root is *always* `SOURCE_FILE`) and `format_node`'s `SOURCE_FILE` precondition (a wrong node is a caller bug, not input-driven). Each carries a justification comment.

## Verification

Clippy `-D warnings` clean on **both** the default and `--all-features --all-targets` configs (all-features surfaces feature-gated/test sites — none remained after the `cfg_attr(not(test))` scoping). `rustledger-parser` test suite passes (the header-string rewrite preserves behavior); fmt clean.

## Scope

This extends deny-panic to the parser (after wasm + loader in #1572). `clippy::indexing_slicing` (the noisy one, many audited `#[allow]`s) and the CI `cargo bench` job remain as the documented L/4 leftovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
