### PR TITLE
ci(release): produce ag-rledger as a release artifact

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -213,6 +213,10 @@ jobs:
 
           # Build LSP separately (no PGO needed)
           cargo build --release --target ${{ matrix.target }} -p rustledger-lsp
+
+          # Build the agent-native CLI (ag-rledger) separately — feature-gated
+          # (pulls agcli/tokio), no PGO.
+          cargo build --release --target ${{ matrix.target }} -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
       - name: Build with PGO (Windows)
         if: matrix.pgo && runner.os == 'Windows'
         shell: pwsh
@@ -232,6 +236,10 @@ jobs:
 
           # Build LSP separately (no PGO needed)
           cargo build --release --target ${{ matrix.target }} -p rustledger-lsp
+
+          # Build the agent-native CLI (ag-rledger) separately — feature-gated
+          # (pulls agcli/tokio), no PGO.
+          cargo build --release --target ${{ matrix.target }} -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
       - name: Build without PGO (cross-compiled targets)
         if: ${{ !matrix.pgo }}
         shell: bash
@@ -251,10 +259,14 @@ jobs:
             cross build --profile $PROFILE --target ${{ matrix.target }} --no-default-features
             # Build LSP separately
             cross build --profile $PROFILE --target ${{ matrix.target }} -p rustledger-lsp
+            # Build the agent-native CLI (ag-rledger) separately — feature-gated
+            cross build --profile $PROFILE --target ${{ matrix.target }} -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
           else
             cargo build --profile $PROFILE --target ${{ matrix.target }} --no-default-features
             # Build LSP separately
             cargo build --profile $PROFILE --target ${{ matrix.target }} -p rustledger-lsp
+            # Build the agent-native CLI (ag-rledger) separately — feature-gated
+            cargo build --profile $PROFILE --target ${{ matrix.target }} -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
           fi
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -274,7 +286,7 @@ jobs:
           # Create archive with all binaries
           ARCHIVE="rustledger-${VERSION}-${{ matrix.target }}.tar.gz"
           tar -czvf "../../../${ARCHIVE}" \
-            rledger rledger-lsp
+            rledger rledger-lsp ag-rledger
 
           # Create checksum
           cd ../../..
@@ -291,7 +303,7 @@ jobs:
           # Create archive with all binaries
           $ARCHIVE = "rustledger-${VERSION}-${{ matrix.target }}.zip"
           $binaries = @(
-            "rledger.exe", "rledger-lsp.exe"
+            "rledger.exe", "rledger-lsp.exe", "ag-rledger.exe"
           )
           Compress-Archive -Path $binaries -DestinationPath "../../../${ARCHIVE}"
 


### PR DESCRIPTION
## What

Builds the agent-native CLI (`ag-rledger`) in CI releases and includes it in the release archives, alongside `rledger` + `rledger-lsp`.

## Why

`ag-rledger` (the #1291 agent-native CLI, gated behind the `ag-rledger` feature → pulls `agcli`/`tokio`) was never built or shipped — release archives only contained `rledger` + `rledger-lsp`, so there was no way to obtain `ag-rledger` from a release.

## How

In `release-build.yml`, build `ag-rledger` in all three build paths (PGO Unix, PGO Windows, cross/native) exactly like `rledger-lsp` — separately, feature-gated, no PGO:

```
cargo build --release --target <T> -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
```

and add it to the Unix `tar.gz` + Windows `zip` archives.

## Verification

- Build invocation verified locally: `cargo check -p rustledger --bin ag-rledger --no-default-features --features ag-rledger` is clean.
- `release-build.yml` is valid YAML.
- Non-breaking: the extra binary doesn't affect the Docker/AUR/binstall consumers, which extract `rledger` by name.
- The release pipeline runs only on tag push, so the full cross-compiled `ag-rledger` build is first exercised at the next release; this mirrors the proven `rledger-lsp` build/package pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
