### PR TITLE
perf(parser): skip LSP-only occurrence collection on the load path (-23MB heap, -2.6% instructions)

### DIFF
--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -470,7 +470,9 @@ impl Loader {
             } else {
                 self.fs.read(path)?
             };
-            let parsed = rustledger_parser::parse(&src);
+            // The processing pipeline never reads currency/account occurrences
+            // (LSP-only); skip collecting them — see `parse_without_occurrences`.
+            let parsed = rustledger_parser::parse_without_occurrences(&src);
             (src, parsed)
         };
 
@@ -645,7 +647,8 @@ impl Loader {
                             // Read through the FileSystem trait so all I/O goes
                             // through one code path (UTF-8 handling, error types, etc.)
                             let source = fs.read(p).ok()?;
-                            let parsed = rustledger_parser::parse(&source);
+                            // Occurrences are LSP-only; skip them on the load path.
+                            let parsed = rustledger_parser::parse_without_occurrences(&source);
                             Some((source, parsed))
                         })
                         .collect();

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -57,6 +57,21 @@ use crate::cst::ast::{
 /// See the module-level rustdoc for the conversion scope.
 #[must_use]
 pub fn parse_via_cst(source: &str) -> ParseResult {
+    parse_via_cst_opts(source, /* collect_occurrences = */ true)
+}
+
+/// Like [`parse_via_cst`], but only collects `currency_occurrences` /
+/// `account_occurrences` when `collect_occurrences` is true.
+///
+/// Those two indices are consumed **solely by the LSP** (rename / references /
+/// highlight). The loader / CLI processing path never reads them, so passing
+/// `false` skips the per-`ACCOUNT`/`CURRENCY` `Account::new` / `Currency::new`
+/// construction and the per-token in-`ERROR_NODE` ancestor walk inside
+/// [`walk_descendants_once`] — profiling flagged that walk as the #1
+/// allocation-count site. Inline errors and top-level comments are still
+/// collected unconditionally (the processing path needs them).
+#[must_use]
+pub fn parse_via_cst_opts(source: &str, collect_occurrences: bool) -> ParseResult {
     // BOM detection mirrors the legacy parser's behavior: strip a
     // leading 3-byte BOM from the source before tokenizing and
     // record its presence in the result. Spans index the original
@@ -79,7 +94,7 @@ pub fn parse_via_cst(source: &str) -> ParseResult {
         top_level_comments,
         currency_occurrences,
         account_occurrences,
-    } = walk_descendants_once(&source_file, bom_offset);
+    } = walk_descendants_once(&source_file, bom_offset, collect_occurrences);
 
     // Fused single pass over the top-level children replaces the
     // five former per-child traversals (error-node, transaction-body,
@@ -2140,7 +2155,11 @@ struct DescendantsWalkResult {
 /// LSP runs them on every keystroke, so collapsing 3·O(N) → 1·O(N)
 /// matters at editor-edge latencies. The state of each former
 /// walk is maintained inline below.
-fn walk_descendants_once(source_file: &SourceFile, bom_offset: u32) -> DescendantsWalkResult {
+fn walk_descendants_once(
+    source_file: &SourceFile,
+    bom_offset: u32,
+    collect_occurrences: bool,
+) -> DescendantsWalkResult {
     let mut inline_errors: Vec<crate::ParseError> = Vec::new();
     let mut top_level_comments: Vec<Spanned<String>> = Vec::new();
     let mut currency_occurrences: Vec<Spanned<Currency>> = Vec::new();
@@ -2196,10 +2215,14 @@ fn walk_descendants_once(source_file: &SourceFile, bom_offset: u32) -> Descendan
         let kind = t.kind();
         let has_bom = t.text().contains(crate::bom::BOM_CHAR);
         let is_error_token = kind == crate::SyntaxKind::ERROR_TOKEN;
-        let needs_in_error_check = matches!(
-            kind,
-            crate::SyntaxKind::CURRENCY | crate::SyntaxKind::ACCOUNT
-        ) || has_bom
+        // CURRENCY/ACCOUNT need the in-ERROR_NODE probe only to decide whether
+        // to record an occurrence; skip it entirely when not collecting.
+        let needs_in_error_check = (collect_occurrences
+            && matches!(
+                kind,
+                crate::SyntaxKind::CURRENCY | crate::SyntaxKind::ACCOUNT
+            ))
+            || has_bom
             || is_error_token;
         if !needs_in_error_check {
             continue;
@@ -2208,8 +2231,9 @@ fn walk_descendants_once(source_file: &SourceFile, bom_offset: u32) -> Descendan
             .parent_ancestors()
             .any(|a| a.kind() == crate::SyntaxKind::ERROR_NODE);
 
-        // CURRENCY occurrences: only outside ERROR_NODE.
-        if kind == crate::SyntaxKind::CURRENCY && !in_error_node {
+        // CURRENCY occurrences: only outside ERROR_NODE, and only when the
+        // caller wants them (LSP path).
+        if collect_occurrences && kind == crate::SyntaxKind::CURRENCY && !in_error_node {
             let range = t.text_range();
             let start: u32 = range.start().into();
             let end: u32 = range.end().into();
@@ -2224,7 +2248,7 @@ fn walk_descendants_once(source_file: &SourceFile, bom_offset: u32) -> Descendan
         // source-position-aware tooling (LSP rename / references /
         // document-highlight) wants the token as the user typed it
         // even during a mid-edit broken state.
-        if kind == crate::SyntaxKind::ACCOUNT && !in_error_node {
+        if collect_occurrences && kind == crate::SyntaxKind::ACCOUNT && !in_error_node {
             let range = t.text_range();
             let start: u32 = range.start().into();
             let end: u32 = range.end().into();

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -67,7 +67,7 @@ pub fn parse_via_cst(source: &str) -> ParseResult {
 /// highlight). The loader / CLI processing path never reads them, so passing
 /// `false` skips the per-`ACCOUNT`/`CURRENCY` `Account::new` / `Currency::new`
 /// construction and the per-token in-`ERROR_NODE` ancestor walk inside
-/// [`walk_descendants_once`] — profiling flagged that walk as the #1
+/// `walk_descendants_once` — profiling flagged that walk as the #1
 /// allocation-count site. Inline errors and top-level comments are still
 /// collected unconditionally (the processing path needs them).
 #[must_use]

--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -56,7 +56,7 @@ mod parser;
 mod syntax_kind;
 mod trivia;
 
-pub use convert::parse_via_cst;
+pub use convert::{parse_via_cst, parse_via_cst_opts};
 // Formatter exports do NOT re-export through `cst` — the sole
 // import path for the formatter is `rustledger_parser::format`
 // (the crate-root sub-module that re-exports the six symbols

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -69,7 +69,7 @@ pub mod format {
 
 pub use cst::{
     BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, lossless_kind_tokens,
-    parse_flat, parse_structured, parse_via_cst,
+    parse_flat, parse_structured, parse_via_cst, parse_via_cst_opts,
 };
 
 // Rowan types CST consumers need. Flat re-exports at the crate
@@ -398,6 +398,23 @@ impl ParseWarning {
 #[must_use]
 pub fn parse(source: &str) -> ParseResult {
     parse_via_cst(source)
+}
+
+/// Parse beancount source for the processing pipeline, **without** collecting
+/// the `currency_occurrences` / `account_occurrences` indices.
+///
+/// Those two indices are consumed only by the LSP. The loader / CLI processing
+/// path (`rustledger_loader::load` and friends) never reads them, so skipping
+/// their collection avoids the largest per-token allocation+CPU cost in the
+/// parser (one `Account::new` / `Currency::new` plus an in-`ERROR_NODE` ancestor
+/// walk per `ACCOUNT` / `CURRENCY` token). The returned [`ParseResult`] is
+/// identical to [`parse`]'s except both occurrence vectors are empty.
+///
+/// Editor / LSP callers that need rename / references / highlight data must use
+/// [`parse`] instead.
+#[must_use]
+pub fn parse_without_occurrences(source: &str) -> ParseResult {
+    parse_via_cst_opts(source, /* collect_occurrences = */ false)
 }
 
 /// Parse beancount source code, returning only directives and errors.

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -1153,8 +1153,23 @@ fn parse_without_occurrences_skips_indices_but_matches_directives() {
         lean.account_occurrences.is_empty() && lean.currency_occurrences.is_empty(),
         "lean parse must skip occurrence collection"
     );
-    // Everything the processing pipeline consumes is unchanged.
-    assert_eq!(full.directives.len(), lean.directives.len());
-    assert_eq!(full.errors.len(), lean.errors.len());
-    assert_eq!(full.options.len(), lean.options.len());
+    // Everything the processing pipeline consumes must be byte-for-byte
+    // identical — only the occurrence indices differ. Compare full contents
+    // (via Debug), not just counts, so a content regression that preserves
+    // lengths can't slip through.
+    assert_eq!(
+        format!("{:?}", full.directives),
+        format!("{:?}", lean.directives),
+        "directives must be identical"
+    );
+    assert_eq!(
+        format!("{:?}", full.errors),
+        format!("{:?}", lean.errors),
+        "errors must be identical"
+    );
+    assert_eq!(
+        format!("{:?}", full.options),
+        format!("{:?}", lean.options),
+        "options must be identical"
+    );
 }

--- a/crates/rustledger-parser/tests/parser_integration_test.rs
+++ b/crates/rustledger-parser/tests/parser_integration_test.rs
@@ -1134,3 +1134,27 @@ fn test_reject_unclosed_cost_brace_at_eof() {
             .collect::<Vec<_>>()
     );
 }
+
+/// `parse_without_occurrences` skips the LSP-only occurrence indices but is
+/// otherwise identical to `parse` (the processing path's view). Pins the
+/// optimization that drops ~40k per-token allocations on the load path.
+#[test]
+fn parse_without_occurrences_skips_indices_but_matches_directives() {
+    let src = "2020-01-01 open Assets:Cash USD\n\
+               2020-02-01 * \"p\" \"m\"\n  Assets:Cash 5.00 USD\n  Income:Salary\n";
+    let full = rustledger_parser::parse(src);
+    let lean = rustledger_parser::parse_without_occurrences(src);
+    // Full parse collects occurrences; lean parse does not.
+    assert!(
+        !full.account_occurrences.is_empty() && !full.currency_occurrences.is_empty(),
+        "full parse should collect occurrences"
+    );
+    assert!(
+        lean.account_occurrences.is_empty() && lean.currency_occurrences.is_empty(),
+        "lean parse must skip occurrence collection"
+    );
+    // Everything the processing pipeline consumes is unchanged.
+    assert_eq!(full.directives.len(), lean.directives.len());
+    assert_eq!(full.errors.len(), lean.errors.len());
+    assert_eq!(full.options.len(), lean.options.len());
+}


### PR DESCRIPTION
## What

**Profiling-driven optimization ④ — the biggest yet.** Skips collecting the `currency_occurrences` / `account_occurrences` indices on the loader / CLI processing path, where they're never read.

`walk_descendants_once` was the **#1 allocation-count site** in the profile. For every `ACCOUNT` / `CURRENCY` token it builds a `Spanned<Account>` / `Spanned<Currency>` (an `Account::new` / `Currency::new` allocation) **and** does an O(depth) in-`ERROR_NODE` ancestor walk. But these two indices are consumed **solely by the LSP** (rename / references / highlight) — confirmed by grep: zero consumers outside `rustledger-parser` + `rustledger-lsp`. The loader / `rledger check|query` pipeline builds them and throws them away.

## Change

- New `parse_without_occurrences(source)` threads `collect_occurrences = false` into `walk_descendants_once`, which then skips the `ACCOUNT`/`CURRENCY` construction *and* their ancestor walks. Inline errors + top-level comments are still collected (the pipeline needs them).
- `parse()` is **unchanged** — the LSP and all 293 other call sites keep full behavior.
- The loader's 2 parse sites switch to the new variant.

## Measured impact (10k-txn workload, dhat + cachegrind)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| **Heap** | 158.7 MB | 135.1 MB | **−23.6 MB (−14.9%)** |
| **Allocations** | 1,223,484 | 1,183,412 | **−40,072** |
| **Instructions** | 1,121,094,109 | 1,092,010,959 | **−29.1M (−2.6%)** |

Largest heap *and* CPU win of the profiling series.

## Safety

- `parse()` semantics unchanged → LSP unaffected; the returned `ParseResult` differs from `parse()`'s only in the two now-empty occurrence vectors.
- Regression test (`parse_without_occurrences_skips_indices_but_matches_directives`) pins: occurrences empty, but `directives` / `errors` / `options` identical to `parse()`.
- `cargo test -p rustledger-parser` (280) + `-p rustledger-loader` (89) pass; parser+loader+lsp `cargo check` + clippy clean.
- Parser change → the BQL **compat suite runs as the CI gate** on this PR.

## Found via

The nightly `profiling` data branch — fourth optimization it surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
