### PR TITLE
ci: compile criterion benches so they do not bitrot (L/4)

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -143,8 +143,10 @@ jobs:
 
           echo "rustledger: ${rustledger_mb}MB"
           echo "beancount:  ${beancount_mb}MB"
-      # Note: Criterion benchmarks removed - they're tracked in ci.yml on main branch pushes
-      # and weren't being reported in the PR comment anyway
+      # Note: Criterion benchmarks aren't run here (timings are noisy on shared
+      # runners and weren't reported in the PR comment anyway). They are compiled
+      # — but not run — by the `Benchmarks Compile` job in ci.yml, which guards
+      # against the criterion bench targets bitrotting.
       - name: Fetch baseline from main branch
         id: baseline
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,26 @@ jobs:
             issue=$(basename "$f" .beancount | sed 's/issue-//')
             echo "- [#$issue](https://github.com/rustledger/rustledger/issues/$issue)" >> $GITHUB_STEP_SUMMARY
           done
+  # Criterion benches must keep COMPILING so they don't bitrot. Nothing else
+  # builds them: `bench-pr.yml` runs a separate custom timing benchmark, and
+  # ci.yml never referenced the criterion targets despite a stale comment in
+  # `bench-pr.yml` claiming it did. We compile only (`--no-run`) — running the
+  # benches on shared CI runners is timing-noisy and adds no gating value; the
+  # real risk this guards is a source change silently breaking a bench build.
+  bench-build:
+    name: Benchmarks Compile
+    needs: [changes]
+    if: needs.changes.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - name: Compile all criterion benches (--no-run)
+        run: cargo bench --workspace --no-run
   # Slim-build ratchet (#1427/#867): `cargo install rustledger
   # --no-default-features` must stay wasmtime/cranelift-free so the minimal
   # native binary builds on platforms where cranelift can't (e.g. Termux). Two
@@ -420,7 +440,7 @@ jobs:
     name: build
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bindings-fresh, component-parity, wit-version-gate]
+    needs: [changes, fmt, unsafe-invariant, sync-primitives, hot-path-collections, plugin-test-quality, ci, doctest, regressions, bench-build, bindings-fresh, component-parity, wit-version-gate]
     steps:
       - name: Check results
         run: |
@@ -452,7 +472,7 @@ jobs:
           # part of the gate (ADR-0004 Phase 3 / #1232): wire-format
           # drift in the generated TS / JSON Schema / Python artifacts
           # blocks merge just like any other failure.
-          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.hot-path-collections.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bindings-fresh.result }} ${{ needs.component-parity.result }}"
+          results="${{ needs.fmt.result }} ${{ needs.unsafe-invariant.result }} ${{ needs.sync-primitives.result }} ${{ needs.hot-path-collections.result }} ${{ needs.ci.result }} ${{ needs.doctest.result }} ${{ needs.regressions.result }} ${{ needs.bench-build.result }} ${{ needs.bindings-fresh.result }} ${{ needs.component-parity.result }}"
           echo "Job results: $results"
 
           if echo "$results" | grep -qE '(failure|cancelled)'; then


### PR DESCRIPTION
## What

Architecture-roadmap **[L/4 leftover — `cargo bench` CI]**: the workspace has 6 criterion bench targets (`parser_bench`, `query_bench`, `validate_bench`, `inventory_bench`, `pipeline_bench`, `v016_baseline`) that **compile nowhere in CI** — so a source change can silently break a bench build and no one notices until someone runs `cargo bench` locally.

A stale comment in `bench-pr.yml` even claimed *"Criterion benchmarks removed - they're tracked in ci.yml on main branch pushes"* — but `ci.yml` has **zero** bench references. They were bitrot-exposed.

## Change

- **New `Benchmarks Compile` job in `ci.yml`** — runs `cargo bench --workspace --no-run`, gated on `should_build` like the other code jobs. **Compile-only**: actually *running* criterion benches on shared CI runners is timing-noisy and adds no gating value; the real risk this guards is a bench that stops *building*.
- Wired into the **`build` gate** (`needs:` + the results check) so a broken bench build blocks merge, consistent with `doctest`/`regressions`.
- **Corrected the stale `bench-pr.yml` comment** to describe the new reality (criterion benches are compiled — not run — by the new job).

## Verification

`cargo bench --workspace --no-run` builds all six bench executables clean (0 errors) locally; both workflow YAMLs parse valid. No source changes — CI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
