### PR TITLE
fix(core): heap corruption / SIGSEGV in inventory lot reduction (shared imbl Vector use-after-free)

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -1401,6 +1401,34 @@ mod reduction_tests {
     }
 
     #[test]
+    fn reduce_on_large_shared_inventory_does_not_corrupt() {
+        // Regression: the rich-workload profiler found a heap-corruption /
+        // SIGSEGV when reducing an inventory that had been cloned (imbl O(1)
+        // structural share, as the booking engine does for working copies).
+        // In-place mutation of the SHARED imbl `Vector` double-freed the interned
+        // `Arc<str>` inside `Position`. Needs >64 distinct lots so the `Vector`
+        // spans multiple Arc-backed chunks — the representation that actually
+        // shares (and corrupted). Without the fix this aborts/segfaults on drop.
+        // 100 distinct-cost lots (>64 = the imbl chunk size) so the `Vector`
+        // spans multiple Arc-backed chunks — the shared representation that
+        // corrupted. Day stays a valid 1..=28 (lots remain distinct by cost).
+        // The Miri CI job (`rustledger-core`, strict provenance) executes this
+        // and flags the use-after-free deterministically when the guard is gone.
+        let mut inv = mk((0i64..100).map(|i| lot(10, 100 + i, ((i % 28) + 1) as u32)));
+        let snapshot = inv.clone(); // structurally shares chunks with `inv`
+        inv.reduce(
+            &sell_stk(700),
+            Some(&CostSpec::default()),
+            BookingMethod::Fifo,
+        )
+        .unwrap();
+        assert_eq!(inv.units("STK"), dec!(300)); // 1000 - 700
+        // The shared snapshot stays independent and intact; `units` re-reads
+        // every interned currency, and dropping both must not double-free.
+        assert_eq!(snapshot.units("STK"), dec!(1000));
+    }
+
+    #[test]
     fn reduce_hifo_commits_basis_units_insufficient() {
         let mut inv = mk([lot(10, 100, 1), lot(10, 300, 2)]);
         let r = inv

--- a/crates/rustledger-core/src/inventory/mod.rs
+++ b/crates/rustledger-core/src/inventory/mod.rs
@@ -584,6 +584,19 @@ impl Inventory {
     ) -> Result<BookingResult, BookingError> {
         let spec = cost_spec.cloned().unwrap_or_default();
 
+        // Force a uniquely-owned positions Vector before any reduction mutates
+        // it. `self.positions` is often structurally shared — the booking engine
+        // clones an account's inventory into a working copy via imbl's O(1)
+        // `clone` — and every reduction method below mutates it in place (via
+        // `IndexMut` / `retain`). Mutating a SHARED imbl `Vector` in place drives
+        // `imbl-sized-chunks`' copy-on-write into a use-after-free of the
+        // interned `Arc<str>` inside `Position` — heap corruption / SIGSEGV on
+        // large ledgers with many lot reductions (found by the rich-workload
+        // profiler). Rebuilding from cloned positions restores a refcount-1
+        // Vector with correct `Arc` refcounting, so in-place mutation below has
+        // no shared chunk to corrupt.
+        self.positions = self.positions.iter().cloned().collect();
+
         // {*} merge operator: merge all lots into a single weighted-average-cost
         // lot before reducing, regardless of the account's booking method.
         if spec.merge {


### PR DESCRIPTION
## What

Fixes a **memory-corruption / SIGSEGV** in the booking engine's inventory lot-reduction path. `rledger check` crashes (heap corruption → `malloc` abort in debug, raw SIGSEGV in release) on realistic ledgers with **cost specs and many lot reductions** (~4000+ mixed entries reproduces deterministically).

## Root cause

The booking engine clones an account's inventory into a working copy via imbl's O(1) **structural-share** `clone` (`book.rs` `working_inventories`). The reduction methods then mutate that `Vector<Position>` **in place** (`&mut self.positions[idx]` + `retain`). Mutating a *shared* imbl `Vector` in place drives `imbl-sized-chunks`' copy-on-write over a `Drop`-bearing element type into a **use-after-free of the interned `Arc<str>`** inside `Position` (Currency/Cost). The corrupt refcount is later double-freed when the `Vector` drops — valgrind shows a wild-pointer read in `reduce_ordered`'s `retain` drop; the debug build trips `malloc_consolidate(): unaligned fastbin chunk`.

It only manifests once an account's inventory exceeds the 64-element chunk size (multiple Arc-backed chunks) **and** is reduced while shared — which is why the simple-transaction workloads never hit it.

## Fix

One guard at the `Inventory::reduce` dispatch (covers all 7 reduction methods): rebuild `self.positions` from cloned positions, restoring a **refcount-1, uniquely-owned** Vector before any in-place mutation. Cloning goes through `Position::clone` (correct `Arc` refcounting), so there is no shared chunk to corrupt.

```rust
// inventory/mod.rs, top of reduce():
self.positions = self.positions.iter().cloned().collect();
```

(Booking already clones the inventory per reduction, so this adds no asymptotic cost on that path.)

## Verification

- **valgrind**: `0 errors` on the formerly-crashing 4000-entry ledger (was a fatal Invalid-read).
- Formerly-crashing workloads (4k/5k/full rich) now exit 0 in **both** debug and release.
- `rustledger-core` (421) + `rustledger-booking` (105) tests pass; clippy clean.
- **Regression test** (`reduce_on_large_shared_inventory_does_not_corrupt`): reduces a cloned (shared) 100-lot inventory — >64 lots so it spans multiple imbl chunks. The **Miri CI job** (rustledger-core, strict provenance) executes it and flags the use-after-free deterministically if the guard is ever removed.

## How it was found

The nightly `profiling` data branch work — broadening the profiling workload to exercise cost specs / lot reductions / metadata surfaced this crash (the simple synthetic never reduced lots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
