### PR TITLE
feat(ci): nightly dhat heap profiling of the load+process pipeline (slice 1)

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -1,0 +1,93 @@
+# Nightly heap profiling — surfaces allocation hotspots in the load → process
+# pipeline so we can spot optimization opportunities. Complements `bench.yml`
+# (wall-clock timing / regressions); this answers "where do the allocations
+# come from". Advisory only — uploads an artifact, never gates merges.
+#
+# Slice 1 (this file): a `dhat` heap profile of `examples/profile_pipeline`
+# over a generated ledger, uploaded as an artifact. Future slices may add
+# flamegraphs, iai-callgrind instruction counts, and a `profiling` data branch
+# for night-over-night trends.
+name: Profile
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # Nightly at 3 AM UTC (offset from bench.yml's 2 AM)
+  workflow_dispatch:
+    inputs:
+      transactions:
+        description: "Number of transactions in the generated workload"
+        default: "10000"
+
+# Profiling runs are independent; never cancel an in-flight one.
+concurrency:
+  group: profiling
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  heap-profile:
+    name: dhat heap profile (load + process)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      - name: Generate workload ledger
+        env:
+          TXNS: ${{ github.event.inputs.transactions || '10000' }}
+        run: |
+          python3 - "$TXNS" > workload.beancount <<'PY'
+          import sys, random, datetime
+          random.seed(42)
+          n = int(sys.argv[1])
+          accounts = ["Assets:Bank:Checking", "Assets:Bank:Savings",
+                      "Expenses:Food", "Expenses:Rent", "Income:Salary",
+                      "Liabilities:CreditCard"]
+          print('option "title" "Profiling Workload"')
+          print('option "operating_currency" "USD"')
+          for a in accounts:
+              print(f"2020-01-01 open {a} USD")
+          print()
+          d = datetime.date(2020, 1, 2)
+          for i in range(n):
+              d += datetime.timedelta(days=1)
+              src, dst = random.choice(accounts), random.choice(accounts)
+              amt = round(random.uniform(1, 500), 2)
+              print(f'{d.isoformat()} * "Payee {i}" "memo {i}"')
+              print(f"  {src}  -{amt} USD")
+              print(f"  {dst}   {amt} USD")
+          PY
+          echo "workload: $(wc -l < workload.beancount) lines"
+
+      - name: Build profiling harness
+        run: cargo build -p rustledger --profile profiling --example profile_pipeline --features dhat-heap
+
+      - name: Run heap profile
+        run: ./target/profiling/examples/profile_pipeline workload.beancount
+
+      - name: Summarize
+        run: |
+          {
+            echo "## Nightly heap profile — load + process"
+            echo ""
+            echo "- Workload: \`$(wc -l < workload.beancount)\` lines"
+            echo "- Profile: \`dhat-heap.json\` ($(du -h dhat-heap.json | cut -f1))"
+            echo ""
+            echo "Download the **dhat-heap-profile** artifact and open \`dhat-heap.json\` at"
+            echo "<https://nnethercote.github.io/dh_view/> for the allocation tree"
+            echo "(which call paths allocate the most bytes — the optimization targets)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload heap profile
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dhat-heap-profile
+          path: |
+            dhat-heap.json
+            workload.beancount
+          retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3220,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "criterion",
+ "dhat",
  "dirs",
  "edit",
  "format_num_pattern",
@@ -4078,6 +4101,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,9 @@ criterion = "0.8"
 insta = { version = "1", features = ["yaml"] }
 rust_decimal_macros = "1.40"
 tempfile = "3"
+# Heap profiling for the nightly `profile.yml` harness. Optional + off by
+# default (only pulled by `rustledger`'s `dhat-heap` feature).
+dhat = "0.3"
 
 # Data formats
 csv = "1"
@@ -269,3 +272,11 @@ opt-level = 3
 
 [profile.bench]
 debug = true
+
+# Profiling build: release-grade codegen, but keep debug symbols (release
+# `strip`s them) so dhat / flamegraph / samply backtraces symbolize. Used by the
+# nightly `profile.yml` heap-profiling harness (`examples/profile_pipeline`).
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -18,6 +18,10 @@ bench = false
 
 [features]
 default = ["python-plugin-wasm"]
+# Heap-profiling harness (`examples/profile_pipeline` + the nightly `profile.yml`
+# workflow). Off by default; pulls the optional `dhat` dep and installs its
+# global allocator in the example. Never enabled for the shipped binary.
+dhat-heap = ["dep:dhat"]
 # Enable Python plugin support via WASM sandbox (adds ~30s to build time).
 # This allows running existing Python beancount plugins, the WASM importer
 # loader, and the directive-plugin runtime — all of which pull `wasmtime`
@@ -53,6 +57,8 @@ required-features = ["ag-rledger"]
 # the sync `rledger` CLI/lib don't carry the async runtime by default.
 agcli = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt"], optional = true }
+# Heap profiling, only under the `dhat-heap` feature (see examples/profile_pipeline.rs).
+dhat = { workspace = true, optional = true }
 rustledger-core.workspace = true
 rustledger-parser.workspace = true
 rustledger-loader.workspace = true

--- a/crates/rustledger/examples/profile_pipeline.rs
+++ b/crates/rustledger/examples/profile_pipeline.rs
@@ -1,0 +1,50 @@
+//! Heap-profiling harness for the `load` → `process` pipeline.
+//!
+//! Runs the same path as `rledger check` (parse + includes + options, then
+//! book + plugins + validate) over a ledger file, under dhat's heap-profiling
+//! global allocator, and writes `dhat-heap.json` to the current directory on
+//! exit — view it at <https://nnethercote.github.io/dh_view/>. The nightly
+//! `profile.yml` workflow runs this over a generated ledger to surface
+//! allocation hotspots ("where do the bytes come from") to optimize.
+//!
+//! ```text
+//! cargo run --profile profiling --example profile_pipeline \
+//!     --features dhat-heap -- <ledger.beancount>
+//! ```
+//!
+//! Without the `dhat-heap` feature the example still builds and runs the
+//! pipeline (no profiling), so it stays green in the default `--all-targets`
+//! build.
+
+// dhat installs a global allocator that wraps the system allocator to record
+// every allocation. Gated behind the feature so the default build is untouched.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() {
+    // Profiles the whole run; on drop it writes `dhat-heap.json`.
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
+    let Some(path) = std::env::args_os().nth(1) else {
+        eprintln!("usage: profile_pipeline <ledger.beancount>");
+        std::process::exit(2);
+    };
+
+    // Mirror `rledger check`: the one-shot `load` runs parse + includes +
+    // options, then book + plugins + validate, so the profile covers the full
+    // pipeline rather than just parsing.
+    let options = rustledger_loader::LoadOptions {
+        run_plugins: true,
+        validate: true,
+        ..Default::default()
+    };
+    match rustledger_loader::load(std::path::Path::new(&path), &options) {
+        Ok(ledger) => eprintln!("processed {} directives", ledger.directives.len()),
+        Err(e) => {
+            eprintln!("load/process failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/rustledger/examples/profile_pipeline.rs
+++ b/crates/rustledger/examples/profile_pipeline.rs
@@ -8,7 +8,7 @@
 //! allocation hotspots ("where do the bytes come from") to optimize.
 //!
 //! ```text
-//! cargo run --profile profiling --example profile_pipeline \
+//! cargo run -p rustledger --profile profiling --example profile_pipeline \
 //!     --features dhat-heap -- <ledger.beancount>
 //! ```
 //!
@@ -41,7 +41,16 @@ fn main() {
         ..Default::default()
     };
     match rustledger_loader::load(std::path::Path::new(&path), &options) {
-        Ok(ledger) => eprintln!("processed {} directives", ledger.directives.len()),
+        Ok(ledger) => {
+            // `load` returns `Ok` even when the pipeline accumulated validation
+            // errors (in `ledger.errors`, like `rledger check`). Surface the
+            // count so a profile over an erroring ledger isn't silently "clean".
+            eprintln!(
+                "processed {} directives ({} pipeline errors)",
+                ledger.directives.len(),
+                ledger.errors.len()
+            );
+        }
         Err(e) => {
             eprintln!("load/process failed: {e}");
             std::process::exit(1);

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -283,6 +283,10 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.dhat]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.digest]]
 version = "0.10.7"
 criteria = "safe-to-deploy"
@@ -546,6 +550,10 @@ criteria = "safe-to-deploy"
 [[exemptions.minicov]]
 version = "0.3.8"
 criteria = "safe-to-run"
+
+[[exemptions.mintex]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
 
 [[exemptions.mio]]
 version = "1.2.1"
@@ -869,6 +877,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.text-size]]
 version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.thousands]]
+version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]


### PR DESCRIPTION
## What

**Nightly heap profiling — slice 1.** Adds a `dhat` heap-profiling harness for the `load → process` pipeline plus a nightly workflow that runs it over a generated ledger and uploads the profile as an artifact. This complements `bench.yml` (wall-clock timing / regressions) by answering *"where do the allocations come from"* — the optimization-opportunity radar you asked for. **Advisory only — uploads an artifact, never gates merges.**

(Verified first that `[profile.bench] debug = true` and PGO already exist; this reuses the PGO-style workload generator and the bench artifact pattern rather than rebuilding them.)

## Changes (4, all additive)

- **`Cargo.toml`** — new `[profile.profiling]` (inherits `release` but keeps `debug` symbols, since `release` `strip`s them — required for symbolized dhat backtraces) + `dhat` as an optional workspace dep.
- **`crates/rustledger/Cargo.toml`** — `dhat-heap` feature (`dep:dhat`) + the optional dep. Off by default; **never in the shipped binary** (confirmed: dhat absent from the default dependency tree).
- **`crates/rustledger/examples/profile_pipeline.rs`** — runs the one-shot `rustledger_loader::load(path, &opts)` (parse + includes + options → book + plugins + validate, same as `rledger check`) under dhat's global allocator; writes `dhat-heap.json`. Builds as a no-op without the feature, so it stays green in `--all-targets`.
- **`.github/workflows/profile.yml`** — nightly (3 AM UTC, offset from bench's 2 AM) + `workflow_dispatch`; generates a 10K-txn workload, runs the harness, writes a step-summary pointer, uploads `dhat-heap.json` + the workload as an artifact (30-day retention).

## How to use

Download the **dhat-heap-profile** artifact from a nightly run and open `dhat-heap.json` at <https://nnethercote.github.io/dh_view/> — it shows which call paths allocate the most bytes.

Locally: `cargo run --profile profiling --example profile_pipeline --features dhat-heap -- <ledger.beancount>`.

## Deliberately deferred (future slices)

flamegraphs (`cargo flamegraph`), `iai-callgrind` deterministic instruction counts, and a `profiling` data branch for night-over-night trends.

## Verification

Example compiles **with and without** the feature; `dhat` absent from the default tree; the harness runs the full pipeline and emits a valid `dhat-heap.json` (v2); `profile.yml` YAML valid; clippy `-D warnings` clean. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
