### PR TITLE
feat(import): preserve a second date column as metadata

### DIFF
--- a/crates/rustledger-importer/src/config.rs
+++ b/crates/rustledger-importer/src/config.rs
@@ -91,6 +91,27 @@ pub struct CsvConfig {
     /// preserve every source row (matches the user's expectation when
     /// auditing migrated data — see issue #972).
     pub skip_zero_amounts: bool,
+    /// A second date column to preserve as metadata (e.g. when a statement has
+    /// both a posted/booking date and a value date). The primary `date_column`
+    /// stays the directive date; this column's value is attached as metadata so
+    /// it isn't silently discarded (#1623).
+    pub secondary_date: Option<SecondaryDate>,
+}
+
+/// A secondary date column preserved as directive metadata.
+///
+/// For example a value date alongside the booking date. The importer reads
+/// `column` with `format` and attaches the parsed date under `meta_key` on the
+/// imported transaction.
+#[derive(Debug, Clone)]
+pub struct SecondaryDate {
+    /// The CSV column holding the secondary date.
+    pub column: ColumnSpec,
+    /// strftime-style format used to parse the column.
+    pub format: String,
+    /// Metadata key the parsed date is stored under (derived from the column
+    /// header, e.g. `value_date`).
+    pub meta_key: String,
 }
 
 impl Default for CsvConfig {
@@ -116,6 +137,7 @@ impl Default for CsvConfig {
             regex_mappings: Vec::new(),
             use_merchant_dict: false,
             skip_zero_amounts: true,
+            secondary_date: None,
         }
     }
 }
@@ -356,6 +378,24 @@ impl CsvConfigBuilder {
     /// Set the date format (strftime-style).
     pub fn date_format(mut self, format: impl Into<String>) -> Self {
         self.config.date_format = format.into();
+        self
+    }
+
+    /// Preserve a second date column (e.g. a value date alongside the booking
+    /// date) as transaction metadata under `meta_key`, parsed with `format`.
+    /// Without this the column is silently dropped (#1623).
+    #[must_use]
+    pub fn secondary_date(
+        mut self,
+        column: impl Into<String>,
+        format: impl Into<String>,
+        meta_key: impl Into<String>,
+    ) -> Self {
+        self.config.secondary_date = Some(SecondaryDate {
+            column: ColumnSpec::Name(column.into()),
+            format: format.into(),
+            meta_key: meta_key.into(),
+        });
         self
     }
 

--- a/crates/rustledger-importer/src/csv_importer.rs
+++ b/crates/rustledger-importer/src/csv_importer.rs
@@ -349,6 +349,24 @@ impl CsvImporter {
             txn = txn.with_payee(p);
         }
 
+        // Preserve a second date column (e.g. a value date alongside the
+        // booking date) as transaction metadata so the timestamp isn't dropped
+        // (#1623). A missing/unparseable secondary value is skipped silently
+        // rather than failing the row — it is supplementary, not the txn date.
+        if let Some(sd) = &csv_config.secondary_date
+            && let Ok(raw) = self.get_column(record, &sd.column, header_map)
+        {
+            let raw = raw.trim();
+            if !raw.is_empty()
+                && let Some(d) = jiff::fmt::strtime::parse(&sd.format, raw)
+                    .ok()
+                    .and_then(|tm| tm.to_date().ok())
+            {
+                txn.meta
+                    .insert(sd.meta_key.clone(), rustledger_core::MetaValue::Date(d));
+            }
+        }
+
         Ok(Some(txn))
     }
 
@@ -511,6 +529,37 @@ mod tests {
         let result = CsvImporter.extract_string(csv_content, &config).unwrap();
         assert_eq!(result.directives.len(), 3);
         assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_csv_import_preserves_secondary_date() {
+        // A statement with both a booking date and a value date: the booking
+        // date is the directive date, the value date is preserved as metadata
+        // instead of being silently dropped (#1623).
+        let config = ImporterConfig::csv()
+            .account("Assets:Bank:Checking")
+            .currency("USD")
+            .date_column("Booking Date")
+            .narration_column("Description")
+            .amount_column("Amount")
+            .date_format("%Y-%m-%d")
+            .secondary_date("Value Date", "%Y-%m-%d", "value_date")
+            .build()
+            .unwrap();
+
+        let csv_content = r"Booking Date,Description,Value Date,Amount
+2024-01-15,Coffee Shop,2024-01-17,-4.50
+";
+        let result = CsvImporter.extract_string(csv_content, &config).unwrap();
+        assert_eq!(result.directives.len(), 1);
+        let Directive::Transaction(txn) = &result.directives[0] else {
+            panic!("expected a transaction");
+        };
+        assert_eq!(txn.date.to_string(), "2024-01-15");
+        match txn.meta.get("value_date") {
+            Some(rustledger_core::MetaValue::Date(d)) => assert_eq!(d.to_string(), "2024-01-17"),
+            other => panic!("expected value_date metadata, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1166,6 +1215,7 @@ not-a-date,Coffee,-5.00
             regex_mappings: Vec::new(),
             use_merchant_dict: false,
             skip_zero_amounts: true,
+            secondary_date: None,
         };
 
         let importer = CsvImporter;

--- a/crates/rustledger-importer/src/csv_inference.rs
+++ b/crates/rustledger-importer/src/csv_inference.rs
@@ -12,7 +12,7 @@
 
 use format_num_pattern::Locale;
 
-use crate::config::{ColumnSpec, CsvConfig};
+use crate::config::{ColumnSpec, CsvConfig, SecondaryDate};
 
 /// Result of CSV format inference.
 ///
@@ -45,6 +45,9 @@ pub struct InferredCsvConfig {
     pub payee_column: Option<ColumnSpec>,
     /// Per-row currency column (detected from a header like "Currency"/"Ccy").
     pub currency_column: Option<ColumnSpec>,
+    /// A second date column (e.g. a value date alongside the booking date),
+    /// preserved as transaction metadata rather than discarded (#1623).
+    pub secondary_date: Option<SecondaryDate>,
     /// Inferred amount locale (decimal/grouping separators). `Some(de_DE)` when
     /// the amounts look comma-decimal (e.g. `-54,23`, `2.500,00`); `None` when
     /// they look period-decimal or carry no signal (the parser defaults to
@@ -70,6 +73,7 @@ impl InferredCsvConfig {
             amount_locale: self.amount_locale.or(Some(Locale::POSIX)),
             has_header: self.has_header,
             delimiter: self.delimiter,
+            secondary_date: self.secondary_date.clone(),
             ..CsvConfig::default()
         }
     }
@@ -150,6 +154,23 @@ pub fn infer_csv_config(content: &str) -> Option<InferredCsvConfig> {
         None => return None, // Can't do anything without a date
     };
 
+    // Preserve a second date column (e.g. a value date alongside the booking
+    // date) as metadata instead of dropping it (#1623). Only when there is a
+    // header, so the metadata key can be derived from the column name.
+    let secondary_date = if has_header {
+        date_col_idx.and_then(|primary| {
+            find_secondary_date_column(&headers, &sample, num_cols, primary).map(|(i, fmt)| {
+                SecondaryDate {
+                    column: ColumnSpec::Name(headers[i].to_string()),
+                    format: fmt,
+                    meta_key: header_to_meta_key(headers[i]),
+                }
+            })
+        })
+    } else {
+        None
+    };
+
     let amount_column = amount_col.map(|i| {
         confidence += 0.3;
         if has_header && i < headers.len() {
@@ -226,6 +247,7 @@ pub fn infer_csv_config(content: &str) -> Option<InferredCsvConfig> {
         narration_column,
         payee_column,
         currency_column,
+        secondary_date,
         amount_locale,
         confidence: f64::min(confidence, 1.0),
     })
@@ -553,6 +575,75 @@ fn find_date_column(
     None
 }
 
+/// Find a SECOND header-named date column (distinct from `primary_idx`) whose
+/// values parse as dates — e.g. a "Value Date" alongside a "Booking Date".
+/// Only header-keyword-matched columns are considered, so a stray date-shaped
+/// column isn't spuriously preserved. Returns `(column index, detected format)`.
+/// See #1623: without this, the second date column is silently dropped.
+fn find_secondary_date_column(
+    headers: &[&str],
+    sample: &[&Vec<String>],
+    num_cols: usize,
+    primary_idx: usize,
+) -> Option<(usize, String)> {
+    let date_keywords = [
+        "date",
+        "posted",
+        "transaction date",
+        "value date",
+        "booking",
+    ];
+    for (i, header) in headers.iter().enumerate() {
+        if i == primary_idx || i >= num_cols {
+            continue;
+        }
+        if !header_matches(&header.to_lowercase(), &date_keywords) {
+            continue;
+        }
+        let values: Vec<&str> = sample
+            .iter()
+            .filter_map(|row| row.get(i).map(String::as_str))
+            .filter(|v| !v.trim().is_empty())
+            .collect();
+        if values.is_empty() {
+            continue;
+        }
+        for &fmt in DATE_FORMATS {
+            let parse_count = values
+                .iter()
+                .filter(|v| jiff::fmt::strtime::parse(fmt, v.trim()).is_ok())
+                .count();
+            if parse_count > 0 && parse_count * 5 >= values.len() * 4 {
+                return Some((i, fmt.to_string()));
+            }
+        }
+    }
+    None
+}
+
+/// Slugify a CSV header into a beancount metadata key: lowercase, runs of
+/// non-alphanumeric become a single `_`, trimmed, and prefixed if it doesn't
+/// start with a letter. E.g. "Value Date" -> `value_date`, "Posted" -> `posted`.
+fn header_to_meta_key(header: &str) -> String {
+    let mut key = String::new();
+    let mut last_underscore = false;
+    for c in header.trim().to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() {
+            key.push(c);
+            last_underscore = false;
+        } else if !last_underscore {
+            key.push('_');
+            last_underscore = true;
+        }
+    }
+    let key = key.trim_matches('_').to_string();
+    if key.chars().next().is_some_and(|c| c.is_ascii_lowercase()) {
+        key
+    } else {
+        format!("date_{key}").trim_end_matches('_').to_string()
+    }
+}
+
 /// Find amount column(s). Returns `(single_amount, debit, credit)`.
 ///
 /// `date_col` is the already-detected date column index, which is skipped
@@ -853,6 +944,50 @@ Date,Description,Debit,Credit
         assert!(config.debit_column.is_some());
         assert!(config.credit_column.is_some());
         assert!(config.amount_column.is_none());
+    }
+
+    #[test]
+    fn infer_preserves_secondary_date_column() {
+        // Booking Date is the primary (directive) date; Value Date is the second
+        // date column and must be preserved rather than silently dropped (#1623).
+        let csv = "\
+Booking Date,Description,Value Date,Amount
+2024-01-15,Coffee,2024-01-17,-5.00
+2024-01-16,Salary,2024-01-16,3000.00
+";
+        let config = infer_csv_config(csv).expect("should infer config");
+        assert!(
+            matches!(config.date_column, ColumnSpec::Name(ref n) if n == "Booking Date"),
+            "primary date should be Booking Date, got {:?}",
+            config.date_column
+        );
+        let sd = config
+            .secondary_date
+            .as_ref()
+            .expect("Value Date should be preserved as a secondary date");
+        assert!(matches!(sd.column, ColumnSpec::Name(ref n) if n == "Value Date"));
+        assert_eq!(sd.meta_key, "value_date");
+    }
+
+    #[test]
+    fn single_date_column_has_no_secondary() {
+        let csv = "\
+Date,Description,Amount
+2024-01-15,Coffee,-5.00
+2024-01-16,Salary,3000.00
+";
+        let config = infer_csv_config(csv).expect("should infer config");
+        assert!(config.secondary_date.is_none());
+    }
+
+    #[test]
+    fn header_to_meta_key_slugifies() {
+        assert_eq!(header_to_meta_key("Value Date"), "value_date");
+        assert_eq!(header_to_meta_key("Booking Date"), "booking_date");
+        assert_eq!(header_to_meta_key("Posted"), "posted");
+        assert_eq!(header_to_meta_key("Settlement / Value"), "settlement_value");
+        // Leading non-letter gets a `date_` prefix so the key stays valid.
+        assert_eq!(header_to_meta_key("2nd date"), "date_2nd_date");
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -100,6 +100,14 @@ pub(super) struct ImporterEntry {
     pub(super) debit_column: Option<toml::Value>,
     /// Credit column name or index.
     pub(super) credit_column: Option<toml::Value>,
+    /// A second date column (header name) to preserve as transaction metadata
+    /// — e.g. a value date alongside the booking `date_column` (#1623).
+    pub(super) secondary_date_column: Option<String>,
+    /// strftime-style format for `secondary_date_column` (default: `date_format`).
+    pub(super) secondary_date_format: Option<String>,
+    /// Metadata key the secondary date is stored under (default: a slug of the
+    /// column name, e.g. `value_date`).
+    pub(super) secondary_date_key: Option<String>,
     /// Amount locale for number parsing (e.g. `de_DE` so `21,12` reads as
     /// 21.12). Mirrors the `--amount-locale` CLI flag.
     pub(super) amount_locale: Option<String>,
@@ -213,6 +221,21 @@ pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterC
     }
     if let Some(ref fmt) = entry.date_format {
         builder = builder.date_format(fmt);
+    }
+    if let Some(ref col) = entry.secondary_date_column {
+        // Format defaults to the primary date format; key defaults to a slug of
+        // the column name (e.g. "Value Date" -> "value_date").
+        let fmt = entry
+            .secondary_date_format
+            .clone()
+            .or_else(|| entry.date_format.clone())
+            .unwrap_or_else(|| "%Y-%m-%d".to_string());
+        let key = entry.secondary_date_key.clone().unwrap_or_else(|| {
+            col.trim()
+                .to_lowercase()
+                .replace(|c: char| !c.is_ascii_alphanumeric(), "_")
+        });
+        builder = builder.secondary_date(col, fmt, key);
     }
     if let Some(ref val) = entry.narration_column
         && let Some(col) = parse_column_value(val)

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -1063,6 +1063,9 @@ narration_column = 1
             currency_column: None,
             debit_column: None,
             credit_column: None,
+            secondary_date_column: None,
+            secondary_date_format: None,
+            secondary_date_key: None,
             amount_locale: None,
             amount_format: None,
             delimiter: None,
@@ -1099,6 +1102,9 @@ narration_column = 1
             currency_column: None,
             debit_column: None,
             credit_column: None,
+            secondary_date_column: None,
+            secondary_date_format: None,
+            secondary_date_key: None,
             amount_locale: None,
             amount_format: None,
             delimiter: None,
@@ -1134,6 +1140,9 @@ narration_column = 1
             currency_column: None,
             debit_column: None,
             credit_column: None,
+            secondary_date_column: None,
+            secondary_date_format: None,
+            secondary_date_key: None,
             amount_locale: None,
             amount_format: None,
             delimiter: None,
@@ -1170,6 +1179,9 @@ narration_column = 1
             currency_column: None,
             debit_column: Some(toml::Value::String("Debit".to_string())),
             credit_column: Some(toml::Value::String("Credit".to_string())),
+            secondary_date_column: Some("Settle Date".to_string()),
+            secondary_date_format: None,
+            secondary_date_key: None,
             amount_locale: None,
             amount_format: None,
             delimiter: Some(";".to_string()),
@@ -1190,6 +1202,13 @@ narration_column = 1
         assert_eq!(csv_config.skip_rows, 2);
         assert!(!csv_config.has_header); // skip_header=true → has_header=false
         assert!(csv_config.invert_sign);
+        // Secondary date: format defaults to date_format, key to a column slug.
+        let sd = csv_config
+            .secondary_date
+            .as_ref()
+            .expect("secondary_date_column should produce a secondary date");
+        assert_eq!(sd.format, "%d/%m/%Y");
+        assert_eq!(sd.meta_key, "settle_date");
     }
 
     #[test]

--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -69,6 +69,40 @@ The `importers.toml` file is searched for automatically in these locations (firs
 1. `importers.toml` in the current directory
 1. `~/.config/rledger/importers.toml`
 
+### Preserving a second date column
+
+Bank statements often carry **two** dates per row — a booking/posted date and a
+value/settlement date. `date_column` becomes the transaction date; rather than
+dropping the other one, rledger preserves it as transaction **metadata** (#1623).
+
+Auto-detect mode does this automatically: when a CSV has a second date-named
+column (e.g. `Value Date` next to `Booking Date`), it is preserved under a key
+slugified from its header (`value_date`):
+
+```beancount
+2024-01-15 * "Coffee Shop"
+  value_date: 2024-01-17
+  Assets:Bank:Checking  -4.50 USD
+  Expenses:Unknown        4.50 USD
+```
+
+For explicit `importers.toml` configs, name the column:
+
+```toml
+[[importers]]
+name = "mybank"
+date_column = "Booking Date"
+date_format = "%Y-%m-%d"
+
+# Preserve the value date as `value_date:` metadata
+secondary_date_column = "Value Date"
+# secondary_date_format = "%Y-%m-%d"   # optional, defaults to date_format
+# secondary_date_key    = "value_date" # optional, defaults to a slug of the column
+```
+
+The value is stored as a typed `date` metadatum, so it round-trips through the
+ledger and is queryable in BQL via `meta("value_date")`.
+
 ### Account Mapping
 
 Map transaction descriptions to accounts automatically:


### PR DESCRIPTION
Closes #1623.

## What

Bank CSVs often carry **two dates per row** — a booking/posted date and a value/settlement date. The importer kept only one and **silently dropped** the other. Now the primary `date_column` stays the transaction date, and a second date column is preserved as transaction **metadata** (a typed `date` value), so no timestamp is lost.

```beancount
2024-01-15 * "Coffee Shop"
  value_date: 2024-01-17          ; preserved instead of dropped
  Assets:Bank:Checking  -4.50 USD
  Expenses:Unknown        4.50 USD
```

## How it works at each layer

- **Auto-inference** (zero-config): `find_secondary_date_column` finds a second *header-named* date column that parses, preserved under a slug of its header (`"Value Date"` → `value_date`). Only header-keyword-matched columns qualify, so a stray date-shaped column isn't spuriously captured. Single-date CSVs are unchanged.
- **Importer**: `parse_row` attaches the parsed secondary date to `txn.meta`. A missing/unparseable secondary value is skipped silently — it's supplementary, not the transaction date, so it never fails a row.
- **Builder**: `CsvConfigBuilder::secondary_date(column, format, meta_key)` for programmatic use.
- **`importers.toml`**: `secondary_date_column` (+ optional `secondary_date_format` defaulting to `date_format`, and `secondary_date_key` defaulting to a column slug).
- **Docs**: a "Preserving a second date column" section in `guides/importing.md`. The value round-trips and is queryable via `meta("value_date")` in BQL.

## Scope

This fixes the concrete **dropped-column data loss**. A first-class booking/value/settlement *timestamp model* (the broader part of #1623) is a Beancount-inherited limitation and is intentionally out of scope here.

## Tests

Across all layers: inference detects/slugs the second column (and doesn't for single-date CSVs), `header_to_meta_key` slugify cases, end-to-end import attaches the typed `value_date` metadatum, and the `importers.toml` → config path. `cargo test -p rustledger-importer` + `-p rustledger` green; clippy (`--all-features --all-targets -D warnings`) + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
