### PR TITLE
perf(booking,validate): FxHashMap for per-transaction balance maps (-8.3%)

### DIFF
--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -39,16 +39,17 @@ pub use pad::{
 use bigdecimal::BigDecimal;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
+use rustc_hash::FxHashMap;
 use rustledger_core::{Amount, Currency, IncompleteAmount, Transaction};
-use std::collections::HashMap;
 
 /// Calculate the tolerance for a set of amounts.
 ///
 /// Tolerance is the maximum of all individual amount tolerances.
 #[must_use]
-pub fn calculate_tolerance(amounts: &[&Amount]) -> HashMap<Currency, Decimal> {
+pub fn calculate_tolerance(amounts: &[&Amount]) -> FxHashMap<Currency, Decimal> {
     // Pre-allocate for typical case (1-3 currencies per transaction)
-    let mut tolerances: HashMap<Currency, Decimal> = HashMap::with_capacity(amounts.len().min(4));
+    let mut tolerances: FxHashMap<Currency, Decimal> =
+        FxHashMap::with_capacity_and_hasher(amounts.len().min(4), Default::default());
 
     for amount in amounts {
         let tol = amount.inferred_tolerance();
@@ -217,10 +218,10 @@ fn cost_weight<D: WeightNum>(
 /// Weight rule (Beancount): a cost spec puts the weight in the cost currency
 /// (`cost` beats `price`); else a price annotation puts it in the price
 /// currency; else the weight is the units themselves.
-fn residual_weight<D: WeightNum>(transaction: &Transaction) -> HashMap<Currency, D> {
+fn residual_weight<D: WeightNum>(transaction: &Transaction) -> FxHashMap<Currency, D> {
     // Pre-allocate for typical case (1-2 currencies per transaction)
-    let mut residuals: HashMap<Currency, D> =
-        HashMap::with_capacity(transaction.postings.len().min(4));
+    let mut residuals: FxHashMap<Currency, D> =
+        FxHashMap::with_capacity_and_hasher(transaction.postings.len().min(4), Default::default());
 
     // Lazily compute inferred currency only when needed (most transactions don't need it)
     let mut inferred_cost_currency: Option<Option<Currency>> = None;
@@ -304,7 +305,7 @@ fn residual_weight<D: WeightNum>(transaction: &Transaction) -> HashMap<Currency,
 /// See: `spec/tla/DoubleEntry.tla`
 #[must_use]
 #[allow(clippy::implicit_hasher)]
-pub fn calculate_residual(transaction: &Transaction) -> HashMap<Currency, Decimal> {
+pub fn calculate_residual(transaction: &Transaction) -> FxHashMap<Currency, Decimal> {
     residual_weight::<Decimal>(transaction)
 }
 
@@ -326,14 +327,14 @@ fn to_big(d: Decimal) -> BigDecimal {
 /// significant digits; this function handles arbitrary precision correctly.
 #[must_use]
 #[allow(clippy::implicit_hasher)]
-pub fn calculate_residual_precise(transaction: &Transaction) -> HashMap<Currency, BigDecimal> {
+pub fn calculate_residual_precise(transaction: &Transaction) -> FxHashMap<Currency, BigDecimal> {
     residual_weight::<BigDecimal>(transaction)
 }
 
 /// Check if a transaction is balanced within tolerance.
 #[must_use]
 #[allow(clippy::implicit_hasher)]
-pub fn is_balanced(transaction: &Transaction, tolerances: &HashMap<Currency, Decimal>) -> bool {
+pub fn is_balanced(transaction: &Transaction, tolerances: &FxHashMap<Currency, Decimal>) -> bool {
     let residuals = calculate_residual(transaction);
 
     for (currency, residual) in residuals {
@@ -493,7 +494,7 @@ mod tests {
                 Amount::new(dec!(-49.00), "USD"),
             ));
         // Residual is 1.00 USD against zero tolerance — clearly unbalanced.
-        let mut tolerances = HashMap::new();
+        let mut tolerances = FxHashMap::default();
         tolerances.insert(Currency::from("USD"), Decimal::ZERO);
         assert!(
             !is_balanced(&txn, &tolerances),
@@ -517,7 +518,7 @@ mod tests {
                 Amount::new(dec!(-50.00), "USD"),
             ));
         // Residual 0.01 exactly equals the tolerance: balanced under `>`.
-        let mut tolerances = HashMap::new();
+        let mut tolerances = FxHashMap::default();
         tolerances.insert(Currency::from("USD"), dec!(0.01));
         assert!(
             is_balanced(&txn, &tolerances),

--- a/crates/rustledger-booking/src/lib.rs
+++ b/crates/rustledger-booking/src/lib.rs
@@ -304,6 +304,8 @@ fn residual_weight<D: WeightNum>(transaction: &Transaction) -> FxHashMap<Currenc
 ///
 /// See: `spec/tla/DoubleEntry.tla`
 #[must_use]
+// clippy::implicit_hasher still fires for a concrete `FxBuildHasher` (it wants
+// the fn generic over `S: BuildHasher`); the explicit fast hasher is the point.
 #[allow(clippy::implicit_hasher)]
 pub fn calculate_residual(transaction: &Transaction) -> FxHashMap<Currency, Decimal> {
     residual_weight::<Decimal>(transaction)

--- a/crates/rustledger-validate/examples/profile_validate.rs
+++ b/crates/rustledger-validate/examples/profile_validate.rs
@@ -1,0 +1,85 @@
+//! Deterministic cachegrind harness for the validation engine: many accounts,
+//! many transactions, and periodic balance assertions — stressing account
+//! open/close tracking + the per-transaction residual/tolerance + running-balance
+//! machinery validation runs. Parallel to the `profile_pipeline` /
+//! `profile_query` / `profile_booking` examples.
+//!
+//! ```text
+//! cargo build -p rustledger-validate --profile profiling --example profile_validate
+//! valgrind --tool=cachegrind ./target/profiling/examples/profile_validate 64 20000 3
+//! ```
+//!
+//! Args: `<subaccounts> <transactions> <iterations>` (defaults `64 20000 5`).
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Balance, Directive, Open, Posting, Transaction};
+use rustledger_validate::{ValidationOptions, ValidationSession};
+
+fn date(y: i32, m: u32, d: u32) -> rustledger_core::NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+fn generate(subaccounts: usize, txns: usize) -> Vec<Directive> {
+    let mut d = Vec::new();
+    d.push(Directive::Open(Open::new(
+        date(2024, 1, 1),
+        "Income:Salary",
+    )));
+    let accts: Vec<String> = (0..subaccounts)
+        .map(|k| format!("Assets:Bank:Sub{k}"))
+        .collect();
+    for a in &accts {
+        d.push(Directive::Open(Open::new(date(2024, 1, 1), a.clone())));
+    }
+    let mut totals = vec![rust_decimal::Decimal::ZERO; subaccounts];
+    for i in 0..txns {
+        let k = i % subaccounts;
+        let amount = dec!(10.00) + rust_decimal::Decimal::from((i % 50) as i64);
+        let month = (i % 12 + 1) as u32;
+        let day = (i % 28 + 1) as u32;
+        let txn = Transaction::new(date(2024, month, day), format!("Deposit {i}"))
+            .with_flag('*')
+            .with_synthesized_posting(Posting::new(accts[k].clone(), Amount::new(amount, "USD")))
+            .with_synthesized_posting(Posting::new("Income:Salary", Amount::new(-amount, "USD")));
+        d.push(Directive::Transaction(txn));
+        totals[k] += amount;
+        // Periodic balance assertion on the touched subaccount (exercises the
+        // balance machinery; date ordering means not all will match, which is
+        // fine — the residual/balance computation runs either way).
+        if i % 100 == 99 {
+            d.push(Directive::Balance(Balance::new(
+                date(2024, month, day),
+                accts[k].clone(),
+                Amount::new(totals[k], "USD"),
+            )));
+        }
+    }
+    d
+}
+
+fn validate(directives: &[Directive]) -> usize {
+    let today = rustledger_core::naive_date(2030, 1, 1).unwrap();
+    let session = ValidationSession::new(ValidationOptions::default());
+    let (session, mut errors) = session.run_early(directives, today);
+    let (session, late) = session.run_late(directives, today);
+    errors.extend(late);
+    errors.extend(session.finalize());
+    errors.len()
+}
+
+fn main() {
+    let mut a = std::env::args().skip(1);
+    let subaccounts: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(64);
+    let txns: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(20_000);
+    let iters: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(5);
+
+    let directives = generate(subaccounts, txns);
+    let mut sink = 0usize;
+    for _ in 0..iters {
+        sink = sink.wrapping_add(validate(std::hint::black_box(&directives)));
+    }
+    eprintln!(
+        "validate profile: {subaccounts} subaccts x {txns} txns x {iters} iters; dirs={} err_sink={sink}",
+        directives.len()
+    );
+}

--- a/crates/rustledger-validate/examples/profile_validate.rs
+++ b/crates/rustledger-validate/examples/profile_validate.rs
@@ -72,6 +72,10 @@ fn main() {
     let subaccounts: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(64);
     let txns: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(20_000);
     let iters: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(5);
+    if subaccounts == 0 {
+        eprintln!("error: <subaccounts> must be > 0");
+        std::process::exit(2);
+    }
 
     let directives = generate(subaccounts, txns);
     let mut sink = 0usize;

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -387,7 +387,7 @@ pub fn calculate_tolerances(
     if options.infer_tolerance_from_cost {
         // Accumulated cost/price tolerances per currency
         let mut cost_tolerances: FxHashMap<rustledger_core::Currency, Decimal> =
-            FxHashMap::default();
+            FxHashMap::with_capacity_and_hasher(txn.postings.len().min(4), Default::default());
 
         for posting in &txn.postings {
             if let Some(units) = posting.amount() {

--- a/crates/rustledger-validate/src/validators/transaction.rs
+++ b/crates/rustledger-validate/src/validators/transaction.rs
@@ -3,7 +3,6 @@
 use rust_decimal::Decimal;
 use rustc_hash::FxHashMap;
 use rustledger_core::{Amount, BookingMethod, Inventory, Posting, Transaction};
-use std::collections::HashMap;
 
 use super::helpers::push_account_not_open;
 use crate::error::{ErrorCode, ValidationError};
@@ -278,7 +277,7 @@ pub fn validate_posting_currency(
 ///    `tolerance = units_quantum * cost_per_unit * tolerance_multiplier`
 pub fn validate_transaction_balance(
     txn: &Transaction,
-    tolerances: &HashMap<rustledger_core::Currency, Decimal>,
+    tolerances: &FxHashMap<rustledger_core::Currency, Decimal>,
     errors: &mut Vec<ValidationError>,
 ) {
     // Skip balance checking if there are any empty cost specs (e.g., `{}`).
@@ -357,10 +356,10 @@ pub fn decimal_quantum(value: Decimal) -> Decimal {
 pub fn calculate_tolerances(
     txn: &Transaction,
     options: &ValidationOptions,
-) -> HashMap<rustledger_core::Currency, Decimal> {
+) -> FxHashMap<rustledger_core::Currency, Decimal> {
     // Pre-allocate for typical case (1-2 currencies)
-    let mut tolerances: HashMap<rustledger_core::Currency, Decimal> =
-        HashMap::with_capacity(txn.postings.len().min(4));
+    let mut tolerances: FxHashMap<rustledger_core::Currency, Decimal> =
+        FxHashMap::with_capacity_and_hasher(txn.postings.len().min(4), Default::default());
 
     // Default tolerance based on quantum of amounts in postings.
     // Only amounts with decimal places contribute (Python's `if expo < 0:` guard).
@@ -387,7 +386,8 @@ pub fn calculate_tolerances(
     // across postings, then max'd with the existing tolerance per currency.
     if options.infer_tolerance_from_cost {
         // Accumulated cost/price tolerances per currency
-        let mut cost_tolerances: HashMap<rustledger_core::Currency, Decimal> = HashMap::new();
+        let mut cost_tolerances: FxHashMap<rustledger_core::Currency, Decimal> =
+            FxHashMap::default();
 
         for posting in &txn.postings {
             if let Some(units) = posting.amount() {
@@ -767,8 +767,8 @@ mod validator_comparison_tests {
 
     // ---- validate_transaction_balance: `residual.abs() > tolerance`
 
-    fn usd_tol(t: Decimal) -> HashMap<rustledger_core::Currency, Decimal> {
-        let mut m = HashMap::new();
+    fn usd_tol(t: Decimal) -> FxHashMap<rustledger_core::Currency, Decimal> {
+        let mut m = FxHashMap::default();
         m.insert(rustledger_core::Currency::from("USD"), t);
         m
     }


### PR DESCRIPTION
## What

The per-transaction balance machinery built **std `HashMap` (SipHash)** currency→decimal maps:
- booking: `calculate_tolerance`, `residual_weight`, `calculate_residual`, `calculate_residual_precise`
- validate: `calculate_tolerances`

These run **once per transaction** (validation calls `calculate_residual` in its balance check at `validators/transaction.rs:304`), and SipHash's high fixed per-op cost is pure waste for 1–4-entry maps. Everything else in both crates already uses `FxHashMap`.

## Why it was found

Profiling validation on a large ledger (the new `profile_validate` harness) showed `sip::Hasher::write` at ~3.7% with no SipHash maps in validation's own state — traced to these per-transaction balance helpers.

## Change

Switch them to `FxHashMap` (rustc-hash), consistent with the rest of the codebase. Pre-1.0 return-type change; the only cross-crate caller iterates the result (hasher-agnostic), so nothing breaks.

## Measurement

cachegrind, validation-heavy workload (64 subaccounts × 20k txns × 3):

| | instructions | `sip::Hasher::write` |
|---|---|---|
| before | 448,899,383 | 17.3M |
| after | 411,780,066 | gone |
| **delta** | **−8.3%** | — |

Also benefits booking directly (same `calculate_residual` path).

## Also

Adds `crates/rustledger-validate/examples/profile_validate.rs`, the harness used here — parallel to `profile_pipeline` / `profile_query` / `profile_booking`.

## Verification

105 booking + all validate tests pass; `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
