### PR TITLE
refactor(booking): route apply onto the shared Position::from_posting (L/7)

### DIFF
--- a/crates/rustledger-booking/fuzz/Cargo.lock
+++ b/crates/rustledger-booking/fuzz/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +55,9 @@ dependencies = [
 
 [[package]]
 name = "bitmaps"
-version = "2.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -142,6 +145,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -241,18 +250,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "im"
-version = "15.1.0"
+name = "imbl"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
 dependencies = [
  "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -542,7 +561,7 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -552,7 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -565,12 +584,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
+name = "rand_core"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -685,7 +710,7 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustledger-booking"
-version = "0.14.1"
+version = "0.16.5"
 dependencies = [
  "bigdecimal",
  "rust_decimal",
@@ -708,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.14.1"
+version = "0.16.5"
 dependencies = [
- "im",
+ "imbl",
  "jiff",
  "rkyv 0.8.16",
  "rust_decimal",
@@ -726,6 +751,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "seahash"
@@ -787,16 +821,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "smallvec"
@@ -898,12 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1002,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -494,12 +494,14 @@ impl BookingEngine {
                     // Add to inventory via the canonical cost-resolve shared with
                     // the Late validator, `build_balances`, and the query engine.
                     // Its per-unit / date / label handling matches the block this
-                    // replaced (see `CostSpec::resolve`); the old inline price /
-                    // cross-posting cost-currency inference was dead code here
-                    // because `apply` only ever runs on *booked* transactions
-                    // (every caller `book_and_interpolate`s first — see the
-                    // `debug_assert` above), so booking has already filled
-                    // `cost_spec.currency`.
+                    // replaced (see `CostSpec::resolve`). The old inline price /
+                    // cross-posting cost-currency inference is unnecessary here:
+                    // `apply` is contracted to run on *booked* transactions (the
+                    // `debug_assert` above; the production pipeline always
+                    // `book_and_interpolate`s first), and booking fills the
+                    // inferred currency into `cost_spec.currency`. Tests that call
+                    // `apply` directly use explicit-currency fixtures, which need
+                    // no inference.
                     inv.add(Position::from_posting(
                         units,
                         posting.cost.as_ref(),
@@ -835,8 +837,9 @@ mod tests {
         // SELLOPT: -1 AAPL {40.0} @ 0.4 USD — the cost has a number (40.0) but no
         // cost currency. Booking infers it from the price annotation and fills it
         // *into* the cost spec, so by the time `apply` runs the currency is already
-        // resolved. `apply` is always called on booked transactions (see its doc),
-        // so this exercises the real pipeline rather than apply's standalone path.
+        // resolved. The production pipeline books before applying, so this drives
+        // that real `book_and_interpolate` → `apply` path rather than calling
+        // `apply` standalone.
         let sell = Transaction::new(date(2022, 6, 17), "SELLOPT")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-1), "AAPL"))

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -491,50 +491,20 @@ impl BookingEngine {
                     // release builds keep the historical ignore-the-Result behavior.
                     let _ = reduced;
                 } else {
-                    // Add to inventory
-                    let position = if let Some(cost_spec) = &posting.cost {
-                        // Resolve per-unit cost: PerUnit/PerUnitFromTotal
-                        // carry it directly; Total needs the
-                        // total/|units| division.
-                        let per_unit_cost = match cost_spec.number {
-                            Some(rustledger_core::CostNumber::PerUnit { value: per }) => Some(per),
-                            Some(rustledger_core::CostNumber::PerUnitFromTotal(b)) => {
-                                Some(b.per_unit)
-                            }
-                            Some(rustledger_core::CostNumber::Total { value: total })
-                                if !units.number.is_zero() =>
-                            {
-                                Some(total / units.number.abs())
-                            }
-                            Some(rustledger_core::CostNumber::Total { value: _ }) | None => None,
-                        };
-
-                        // Infer cost currency from price annotation or other postings.
-                        // `kind` doesn't affect the currency — see the parallel
-                        // block above for the same pattern.
-                        let cost_currency = cost_spec.currency.clone().or_else(|| {
-                            posting
-                                .price
-                                .as_ref()
-                                .and_then(|p| p.amount.as_ref())
-                                .and_then(|inc| inc.currency().map(Into::into))
-                                .or_else(|| crate::infer_cost_currency_from_postings(txn))
-                        });
-
-                        if let (Some(per_unit), Some(currency)) = (per_unit_cost, cost_currency) {
-                            Position::with_cost(
-                                units.clone(),
-                                Cost::new(per_unit, currency)
-                                    .with_date_opt(cost_spec.date.or(Some(txn.date)))
-                                    .with_label_opt(cost_spec.label.clone()),
-                            )
-                        } else {
-                            Position::simple(units.clone())
-                        }
-                    } else {
-                        Position::simple(units.clone())
-                    };
-                    inv.add(position);
+                    // Add to inventory via the canonical cost-resolve shared with
+                    // the Late validator, `build_balances`, and the query engine.
+                    // Its per-unit / date / label handling matches the block this
+                    // replaced (see `CostSpec::resolve`); the old inline price /
+                    // cross-posting cost-currency inference was dead code here
+                    // because `apply` only ever runs on *booked* transactions
+                    // (every caller `book_and_interpolate`s first — see the
+                    // `debug_assert` above), so booking has already filled
+                    // `cost_spec.currency`.
+                    inv.add(Position::from_posting(
+                        units,
+                        posting.cost.as_ref(),
+                        txn.date,
+                    ));
                 }
             }
         }
@@ -862,8 +832,11 @@ mod tests {
     fn test_cost_spec_currency_inference() {
         let mut engine = BookingEngine::new();
 
-        // Create SELLOPT: -1 AAPL {40.0} @ 0.4 USD
-        // This has cost number (40.0) but NO cost currency - should infer from price
+        // SELLOPT: -1 AAPL {40.0} @ 0.4 USD — the cost has a number (40.0) but no
+        // cost currency. Booking infers it from the price annotation and fills it
+        // *into* the cost spec, so by the time `apply` runs the currency is already
+        // resolved. `apply` is always called on booked transactions (see its doc),
+        // so this exercises the real pipeline rather than apply's standalone path.
         let sell = Transaction::new(date(2022, 6, 17), "SELLOPT")
             .with_synthesized_posting(
                 Posting::new("Assets:Stock", Amount::new(dec!(-1), "AAPL"))
@@ -876,21 +849,18 @@ mod tests {
             )
             .with_synthesized_posting(Posting::new("Assets:Stock", Amount::new(dec!(40.0), "USD")));
 
-        eprintln!("SELLOPT posting.cost = {:?}", sell.postings[0].cost);
-        eprintln!("SELLOPT posting.price = {:?}", sell.postings[0].price);
-
-        engine.apply(&sell);
+        let booked = engine
+            .book_and_interpolate(&sell)
+            .expect("booking should succeed");
+        engine.apply(&booked.transaction);
 
         let inv = engine.inventory(&"Assets:Stock".into()).unwrap();
-        eprintln!("Inventory after SELLOPT: {inv:?}");
 
-        // Check that the AAPL position has cost with USD currency
+        // The AAPL position carries cost with the price-inferred USD currency.
         let aapl_pos = inv
             .positions()
             .find(|p| p.units.currency.as_ref() == "AAPL")
             .expect("Should have AAPL position");
-
-        eprintln!("AAPL position: {aapl_pos:?}");
 
         assert!(aapl_pos.cost.is_some(), "AAPL position should have cost");
         let cost = aapl_pos.cost.as_ref().unwrap();


### PR DESCRIPTION
## What

Architecture-roadmap **[L/7 inventory-accumulation tail]**: route `BookingEngine::apply`'s inventory addition onto the canonical **`Position::from_posting`** — the same cost-resolve helper the Late validator (`process_inventory_addition`), `build_balances`, and the query engine already share. `apply` was the lone remaining hand-roller.

## The investigation

The roadmap framed this as "Late validation reuses booked inventories" — but that's **infeasible**: the validator's inventories are *incremental* (point-in-time balance assertions), *pad-adjusted*, and *error-emitting*, none of which booking's final-state inventories provide. The reduction-detection (`is_booking_reduction`) was the genuinely-shared piece and is already unified.

The real dedup is the inverse: `apply` hand-rolled ~40 lines (per-unit match + cost-currency inference + `Position::with_cost`) to build a position that `Position::from_posting` already builds. So this replaces that block with a one-liner.

## Why it's equivalent

- **per-unit / date / label**: identical — `CostSpec::resolve`'s own doc says *"Matches the zero-units guard in BookingEngine::apply"*.
- **cost currency**: the old inline price/cross-posting inference was **dead code** for `apply`'s actual inputs. `apply` only runs on *booked* transactions (every caller `book_and_interpolate`s first — see its `debug_assert`), and `book()` fills the inferred currency *into* `cost_spec.currency` for augmentations (book.rs ~368-405). So by apply-time the currency is already resolved, and `from_posting` (which reads `cost_spec.currency`) produces the same cost.

## Test

`test_cost_spec_currency_inference` previously called `apply` **directly** on an unbooked txn to exercise the standalone inference. Updated it to use the real `book_and_interpolate → apply` pipeline — it still asserts the price-inferred USD cost, now **proving** booking fills the currency and the dedup is behavior-preserving (rather than pinning a path production never takes).

## Verification

Full `rustledger-booking` suite green (104+ tests incl. all lot-matching + the inference test); clippy `-D warnings` clean; the booking fuzz target compiles. Public API unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
