### PR TITLE
fix(nix): skip the test suite in the release binary build (doCheck = false)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,14 @@
             // {
               inherit cargoArtifacts;
               meta.mainProgram = "rledger";
+              # Build the binary WITHOUT running the test suite. crane's
+              # `srcFilter` strips test fixtures (`.bin` fuzz corpora,
+              # `spec/*.md`, importer stubs) for caching, so `cargo test` fails
+              # to compile fixture-dependent tests — repeatedly breaking the Nix
+              # release channel one fixture at a time. Tests run in CI on the
+              # full, unfiltered repo; the Nix release-channel check only needs
+              # the binary to build and run (`nix run … -- --version`).
+              doCheck = false;
             }
           );
 


### PR DESCRIPTION
Fixes the recurring **Test Nix release-channel** failure at its root.

## Why it keeps breaking
The channel test runs `nix run … -- --version` — it builds rustledger from the flake, and crane runs the **full test suite** (`checkPhase`) by default. But the flake's `srcFilter` strips test fixtures (`.bin` fuzz corpora, `spec/*.md`, the importer `sample_stub`) for caching, so **fixture-dependent tests fail to compile**. Fixing one fixture just exposes the next (validation.md → parser `fuzz_regressions/*.bin` → importer stub) — whack-a-mole.

## Fix
`doCheck = false` on the `rustledger` crane build. The release-channel check only needs the **binary** to build and run; tests run in CI on the full, unfiltered repo. One change fixes the whole class, including future fixtures.

Verified: `nix eval .#packages.x86_64-linux.rustledger.drvPath` resolves cleanly with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)