### PR TITLE
fix(release): publish @rustledger/mcp-server at the release-tag version

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -257,6 +257,17 @@ jobs:
           done
           echo "Package not available after 6 minutes"
           exit 1
+      - name: Sync package version to the release tag
+        run: |
+          # The MCP server is a standalone npm package whose version is NOT
+          # derived from any Cargo.toml (unlike @rustledger/wasm), so the
+          # `cargo set-version` run during the release cut never touches it.
+          # Force it to the release tag here so a forgotten manual bump of
+          # packages/mcp-server/package.json can't publish the wrong version —
+          # the v0.17.0 channel-test failure was exactly that (package.json was
+          # still 0.16.5, so @rustledger/mcp-server@0.17.0 was never published).
+          cd packages/mcp-server
+          npm version "${RELEASE_TAG#v}" --no-git-tag-version --allow-same-version
       - name: Install dependencies
         run: |
           cd packages/mcp-server

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustledger/mcp-server",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes the `Release Channel Testing` → **npm (@rustledger/mcp-server)** failure for v0.17.0.

## Root cause
`@rustledger/wasm` derives its npm version from the Rust crate's `Cargo.toml` (which `cargo set-version` bumps during a release cut), so it published `0.17.0` fine. But **`@rustledger/mcp-server` is a standalone npm package** — its version lives only in `packages/mcp-server/package.json`, which `cargo set-version` never touches, and `release-build`'s `validate-version` only compares the **crate** version to the tag. So `package.json` was still `0.16.5`; `publish-npm-mcp` reads the version from `package.json` and thus republished/skipped `0.16.5`. `@rustledger/mcp-server@0.17.0` was never published, and the channel test timed out waiting for it.

## Fix
- **`publish-npm-mcp` now syncs the version to the release tag** (`npm version <tag> --no-git-tag-version --allow-same-version`) before build/publish, so the published version always matches the tag regardless of what's committed in `package.json` — this drift can't recur on future releases.
- Bumped `packages/mcp-server/package.json` to `0.17.0` (and the stale `package-lock.json`, which was at `0.16.1`).

## Follow-up to ship 0.17.0
After this merges to `main`, I'll re-dispatch **Release Publish** (`tag=v0.17.0`) — its crates.io/wasm jobs are idempotent (monotonicity-guarded, skip already-published versions) and `publish-npm-mcp` will now publish `@rustledger/mcp-server@0.17.0` — then re-run Channel Testing to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
