### PR TITLE
fix(price): centralize JSON->Decimal price conversion + document f64 bound

### DIFF
--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -132,15 +132,7 @@ impl ExternalCommandSource {
 
         let price = json
             .get("price")
-            .and_then(|v| {
-                if let Some(n) = v.as_number() {
-                    Decimal::from_str(&n.to_string()).ok()
-                } else if let Some(s) = v.as_str() {
-                    Decimal::from_str(s).ok()
-                } else {
-                    None
-                }
-            })
+            .and_then(super::price_decimal_from_json)
             .with_context(|| "Missing or invalid 'price' field in JSON")?;
 
         let currency = json

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -63,6 +63,32 @@ pub struct PriceResponse {
     pub source: String,
 }
 
+/// Parse a price quote from a JSON value into a [`Decimal`].
+///
+/// Handles both shapes price APIs use:
+/// - **String** quotes (`"1.2345"`) parse exactly.
+/// - **Integer** numbers parse exactly.
+/// - **Float** numbers are bounded by `f64` (~15–17 significant digits): a JSON
+///   float has already been parsed into an `f64` by the time it reaches a
+///   `serde_json::Value` (serde_json is built without `arbitrary_precision`), so
+///   the most we can recover is its shortest round-trippable string. That is
+///   exact for every human-scale quote (FX / equities / crypto) and only loses
+///   precision past ~15 significant digits — far beyond any real price.
+///
+/// We deliberately do not enable serde_json's `arbitrary_precision` feature: it
+/// is global and breaks the workspace's `#[serde(untagged)]` / `flatten` enums.
+/// A per-field `RawValue` rewrite of every network source was judged
+/// disproportionate for the negligible gain (see #1621).
+#[must_use]
+pub fn price_decimal_from_json(value: &serde_json::Value) -> Option<Decimal> {
+    use std::str::FromStr;
+    match value {
+        serde_json::Value::String(s) => Decimal::from_str(s).ok(),
+        serde_json::Value::Number(n) => Decimal::from_str(&n.to_string()).ok(),
+        _ => None,
+    }
+}
+
 /// Registry of available price sources.
 pub struct PriceSourceRegistry {
     sources: HashMap<String, Arc<dyn PriceSource>>,
@@ -351,6 +377,34 @@ pub fn fetch_price(
 mod tests {
     use super::*;
     use crate::config::{FallbackDetail, FallbackEntry};
+
+    #[test]
+    fn test_price_decimal_from_json() {
+        use std::str::FromStr;
+        // String quotes parse exactly, including beyond f64 precision.
+        assert_eq!(
+            price_decimal_from_json(&serde_json::json!("1.23456789012345678901234567")),
+            Some(Decimal::from_str("1.23456789012345678901234567").unwrap())
+        );
+        // Integer numbers are exact.
+        assert_eq!(
+            price_decimal_from_json(&serde_json::json!(42)),
+            Some(Decimal::from(42))
+        );
+        // Ordinary float quotes round-trip to the expected decimal.
+        assert_eq!(
+            price_decimal_from_json(&serde_json::json!(1.25)),
+            Some(Decimal::from_str("1.25").unwrap())
+        );
+        // Non-numeric / wrong-shape values yield None.
+        assert_eq!(
+            price_decimal_from_json(&serde_json::json!("not-a-number")),
+            None
+        );
+        assert_eq!(price_decimal_from_json(&serde_json::json!(true)), None);
+        assert_eq!(price_decimal_from_json(&serde_json::json!(null)), None);
+        assert_eq!(price_decimal_from_json(&serde_json::json!([1, 2])), None);
+    }
 
     #[test]
     fn test_price_request_builder() {

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -70,12 +70,12 @@ pub struct PriceResponse {
 /// - **Integer** numbers parse exactly.
 /// - **Float** numbers are bounded by `f64` (~15–17 significant digits): a JSON
 ///   float has already been parsed into an `f64` by the time it reaches a
-///   `serde_json::Value` (serde_json is built without `arbitrary_precision`), so
+///   `serde_json::Value` (`serde_json` is built without `arbitrary_precision`), so
 ///   the most we can recover is its shortest round-trippable string. That is
 ///   exact for every human-scale quote (FX / equities / crypto) and only loses
 ///   precision past ~15 significant digits — far beyond any real price.
 ///
-/// We deliberately do not enable serde_json's `arbitrary_precision` feature: it
+/// We deliberately do not enable `serde_json`'s `arbitrary_precision` feature: it
 /// is global and breaks the workspace's `#[serde(untagged)]` / `flatten` enums.
 /// A per-field `RawValue` rewrite of every network source was judged
 /// disproportionate for the negligible gain (see #1621).

--- a/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
@@ -5,9 +5,7 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
-use rust_decimal::Decimal;
 use std::env;
-use std::str::FromStr;
 use std::time::Duration;
 
 /// `CoinMarketCap` price source.
@@ -120,16 +118,8 @@ impl PriceSource for CoinMarketCapSource {
             .get("price")
             .with_context(|| "Missing price in quote")?;
 
-        let price_str = if let Some(n) = price_value.as_f64() {
-            n.to_string()
-        } else if let Some(s) = price_value.as_str() {
-            s.to_string()
-        } else {
-            anyhow::bail!("Invalid price format");
-        };
-
-        let price = Decimal::from_str(&price_str)
-            .with_context(|| format!("Failed to parse price: {price_str}"))?;
+        let price = crate::cmd::price::price_decimal_from_json(price_value)
+            .with_context(|| format!("Invalid price format: {price_value}"))?;
 
         let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
 

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -7,7 +7,6 @@ use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use rustledger_core::NaiveDate;
-use std::str::FromStr;
 use std::time::Duration;
 
 /// European Central Bank price source.
@@ -89,10 +88,9 @@ impl EcbSource {
         let rate_value = obs_value
             .as_array()
             .and_then(|a| a.first())
-            .and_then(serde_json::Value::as_f64)
             .with_context(|| "Invalid rate value in ECB response")?;
 
-        let rate = Decimal::from_str(&rate_value.to_string())
+        let rate = crate::cmd::price::price_decimal_from_json(rate_value)
             .with_context(|| format!("Failed to parse rate: {rate_value}"))?;
 
         // Try to get the date from the structure

--- a/crates/rustledger/src/cmd/price/sources/quandl.rs
+++ b/crates/rustledger/src/cmd/price/sources/quandl.rs
@@ -5,10 +5,8 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
-use rust_decimal::Decimal;
 use rustledger_core::NaiveDate;
 use std::env;
-use std::str::FromStr;
 use std::time::Duration;
 
 /// Quandl (Nasdaq Data Link) price source.
@@ -157,16 +155,8 @@ impl PriceSource for QuandlSource {
         // Extract price
         let price_value = data.get(price_idx).with_context(|| "Missing price value")?;
 
-        let price_str = if let Some(n) = price_value.as_f64() {
-            n.to_string()
-        } else if let Some(s) = price_value.as_str() {
-            s.to_string()
-        } else {
-            anyhow::bail!("Invalid price format");
-        };
-
-        let price = Decimal::from_str(&price_str)
-            .with_context(|| format!("Failed to parse price: {price_str}"))?;
+        let price = crate::cmd::price::price_decimal_from_json(price_value)
+            .with_context(|| format!("Invalid price format: {price_value}"))?;
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -6,7 +6,6 @@ use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
-use std::str::FromStr;
 use std::time::Duration;
 
 /// Rates API price source.
@@ -93,16 +92,8 @@ impl PriceSource for RatesApiSource {
             .get(&target_currency)
             .with_context(|| format!("Rate for {target_currency} not found"))?;
 
-        let rate_str = if let Some(n) = rate_value.as_f64() {
-            n.to_string()
-        } else if let Some(s) = rate_value.as_str() {
-            s.to_string()
-        } else {
-            anyhow::bail!("Invalid rate format");
-        };
-
-        let price = Decimal::from_str(&rate_str)
-            .with_context(|| format!("Failed to parse rate: {rate_str}"))?;
+        let price = crate::cmd::price::price_decimal_from_json(rate_value)
+            .with_context(|| format!("Invalid rate format: {rate_value}"))?;
 
         let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
 

--- a/crates/rustledger/src/cmd/price/sources/tsp.rs
+++ b/crates/rustledger/src/cmd/price/sources/tsp.rs
@@ -5,9 +5,7 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
-use rust_decimal::Decimal;
 use rustledger_core::NaiveDate;
-use std::str::FromStr;
 use std::time::Duration;
 
 /// Thrift Savings Plan price source.
@@ -105,16 +103,8 @@ impl PriceSource for TspSource {
             .or_else(|| latest.get(fund_name))
             .with_context(|| format!("Fund {fund_name} not found in TSP data"))?;
 
-        let price_str = if let Some(n) = price_value.as_f64() {
-            n.to_string()
-        } else if let Some(s) = price_value.as_str() {
-            s.to_string()
-        } else {
-            anyhow::bail!("Invalid price format for {fund_name}");
-        };
-
-        let price = Decimal::from_str(&price_str)
-            .with_context(|| format!("Failed to parse price: {price_str}"))?;
+        let price = crate::cmd::price::price_decimal_from_json(price_value)
+            .with_context(|| format!("Invalid price format for {fund_name}: {price_value}"))?;
 
         // Get the date from the response
         let date = latest

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -5,8 +5,6 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
-use rust_decimal::Decimal;
-use std::str::FromStr;
 use std::time::Duration;
 
 /// Yahoo Finance price source.
@@ -82,15 +80,8 @@ impl PriceSource for YahooFinanceSource {
             .get("regularMarketPrice")
             .with_context(|| format!("No price found for {}", request.ticker))?;
 
-        // Parse directly from JSON number representation to avoid f64 precision loss
-        let price_str = match price_value {
-            serde_json::Value::Number(n) => n.to_string(),
-            serde_json::Value::String(s) => s.clone(),
-            _ => anyhow::bail!("Invalid price format for {}", request.ticker),
-        };
-
-        let price = Decimal::from_str(&price_str)
-            .with_context(|| format!("Failed to convert price {price_str} to decimal"))?;
+        let price = crate::cmd::price::price_decimal_from_json(price_value)
+            .with_context(|| format!("Invalid price for {}", request.ticker))?;
 
         // Get the currency from the response
         let currency = meta


### PR DESCRIPTION
Closes #1621.

## The deep question: what's the best *and safest* code here?

#1621 flags an f64 hop on a money value: several price sources read a JSON-number quote via `as_f64().to_string()`. I worked the options and **neither blanket fix is appropriate**:

- **`serde_json` `arbitrary_precision`** (the issue's suggestion) is a **global** feature and is known to break `#[serde(untagged)]` / `flatten` deserialization. The workspace has **9 `untagged` + 2 `flatten`** enums — high blast radius.
- **A per-field `RawValue` rewrite of all 6 sources** is disproportionate: 5/6 navigate **dynamic JSON keys**, all are network code I can't test against live APIs, and the gain is **negligible in practice** — real FX/equity/crypto quotes are human-scale, well inside f64's ~15–17 significant digits. (Mirrors the project's `>28-digit literal` / decimal-side-channel proportionality calls.)

## What this PR does (safe + good)

One documented, unit-tested helper used by every source and `external.rs`:

```rust
pub fn price_decimal_from_json(value: &serde_json::Value) -> Option<Decimal>
```

- **String** quotes → parsed **exactly** (some sources previously only handled `as_f64`, so this is a strict improvement).
- **Integer** numbers → exact.
- **Float** numbers → f64-bounded, which is **shortest-round-trip-exact for any real price**; the bound is documented as a deliberate limitation in the helper's doc comment (with the rationale above).
- Removes the **misleading** `yahoo.rs` comment that claimed `n.to_string()` "avoids f64 precision loss" (it doesn't).
- Removes 6 copies of the duplicated conversion block → one tested place to harden later if a real need ever appears.

## Verify

`cargo test -p rustledger price` (incl. new `test_price_decimal_from_json`) green · build 0 warnings · fmt + clippy clean. No new dependencies or feature flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
