### PR TITLE
fix(ops): preserve cost on held-at-cost opening-balance contra in clamp (#1656)

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -612,6 +612,58 @@ fn session_clamp_preserves_cost_basis() -> Result<()> {
     Ok(())
 }
 
+/// #1656: a held-at-cost lot summarized into the clamp opening balance must keep
+/// its cost on the `Equity:Opening-Balances` contra, so the opening transaction
+/// balances by weight. The component's `clamp` is what rustfava uses for time
+/// filtering; a bare-units contra breaks any at-cost view of the clamped ledger.
+#[test]
+fn clamp_opening_balance_contra_keeps_cost() -> Result<()> {
+    use rustledger::ledger::types::Directive;
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let comp = inst.rustledger_ledger_ledger();
+    let session = comp.session();
+    let src = "\
+2000-01-01 open Assets:MC
+2000-01-01 open Equity:Open
+2000-01-02 * \"seed\"
+  Assets:MC   100 USD
+  Equity:Open  -100 USD
+2000-01-03 * \"buy\"
+  Assets:MC    1 XYZ {50 USD}
+  Assets:MC  -50 USD
+";
+    let handle = session.call_constructor(&mut store, src)?;
+    // Clamp to a window AFTER all entries: everything becomes opening balance.
+    let clamped = session.call_clamp(&mut store, handle, "2014-01-01", "2015-01-01")?;
+    let opening = clamped
+        .iter()
+        .find_map(|d| match d {
+            Directive::Transaction(t) if t.narration.as_deref() == Some("Opening balance") => {
+                Some(t)
+            }
+            _ => None,
+        })
+        .expect("an Opening balance transaction is synthesized");
+    let xyz_contra = opening
+        .postings
+        .iter()
+        .find(|p| {
+            p.account == "Equity:Opening-Balances"
+                && p.units.as_ref().is_some_and(|u| u.currency == "XYZ")
+        })
+        .expect("an Equity:Opening-Balances contra for the XYZ lot");
+    assert!(
+        xyz_contra.cost.is_some(),
+        "held-at-cost contra must keep its cost through the component clamp (#1656)",
+    );
+    handle.resource_drop(&mut store)?;
+    Ok(())
+}
+
 /// `builder.query-entries` (rustfava#173): query an already-loaded directive
 /// set directly, matching the source-based `query` — the typed alternative to
 /// re-rendering entries to source.

--- a/crates/rustledger-ops/src/clamp.rs
+++ b/crates/rustledger-ops/src/clamp.rs
@@ -103,31 +103,40 @@ fn synthetic_transaction(date: NaiveDate, postings: Vec<Spanned<Posting>>) -> Di
     })
 }
 
+/// The cost spec to carry on a synthesized opening-balance posting for a held
+/// lot, or `None` for a plain-currency position.
+fn position_cost_spec(position: &Position) -> Option<CostSpec> {
+    position.cost.as_ref().map(|c| CostSpec {
+        number: Some(CostNumber::PerUnit { value: c.number }),
+        currency: Some(c.currency.clone()),
+        date: c.date,
+        label: c.label.clone(),
+        merge: false,
+    })
+}
+
 /// One opening-balance transaction for an account's inventory.
 fn summary_transaction(account: &str, inventory: &Inventory, date: NaiveDate) -> Directive {
     let mut postings = Vec::new();
     for position in inventory.positions() {
-        let cost = position.cost.as_ref().map(|c| CostSpec {
-            number: Some(CostNumber::PerUnit { value: c.number }),
-            currency: Some(c.currency.clone()),
-            date: c.date,
-            label: c.label.clone(),
-            merge: false,
-        });
         postings.push(synthetic_posting(
             account,
             position.units.number,
             &position.units.currency,
-            cost,
+            position_cost_spec(position),
         ));
     }
-    // Balancing Equity:Opening-Balances posting per position.
+    // Balancing Equity:Opening-Balances posting per position. A held-at-cost lot
+    // MUST carry the same cost here so the opening transaction balances by weight
+    // (#1656): the asset leg's weight is `N * cost` in the cost currency, so a
+    // bare-units contra leaves that weight unoffset and any at-cost view of the
+    // clamped ledger stops summing to zero.
     for position in inventory.positions() {
         postings.push(synthetic_posting(
             "Equity:Opening-Balances",
             -position.units.number,
             &position.units.currency,
-            None,
+            position_cost_spec(position),
         ));
     }
     synthetic_transaction(date, postings)
@@ -391,6 +400,52 @@ mod tests {
             out.iter()
                 .any(|dir| mentions(dir, "Equity:Earnings:Previous")),
             "expected an earnings roll-up posting",
+        );
+    }
+
+    #[test]
+    fn held_at_cost_opening_contra_keeps_its_cost() {
+        // #1656: a held-at-cost lot summarized into the opening balance must keep
+        // its cost on the Equity:Opening-Balances contra leg, or the opening
+        // transaction does not balance by weight — the asset leg's weight is
+        // `N * cost` in the cost currency, so a bare-units contra leaves it
+        // unoffset and any at-cost view of the clamped ledger stops summing to 0.
+        let input = dirs(
+            "2000-01-01 open Assets:MC\n\
+             2000-01-01 open Equity:Open\n\
+             2000-01-02 * \"seed\"\n  Assets:MC   100 USD\n  Equity:Open  -100 USD\n\
+             2000-01-03 * \"buy\"\n  Assets:MC    1 XYZ {50 USD}\n  Assets:MC  -50 USD\n",
+        );
+        // Clamp to a window AFTER all entries: everything becomes opening balance.
+        let out = clamp(&input, d(2014, 1, 1), d(2015, 1, 1));
+
+        let opening = out
+            .iter()
+            .find_map(|dir| match dir {
+                Directive::Transaction(t)
+                    if t.flag == 'S' && t.narration.to_string() == "Opening balance" =>
+                {
+                    Some(t)
+                }
+                _ => None,
+            })
+            .expect("an Opening balance summary is synthesized");
+
+        let xyz_contra = opening
+            .postings
+            .iter()
+            .find(|p| {
+                p.value.account.to_string() == "Equity:Opening-Balances"
+                    && p.value
+                        .units
+                        .as_ref()
+                        .and_then(IncompleteAmount::as_amount)
+                        .is_some_and(|a| a.currency.to_string() == "XYZ")
+            })
+            .expect("an Equity:Opening-Balances contra for the XYZ lot");
+        assert!(
+            xyz_contra.value.cost.is_some(),
+            "held-at-cost contra must keep its cost (#1656), got bare units",
         );
     }
 }


### PR DESCRIPTION
Closes #1656.

## Bug
When `clamp`/summarize carries a **held-at-cost** position into the opening balance of a time-filtered view, the synthesized `Equity:Opening-Balances` contra posting was emitted in **bare units with no cost**, while the asset leg kept the cost:

```
S "Opening balance"
    Assets:MC                  1 XYZ {50 USD}     ← weight +50 USD
    Equity:Opening-Balances   -1 XYZ             ← weight −1 XYZ  (cost dropped)
```

So the opening transaction doesn't balance by weight, and any at-cost/value view of a clamped ledger stops summing to zero. In rustfava this is the broken `trial_balance?time=<year-after-the-lots>` (asset lot renders at its cost currency, equity contra stays in bare units).

## Root cause
`rustledger-ops/src/clamp.rs::summary_transaction` computed the cost for the asset leg but passed `None` for the balancing `Equity:Opening-Balances` leg.

## Fix
The contra leg now carries the same cost as the asset leg (extracted into a shared `position_cost_spec` helper), yielding `Equity:Opening-Balances -1 XYZ {50 USD}` (weight −50 USD). The opening txn balances: `50 + 50 − 50 − 50 = 0`. Matches Beancount's `summarize.open`. `earnings_transaction`'s bare contra is intentionally left as-is — P&L closes in plain currency, not at cost.

## Tests
- **ops** (`clamp.rs`): a held-at-cost lot's opening-balance contra keeps its cost.
- **FFI component parity** (`parity.rs`): `clamp` through the component preserves the contra cost — the existing `session_clamp_preserves_cost_basis` only checked the *surviving* transaction's cost, which is how this slipped past.

## Verification
105 ops + 17 FFI parity tests pass; clippy `-D warnings` clean. Affects rustfava through the component `clamp`, so it'll want a **v0.17.2** patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
