### PR TITLE
perf(import): FxHashMap for CSV header map (-5.6%) + format/import harnesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,7 @@ dependencies = [
  "regex",
  "rmp-serde",
  "rust_decimal",
+ "rustc-hash 2.1.2",
  "rustledger-core",
  "rustledger-ops",
  "rustledger-plugin",

--- a/crates/rustledger-core/examples/profile_format.rs
+++ b/crates/rustledger-core/examples/profile_format.rs
@@ -1,0 +1,87 @@
+//! Deterministic cachegrind harness for the formatter (`format_directives`):
+//! a varied ledger (transactions with costs/prices, opens, balances) formatted
+//! to text in a loop, isolating the pretty-printer from parsing.
+//!
+//! ```text
+//! cargo build -p rustledger-core --profile profiling --example profile_format
+//! valgrind --tool=cachegrind ./target/profiling/examples/profile_format 20000 5
+//! ```
+
+use rust_decimal_macros::dec;
+use rustledger_core::{
+    Amount, Balance, CostNumber, CostSpec, Directive, FormatConfig, Open, Posting, PriceAnnotation,
+    Transaction, format_directives,
+};
+
+fn d(y: i32, m: u32, day: u32) -> rustledger_core::NaiveDate {
+    rustledger_core::naive_date(y, m, day).unwrap()
+}
+
+fn generate(n: usize) -> Vec<Directive> {
+    let mut out = Vec::with_capacity(n + 40);
+    for k in 0..16 {
+        out.push(Directive::Open(Open::new(
+            d(2024, 1, 1),
+            format!("Assets:Acct{k}"),
+        )));
+    }
+    out.push(Directive::Open(Open::new(d(2024, 1, 1), "Income:Salary")));
+    out.push(Directive::Open(Open::new(d(2024, 1, 1), "Assets:Stock")));
+    for i in 0..n {
+        let month = (i % 12 + 1) as u32;
+        let day = (i % 28 + 1) as u32;
+        let amt = dec!(10.00) + rust_decimal::Decimal::from((i % 9000) as i64);
+        let txn = if i % 3 == 0 {
+            // cost + price posting (exercises format_cost_spec / format_price)
+            Transaction::new(d(2024, month, day), format!("Buy lot {i}"))
+                .with_flag('*')
+                .with_synthesized_posting(
+                    Posting::new("Assets:Stock", Amount::new(dec!(10), "AAPL")).with_cost(
+                        CostSpec::empty()
+                            .with_number(CostNumber::PerUnit { value: amt })
+                            .with_currency("USD"),
+                    ),
+                )
+                .with_synthesized_posting(
+                    Posting::new("Assets:Acct0", Amount::new(-amt * dec!(10), "USD"))
+                        .with_price(PriceAnnotation::unit(Amount::new(amt, "USD"))),
+                )
+        } else {
+            Transaction::new(d(2024, month, day), format!("Payment {i}"))
+                .with_flag('*')
+                .with_synthesized_posting(Posting::new(
+                    format!("Assets:Acct{}", i % 16),
+                    Amount::new(amt, "USD"),
+                ))
+                .with_synthesized_posting(Posting::new("Income:Salary", Amount::new(-amt, "USD")))
+        };
+        out.push(Directive::Transaction(txn));
+        if i % 50 == 49 {
+            out.push(Directive::Balance(Balance::new(
+                d(2024, month, day),
+                format!("Assets:Acct{}", i % 16),
+                Amount::new(amt, "USD"),
+            )));
+        }
+    }
+    out
+}
+
+fn main() {
+    let mut a = std::env::args().skip(1);
+    let n: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(20_000);
+    let iters: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(5);
+
+    let directives = generate(n);
+    let config = FormatConfig::default();
+    let mut sink = 0usize;
+    for _ in 0..iters {
+        let s = format_directives(std::hint::black_box(&directives), &config);
+        sink = sink.wrapping_add(s.len());
+    }
+    eprintln!(
+        "format profile: {n} txns x {iters} iters; dirs={} out_chars/iter={}",
+        directives.len(),
+        sink / iters.max(1)
+    );
+}

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -36,6 +36,7 @@ rustledger-plugin = { workspace = true, features = ["wasm-runtime"], optional = 
 rustledger-plugin-types.workspace = true
 jiff.workspace = true
 rust_decimal.workspace = true
+rustc-hash.workspace = true
 regex.workspace = true
 anyhow.workspace = true
 format_num_pattern.workspace = true

--- a/crates/rustledger-importer/examples/profile_import.rs
+++ b/crates/rustledger-importer/examples/profile_import.rs
@@ -1,0 +1,55 @@
+//! Deterministic cachegrind harness for the CSV importer
+//! (`CsvImporter::extract_string`): a large generated CSV parsed into directives
+//! in a loop, isolating import from file I/O.
+//!
+//! ```text
+//! cargo build -p rustledger-importer --profile profiling --example profile_import
+//! valgrind --tool=cachegrind ./target/profiling/examples/profile_import 20000 5
+//! ```
+
+use rustledger_importer::ImporterConfig;
+use rustledger_importer::csv_importer::CsvImporter;
+
+fn generate_csv(rows: usize) -> String {
+    let mut s = String::from("Date,Description,Amount\n");
+    for i in 0..rows {
+        let month = i % 12 + 1;
+        let day = i % 28 + 1;
+        let amt = if i % 2 == 0 {
+            -((i % 500) as f64) - 0.50
+        } else {
+            (i % 1000) as f64 + 1.00
+        };
+        s.push_str(&format!("{month:02}/{day:02}/2024,Merchant {i},{amt:.2}\n"));
+    }
+    s
+}
+
+fn main() {
+    let mut a = std::env::args().skip(1);
+    let rows: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(20_000);
+    let iters: usize = a.next().and_then(|s| s.parse().ok()).unwrap_or(5);
+
+    let csv = generate_csv(rows);
+    let config = ImporterConfig::csv()
+        .account("Assets:Bank:Checking")
+        .currency("USD")
+        .date_column("Date")
+        .narration_column("Description")
+        .amount_column("Amount")
+        .date_format("%m/%d/%Y")
+        .build()
+        .unwrap();
+
+    let mut sink = 0usize;
+    for _ in 0..iters {
+        let r = CsvImporter
+            .extract_string(std::hint::black_box(&csv), &config)
+            .unwrap();
+        sink = sink.wrapping_add(r.directives.len());
+    }
+    eprintln!(
+        "import profile: {rows} rows x {iters} iters; dirs/iter={}",
+        sink / iters.max(1)
+    );
+}

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -4,9 +4,9 @@ use crate::config::{AmountFormat, ColumnSpec, CsvConfig, ImporterConfig, Importe
 use crate::{EnrichedImportResult, ImportResult, Importer};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
+use rustc_hash::FxHashMap as HashMap;
 use rustledger_core::{Amount, Directive, Posting, Transaction};
 use rustledger_ops::enrichment::{CategorizationMethod, Enrichment};
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
@@ -112,7 +112,7 @@ impl CsvImporter {
                 .map(|(i, h)| (h.to_string(), i))
                 .collect()
         } else {
-            HashMap::new()
+            HashMap::default()
         };
 
         let mut directives = Vec::new();


### PR DESCRIPTION
## What

Profiling the CSV importer (new `profile_import` harness) showed `sip::Hasher::write` + `hash_one` at ~3.7%: the header-name → column-index map in `csv_importer.rs` used std `HashMap` (SipHash) and is looked up **per column, per row**. Over a 20k-row file that's a lot of SipHash work on short column names.

Swap it to `FxHashMap` — **internal only** (it's a local + `&` params on private fns, no public API change), consistent with the rest of the codebase.

## Measurement

cachegrind, 20k-row CSV × 5 iters:

| | instructions |
|---|---|
| before | 845,456,287 |
| after | 798,033,363 |
| **delta** | **−5.6%** |

## Also: two profiling harnesses

Parallel to `profile_pipeline` / `profile_query` / `profile_booking` / `profile_validate`:
- `rustledger-core/examples/profile_format.rs`
- `rustledger-importer/examples/profile_import.rs`

**Format finding (documented, not chased):** formatting is allocation-bound (~40% allocator + ~8% `core::fmt`), from per-line `String`/`format!` intermediates. The lever is a pretty-printer refactor (write into a reused buffer), but `rledger format` is an occasional command, so it's not worth that churn now — the harness makes it re-measurable if that changes.

## Verification

159 importer tests pass; `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
