### PR TITLE
feat(ci): nightly deterministic instruction counts via iai-callgrind (profiling slice 3)

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -99,3 +99,37 @@ jobs:
             flamegraph.svg
             workload.beancount
           retention-days: 30
+
+  # Deterministic instruction counts (Valgrind/Callgrind via iai-callgrind) —
+  # identical run-to-run, so diffable night-over-night unlike wall-clock. The
+  # runner version must match the `iai-callgrind` crate version (see Cargo.toml).
+  iai:
+    name: Instruction counts (iai-callgrind)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - name: Install Valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+      - name: Install iai-callgrind-runner (must match the crate version)
+        run: cargo install iai-callgrind-runner --version 0.16.1 --locked
+      - name: Run instruction-count benches
+        run: cargo bench -p rustledger --bench iai_pipeline | tee iai-results.txt
+      - name: Summarize
+        run: |
+          {
+            echo "## Nightly instruction counts (iai-callgrind)"
+            echo ""
+            echo '```'
+            grep -E "parse_ledger|Instructions|Estimated Cycles" iai-results.txt || cat iai-results.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload instruction counts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: iai-instruction-counts
+          path: iai-results.txt
+          retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1156,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dhat"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1743,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "iai-callgrind"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3334,6 +3400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3459,7 @@ dependencies = [
  "edit",
  "format_num_pattern",
  "glob",
+ "iai-callgrind",
  "insta",
  "jiff",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,8 @@ imbl = { version = "7", features = ["serde"] }
 # Testing
 proptest = "1"
 criterion = "0.8"
+# Deterministic instruction-count benchmarks (Valgrind/Callgrind), run nightly.
+iai-callgrind = "0.16"
 insta = { version = "1", features = ["yaml"] }
 rust_decimal_macros = "1.40"
 tempfile = "3"

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -107,9 +107,18 @@ insta.workspace = true
 # tests to author tiny .wasm fixtures for build_registry coverage
 # without checking compiled binaries into the repo.
 wat = { workspace = true }
+# Deterministic instruction-count benchmarks (Valgrind/Callgrind) — immune to
+# CI runner noise. Run nightly by profile.yml; see benches/iai_pipeline.rs.
+iai-callgrind = { workspace = true }
 
 [[bench]]
 name = "pipeline_bench"
+harness = false
+
+# Deterministic instruction counts via iai-callgrind (Valgrind). Not in PR CI
+# (needs Valgrind + the runner); run nightly by profile.yml.
+[[bench]]
+name = "iai_pipeline"
 harness = false
 
 # Baseline for the v0.16.0 perf-sensitive paths. Not wired into PR CI — too

--- a/crates/rustledger/benches/iai_pipeline.rs
+++ b/crates/rustledger/benches/iai_pipeline.rs
@@ -1,0 +1,56 @@
+//! Deterministic instruction-count benchmarks via iai-callgrind (Valgrind /
+//! Callgrind).
+//!
+//! Unlike the criterion wall-clock benches (`pipeline_bench`), these report
+//! **instruction counts** — identical run-to-run regardless of machine load, so
+//! they're diffable night-over-night and immune to CI-runner noise. The nightly
+//! `profile.yml` workflow runs them (it installs Valgrind + the
+//! `iai-callgrind-runner`); they are intentionally **not** wired into PR CI.
+//!
+//! Run locally with Valgrind installed:
+//! ```text
+//! cargo install iai-callgrind-runner --version 0.16.1
+//! cargo bench -p rustledger --bench iai_pipeline
+//! ```
+
+use std::hint::black_box;
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+
+/// Generate a deterministic ledger of `n` balanced 2-posting transactions.
+fn generate_ledger(n: usize) -> String {
+    let mut s = String::from("option \"operating_currency\" \"USD\"\n");
+    for account in [
+        "Assets:Bank",
+        "Expenses:Food",
+        "Income:Salary",
+        "Liabilities:Card",
+    ] {
+        s.push_str("2020-01-01 open ");
+        s.push_str(account);
+        s.push_str(" USD\n");
+    }
+    for i in 0..n {
+        let month = (i / 28) % 12 + 1;
+        let day = i % 28 + 1;
+        let amt = i % 500 + 1;
+        s.push_str(&format!(
+            "2021-{month:02}-{day:02} * \"Payee {i}\" \"memo\"\n  \
+             Expenses:Food  {amt}.00 USD\n  Assets:Bank  -{amt}.00 USD\n"
+        ));
+    }
+    s
+}
+
+// Parser instruction count at two ledger sizes. The `generate_ledger` setup in
+// each `#[bench]` runs *outside* the measured region — only the parse is counted.
+// (A `///` doc comment here is rejected by the `#[library_benchmark]` macro.)
+#[library_benchmark]
+#[bench::txns_1k(generate_ledger(1_000))]
+#[bench::txns_10k(generate_ledger(10_000))]
+fn parse_ledger(source: String) -> rustledger_parser::ParseResult {
+    black_box(rustledger_parser::parse(black_box(&source)))
+}
+
+library_benchmark_group!(name = pipeline; benchmarks = parse_ledger);
+main!(library_benchmark_groups = pipeline);

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -119,6 +119,10 @@ criteria = "safe-to-deploy"
 version = "0.4.10"
 criteria = "safe-to-deploy"
 
+[[exemptions.bincode]]
+version = "1.3.3"
+criteria = "safe-to-run"
+
 [[exemptions.bitflags]]
 version = "2.13.0"
 criteria = "safe-to-deploy"
@@ -291,6 +295,14 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.derive_more]]
+version = "2.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.derive_more-impl]]
+version = "2.1.1"
+criteria = "safe-to-run"
+
 [[exemptions.dhat]]
 version = "0.3.3"
 criteria = "safe-to-deploy"
@@ -426,6 +438,18 @@ criteria = "safe-to-deploy"
 [[exemptions.hybrid-array]]
 version = "0.4.12"
 criteria = "safe-to-deploy"
+
+[[exemptions.iai-callgrind]]
+version = "0.16.1"
+criteria = "safe-to-run"
+
+[[exemptions.iai-callgrind-macros]]
+version = "0.6.1"
+criteria = "safe-to-run"
+
+[[exemptions.iai-callgrind-runner]]
+version = "0.16.1"
+criteria = "safe-to-run"
 
 [[exemptions.iana-time-zone]]
 version = "0.1.65"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2259,6 +2259,24 @@ For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.rustc_version]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.4.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustc_version]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.4.0 -> 0.4.1"
+notes = "No unsafe, net or fs."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.rustversion]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## What

**Nightly profiling — slice 3: deterministic instruction counts.** Adds an `iai-callgrind` bench (`benches/iai_pipeline.rs` — parser instruction counts at 1k/10k txns, under Valgrind/Callgrind) plus an `iai` job in the nightly `profile.yml`. Unlike the criterion wall-clock benches, instruction counts are **identical run-to-run and machine-independent** — so they're diffable night-over-night and immune to CI-runner noise (the canonical use for CI regression detection). Advisory; never gates merges.

## Supply chain (front-loaded this time)

Verified *before* writing: only **7 new deps**, all permissive SPDX; `cargo-deny` "bans ok, licenses ok"; **zero** Dependency Review flags. No allowlist changes needed (unlike the flamegraph slice).

## Verification

- The bench **compiles** (verified locally + in PR CI via the Benchmarks Compile gate).
- The Valgrind **run** is nightly-only (`profile.yml` is cron) — so the PR's CI only compiles it. I couldn't cleanly run the iai runner in the local nix sandbox (a crate↔runner version-handshake quirk specific to the layered env, not the bench), so I **verified the actual run via `workflow_dispatch` on this branch** in CI's clean environment to confirm it emits real instruction counts before relying on it.

## Remaining deferred slice

A `profiling` data branch for night-over-night trend tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
