### PR TITLE
fix(parser): green cost-spec must latch first post-# NUMBER like red

### DIFF
--- a/crates/rustledger-parser/src/cst/green.rs
+++ b/crates/rustledger-parser/src/cst/green.rs
@@ -251,6 +251,7 @@ fn convert_cost_spec(node: &rowan::GreenNodeData) -> CostSpec {
     let mut first_number: Option<rust_decimal::Decimal> = None;
     let mut seen_number = false;
     let mut past_hash = false;
+    let mut post_hash_seen = false;
     let mut post_hash_total: Option<rust_decimal::Decimal> = None;
     let mut currency: Option<Currency> = None;
     let mut date: Option<NaiveDate> = None;
@@ -267,8 +268,19 @@ fn convert_cost_spec(node: &rowan::GreenNodeData) -> CostSpec {
             // computed separately in `cost_is_merge` (see its note).
             K::L_DOUBLE_BRACE => is_total = true,
             K::NUMBER => {
-                if past_hash && post_hash_total.is_none() {
-                    post_hash_total = parse_decimal_token(t.text());
+                if past_hash {
+                    // Latch the FIRST post-`#` NUMBER token (parsed or not),
+                    // exactly like red's `cost_total_after_hash`, which `return`s
+                    // at the first NUMBER after the hash regardless of whether it
+                    // parses. The old `post_hash_total.is_none()` guard kept
+                    // scanning past an unparseable total and latched a *later*
+                    // number, so green produced `Total{later}` where red yielded
+                    // `None` (→ `PerUnit{first}`) — the `fuzz_green_eq_red`
+                    // divergence on `{N # <unparseable> T}`.
+                    if !post_hash_seen {
+                        post_hash_seen = true;
+                        post_hash_total = parse_decimal_token(t.text());
+                    }
                 } else if !seen_number {
                     seen_number = true;
                     first_number = parse_decimal_token(t.text());
@@ -1251,6 +1263,13 @@ mod tests {
             // stops), then a SECOND opener + `*`. Green must mirror red and not
             // re-arm on the later `{`, which used to flip `merge` to true.
             "2020-01-01 *\n Aa:B 1 USD{,{*",
+            // Regression (fuzz_green_eq_red cost-number): `{N # <X> T}` where the
+            // first post-`#` token is a NUMBER that does NOT parse (here
+            // `\u{06f6}`, an Arabic-Indic digit the lexer tokenizes as NUMBER but
+            // rust_decimal rejects). Green must latch that FIRST post-hash NUMBER
+            // (-> None -> PerUnit{N}, mirroring red's `cost_total_after_hash`),
+            // NOT scan on to the later parseable `0` and emit `Total{0}`.
+            "7046/7/1D\n\tA:F{7#\u{06f6}>0",
             "\u{feff}2020-01-01 * \"p\"\n  A 1 USD\n  B\n", // BOM
             "2020-01-01 * \"é\" \"münts\"\n  Aaa 1 EUR\n  B\n", // multi-byte
             "garbage\n2020-01-01 open A\n2020-01-01 * \"p\"\n  A 1 USD\n  B\n", // error recovery


### PR DESCRIPTION
## What

`fuzz_green_eq_red` surfaced a green-vs-red parser divergence on the `{N # T}` (per-unit + total) cost-spec form when the first token after `#` is a NUMBER the lexer accepts but `rust_decimal` rejects (e.g. an Arabic-Indic digit `۶`).

Minimized reproducer (21 bytes):
```
7046/7/1D
	A:F{7#۶>0
```
- **GREEN:** `CostSpec { number: Some(Total { value: 0 }) }`
- **RED:** `CostSpec { number: Some(PerUnit { value: 7 }) }`

## Root cause

Red's `cost_total_after_hash` returns at the **first** post-`#` NUMBER token regardless of whether it parses — so on `# ۶ > 0` it latches `۶`, parses to `None`, and the caller falls back to `PerUnit{first}`. Green guarded the post-hash slot with `post_hash_total.is_none()`, so it **skipped** the unparseable `۶` and scanned on to `0`, emitting `Total{0}`.

Same class as the previously-fixed date and cost-merge (#1605) green divergences: *latch the first **token** of a kind, not the first that **parses**.*

## Fix

Latch the first post-`#` NUMBER via a `post_hash_seen` flag, mirroring red byte-for-byte. Purely the green converter (one file, +21/-2).

## Tests

- Added the minimized input to the `parse_green_eq_red_corpus` regression list.
- Verified the original 338-byte crash artifact and the minimized input now MATCH; well-formed `{{T}}` and `{N # T}` cost forms unaffected.
- `cargo test -p rustledger-parser` (553 tests) green; fmt + clippy clean.

Found while merging #1607 — the `fuzz_green_eq_red` job is non-required so it hadn't blocked merges, but it fails until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
