### PR TITLE
chore: release v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "agcli",
  "anyhow",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3447,11 +3447,11 @@ dependencies = [
 
 [[package]]
 name = "rustledger-completion"
-version = "0.16.5"
+version = "0.17.0"
 
 [[package]]
 name = "rustledger-core"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "criterion",
  "imbl",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "jiff",
  "rustledger-booking",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component-tests"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "rustledger-ffi-wasi",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.2",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "glob",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "crossbeam-channel",
  "jiff",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.16.5"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-only"
@@ -192,19 +192,19 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.16.5", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.16.5", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.16.5", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.16.5", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.16.5", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.16.5", path = "crates/rustledger-query" }
-rustledger-completion = { version = "0.16.5", path = "crates/rustledger-completion" }
-rustledger-plugin = { version = "0.16.5", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.16.5", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.16.5", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.16.5", path = "crates/rustledger-ops" }
-rustledger-ffi-wasi = { version = "0.16.5", path = "crates/rustledger-ffi-wasi" }
-rustledger-wasm = { version = "0.16.5", path = "crates/rustledger-wasm" }
+rustledger-core = { version = "0.17.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.17.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.17.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.17.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.17.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.17.0", path = "crates/rustledger-query" }
+rustledger-completion = { version = "0.17.0", path = "crates/rustledger-completion" }
+rustledger-plugin = { version = "0.17.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.17.0", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.17.0", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.17.0", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.17.0", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.17.0", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-completion"
 description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Slimmed FFI-support helpers reused by the rustledger WASI component FFI (loader orchestration + WIT-input construction + directive hashing; the wasip1 JSON-RPC surface and Directive-to-JSON DTO were removed in #1419)"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.16.5"
+version = "0.17.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.16.5"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Release **v0.17.0** — workspace version bump (cargo set-version, 0.16.5 → 0.17.0, cascades to all crates).

Minor/breaking bump per Cargo 0.x semver: this release removes the **wasip1 JSON-RPC FFI surface** (#1419, Phase 5 complete), bumps the WIT contract **2.1.0 → 3.0.0**, and adds the opt-in **expand-pads** load parameter (#1632).

On merge, I will tag `v0.17.0` at the merge commit, which triggers `release-build.yml` (artifacts incl. **rustledger-ffi-component-v0.17.0.wasm**) and the published-release → crates.io publish. Diff is version-only (17 files, 46/46 version lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)