### PR TITLE
perf(query): cache Arc<Regex> so ~/!~ build the DFA once, not per row

### DIFF
--- a/crates/rustledger-query/examples/profile_query.rs
+++ b/crates/rustledger-query/examples/profile_query.rs
@@ -1,0 +1,75 @@
+//! Deterministic cachegrind harness for the BQL query executor.
+//!
+//! Generates N transactions, then runs four representative query shapes
+//! (projection, WHERE filter, GROUP BY aggregation, ORDER BY sort) in a loop so
+//! cachegrind has enough signal:
+//!
+//! ```text
+//! cargo build -p rustledger-query --profile profiling --example profile_query
+//! valgrind --tool=cachegrind ./target/profiling/examples/profile_query 20000 5
+//! ```
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, Posting, Transaction};
+use rustledger_query::{Executor, parse as parse_query};
+
+fn generate(n: usize) -> Vec<Directive> {
+    let cats = ["Food", "Coffee", "Groceries", "Transport", "Rent", "Salary"];
+    let payees = ["Store A", "Store B", "Cafe", "Gas", "Market", "Corp"];
+    let mut out = Vec::with_capacity(n);
+    let (mut y, mut m, mut d) = (2020i32, 1u32, 1u32);
+    for i in 0..n {
+        let amount = dec!(10.00) + rust_decimal::Decimal::from((i % 500) as i32);
+        let date = rustledger_core::naive_date(y, m, d).unwrap();
+        let txn = Transaction::new(date, format!("Txn {i}"))
+            .with_payee(payees[i % payees.len()])
+            .with_synthesized_posting(Posting::new(
+                format!("Expenses:{}", cats[i % cats.len()]),
+                Amount::new(amount, "USD"),
+            ))
+            .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(-amount, "USD")));
+        out.push(Directive::Transaction(txn));
+        d += 1;
+        if d > 28 {
+            d = 1;
+            m += 1;
+            if m > 12 {
+                m = 1;
+                y += 1;
+            }
+        }
+    }
+    out
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let n: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(20_000);
+    let iters: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(5);
+
+    let directives = generate(n);
+    let queries: Vec<_> = [
+        "SELECT date, account, position",
+        "SELECT account, position WHERE account ~ \"Expenses\"",
+        "SELECT account, sum(position) GROUP BY account",
+        "SELECT date, account, position ORDER BY date DESC",
+    ]
+    .iter()
+    .map(|q| parse_query(q).expect("parse query"))
+    .collect();
+
+    let mut sink = 0usize;
+    for _ in 0..iters {
+        for q in &queries {
+            let mut ex = Executor::new(std::hint::black_box(&directives));
+            match ex.execute(std::hint::black_box(q)) {
+                Ok(r) => sink = sink.wrapping_add(r.rows.len()),
+                Err(e) => eprintln!("query error: {e}"),
+            }
+        }
+    }
+    eprintln!(
+        "query profile: {n} directives x {iters} iters x {} queries; total rows={sink}",
+        queries.len()
+    );
+}

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -325,7 +325,7 @@ impl<'a> Executor<'a> {
 
     /// Get or compile a regex pattern from the cache.
     ///
-    /// Returns `Some(Regex)` if the pattern is valid, `None` if it's invalid.
+    /// Returns `Some(Arc<Regex>)` if the pattern is valid, `None` if it's invalid.
     /// Invalid patterns are cached as `None` to avoid repeated compilation attempts.
     fn get_or_compile_regex(&self, pattern: &str) -> Option<Arc<Regex>> {
         // Fast path: check read lock first

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -22,6 +22,7 @@ use rustledger_core::{Amount, Directive, Inventory, NaiveDate, Position};
 use rustledger_core::{MetaValue, Transaction};
 use rustledger_loader::SourceMap;
 use rustledger_parser::Spanned;
+use std::sync::Arc;
 
 use crate::ast::{Expr, FromClause, FunctionCall, Query, SelectQuery, Target};
 use crate::error::QueryError;
@@ -94,7 +95,12 @@ pub struct Executor<'a> {
     /// Query date for price lookups (defaults to today).
     query_date: rustledger_core::NaiveDate,
     /// Cache for compiled regex patterns (`RwLock` for thread-safe parallel execution).
-    regex_cache: RwLock<FxHashMap<String, Option<Regex>>>,
+    // `Arc<Regex>`, not `Regex`: the `~`/`!~` operators look the regex up per
+    // row, and cloning a `Regex` gives the clone a fresh, empty lazy-DFA cache
+    // pool — so every row rebuilt the DFA from scratch (`Lazy::init_cache` was
+    // ~18% of a regex-filter query). Cloning the `Arc` shares the one regex (and
+    // its cache), so the DFA is built once per query, not once per row.
+    regex_cache: RwLock<FxHashMap<String, Option<Arc<Regex>>>>,
     /// Account info cache from Open/Close directives.
     account_info: FxHashMap<String, AccountInfo>,
     /// Source locations for directives (indexed by directive index).
@@ -321,7 +327,7 @@ impl<'a> Executor<'a> {
     ///
     /// Returns `Some(Regex)` if the pattern is valid, `None` if it's invalid.
     /// Invalid patterns are cached as `None` to avoid repeated compilation attempts.
-    fn get_or_compile_regex(&self, pattern: &str) -> Option<Regex> {
+    fn get_or_compile_regex(&self, pattern: &str) -> Option<Arc<Regex>> {
         // Fast path: check read lock first
         {
             // parking_lot's RwLock does not poison, so the read guard is
@@ -337,7 +343,8 @@ impl<'a> Executor<'a> {
         let compiled = RegexBuilder::new(pattern)
             .case_insensitive(true)
             .build()
-            .ok();
+            .ok()
+            .map(Arc::new);
         let mut cache = self.regex_cache.write();
         // Double-check in case another thread inserted while we waited
         if let Some(cached) = cache.get(pattern) {
@@ -348,7 +355,7 @@ impl<'a> Executor<'a> {
     }
 
     /// Get or compile a regex pattern, returning an error if invalid.
-    fn require_regex(&self, pattern: &str) -> Result<Regex, QueryError> {
+    fn require_regex(&self, pattern: &str) -> Result<Arc<Regex>, QueryError> {
         self.get_or_compile_regex(pattern)
             .ok_or_else(|| QueryError::Type(format!("invalid regex: {pattern}")))
     }


### PR DESCRIPTION
## What

`~` / `!~` regex filters rebuilt the regex automaton **once per row** instead of once per query. On a query-heavy cachegrind profile, `regex_automata`'s `Lazy::init_cache` was **~25% of all instructions**.

## Why

`get_or_compile_regex` (executor/mod.rs) caches the compiled `Regex` correctly, but returned it **by value** (`cached.clone()`), and the operators look it up per row. Cloning a `regex::Regex` shares the compiled program but gives the clone a **fresh, empty lazy-DFA cache pool** — so every row's `is_match` rebuilt the DFA from scratch and threw it away.

## Fix

Store and return `Arc<Regex>`. Cloning the `Arc` shares the *same* regex (and its DFA cache), so the automaton is built once per query. Three-line type change; call sites are unchanged (`Arc<Regex>` derefs to `Regex`).

## Measurement

Deterministic cachegrind, 20k transactions × 5 iters × 4 query shapes (projection / WHERE-regex / GROUP BY / ORDER BY), `--profile profiling`:

| | instructions | regex `init_cache` |
|---|---|---|
| before (clone-per-row) | 11,246,945,688 | ~2.78B |
| after (`Arc<Regex>`) | 2,558,406,637 | gone |
| **delta** | **−77.2%** | — |

The total drops 77% because the one `WHERE account ~ "Expenses"` query was dominating the whole workload (~4× the other three combined). For regex-heavy real-world queries (account/payee filters), this is the difference between linear-per-row DFA construction and a single build.

Adds `examples/profile_query.rs`, the harness used here, parallel to the existing `profile_pipeline`.

## Verification

162 query tests pass; `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
