### PR TITLE
feat(price): opt-in --source-meta to record price provenance

### DIFF
--- a/crates/rustledger/src/bin/ag-rledger.rs
+++ b/crates/rustledger/src/bin/ag-rledger.rs
@@ -808,6 +808,7 @@ fn build_price_args(
         currency: string_flag(req, "currency", Some("c")).unwrap_or_else(|| "USD".to_string()),
         date: string_flag(req, "date", Some("d")),
         beancount: bool_flag(req, "beancount", Some("b")),
+        source_meta: bool_flag(req, "source-meta", None),
         verbose: bool_flag(req, "verbose", Some("v")),
         mapping: flag_values(req, "mapping", Some("m")),
         source: string_flag(req, "source", Some("s")),

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -52,6 +52,14 @@ pub struct PriceArgs {
     #[arg(short = 'b', long)]
     pub beancount: bool,
 
+    /// With `--beancount`, also record which source produced each quote as a
+    /// `source:` metadata line on the generated price directive (opt-in
+    /// provenance). Off by default to keep the bare, dedup-friendly bean-price
+    /// line shape; the source is normally knowable from the commodity's
+    /// `price:` declaration.
+    #[arg(long, requires = "beancount")]
+    pub source_meta: bool,
+
     /// Show verbose output.
     #[arg(short, long)]
     pub verbose: bool,
@@ -414,7 +422,7 @@ pub fn run_with_writer<W: Write>(
                 if args.verbose {
                     eprintln!("{symbol}: cached (source: {})", cached.source);
                 }
-                write_price(out, symbol, &cached, args.beancount)?;
+                write_price(out, symbol, &cached, args.beancount, args.source_meta)?;
                 continue;
             }
 
@@ -482,7 +490,7 @@ pub fn run_with_writer<W: Write>(
                         }
                         continue;
                     }
-                    write_price(out, symbol, &response, args.beancount)?;
+                    write_price(out, symbol, &response, args.beancount, args.source_meta)?;
                 }
                 Err(e) => {
                     if args.verbose {
@@ -753,6 +761,7 @@ fn write_price(
     symbol: &str,
     response: &crate::cmd::price::PriceResponse,
     beancount: bool,
+    source_meta: bool,
 ) -> Result<()> {
     if beancount {
         let date_str = response.date.to_string();
@@ -761,6 +770,12 @@ fn write_price(
             "{date_str} price {symbol} {} {}",
             response.price, response.currency
         )?;
+        // Opt-in provenance (see PriceArgs::source_meta): record the fetching
+        // source as beancount metadata on the directive. Off by default so the
+        // bare bean-price line shape is preserved.
+        if source_meta {
+            writeln!(handle, "  source: \"{}\"", response.source)?;
+        }
     } else {
         writeln!(handle, "{symbol}: {} {}", response.price, response.currency)?;
     }
@@ -871,16 +886,7 @@ fn run_with_external_command<W: Write>(
                         }
                         continue;
                     }
-                    if args.beancount {
-                        let date_str = response.date.to_string();
-                        writeln!(
-                            handle,
-                            "{date_str} price {symbol} {} {}",
-                            response.price, response.currency
-                        )?;
-                    } else {
-                        writeln!(handle, "{symbol}: {} {}", response.price, response.currency)?;
-                    }
+                    write_price(handle, symbol, &response, args.beancount, args.source_meta)?;
                 }
                 Err(e) => {
                     if args.verbose {
@@ -1386,6 +1392,42 @@ mod tests {
         let mut argv = vec!["price"];
         argv.extend_from_slice(extra);
         Args::parse_from(argv).price_args
+    }
+
+    #[test]
+    fn write_price_source_meta_is_opt_in() {
+        let resp = crate::cmd::price::PriceResponse {
+            price: "1.0856".parse().unwrap(),
+            currency: "USD".to_string(),
+            date: "2024-05-02".parse::<NaiveDate>().unwrap(),
+            source: "ecb".to_string(),
+        };
+
+        // Default beancount output is bare (no source metadata).
+        let mut out = Vec::new();
+        write_price(&mut out, "EURUSD", &resp, true, false).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("2024-05-02 price EURUSD 1.0856 USD"));
+        assert!(!s.contains("source:"));
+
+        // --source-meta appends a `source:` metadata line.
+        let mut out = Vec::new();
+        write_price(&mut out, "EURUSD", &resp, true, true).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("2024-05-02 price EURUSD 1.0856 USD"));
+        assert!(s.contains("  source: \"ecb\""));
+
+        // Non-beancount output never emits metadata, even with source_meta.
+        let mut out = Vec::new();
+        write_price(&mut out, "EURUSD", &resp, false, true).unwrap();
+        assert!(!String::from_utf8(out).unwrap().contains("source:"));
+    }
+
+    #[test]
+    fn source_meta_requires_beancount() {
+        // --source-meta without -b is rejected by clap (requires = "beancount").
+        assert!(Args::try_parse_from(["price", "AAPL", "--source-meta"]).is_err());
+        assert!(Args::try_parse_from(["price", "AAPL", "-b", "--source-meta"]).is_ok());
     }
 
     /// Multi-quote `price:` metadata produces one dry-run row per declared

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -26,6 +26,7 @@ rledger price [OPTIONS] [SYMBOL]...
 | `-c, --currency <CURRENCY>` | Base currency for price quotes [default: USD] |
 | `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today) |
 | `-b, --beancount` | Output as beancount price directives |
+| `--source-meta` | With `-b`, also write a `source:` metadata line on each price directive recording which provider produced the quote (opt-in provenance — see note below). Requires `-b`. |
 | `-s, --source <SOURCE>` | Use specific source (overrides mapping) |
 | `--source-cmd <CMD>` | Use ad-hoc external command as source |
 | `-m, --mapping <MAPPING>` | Symbol mapping (e.g., `VTI:VTI,BTC:BTC-USD`) |
@@ -37,6 +38,26 @@ rledger price [OPTIONS] [SYMBOL]...
 | `--no-cache` | Disable the price cache for this run |
 | `--clear-cache` | Clear the price cache before fetching |
 | `-v, --verbose` | Show verbose output |
+
+## Recording the price source (`--source-meta`)
+
+By default — like `bean-price` — generated `price` directives are bare:
+
+```beancount
+2024-05-02 price AAPL 150.00 USD
+```
+
+The provider isn't repeated on every line because it's normally knowable from the commodity's `price:` declaration (e.g. `price: "USD:yahoo/AAPL"`), which is the single source of truth for where a commodity's prices come from. Keeping the line bare also matches `bean-price` and keeps the output easy to diff, dedup, and `--clobber`.
+
+Pass `--source-meta` (with `-b`) when you want **per-price provenance** — useful when prices for the same commodity can come from different providers (an ad-hoc `--source`/`--source-cmd` run, manual entries, or mixed sources), or for audit ("which feed gave us this rate?"):
+
+```console
+$ rledger price -b --source-meta -s ecb EURUSD
+2024-05-02 price EURUSD 1.0856 USD
+  source: "ecb"
+```
+
+The `source:` value is plain metadata, so it round-trips through the ledger and is queryable in BQL via `meta("source")`.
 
 ## Discovering Symbols from a Ledger
 


### PR DESCRIPTION
Closes #1622.

## What

A generated `price` directive dropped the fetching source. This adds an **opt-in** `--source-meta` flag (requires `-b/--beancount`) that records it as metadata:

```console
$ rledger price -b --source-meta -s ecb EURUSD
2024-05-02 price EURUSD 1.0856 USD
  source: "ecb"
```

The value is plain metadata, so it round-trips through the ledger and is queryable via `meta("source")` in BQL.

## Why opt-in (not default) — researched bean-price's rationale

bean-price **does** track the source — on the **Commodity** directive (`price: "USD:yahoo/AAPL"`), the single source of truth for where a commodity's prices come from — and keeps output `price` directives deliberately **bare** so they diff, dedup, and `--clobber` cleanly. rustledger's `--beancount` line shape is documented/tested as bean-price-compatible (`tests/bean_price_compat.rs`).

So default-on would break that compat and re-state the provider on every line redundantly. `--source-meta` is for the case the commodity declaration *can't* answer: heterogeneous/ad-hoc prices (a one-off `--source`/`--source-cmd`, manual entries, mixed providers) and audit ("which feed gave us this rate?"). Right-sizes #1622 as a convenience for the heterogeneous case, not a correctness gap.

## Changes

- `--source-meta` flag (`requires = "beancount"`); `write_price` emits `  source: "<provider>"` when set.
- Routed the duplicated external-command emission path through `write_price` (one emission site).
- Docs: `docs/commands/price.md` Options row + a "Recording the price source" rationale section; `--help` text.
- Tests: `write_price_source_meta_is_opt_in` (bare by default / metadata when set / never in non-beancount output) + `source_meta_requires_beancount` (clap rejects without `-b`).

## Verify

build `--all-features` clean (incl. `ag-rledger`), `cargo test -p rustledger source_meta` green, fmt + clippy (`--all-features --all-targets -D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
