### PR TITLE
feat(ffi)!: opt-in pad expansion on load/load-file (expand-pads)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ The project is a Cargo workspace with 16 crates plus editor extensions:
 | `rustledger-wasm` | WebAssembly library target |
 | `rustledger-lsp` | Language Server Protocol implementation |
 | `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — legacy, slated for removal in Phase 5 (#1419) |
-| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract, `rustledger:ledger@2.1.0`) — primary embedding surface, default in the rustfava embedder (#1384 Phase 4) |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract, `rustledger:ledger@3.0.0`) — primary embedding surface, default in the rustfava embedder (#1384 Phase 4) |
 
 | Package | Purpose |
 |---------|---------|

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -192,9 +192,12 @@ fn clamp_runs_and_summarizes_pre_range() -> Result<()> {
         return Ok(());
     }
     let (mut store, inst) = instantiate()?;
-    let loaded =
-        inst.rustledger_ledger_ledger()
-            .call_load(&mut store, LEDGER_WITH_HISTORY, "<stdin>", false)?;
+    let loaded = inst.rustledger_ledger_ledger().call_load(
+        &mut store,
+        LEDGER_WITH_HISTORY,
+        "<stdin>",
+        false,
+    )?;
     let clamped = inst.rustledger_ledger_builder().call_clamp(
         &mut store,
         &loaded.entries,
@@ -351,9 +354,13 @@ fn load_file_reads_and_resolves_includes() -> Result<()> {
         "include \"sub.bean\"\n2024-01-02 open Expenses:Food USD\n",
     )?;
     let (mut store, inst) = instantiate_in(dir.path())?;
-    let r =
-        inst.rustledger_ledger_ledger()
-            .call_load_file(&mut store, "/work/main.bean", true, &[], false)?;
+    let r = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/main.bean",
+        true,
+        &[],
+        false,
+    )?;
     assert!(r.errors.is_empty(), "load_file errored: {:?}", r.errors);
     // Opens from both the entry file and the included file.
     assert!(
@@ -437,9 +444,13 @@ fn load_file_runs_requested_plugin() -> Result<()> {
 ",
     )?;
     let (mut store, inst) = instantiate_in(dir.path())?;
-    let without =
-        inst.rustledger_ledger_ledger()
-            .call_load_file(&mut store, "/work/main.bean", true, &[], false)?;
+    let without = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/main.bean",
+        true,
+        &[],
+        false,
+    )?;
     let with = inst.rustledger_ledger_ledger().call_load_file(
         &mut store,
         "/work/main.bean",
@@ -507,9 +518,12 @@ fn load_runs_auto_accounts_synth() -> Result<()> {
         return Ok(());
     }
     let (mut store, inst) = instantiate()?;
-    let loaded =
-        inst.rustledger_ledger_ledger()
-            .call_load(&mut store, AUTO_ACCOUNTS_LEDGER, "<stdin>", false)?;
+    let loaded = inst.rustledger_ledger_ledger().call_load(
+        &mut store,
+        AUTO_ACCOUNTS_LEDGER,
+        "<stdin>",
+        false,
+    )?;
     assert_generated_opens(&loaded.entries, "component load");
     Ok(())
 }
@@ -523,9 +537,13 @@ fn load_file_runs_auto_accounts_synth() -> Result<()> {
     let dir = tempfile::tempdir()?;
     std::fs::write(dir.path().join("main.bean"), AUTO_ACCOUNTS_LEDGER)?;
     let (mut store, inst) = instantiate_in(dir.path())?;
-    let loaded =
-        inst.rustledger_ledger_ledger()
-            .call_load_file(&mut store, "/work/main.bean", true, &[], false)?;
+    let loaded = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/main.bean",
+        true,
+        &[],
+        false,
+    )?;
     assert_generated_opens(&loaded.entries, "component load_file");
     Ok(())
 }

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -138,7 +138,7 @@ fn load_entry_count_matches_jsonrpc() -> Result<()> {
     let (mut store, inst) = instantiate()?;
     let result = inst
         .rustledger_ledger_ledger()
-        .call_load(&mut store, LEDGER, "<stdin>")?;
+        .call_load(&mut store, LEDGER, "<stdin>", false)?;
     let expected = rustledger_ffi_wasi::helpers::load_source(LEDGER)
         .directives
         .len();
@@ -194,7 +194,7 @@ fn clamp_runs_and_summarizes_pre_range() -> Result<()> {
     let (mut store, inst) = instantiate()?;
     let loaded =
         inst.rustledger_ledger_ledger()
-            .call_load(&mut store, LEDGER_WITH_HISTORY, "<stdin>")?;
+            .call_load(&mut store, LEDGER_WITH_HISTORY, "<stdin>", false)?;
     let clamped = inst.rustledger_ledger_builder().call_clamp(
         &mut store,
         &loaded.entries,
@@ -273,7 +273,7 @@ fn filter_keeps_pre_begin_open_and_drops_commodity() -> Result<()> {
 ";
     let loaded = inst
         .rustledger_ledger_ledger()
-        .call_load(&mut store, src, "<stdin>")?;
+        .call_load(&mut store, src, "<stdin>", false)?;
     let filtered = inst.rustledger_ledger_builder().call_filter(
         &mut store,
         &loaded.entries,
@@ -306,7 +306,7 @@ fn custom_directive_values_keep_their_type_tag() -> Result<()> {
     let src = "2024-01-01 custom \"budget\" Assets:Cash \"monthly\"\n";
     let loaded = inst
         .rustledger_ledger_ledger()
-        .call_load(&mut store, src, "<stdin>")?;
+        .call_load(&mut store, src, "<stdin>", false)?;
     let custom = loaded
         .entries
         .iter()
@@ -353,7 +353,7 @@ fn load_file_reads_and_resolves_includes() -> Result<()> {
     let (mut store, inst) = instantiate_in(dir.path())?;
     let r =
         inst.rustledger_ledger_ledger()
-            .call_load_file(&mut store, "/work/main.bean", true, &[])?;
+            .call_load_file(&mut store, "/work/main.bean", true, &[], false)?;
     assert!(r.errors.is_empty(), "load_file errored: {:?}", r.errors);
     // Opens from both the entry file and the included file.
     assert!(
@@ -388,6 +388,7 @@ fn load_file_path_security_confines_cross_tree_includes() -> Result<()> {
         "/work/entry/main.bean",
         false,
         &[],
+        false,
     )?;
     // Assert specifically on the path-traversal rejection, not just any error,
     // so an incidental I/O or parse failure can't make this pass for the wrong
@@ -407,6 +408,7 @@ fn load_file_path_security_confines_cross_tree_includes() -> Result<()> {
         "/work/entry/main.bean",
         true,
         &[],
+        false,
     )?;
     assert!(
         open.errors.is_empty(),
@@ -437,12 +439,13 @@ fn load_file_runs_requested_plugin() -> Result<()> {
     let (mut store, inst) = instantiate_in(dir.path())?;
     let without =
         inst.rustledger_ledger_ledger()
-            .call_load_file(&mut store, "/work/main.bean", true, &[])?;
+            .call_load_file(&mut store, "/work/main.bean", true, &[], false)?;
     let with = inst.rustledger_ledger_ledger().call_load_file(
         &mut store,
         "/work/main.bean",
         true,
         &["implicit_prices".to_string()],
+        false,
     )?;
     let count_prices = |entries: &[Directive]| {
         entries
@@ -506,7 +509,7 @@ fn load_runs_auto_accounts_synth() -> Result<()> {
     let (mut store, inst) = instantiate()?;
     let loaded =
         inst.rustledger_ledger_ledger()
-            .call_load(&mut store, AUTO_ACCOUNTS_LEDGER, "<stdin>")?;
+            .call_load(&mut store, AUTO_ACCOUNTS_LEDGER, "<stdin>", false)?;
     assert_generated_opens(&loaded.entries, "component load");
     Ok(())
 }
@@ -522,7 +525,7 @@ fn load_file_runs_auto_accounts_synth() -> Result<()> {
     let (mut store, inst) = instantiate_in(dir.path())?;
     let loaded =
         inst.rustledger_ledger_ledger()
-            .call_load_file(&mut store, "/work/main.bean", true, &[])?;
+            .call_load_file(&mut store, "/work/main.bean", true, &[], false)?;
     assert_generated_opens(&loaded.entries, "component load_file");
     Ok(())
 }
@@ -604,7 +607,7 @@ fn query_entries_matches_source_query() -> Result<()> {
     let q = "SELECT account, position";
     let loaded = inst
         .rustledger_ledger_ledger()
-        .call_load(&mut store, LEDGER, "<stdin>")?;
+        .call_load(&mut store, LEDGER, "<stdin>", false)?;
     let via_entries =
         inst.rustledger_ledger_builder()
             .call_query_entries(&mut store, &loaded.entries, q)?;

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -305,17 +305,29 @@ fn options(o: ffi::LedgerOptions) -> wit::LedgerOptions {
 }
 
 /// `ledger.load` — parse + book `source`, returning a typed load result.
-pub fn load(source: &str, filename: &str) -> out::LoadResult {
-    load_result(ffi::helpers::load_source(source), filename)
+/// `expand_pads` materializes `pad` directives into synthesized `Padding`
+/// transactions (balance consumers opt in); default-off is source-faithful (#1628).
+pub fn load(source: &str, filename: &str, expand_pads: bool) -> out::LoadResult {
+    load_result(ffi::helpers::load_source(source), filename, expand_pads)
 }
 
 /// Build a WIT load-result from a consumed `ffi-wasi` load result (shared by
-/// `load` and `batch`).
-fn load_result(loaded: ffi::helpers::LoadResult, filename: &str) -> out::LoadResult {
-    let entries = loaded
-        .directives
+/// `load` and `batch`). `batch` always passes `expand_pads = false` — its load
+/// section is source-faithful and its queries pad-expand separately.
+fn load_result(
+    loaded: ffi::helpers::LoadResult,
+    filename: &str,
+    expand_pads: bool,
+) -> out::LoadResult {
+    // Synthesized pad transactions have no source line (tagged 0).
+    let (directives, directive_lines) = if expand_pads {
+        ffi::helpers::expand_pads(loaded.directives, loaded.directive_lines, &0u32)
+    } else {
+        (loaded.directives, loaded.directive_lines)
+    };
+    let entries = directives
         .iter()
-        .zip(loaded.directive_lines.iter())
+        .zip(directive_lines.iter())
         .map(|(d, &line)| directive(ffi::convert::directive_to_json(d, line, filename)))
         .collect();
     out::LoadResult {
@@ -538,7 +550,7 @@ pub fn batch(source: &str, queries: &[String]) -> out::BatchResult {
             .collect()
     };
     out::BatchResult {
-        load: load_result(loaded, "<stdin>"),
+        load: load_result(loaded, "<stdin>", false),
         queries: query_results,
     }
 }
@@ -560,6 +572,7 @@ pub fn load_file(
     path: &str,
     allow_unrestricted_includes: bool,
     plugins: &[String],
+    expand_pads: bool,
 ) -> out::LoadResult {
     // The loader takes `path_security` (true = confine includes); the WIT flag
     // is inverted so the safe state is the `false`/zero default.
@@ -580,6 +593,21 @@ pub fn load_file(
                 &mut errors,
                 &opts,
             );
+            // Opt-in pad expansion for balance consumers (#1628); synthesized
+            // transactions have no source location.
+            let (directives, directive_lines, directive_files) = if expand_pads {
+                let tags: Vec<(u32, String)> =
+                    directive_lines.into_iter().zip(directive_files).collect();
+                let (directives, tags) = ffi::helpers::expand_pads(
+                    directives,
+                    tags,
+                    &(0u32, "<synthesized>".to_string()),
+                );
+                let (lines, files): (Vec<u32>, Vec<String>) = tags.into_iter().unzip();
+                (directives, lines, files)
+            } else {
+                (directives, directive_lines, directive_files)
+            };
             let entries = directives
                 .iter()
                 .enumerate()

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -41,9 +41,9 @@ use exports::rustledger::ledger::ledger::{
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. Mirrors
-/// `rustledger-ffi-wasi`'s `API_VERSION` (additive 2.1 — per-position cost).
-const API_VERSION: &str = "2.1";
+/// The Component-Model api-version this build implements. Bumped to 3.0 for the
+/// breaking `expand-pads` parameter added to `load`/`load-file` (#1628).
+const API_VERSION: &str = "3.0";
 
 struct Component;
 
@@ -53,15 +53,16 @@ impl LedgerGuest for Component {
     fn version() -> String {
         API_VERSION.to_string()
     }
-    fn load(source: String, filename: String) -> LoadResult {
-        convert::load(&source, &filename)
+    fn load(source: String, filename: String, expand_pads: bool) -> LoadResult {
+        convert::load(&source, &filename, expand_pads)
     }
     fn load_file(
         path: String,
         allow_unrestricted_includes: bool,
         plugins: Vec<String>,
+        expand_pads: bool,
     ) -> LoadResult {
-        convert::load_file(&path, allow_unrestricted_includes, &plugins)
+        convert::load_file(&path, allow_unrestricted_includes, &plugins, expand_pads)
     }
     fn validate(source: String) -> ValidateResult {
         convert::validate(&source)

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@2.1.0;
+package rustledger:ledger@3.0.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -387,7 +387,7 @@ interface ledger {
     queries: list<query-result>,
   }
 
-  /// The api-version string this component implements (e.g. "2.1"). The WIT
+  /// The api-version string this component implements (e.g. "3.0"). The WIT
   /// contract is itself the versioned wire shape; this exists for runtime
   /// negotiation, replacing the `api_version` field formerly stamped onto every
   /// JSON-RPC response.
@@ -395,7 +395,11 @@ interface ledger {
 
   /// Parse + book a ledger from source text. `filename` is recorded as the
   /// directives' source location (e.g. `<string>`); pass `<stdin>` if unknown.
-  load: func(source: string, filename: string) -> load-result;
+  /// When `expand-pads` is `true`, `pad` directives are materialized into
+  /// synthesized `Padding` transactions in the returned entries (sorted by
+  /// date, no source location) — balance-computing consumers want this; the
+  /// `false`/default keeps the source-faithful stream (#1628).
+  load: func(source: string, filename: string, expand-pads: bool) -> load-result;
   /// Like `load`, but from a file path (the host grants filesystem access).
   /// By default the include graph is confined to the entry file's directory
   /// tree (path-traversal protection); set `allow-unrestricted-includes` to
@@ -407,8 +411,10 @@ interface ledger {
   /// name with no config. The ledger's own `plugin "name" "config"` directives
   /// already run (with their config) during the load — a plugin that needs
   /// configuration must be declared in the ledger, since this list carries only
-  /// names.
-  load-file: func(path: string, allow-unrestricted-includes: bool, plugins: list<string>) -> load-result;
+  /// names. `expand-pads` materializes `pad` directives into synthesized
+  /// `Padding` transactions in the returned entries (see `load`); default
+  /// `false` keeps the source-faithful stream (#1628).
+  load-file: func(path: string, allow-unrestricted-includes: bool, plugins: list<string>, expand-pads: bool) -> load-result;
 
   /// Validate source text (parse + semantic checks).
   validate: func(source: string) -> validate-result;

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -307,6 +307,31 @@ pub struct FileLoad {
     pub loaded_files: Vec<String>,
 }
 
+/// Expand `pad` directives into synthesized `Padding` transactions for
+/// balance-computing consumers, preserving each directive's parallel tag
+/// (line, or line+file).
+///
+/// Mirrors `Ledger::balance_view`: prepend the synthesized transactions —
+/// which have no source location, so they take `synth_tag` — then stable-sort
+/// the whole stream by date. Source-faithful callers skip this; only the
+/// `load`/`load-file` consumers that opt in (#1628) expand. The input must not
+/// already contain synth pad transactions (it is the raw load stream).
+#[must_use]
+pub fn expand_pads<T: Clone>(
+    directives: Vec<Directive>,
+    tags: Vec<T>,
+    synth_tag: &T,
+) -> (Vec<Directive>, Vec<T>) {
+    let pads = rustledger_booking::process_pads(&directives).padding_transactions;
+    let mut pairs: Vec<(Directive, T)> = Vec::with_capacity(directives.len() + pads.len());
+    for txn in pads {
+        pairs.push((Directive::Transaction(txn), synth_tag.clone()));
+    }
+    pairs.extend(directives.into_iter().zip(tags));
+    pairs.sort_by_key(|(d, _)| d.date());
+    pairs.into_iter().unzip()
+}
+
 /// Load a ledger from a file path, resolving `include` directives and booking
 /// transactions. Shared by the JSON-RPC `ledger.loadFile` handler and the WIT
 /// component (#1384).
@@ -524,3 +549,38 @@ pub fn apply_plugins(
 // call sites (`util.types`, `util.getAccountType`) that already reference
 // `helpers::{ACCOUNT_TYPES, account_type}`.
 pub use rustledger_core::{ACCOUNT_TYPES, account_type};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A ledger whose balance depends on pad expansion (#1628 repro).
+    const PAD_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:SomeName USD
+2020-01-01 open Equity:Opening-balances
+2024-01-20 pad Assets:SomeName Equity:Opening-balances
+2024-01-21 balance Assets:SomeName 42 USD
+";
+
+    #[test]
+    fn expand_pads_materializes_padding_transaction() {
+        let load = load_source(PAD_LEDGER);
+        // The source-faithful load stream has no synthesized padding transaction.
+        assert!(!load.directives.iter().any(|d| matches!(
+            d,
+            Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t)
+        )));
+        let raw_len = load.directives.len();
+
+        let (expanded, lines) = expand_pads(load.directives, load.directive_lines, &0u32);
+        // Exactly one synthesized Padding transaction is inserted, tags aligned.
+        assert_eq!(expanded.len(), raw_len + 1);
+        assert_eq!(expanded.len(), lines.len());
+        let synth = expanded
+            .iter()
+            .filter(|d| matches!(d, Directive::Transaction(t) if rustledger_booking::is_synthesized_pad(t)))
+            .count();
+        assert_eq!(synth, 1, "expected exactly one synthesized Padding txn");
+    }
+}

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/request.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/request.rs
@@ -136,6 +136,11 @@ pub struct LoadParams {
     /// Optional filename for error messages.
     #[serde(default)]
     pub filename: Option<String>,
+    /// Expand `pad` directives into synthesized `Padding` transactions in the
+    /// returned entry stream (default `false` = source-faithful). Balance-
+    /// computing consumers (e.g. fava) set this; see #1628.
+    #[serde(default)]
+    pub expand_pads: bool,
 }
 
 /// Parameters for ledger.loadFile method.
@@ -155,6 +160,11 @@ pub struct LoadFileParams {
     /// argument.
     #[serde(default = "default_true")]
     pub path_security: bool,
+    /// Expand `pad` directives into synthesized `Padding` transactions in the
+    /// returned entry stream (default `false` = source-faithful). Balance-
+    /// computing consumers (e.g. fava) set this; see #1628.
+    #[serde(default)]
+    pub expand_pads: bool,
 }
 
 const fn default_true() -> bool {

--- a/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
+++ b/crates/rustledger-ffi-wasi/src/jsonrpc/router.rs
@@ -96,10 +96,16 @@ fn handle_load(params: &serde_json::Value) -> Result<serde_json::Value, RpcError
     let filename = params.filename.as_deref().unwrap_or("<stdin>");
     let load = load_source(&params.source);
 
-    let entries: Vec<DirectiveJson> = load
-        .directives
+    // Source-faithful by default; opt into pad-expansion for balance consumers
+    // (#1628). Synthesized transactions have no source line (tagged 0).
+    let (directives, directive_lines) = if params.expand_pads {
+        crate::helpers::expand_pads(load.directives, load.directive_lines, &0u32)
+    } else {
+        (load.directives, load.directive_lines)
+    };
+    let entries: Vec<DirectiveJson> = directives
         .iter()
-        .zip(load.directive_lines.iter())
+        .zip(directive_lines.iter())
         .map(|(d, &line)| directive_to_json(d, line, filename))
         .collect();
 
@@ -143,6 +149,18 @@ fn handle_load_file(params: &serde_json::Value) -> Result<serde_json::Value, Rpc
     );
 
     // `options`, `plugins`, `loaded_files` come from `helpers::load_file` above.
+
+    // Source-faithful by default; opt into pad-expansion for balance consumers
+    // (#1628). Synthesized transactions have no source location.
+    let (directives, directive_lines, directive_files) = if params.expand_pads {
+        let tags: Vec<(u32, String)> = directive_lines.into_iter().zip(directive_files).collect();
+        let (directives, tags) =
+            crate::helpers::expand_pads(directives, tags, &(0u32, "<synthesized>".to_string()));
+        let (lines, files): (Vec<u32>, Vec<String>) = tags.into_iter().unzip();
+        (directives, lines, files)
+    } else {
+        (directives, directive_lines, directive_files)
+    };
 
     // Build entries
     let entries: Vec<DirectiveJson> = directives
@@ -674,3 +692,30 @@ fn handle_get_account_type(params: &serde_json::Value) -> Result<serde_json::Val
 
 // `build_ledger_options` moved to `crate::helpers` so the WIT component
 // crate (#1384) can reuse it via `helpers::load_file`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAD_LEDGER: &str = "\
+option \"operating_currency\" \"USD\"
+2020-01-01 open Assets:SomeName USD
+2020-01-01 open Equity:Opening-balances
+2024-01-20 pad Assets:SomeName Equity:Opening-balances
+2024-01-21 balance Assets:SomeName 42 USD
+";
+
+    fn entry_count(v: &serde_json::Value) -> usize {
+        v["entries"].as_array().map_or(0, Vec::len)
+    }
+
+    #[test]
+    fn load_expand_pads_flag_adds_padding_entry() {
+        // Source-faithful by default; `expand_pads: true` adds the synthesized
+        // Padding transaction to the returned entry stream (#1628).
+        let raw = handle_load(&serde_json::json!({ "source": PAD_LEDGER })).unwrap();
+        let expanded =
+            handle_load(&serde_json::json!({ "source": PAD_LEDGER, "expand_pads": true })).unwrap();
+        assert_eq!(entry_count(&expanded), entry_count(&raw) + 1);
+    }
+}

--- a/crates/rustledger-ffi-wasi/src/lib.rs
+++ b/crates/rustledger-ffi-wasi/src/lib.rs
@@ -82,6 +82,13 @@ pub use types::input_entry_to_directive;
 ///
 /// # Version history
 ///
+/// * **2.2** — `ledger.load`/`ledger.loadFile` accept an optional
+///   `expand_pads` request field; when `true`, `pad` directives are
+///   materialized into synthesized `Padding` transactions in the returned
+///   entries (balance-computing consumers opt in). Additive and backward
+///   compatible — the field defaults to `false` (source-faithful) — hence a
+///   minor bump per the policy above (#1628). (The WIT component delivers the
+///   same capability via a *breaking* parameter, so it bumps to 3.0.)
 /// * **2.1** — `Inventory`/`Position` query values now include an optional
 ///   `cost` object per position when the holding was booked at cost, using the
 ///   same wire shape as a directive `PostingCost` (`number` is a tagged
@@ -99,4 +106,4 @@ pub use types::input_entry_to_directive;
 ///   should refuse to talk to a v2.x server. See `README.md` for the
 ///   migration recipe.
 /// * **1.0** — initial API.
-pub const API_VERSION: &str = "2.1";
+pub const API_VERSION: &str = "2.2";

--- a/docs/guides/integration.md
+++ b/docs/guides/integration.md
@@ -380,7 +380,7 @@ echo '[
 
 Instead of a hand-rolled JSON-RPC wire shape, this surface exposes a generated
 **WIT contract** (`crates/rustledger-ffi-component/wit/world.wit`, versioned
-package `rustledger:ledger@2.1.0`). The same operations — `load` / `validate` /
+package `rustledger:ledger@3.0.0`). The same operations — `load` / `validate` /
 `query` / `batch` (+ `-file` variants), entry `create` / `filter` / `clamp`,
 `util`, and `format` — are strongly-typed component functions with no JSON
 envelope. The contract itself is the versioned wire shape; a `version()` func

--- a/docs/reference/adr/0006-wit-component-model-embedding.md
+++ b/docs/reference/adr/0006-wit-component-model-embedding.md
@@ -7,7 +7,7 @@ exports wired; builds as a real `wasm32-wasip2` component; parity harness)
 landed in #1384. Phase 3 (release artifact — the built wasip2 component ships as
 a prebuilt `.wasm` on GitHub releases) and Phase 4 (rustfava default) have since
 **landed**: the Component-Model path (`rustledger-ffi-component`, WASI Preview 2,
-package `rustledger:ledger@2.1.0`) is now the **primary, default embedding
+package `rustledger:ledger@3.0.0`) is now the **primary, default embedding
 surface** — the default backend in rustfava (rustfava
 [#183](https://github.com/rustledger/rustfava/pull/183) / rustfava #173). The
 JSON-RPC embedding surface (`rustledger-ffi-wasi`, WASI Preview 1) is now

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -108,7 +108,7 @@ This document describes rustledger's crate structure and data flow.
 | `rustledger` | CLI binary (`rledger`, `bean-*` commands) |
 | `rustledger-wasm` | WebAssembly bindings for JS/TS |
 | `rustledger-ffi-wasi` | FFI via WASI (wasip1) JSON-RPC for embedding — legacy, slated for removal in Phase 5 ([#1419](https://github.com/rustledger/rustledger/issues/1419)) |
-| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract, `rustledger:ledger@2.1.0`) — primary embedding surface, default in the rustfava embedder ([#1384](https://github.com/rustledger/rustledger/issues/1384) Phase 4) |
+| `rustledger-ffi-component` | FFI via WASI Preview 2 / Component Model (typed WIT contract, `rustledger:ledger@3.0.0`) — primary embedding surface, default in the rustfava embedder ([#1384](https://github.com/rustledger/rustledger/issues/1384) Phase 4) |
 
 ## Data Flow
 


### PR DESCRIPTION
Closes #1628.

## Problem

The FFI `load`/`load-file` exports returned the **source-faithful** directive stream (raw `Pad`, no synthesized `Padding` transactions), while the `query`/`batch`/`session` paths pad-expand via `merge_with_padding`. So a balance-computing embedder (rustfava) reading the *load* result silently omitted pad-inserted amounts — even though `rledger report … balances` (which uses `balance_view()`) is correct. Beancount's `loader.load_file` *does* materialize Padding at load, so the source-faithful load isn't loader-equivalent for fava.

## Fix — opt-in `expand-pads`, both backends (per the maintainer: breaking OK, JSON-RPC parity required)

Off by default preserves the source-faithful contract; **on** materializes synthesized `Padding` transactions into the returned entries (sorted by date, no source location) — exactly `balance_view()`'s output, which fava needs for **both** correct balances and journal display.

- **Shared helper** `helpers::expand_pads` replicates `Ledger::balance_view`'s algorithm (prepend synth Padding, stable-sort by date) while **preserving each directive's parallel tags** (line, and line+file) — the wrinkle that made this non-trivial, since expansion prepends tag-less synth txns and re-sorts. Synth txns are tagged line `0` / file `<synthesized>`.
- **Component (WIT)** — `expand-pads: bool` added to `load` + `load-file`. This is a **breaking arity change**, so the contract bumps `rustledger:ledger@2.1.0` → **`3.0.0`** (component `API_VERSION` → `3.0`).
- **JSON-RPC (ffi-wasi)** — optional `expand_pads` request field (`#[serde(default)]` = `false`) on `ledger.load`/`ledger.loadFile`. Backward-compatible → **additive**, so wasi `API_VERSION` → **`2.2`** (a version-history entry explains why the two backends bump differently).
- `batch`'s load section stays source-faithful (its queries pad-expand separately).

## Tests

- `expand_pads_materializes_padding_transaction` (ffi-wasi): the #1628 repro loads with exactly one synthesized `Padding` txn inserted and tags stay aligned (`expanded.len() == lines.len()`).
- `load_expand_pads_flag_adds_padding_entry` (router): `expand_pads: true` adds exactly one entry through the JSON-RPC handler.

## Consumer note

rustfava (rustledger/rustfava#192) opts in by passing `expand-pads`/`expand_pads` and regenerating its WIT bindings for `3.0.0`.

## Verify

`cargo test -p rustledger-ffi-wasi -p rustledger-ffi-component --all-features` green; **workspace** clippy (`--all-features --all-targets -D warnings`, the CI command) + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
