### PR TITLE
fix(validate): read the spec doc at runtime in the error-code test (fixes Nix channel)

### DIFF
--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -345,7 +345,20 @@ mod tests {
         // strict equality.) Codes are backtick-wrapped in the spec (`**Code:**
         // `E1001``), so the backtick delimiters keep `E1001` from matching
         // inside `E10001`.
-        let spec = include_str!("../../../spec/core/validation.md");
+        // The spec lives at the workspace root (`spec/core/validation.md`),
+        // OUTSIDE this crate, so it is not packaged to crates.io. Read it at
+        // runtime relative to `CARGO_MANIFEST_DIR` and skip when it is absent —
+        // e.g. `cargo test` on the published crate, which the Nix release channel
+        // runs — rather than `include_str!`-ing it at compile time, which would
+        // fail to build the published crate's tests (broke the Nix release
+        // channel on 0.17.x).
+        let spec_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../spec/core/validation.md");
+        let Ok(spec) = std::fs::read_to_string(spec_path) else {
+            eprintln!(
+                "skipping error_codes_documented_in_spec: {spec_path} not present (published-crate build)"
+            );
+            return;
+        };
         let missing: Vec<&str> = ErrorCode::ALL
             .iter()
             .map(ErrorCode::code)


### PR DESCRIPTION
Fixes the **`Test Nix` release-channel failure** (surfaced verifying the v0.17.2 channel run).

## Root cause
`rustledger-validate`'s `error_codes_documented_in_spec` test did:
```rust
let spec = include_str!("../../../spec/core/validation.md");
```
That reaches the workspace-root `spec/` dir, **outside the crate**, so it isn't packaged to crates.io. When the Nix channel builds **and tests the published crate**, the test module fails to compile:
```
error: couldn't read `crates/rustledger-validate/src/../../../spec/core/validation.md`: No such file or directory
```
It's a `#[cfg(test)]` test, so it never affected the library/binary/component or normal `cargo install` consumers — only test builds of the published crate (Nix, `cargo test` from crates.io). It's been red on Nix across the 0.17.x releases.

## Fix
Read the spec **at runtime** relative to `CARGO_MANIFEST_DIR`, and **skip gracefully** when it's absent (the published-crate case), instead of `include_str!` at compile time. The drift guard still runs in the workspace (spec present) — verified passing here.

Test-only change; no shipped artifact changes. Verified: the test passes in-workspace, clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
