### PR TITLE
perf(parser): green-tree transaction conversion with red fallback (-16% load)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,6 +31,7 @@ on:
           - all
           - fuzz_parse
           - fuzz_parse_line
+          - fuzz_green_eq_red
           - fuzz_query_parse
           - fuzz_query_execute
           - fuzz_booking
@@ -55,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [fuzz_parse, fuzz_parse_line]
+        target: [fuzz_parse, fuzz_parse_line, fuzz_green_eq_red]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check if target should run

--- a/crates/rustledger-parser/fuzz/Cargo.lock
+++ b/crates/rustledger-parser/fuzz/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,12 +57,9 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bitmaps"
-version = "2.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -145,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +182,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "derive_arbitrary"
@@ -243,6 +258,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -254,18 +275,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
-name = "im"
-version = "15.1.0"
+name = "imbl"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
 dependencies = [
  "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -439,6 +470,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,7 +617,7 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -574,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -587,12 +640,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
+name = "rand_core"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -690,6 +749,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +789,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -733,14 +810,14 @@ dependencies = [
 
 [[package]]
 name = "rustledger-core"
-version = "0.15.0"
+version = "0.16.5"
 dependencies = [
- "im",
+ "imbl",
  "jiff",
  "rkyv 0.8.16",
  "rust_decimal",
  "rust_decimal_macros",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "smallvec",
@@ -748,13 +825,16 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.15.0"
+version = "0.16.5"
 dependencies = [
  "logos",
+ "num_enum",
  "rkyv 0.8.16",
+ "rowan",
  "rust_decimal",
  "rustledger-core",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -771,6 +851,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "seahash"
@@ -840,16 +929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +961,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "tinyvec"
@@ -927,12 +1012,6 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1015,6 +1094,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/crates/rustledger-parser/fuzz/Cargo.toml
+++ b/crates/rustledger-parser/fuzz/Cargo.toml
@@ -32,3 +32,10 @@ path = "fuzz_targets/fuzz_parse_line.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_green_eq_red"
+path = "fuzz_targets/fuzz_green_eq_red.rs"
+test = false
+doc = false
+bench = false

--- a/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
+++ b/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
@@ -1,0 +1,39 @@
+#![no_main]
+//! Differential fuzz target for the green transaction conversion (the
+//! lossless-CST-tax removal). The green-wired `parse` must produce output
+//! **byte-identical** to the pure-red path on every input: the green
+//! transaction converter returns `Some` only when it exactly replicates red,
+//! and bails to red otherwise — so any divergence here is a green-path bug.
+use libfuzzer_sys::fuzz_target;
+use rustledger_parser::{parse, parse_red_only};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(src) = std::str::from_utf8(data) else {
+        return;
+    };
+    let green = parse(src);
+    let red = parse_red_only(src);
+
+    // Compare the full result via Debug (avoids requiring `PartialEq` on every
+    // field type). Directives + errors are where a green divergence would show.
+    assert_eq!(
+        format!("{:?}", green.directives),
+        format!("{:?}", red.directives),
+        "green vs red directives diverged"
+    );
+    assert_eq!(
+        format!("{:?}", green.errors),
+        format!("{:?}", red.errors),
+        "green vs red errors diverged"
+    );
+    assert_eq!(
+        format!("{:?}", green.options),
+        format!("{:?}", red.options),
+        "green vs red options diverged"
+    );
+    assert_eq!(
+        format!("{:?}", green.comments),
+        format!("{:?}", red.comments),
+        "green vs red comments diverged"
+    );
+});

--- a/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
+++ b/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
@@ -5,7 +5,8 @@
 //! transaction converter returns `Some` only when it exactly replicates red,
 //! and bails to red otherwise — so any divergence here is a green-path bug.
 use libfuzzer_sys::fuzz_target;
-use rustledger_parser::{parse, parse_red_only};
+use rustledger_parser::cst::parse_red_only;
+use rustledger_parser::parse;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(src) = std::str::from_utf8(data) else {

--- a/crates/rustledger-parser/src/cst/ast.rs
+++ b/crates/rustledger-parser/src/cst/ast.rs
@@ -188,30 +188,8 @@ impl StringLit {
     /// lexer. Returns an owned `String` (decoding may shrink the content).
     /// Returns `None` if the raw text isn't a well-formed quoted string.
     pub fn text_decoded(&self) -> Option<String> {
-        let raw = self.text_unquoted()?;
-        if !raw.contains('\\') {
-            return Some(raw.to_string());
-        }
-        let mut out = String::with_capacity(raw.len());
-        let mut chars = raw.chars();
-        while let Some(c) = chars.next() {
-            if c != '\\' {
-                out.push(c);
-                continue;
-            }
-            match chars.next() {
-                Some('"') => out.push('"'),
-                Some('\\') => out.push('\\'),
-                Some('n') => out.push('\n'),
-                Some('t') => out.push('\t'),
-                Some('r') => out.push('\r'),
-                // Unknown escape: drop the backslash, keep the char (Beancount).
-                Some(other) => out.push(other),
-                // Trailing lone backslash (not reachable for a valid token).
-                None => {}
-            }
-        }
-        Some(out)
+        // Shared text-based decoder (one source of truth for red + green paths).
+        super::convert::decode_string_token(self.text())
     }
 }
 

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -2344,7 +2344,7 @@ fn section_marker_check(
 /// and single-digit month/day. Returns `None` when the token
 /// can't be turned into a real calendar date (invalid month,
 /// invalid day for the given month, etc.).
-fn parse_date_token(text: &str) -> Option<NaiveDate> {
+pub(super) fn parse_date_token(text: &str) -> Option<NaiveDate> {
     // Fast path: canonical "YYYY-MM-DD".
     if text.len() == 10
         && text.as_bytes()[4] == b'-'
@@ -2390,6 +2390,40 @@ fn parse_directive_date(
         span,
     ));
     None
+}
+
+/// Decode a `STRING` token's text (with surrounding quotes) into its semantic
+/// value: quotes stripped, escapes decoded (`\"`→`"`, `\\`→`\`, `\n`/`\t`/`\r`,
+/// unknown escape drops the backslash). `None` if not a well-formed quoted
+/// string. Text-based so both the red ([`ast::StringLit::text_decoded`]) and
+/// green conversion paths share one source of truth.
+pub(super) fn decode_string_token(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
+        return None;
+    }
+    let raw = &text[1..text.len() - 1];
+    if !raw.contains('\\') {
+        return Some(raw.to_string());
+    }
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some(other) => out.push(other),
+            None => {}
+        }
+    }
+    Some(out)
 }
 
 /// Parse a numeric token. Tolerates leading sign and thousands-

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -183,7 +183,17 @@ pub fn parse_via_cst_opts(source: &str, collect_occurrences: bool) -> ParseResul
             ast::Directive::Pad(node) => convert_pad(&node, bom_offset, &mut errors),
             ast::Directive::Custom(node) => convert_custom(&node, bom_offset, &mut errors),
             ast::Directive::Transaction(node) => {
-                convert_transaction(&node, bom_offset, &mut errors)
+                // Green-tree conversion (no red-node allocation) with a red
+                // fallback for transactions it doesn't yet handle exactly. The
+                // green path returns `Some` only when its output is identical to
+                // red's, so the hybrid is output-equivalent to the pure-red path.
+                let green = node.syntax().green();
+                let base =
+                    u32::from(node.syntax().text_range().start()) as usize + bom_offset as usize;
+                match super::green::convert_transaction(&green, base) {
+                    Some(d) => Some(d),
+                    None => convert_transaction(&node, bom_offset, &mut errors),
+                }
             }
             ast::Directive::Option(node) => {
                 if let Some(triple) = convert_option(&node, bom_offset) {

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -72,6 +72,21 @@ pub fn parse_via_cst(source: &str) -> ParseResult {
 /// collected unconditionally (the processing path needs them).
 #[must_use]
 pub fn parse_via_cst_opts(source: &str, collect_occurrences: bool) -> ParseResult {
+    parse_via_cst_inner(source, collect_occurrences, /* use_green = */ true)
+}
+
+/// Test/fuzz hook: parse like [`crate::parse`] but force the **red** conversion
+/// path (green transaction conversion disabled). Used by the `green_eq_red`
+/// differential fuzz target to assert the green-wired path is output-equivalent.
+#[doc(hidden)]
+#[must_use]
+pub fn parse_red_only(source: &str) -> ParseResult {
+    parse_via_cst_inner(
+        source, /* collect_occurrences = */ true, /* use_green = */ false,
+    )
+}
+
+fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool) -> ParseResult {
     // BOM detection mirrors the legacy parser's behavior: strip a
     // leading 3-byte BOM from the source before tokenizing and
     // record its presence in the result. Spans index the original
@@ -190,7 +205,12 @@ pub fn parse_via_cst_opts(source: &str, collect_occurrences: bool) -> ParseResul
                 let green = node.syntax().green();
                 let base =
                     u32::from(node.syntax().text_range().start()) as usize + bom_offset as usize;
-                match super::green::convert_transaction(&green, base) {
+                let green_dir = if use_green {
+                    super::green::convert_transaction(&green, base)
+                } else {
+                    None
+                };
+                match green_dir {
                     Some(d) => Some(d),
                     None => convert_transaction(&node, bom_offset, &mut errors),
                 }

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -1705,7 +1705,7 @@ fn pushmeta_value(node: &crate::SyntaxNode) -> MetaValue {
 /// Comment-like syntax kinds that the legacy parser surfaces as
 /// `ParseResult.comments` entries when they appear at the top
 /// level (outside any directive's content).
-const fn is_comment_kind(kind: crate::SyntaxKind) -> bool {
+pub(super) const fn is_comment_kind(kind: crate::SyntaxKind) -> bool {
     matches!(
         kind,
         crate::SyntaxKind::COMMENT
@@ -2428,7 +2428,7 @@ pub(super) fn decode_string_token(text: &str) -> Option<String> {
 
 /// Parse a numeric token. Tolerates leading sign and thousands-
 /// separator commas (legacy parser drops them).
-fn parse_decimal_token(text: &str) -> Option<Decimal> {
+pub(super) fn parse_decimal_token(text: &str) -> Option<Decimal> {
     use std::str::FromStr;
     let cleaned: String;
     let s = if text.contains(',') {

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -87,6 +87,7 @@ pub(super) fn convert_transaction_header(
     let span = Span::new(base, base + u32::from(node.text_len()) as usize);
 
     let mut date: Option<NaiveDate> = None;
+    let mut date_seen = false;
     let mut flag = '*';
     let mut seen_flag = false;
     let mut seen_str_tag_link = false;
@@ -123,7 +124,13 @@ pub(super) fn convert_transaction_header(
         } else {
             match kind {
                 K::NEWLINE => past_header = true,
-                K::DATE if date.is_none() => date = parse_date_token(text),
+                // Latch on the FIRST date token (like red's `node.date()`): if it
+                // fails to parse, `date` stays None and the directive bails to red
+                // — don't scan ahead to a later valid-looking date in junk input.
+                K::DATE if !date_seen => {
+                    date_seen = true;
+                    date = parse_date_token(text);
+                }
                 K::STRING => {
                     seen_str_tag_link = true;
                     if let Some(s) = decode_string_token(text) {
@@ -245,7 +252,9 @@ fn convert_cost_spec(node: &rowan::GreenNodeData) -> CostSpec {
     let mut post_hash_total: Option<rust_decimal::Decimal> = None;
     let mut currency: Option<Currency> = None;
     let mut date: Option<NaiveDate> = None;
+    let mut date_seen = false;
     let mut label: Option<String> = None;
+    let mut label_seen = false;
     for child in node.children() {
         let NodeOrToken::Token(t) = child else {
             continue;
@@ -282,12 +291,14 @@ fn convert_cost_spec(node: &rowan::GreenNodeData) -> CostSpec {
                 merge_phase = false;
                 currency = Some(Currency::new(t.text()));
             }
-            K::DATE if date.is_none() => {
+            K::DATE if !date_seen => {
                 merge_phase = false;
+                date_seen = true;
                 date = parse_date_token(t.text());
             }
-            K::STRING if label.is_none() => {
+            K::STRING if !label_seen => {
                 merge_phase = false;
+                label_seen = true;
                 label = decode_string_token(t.text());
             }
             _ => merge_phase = false,
@@ -534,12 +545,11 @@ mod tests {
                     NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
                     NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
                 };
-                if let NodeOrToken::Node(n) = child {
-                    if crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::TRANSACTION
-                    {
-                        txn_node = Some((n, offset));
-                        break;
-                    }
+                if let NodeOrToken::Node(n) = child
+                    && crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::TRANSACTION
+                {
+                    txn_node = Some((n, offset));
+                    break;
                 }
                 offset += len;
             }
@@ -598,12 +608,11 @@ mod tests {
                     NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
                     NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
                 };
-                if let NodeOrToken::Node(n) = child {
-                    if crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::TRANSACTION
-                    {
-                        txn = Some((n, off));
-                        break;
-                    }
+                if let NodeOrToken::Node(n) = child
+                    && crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::TRANSACTION
+                {
+                    txn = Some((n, off));
+                    break;
                 }
                 off += len;
             }
@@ -616,14 +625,14 @@ mod tests {
                     NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
                     NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
                 };
-                if let NodeOrToken::Node(n) = child {
-                    if crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::POSTING {
-                        let gp = convert_simple_posting(n, poff).expect("simple posting");
-                        let rp = &rtxn.postings[gi];
-                        assert_eq!(gp.value, rp.value, "posting {gi} value {src:?}");
-                        assert_eq!(gp.span, rp.span, "posting {gi} span {src:?}");
-                        gi += 1;
-                    }
+                if let NodeOrToken::Node(n) = child
+                    && crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::POSTING
+                {
+                    let gp = convert_simple_posting(n, poff).expect("simple posting");
+                    let rp = &rtxn.postings[gi];
+                    assert_eq!(gp.value, rp.value, "posting {gi} value {src:?}");
+                    assert_eq!(gp.span, rp.span, "posting {gi} span {src:?}");
+                    gi += 1;
                 }
                 poff += len;
             }
@@ -650,6 +659,12 @@ mod tests {
             "2020-01-01 * \"p\"\n  A 5 USD 3 USD\n  B\n", // multi-amount -> fallback
             "2020-01-01 * \"p\" | \"n\"\n  A 1 USD\n  B\n", // deprecated pipe -> fallback
             "2020-13-99 * \"bad date\"\n  A 1 USD\n  B\n", // invalid date -> fallback
+            // Regression (fuzz_green_eq_red crash-a45e3089): an invalid FIRST date
+            // followed by a valid-looking later date token. Green must latch the
+            // first date (-> None -> bail to red, which drops the directive), NOT
+            // scan ahead to the second date and keep a directive red discards.
+            "2020-99-99 * \"x\" 2021-01-01\n  A 1 USD\n  B\n",
+            "3333/33/3 X\n", // the minimized fuzz shape (slash date, month 33)
             "\u{feff}2020-01-01 * \"p\"\n  A 1 USD\n  B\n", // BOM
             "2020-01-01 * \"é\" \"münts\"\n  Aaa 1 EUR\n  B\n", // multi-byte
             "garbage\n2020-01-01 open A\n2020-01-01 * \"p\"\n  A 1 USD\n  B\n", // error recovery

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -8,15 +8,16 @@
 //! parallel with [`super::convert`] and gated by a differential oracle that
 //! pins its output byte-identical to the red path.
 //!
-//! Status: foundation + transaction **header** conversion (date / flag /
-//! payee+narration / tags / links / span), reusing the shared text parsers in
-//! [`super::convert`]. Postings + metadata + comments + error recovery layer on
-//! next; the field-level oracle (`green_txn_header_matches_red`) pins each field
-//! against the red path as it's built.
+//! Status: full transaction conversion (header + postings + cost/price), wired
+//! into `parse_via_cst_opts` with a **red fallback** — green returns `Some` only
+//! when it exactly replicates red, bailing on transaction metadata, direct-child
+//! comments, deprecated `|`, unparseable amounts, and posting flag/metadata/
+//! arithmetic (those layer on next). Measured −16% load on a 10k-txn workload.
+//! Pinned by field-level oracles + the `parse_green_eq_red_corpus` differential
+//! test + the `fuzz_green_eq_red` fuzz target.
 
-// PR1 WIP: this parallel green path is built + verified by the differential
-// tests below before being wired into `parse_via_cst`; until that wiring lands
-// its functions are exercised only by tests.
+// `top_level_node_spans` is a span-validation helper exercised only by the
+// differential tests; the rest of this module is wired into `parse_via_cst_opts`.
 #![allow(dead_code)]
 
 use super::convert::{decode_string_token, is_comment_kind, parse_date_token, parse_decimal_token};
@@ -625,6 +626,49 @@ mod tests {
                 poff += len;
             }
             assert_eq!(gi, rtxn.postings.len(), "posting count {src:?}");
+        }
+    }
+
+    /// End-to-end differential: the green-wired `parse` must equal the pure-red
+    /// `parse_red_only` on every input — exercising the green path (simple txns)
+    /// AND every red-fallback trigger (flag / metadata / comment / arithmetic /
+    /// multi-amount / pipe / invalid date), plus non-transaction directives,
+    /// BOM, multi-byte, and error recovery. (The fuzz target generalizes this.)
+    #[test]
+    fn parse_green_eq_red_corpus() {
+        let corpus = [
+            "",
+            "2020-01-01 * \"p\" \"n\"\n  A 1 USD\n  B\n",
+            "2020-01-01 ! \"x\" #t ^l\n  A 10 AAPL {2 USD} @ 3 USD\n  B -20 USD\n  Income:G\n",
+            "2020-01-01 * \"p\"\n  ! A 1 USD\n  B\n", // posting flag -> red fallback
+            "2020-01-01 * \"p\"\n  A 1 USD\n    note: \"m\"\n  B\n", // posting meta -> fallback
+            "2020-01-01 * \"p\"\n  meta: \"x\"\n  A 1 USD\n  B\n", // txn meta -> fallback
+            "2020-01-01 * \"p\"\n  ; a comment\n  A 1 USD\n  B\n", // body comment -> fallback
+            "2020-01-01 * \"p\"\n  A 5 USD + 3 USD\n  B\n", // arithmetic -> fallback
+            "2020-01-01 * \"p\"\n  A 5 USD 3 USD\n  B\n", // multi-amount -> fallback
+            "2020-01-01 * \"p\" | \"n\"\n  A 1 USD\n  B\n", // deprecated pipe -> fallback
+            "2020-13-99 * \"bad date\"\n  A 1 USD\n  B\n", // invalid date -> fallback
+            "\u{feff}2020-01-01 * \"p\"\n  A 1 USD\n  B\n", // BOM
+            "2020-01-01 * \"é\" \"münts\"\n  Aaa 1 EUR\n  B\n", // multi-byte
+            "garbage\n2020-01-01 open A\n2020-01-01 * \"p\"\n  A 1 USD\n  B\n", // error recovery
+            "2020-01-01 open A\n2020-01-02 close A\noption \"x\" \"y\"\n", // non-txn
+        ];
+        for src in corpus {
+            let g = crate::parse(src);
+            let r = crate::parse_red_only(src);
+            let dbg = |p: &crate::ParseResult| {
+                (
+                    format!("{:?}", p.directives),
+                    format!("{:?}", p.errors),
+                    format!("{:?}", p.comments),
+                    format!("{:?}", p.options),
+                )
+            };
+            assert_eq!(
+                dbg(&g),
+                dbg(&r),
+                "green-wired parse diverged from red for: {src:?}"
+            );
         }
     }
 }

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -21,6 +21,8 @@
 
 use super::convert::{decode_string_token, is_comment_kind, parse_date_token, parse_decimal_token};
 use rowan::{Language, NodeOrToken};
+use rustledger_core::cost::{CostNumber, CostSpec};
+use rustledger_core::directive::{PriceAnnotation, PriceKind};
 use rustledger_core::{
     Account, Amount, Currency, IncompleteAmount, InternedStr, Link, Metadata, NaiveDate, Posting,
     Span, Spanned, Tag,
@@ -216,6 +218,125 @@ fn simple_amount(node: &rowan::GreenNodeData) -> Option<IncompleteAmount> {
     }
 }
 
+/// Convert a `COST_SPEC` green node into a `CostSpec` (forms `{N CCY}`,
+/// `{{T CCY}}`, `{N # T CCY}`, `{*}` merge, plus optional date + label). Mirrors
+/// `convert_cost_spec` / `cost_total_after_hash` in [`super::convert`]. Cost
+/// numbers are plain `NUMBER` tokens (no arithmetic), so this always succeeds.
+fn convert_cost_spec(node: &rowan::GreenNodeData) -> CostSpec {
+    use crate::SyntaxKind as K;
+    let mut is_total = false;
+    let mut is_merge = false;
+    let mut merge_phase = false; // after opener, while only WHITESPACE seen
+    let mut first_number: Option<rust_decimal::Decimal> = None;
+    let mut seen_number = false;
+    let mut past_hash = false;
+    let mut post_hash_total: Option<rust_decimal::Decimal> = None;
+    let mut currency: Option<Currency> = None;
+    let mut date: Option<NaiveDate> = None;
+    let mut label: Option<String> = None;
+    for child in node.children() {
+        let NodeOrToken::Token(t) = child else {
+            continue;
+        };
+        match crate::BeancountLanguage::kind_from_raw(t.kind()) {
+            K::L_DOUBLE_BRACE => {
+                is_total = true;
+                merge_phase = true;
+            }
+            K::L_BRACE | K::L_BRACE_HASH => merge_phase = true,
+            K::WHITESPACE => {} // keep merge_phase across leading whitespace
+            K::STAR => {
+                if merge_phase {
+                    is_merge = true;
+                }
+                merge_phase = false;
+            }
+            K::NUMBER => {
+                merge_phase = false;
+                if past_hash && post_hash_total.is_none() {
+                    post_hash_total = parse_decimal_token(t.text());
+                } else if !seen_number {
+                    seen_number = true;
+                    first_number = parse_decimal_token(t.text());
+                }
+            }
+            K::HASH => {
+                merge_phase = false;
+                if seen_number {
+                    past_hash = true;
+                }
+            }
+            K::CURRENCY if currency.is_none() => {
+                merge_phase = false;
+                currency = Some(Currency::new(t.text()));
+            }
+            K::DATE if date.is_none() => {
+                merge_phase = false;
+                date = parse_date_token(t.text());
+            }
+            K::STRING if label.is_none() => {
+                merge_phase = false;
+                label = decode_string_token(t.text());
+            }
+            _ => merge_phase = false,
+        }
+    }
+    let number = if let Some(total) = post_hash_total {
+        Some(CostNumber::Total { value: total })
+    } else {
+        match (first_number, is_total) {
+            (Some(v), true) => Some(CostNumber::Total { value: v }),
+            (Some(v), false) => Some(CostNumber::PerUnit { value: v }),
+            (None, _) => None,
+        }
+    };
+    CostSpec {
+        number,
+        currency,
+        date,
+        label,
+        merge: is_merge,
+    }
+}
+
+/// Convert a `PRICE_ANNOTATION` green node into a `PriceAnnotation`: `@@`→Total,
+/// `@`→Unit, with the (non-arithmetic) amount. Returns `None` when the amount is
+/// present but arithmetic/malformed, signalling the caller to bail (later
+/// increment evaluates those).
+fn convert_price_annotation(node: &rowan::GreenNodeData) -> Option<PriceAnnotation> {
+    use crate::SyntaxKind as K;
+    let mut is_total = false;
+    let mut amount_present = false;
+    let mut amount: Option<IncompleteAmount> = None;
+    for child in node.children() {
+        match &child {
+            NodeOrToken::Token(t) => {
+                if crate::BeancountLanguage::kind_from_raw(t.kind()) == K::AT_AT {
+                    is_total = true;
+                }
+            }
+            NodeOrToken::Node(n) => {
+                if crate::BeancountLanguage::kind_from_raw(n.kind()) == K::AMOUNT && !amount_present
+                {
+                    amount_present = true;
+                    amount = simple_amount(n);
+                }
+            }
+        }
+    }
+    if amount_present && amount.is_none() {
+        return None; // arithmetic / malformed price amount — bail
+    }
+    Some(PriceAnnotation {
+        kind: if is_total {
+            PriceKind::Total
+        } else {
+            PriceKind::Unit
+        },
+        amount,
+    })
+}
+
 /// Convert a **simple** `POSTING` green node (account + non-arithmetic units +
 /// span + same-line trailing comments). Returns `None` for postings with a
 /// flag, cost spec, price annotation, metadata, a trailing-sibling amount, or
@@ -229,6 +350,8 @@ pub(super) fn convert_simple_posting(
     use crate::SyntaxKind as K;
     let mut account: Option<Account> = None;
     let mut units: Option<IncompleteAmount> = None;
+    let mut cost: Option<CostSpec> = None;
+    let mut price: Option<PriceAnnotation> = None;
     let mut trailing_comments: Vec<String> = Vec::new();
     let mut newline_off: Option<usize> = None;
     let mut amount_seen = false;
@@ -257,7 +380,13 @@ pub(super) fn convert_simple_posting(
                     // `?` bails on an arithmetic/malformed amount (later increment).
                     units = Some(simple_amount(n)?);
                 }
-                K::AMOUNT | K::COST_SPEC | K::PRICE_ANNOTATION | K::META_ENTRY => return None,
+                K::COST_SPEC if cost.is_none() => cost = Some(convert_cost_spec(n)),
+                // `?` bails if the price amount is arithmetic/malformed.
+                K::PRICE_ANNOTATION if price.is_none() => {
+                    price = Some(convert_price_annotation(n)?);
+                }
+                // second amount / posting metadata — later increments.
+                K::AMOUNT | K::META_ENTRY => return None,
                 _ => {}
             },
         }
@@ -269,8 +398,8 @@ pub(super) fn convert_simple_posting(
         Posting {
             account,
             units,
-            cost: None,
-            price: None,
+            cost,
+            price,
             flag: None,
             meta: Metadata::default(),
             comments: Vec::new(),
@@ -386,6 +515,16 @@ mod tests {
             "2020-01-01 * \"p\"\n  Assets:A -10 EUR\n  Assets:B 10 EUR\n",
             "2020-01-01 * \"p\"\n  A 5 USD  ; note here\n  B\n",
             "2020-01-01 * \"p\"\n  A 1234.5678 USD\n  B 0 USD\n",
+            // cost specs
+            "2020-01-01 * \"p\"\n  Assets:Stock 10 AAPL {2.00 USD}\n  Assets:Cash -20.00 USD\n",
+            "2020-01-01 * \"p\"\n  Assets:Stock 10 AAPL {{20.00 USD}}\n  Assets:Cash -20.00 USD\n",
+            "2020-01-01 * \"p\"\n  A 10 AAPL {2.00 USD, 2021-06-01}\n  B -20.00 USD\n",
+            "2020-01-01 * \"p\"\n  A 10 AAPL {2.00 USD, \"lot-1\"}\n  B -20.00 USD\n",
+            "2020-01-01 * \"p\"\n  A -5 AAPL {1.50 # 8.00 USD}\n  B 8.00 USD\n  Income:G\n",
+            // prices (@ unit, @@ total) + cost+price together
+            "2020-01-01 * \"p\"\n  A 10 AAPL @ 3.00 USD\n  B -30.00 USD\n",
+            "2020-01-01 * \"p\"\n  A 10 AAPL @@ 25.00 USD\n  B -25.00 USD\n",
+            "2020-01-01 * \"p\"\n  A -5 AAPL {2.00 USD} @ 3.00 USD\n  B 15.00 USD\n  Income:G\n",
         ];
         for src in cases {
             let red = crate::parse(src);

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -19,9 +19,12 @@
 // its functions are exercised only by tests.
 #![allow(dead_code)]
 
-use super::convert::{decode_string_token, parse_date_token};
+use super::convert::{decode_string_token, is_comment_kind, parse_date_token, parse_decimal_token};
 use rowan::{Language, NodeOrToken};
-use rustledger_core::{InternedStr, Link, Metadata, NaiveDate, Span, Tag};
+use rustledger_core::{
+    Account, Amount, Currency, IncompleteAmount, InternedStr, Link, Metadata, NaiveDate, Posting,
+    Span, Spanned, Tag,
+};
 
 /// Every top-level (child-of-root) **node** paired with its source [`Span`],
 /// computed by threading the absolute byte offset through the green tree — no
@@ -169,6 +172,114 @@ pub(super) fn convert_transaction_header(
     Some((txn, span))
 }
 
+/// Convert a non-arithmetic `AMOUNT` green node into an `IncompleteAmount`.
+/// Returns `None` for arithmetic-expression amounts (`5 + 3 USD`) — those are a
+/// later increment; the simple oracle corpus excludes them.
+fn simple_amount(node: &rowan::GreenNodeData) -> Option<IncompleteAmount> {
+    use crate::SyntaxKind as K;
+    let mut sign_minus = false;
+    let mut number: Option<rust_decimal::Decimal> = None;
+    let mut currency: Option<Currency> = None;
+    let mut complex = false;
+    for child in node.children() {
+        let NodeOrToken::Token(t) = child else {
+            complex = true;
+            continue;
+        };
+        match crate::BeancountLanguage::kind_from_raw(t.kind()) {
+            K::MINUS if number.is_none() => sign_minus = true,
+            K::PLUS if number.is_none() => {}
+            K::NUMBER if number.is_none() => number = parse_decimal_token(t.text()),
+            K::CURRENCY if currency.is_none() => currency = Some(Currency::new(t.text())),
+            K::WHITESPACE => {}
+            // Operator, second number, or extra currency => arithmetic/complex.
+            K::NUMBER
+            | K::PLUS
+            | K::MINUS
+            | K::STAR
+            | K::SLASH
+            | K::L_PAREN
+            | K::R_PAREN
+            | K::CURRENCY => complex = true,
+            _ => {}
+        }
+    }
+    if complex {
+        return None;
+    }
+    let number = number.map(|n| if sign_minus { -n } else { n });
+    match (number, currency) {
+        (Some(n), Some(c)) => Some(IncompleteAmount::Complete(Amount::new(n, c))),
+        (Some(n), None) => Some(IncompleteAmount::NumberOnly(n)),
+        (None, Some(c)) => Some(IncompleteAmount::CurrencyOnly(c)),
+        (None, None) => None,
+    }
+}
+
+/// Convert a **simple** `POSTING` green node (account + non-arithmetic units +
+/// span + same-line trailing comments). Returns `None` for postings with a
+/// flag, cost spec, price annotation, metadata, a trailing-sibling amount, or
+/// an arithmetic amount — those layer on in later increments, and the simple
+/// oracle corpus excludes them. `base` is the node's absolute start offset.
+/// Span policy matches red `posting_span`: ends at the first NEWLINE's start.
+pub(super) fn convert_simple_posting(
+    node: &rowan::GreenNodeData,
+    base: usize,
+) -> Option<Spanned<Posting>> {
+    use crate::SyntaxKind as K;
+    let mut account: Option<Account> = None;
+    let mut units: Option<IncompleteAmount> = None;
+    let mut trailing_comments: Vec<String> = Vec::new();
+    let mut newline_off: Option<usize> = None;
+    let mut amount_seen = false;
+    let mut offset = base;
+    for child in node.children() {
+        let len = match &child {
+            NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
+            NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
+        };
+        match &child {
+            NodeOrToken::Token(t) => {
+                let kind = crate::BeancountLanguage::kind_from_raw(t.kind());
+                if kind == K::ACCOUNT && account.is_none() {
+                    account = Some(Account::new(t.text()));
+                } else if kind == K::NEWLINE && newline_off.is_none() {
+                    newline_off = Some(offset);
+                } else if newline_off.is_none() && is_comment_kind(kind) {
+                    trailing_comments.push(t.text().to_string());
+                } else if matches!(kind, K::FLAG | K::STAR | K::HASH | K::PENDING_KW) {
+                    return None; // posting flag — later increment
+                }
+            }
+            NodeOrToken::Node(n) => match crate::BeancountLanguage::kind_from_raw(n.kind()) {
+                K::AMOUNT if !amount_seen => {
+                    amount_seen = true;
+                    // `?` bails on an arithmetic/malformed amount (later increment).
+                    units = Some(simple_amount(n)?);
+                }
+                K::AMOUNT | K::COST_SPEC | K::PRICE_ANNOTATION | K::META_ENTRY => return None,
+                _ => {}
+            },
+        }
+        offset += len;
+    }
+    let account = account?;
+    let end = newline_off.unwrap_or(base + u32::from(node.text_len()) as usize);
+    Some(Spanned::new(
+        Posting {
+            account,
+            units,
+            cost: None,
+            price: None,
+            flag: None,
+            meta: Metadata::default(),
+            comments: Vec::new(),
+            trailing_comments,
+        },
+        Span::new(base, end),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,6 +373,65 @@ mod tests {
             assert_eq!(g.tags, r.tags, "tags {src:?}");
             assert_eq!(g.links, r.links, "links {src:?}");
             assert_eq!(g_span, red_sp.span, "span {src:?}");
+        }
+    }
+
+    /// Field oracle: green simple-posting conversion must equal the red path's,
+    /// for simple postings (account + non-arithmetic units + trailing comment +
+    /// elided units). No BOM in these cases.
+    #[test]
+    fn green_simple_posting_matches_red() {
+        let cases = [
+            "2020-01-01 * \"p\"\n  Assets:Cash 5.00 USD\n  Income:X\n",
+            "2020-01-01 * \"p\"\n  Assets:A -10 EUR\n  Assets:B 10 EUR\n",
+            "2020-01-01 * \"p\"\n  A 5 USD  ; note here\n  B\n",
+            "2020-01-01 * \"p\"\n  A 1234.5678 USD\n  B 0 USD\n",
+        ];
+        for src in cases {
+            let red = crate::parse(src);
+            let Directive::Transaction(rtxn) = &red.directives[0].value else {
+                panic!("txn {src:?}");
+            };
+            let root = parse_structured(src);
+            let green = root.green();
+            // locate the TRANSACTION node + base
+            let mut off = 0usize;
+            let mut txn = None;
+            for child in green.children() {
+                let len = match &child {
+                    NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
+                    NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
+                };
+                if let NodeOrToken::Node(n) = child {
+                    if crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::TRANSACTION
+                    {
+                        txn = Some((n, off));
+                        break;
+                    }
+                }
+                off += len;
+            }
+            let (txn_node, txn_base) = txn.expect("txn node");
+            // walk its POSTING children, comparing each to red.
+            let mut poff = txn_base;
+            let mut gi = 0usize;
+            for child in txn_node.children() {
+                let len = match &child {
+                    NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
+                    NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
+                };
+                if let NodeOrToken::Node(n) = child {
+                    if crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::POSTING {
+                        let gp = convert_simple_posting(n, poff).expect("simple posting");
+                        let rp = &rtxn.postings[gi];
+                        assert_eq!(gp.value, rp.value, "posting {gi} value {src:?}");
+                        assert_eq!(gp.span, rp.span, "posting {gi} span {src:?}");
+                        gi += 1;
+                    }
+                }
+                poff += len;
+            }
+            assert_eq!(gi, rtxn.postings.len(), "posting count {src:?}");
         }
     }
 }

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -181,6 +181,7 @@ fn simple_amount(node: &rowan::GreenNodeData) -> Option<IncompleteAmount> {
     use crate::SyntaxKind as K;
     let mut sign_minus = false;
     let mut number: Option<rust_decimal::Decimal> = None;
+    let mut number_seen = false;
     let mut currency: Option<Currency> = None;
     let mut complex = false;
     for child in node.children() {
@@ -189,9 +190,17 @@ fn simple_amount(node: &rowan::GreenNodeData) -> Option<IncompleteAmount> {
             continue;
         };
         match crate::BeancountLanguage::kind_from_raw(t.kind()) {
-            K::MINUS if number.is_none() => sign_minus = true,
-            K::PLUS if number.is_none() => {}
-            K::NUMBER if number.is_none() => number = parse_decimal_token(t.text()),
+            K::MINUS if !number_seen => sign_minus = true,
+            K::PLUS if !number_seen => {}
+            K::NUMBER if !number_seen => {
+                number_seen = true;
+                number = parse_decimal_token(t.text());
+                // An unparseable NUMBER (e.g. >28 digits) makes red emit a
+                // diagnostic; bail to red so the error isn't dropped.
+                if number.is_none() {
+                    complex = true;
+                }
+            }
             K::CURRENCY if currency.is_none() => currency = Some(Currency::new(t.text())),
             K::WHITESPACE => {}
             // Operator, second number, or extra currency => arithmetic/complex.
@@ -406,6 +415,51 @@ pub(super) fn convert_simple_posting(
             trailing_comments,
         },
         Span::new(base, end),
+    ))
+}
+
+/// Assemble a full `TRANSACTION` directive from its green node, or return `None`
+/// to fall back to red. Returns `Some` **only** when the transaction is fully
+/// and identically convertible on green: a valid date and all simple postings,
+/// with NO transaction-level metadata, direct-child comments, or deprecated `|`
+/// — each of which red handles with attach/diagnostic logic the green path
+/// doesn't yet replicate. Bailing to red on those keeps the hybrid's output
+/// exactly equal to the pure-red path. `base` is the node's absolute start.
+pub(super) fn convert_transaction(
+    node: &rowan::GreenNodeData,
+    base: usize,
+) -> Option<Spanned<rustledger_core::Directive>> {
+    use crate::SyntaxKind as K;
+    let (mut txn, span) = convert_transaction_header(node, base)?;
+    let mut postings = Vec::new();
+    let mut offset = base;
+    for child in node.children() {
+        let len = match &child {
+            NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
+            NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
+        };
+        match &child {
+            NodeOrToken::Token(t) => {
+                let kind = crate::BeancountLanguage::kind_from_raw(t.kind());
+                // Direct-child comments (header-trailing / inter-posting /
+                // txn-trailing) and the deprecated `|` need red's attach +
+                // diagnostic logic — bail.
+                if is_comment_kind(kind) || kind == K::PIPE {
+                    return None;
+                }
+            }
+            NodeOrToken::Node(n) => match crate::BeancountLanguage::kind_from_raw(n.kind()) {
+                K::POSTING => postings.push(convert_simple_posting(n, offset)?),
+                K::META_ENTRY => return None, // transaction-level metadata — later increment
+                _ => {}
+            },
+        }
+        offset += len;
+    }
+    txn.postings = postings;
+    Some(Spanned::new(
+        rustledger_core::Directive::Transaction(txn),
+        span,
     ))
 }
 

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -8,27 +8,33 @@
 //! parallel with [`super::convert`] and gated by a differential oracle that
 //! pins its output byte-identical to the red path.
 //!
-//! Status: foundation. This first increment establishes the top-down green
-//! walk + offset threading and proves it produces spans identical to the red
-//! `node_span`; directive *body* conversion is layered on next.
+//! Status: foundation + transaction **header** conversion (date / flag /
+//! payee+narration / tags / links / span), reusing the shared text parsers in
+//! [`super::convert`]. Postings + metadata + comments + error recovery layer on
+//! next; the field-level oracle (`green_txn_header_matches_red`) pins each field
+//! against the red path as it's built.
 
-use crate::Span;
+// PR1 WIP: this parallel green path is built + verified by the differential
+// tests below before being wired into `parse_via_cst`; until that wiring lands
+// its functions are exercised only by tests.
+#![allow(dead_code)]
+
+use super::convert::{decode_string_token, parse_date_token};
 use rowan::{Language, NodeOrToken};
+use rustledger_core::{InternedStr, Link, Metadata, NaiveDate, Span, Tag};
 
 /// Every top-level (child-of-root) **node** paired with its source [`Span`],
 /// computed by threading the absolute byte offset through the green tree — no
 /// red-node allocation. Equivalent to `root.children().map(node_span)` on the
 /// red tree; the differential test pins that equivalence. Offset drift (esp.
-/// across a leading BOM and multi-byte text) is the #1 correctness hazard of
-/// the rewrite, so this foundation validates it before any body conversion
-/// rides on it. The directive *kind* dispatch + body conversion layer on next.
+/// across a leading BOM and multi-byte text) is the #1 correctness hazard, so
+/// this validates it before any body conversion rides on it.
 pub(super) fn top_level_node_spans(
     root: &crate::SyntaxNode,
     bom_offset: u32,
 ) -> Vec<(crate::SyntaxKind, Span)> {
     let green = root.green();
     let mut out = Vec::new();
-    // Spans index the original (BOM-inclusive) frame, matching `node_span`.
     let mut offset = bom_offset as usize;
     for child in green.children() {
         let len = match &child {
@@ -44,12 +50,131 @@ pub(super) fn top_level_node_spans(
     out
 }
 
+/// Flag char for a header flag-token kind. Mirrors `TransactionFlag::cast` +
+/// `flag_char_from_transaction` in [`super::convert`]: STAR/TXN→`*`,
+/// PENDING→`!`, HASH→`#`, FLAG/single-char-CURRENCY → first char.
+fn flag_char(kind: crate::SyntaxKind, text: &str) -> Option<char> {
+    use crate::SyntaxKind as K;
+    match kind {
+        K::STAR | K::TXN_KW => Some('*'),
+        K::PENDING_KW => Some('!'),
+        K::HASH => Some('#'),
+        K::FLAG => text.chars().next(),
+        K::CURRENCY if text.len() == 1 => text.chars().next(),
+        _ => None,
+    }
+}
+
+/// Convert a `TRANSACTION` green node's **header** (date / flag / payee+
+/// narration / tags / links) and span, in a single fused pass over its direct
+/// children — no red-node allocation. Metadata, postings, and trailing comments
+/// are left empty here (next increment); the oracle compares only the header
+/// fields for now. `base` is the node's absolute start offset (BOM-inclusive).
+///
+/// Returns `None` if the date is absent/invalid (matching red, which drops the
+/// directive). Error emission for an invalid date lands with the next increment.
+pub(super) fn convert_transaction_header(
+    node: &rowan::GreenNodeData,
+    base: usize,
+) -> Option<(rustledger_core::directive::Transaction, Span)> {
+    use crate::SyntaxKind as K;
+    let span = Span::new(base, base + u32::from(node.text_len()) as usize);
+
+    let mut date: Option<NaiveDate> = None;
+    let mut flag = '*';
+    let mut seen_flag = false;
+    let mut seen_str_tag_link = false;
+    let mut strings: Vec<String> = Vec::new();
+    let mut tags: Vec<Tag> = Vec::new();
+    let mut links: Vec<Link> = Vec::new();
+    let mut past_header = false;
+
+    for child in node.children() {
+        let NodeOrToken::Token(t) = child else {
+            // POSTING / META_ENTRY child nodes — handled in the next increment.
+            continue;
+        };
+        let kind = crate::BeancountLanguage::kind_from_raw(t.kind());
+        let text = t.text();
+        if past_header {
+            // Body-level flat TAG/LINK tokens (between postings) join the set,
+            // deduped against what the header already contributed.
+            match kind {
+                K::TAG => {
+                    let tg = Tag::new(text.trim_start_matches('#'));
+                    if !tags.contains(&tg) {
+                        tags.push(tg);
+                    }
+                }
+                K::LINK => {
+                    let lk = Link::new(text.trim_start_matches('^'));
+                    if !links.contains(&lk) {
+                        links.push(lk);
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            match kind {
+                K::NEWLINE => past_header = true,
+                K::DATE if date.is_none() => date = parse_date_token(text),
+                K::STRING => {
+                    seen_str_tag_link = true;
+                    if let Some(s) = decode_string_token(text) {
+                        strings.push(s);
+                    }
+                }
+                K::TAG => {
+                    seen_str_tag_link = true;
+                    tags.push(Tag::new(text.trim_start_matches('#')));
+                }
+                K::LINK => {
+                    seen_str_tag_link = true;
+                    links.push(Link::new(text.trim_start_matches('^')));
+                }
+                // Flag region: the first flag-kind token before any STRING/TAG/LINK.
+                k if !seen_flag && !seen_str_tag_link => {
+                    if let Some(c) = flag_char(k, text) {
+                        flag = c;
+                        seen_flag = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    let date = date?;
+
+    // 0 -> empty narration; 1 -> narration only; 2 -> payee + narration;
+    // 3+ -> last is narration, payee dropped (matches red).
+    let mut it = strings.into_iter();
+    let (payee_str, narration_str) = match (it.next(), it.next(), it.next()) {
+        (None, _, _) => (None, String::new()),
+        (Some(n), None, _) => (None, n),
+        (Some(p), Some(n), None) => (Some(p), n),
+        (Some(_), Some(_), Some(c)) => (None, it.last().unwrap_or(c)),
+    };
+
+    let txn = rustledger_core::directive::Transaction {
+        date,
+        flag,
+        payee: payee_str.map(InternedStr::from),
+        narration: InternedStr::from(narration_str),
+        tags,
+        links,
+        meta: Metadata::default(),
+        postings: Vec::new(),
+        trailing_comments: Vec::new(),
+    };
+    Some((txn, span))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{SyntaxKind, parse_structured};
+    use rustledger_core::Directive;
 
-    /// Red reference: the existing red-cursor way of getting top-level spans.
     fn red_spans(root: &crate::SyntaxNode, bom: u32) -> Vec<(SyntaxKind, Span)> {
         root.children()
             .map(|n| {
@@ -70,9 +195,9 @@ mod tests {
             "; leading comment\n\n2020-01-01 open A\n2020-01-02 close A\n",
             "option \"title\" \"x\"\n2020-01-01 commodity USD\n",
             "2020-01-01 price AAPL 5 USD\n2020-01-01 balance A 0 USD\n",
-            "\u{feff}2020-01-01 open A\n", // leading BOM -> bom_offset 3
-            "2020-01-01 * \"é\" \"münts\"\n  A 1 EUR\n  B\n", // multi-byte
-            "garbage !! line\n2020-01-01 open A\n", // error recovery
+            "\u{feff}2020-01-01 open A\n",
+            "2020-01-01 * \"é\" \"münts\"\n  A 1 EUR\n  B\n",
+            "garbage !! line\n2020-01-01 open A\n",
             "2020-01-01 txn \"x\"\n  A 10 AAPL {2.00 USD}\n  B -20.00 USD\n",
         ];
         for src in cases {
@@ -84,6 +209,59 @@ mod tests {
                 red_spans(&root, bom),
                 "green vs red node spans diverged for: {src:?}"
             );
+        }
+    }
+
+    /// Field-level oracle: green transaction-header fields must equal the red
+    /// path's. (No BOM in these cases, so absolute offset == stripped offset.)
+    #[test]
+    fn green_txn_header_matches_red() {
+        let cases = [
+            "2020-01-01 * \"payee\" \"narr\"\n  A 1 USD\n  B\n",
+            "2020-01-01 ! \"only narration\"\n  A 1 USD\n  B\n",
+            "2020-01-01 txn \"n\"\n  A 1 USD\n  B\n",
+            "2020-01-01 # \"flagged\"\n  A 1 USD\n  B\n",
+            "2020-01-01 *\n  A 1 USD\n  B\n",
+            "2020-01-01 * \"p\" \"n\" #tag1 #tag2 ^link-a\n  A 1 USD\n  B\n",
+            "2020-01-01 * \"esc \\\"q\\\" tab\\there\"\n  A 1 USD\n  B\n",
+            "2020-01-01 * \"é payee\" \"münts\"\n  A 1 EUR\n  B\n",
+        ];
+        for src in cases {
+            // green: find the first TRANSACTION node + its offset, convert header.
+            let root = parse_structured(src);
+            let green = root.green();
+            let mut offset = 0usize;
+            let mut txn_node = None;
+            for child in green.children() {
+                let len = match &child {
+                    NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
+                    NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
+                };
+                if let NodeOrToken::Node(n) = child {
+                    if crate::BeancountLanguage::kind_from_raw(n.kind()) == SyntaxKind::TRANSACTION
+                    {
+                        txn_node = Some((n, offset));
+                        break;
+                    }
+                }
+                offset += len;
+            }
+            let (txn_green, base) = txn_node.expect("transaction node");
+            let (g, g_span) = convert_transaction_header(txn_green, base).expect("green header");
+
+            // red: full parse, pull the first transaction directive.
+            let red = crate::parse(src);
+            let red_sp = &red.directives[0];
+            let Directive::Transaction(r) = &red_sp.value else {
+                panic!("expected transaction for {src:?}");
+            };
+            assert_eq!(g.date, r.date, "date {src:?}");
+            assert_eq!(g.flag, r.flag, "flag {src:?}");
+            assert_eq!(g.payee, r.payee, "payee {src:?}");
+            assert_eq!(g.narration, r.narration, "narration {src:?}");
+            assert_eq!(g.tags, r.tags, "tags {src:?}");
+            assert_eq!(g.links, r.links, "links {src:?}");
+            assert_eq!(g_span, red_sp.span, "span {src:?}");
         }
     }
 }

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -16,10 +16,6 @@
 //! Pinned by field-level oracles + the `parse_green_eq_red_corpus` differential
 //! test + the `fuzz_green_eq_red` fuzz target.
 
-// `top_level_node_spans` is a span-validation helper exercised only by the
-// differential tests; the rest of this module is wired into `parse_via_cst_opts`.
-#![allow(dead_code)]
-
 use super::convert::{decode_string_token, is_comment_kind, parse_date_token, parse_decimal_token};
 use rowan::{Language, NodeOrToken};
 use rustledger_core::cost::{CostNumber, CostSpec};
@@ -35,6 +31,10 @@ use rustledger_core::{
 /// red tree; the differential test pins that equivalence. Offset drift (esp.
 /// across a leading BOM and multi-byte text) is the #1 correctness hazard, so
 /// this validates it before any body conversion rides on it.
+// Span-validation helper exercised only by the differential tests (the wired
+// path threads offsets inline); targeted allow so the rest of the module is
+// still checked for dead code.
+#[allow(dead_code)]
 pub(super) fn top_level_node_spans(
     root: &crate::SyntaxNode,
     bom_offset: u32,
@@ -231,7 +231,9 @@ fn simple_amount(node: &rowan::GreenNodeData) -> Option<IncompleteAmount> {
 /// Convert a `COST_SPEC` green node into a `CostSpec` (forms `{N CCY}`,
 /// `{{T CCY}}`, `{N # T CCY}`, `{*}` merge, plus optional date + label). Mirrors
 /// `convert_cost_spec` / `cost_total_after_hash` in [`super::convert`]. Cost
-/// numbers are plain `NUMBER` tokens (no arithmetic), so this always succeeds.
+/// numbers are plain `NUMBER` tokens (no arithmetic evaluation); an unparseable
+/// one yields `number: None` like red, which emits no diagnostic for cost
+/// numbers — so this needs no bail and always returns a `CostSpec`.
 fn convert_cost_spec(node: &rowan::GreenNodeData) -> CostSpec {
     use crate::SyntaxKind as K;
     let mut is_total = false;
@@ -347,12 +349,12 @@ fn convert_price_annotation(node: &rowan::GreenNodeData) -> Option<PriceAnnotati
     })
 }
 
-/// Convert a **simple** `POSTING` green node (account + non-arithmetic units +
-/// span + same-line trailing comments). Returns `None` for postings with a
-/// flag, cost spec, price annotation, metadata, a trailing-sibling amount, or
-/// an arithmetic amount — those layer on in later increments, and the simple
-/// oracle corpus excludes them. `base` is the node's absolute start offset.
-/// Span policy matches red `posting_span`: ends at the first NEWLINE's start.
+/// Convert a `POSTING` green node (account + non-arithmetic units + cost spec +
+/// price annotation + span + same-line trailing comments). Returns `None` for
+/// postings with a flag, per-posting metadata, a trailing-sibling amount, or an
+/// arithmetic amount — those layer on in later increments, so the posting falls
+/// back to red. `base` is the node's absolute start offset. Span policy matches
+/// red `posting_span`: ends at the first NEWLINE's start.
 pub(super) fn convert_simple_posting(
     node: &rowan::GreenNodeData,
     base: usize,
@@ -655,7 +657,7 @@ mod tests {
         ];
         for src in corpus {
             let g = crate::parse(src);
-            let r = crate::parse_red_only(src);
+            let r = crate::cst::parse_red_only(src);
             let dbg = |p: &crate::ParseResult| {
                 (
                     format!("{:?}", p.directives),

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -1,0 +1,89 @@
+//! Green-tree conversion path (PR 1 of the lossless-CST-tax removal — see the
+//! profiling sizing spike: the CST→AST conversion is ~74% of the load, and
+//! ~33% of that is red-node (`SyntaxNode` cursor) traversal that allocates +
+//! refcounts a `NodeData` per node touch).
+//!
+//! This module walks the **immutable green tree** top-down, threading the
+//! absolute byte offset, instead of materializing red nodes. It is built in
+//! parallel with [`super::convert`] and gated by a differential oracle that
+//! pins its output byte-identical to the red path.
+//!
+//! Status: foundation. This first increment establishes the top-down green
+//! walk + offset threading and proves it produces spans identical to the red
+//! `node_span`; directive *body* conversion is layered on next.
+
+use crate::Span;
+use rowan::{Language, NodeOrToken};
+
+/// Every top-level (child-of-root) **node** paired with its source [`Span`],
+/// computed by threading the absolute byte offset through the green tree — no
+/// red-node allocation. Equivalent to `root.children().map(node_span)` on the
+/// red tree; the differential test pins that equivalence. Offset drift (esp.
+/// across a leading BOM and multi-byte text) is the #1 correctness hazard of
+/// the rewrite, so this foundation validates it before any body conversion
+/// rides on it. The directive *kind* dispatch + body conversion layer on next.
+pub(super) fn top_level_node_spans(
+    root: &crate::SyntaxNode,
+    bom_offset: u32,
+) -> Vec<(crate::SyntaxKind, Span)> {
+    let green = root.green();
+    let mut out = Vec::new();
+    // Spans index the original (BOM-inclusive) frame, matching `node_span`.
+    let mut offset = bom_offset as usize;
+    for child in green.children() {
+        let len = match &child {
+            NodeOrToken::Node(n) => u32::from(n.text_len()) as usize,
+            NodeOrToken::Token(t) => u32::from(t.text_len()) as usize,
+        };
+        if let NodeOrToken::Node(n) = child {
+            let kind = crate::BeancountLanguage::kind_from_raw(n.kind());
+            out.push((kind, Span::new(offset, offset + len)));
+        }
+        offset += len;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SyntaxKind, parse_structured};
+
+    /// Red reference: the existing red-cursor way of getting top-level spans.
+    fn red_spans(root: &crate::SyntaxNode, bom: u32) -> Vec<(SyntaxKind, Span)> {
+        root.children()
+            .map(|n| {
+                let r = n.text_range();
+                let s = (u32::from(r.start()) + bom) as usize;
+                let e = (u32::from(r.end()) + bom) as usize;
+                (n.kind(), Span::new(s, e))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn green_node_spans_match_red() {
+        let cases = [
+            "",
+            "2020-01-01 open Assets:Cash USD\n",
+            "2020-01-01 * \"p\" \"m\"\n  Assets:Cash 5.00 USD\n  Income:X\n",
+            "; leading comment\n\n2020-01-01 open A\n2020-01-02 close A\n",
+            "option \"title\" \"x\"\n2020-01-01 commodity USD\n",
+            "2020-01-01 price AAPL 5 USD\n2020-01-01 balance A 0 USD\n",
+            "\u{feff}2020-01-01 open A\n", // leading BOM -> bom_offset 3
+            "2020-01-01 * \"é\" \"münts\"\n  A 1 EUR\n  B\n", // multi-byte
+            "garbage !! line\n2020-01-01 open A\n", // error recovery
+            "2020-01-01 txn \"x\"\n  A 10 AAPL {2.00 USD}\n  B -20.00 USD\n",
+        ];
+        for src in cases {
+            let (stripped, has_bom) = crate::bom::strip_leading(src);
+            let bom = if has_bom { 3 } else { 0 };
+            let root = parse_structured(stripped);
+            assert_eq!(
+                top_level_node_spans(&root, bom),
+                red_spans(&root, bom),
+                "green vs red node spans diverged for: {src:?}"
+            );
+        }
+    }
+}

--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -57,7 +57,7 @@ mod parser;
 mod syntax_kind;
 mod trivia;
 
-pub use convert::{parse_via_cst, parse_via_cst_opts};
+pub use convert::{parse_red_only, parse_via_cst, parse_via_cst_opts};
 // Formatter exports do NOT re-export through `cst` — the sole
 // import path for the formatter is `rustledger_parser::format`
 // (the crate-root sub-module that re-exports the six symbols

--- a/crates/rustledger-parser/src/cst/mod.rs
+++ b/crates/rustledger-parser/src/cst/mod.rs
@@ -51,6 +51,7 @@
 pub mod ast;
 mod convert;
 pub(crate) mod format;
+mod green;
 mod lossless_tokens;
 mod parser;
 mod syntax_kind;

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -69,7 +69,7 @@ pub mod format {
 
 pub use cst::{
     BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, lossless_kind_tokens,
-    parse_flat, parse_red_only, parse_structured, parse_via_cst, parse_via_cst_opts,
+    parse_flat, parse_structured, parse_via_cst, parse_via_cst_opts,
 };
 
 // Rowan types CST consumers need. Flat re-exports at the crate

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -69,7 +69,7 @@ pub mod format {
 
 pub use cst::{
     BeancountLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, lossless_kind_tokens,
-    parse_flat, parse_structured, parse_via_cst, parse_via_cst_opts,
+    parse_flat, parse_red_only, parse_structured, parse_via_cst, parse_via_cst_opts,
 };
 
 // Rowan types CST consumers need. Flat re-exports at the crate


### PR DESCRIPTION
## What

**Green-tree transaction conversion — the lossless-CST-tax removal (PR 1).** Converts transactions off the immutable **green** tree instead of red `SyntaxNode` cursors, wired into the load path with a **red fallback**.

Measured on a 10k-txn load: **1,062,145,403 → 891,072,035 I refs (−16.1%)**.

## Why (the profiling chain)

The nightly `profiling` data branch + a sizing spike showed the CST→AST conversion is **~74% of the load**, and ~33% of *that* is red-node traversal — each node touch heap-allocates + refcounts a `NodeData`. A prototype measured green traversal at **~24× cheaper per pass**. This PR realizes it for transactions (the bulk of real ledgers).

## How — correct by construction

- `cst/green.rs`: a top-down green walk threading the absolute byte offset (no red-node allocation), building the full transaction (date / flag / payee+narration / tags / links / **postings** with units, all **cost-spec** forms `{N CCY}`/`{{T CCY}}`/`{N # T CCY}`, **prices** `@`/`@@`). Value parsing reuses the now-shared text parsers (`parse_date_token`, `decode_string_token`, `parse_decimal_token`, `is_comment_kind`) — one source of truth for red + green.
- `green::convert_transaction` returns `Some` **only when its output is byte-identical to red**, and bails to red on anything it doesn't yet replicate (transaction metadata, direct-child comments, deprecated `|`, unparseable amounts, posting flags/metadata/arithmetic). So the hybrid is **output-equivalent to the pure-red path** by construction.

## Verification

- **283 parser + 57 integration + 89 loader + booking tests pass** (they pin exact `parse()` output).
- Field-level oracles for header / posting / cost / price (byte-identical to red).
- **`parse_green_eq_red_corpus`** differential unit test: green-wired `parse` == `parse_red_only` across the green path *and* every fallback trigger (flag / meta / comment / arithmetic / multi-amount / pipe / invalid date / BOM / multi-byte / error recovery).
- **`fuzz_green_eq_red`** differential fuzz target (registered in `fuzz.yml`) generalizes that invariant to arbitrary input.

## Scope

This is the first slice. The `walk_descendants_once` / `walk_top_level_once` passes are still red (greening them adds more), and posting flags/metadata/arithmetic still fall back to red — all additive follow-ons the fallback already handles correctly. For context: the four prior optimization PRs combined moved the load ~−1.4%; this one moves it **−16.1%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
