### PR TITLE
perf(parser): pre-size lexer token vectors to kill reallocation churn (-10.8% heap)

### DIFF
--- a/crates/rustledger-parser/src/cst/lossless_tokens.rs
+++ b/crates/rustledger-parser/src/cst/lossless_tokens.rs
@@ -26,8 +26,11 @@ const UTF8_BOM_LEN: usize = 3;
 #[must_use]
 pub fn lossless_kind_tokens(source: &str) -> Vec<(SyntaxKind, Range<usize>)> {
     // Pre-size (~4 bytes per token) to avoid reallocation churn — profiling
-    // flagged this as the 2nd-largest lexer allocation. See `tokenize_inner`.
-    let mut out: Vec<(SyntaxKind, Range<usize>)> = Vec::with_capacity(source.len() / 4);
+    // flagged this as the 2nd-largest lexer allocation. Capped (like
+    // `tokenize_inner`) so a pathological input can't over-reserve. See
+    // `crate::logos_lexer::{tokenize_inner, TOKEN_CAPACITY_CAP}`.
+    let mut out: Vec<(SyntaxKind, Range<usize>)> =
+        Vec::with_capacity((source.len() / 4).min(crate::logos_lexer::TOKEN_CAPACITY_CAP));
 
     let (lexer_source, had_bom) = strip_leading(source);
     let offset = if had_bom {

--- a/crates/rustledger-parser/src/cst/lossless_tokens.rs
+++ b/crates/rustledger-parser/src/cst/lossless_tokens.rs
@@ -25,7 +25,9 @@ const UTF8_BOM_LEN: usize = 3;
 /// covering every byte exactly once.
 #[must_use]
 pub fn lossless_kind_tokens(source: &str) -> Vec<(SyntaxKind, Range<usize>)> {
-    let mut out: Vec<(SyntaxKind, Range<usize>)> = Vec::new();
+    // Pre-size (~4 bytes per token) to avoid reallocation churn — profiling
+    // flagged this as the 2nd-largest lexer allocation. See `tokenize_inner`.
+    let mut out: Vec<(SyntaxKind, Range<usize>)> = Vec::with_capacity(source.len() / 4);
 
     let (lexer_source, had_bom) = strip_leading(source);
     let offset = if had_bom {

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -548,7 +548,12 @@ pub fn tokenize_lossless(source: &str) -> Vec<(Token<'_>, Span)> {
 }
 
 fn tokenize_inner(source: &str, keep_whitespace: bool) -> Vec<(Token<'_>, Span)> {
-    let mut tokens = Vec::new();
+    // Pre-size to avoid reallocation churn. A beancount token averages ~4 bytes
+    // of source (dates, numbers, currencies, whitespace runs), so `len / 4` is a
+    // close estimate of the token count. Profiling showed the unsized `Vec`
+    // reallocating ~17× — the single largest lexer allocation (see the
+    // `profiling` data branch).
+    let mut tokens = Vec::with_capacity(source.len() / 4);
     let mut lexer = Token::lexer(source);
     let mut at_line_start = true;
     let mut last_newline_end = 0usize;

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -547,13 +547,22 @@ pub fn tokenize_lossless(source: &str) -> Vec<(Token<'_>, Span)> {
     tokenize_inner(source, /* keep_whitespace = */ true)
 }
 
+/// Upper bound on the up-front token-vector reservation (see `tokenize_inner` /
+/// `lossless_kind_tokens`). ~4M entries (~100 MB for a `(kind, span)` tuple) is
+/// far above any real ledger's token count, but stops a pathological input from
+/// turning `source.len() / 4` into a multi-GB reservation.
+pub(crate) const TOKEN_CAPACITY_CAP: usize = 4 << 20;
+
 fn tokenize_inner(source: &str, keep_whitespace: bool) -> Vec<(Token<'_>, Span)> {
     // Pre-size to avoid reallocation churn. A beancount token averages ~4 bytes
     // of source (dates, numbers, currencies, whitespace runs), so `len / 4` is a
     // close estimate of the token count. Profiling showed the unsized `Vec`
     // reallocating ~17× — the single largest lexer allocation (see the
-    // `profiling` data branch).
-    let mut tokens = Vec::with_capacity(source.len() / 4);
+    // `profiling` data branch). Capped so a pathological input (e.g. a huge
+    // whitespace/comment run that lexes to few tokens) can't amplify into a
+    // multi-GB up-front reservation — the parser must handle malformed input
+    // gracefully; beyond the cap the `Vec` just grows normally.
+    let mut tokens = Vec::with_capacity((source.len() / 4).min(TOKEN_CAPACITY_CAP));
     let mut lexer = Token::lexer(source);
     let mut at_line_start = true;
     let mut last_newline_end = 0usize;


### PR DESCRIPTION
## What

**Profiling-driven optimization.** Pre-sizes the two lexer token vectors that the new nightly profiling (the `profiling` data branch) flagged as the largest allocations — eliminating reallocation churn.

`tokenize_inner` (`logos_lexer.rs`) and `lossless_kind_tokens` (`cst/lossless_tokens.rs`) both built their output `Vec` from `Vec::new()` and grew via `push`, reallocating ~17× as the geometric doubling kicked in. A beancount token averages ~4 bytes of source, so `Vec::with_capacity(source.len() / 4)` reserves close to the final count up front.

## Measured impact (10k-txn workload, dhat + cachegrind)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| `tokenize_inner` allocations | 20.97 MB in **17 blocks** | 10.25 MB in **1 block** | churn eliminated |
| **Total heap allocated** | 158.7 MB | **141.6 MB** | **−17.1 MB (−10.8%)** |
| Instructions | 1,121,094,109 | 1,118,784,650 | −2.3M |

(`lossless_kind_tokens` dropped out of the top-4 allocators entirely.)

## Why it's safe

Allocation-only change — no behavioral difference. `cargo test -p rustledger-parser` passes; clippy `-D warnings` clean. The win will show up as a step down in `heap_total_bytes` on the next nightly `profiling` trend point.

## How it was found

This is the payoff of the profiling work (slices 1–4): the dhat heap profile ranked these two `Vec::new()` sites #1 and #2 by bytes, and cachegrind confirmed ~12% of CPU was in `malloc`/`free`. More targets remain (the `Transaction::clone` ×2 per txn, the 190k-allocation `walk_descendants_once`, happy-path error-scan allocations) — follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
