### PR TITLE
ci(miri): scope to rowan-free crates (core + booking)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -6,12 +6,11 @@
 # are miri-compatible; WASM/FFI crates and fs/wasmtime-heavy crates are
 # excluded because miri can't run their targets.
 #
-# Memory model: Stacked Borrows (miri's default). #1239 Q2 originally chose
-# Tree Borrows, but the *experimental* Tree-Borrows ruleset false-positives on
-# the `rowan` dependency's `ThinArc::clone` (a "write through Frozen" report
-# that miri itself flags as experimental), which the parser reaches via CST
-# conversion. `rowan` is clean under Stacked Borrows (as it is for
-# rust-analyzer), so we use the default model.
+# Memory model: Stacked Borrows (miri's default). The job is scoped to the
+# rowan-free crates because rowan's `ThinArc` green tree trips miri under BOTH
+# Stacked Borrows AND Tree Borrows (a known, open aliasing-model question, not a
+# rowan bug), so no memory-model flag fixes it. See the "Run Miri on rowan-free
+# crates" step below for the full rationale and upstream references.
 name: Miri
 on:
   schedule:
@@ -51,8 +50,9 @@ jobs:
       # internal unsafe, not ours. It's a known, still-open upstream question, not
       # a rowan bug we can fix or upgrade away from:
       #   - https://github.com/rust-analyzer/rowan/issues/108 (open since 2021)
-      #   - tied to rust-lang/unsafe-code-guidelines #134 / #256 / #276; the Rust
-      #     teams' "general temperature" is that this pattern SHOULD be allowed.
+      #   - tied to rust-lang/unsafe-code-guidelines#134 / #256 / #276 (i.e.
+      #     github.com/rust-lang/unsafe-code-guidelines/issues/{134,256,276}); the
+      #     Rust teams' "general temperature" is that this pattern SHOULD be allowed.
       #   - rowan 0.16.1 is the latest release; no Miri-clean version exists.
       # Tree Borrows does not help (verified), so the established practice for a
       # Miri-incompatible dependency applies: scope Miri away from it. We still
@@ -83,8 +83,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Memory model: Stacked Borrows (miri default)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Checked crates:" >> $GITHUB_STEP_SUMMARY
+          echo "Checked crates (rowan-free):" >> $GITHUB_STEP_SUMMARY
           echo "- rustledger-core" >> $GITHUB_STEP_SUMMARY
-          echo "- rustledger-parser" >> $GITHUB_STEP_SUMMARY
           echo "- rustledger-booking" >> $GITHUB_STEP_SUMMARY
-          echo "- rustledger-query" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Excluded — rowan's ThinArc is miri-incompatible under Stacked AND Tree Borrows: rustledger-parser, rustledger-query." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -42,22 +42,30 @@ jobs:
       # "the 'miri' component ... is not available for the 'stable' toolchain").
       - name: Setup Miri
         run: cargo +nightly miri setup
-      - name: Run Miri on core crates
+      # Scoped to the rowan-free crates. rustledger-parser and rustledger-query
+      # depend on `rowan`, whose green tree is a `ThinArc` (header + slice packed
+      # into one allocation). That thin-pointer "header fattening" is rejected by
+      # Miri under BOTH Stacked Borrows and Tree Borrows (a write/retag through a
+      # pointer not in the borrow stack at SyntaxNode::green().into_owned()).
+      # rustledger-parser is #![forbid(unsafe_code)], so this is entirely rowan's
+      # internal unsafe, not ours. It's a known, still-open upstream question, not
+      # a rowan bug we can fix or upgrade away from:
+      #   - https://github.com/rust-analyzer/rowan/issues/108 (open since 2021)
+      #   - tied to rust-lang/unsafe-code-guidelines #134 / #256 / #276; the Rust
+      #     teams' "general temperature" is that this pattern SHOULD be allowed.
+      #   - rowan 0.16.1 is the latest release; no Miri-clean version exists.
+      # Tree Borrows does not help (verified), so the established practice for a
+      # Miri-incompatible dependency applies: scope Miri away from it. We still
+      # catch transitive-`unsafe` UB in our own logic via core + booking (+ their
+      # deps: rust_decimal, bigdecimal, imbl, smallvec, ...).
+      - name: Run Miri on rowan-free crates
         run: |
           echo "::group::rustledger-core"
           cargo +nightly miri test --package rustledger-core --all-features
           echo "::endgroup::"
 
-          echo "::group::rustledger-parser"
-          cargo +nightly miri test --package rustledger-parser --all-features
-          echo "::endgroup::"
-
           echo "::group::rustledger-booking"
           cargo +nightly miri test --package rustledger-booking --all-features
-          echo "::endgroup::"
-
-          echo "::group::rustledger-query"
-          cargo +nightly miri test --package rustledger-query --all-features
           echo "::endgroup::"
         env:
           # -Zmiri-disable-isolation: some tests read the realtime clock


### PR DESCRIPTION
## What

The nightly **Miri** job has failed for months on a rowan aliasing violation at `SyntaxNode::green().into_owned()` (`rustledger-parser` is `#![forbid(unsafe_code)]`, so the UB is entirely in rowan's internal `unsafe`).

## Why a flag/upgrade can't fix it

rowan's green tree is a `ThinArc` (header + slice in one allocation). That thin-pointer "header fattening" is rejected by Miri under **both** Stacked Borrows **and** Tree Borrows (I verified TB fails too, with the same allocation). It's a **known, still-open upstream question, not a rowan bug**:
- [rust-analyzer/rowan#108](https://github.com/rust-analyzer/rowan/issues/108) — open since 2021
- tied to `rust-lang/unsafe-code-guidelines` #134/#256/#276; the Rust teams' "general temperature" is that this pattern **should be allowed**
- rowan `0.16.1` is the latest release — no Miri-clean version to upgrade to

## Fix

The established practice for a Miri-incompatible dependency is to **scope Miri away from it**. This PR runs Miri only on the **rowan-free crates** (`rustledger-core` + `rustledger-booking`), excluding the two rowan-dependent crates (`parser`, `query`). Documented inline with the upstream references.

Miri still catches transitive-`unsafe` UB in our own logic and these crates' deps (`rust_decimal`, `bigdecimal`, `imbl`, `smallvec`, …) — the actual goal of #1239. It just stops Miri-testing rowan's interpreter-compatibility, which was never our code to fix.

## Verification

- `rustledger-core` is already proven green under Miri (it completed fully in the failing runs before they aborted at `parser`).
- `rustledger-booking` verified via a `workflow_dispatch` (booking-only) run — link in a comment below.

Supersedes #1618 (the Tree-Borrows-flag approach, which I verified does **not** work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
