### PR TITLE
ci(release): enable mimalloc in release rledger binaries (-7% load)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -256,16 +256,17 @@ jobs:
           fi
 
           if [ "${{ matrix.cross }}" = "true" ]; then
-            # NOTE: mimalloc (a vendored C lib) is intentionally NOT enabled for
-            # cross-compiled targets — its C build isn't validated under `cross`
-            # here, and a release shouldn't hinge on it. Cross targets ship
-            # without the allocator; native (PGO + non-cross) targets get it.
+            # Cross-compiled targets: NO mimalloc. mimalloc is a vendored C lib
+            # whose cross build isn't validated under `cross`, and a release
+            # shouldn't hinge on it — these targets ship without the allocator.
+            # (The non-cross `else` branch below enables it, as do the PGO steps.)
             cross build --profile $PROFILE --target ${{ matrix.target }} --no-default-features
             # Build LSP separately
             cross build --profile $PROFILE --target ${{ matrix.target }} -p rustledger-lsp
             # Build the agent-native CLI (ag-rledger) separately — feature-gated
             cross build --profile $PROFILE --target ${{ matrix.target }} -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
           else
+            # Native (non-cross) target: mimalloc enabled (cc is available).
             cargo build --profile $PROFILE --target ${{ matrix.target }} --no-default-features --features mimalloc
             # Build LSP separately
             cargo build --profile $PROFILE --target ${{ matrix.target }} -p rustledger-lsp

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -201,7 +201,7 @@ jobs:
           fi
 
           # Step 1: Build instrumented binary
-          cargo pgo build -- --no-default-features
+          cargo pgo build -- --no-default-features --features mimalloc
 
           # Step 2: Run workload to collect profile data
           for i in {1..10}; do
@@ -209,7 +209,7 @@ jobs:
           done
 
           # Step 3: Build optimized binary using profile data
-          cargo pgo optimize build -- --no-default-features
+          cargo pgo optimize build -- --no-default-features --features mimalloc
 
           # Build LSP separately (no PGO needed)
           cargo build --release --target ${{ matrix.target }} -p rustledger-lsp
@@ -224,7 +224,7 @@ jobs:
           $benchmarkPath = Join-Path $env:RUNNER_TEMP "benchmark.beancount"
 
           # Step 1: Build instrumented binary
-          cargo pgo build -- --no-default-features
+          cargo pgo build -- --no-default-features --features mimalloc
 
           # Step 2: Run workload to collect profile data
           for ($i = 0; $i -lt 10; $i++) {
@@ -232,7 +232,7 @@ jobs:
           }
 
           # Step 3: Build optimized binary using profile data
-          cargo pgo optimize build -- --no-default-features
+          cargo pgo optimize build -- --no-default-features --features mimalloc
 
           # Build LSP separately (no PGO needed)
           cargo build --release --target ${{ matrix.target }} -p rustledger-lsp
@@ -256,13 +256,17 @@ jobs:
           fi
 
           if [ "${{ matrix.cross }}" = "true" ]; then
+            # NOTE: mimalloc (a vendored C lib) is intentionally NOT enabled for
+            # cross-compiled targets — its C build isn't validated under `cross`
+            # here, and a release shouldn't hinge on it. Cross targets ship
+            # without the allocator; native (PGO + non-cross) targets get it.
             cross build --profile $PROFILE --target ${{ matrix.target }} --no-default-features
             # Build LSP separately
             cross build --profile $PROFILE --target ${{ matrix.target }} -p rustledger-lsp
             # Build the agent-native CLI (ag-rledger) separately — feature-gated
             cross build --profile $PROFILE --target ${{ matrix.target }} -p rustledger --bin ag-rledger --no-default-features --features ag-rledger
           else
-            cargo build --profile $PROFILE --target ${{ matrix.target }} --no-default-features
+            cargo build --profile $PROFILE --target ${{ matrix.target }} --no-default-features --features mimalloc
             # Build LSP separately
             cargo build --profile $PROFILE --target ${{ matrix.target }} -p rustledger-lsp
             # Build the agent-native CLI (ag-rledger) separately — feature-gated


### PR DESCRIPTION
## What

Enables the `mimalloc` global allocator in the release `rledger` binaries (the `-7%` load win from #1599), for native targets.

## Why

#1599 added `mimalloc` as an **opt-in** feature (correctly non-default, so it doesn't force a C dep on library consumers). But the release pipeline builds with `--no-default-features`, so the win wasn't reaching shipped binaries. This wires `--features mimalloc` into those builds.

## How

Append `--features mimalloc` to the `rledger` build commands in `release-build.yml`:
- PGO Unix + Windows (`cargo pgo build` / `cargo pgo optimize build`)
- native non-cross (`cargo build --profile …`)

## Cross targets intentionally excluded

mimalloc is a vendored **C** library; its cross build (musl / Windows-ARM / …) under `cross` isn't validated here, and a release shouldn't hinge on it. Cross-compiled targets ship **without** the allocator (no win, no risk); native targets get it. `rledger-lsp` / `ag-rledger` are separate binaries and unaffected.

## Verification

- Feature resolves at the virtual-workspace root without `-p`: `cargo build --no-default-features --features mimalloc` builds clean (tested locally).
- `release-build.yml` is valid YAML; mimalloc added to 4 native build lines, cross excluded.
- Output is unchanged — mimalloc is an allocator swap, no logic change (smoke-tested in #1599: `rledger check` identical).
- Release-only: first exercised at the next tag; the rledger+mimalloc native build itself was verified locally in #1599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
