### PR TITLE
perf(query): FxHashMap for executor GROUP BY/pivot/window/price maps

### DIFF
--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -1,6 +1,6 @@
 //! Aggregation and grouping functions.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 use rust_decimal::Decimal;
 use rustledger_core::{Amount, Inventory, Position};
@@ -192,7 +192,7 @@ impl<'a> Executor<'a> {
             // Use HashMap for O(1) grouping, with a Vec to preserve insertion order
             // so results without ORDER BY are deterministic across runs.
             let mut group_map: HashMap<String, (Vec<Value>, Vec<&PostingContext<'a>>)> =
-                HashMap::new();
+                HashMap::default();
             let mut key_order: Vec<String> = Vec::new();
 
             for ctx in postings {

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -573,7 +573,7 @@ impl Executor<'_> {
         table: &Table,
         column_map: &FxHashMap<String, usize>,
     ) -> Result<QueryResult, QueryError> {
-        use std::collections::HashMap;
+        use rustc_hash::FxHashMap as HashMap;
 
         // Determine column names for the result
         let column_names = self.resolve_subquery_column_names(&query.targets, &table.columns)?;
@@ -594,7 +594,7 @@ impl Executor<'_> {
 
         // Group table rows by GROUP BY key.
         // Maintain a Vec of keys in insertion order for deterministic results.
-        let mut group_map: HashMap<String, (Vec<Value>, Vec<&Row>)> = HashMap::new();
+        let mut group_map: HashMap<String, (Vec<Value>, Vec<&Row>)> = HashMap::default();
         let mut key_order: Vec<String> = Vec::new();
 
         for row in &table.rows {

--- a/crates/rustledger-query/src/executor/sort.rs
+++ b/crates/rustledger-query/src/executor/sort.rs
@@ -1,6 +1,6 @@
 //! Sorting and pivoting functions.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::ast::{Expr, Literal, OrderSpec, SortDirection};
 use crate::error::QueryError;
@@ -25,7 +25,7 @@ impl Executor<'_> {
         }
 
         // Build a map from column names to indices
-        let column_indices: std::collections::HashMap<&str, usize> = result
+        let column_indices: rustc_hash::FxHashMap<&str, usize> = result
             .columns
             .iter()
             .enumerate()
@@ -254,7 +254,7 @@ impl Executor<'_> {
         // that share a u64 hash (probability ~2⁻⁶⁴, but pinned out
         // for correctness). Same pattern as `pivot_lookup` below.
         let mut groups: Vec<(Value, Vec<&Row>)> = Vec::new();
-        let mut group_index: HashMap<u64, Vec<usize>> = HashMap::new();
+        let mut group_index: HashMap<u64, Vec<usize>> = HashMap::default();
         for row in &result.rows {
             let key = row.get(key_col_idx).cloned().unwrap_or(Value::Null);
             let h = hash_single_value(&key);
@@ -282,7 +282,7 @@ impl Executor<'_> {
             // If multiple input rows share the same `(key, pivot_value)`
             // pair, only the first one wins — see "Input contract" in
             // the function docstring.
-            let mut pivot_lookup: HashMap<u64, Vec<&Row>> = HashMap::new();
+            let mut pivot_lookup: HashMap<u64, Vec<&Row>> = HashMap::default();
             for &row in &group_rows {
                 let pv = row.get(pivot_value_col_idx).cloned().unwrap_or(Value::Null);
                 pivot_lookup

--- a/crates/rustledger-query/src/executor/window.rs
+++ b/crates/rustledger-query/src/executor/window.rs
@@ -1,6 +1,6 @@
 //! Window function support.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::ast::{Expr, SortDirection, Target, WindowFunction};
 use crate::error::QueryError;
@@ -54,7 +54,7 @@ impl Executor<'_> {
         }
 
         // Group posting indices by partition key
-        let mut partitions: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut partitions: HashMap<String, Vec<usize>> = HashMap::default();
         for (idx, key) in partition_keys.iter().enumerate() {
             partitions.entry(key.clone()).or_default().push(idx);
         }

--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -4,8 +4,8 @@
 //! and allows looking up prices for currency conversions.
 
 use rust_decimal::Decimal;
+use rustc_hash::FxHashMap as HashMap;
 use rustledger_core::{Amount, Directive, NaiveDate, Price as PriceDirective, Transaction};
-use std::collections::HashMap;
 
 /// A price entry.
 ///
@@ -48,7 +48,7 @@ impl PriceDatabase {
     /// Create a new empty price database.
     pub fn new() -> Self {
         Self {
-            prices: HashMap::new(),
+            prices: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
## What

Following the same SipHash-on-hot-paths fix in **validation (#1607)** and **import (#1608)**, the cross-workspace grep surfaced the **query executor**: several per-row maps used std `HashMap` (SipHash) while `execution.rs` already used `FxHashMap` elsewhere:

- `aggregation.rs` + `execution.rs` — the **GROUP BY** `group_map` (per row)
- `sort.rs` — the **PIVOT** group/lookup maps, **keyed by `u64`** (SipHash on integers is especially wasteful vs FxHash)
- `window.rs` — window-function partitions
- `price.rs` — the price index (per price conversion)

Swap them to `FxHashMap` — all internal, no public API change.

## Measurement

The earlier query profile flagged GROUP BY SipHash at ~5.5%; this removes `sip::Hasher::write` entirely. cachegrind, `profile_query` mixed 4-query workload (20k rows × 5):

| | instructions | `sip::Hasher::write` |
|---|---|---|
| before | 2,557,100,523 | 16.4M |
| after | 2,503,292,153 | gone |
| **delta** | **−2.1%** | — |

Modest overall here because GROUP BY is 1 of 4 queries in that workload; **GROUP-BY / PIVOT / window / price-conversion** queries benefit more directly.

## Verification

162 + 398 query tests pass; `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
