### PR TITLE
fix(check): treat E7003 duplicate option as a warning, not an error (#1546)

### DIFF
--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -246,10 +246,12 @@ impl Options {
 
         // Check for duplicate non-repeatable options (E7003).
         //
-        // Stricter than beancount: `bean-check` silently lets the last value
-        // win (exit 0). We flag the duplicate so the CLI can surface it as an
-        // error (a repeated non-repeatable option is almost always a mistake) —
-        // a DELIBERATE deviation. See `cmd::check` E7003 handling.
+        // Emitted as a WARNING (not an error), matching `bean-check`, which
+        // silently lets the last value win (exit 0). A master ledger that
+        // `include`s self-contained sub-ledgers — each setting its own
+        // `option "title"` / `booking_method` / ... for standalone use — is a
+        // legitimate layout (issue #1546). The value below is applied last-wins
+        // to match. `cmd::check` and `validate` both surface this as a warning.
         let is_repeatable = REPEATABLE_OPTIONS.contains(&key);
         if is_known && !is_repeatable && self.set_options.contains(key) {
             self.warnings.push(OptionWarning {

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -463,7 +463,8 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
 
     // All option warnings collected by `Options::set` (E7001 unknown option,
     // E7002 invalid value, E7003 duplicate non-repeatable, E7004/E7005/E7006
-    // read-only and related) are surfaced here as hard errors.
+    // read-only and related) are surfaced here. Everything except E7003 is a
+    // hard error; E7003 is a warning (see below).
     //
     // E7001/E7002 match beancount: `bean-check` exits non-zero on an unknown
     // option or an invalid option value.

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -468,15 +468,20 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
     // E7001/E7002 match beancount: `bean-check` exits non-zero on an unknown
     // option or an invalid option value.
     //
-    // E7003 is a DELIBERATE deviation, stricter than beancount (Python
-    // compatibility policy bucket 1): `bean-check` silently accepts a repeated
-    // non-repeatable option (last value wins, exit 0), but a duplicated
-    // `option "title"` / `option "name_*"` is almost always a copy-paste
-    // mistake, so we surface it as an error. Pinned by
-    // `cli_commands_test::test_check_duplicate_option_is_error`.
+    // E7003 (duplicate non-repeatable option) is a WARNING, not an error —
+    // matching `bean-check` (last value wins, exit 0), the loader, and
+    // `validate`. A master ledger that `include`s self-contained sub-ledgers,
+    // each declaring its own `option "title"` / `booking_method` / ... for
+    // standalone use, is a legitimate beancount layout; erroring on it rejected
+    // that pattern and disagreed with our own loader/`validate` (issue #1546).
+    // The value is already last-wins (the loader applies the latest). Pinned by
+    // `cli_commands_test::test_check_duplicate_option_warns`.
     let main_file_str = file.display().to_string();
-    let option_error_count = load_result.options.warnings.len();
+    let mut option_error_count = 0;
+    let mut option_warning_count = 0;
     for warning in &load_result.options.warnings {
+        let is_error = warning.code != "E7003";
+        let severity = if is_error { "error" } else { "warning" };
         if json_mode {
             diagnostics.push(JsonDiagnostic {
                 file: main_file_str.clone(),
@@ -484,16 +489,23 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
                 column: 1,
                 end_line: 1,
                 end_column: 1,
-                severity: "error".to_string(),
+                severity: severity.to_string(),
                 phase: "parse".to_string(),
                 code: warning.code.to_string(),
                 message: warning.message.clone(),
                 hint: None,
                 context: None,
             });
-            parse_error_count += 1;
+            if is_error {
+                parse_error_count += 1;
+            }
         } else if !args.quiet {
-            writeln!(stdout, "error[{}]: {}", warning.code, warning.message)?;
+            writeln!(stdout, "{severity}[{}]: {}", warning.code, warning.message)?;
+        }
+        if is_error {
+            option_error_count += 1;
+        } else {
+            option_warning_count += 1;
         }
     }
     error_count += option_error_count;
@@ -609,14 +621,15 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
             error_count += 1;
         }
     }
-    let warning_count = ledger
-        .errors
-        .iter()
-        .filter(|e| {
-            matches!(e.severity, rustledger_loader::ErrorSeverity::Warning)
-                && !is_advisory_only_code(&e.code)
-        })
-        .count();
+    let warning_count = option_warning_count
+        + ledger
+            .errors
+            .iter()
+            .filter(|e| {
+                matches!(e.severity, rustledger_loader::ErrorSeverity::Warning)
+                    && !is_advisory_only_code(&e.code)
+            })
+            .count();
     #[cfg(feature = "python-plugin-wasm")]
     let mut warning_count = warning_count;
 

--- a/crates/rustledger/tests/cli_commands_test.rs
+++ b/crates/rustledger/tests/cli_commands_test.rs
@@ -1749,13 +1749,13 @@ fn test_price_no_self_quote_directive() {
     );
 }
 
-/// `rledger check` rejects a repeated non-repeatable option (E7003) as an
-/// error. This is a DELIBERATE deviation, stricter than beancount: `bean-check`
-/// silently accepts the duplicate (last value wins, exit 0). A duplicated
-/// non-repeatable `option` is almost always a copy-paste mistake, so we surface
-/// it. See the E7003 handling in `cmd::check`.
+/// `rledger check` treats a repeated non-repeatable option (E7003) as a
+/// WARNING, not an error — matching `bean-check` (last value wins, exit 0), the
+/// loader, and `validate`. Issue #1546: erroring rejected the legitimate
+/// multi-entity `include` layout and disagreed with our own loader/`validate`.
+/// See the E7003 handling in `cmd::check`.
 #[test]
-fn test_check_duplicate_option_is_error() {
+fn test_check_duplicate_option_warns() {
     let rledger = require_rledger!();
     let tmp = tempfile::NamedTempFile::new().expect("tempfile");
     std::fs::write(
@@ -1771,8 +1771,9 @@ fn test_check_duplicate_option_is_error() {
         .expect("Failed to run rledger check");
 
     assert!(
-        !output.status.success(),
-        "duplicate non-repeatable option should fail check (stricter than beancount)"
+        output.status.success(),
+        "duplicate non-repeatable option must NOT fail check (last value wins, like beancount); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
     let combined = format!(
         "{}{}",
@@ -1780,8 +1781,45 @@ fn test_check_duplicate_option_is_error() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("E7003"),
-        "output should cite E7003; got: {combined}"
+        combined.contains("E7003") && combined.contains("warning"),
+        "output should surface E7003 as a warning; got: {combined}"
+    );
+}
+
+/// Issue #1546 end-to-end: a master ledger that `include`s self-contained
+/// sub-ledgers, each setting its own `option "title"`, must pass `check`
+/// (matching beancount) — the cross-include duplicate is a warning, not an error.
+#[test]
+fn test_check_multi_entity_include_duplicate_option_ok() {
+    let rledger = require_rledger!();
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("a.beancount"),
+        "option \"title\" \"Entity A\"\n2020-01-01 open Assets:A\n",
+    )
+    .expect("write a");
+    std::fs::write(
+        dir.path().join("b.beancount"),
+        "option \"title\" \"Entity B\"\n2020-01-01 open Assets:B\n",
+    )
+    .expect("write b");
+    let master = dir.path().join("master.beancount");
+    std::fs::write(
+        &master,
+        "option \"title\" \"Combined\"\ninclude \"a.beancount\"\ninclude \"b.beancount\"\n",
+    )
+    .expect("write master");
+
+    let output = Command::new(&rledger)
+        .args(["check", "--no-cache"])
+        .arg(&master)
+        .output()
+        .expect("Failed to run rledger check");
+
+    assert!(
+        output.status.success(),
+        "multi-entity include tree with per-entity `option \"title\"` must pass check; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 


### PR DESCRIPTION
## What

Fixes **#1546**: `rledger check` treated **E7003 (duplicate non-repeatable option)** as a hard error, diverging from `bean-check` (which silently takes the last value, exit 0) **and** from rledger's own loader / `validate` (which record it as a *warning*). This rejected a legitimate, common layout — a master ledger that `include`s several self-contained sub-ledgers, each declaring its own `option "title"` / `booking_method` / … for standalone use.

## Root cause

`cmd/check.rs` looped over *all* `load_result.options.warnings` and emitted each as `severity: "error"`, lumping E7003 in with E7001 (unknown option) and E7002 (invalid value). The error-promotion was a *deliberate* "stricter than beancount" deviation (the rationale: a same-file duplicate is usually a typo) — but it can't distinguish that from the legitimate cross-`include` case, so it over-rejected.

## Change

- **`cmd/check.rs`**: E7001/E7002 stay errors (beancount rejects those); **E7003 is now a warning** — emitted with `warning` severity, counted in `warning_count` (not `error_count`), and no longer fails the check. The option **value was already last-wins** (the loader applies the latest), so only the error-promotion needed removing.
- **`loader/options.rs`**: updated the stale rationale comment (no logic change — it already emits E7003 as a warning).

## Tests

- `test_check_duplicate_option_is_error` → **`test_check_duplicate_option_warns`**: now asserts `check` **exits 0** and surfaces E7003 as a *warning*.
- New **`test_check_multi_entity_include_duplicate_option_ok`**: the exact issue repro — `master.beancount` including `a`/`b` sub-ledgers that each set `option "title"` — passes `check`.
- The loader's `test_duplicate_option_warning` is unchanged (still emits the warning).

## Verification

`rustledger` + binary build clean; the E7003 CLI tests + the loader test pass; clippy `-D warnings` clean. `validate` and `check` now agree, both matching beancount.

Closes #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
