### PR TITLE
fix(query): ORDER BY a raw column aliased in SELECT no longer fails

### DIFF
--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -289,18 +289,19 @@ impl Executor<'_> {
                 }
             }
 
-            // Check if it's already in SELECT (by expression or by alias)
+            // Check if this ORDER BY is already reachable by name in the
+            // projected output. A target only covers it when the sorted output
+            // column carries the ORDER BY's name: either the target is
+            // unaliased (its output name is the expression itself) or its alias
+            // equals the ORDER BY reference. A target whose expression matches
+            // but is aliased to a *different* name does NOT cover it — the
+            // output column is named by the alias, so `sort_results` would fail
+            // a literal name lookup for the raw column (#1627). In that case we
+            // still append a hidden column carrying the raw name.
             let expr_str = spec.expr.to_string();
             let in_select = query.targets.iter().any(|t| {
-                if t.expr == spec.expr {
-                    return true;
-                }
-                if let Some(alias) = &t.alias
-                    && alias == &expr_str
-                {
-                    return true;
-                }
-                false
+                (t.expr == spec.expr && t.alias.is_none())
+                    || t.alias.as_deref() == Some(expr_str.as_str())
             });
 
             if !in_select {

--- a/crates/rustledger-query/src/executor/tests.rs
+++ b/crates/rustledger-query/src/executor/tests.rs
@@ -164,6 +164,43 @@ fn test_order_by() {
 }
 
 #[test]
+fn order_by_raw_column_when_aliased_in_select() {
+    // #1627: ORDER BY a raw column that is aliased in SELECT must not fail with
+    // "column not found". The alias renames the output column, but the raw name
+    // is still a valid sort reference — a hidden sort column is appended and
+    // stripped after sorting.
+    let directives = sample_directives();
+    let mut executor = Executor::new(&directives);
+
+    // Aggregate: alias the grouped column, then ORDER BY the raw column.
+    let aliased = executor
+        .execute(&parse("SELECT date AS d GROUP BY date ORDER BY date").unwrap())
+        .expect("ORDER BY raw column should resolve even when aliased (#1627)");
+    // The hidden `date` sort column is stripped; only the aliased column shows.
+    assert_eq!(aliased.columns, vec!["d"]);
+
+    // Same result as ORDER BY <alias> (the documented workaround) and as the
+    // un-aliased form.
+    let by_alias = executor
+        .execute(&parse("SELECT date AS d GROUP BY date ORDER BY d").unwrap())
+        .unwrap();
+    assert_eq!(aliased.rows, by_alias.rows);
+
+    let unaliased = executor
+        .execute(&parse("SELECT date GROUP BY date ORDER BY date").unwrap())
+        .unwrap();
+    assert_eq!(aliased.rows, unaliased.rows);
+
+    // DESC and the non-aggregate form must resolve too.
+    executor
+        .execute(&parse("SELECT date AS d GROUP BY date ORDER BY date DESC").unwrap())
+        .expect("aliased ORDER BY ... DESC should resolve (#1627)");
+    executor
+        .execute(&parse("SELECT date AS d ORDER BY date").unwrap())
+        .expect("non-aggregate aliased ORDER BY should resolve (#1627)");
+}
+
+#[test]
 fn test_hash_value_all_variants() {
     use rustledger_core::{Cost, Inventory, Position};
 


### PR DESCRIPTION
Closes #1627.

## The bug

```bql
SELECT cost_date AS acq GROUP BY cost_date ORDER BY cost_date   -- ERR: column 'cost_date' not found
SELECT cost_date AS acq GROUP BY cost_date ORDER BY acq         -- OK
SELECT cost_date        GROUP BY cost_date ORDER BY cost_date   -- OK
```

`ORDER BY` a column that is **aliased** in `SELECT` (and referenced by its **raw** name) failed to resolve — surfacing as a compile error / HTTP 500 in consumers.

## Root cause

Two cooperating spots:

1. **`executor/execution.rs` — `find_hidden_order_by_targets`**: the "already in SELECT" check returned `true` whenever `t.expr == spec.expr`, **ignoring the target's alias**. So no hidden sort column was appended for `cost_date AS acq … ORDER BY cost_date`.
2. **`executor/sort.rs` — `sort_results`**: resolves `ORDER BY` column references against **output column names**. The output column is named `acq` (the alias), so the literal lookup of `cost_date` missed → `UnknownColumn`.

## Fix

One predicate in `find_hidden_order_by_targets`: a SELECT target covers an `ORDER BY` only when the sorted output column carries the `ORDER BY`'s name —

```rust
let in_select = query.targets.iter().any(|t| {
    (t.expr == spec.expr && t.alias.is_none())          // unaliased: output name == expr
        || t.alias.as_deref() == Some(expr_str.as_str()) // alias matches the reference
});
```

An aliased-mismatch target no longer counts as covered, so a hidden raw-named column is appended and stripped after sorting — exactly the mechanism un-aliased `ORDER BY` already uses (`sort_results` already strips trailing hidden columns; see its `visible_cols` doc).

I considered the alternative (resolve the name in `sort_results` against target expressions) but `sort_results` doesn't receive the query targets — that needs a signature change across 4 call sites. This fix is one predicate, no new plumbing.

## Tests

`order_by_raw_column_when_aliased_in_select` pins all repro cases: aggregate aliased `ORDER BY raw` (errored before), result-equality with both `ORDER BY <alias>` and the un-aliased form, plus `... DESC` and the non-aggregate aliased form. All currently-working cases (`ORDER BY alias`, unaliased, self-alias) are preserved.

## Impact

Engine-side cause of rustledger/rustfava#190 (Holdings report 500s); rustfava#195 is only a frontend workaround (order by the alias). This fixes any aliased-`ORDER BY` query.

Verified: `cargo test -p rustledger-query` green, clippy (`--all-features --all-targets -D warnings`) + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
