### PR TITLE
feat(wasm): rich error codes, phase, hint, and end spans (#1597)

### DIFF
--- a/crates/rustledger-wasm/bindings/index.d.ts
+++ b/crates/rustledger-wasm/bindings/index.d.ts
@@ -41,12 +41,12 @@ export type BeancountError = {
   code: string | null;
   /**
    * Processing phase that produced the error: typically `"parse"`,
-   * `"validate"`, `"booking"`, `"plugin"`, or `"lint"`. `null` when not
+   * `"validate"`, `"plugin"`, or `"lint"`. `null` when not
    * attributable to a phase. The set is open (the loader phase is a free
    * string), so the TS type is a union of the known values plus `string` —
    * consumers get autocomplete on the common phases without rejecting others.
    */
-  phase: "parse" | "validate" | "booking" | "plugin" | "lint" | (string & {}) | null;
+  phase: "parse" | "validate" | "plugin" | "lint" | (string & {}) | null;
   /**
    * Actionable hint for fixing the error, when one is available. `null`
    * otherwise.

--- a/crates/rustledger-wasm/bindings/index.d.ts
+++ b/crates/rustledger-wasm/bindings/index.d.ts
@@ -33,7 +33,29 @@ export type BeancountError = {
    */
   message: string;
   /**
-   * Line number (1-based). `null` when the error has no source
+   * Stable error code (e.g. `"P0001"` for a parse error, `"E3001"` for a
+   * validation error). `null` for errors without a code (generic processing
+   * / query / plugin errors). Lets consumers branch on error type instead of
+   * matching on message text.
+   */
+  code: string | null;
+  /**
+   * Processing phase that produced the error: `"parse"`, `"validate"`,
+   * `"booking"`, or `"plugin"`. `null` when not attributable to a phase.
+   */
+  phase: string | null;
+  /**
+   * Actionable hint for fixing the error, when one is available. `null`
+   * otherwise.
+   */
+  hint: string | null;
+  /**
+   * Source file the error came from (multi-file ledgers). `null` for the
+   * single-source WASM entry points (`parse`, `check`, …).
+   */
+  file: string | null;
+  /**
+   * Start line (1-based). `null` when the error has no source
    * location (e.g. validation errors not tied to a span). Field is
    * always present on the wire (no `skip_serializing_if`); see the
    * struct-level `schemars(extend)` for the required-and-nullable
@@ -43,10 +65,18 @@ export type BeancountError = {
    */
   line: number | null;
   /**
-   * Column number (1-based). `null` when the error has no source
+   * Start column (1-based). `null` when the error has no source
    * location. See `line` above for `range` rationale.
    */
   column: number | null;
+  /**
+   * End line (1-based) of the error span. `null` when no span. See `line`.
+   */
+  end_line: number | null;
+  /**
+   * End column (1-based) of the error span. `null` when no span. See `line`.
+   */
+  end_column: number | null;
   /**
    * Error severity.
    */

--- a/crates/rustledger-wasm/bindings/index.d.ts
+++ b/crates/rustledger-wasm/bindings/index.d.ts
@@ -40,10 +40,13 @@ export type BeancountError = {
    */
   code: string | null;
   /**
-   * Processing phase that produced the error: `"parse"`, `"validate"`,
-   * `"booking"`, or `"plugin"`. `null` when not attributable to a phase.
+   * Processing phase that produced the error: typically `"parse"`,
+   * `"validate"`, `"booking"`, `"plugin"`, or `"lint"`. `null` when not
+   * attributable to a phase. The set is open (the loader phase is a free
+   * string), so the TS type is a union of the known values plus `string` —
+   * consumers get autocomplete on the common phases without rejecting others.
    */
-  phase: string | null;
+  phase: "parse" | "validate" | "booking" | "plugin" | "lint" | (string & {}) | null;
   /**
    * Actionable hint for fixing the error, when one is available. `null`
    * otherwise.

--- a/crates/rustledger-wasm/bindings/index.schema.json
+++ b/crates/rustledger-wasm/bindings/index.schema.json
@@ -59,7 +59,7 @@
           "type": "string"
         },
         "phase": {
-          "description": "Processing phase that produced the error: typically `\"parse\"`,\n`\"validate\"`, `\"booking\"`, `\"plugin\"`, or `\"lint\"`. `null` when not\nattributable to a phase. The set is open (the loader phase is a free\nstring), so the TS type is a union of the known values plus `string` —\nconsumers get autocomplete on the common phases without rejecting others.",
+          "description": "Processing phase that produced the error: typically `\"parse\"`,\n`\"validate\"`, `\"plugin\"`, or `\"lint\"`. `null` when not\nattributable to a phase. The set is open (the loader phase is a free\nstring), so the TS type is a union of the known values plus `string` —\nconsumers get autocomplete on the common phases without rejecting others.",
           "type": ["string", "null"]
         },
         "severity": {

--- a/crates/rustledger-wasm/bindings/index.schema.json
+++ b/crates/rustledger-wasm/bindings/index.schema.json
@@ -59,7 +59,7 @@
           "type": "string"
         },
         "phase": {
-          "description": "Processing phase that produced the error: `\"parse\"`, `\"validate\"`,\n`\"booking\"`, or `\"plugin\"`. `null` when not attributable to a phase.",
+          "description": "Processing phase that produced the error: typically `\"parse\"`,\n`\"validate\"`, `\"booking\"`, `\"plugin\"`, or `\"lint\"`. `null` when not\nattributable to a phase. The set is open (the loader phase is a free\nstring), so the TS type is a union of the known values plus `string` —\nconsumers get autocomplete on the common phases without rejecting others.",
           "type": ["string", "null"]
         },
         "severity": {

--- a/crates/rustledger-wasm/bindings/index.schema.json
+++ b/crates/rustledger-wasm/bindings/index.schema.json
@@ -18,14 +18,38 @@
     "BeancountError": {
       "description": "An error with source location.\n\n**Renamed to `BeancountError` on the TS side** to avoid shadowing\nthe JS-builtin `Error` type. The Rust struct keeps the shorter\n`Error` name for internal use; the rename is applied via\n`#[ts(rename = ...)]` so consumers see a non-shadowing name.",
       "properties": {
+        "code": {
+          "description": "Stable error code (e.g. `\"P0001\"` for a parse error, `\"E3001\"` for a\nvalidation error). `null` for errors without a code (generic processing\n/ query / plugin errors). Lets consumers branch on error type instead of\nmatching on message text.",
+          "type": ["string", "null"]
+        },
         "column": {
-          "description": "Column number (1-based). `null` when the error has no source\nlocation. See `line` above for `range` rationale.",
+          "description": "Start column (1-based). `null` when the error has no source\nlocation. See `line` above for `range` rationale.",
           "format": "uint32",
           "minimum": 1,
           "type": ["integer", "null"]
         },
+        "end_column": {
+          "description": "End column (1-based) of the error span. `null` when no span. See `line`.",
+          "format": "uint32",
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
+        "end_line": {
+          "description": "End line (1-based) of the error span. `null` when no span. See `line`.",
+          "format": "uint32",
+          "minimum": 1,
+          "type": ["integer", "null"]
+        },
+        "file": {
+          "description": "Source file the error came from (multi-file ledgers). `null` for the\nsingle-source WASM entry points (`parse`, `check`, …).",
+          "type": ["string", "null"]
+        },
+        "hint": {
+          "description": "Actionable hint for fixing the error, when one is available. `null`\notherwise.",
+          "type": ["string", "null"]
+        },
         "line": {
-          "description": "Line number (1-based). `null` when the error has no source\nlocation (e.g. validation errors not tied to a span). Field is\nalways present on the wire (no `skip_serializing_if`); see the\nstruct-level `schemars(extend)` for the required-and-nullable\nrationale. `range(min = 1)` enforces the 1-based documented\ncontract on the JSON Schema side (schemars defaults to\n`minimum: 0` for u32).",
+          "description": "Start line (1-based). `null` when the error has no source\nlocation (e.g. validation errors not tied to a span). Field is\nalways present on the wire (no `skip_serializing_if`); see the\nstruct-level `schemars(extend)` for the required-and-nullable\nrationale. `range(min = 1)` enforces the 1-based documented\ncontract on the JSON Schema side (schemars defaults to\n`minimum: 0` for u32).",
           "format": "uint32",
           "minimum": 1,
           "type": ["integer", "null"]
@@ -34,12 +58,27 @@
           "description": "Error message.",
           "type": "string"
         },
+        "phase": {
+          "description": "Processing phase that produced the error: `\"parse\"`, `\"validate\"`,\n`\"booking\"`, or `\"plugin\"`. `null` when not attributable to a phase.",
+          "type": ["string", "null"]
+        },
         "severity": {
           "$ref": "#/$defs/Severity",
           "description": "Error severity."
         }
       },
-      "required": ["message", "line", "column", "severity"],
+      "required": [
+        "message",
+        "code",
+        "phase",
+        "hint",
+        "file",
+        "line",
+        "column",
+        "end_line",
+        "end_column",
+        "severity"
+      ],
       "type": "object"
     },
     "CellValue": {

--- a/crates/rustledger-wasm/bindings/types.py
+++ b/crates/rustledger-wasm/bindings/types.py
@@ -339,7 +339,7 @@ class BeancountError(BaseModel):
     message: str = Field(..., description="Error message.")
     phase: str | None = Field(
         ...,
-        description='Processing phase that produced the error: typically `"parse"`,\n`"validate"`, `"booking"`, `"plugin"`, or `"lint"`. `null` when not\nattributable to a phase. The set is open (the loader phase is a free\nstring), so the TS type is a union of the known values plus `string` —\nconsumers get autocomplete on the common phases without rejecting others.',
+        description='Processing phase that produced the error: typically `"parse"`,\n`"validate"`, `"plugin"`, or `"lint"`. `null` when not\nattributable to a phase. The set is open (the loader phase is a free\nstring), so the TS type is a union of the known values plus `string` —\nconsumers get autocomplete on the common phases without rejecting others.',
     )
     severity: Severity = Field(..., description="Error severity.")
 

--- a/crates/rustledger-wasm/bindings/types.py
+++ b/crates/rustledger-wasm/bindings/types.py
@@ -339,7 +339,7 @@ class BeancountError(BaseModel):
     message: str = Field(..., description="Error message.")
     phase: str | None = Field(
         ...,
-        description='Processing phase that produced the error: `"parse"`, `"validate"`,\n`"booking"`, or `"plugin"`. `null` when not attributable to a phase.',
+        description='Processing phase that produced the error: typically `"parse"`,\n`"validate"`, `"booking"`, `"plugin"`, or `"lint"`. `null` when not\nattributable to a phase. The set is open (the loader phase is a free\nstring), so the TS type is a union of the known values plus `string` —\nconsumers get autocomplete on the common phases without rejecting others.',
     )
     severity: Severity = Field(..., description="Error severity.")
 

--- a/crates/rustledger-wasm/bindings/types.py
+++ b/crates/rustledger-wasm/bindings/types.py
@@ -304,17 +304,43 @@ class BeancountError(BaseModel):
     `#[ts(rename = ...)]` so consumers see a non-shadowing name.
     """
 
+    code: str | None = Field(
+        ...,
+        description='Stable error code (e.g. `"P0001"` for a parse error, `"E3001"` for a\nvalidation error). `null` for errors without a code (generic processing\n/ query / plugin errors). Lets consumers branch on error type instead of\nmatching on message text.',
+    )
     column: int | None = Field(
         ...,
-        description="Column number (1-based). `null` when the error has no source\nlocation. See `line` above for `range` rationale.",
+        description="Start column (1-based). `null` when the error has no source\nlocation. See `line` above for `range` rationale.",
         ge=1,
+    )
+    end_column: int | None = Field(
+        ...,
+        description="End column (1-based) of the error span. `null` when no span. See `line`.",
+        ge=1,
+    )
+    end_line: int | None = Field(
+        ...,
+        description="End line (1-based) of the error span. `null` when no span. See `line`.",
+        ge=1,
+    )
+    file: str | None = Field(
+        ...,
+        description="Source file the error came from (multi-file ledgers). `null` for the\nsingle-source WASM entry points (`parse`, `check`, …).",
+    )
+    hint: str | None = Field(
+        ...,
+        description="Actionable hint for fixing the error, when one is available. `null`\notherwise.",
     )
     line: int | None = Field(
         ...,
-        description="Line number (1-based). `null` when the error has no source\nlocation (e.g. validation errors not tied to a span). Field is\nalways present on the wire (no `skip_serializing_if`); see the\nstruct-level `schemars(extend)` for the required-and-nullable\nrationale. `range(min = 1)` enforces the 1-based documented\ncontract on the JSON Schema side (schemars defaults to\n`minimum: 0` for u32).",
+        description="Start line (1-based). `null` when the error has no source\nlocation (e.g. validation errors not tied to a span). Field is\nalways present on the wire (no `skip_serializing_if`); see the\nstruct-level `schemars(extend)` for the required-and-nullable\nrationale. `range(min = 1)` enforces the 1-based documented\ncontract on the JSON Schema side (schemars defaults to\n`minimum: 0` for u32).",
         ge=1,
     )
     message: str = Field(..., description="Error message.")
+    phase: str | None = Field(
+        ...,
+        description='Processing phase that produced the error: `"parse"`, `"validate"`,\n`"booking"`, or `"plugin"`. `null` when not attributable to a phase.',
+    )
     severity: Severity = Field(..., description="Error severity.")
 
 

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -11,7 +11,9 @@ use rustledger_loader::{FileSystem, LoadError, LoadResult};
 use rustledger_parser::parse as parse_beancount;
 
 use crate::convert::{directive_to_json, value_to_cell};
-use crate::helpers::{extract_options, has_fatal, load_and_book, run_validation, to_js};
+use crate::helpers::{
+    extract_options, has_fatal, load_and_book, parse_error_to_wasm, run_validation, to_js,
+};
 #[cfg(feature = "completions")]
 use crate::types::{CompletionJson, CompletionResultJson};
 use crate::types::{
@@ -71,7 +73,7 @@ pub fn parse(source: &str) -> Result<JsValue, JsError> {
     let errors: Vec<Error> = result
         .errors
         .iter()
-        .map(|e| Error::with_line(e.to_string(), lookup.byte_to_line(e.span().0)))
+        .map(|e| parse_error_to_wasm(e, &lookup, None))
         .collect();
 
     // Extract options from parsed result
@@ -211,7 +213,7 @@ pub fn format(source: &str) -> Result<JsValue, JsError> {
             errors: parse_result
                 .errors
                 .iter()
-                .map(|e| Error::with_line(e.to_string(), lookup.byte_to_line(e.span().0)))
+                .map(|e| parse_error_to_wasm(e, &lookup, None))
                 .collect(),
         };
         return to_js(&result);

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -35,21 +35,22 @@ fn load_errors_to_errors(load_result: &LoadResult) -> Vec<Error> {
                 path,
                 errors: parse_errors,
             } => {
-                // Expand parse errors with file path and line info
+                // Expand parse errors with the same rich fields as the
+                // single-file path (code / phase / hint / file / full span).
                 for parse_error in parse_errors {
                     let span = parse_error.span();
-                    // Try to get line number from source map
-                    let line = load_result
-                        .source_map
-                        .get_by_path(path)
-                        .map(|file| file.line_col(span.0).0 as u32);
-
-                    let msg = format!("{}: {}", path.display(), parse_error);
-                    if let Some(line_num) = line {
-                        errors.push(Error::with_line(msg, line_num));
-                    } else {
-                        errors.push(Error::new(msg));
+                    let file = load_result.source_map.get_by_path(path);
+                    let mut err = Error::new(format!("{}: {}", path.display(), parse_error))
+                        .with_code(format!("P{:04}", parse_error.kind_code()))
+                        .with_phase("parse")
+                        .with_hint(parse_error.hint.clone())
+                        .with_file(Some(path.display().to_string()));
+                    if let Some(file) = file {
+                        let (sl, sc) = file.line_col(span.0);
+                        let (el, ec) = file.line_col(span.1);
+                        err = err.with_span((sl as u32, sc as u32), (el as u32, ec as u32));
                     }
+                    errors.push(err);
                 }
             }
             other => {

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -25,7 +25,11 @@ use rustledger_core::Directive;
 use crate::types::{Error, LedgerOptions};
 
 /// Current cache format version. Increment when the serialized format changes.
-pub const CACHE_VERSION: u32 = 1;
+///
+/// v2 (#1597): `Error` gained `code`/`phase`/`hint`/`file`/`end_line`/
+/// `end_column`, changing its rkyv archived layout — a v1 blob must be rejected
+/// and re-parsed rather than mis-read under the new layout.
+pub const CACHE_VERSION: u32 = 2;
 
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -18,7 +18,7 @@ pub fn parse_error_to_wasm(
     lookup: &LineLookup,
     file: Option<String>,
 ) -> Error {
-    Error::new(e.message())
+    Error::new(e.to_string())
         .with_code(format!("P{:04}", e.kind_code()))
         .with_phase("parse")
         .with_hint(e.hint.clone())

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -40,7 +40,16 @@ pub fn validation_error_to_wasm(
     file: Option<String>,
     fallback_line: Option<u32>,
 ) -> Error {
-    let mut out = Error::new(e.message.clone())
+    // Map the validation code's own severity (Info/Warning/Error) to the WASM
+    // 2-level severity, so advisory codes (FutureDate, SinglePosting, …) surface
+    // as warnings instead of being reported as hard errors — matching `rledger
+    // check`'s error/warning split.
+    let base = if matches!(e.code.severity(), rustledger_validate::Severity::Error) {
+        Error::new(e.message.clone())
+    } else {
+        Error::warning(e.message.clone())
+    };
+    let mut out = base
         .with_code(e.code.code())
         .with_phase("validate")
         .with_hint(e.note.clone().or_else(|| e.context.clone()))
@@ -310,5 +319,21 @@ mod warning_severity_tests {
             e.end_line.is_some() && e.end_column.is_some(),
             "parse error should have an end position"
         );
+    }
+
+    /// #1597: a validation error's WASM severity now follows its code's own
+    /// severity — advisory codes surface as `Warning` (so they don't invalidate
+    /// a ledger), real codes as `Error`.
+    #[test]
+    fn validation_severity_follows_code() {
+        use rustledger_validate::{ErrorCode, ValidationError};
+        let lookup = LineLookup::new("x");
+        let date = rustledger_core::naive_date(2020, 1, 1).unwrap();
+        let mk = |code| ValidationError::new(code, "m", date);
+        // DateOutOfOrder is a warning code; AccountNotOpen (E1001) is an error.
+        let warn = validation_error_to_wasm(&mk(ErrorCode::DateOutOfOrder), &lookup, None, Some(1));
+        assert_eq!(warn.severity, Severity::Warning);
+        let err = validation_error_to_wasm(&mk(ErrorCode::AccountNotOpen), &lookup, None, Some(1));
+        assert_eq!(err.severity, Severity::Error);
     }
 }

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -10,6 +10,52 @@ use rustledger_parser::{ParseResult as ParserResult, parse as parse_beancount};
 use crate::types::{Error, LedgerOptions, Severity};
 use crate::utils::LineLookup;
 
+/// Convert a parser [`rustledger_parser::ParseError`] into the rich WASM
+/// [`Error`]: stable code (`P####`), `phase: "parse"`, hint, and the full
+/// source span (start + end line/column).
+pub fn parse_error_to_wasm(
+    e: &rustledger_parser::ParseError,
+    lookup: &LineLookup,
+    file: Option<String>,
+) -> Error {
+    Error::new(e.message())
+        .with_code(format!("P{:04}", e.kind_code()))
+        .with_phase("parse")
+        .with_hint(e.hint.clone())
+        .with_file(file)
+        .with_span(
+            lookup.byte_to_line_col(e.span.start),
+            lookup.byte_to_line_col(e.span.end),
+        )
+}
+
+/// Convert a [`rustledger_validate::ValidationError`] into the rich WASM
+/// [`Error`]: stable code (`E####`), `phase: "validate"`, hint (the advisory
+/// note, else context), and the source span when present. When the error has
+/// no span, falls back to `fallback_line` (the directive's date→line) to
+/// preserve the prior location behavior.
+pub fn validation_error_to_wasm(
+    e: &rustledger_validate::ValidationError,
+    lookup: &LineLookup,
+    file: Option<String>,
+    fallback_line: Option<u32>,
+) -> Error {
+    let mut out = Error::new(e.message.clone())
+        .with_code(e.code.code())
+        .with_phase("validate")
+        .with_hint(e.note.clone().or_else(|| e.context.clone()))
+        .with_file(file);
+    if let Some(span) = e.span {
+        out = out.with_span(
+            lookup.byte_to_line_col(span.start),
+            lookup.byte_to_line_col(span.end),
+        );
+    } else {
+        out.line = fallback_line;
+    }
+    out
+}
+
 /// Result of loading and processing a source file.
 pub struct ProcessedLedger {
     pub directives: Vec<Directive>,
@@ -35,7 +81,7 @@ pub fn load_and_book(source: &str) -> ProcessedLedger {
         let errors: Vec<Error> = parse_result
             .errors
             .iter()
-            .map(|e| Error::with_line(e.to_string(), lookup.byte_to_line(e.span().0)))
+            .map(|e| parse_error_to_wasm(e, &lookup, None))
             .collect();
 
         let options = extract_options(&parse_result.options);
@@ -150,15 +196,10 @@ pub fn run_validation(load: &ProcessedLedger) -> Vec<Error> {
     errors.extend(session.finalize());
 
     errors
-        .into_iter()
+        .iter()
         .map(|err| {
-            let line = date_to_line.get(&err.date.to_string()).copied();
-            Error {
-                message: err.message,
-                line,
-                column: None,
-                severity: Severity::Error,
-            }
+            let fallback_line = date_to_line.get(&err.date.to_string()).copied();
+            validation_error_to_wasm(err, &load.lookup, None, fallback_line)
         })
         .collect()
 }
@@ -231,9 +272,43 @@ mod warning_severity_tests {
         );
         assert!(!has_fatal(&load.errors), "a warning must not be fatal");
         let validation = run_validation(&load);
+        let e = validation
+            .iter()
+            .find(|e| e.message.contains("NeverOpened"))
+            .expect("validation must run despite the warning and report E1001");
+        // #1597: validation errors now carry a stable code + phase + location.
+        assert_eq!(e.phase.as_deref(), Some("validate"), "phase");
         assert!(
-            validation.iter().any(|e| e.message.contains("NeverOpened")),
-            "validation must run despite the warning and report E1001"
+            e.code.as_deref().is_some_and(|c| c.starts_with('E')),
+            "expected an E#### code, got {:?}",
+            e.code
+        );
+        assert!(e.line.is_some(), "validation error should carry a line");
+    }
+
+    /// #1597: parse errors carry a `P####` code, `phase: "parse"`, and the full
+    /// start + end span.
+    #[test]
+    fn parse_error_carries_rich_fields() {
+        // A top-level directive indented past column 0 is a parse error.
+        let load = load_and_book("  2020-01-01 open Assets:A\n");
+        let e = load
+            .errors
+            .iter()
+            .find(|e| e.phase.as_deref() == Some("parse"))
+            .expect("expected a parse-phase error");
+        assert!(
+            e.code.as_deref().is_some_and(|c| c.starts_with('P')),
+            "expected a P#### code, got {:?}",
+            e.code
+        );
+        assert!(
+            e.line.is_some() && e.column.is_some(),
+            "parse error should have start line+column"
+        );
+        assert!(
+            e.end_line.is_some() && e.end_column.is_some(),
+            "parse error should have an end position"
         );
     }
 }

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -577,15 +577,13 @@ pub struct Error {
     /// matching on message text.
     pub code: Option<String>,
     /// Processing phase that produced the error: typically `"parse"`,
-    /// `"validate"`, `"booking"`, `"plugin"`, or `"lint"`. `null` when not
+    /// `"validate"`, `"plugin"`, or `"lint"`. `null` when not
     /// attributable to a phase. The set is open (the loader phase is a free
     /// string), so the TS type is a union of the known values plus `string` —
     /// consumers get autocomplete on the common phases without rejecting others.
     #[cfg_attr(
         feature = "ts-export",
-        ts(
-            type = "\"parse\" | \"validate\" | \"booking\" | \"plugin\" | \"lint\" | (string & {}) | null"
-        )
+        ts(type = "\"parse\" | \"validate\" | \"plugin\" | \"lint\" | (string & {}) | null")
     )]
     pub phase: Option<String>,
     /// Actionable hint for fixing the error, when one is available. `null`

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -565,13 +565,27 @@ pub enum Severity {
     feature = "json-schema",
     schemars(
         rename = "BeancountError",
-        extend("required" = ["message", "line", "column", "severity"])
+        extend("required" = ["message", "code", "phase", "hint", "file", "line", "column", "end_line", "end_column", "severity"])
     )
 )]
 pub struct Error {
     /// Error message.
     pub message: String,
-    /// Line number (1-based). `null` when the error has no source
+    /// Stable error code (e.g. `"P0001"` for a parse error, `"E3001"` for a
+    /// validation error). `null` for errors without a code (generic processing
+    /// / query / plugin errors). Lets consumers branch on error type instead of
+    /// matching on message text.
+    pub code: Option<String>,
+    /// Processing phase that produced the error: `"parse"`, `"validate"`,
+    /// `"booking"`, or `"plugin"`. `null` when not attributable to a phase.
+    pub phase: Option<String>,
+    /// Actionable hint for fixing the error, when one is available. `null`
+    /// otherwise.
+    pub hint: Option<String>,
+    /// Source file the error came from (multi-file ledgers). `null` for the
+    /// single-source WASM entry points (`parse`, `check`, …).
+    pub file: Option<String>,
+    /// Start line (1-based). `null` when the error has no source
     /// location (e.g. validation errors not tied to a span). Field is
     /// always present on the wire (no `skip_serializing_if`); see the
     /// struct-level `schemars(extend)` for the required-and-nullable
@@ -580,56 +594,117 @@ pub struct Error {
     /// `minimum: 0` for u32).
     #[cfg_attr(feature = "json-schema", schemars(range(min = 1)))]
     pub line: Option<u32>,
-    /// Column number (1-based). `null` when the error has no source
+    /// Start column (1-based). `null` when the error has no source
     /// location. See `line` above for `range` rationale.
     #[cfg_attr(feature = "json-schema", schemars(range(min = 1)))]
     pub column: Option<u32>,
+    /// End line (1-based) of the error span. `null` when no span. See `line`.
+    #[cfg_attr(feature = "json-schema", schemars(range(min = 1)))]
+    pub end_line: Option<u32>,
+    /// End column (1-based) of the error span. `null` when no span. See `line`.
+    #[cfg_attr(feature = "json-schema", schemars(range(min = 1)))]
+    pub end_column: Option<u32>,
     /// Error severity.
     pub severity: Severity,
 }
 
 impl Error {
-    /// Create a new error with a message.
-    pub fn new(message: impl Into<String>) -> Self {
+    /// Bare error with the given message + severity; all location/code/phase/
+    /// hint/file fields `None`. Fill them via the builder methods below or the
+    /// `*_to_wasm` conversion helpers in `helpers`.
+    fn base(message: impl Into<String>, severity: Severity) -> Self {
         Self {
             message: message.into(),
+            code: None,
+            phase: None,
+            hint: None,
+            file: None,
             line: None,
             column: None,
-            severity: Severity::Error,
+            end_line: None,
+            end_column: None,
+            severity,
         }
     }
 
-    /// Create an error with a line number.
+    /// Create a new error with a message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self::base(message, Severity::Error)
+    }
+
+    /// Create an error with a (start) line number.
     pub fn with_line(message: impl Into<String>, line: u32) -> Self {
         Self {
-            message: message.into(),
             line: Some(line),
-            column: None,
-            severity: Severity::Error,
+            ..Self::base(message, Severity::Error)
         }
     }
 
     /// Create a warning.
     pub fn warning(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-            line: None,
-            column: None,
-            severity: Severity::Warning,
-        }
+        Self::base(message, Severity::Warning)
+    }
+
+    /// Builder: set the stable error code (e.g. `"P0001"`, `"E3001"`).
+    #[must_use]
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+
+    /// Builder: set the processing phase (`"parse"`, `"validate"`, …).
+    #[must_use]
+    pub fn with_phase(mut self, phase: impl Into<String>) -> Self {
+        self.phase = Some(phase.into());
+        self
+    }
+
+    /// Builder: set the actionable hint (no-op for `None`).
+    #[must_use]
+    pub fn with_hint(mut self, hint: Option<String>) -> Self {
+        self.hint = hint;
+        self
+    }
+
+    /// Builder: set the source file.
+    #[must_use]
+    pub fn with_file(mut self, file: Option<String>) -> Self {
+        self.file = file;
+        self
+    }
+
+    /// Builder: set the full 1-based span (start + end line/column).
+    #[must_use]
+    pub fn with_span(mut self, start: (u32, u32), end: (u32, u32)) -> Self {
+        self.line = Some(start.0);
+        self.column = Some(start.1);
+        self.end_line = Some(end.0);
+        self.end_column = Some(end.1);
+        self
     }
 }
 
 impl From<rustledger_loader::LedgerError> for Error {
     fn from(e: rustledger_loader::LedgerError) -> Self {
         Self {
-            message: e.message,
+            // `LedgerError` already carries code + phase + file location.
+            code: (!e.code.is_empty()).then(|| e.code.clone()),
+            phase: (!e.phase.is_empty()).then(|| e.phase.clone()),
+            hint: None,
+            file: e
+                .location
+                .as_ref()
+                .map(|loc| loc.file.display().to_string()),
             line: e.location.as_ref().map(|loc| loc.line as u32),
             column: e.location.as_ref().map(|loc| loc.column as u32),
+            // `ErrorLocation` is a single point (no end); leave end positions null.
+            end_line: None,
+            end_column: None,
             severity: match e.severity {
                 rustledger_loader::ErrorSeverity::Error => Severity::Error,
                 rustledger_loader::ErrorSeverity::Warning => Severity::Warning,
             },
+            message: e.message,
         }
     }
 }

--- a/crates/rustledger-wasm/src/types.rs
+++ b/crates/rustledger-wasm/src/types.rs
@@ -576,8 +576,17 @@ pub struct Error {
     /// / query / plugin errors). Lets consumers branch on error type instead of
     /// matching on message text.
     pub code: Option<String>,
-    /// Processing phase that produced the error: `"parse"`, `"validate"`,
-    /// `"booking"`, or `"plugin"`. `null` when not attributable to a phase.
+    /// Processing phase that produced the error: typically `"parse"`,
+    /// `"validate"`, `"booking"`, `"plugin"`, or `"lint"`. `null` when not
+    /// attributable to a phase. The set is open (the loader phase is a free
+    /// string), so the TS type is a union of the known values plus `string` —
+    /// consumers get autocomplete on the common phases without rejecting others.
+    #[cfg_attr(
+        feature = "ts-export",
+        ts(
+            type = "\"parse\" | \"validate\" | \"booking\" | \"plugin\" | \"lint\" | (string & {}) | null"
+        )
+    )]
     pub phase: Option<String>,
     /// Actionable hint for fixing the error, when one is available. `null`
     /// otherwise.

--- a/crates/rustledger-wasm/src/utils.rs
+++ b/crates/rustledger-wasm/src/utils.rs
@@ -65,6 +65,23 @@ mod tests {
     }
 
     #[test]
+    fn test_byte_to_line_col() {
+        let source = "ab\ncde\n"; // line1="ab"(0,1,\n@2), line2="cde"(3,4,5,\n@6), len=7
+        let lookup = LineLookup::new(source);
+        assert_eq!(lookup.byte_to_line_col(0), (1, 1)); // 'a'
+        assert_eq!(lookup.byte_to_line_col(1), (1, 2)); // 'b'
+        assert_eq!(lookup.byte_to_line_col(2), (1, 3)); // '\n' (col past 'b')
+        assert_eq!(lookup.byte_to_line_col(3), (2, 1)); // 'c' (start of line 2)
+        assert_eq!(lookup.byte_to_line_col(5), (2, 3)); // 'e'
+        // End-of-file on a trailing newline maps to the next (empty) line, col 1
+        // — this matches the CLI's `byte_offset_to_line_col` for an end-exclusive
+        // span boundary at EOF (both walk past the final '\n').
+        assert_eq!(lookup.byte_to_line_col(7), (3, 1));
+        // Empty source: offset 0 is (1, 1).
+        assert_eq!(LineLookup::new("").byte_to_line_col(0), (1, 1));
+    }
+
+    #[test]
     fn test_byte_to_line_no_trailing_newline() {
         let source = "line1\nline2";
         let lookup = LineLookup::new(source);

--- a/crates/rustledger-wasm/src/utils.rs
+++ b/crates/rustledger-wasm/src/utils.rs
@@ -20,6 +20,20 @@ impl LineLookup {
     pub fn byte_to_line(&self, byte: usize) -> u32 {
         self.line_starts.partition_point(|&start| start <= byte) as u32
     }
+
+    /// Convert a byte offset to a 1-based `(line, column)`. The column is the
+    /// byte offset within the line + 1 — equal to the character column for
+    /// ASCII text; on lines with multi-byte UTF-8 it may read higher (we don't
+    /// retain the source here to count characters). Lines are exact.
+    #[must_use]
+    pub fn byte_to_line_col(&self, byte: usize) -> (u32, u32) {
+        let line = self
+            .line_starts
+            .partition_point(|&start| start <= byte)
+            .max(1);
+        let line_start = self.line_starts.get(line - 1).copied().unwrap_or(0);
+        (line as u32, (byte.saturating_sub(line_start) as u32) + 1)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1597.

## What

The WASM `Error` DTO (`BeancountError`) only exposed `message` / `line` / `column` / `severity`, so JS consumers had to string-match messages to classify errors. This adds the rich fields the CLI's `rledger check -f json` already emits: **`code`**, **`phase`**, **`hint`**, **`file`**, **`end_line`**, **`end_column`**.

## How

The data already existed upstream — this threads it through (the CLI's `cmd/check.rs` is the reference mapping):

- **`Error` builder** — `with_code` / `with_phase` / `with_hint` / `with_file` / `with_span`.
- **Parse errors** (`parse_error_to_wasm`) → `P####` code, `phase: "parse"`, hint, full start+end span. Applied at every parse-error site (`parse`, `load_and_book`, `format`).
- **Validation errors** (`validation_error_to_wasm`) → `E####` code (`ValidationError::code`), `phase: "validate"`, hint (advisory note → context), span when present; **falls back to the date→line** when an error has no span (preserves prior behavior).
- **Loader/booking errors** (`From<LedgerError>`) → now also carries the loader's `code` + `phase` + file location.
- `LineLookup::byte_to_line_col` for start/end positions.

New fields are **required-but-nullable** (added to the schemars `required` list), matching the existing `line`/`column` contract — consumers always see the field, `null` when absent.

## Scope / notes

- Generic query/plugin errors keep `phase: null` (they have no structured codes) — a clean future follow-up.
- `column` is the byte offset within the line (== character column for ASCII; documented).
- **Bindings regenerated** (`index.d.ts` / `index.schema.json` / `types.py`) via `scripts/regen-bindings.sh`.

## Verification

- **87 wasm tests pass** (incl. 2 new: parse + validation errors carry code/phase/positions); `clippy --all-targets` clean.
- Bindings are fresh (regenerated), so the "Wire-format bindings freshness" check passes. The `ag-rledger`/WASM binary is exercised by `ci.yml`'s `--all-features` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
