### PR TITLE
fix(loader): normalize @@ prices in the shared finalize phase

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -645,3 +645,51 @@ fn query_entries_matches_source_query() -> Result<()> {
     );
     Ok(())
 }
+
+/// `@@` (total price) must surface through the component as a **per-unit** price,
+/// exactly as `rledger check` reports it. The `@@`→`@` conversion lives in the
+/// loader's shared `finalize` phase, so the FFI surface and the CLI cannot
+/// disagree.
+///
+/// Regression guard for the v0.17.0 bug: the FFI path exposed the raw `@@` total
+/// (`7 USD @@ 10 EUR` → price `10`) instead of the per-unit price (`10/7 ≈
+/// 1.4286`), because the normalization had lived only in the CLI `check` path
+/// and was lost when the FFI surface moved onto the shared pipeline (#1462).
+#[test]
+fn total_price_at_at_normalized_to_per_unit() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    use rustledger::ledger::types::Directive;
+    let (mut store, inst) = instantiate()?;
+    let ledger = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Assets:Other EUR
+2024-01-02 * \"total price\"
+  Assets:Cash   7 USD @@ 10 EUR
+  Assets:Other  -10 EUR
+";
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, ledger, "<stdin>", false)?;
+    let (number, currency) = loaded
+        .entries
+        .iter()
+        .find_map(|d| match d {
+            Directive::Transaction(t) => t.postings.iter().find_map(|p| {
+                p.price
+                    .as_ref()
+                    .map(|a| (a.number.clone(), a.currency.clone()))
+            }),
+            _ => None,
+        })
+        .expect("the `@@` posting should carry a price");
+    assert_eq!(currency, "EUR");
+    // 10 EUR / 7 USD = 1.4285714… per unit — NOT the raw total `10`.
+    assert!(
+        number.starts_with("1.42857"),
+        "`@@` total must be normalized to per-unit, got `{number}` {currency}",
+    );
+    Ok(())
+}

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -744,6 +744,26 @@ impl crate::Directives<crate::LateValidated> {
         let mut v = std::mem::take(self.as_vec_mut());
         v.extend(failed.into_inner());
         v.sort_by_key(canonical_sort_key);
+
+        // Normalize `@@` total prices to per-unit (`@`) as the final pipeline
+        // step. This runs AFTER Late validation, so exact totals still survived
+        // for the precise balance-residual check (#1240) — which is the entire
+        // reason normalization is deferred rather than done during booking.
+        //
+        // Doing it HERE, in the one transition that produces `Finalized` (the
+        // only publicly-exposed phase), makes "prices are normalized" an
+        // invariant of every loaded `Ledger`: `rledger check`, the FFI/MCP
+        // component, and BQL all get it by construction, and none can drift by
+        // forgetting to normalize. It was previously bolted onto the CLI `check`
+        // path only, so the FFI surface silently regressed to exposing raw `@@`
+        // totals when it moved onto this shared pipeline (#1462).
+        #[cfg(feature = "booking")]
+        for spanned in &mut v {
+            if let Directive::Transaction(txn) = &mut spanned.value {
+                rustledger_booking::normalize_prices(txn);
+            }
+        }
+
         crate::Directives::new_unchecked(v)
     }
 }
@@ -1526,6 +1546,59 @@ fn run_error_to_ledger(e: &rustledger_plugin::PluginRunError) -> LedgerError {
         Rn::PythonFailed { message } => {
             LedgerError::error("E8002", message.clone()).with_phase("plugin")
         }
+    }
+}
+
+#[cfg(all(test, feature = "booking", feature = "validation"))]
+mod finalize_price_tests {
+    use rustledger_core::{Directive, PriceKind};
+
+    /// `finalize` normalizes `@@` (total) prices to per-unit (`@`), so every
+    /// loaded `Ledger` carries normalized prices by construction — the FFI
+    /// component and `rledger check` cannot disagree. Regression guard for #1462,
+    /// where the FFI surface lost the normalization that lived only in the CLI
+    /// `check` path and so exposed the raw `@@` total.
+    #[test]
+    fn finalize_normalizes_total_at_at_price_to_per_unit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("main.bean");
+        std::fs::write(
+            &path,
+            "2024-01-01 open Assets:Cash USD\n\
+             2024-01-01 open Assets:Other EUR\n\
+             2024-01-02 * \"total price\"\n  \
+               Assets:Cash   7 USD @@ 10 EUR\n  \
+               Assets:Other  -10 EUR\n",
+        )
+        .unwrap();
+
+        let ledger =
+            super::load(&path, &super::LoadOptions::default()).expect("ledger should load");
+        let price = ledger
+            .directives
+            .iter()
+            .find_map(|s| match &s.value {
+                Directive::Transaction(t) => t.postings.iter().find_map(|p| p.price.as_ref()),
+                _ => None,
+            })
+            .expect("the `@@` posting should carry a price");
+
+        assert_eq!(
+            price.kind,
+            PriceKind::Unit,
+            "`@@` must be normalized to a per-unit price, not left as a total"
+        );
+        let amount = price
+            .amount
+            .as_ref()
+            .and_then(|a| a.as_amount())
+            .expect("normalized per-unit amount present");
+        // 10 EUR / 7 USD = 1.4285714… per unit — NOT the raw total `10`.
+        assert!(
+            amount.number.to_string().starts_with("1.42857"),
+            "per-unit price should be 10/7, got {}",
+            amount.number
+        );
     }
 }
 

--- a/crates/rustledger/src/cmd/check.rs
+++ b/crates/rustledger/src/cmd/check.rs
@@ -4,7 +4,6 @@ use crate::cmd::completions::ShellType;
 use crate::report::{self, SourceCache};
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
-use rustledger_core::Directive;
 use rustledger_loader::LoadError;
 #[cfg(feature = "python-plugin-wasm")]
 use rustledger_plugin::PluginManager;
@@ -542,14 +541,10 @@ pub fn run_with_writer<W: Write>(args: &Args, stdout: &mut W) -> Result<ExitCode
     let ledger = rustledger_loader::process(process_input, &load_options)
         .with_context(|| "processing pipeline failed")?;
 
-    // Normalize total prices (@@→@) AFTER validation to preserve exact totals for
-    // precise residual calculation.
-    let mut spanned_directives = ledger.directives;
-    for spanned in &mut spanned_directives {
-        if let Directive::Transaction(txn) = &mut spanned.value {
-            rustledger_booking::normalize_prices(txn);
-        }
-    }
+    // `@@`→`@` price normalization is done in the loader's `finalize` phase (the
+    // shared pipeline), so `ledger.directives` is already normalized — every
+    // consumer gets it by construction. See `process::finalize`.
+    let spanned_directives = ledger.directives;
 
     let source_map = &ledger.source_map;
     // One renderer per invocation: amortizes GraphicalReportHandler setup


### PR DESCRIPTION
## The bug
A **v0.17.0 regression**: `7 USD @@ 10 EUR` surfaces through the FFI component (what rustfava reads) as the **raw total price `10`** instead of the Beancount-style **per-unit price `10/7 ≈ 1.428`**. `rledger check` was unaffected.

## Root cause
The `@@`→`@` normalization (`normalize_prices`) lived in **exactly one place** — the CLI's `check.rs` — *not* in the loader's shared `process()` pipeline. PR #1462 (`fix(ffi): route load_source through the canonical pipeline`) routed the FFI/MCP surface through that shared pipeline to deduplicate the loader, and in doing so **dropped the normalization** the CLI still did separately. So `process()` returned a `Finalized` ledger that wasn't actually finalized.

This is the **same drift category as #1648** (LSP-vs-`check`): a step that should be a pipeline invariant is instead a per-consumer responsibility, so the next consumer to route through the pipeline silently diverges.

## Fix — put the invariant in the type, not the consumer
- **Call `normalize_prices` in the loader's `finalize` transition** (`LateValidated → Finalized`). It runs *after* Late validation, so exact totals still survive for the precise balance-residual check (#1240) — which is the entire reason normalization is deferred rather than done during booking. `finalize` is the unique correct home.
- `Finalized` is the **only publicly-exposed phase** and `process()` is the **only path to a `Ledger`**, so "prices are normalized" is now an **invariant every consumer gets by construction** — CLI, FFI/MCP component, BQL. None can drift, and the compiler enforces it (you cannot obtain a non-finalized ledger).
- Removed the now-redundant normalize loop (and the unused `Directive` import) from `check.rs`.

## Tests
- **Loader invariant** (`process.rs`): `process()`/finalize normalizes `@@` to a per-unit `@` price (runs without the wasm).
- **FFI component parity** (`parity.rs`): the component surfaces `7 USD @@ 10 EUR` as per-unit `1.42857…`, matching `check` — the CLI↔FFI parity guard the regression slipped past.

## Verification
No regressions: **16** FFI parity + **92** loader + **105** booking + **362** CLI + **163** query + **104** ops tests pass; `clippy -D warnings` clean; `fmt` clean. The only `normalize_prices` caller is now `process::finalize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
