### PR TITLE
refactor(core): remove dead, fake sha256_hex helper

### DIFF
--- a/crates/rustledger-core/src/synthetic/manifest.rs
+++ b/crates/rustledger-core/src/synthetic/manifest.rs
@@ -178,26 +178,6 @@ impl ManifestEntry {
     }
 }
 
-/// Calculate SHA-256 hash of content (requires sha2 crate in calling code).
-/// Returns hex-encoded string.
-pub fn sha256_hex(content: &[u8]) -> String {
-    use std::fmt::Write;
-
-    // Simple SHA-256 implementation using std only is complex,
-    // so this function expects the caller to provide the hash.
-    // This is a placeholder that returns a dummy value.
-    // In actual use, use sha2::Sha256::digest(content).
-    let mut result = String::with_capacity(64);
-    for byte in content.iter().take(32) {
-        write!(&mut result, "{byte:02x}").unwrap();
-    }
-    // Pad with zeros if content is shorter
-    while result.len() < 64 {
-        result.push('0');
-    }
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Removes `rustledger_core::synthetic::manifest::sha256_hex` — dead code that was also **wrong**.

Found during a repo-wide unfinished-work audit. The function:
- has **zero callers** anywhere in the workspace, and
- does **not** compute SHA-256 — it hex-encodes the first 32 input bytes and zero-pads to 64 chars. Its own doc comment said *"This is a placeholder that returns a dummy value."*

A `pub fn` named `sha256_hex` that returns a fake digest is a footgun: any future caller would silently get a non-cryptographic, collision-prone "hash." The manifest's `sha256` field is populated by callers via `with_sha256(...)`, so nothing depended on this helper.

## Change

Delete the function. If real content hashing is needed later, use `sha2::Sha256::digest(content)` (as the old comment itself suggested).

## Verification

422 core tests pass; `clippy --all-targets` clean. No references existed to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
