### PR TITLE
perf(parser): skip cost-brace scan when source has no { (-1.6% instructions, -50k allocs)

### DIFF
--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -98,7 +98,17 @@ pub fn parse_via_cst(source: &str) -> ParseResult {
     comments.sort_by_key(|s| s.span.start);
     comments.dedup_by_key(|s| s.span.start);
     let mut errors = top_level_errors;
-    errors.extend(extract_unclosed_cost_brace_errors(&source_file, bom_offset));
+    // Cost specs are always delimited by '{' (L_BRACE / L_DOUBLE_BRACE /
+    // L_BRACE_HASH all start with it). If the source has no '{' at all there can
+    // be no COST_SPEC node, so skip the whole-tree `descendants()` scan inside
+    // `extract_unclosed_cost_brace_errors` — it allocates a red `SyntaxNode` per
+    // node. Profiling flagged that scan as ~50k wasted allocations on
+    // cost-spec-free ledgers (the common case); the `contains('{')` guard is a
+    // memchr byte scan with no allocation. A '{' inside a string/comment only
+    // costs the (already-correct) full scan — never a false skip.
+    if stripped.contains('{') {
+        errors.extend(extract_unclosed_cost_brace_errors(&source_file, bom_offset));
+    }
     errors.extend(inline_errors);
     let warnings = Vec::new();
 


### PR DESCRIPTION
## What

**Profiling-driven optimization ②.** Guards the whole-tree cost-brace scan behind a cheap `source.contains('{')` check, so it's skipped entirely on ledgers with no cost specs (the common case).

`extract_unclosed_cost_brace_errors` walks **every descendant** of the CST (`source_file.syntax().descendants()` — which allocates a red `SyntaxNode` per node) looking for `COST_SPEC` nodes. On a ledger with no cost specs it finds nothing, but still pays for the full traversal + ~50k allocations. Since every cost-spec opener (`{`, `{{`, `{#`) contains `{`, a `stripped.contains('{')` guard (a memchr byte scan, no allocation) skips the scan when there can't be any cost specs.

## Measured impact (10k-txn workload, dhat + cachegrind)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| **Instructions** | 1,121,094,109 | 1,103,144,384 | **−17.9M (−1.6%)** |
| **Allocations** | 1,223,484 | 1,173,476 | **−50,008 (−4.1%)** |
| Heap bytes | 158.7 MB | 155.5 MB | −3.2 MB |

`extract_unclosed_cost_brace_errors` disappears from the dhat profile entirely. The instruction win is the headline — skipping the traversal, not just the allocations — against the ~12% of CPU cachegrind attributed to `malloc`/`free`.

## Correctness

Behavior-preserving: the guard only skips when `{` is **absent**, in which case there can be no `COST_SPEC` node and the scan would return empty anyway. A `{` inside a string/comment still triggers the (already-correct) full scan — never a false skip. Pinned by existing tests (`parser_integration_test.rs` unclosed-brace cases + `convert.rs` inline test); all 280 parser tests pass, clippy clean.

## Found via

The nightly profiling (`profiling` data branch). This is the second optimization it surfaced, after the lexer pre-size (#1587).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
