### PR TITLE
perf(parser): green walk_descendants pass (PR3)

### DIFF
--- a/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
+++ b/crates/rustledger-parser/fuzz/fuzz_targets/fuzz_green_eq_red.rs
@@ -37,4 +37,15 @@ fuzz_target!(|data: &[u8]| {
         format!("{:?}", red.comments),
         "green vs red comments diverged"
     );
+    // Occurrences come from the green walk_descendants pass.
+    assert_eq!(
+        format!("{:?}", green.account_occurrences),
+        format!("{:?}", red.account_occurrences),
+        "green vs red account_occurrences diverged"
+    );
+    assert_eq!(
+        format!("{:?}", green.currency_occurrences),
+        format!("{:?}", red.currency_occurrences),
+        "green vs red currency_occurrences diverged"
+    );
 });

--- a/crates/rustledger-parser/src/cst/convert.rs
+++ b/crates/rustledger-parser/src/cst/convert.rs
@@ -109,7 +109,12 @@ fn parse_via_cst_inner(source: &str, collect_occurrences: bool, use_green: bool)
         top_level_comments,
         currency_occurrences,
         account_occurrences,
-    } = walk_descendants_once(&source_file, bom_offset, collect_occurrences);
+    } = if use_green {
+        // Green-tree walk (no per-node red allocation); byte-identical to red.
+        super::green::walk_descendants(source_file.syntax(), bom_offset, collect_occurrences)
+    } else {
+        walk_descendants_once(&source_file, bom_offset, collect_occurrences)
+    };
 
     // Fused single pass over the top-level children replaces the
     // five former per-child traversals (error-node, transaction-body,
@@ -2171,11 +2176,11 @@ fn classify_recovery_error(line_text: &str, span: Span) -> crate::ParseError {
 /// already cover those.
 /// Result of the fused descendants-walk visitor that powers
 /// `walk_descendants_once`.
-struct DescendantsWalkResult {
-    inline_errors: Vec<crate::ParseError>,
-    top_level_comments: Vec<Spanned<String>>,
-    currency_occurrences: Vec<Spanned<Currency>>,
-    account_occurrences: Vec<Spanned<rustledger_core::Account>>,
+pub(super) struct DescendantsWalkResult {
+    pub(super) inline_errors: Vec<crate::ParseError>,
+    pub(super) top_level_comments: Vec<Spanned<String>>,
+    pub(super) currency_occurrences: Vec<Spanned<Currency>>,
+    pub(super) account_occurrences: Vec<Spanned<rustledger_core::Account>>,
 }
 
 /// Fused single-pass visitor over `source_file`'s descendants -

--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -16,8 +16,10 @@
 //! Pinned by field-level oracles + the `parse_green_eq_red_corpus` differential
 //! test + the `fuzz_green_eq_red` fuzz target.
 
+use super::ast::AstNode as _; // brings `Directive::can_cast` into scope
 use super::convert::{
-    decode_string_token, is_comment_kind, number_meta_value, parse_date_token, parse_decimal_token,
+    DescendantsWalkResult, decode_string_token, is_comment_kind, number_meta_value,
+    parse_date_token, parse_decimal_token,
 };
 use rowan::{Language, NodeOrToken};
 use rustledger_core::cost::{CostNumber, CostSpec};
@@ -624,6 +626,137 @@ pub(super) fn convert_transaction(
     ))
 }
 
+/// Green-tree re-implementation of `walk_descendants_once` — the #1 allocation
+/// site in the conversion (red `descendants_with_tokens()` heap-allocates +
+/// refcounts a `NodeData` per node touched, over EVERY token in the file).
+///
+/// Recursively walks the green tree threading three pieces of state that red got
+/// for free from the red cursor: the absolute byte `offset`, an `in_error_node`
+/// flag (replacing red's per-token `parent_ancestors()` `ERROR_NODE` probe — the
+/// green tree has no parent pointers), and the linear `preceded_by_ws` column-0
+/// comment state. Produces a byte-identical [`DescendantsWalkResult`]. Tree
+/// depth is grammar-bounded (~6 levels; arithmetic and error recovery don't nest
+/// structurally), so the recursion can't blow the stack on adversarial input.
+pub(super) fn walk_descendants(
+    root: &crate::SyntaxNode,
+    bom_offset: u32,
+    collect_occurrences: bool,
+) -> DescendantsWalkResult {
+    let mut w = DescendantsWalker {
+        offset: bom_offset as usize,
+        preceded_by_ws: false,
+        collect_occurrences,
+        result: DescendantsWalkResult {
+            inline_errors: Vec::new(),
+            top_level_comments: Vec::new(),
+            currency_occurrences: Vec::new(),
+            account_occurrences: Vec::new(),
+        },
+    };
+    w.walk(&root.green(), false);
+    w.result
+}
+
+struct DescendantsWalker {
+    offset: usize,
+    preceded_by_ws: bool,
+    collect_occurrences: bool,
+    result: DescendantsWalkResult,
+}
+
+impl DescendantsWalker {
+    fn walk(&mut self, node: &rowan::GreenNodeData, in_error_node: bool) {
+        use crate::SyntaxKind as K;
+        for child in node.children() {
+            match child {
+                NodeOrToken::Node(n) => {
+                    let kind = crate::BeancountLanguage::kind_from_raw(n.kind());
+                    // Directive nodes reset the column-0 comment state (mirrors the
+                    // red walk's `Node` arm).
+                    if super::ast::Directive::can_cast(kind) {
+                        self.preceded_by_ws = false;
+                    }
+                    self.walk(n, in_error_node || kind == K::ERROR_NODE);
+                }
+                NodeOrToken::Token(t) => {
+                    let start = self.offset;
+                    let len = u32::from(t.text_len()) as usize;
+                    self.offset += len;
+                    let kind = crate::BeancountLanguage::kind_from_raw(t.kind());
+                    self.token(kind, t.text(), start, len, in_error_node);
+                }
+            }
+        }
+    }
+
+    fn token(
+        &mut self,
+        kind: crate::SyntaxKind,
+        text: &str,
+        start: usize,
+        len: usize,
+        in_error_node: bool,
+    ) {
+        use crate::SyntaxKind as K;
+        // ---- column-0 comment state machine ----
+        match kind {
+            K::NEWLINE => self.preceded_by_ws = false,
+            K::WHITESPACE => self.preceded_by_ws = true,
+            k if is_comment_kind(k) => {
+                if !self.preceded_by_ws {
+                    self.result.top_level_comments.push(Spanned::new(
+                        text.to_string(),
+                        Span::new(start, start + len),
+                    ));
+                }
+            }
+            _ => self.preceded_by_ws = false,
+        }
+
+        // ---- inline errors + occurrence collection ----
+        if kind == K::BOM {
+            return;
+        }
+        let has_bom = text.contains(crate::bom::BOM_CHAR);
+        let is_error_token = kind == K::ERROR_TOKEN;
+        // The ERROR_NODE check is only consulted for tokens whose emission depends
+        // on it; gate the rest out fast (most tokens are plain whitespace/idents).
+        let needs = (self.collect_occurrences && matches!(kind, K::CURRENCY | K::ACCOUNT))
+            || has_bom
+            || is_error_token;
+        if !needs {
+            return;
+        }
+        let span = Span::new(start, start + len);
+        if self.collect_occurrences && kind == K::CURRENCY && !in_error_node {
+            self.result
+                .currency_occurrences
+                .push(Spanned::new(Currency::new(text), span));
+        }
+        if self.collect_occurrences && kind == K::ACCOUNT && !in_error_node {
+            self.result
+                .account_occurrences
+                .push(Spanned::new(Account::new(text), span));
+        }
+        // Inline errors: a BOM byte (-> BomInDirectiveBody) or ERROR_TOKEN
+        // (-> SyntaxError) in a recognized directive; skip inside ERROR_NODE.
+        if (!has_bom && !is_error_token) || in_error_node {
+            return;
+        }
+        if has_bom {
+            self.result.inline_errors.push(
+                crate::ParseError::new(crate::ParseErrorKind::BomInDirectiveBody, span)
+                    .with_hint(crate::diagnostics::BOM_REMOVAL_HINT),
+            );
+        } else {
+            self.result.inline_errors.push(crate::ParseError::new(
+                crate::ParseErrorKind::SyntaxError("unexpected input".to_string()),
+                span,
+            ));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -826,6 +959,12 @@ mod tests {
             "2020-01-01 * \"p\"\n  meta1: \"x\"\n  count: 3\n  Assets:A 1 USD\n  Assets:B -1 USD\n",
             // flag + cost + price + posting-meta together
             "2020-01-01 * \"p\"\n  ! Assets:S 10 AAPL {2 USD} @ 3 USD\n    lot: \"q1\"\n  Assets:C 15 USD\n  Income:G\n",
+            // walk_descendants distinctive paths:
+            "; column-0 comment\n  ; indented comment\n2020-01-01 open Assets:A USD\n",
+            "2020-01-01 * \"p\"\n  Assets:Cash 5 USD\n  Income:Salary -5 EUR\n", // occurrences
+            "!!garbage Assets:InError 5 BAD!!\n2020-01-01 open Assets:Real USD\n", // error-node suppresses occ
+            "* Org Section Heading\n** Sub\n2020-01-01 open A\n", // org-mode section markers
+            "2020-01-01 open A\n2020-01-01 open B\n2020-01-01 open C\n", // many account occurrences
         ];
         for src in corpus {
             let g = crate::parse(src);
@@ -836,6 +975,9 @@ mod tests {
                     format!("{:?}", p.errors),
                     format!("{:?}", p.comments),
                     format!("{:?}", p.options),
+                    // The green walk_descendants produces these too.
+                    format!("{:?}", p.account_occurrences),
+                    format!("{:?}", p.currency_occurrences),
                 )
             };
             assert_eq!(


### PR DESCRIPTION
## What

**PR 3 of the lossless-CST-tax removal.** Re-implements `walk_descendants_once` on the **green tree**. Unlike the directive conversion (#1594/#1595, which only touches transactions), this pass walks **every token in the file** — and was the **#1 allocation site** in the conversion (red `descendants_with_tokens()` heap-allocates + refcounts a `NodeData` per node). So greening it extends the win on the standard workload itself.

## How

A recursive green walker threads the three pieces of state red got for free from its cursor:
- **byte `offset`** (advanced per token),
- **`in_error_node`** — replaces red's per-token `parent_ancestors().any(ERROR_NODE)` probe (the green tree has **no parent pointers**), threaded top-down,
- **`preceded_by_ws`** — the linear column-0-comment state machine.

It produces a byte-identical `DescendantsWalkResult` (inline errors, top-level comments, currency/account occurrences) and is wired into `parse_via_cst_inner` behind the existing `use_green` flag (red fallback intact). Tree depth is grammar-bounded (~6 levels — arithmetic and error recovery don't nest structurally), so the recursion is safe on adversarial input.

## Verification

- **284 + 57 parser/integration tests pass** (they pin errors + comments, now produced by the green walk), plus the LSP occurrence suites.
- `clippy --all-targets -D warnings` clean.
- **`parse_green_eq_red_corpus`** + **`fuzz_green_eq_red`** extended to also compare **account/currency occurrences**; corpus gains column-0-comment, error-node-occurrence-suppression, org-section-marker, and occurrence-heavy cases. Green byte-identical to red.

## Performance

Measured on the standard 10k-txn workload (instruction count added below) — this is *additional* reduction on top of #1594's −16%, because the walk runs on every directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Measured win on the standard 10k-txn workload

```
red baseline (pre-green)     = 1,062,145,403
#1594 (green directive only) =   891,072,035  (-16.1% vs red)
this branch (+ green walk)   =   802,238,402  (-24.5% vs red, -10.0% vs #1594)
```

The walk runs on **every** token, so unlike the directive conversion this moves the standard-workload number directly: **another −10%** on top of #1594, for a cumulative **−24.5%** vs the pre-green red baseline.
