### PR TITLE
refactor(query): route BALANCES through scan_postings; fix ignored FROM window (XL/8 tail)

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -405,7 +405,7 @@ impl<'a> Executor<'a> {
         // — `BALANCES` applies its own `WHERE` to the result afterward, and
         // `account_balances` is WHERE-independent by construction anyway.
         Ok(self
-            .scan_postings(from, None, false, true, false)?
+            .scan_postings(from, None, false, true, false, false)?
             .account_balances)
     }
 
@@ -450,6 +450,7 @@ impl<'a> Executor<'a> {
                 needs_balance,
                 needs_account_balance,
                 where_reads_balance,
+                true,
             )?
             .postings)
     }
@@ -464,6 +465,15 @@ impl<'a> Executor<'a> {
     /// yields one [`PostingContext`] per surviving posting. The `needs_*` flags
     /// gate the per-posting Inventory clones (issue #1080); pass them all `true`
     /// with no filter to materialize the full unfiltered table.
+    ///
+    /// `collect_contexts` controls whether the per-posting [`PostingContext`]
+    /// stream is built at all. Callers that only consume `account_balances` (the
+    /// `BALANCES` command) pass `false` to skip materializing — and immediately
+    /// discarding — a context per posting; the returned `postings` is then empty.
+    // Four independent, individually-documented scan toggles on one internal hot
+    // path; a flags struct would add per-call construction churn here without
+    // changing the boolean nature of the configuration.
+    #[allow(clippy::fn_params_excessive_bools)]
     fn scan_postings(
         &self,
         from: Option<&FromClause>,
@@ -471,6 +481,7 @@ impl<'a> Executor<'a> {
         needs_balance: bool,
         needs_account_balance: bool,
         where_reads_balance: bool,
+        collect_contexts: bool,
     ) -> Result<PostingScan<'a>, QueryError> {
         let mut postings = Vec::new();
         // Per-account running balance — accumulates every posting the FROM clause
@@ -551,6 +562,16 @@ impl<'a> Executor<'a> {
                     if needs_account_balance && let Some(pos) = resolved.clone() {
                         let bal = account_balances.entry(posting.account.clone()).or_default();
                         bal.add(pos);
+                    }
+
+                    // Callers that only want the per-account totals (BALANCES, via
+                    // `build_balances_with_filter`) pass `collect_contexts = false`:
+                    // `account_balances` is already updated above, so skip building
+                    // and pushing a `PostingContext` (and its per-posting Inventory
+                    // clone) for every posting — a large-ledger CPU/memory win that
+                    // avoids materializing a stream BALANCES would just discard.
+                    if !collect_contexts {
+                        continue;
                     }
 
                     // Build the context with both balance views. The cumulative

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -121,6 +121,16 @@ mod window;
 pub const WILDCARD_COLUMNS: &[&str] =
     &["date", "flag", "payee", "narration", "account", "position"];
 
+/// Result of [`Executor::scan_postings`]: the per-posting contexts plus the
+/// final per-account running balances. `account_balances` is only meaningful
+/// when the scan was asked for it (`needs_account_balance`); it honors the same
+/// `FROM` window (`open_on`/`close_on`) as the rest of the scan, so consumers
+/// like `BALANCES` get the windowed per-account totals for free.
+pub(crate) struct PostingScan<'a> {
+    pub(crate) postings: Vec<PostingContext<'a>>,
+    pub(crate) account_balances: FxHashMap<rustledger_core::Account, Inventory>,
+}
+
 impl<'a> Executor<'a> {
     /// Create a new executor with the given directives.
     pub fn new(directives: &'a [Directive]) -> Self {
@@ -384,32 +394,19 @@ impl<'a> Executor<'a> {
         &self,
         from: Option<&FromClause>,
     ) -> Result<FxHashMap<rustledger_core::Account, Inventory>, QueryError> {
-        let mut balances: FxHashMap<rustledger_core::Account, Inventory> = FxHashMap::default();
-
-        // Iterate over whichever directive source is populated (see
-        // `resolved_directives`).
-        for directive in self.resolved_directives() {
-            if let Directive::Transaction(txn) = directive {
-                // Apply FROM filter if present
-                if let Some(from_clause) = from
-                    && let Some(filter) = &from_clause.filter
-                    && !self.evaluate_from_filter(filter, txn)?
-                {
-                    continue;
-                }
-
-                for posting in &txn.postings {
-                    if let Some(units) = posting.amount() {
-                        let balance = balances.entry(posting.account.clone()).or_default();
-
-                        let pos = Position::from_posting(units, posting.cost.as_ref(), txn.date);
-                        balance.add(pos);
-                    }
-                }
-            }
-        }
-
-        Ok(balances)
+        // Delegate to the shared posting scan so BALANCES uses the SAME cost
+        // resolution AND the SAME `FROM` window (`open_on` / `close_on`) as the
+        // default SELECT path. `scan_postings`' per-account `account_balances`
+        // (requested via `needs_account_balance = true`) is exactly the windowed
+        // per-account total BALANCES wants. Previously this re-iterated postings
+        // and applied only `from.filter`, silently ignoring `OPEN ON`/`CLOSE ON`.
+        //
+        // `needs_balance = false` (no cumulative needed); `where_clause = None`
+        // — `BALANCES` applies its own `WHERE` to the result afterward, and
+        // `account_balances` is WHERE-independent by construction anyway.
+        Ok(self
+            .scan_postings(from, None, false, true, false)?
+            .account_balances)
     }
 
     /// Collect postings matching the FROM and WHERE clauses.
@@ -446,13 +443,15 @@ impl<'a> Executor<'a> {
         let where_reads_balance =
             where_clause.is_some_and(|w| expr_references_column(w, "balance"));
 
-        self.scan_postings(
-            from,
-            where_clause,
-            needs_balance,
-            needs_account_balance,
-            where_reads_balance,
-        )
+        Ok(self
+            .scan_postings(
+                from,
+                where_clause,
+                needs_balance,
+                needs_account_balance,
+                where_reads_balance,
+            )?
+            .postings)
     }
 
     /// The single posting-source scan, shared by the default `SELECT` path
@@ -472,7 +471,7 @@ impl<'a> Executor<'a> {
         needs_balance: bool,
         needs_account_balance: bool,
         where_reads_balance: bool,
-    ) -> Result<Vec<PostingContext<'a>>, QueryError> {
+    ) -> Result<PostingScan<'a>, QueryError> {
         let mut postings = Vec::new();
         // Per-account running balance — accumulates every posting the FROM clause
         // keeps (plus the pre-`open_on` carry-in below), independent of the WHERE
@@ -617,7 +616,10 @@ impl<'a> Executor<'a> {
             }
         }
 
-        Ok(postings)
+        Ok(PostingScan {
+            postings,
+            account_balances,
+        })
     }
     fn evaluate_function(
         &self,

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -595,7 +595,7 @@ impl Executor<'_> {
         // there are no predicates to evaluate, so the scan is infallible here —
         // assert that invariant rather than silently emitting an empty table.
         let contexts = self
-            .scan_postings(None, None, true, true, false)
+            .scan_postings(None, None, true, true, false, true)
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")
             .postings;
 

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -596,7 +596,8 @@ impl Executor<'_> {
         // assert that invariant rather than silently emitting an empty table.
         let contexts = self
             .scan_postings(None, None, true, true, false)
-            .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail");
+            .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")
+            .postings;
 
         for ctx in contexts {
             let txn = ctx.transaction;

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -1543,6 +1543,27 @@ fn test_close_on_first_txn_date_yields_empty() {
 }
 
 #[test]
+fn test_balances_honors_close_on_window() {
+    // Regression: `BALANCES FROM CLOSE ON D` must honor the FROM date window like
+    // the SELECT path (and bean-query). `build_balances_with_filter` previously
+    // applied only `from.filter`, silently ignoring `open_on`/`close_on` — so a
+    // windowed BALANCES summed every posting regardless of the close date. Now it
+    // routes through `scan_postings`, which excludes post-`close_on` txns. With
+    // CLOSE ON the earliest txn date, every txn is excluded → no balances.
+    let directives = make_test_directives();
+    let windowed = execute_query("BALANCES FROM CLOSE ON 2024-01-15", &directives);
+    assert!(
+        windowed.is_empty(),
+        "BALANCES FROM CLOSE ON the earliest txn date must exclude all txns; got {} rows",
+        windowed.len()
+    );
+    // Sanity: the same query without the window has balances, so the empty
+    // result above is the window doing its job (not an empty ledger).
+    let full = execute_query("BALANCES", &directives);
+    assert!(!full.is_empty(), "unfiltered BALANCES should have balances");
+}
+
+#[test]
 fn test_execute_balances_with_where() {
     let directives = make_test_directives();
     let query = parse("BALANCES WHERE account ~ 'Assets:'").expect("should parse");

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -1564,6 +1564,48 @@ fn test_balances_honors_close_on_window() {
 }
 
 #[test]
+fn test_balances_close_on_partial_window() {
+    // Partial window: CLOSE ON 2024-01-22 (exclusive) keeps only txns strictly
+    // before it (2024-01-15 salary, 2024-01-20 groceries). Accounts touched ONLY
+    // on/after the boundary must be absent; accounts touched before must remain.
+    let directives = make_test_directives();
+    let result = execute_query("BALANCES FROM CLOSE ON 2024-01-22", &directives);
+    let accounts: Vec<&str> = result
+        .rows
+        .iter()
+        .filter_map(|r| match &r[0] {
+            Value::String(a) => Some(a.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        accounts.contains(&"Expenses:Food") && accounts.contains(&"Income:Salary"),
+        "pre-boundary accounts must remain; got {accounts:?}"
+    );
+    // `Expenses:Transport` is touched only on the 2024-01-22 boundary (excluded by
+    // the exclusive close); `Assets:Bank:Savings` only after — both must be absent.
+    assert!(
+        !accounts.contains(&"Expenses:Transport") && !accounts.contains(&"Assets:Bank:Savings"),
+        "on/after-boundary-only accounts must be excluded; got {accounts:?}"
+    );
+}
+
+#[test]
+fn test_balances_open_on_is_noop_for_totals() {
+    // OPEN ON folds pre-date postings into the running balance as carry-in, so an
+    // account TOTAL is unchanged by where OPEN ON falls (matches bean-query). The
+    // result must be identical to unfiltered BALANCES.
+    let directives = make_test_directives();
+    let full = execute_query("BALANCES", &directives);
+    let windowed = execute_query("BALANCES FROM OPEN ON 2024-01-22", &directives);
+    assert_eq!(
+        format!("{:?}", full.rows),
+        format!("{:?}", windowed.rows),
+        "OPEN ON must not change BALANCES totals (carry-in keeps pre-date postings)"
+    );
+}
+
+#[test]
 fn test_execute_balances_with_where() {
     let directives = make_test_directives();
     let query = parse("BALANCES WHERE account ~ 'Assets:'").expect("should parse");


### PR DESCRIPTION
## What

Architecture-roadmap [XL/8 tail] — **route `build_balances_with_filter` (the BALANCES command) through the shared `scan_postings` stream**, finishing the posting-iteration unification (the other consumers — default SELECT, `#postings`, aggregation — already share `scan_postings`). **This also fixes a latent bug.**

## The bug it fixes

`BalancesQuery.from` is a full `FromClause` (the parser accepts `BALANCES FROM ... OPEN ON d CLOSE ON d` — there's a parse test), but `build_balances_with_filter` applied **only** `from.filter`, silently **ignoring `open_on`/`close_on`**. So `BALANCES FROM CLOSE ON 2024-01-22` summed *every* posting regardless of the close date — diverging from the SELECT path (and bean-query), which window correctly.

(`OPEN ON` is a no-op for BALANCES *totals* — its pre-date carry-in keeps those postings in the sum — so the visible bug is the `CLOSE ON` / window-upper-bound side.)

## Change

- `scan_postings` now returns a small `PostingScan { postings, account_balances }` (it already maintained `account_balances` internally for the `account_balance` column; this just exposes it). The two existing callers take `.postings`.
- `build_balances_with_filter` becomes a one-liner: `scan_postings(from, None, /*needs_balance*/ false, /*needs_account_balance*/ true, false)?.account_balances`. That map is the **windowed, FROM-filtered, WHERE-independent** per-account total — exactly what BALANCES wants — and it shares the single `Position::from_posting` cost resolution.

## Behavior

For the common case (no `OPEN/CLOSE ON`), the result is **identical** (both sum FROM-filtered postings per account — the full existing BALANCES suite passes unchanged). The only change is the **fix**: `BALANCES FROM CLOSE ON d` now honors the window, consistent with `SELECT ... FROM CLOSE ON d`. New regression test `test_balances_honors_close_on_window` pins it.

## Verification

New regression test passes (proving the window is applied); full `rustledger-query` suite green (no SELECT/`#postings`/BALANCES regression); clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
