### PR TITLE
ci: cap-lints=warn for Benchmarks Compile (unblock the gate from #1578)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,15 @@ jobs:
           toolchain: stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      # `cargo bench` compiles the lib WITHOUT its `#[test]` fns (only `#[bench]`
+      # + the lib), so test-only helpers used solely by `#[test]` look dead here
+      # and the workflow-wide `-Dwarnings` (env above) would fail the gate on
+      # incidental dead-code — not a bench-compile problem. Cap lints to `warn`
+      # so this job checks *compilation* only; clippy / `ci` lint the real
+      # targets. A genuine compile error still fails (cap-lints affects lints).
       - name: Compile all criterion benches (--no-run)
+        env:
+          RUSTFLAGS: "--cap-lints=warn"
         run: cargo bench --workspace --no-run
   # Slim-build ratchet (#1427/#867): `cargo install rustledger
   # --no-default-features` must stay wasmtime/cranelift-free so the minimal


### PR DESCRIPTION
## What

Fixes the **`Benchmarks Compile`** gate (added in #1578), which is **failing on every PR** and blocking merges — a flaw in that gate, not in any PR.

## Root cause

`cargo bench --no-run` compiles each crate's lib **without** its `#[test]` functions (it builds `#[bench]` + the lib). So a test-only helper used *solely* by `#[test]` (e.g. `make_transaction` / `make_posting` in `rustledger-ffi-wasi/src/commands/clamp.rs`) appears as **dead code** in the bench-compile view — even though it's perfectly live in the normal test build. The workflow-wide `RUSTFLAGS: -Dwarnings` (ci.yml) then turns that incidental `dead_code` into a hard error:

```
error: function `make_transaction` is never used  (clamp.rs:66)
error: could not compile `rustledger-ffi-wasi` (lib test)  →  exit 101
```

This is **structural** — it will recur for any crate that adds a `#[test]`-only helper — so the fix belongs in the gate, not in whack-a-mole per-crate `#[allow(dead_code)]`s.

## Fix

Run the bench-compile step with `RUSTFLAGS: "--cap-lints=warn"`. The gate's job is to verify the benches **compile** (anti-bitrot); `clippy` and the `ci` job already lint the real targets with `-Dwarnings`. Capping lints to `warn` stops incidental test-helper dead-code from failing the gate **while still failing on a genuine compile error** (cap-lints only affects lints, not errors). There's existing precedent for a per-job `RUSTFLAGS` override in this workflow (the doctest job clears it).

## Verification

`RUSTFLAGS="--cap-lints=warn" cargo bench -p rustledger-ffi-wasi --no-run` → **Finished** (the failing crate now compiles); YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
