### PR TITLE
ci(kani): relax MSRV gate for Kani's bundled nightly toolchain

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -66,6 +66,13 @@ jobs:
           # post-1.93 language feature would still surface as a normal compile
           # error rather than this spurious gate.
           sed -i 's/^rust-version = .*/rust-version = "1.85"/' Cargo.toml
+          # Fail loudly if the substitution did not take (e.g. the Cargo.toml
+          # layout changed), instead of silently leaving the gate in place and
+          # letting Kani hit the same cryptic MSRV error later.
+          grep -qx 'rust-version = "1.85"' Cargo.toml || {
+            echo "::error::MSRV relax failed: did not rewrite [workspace.package].rust-version in Cargo.toml" >&2
+            exit 1
+          }
       - name: Install Kani
         run: |
           cargo install --locked kani-verifier

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -54,6 +54,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
           toolchain: stable
+      - name: Relax the MSRV gate for Kani's bundled toolchain
+        run: |
+          # Kani vendors its own nightly (v0.67 ships nightly-2025-11-21 =
+          # rustc 1.93.0-nightly), OLDER than our workspace MSRV. Kani only needs
+          # the proof harnesses to compile, not MSRV enforcement, so cargo's
+          # `rust-version` gate fails the whole run before any harness executes
+          # ("rustc 1.93.0-nightly is not supported ... requires rustc 1.96").
+          # Lower `[workspace.package].rust-version` below Kani's toolchain for
+          # this ephemeral CI checkout only (never committed). A genuine
+          # post-1.93 language feature would still surface as a normal compile
+          # error rather than this spurious gate.
+          sed -i 's/^rust-version = .*/rust-version = "1.85"/' Cargo.toml
       - name: Install Kani
         run: |
           cargo install --locked kani-verifier


### PR DESCRIPTION
## What

The nightly **Kani Verification** job has been red. Root cause:

```
error: rustc 1.93.0-nightly is not supported by the following package:
  rustledger-core@0.16.5 requires rustc 1.96
```

Kani vendors its **own** toolchain — v0.67.0 ships `nightly-2025-11-21` (= `rustc 1.93.0-nightly`), which is **older than our workspace MSRV (`1.96`)**, set by a routine "bump toolchain + MSRV" commit. cargo's `rust-version` gate then aborts the whole run *before any proof harness compiles* — it's not a verification failure (no `VERIFICATION FAILED`), just a toolchain/MSRV mismatch.

## Fix

Kani only needs the harnesses to **compile**, not MSRV enforcement. Add a CI-only step that lowers `[workspace.package].rust-version` below Kani's bundled nightly for the ephemeral checkout (sed; **never committed**). A genuine post-1.93 language feature would still surface as a normal compile error rather than this gate.

```yaml
- name: Relax the MSRV gate for Kani's bundled toolchain
  run: sed -i 's/^rust-version = .*/rust-version = "1.85"/' Cargo.toml
```

## Verification

Triggered via `workflow_dispatch` on this branch — see the Kani run linked below. (The `Miri` nightly red is a separate, long-standing rowan/Stacked-Borrows issue tracked under #1239, out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
