### PR TITLE
feat(ffi)!: load reports balance failures + balance diff on directives (#1663, WIT 3.1.0)

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -745,3 +745,58 @@ fn total_price_at_at_normalized_to_per_unit() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1663: `load` (not only `validate`) must report balance-assertion failures,
+/// so an embedder that loads via `load` (rustfava) sees a failing `balance`
+/// instead of a silent green. Load-vs-validate parity for the balance check.
+#[test]
+fn load_reports_balance_assertion_failure() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    // Real balance of Assets:Cash is -5 USD, but the ledger asserts 999 USD.
+    let src = "\
+2024-01-01 open Assets:Cash USD
+2024-01-01 open Expenses:X USD
+2024-01-02 * \"t\"
+  Expenses:X   5 USD
+  Assets:Cash
+2024-01-03 balance Assets:Cash   999 USD
+";
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, src, "<stdin>", false)?;
+    let has_balance_err = loaded
+        .errors
+        .iter()
+        .any(|e| e.message.contains("Balance failed") && e.message.contains("Assets:Cash"));
+    assert!(
+        has_balance_err,
+        "`load` must surface the failing balance assertion (#1663); got errors: {:?}",
+        loaded
+            .errors
+            .iter()
+            .map(|e| e.message.clone())
+            .collect::<Vec<_>>()
+    );
+
+    // #1663 Part 2: the balance directive carries the computed diff (WIT 3.1.0),
+    // so UIs render pass/fail without re-deriving. computed(-5) − asserted(999).
+    let bal_diff = loaded
+        .entries
+        .iter()
+        .find_map(|d| match d {
+            rustledger::ledger::types::Directive::Balance(b) => b.diff.clone(),
+            _ => None,
+        })
+        .expect("the balance directive should carry a diff (#1663 Part 2)");
+    assert_eq!(bal_diff.currency, "USD");
+    assert!(
+        bal_diff.number.starts_with("-1004"),
+        "diff should be computed − asserted = -1004, got `{}`",
+        bal_diff.number
+    );
+    Ok(())
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -170,6 +170,9 @@ fn directive_from_core(d: &Directive, line: u32, filename: &str) -> wit::Directi
             account: b.account.to_string(),
             amount: amount_from_core(&b.amount),
             tolerance: b.tolerance.map(|t| t.to_string()),
+            // Filled in by `attach_balance_diffs` after validation runs (#1663);
+            // `directive_from_core` has no ledger-wide context on its own.
+            diff: None,
             meta: meta(&b.meta),
         }),
         Directive::Pad(p) => wit::Directive::Pad(wit::PadDir {
@@ -297,6 +300,82 @@ pub fn load(source: &str, filename: &str, expand_pads: bool) -> out::LoadResult 
     load_result(ffi::helpers::load_source(source), filename, expand_pads)
 }
 
+/// Run the semantic validation session over a loaded result and return its
+/// validation-phase errors. Empty when the input has parse errors (validation
+/// only runs on syntactically-valid input, matching `validate`).
+///
+/// Shared by `validate` and the `load`/`load_file` path so the primary load
+/// surface reports balance-assertion failures (and the other Late checks) like
+/// beancount's `loader.load_file` — not only `validate`. Embedders that load via
+/// `load` (rustfava) would otherwise see a failing `balance` as `errors: []`
+/// (#1663).
+fn semantic_validation_errors(
+    loaded: &ffi::helpers::LoadResult,
+) -> (Vec<ffi::Error>, Vec<rustledger_validate::BalanceActual>) {
+    if loaded.errors.iter().any(|e| e.phase == "parse") {
+        return (Vec::new(), Vec::new());
+    }
+    let today = jiff::Zoned::now().date();
+    let session = rustledger_validate::ValidationSession::new(
+        rustledger_validate::ValidationOptions::default(),
+    );
+    let (session, mut verrs) = session.run_early_spanned(&loaded.spanned_directives, today);
+    let (session, late) = session.run_late_spanned(&loaded.spanned_directives, today);
+    verrs.extend(late);
+    // Capture the per-balance computed results (#1663) before `finalize` consumes
+    // the session.
+    let actuals = session.balance_actuals().to_vec();
+    verrs.extend(session.finalize());
+    let errors = verrs
+        .into_iter()
+        .map(|err| {
+            let mut e = ffi::Error::new(&err.message).validate_phase();
+            if let Some(span) = err.span {
+                e = e.with_line(loaded.line_lookup.byte_to_line(span.start));
+            }
+            e
+        })
+        .collect();
+    (errors, actuals)
+}
+
+/// Attach the computed `diff` (`computed − asserted`) to each `balance` directive
+/// entry from the validator's recorded results (#1663), keyed by
+/// `(date, account, currency)`.
+fn attach_balance_diffs(
+    entries: &mut [wit::Directive],
+    actuals: &[rustledger_validate::BalanceActual],
+) {
+    if actuals.is_empty() {
+        return;
+    }
+    let map: std::collections::HashMap<(String, String, String), rustledger_core::Decimal> =
+        actuals
+            .iter()
+            .map(|a| {
+                (
+                    (
+                        a.date.to_string(),
+                        a.account.to_string(),
+                        a.currency.to_string(),
+                    ),
+                    a.diff,
+                )
+            })
+            .collect();
+    for entry in entries.iter_mut() {
+        if let wit::Directive::Balance(b) = entry {
+            let key = (b.date.clone(), b.account.clone(), b.amount.currency.clone());
+            if let Some(diff) = map.get(&key) {
+                b.diff = Some(wit::Amount {
+                    number: diff.to_string(),
+                    currency: b.amount.currency.clone(),
+                });
+            }
+        }
+    }
+}
+
 /// Build a WIT load-result from a consumed `ffi-wasi` load result (shared by
 /// `load` and `batch`). `batch` always passes `expand_pads = false` — its load
 /// section is source-faithful and its queries pad-expand separately.
@@ -305,20 +384,30 @@ fn load_result(
     filename: &str,
     expand_pads: bool,
 ) -> out::LoadResult {
+    // #1663: run semantic validation (balance assertions and the other Late
+    // checks) so `load`/`load_file` report them like beancount's
+    // `loader.load_file` — not only `validate`. Computed before `loaded` is
+    // consumed below.
+    let (validation_errs, balance_actuals) = semantic_validation_errors(&loaded);
+
     // Synthesized pad transactions have no source line (tagged 0).
     let (directives, directive_lines) = if expand_pads {
         ffi::helpers::expand_pads(loaded.directives, loaded.directive_lines, &0u32)
     } else {
         (loaded.directives, loaded.directive_lines)
     };
-    let entries = directives
+    let mut entries: Vec<wit::Directive> = directives
         .iter()
         .zip(directive_lines.iter())
         .map(|(d, &line)| directive_from_core(d, line, filename))
         .collect();
+    // #1663 (Part 2): stamp each `balance` directive with `computed − asserted`.
+    attach_balance_diffs(&mut entries, &balance_actuals);
+    let mut errors = loaded.errors;
+    errors.extend(validation_errs);
     out::LoadResult {
         entries,
-        errors: loaded.errors.into_iter().map(error).collect(),
+        errors: errors.into_iter().map(error).collect(),
         options: options(loaded.options),
         plugins: loaded
             .plugins
@@ -506,26 +595,9 @@ fn simple_error(message: String) -> wit::Error {
 pub fn validate(source: &str) -> out::ValidateResult {
     let load = ffi::helpers::load_source(source);
     let parse_error_count = load.errors.iter().filter(|e| e.phase == "parse").count();
+    let (validation_errs, _actuals) = semantic_validation_errors(&load);
     let mut errors = load.errors;
-
-    // Only run semantic validation when there are no syntactic errors.
-    if parse_error_count == 0 {
-        let today = jiff::Zoned::now().date();
-        let session = rustledger_validate::ValidationSession::new(
-            rustledger_validate::ValidationOptions::default(),
-        );
-        let (session, mut verrs) = session.run_early_spanned(&load.spanned_directives, today);
-        let (session, late) = session.run_late_spanned(&load.spanned_directives, today);
-        verrs.extend(late);
-        verrs.extend(session.finalize());
-        for err in verrs {
-            let mut e = ffi::Error::new(&err.message).validate_phase();
-            if let Some(span) = err.span {
-                e = e.with_line(load.line_lookup.byte_to_line(span.start));
-            }
-            errors.push(e);
-        }
-    }
+    errors.extend(validation_errs);
 
     let validate_error_count = errors.iter().filter(|e| e.phase == "validate").count();
     out::ValidateResult {
@@ -1490,8 +1562,7 @@ mod tests {
         m.user
             .iter()
             .find(|(k, _)| k == key)
-            .map(|(_, v)| v)
-            .unwrap_or_else(|| panic!("missing meta key {key}"))
+            .map_or_else(|| panic!("missing meta key {key}"), |(_, v)| v)
     }
 
     fn load() -> (Vec<Directive>, Vec<u32>) {

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -44,9 +44,11 @@ use exports::rustledger::ledger::ledger::{
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. Bumped to 3.0 for the
-/// breaking `expand-pads` parameter added to `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.0";
+/// The Component-Model api-version this build implements. 3.1 adds the `diff`
+/// field on `balance-dir` (computed − asserted) so consumers can render
+/// per-assertion pass/fail (#1663); 3.0 was the breaking `expand-pads` parameter
+/// added to `load`/`load-file` (#1628).
+const API_VERSION: &str = "3.1";
 
 struct Component;
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.0.0;
+package rustledger:ledger@3.1.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -114,6 +114,12 @@ interface types {
     account: string,
     amount: amount,
     tolerance: option<string>,
+    // `computed - asserted` in the asserted currency, when the assertion was
+    // checked (present on `load`/`load-file` and `validate`; `none` if load had
+    // parse errors or the account is unknown). Zero means the assertion matched
+    // exactly; non-zero means it failed. Lets UIs render per-assertion pass/fail
+    // without re-deriving the balance. Added in 3.1.0 (#1663).
+    diff: option<amount>,
     meta: meta,
   }
   record pad-dir {

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -295,6 +295,25 @@ struct PendingPad {
     location: Option<(rustledger_parser::Span, u16)>,
 }
 
+/// The computed result of a `balance` assertion, recorded during Late
+/// validation (#1663).
+///
+/// `diff` is `computed − asserted` in the asserted currency — zero means the
+/// assertion matched exactly. Exposed via [`ValidationSession::balance_actuals`]
+/// so the FFI `load` surface (and any consumer) can render per-assertion
+/// pass/fail without re-deriving the balance from scratch.
+#[derive(Debug, Clone)]
+pub struct BalanceActual {
+    /// The `balance` directive's date.
+    pub date: NaiveDate,
+    /// The asserted account.
+    pub account: Account,
+    /// The asserted currency.
+    pub currency: rustledger_core::Currency,
+    /// `computed − asserted` in `currency` (zero = exact match).
+    pub diff: rustledger_core::Decimal,
+}
+
 /// Ledger state for validation.
 #[derive(Debug, Default)]
 pub struct LedgerState {
@@ -340,6 +359,10 @@ pub struct LedgerState {
     /// keyed by source identity so a different posting that merely shares an
     /// account/date is still reported.
     pub(crate) account_not_open_early: FxHashSet<(u16, rustledger_core::Span)>,
+    /// Per-`balance`-assertion computed result recorded during Late validation:
+    /// `diff = computed − asserted`. Lets consumers render per-assertion pass/fail
+    /// without re-deriving the balance (#1663).
+    pub(crate) balance_actuals: Vec<BalanceActual>,
 }
 
 impl LedgerState {
@@ -944,6 +967,18 @@ pub use phase::{EarlyDone, LateDone, Pending, SessionPhase};
 pub struct ValidationSession<P: SessionPhase = Pending> {
     state: LedgerState,
     _phase: std::marker::PhantomData<P>,
+}
+
+impl<P: SessionPhase> ValidationSession<P> {
+    /// The per-`balance`-assertion computed results recorded during Late
+    /// validation (`diff = computed − asserted`). Populated by the Late balance
+    /// check; call after `run_late`/`run_late_spanned`. Lets consumers (the FFI
+    /// `load` surface) render per-assertion pass/fail without re-deriving the
+    /// balance — #1663.
+    #[must_use]
+    pub fn balance_actuals(&self) -> &[BalanceActual] {
+        &self.state.balance_actuals
+    }
 }
 
 impl ValidationSession<Pending> {

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -238,6 +238,17 @@ pub fn validate_balance_late(
     let expected = bal.amount.number;
     let difference = (actual - expected).abs();
 
+    // Record the computed result so consumers can render per-assertion pass/fail
+    // without re-deriving the balance (#1663). `diff` is signed (`computed −
+    // asserted`); this is the validator's own `actual`, so the load/validate
+    // surfaces can't diverge from the check.
+    state.balance_actuals.push(crate::BalanceActual {
+        date: bal.date,
+        account: bal.account.clone(),
+        currency: bal.amount.currency.clone(),
+        diff: actual - expected,
+    });
+
     // Determine tolerance via the shared helper so out-of-pipeline
     // consumers (LSP code lens) and the validator stay in lockstep.
     let is_explicit = bal.tolerance.is_some();


### PR DESCRIPTION
Closes #1663. **Breaking WIT change: `rustledger:ledger` 3.0.0 → 3.1.0** — rustfava must regenerate bindings.

## Part 1 — `load`/`load-file` now report balance-assertion failures (correctness)
`load`/`load_file` ran only parse + booking; semantic checks (balance assertions are a Late check) lived only in `validate`. So an embedder that loads via `load` (rustfava) got `errors: []` for a failing `balance` — a **silent correctness failure**. Now `load`/`load_file` run the same `ValidationSession` as `validate` (shared `semantic_validation_errors` helper), matching beancount's `loader.load_file`. `query`/`clamp` stay validation-free (they operate on an already-loaded ledger).

## Part 2 — `balance-dir.diff` (UX)
`balance-dir` gains `diff: option<amount>` = **computed − asserted** in the asserted currency (zero = matched exactly, non-zero = failed; `none` if not checked). UIs can render per-assertion pass/fail without re-deriving the balance.

Crucially, the value comes from the **validator's own computed `actual`** — `rustledger-validate` records `BalanceActual` during the Late balance check (exposed via `ValidationSession::balance_actuals()`), and `convert` stamps it. **No re-derivation**, so this can't drift from the check (the recurring lesson from #1648/#1656/`@@`).

## Tests
- Load-vs-validate parity: the repro (`balance Assets:Cash 999 USD` when it's really `-5 USD`) surfaces the failing balance in `load`'s `errors` **and** the directive carries `diff = -1004 USD`.
- 92 `rustledger-validate` + 18 FFI parity tests pass; clippy `-D warnings` + fmt clean. The WIT 3.1.0 record change broke none of the 16 existing parity tests.

## Release note
This is a **breaking FFI/WIT change** (3.1.0) — it'll want a **0.18.0** release, and rustfava must regenerate its component bindings to pick up `balance-dir.diff` and the `load`-reports-balances behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
