### PR TITLE
feat(ci): commit nightly profiling metrics to the profiling trend branch (slice 4)

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -189,6 +189,8 @@ jobs:
           name: cachegrind-instructions
           path: dl-cg
       - name: Append data point to the profiling branch
+        env:
+          TXNS: ${{ github.event.inputs.transactions || '10000' }}
         run: |
           set -euo pipefail
           # The count is AFTER "refs:" — the line is "==PID== I refs: N", so take
@@ -202,10 +204,12 @@ jobs:
           git checkout profiling
           mkdir -p latest
           cp dl-profile/flamegraph.svg dl-profile/dhat-heap.json latest/
-          printf '{"date":"%s","commit":"%s","txns":10000,"instructions":%s,"heap_total_bytes":%s,"heap_peak_bytes":%s,"heap_blocks":%s}\n' \
-            "$DATE" "$COMMIT" "$INSTR" "$HB" "$HP" "$HK" >> history.jsonl
+          printf '{"date":"%s","commit":"%s","txns":%s,"instructions":%s,"heap_total_bytes":%s,"heap_peak_bytes":%s,"heap_blocks":%s}\n' \
+            "$DATE" "$COMMIT" "$TXNS" "$INSTR" "$HB" "$HP" "$HK" >> history.jsonl
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          # Stage only the data-branch files — NOT the downloaded `dl-*` artifact
+          # dirs, which `git add -A` would commit into the data branch.
+          git add history.jsonl latest/
           git diff --staged --quiet || git commit -m "profiling: nightly data point ($DATE)"
           git push origin profiling

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -191,7 +191,9 @@ jobs:
       - name: Append data point to the profiling branch
         run: |
           set -euo pipefail
-          INSTR=$(grep -aE "I +refs:" dl-cg/cachegrind.txt | grep -aoE "[0-9,]+" | head -1 | tr -d ,)
+          # The count is AFTER "refs:" — the line is "==PID== I refs: N", so take
+          # the number following the label (not the leading PID).
+          INSTR=$(grep -aE "I +refs:" dl-cg/cachegrind.txt | sed -E 's/.*refs:[[:space:]]*([0-9,]+).*/\1/' | tr -d ' ,')
           # heap totals from dhat-heap.json: sum tb (total bytes), tbk (blocks), gb (peak bytes)
           read -r HB HK HP < <(python3 -c "import json;d=json.load(open('dl-profile/dhat-heap.json'));print(sum(p['tb'] for p in d['pps']),sum(p['tbk'] for p in d['pps']),sum(p.get('gb',0) for p in d['pps']))")
           DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -167,3 +167,43 @@ jobs:
             cachegrind.out
             cachegrind.txt
           retention-days: 30
+
+  # Append a deterministic data point to the `profiling` data branch each night
+  # (mirrors how bench.yml maintains `benchmarks`). Reuses the instruction count
+  # from the `cachegrind` job + the heap totals from the `profile` job — no
+  # re-running of the tools.
+  trend:
+    name: Commit trend data point
+    needs: [profile, cachegrind]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-profile
+          path: dl-profile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cachegrind-instructions
+          path: dl-cg
+      - name: Append data point to the profiling branch
+        run: |
+          set -euo pipefail
+          INSTR=$(grep -aE "I +refs:" dl-cg/cachegrind.txt | grep -aoE "[0-9,]+" | head -1 | tr -d ,)
+          # heap totals from dhat-heap.json: sum tb (total bytes), tbk (blocks), gb (peak bytes)
+          read -r HB HK HP < <(python3 -c "import json;d=json.load(open('dl-profile/dhat-heap.json'));print(sum(p['tb'] for p in d['pps']),sum(p['tbk'] for p in d['pps']),sum(p.get('gb',0) for p in d['pps']))")
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          COMMIT=$(git rev-parse HEAD)   # the commit being measured (before switching branches)
+          git fetch origin profiling
+          git checkout profiling
+          mkdir -p latest
+          cp dl-profile/flamegraph.svg dl-profile/dhat-heap.json latest/
+          printf '{"date":"%s","commit":"%s","txns":10000,"instructions":%s,"heap_total_bytes":%s,"heap_peak_bytes":%s,"heap_blocks":%s}\n' \
+            "$DATE" "$COMMIT" "$INSTR" "$HB" "$HP" "$HK" >> history.jsonl
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "profiling: nightly data point ($DATE)"
+          git push origin profiling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ resolve unless you've fetched it locally).
 |--------|---------------|
 | `spike/ffi-wit-component` | WIT / Component-Model FFI design spike for #1384. Reference if the `rustledger:ledger` component contract (the typed WIT API) changes. |
 | `spike/ledger-resource` | Stateful `resource session` "A+B boundary" redesign spike for #173. Reference for a future stateful embedding API. |
-| `benchmarks`, `compatibility` | CI-managed data branches (nightly benchmark / compatibility results). Written by automation — never hand-delete. |
+| `benchmarks`, `compatibility`, `profiling` | CI-managed data branches (nightly benchmark / compatibility results; `profiling` holds the deterministic instruction-count + heap trend history written by `profile.yml`). Written by automation — never hand-delete. |
 
 When pruning merged/closed PR branches, skip the rows above.
 


### PR DESCRIPTION
## What

**Nightly profiling — slice 4: trend data branch.** Completes the profiling work by recording a deterministic data point every night to a new `profiling` data branch (mirroring how `bench.yml` maintains `benchmarks`).

## The `profiling` branch (already seeded)

I created the orphan **`profiling`** branch and **seeded it with real, locally-measured baseline data** (commit `200c6f4`, 10k-txn workload):

```json
{"instructions":1121094109,"heap_total_bytes":253682,"heap_peak_bytes":112151,"heap_blocks":5088}
```

It holds:
- `history.jsonl` — one JSON object per nightly run (the trend log).
- `latest/flamegraph.svg` + `latest/dhat-heap.json` — newest artifacts for browsing.
- `README.md` — explains it's CI-managed; don't hand-edit.

## This PR

- **`profile.yml`** — adds a `trend` job (`needs: [profile, cachegrind]`, `contents: write`) that downloads the metric artifacts the other jobs already produce, extracts the **instruction count** (cachegrind `I refs`) + **heap totals** (dhat `dhat-heap.json`), appends a line to `history.jsonl`, refreshes `latest/`, and commits to the `profiling` branch. No re-running of the tools.
- **`CLAUDE.md`** — lists `profiling` alongside `benchmarks`/`compatibility` in the "do-not-delete" data-branch table.

## Why deterministic

Instruction count + heap bytes are **machine-independent and identical run-to-run** — so diffing `history.jsonl` night-over-night surfaces real regressions/wins without the wall-clock noise of the `benchmarks` branch.

## Verification

The `profiling` branch is pushed + seeded. I dispatched `profile.yml` on this branch to confirm the `trend` job appends a second data point end-to-end.

This completes nightly profiling: **heap** · **CPU flamegraph** · **instruction counts** · **trend history**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
