### PR TITLE
ci(release): serialize the two AUR publish jobs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -542,7 +542,11 @@ jobs:
           commit_message: "Update to ${{ env.RELEASE_TAG }}"
   update-aur-bin:
     name: Update AUR (rustledger-bin)
-    needs: wait-for-assets
+    # Serialize after the source package so the two jobs don't clone/push
+    # aur.archlinux.org simultaneously. Parallel access caused a transient
+    # `SSL_read: unexpected eof` failure cloning the AUR repo during the v0.17.0
+    # release; running them back-to-back removes that contention.
+    needs: [wait-for-assets, update-aur-source]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
The `rustledger` and `rustledger-bin` AUR update jobs both depend only on `wait-for-assets`, so they clone/push `aur.archlinux.org` **in parallel**. During the v0.17.0 release that contention produced a transient `OpenSSL SSL_read: unexpected eof while reading` failure cloning the AUR repo in `update-aur-bin` (the `update-aur-source` job, doing the same thing concurrently, happened to succeed).

## Fix
`update-aur-bin` now `needs: [wait-for-assets, update-aur-source]`, so the two AUR pushes run **back-to-back** instead of simultaneously — removing the contention against the AUR server.

## Note
This was a transient network flake, not a code/checksum bug (the PKGBUILD prep and checksums were correct). Re-running the failed job already pushed **rustledger-bin 0.17.0** to AUR, so both AUR packages (`rustledger` source + `rustledger-bin` binary) are current. This change just makes the flake far less likely on future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)