### PR TITLE
fix(booking,validate): lot-label on reduction + balance currency + dedup oversell (#1666, #1668)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -294,14 +294,23 @@ impl BookingEngine {
                                                 .and_then(|c| c.date),
                                         );
 
-                                // Update posting with filled cost
+                                // Update posting with filled cost. Carry the
+                                // matched lot's label (as the date already is) so
+                                // the reduction shares lot identity with its
+                                // augmenting lot and nets against it — otherwise a
+                                // labeled reduction leaves a phantom unlabeled
+                                // negative lot in the holdings view (#1666).
                                 result.postings[idx].cost = Some(CostSpec {
                                     number: Some(rustledger_core::CostNumber::PerUnit {
                                         value: matched_cost.number,
                                     }),
                                     currency: Some(matched_cost.currency.clone()),
                                     date: matched_cost.date,
-                                    label: None,
+                                    label: booking_result
+                                        .matched
+                                        .first()
+                                        .and_then(|p| p.cost.as_ref())
+                                        .and_then(|c| c.label.clone()),
                                     merge: false,
                                 });
                                 booked_indices.insert(idx);
@@ -685,6 +694,55 @@ mod tests {
         // Check inventory
         let inv = engine.inventory(&"Assets:Stock".into()).unwrap();
         assert_eq!(inv.units("AAPL"), dec!(10));
+    }
+
+    #[test]
+    fn test_reduction_carries_matched_lot_label() {
+        // #1666: reducing a labeled lot must carry that lot's label onto the
+        // reduction posting so it nets against the augmenting lot, instead of
+        // leaving a phantom unlabeled negative lot in the holdings view.
+        let mut engine = BookingEngine::new();
+
+        let buy = |label: &str| {
+            let mut cost = CostSpec::empty()
+                .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(10) })
+                .with_currency("USD");
+            cost.label = Some(label.to_string());
+            Transaction::new(date(2020, 2, 1), "buy")
+                .with_synthesized_posting(
+                    Posting::new("Assets:S", Amount::new(dec!(10), "X")).with_cost(cost),
+                )
+                .with_synthesized_posting(Posting::new(
+                    "Assets:Cash",
+                    Amount::new(dec!(-100), "USD"),
+                ))
+        };
+        engine.apply(&buy("lot-a"));
+        engine.apply(&buy("lot-b"));
+
+        // Sell 5 X explicitly from lot-b.
+        let mut sell_cost = CostSpec::empty()
+            .with_number(rustledger_core::CostNumber::PerUnit { value: dec!(10) })
+            .with_currency("USD");
+        sell_cost.label = Some("lot-b".to_string());
+        let sell = Transaction::new(date(2020, 4, 1), "sell from lot-b")
+            .with_synthesized_posting(
+                Posting::new("Assets:S", Amount::new(dec!(-5), "X")).with_cost(sell_cost),
+            )
+            .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(50), "USD")));
+
+        let result = engine
+            .book_and_interpolate(&sell)
+            .expect("sell should book against lot-b");
+        let label = result.transaction.postings[0]
+            .cost
+            .as_ref()
+            .and_then(|c| c.label.clone());
+        assert_eq!(
+            label.as_deref(),
+            Some("lot-b"),
+            "reduction posting must carry the matched lot's label (#1666)"
+        );
     }
 
     #[test]

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -800,3 +800,45 @@ fn load_reports_balance_assertion_failure() -> Result<()> {
     );
     Ok(())
 }
+
+/// #1668: an oversell reports the "Not enough units" error exactly ONCE via
+/// `load`. Booking (run inside `load_source`) already reports it with
+/// transaction context; the validation session's context-free reduce-check
+/// (a standalone-validation safety net) must not duplicate it.
+#[test]
+fn load_oversell_reports_single_error() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let src = "\
+2020-01-01 open Assets:S
+2020-01-01 open Assets:Cash
+2020-02-01 * \"buy\"
+  Assets:S   5 X {10 USD}
+  Assets:Cash
+2020-03-01 * \"oversell\"
+  Assets:S   -10 X {10 USD}
+  Assets:Cash   100 USD
+";
+    let loaded = inst
+        .rustledger_ledger_ledger()
+        .call_load(&mut store, src, "<stdin>", false)?;
+    let n = loaded
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("Not enough units"))
+        .count();
+    assert_eq!(
+        n,
+        1,
+        "oversell must report 'Not enough units' exactly once (#1668); got {n}: {:?}",
+        loaded
+            .errors
+            .iter()
+            .map(|e| e.message.clone())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -326,8 +326,24 @@ fn semantic_validation_errors(
     // the session.
     let actuals = session.balance_actuals().to_vec();
     verrs.extend(session.finalize());
+    // `load_source` already ran booking, which reports reduction failures
+    // (insufficient units / no-matching-lot / ambiguous match) WITH transaction
+    // context. The validation session re-derives the same failures context-free
+    // (its reduce-check is a standalone-validation safety net), so a fresh error
+    // here would duplicate the one already in `loaded.errors` — once with
+    // context, once without (#1668). Drop a session error when a load error is
+    // identical or is that message followed by booking's ` (date, "narration")`
+    // suffix.
+    let load_msgs: Vec<&str> = loaded.errors.iter().map(|e| e.message.as_str()).collect();
+    let is_dup_of_booking = |msg: &str| {
+        let with_ctx = format!("{msg} (");
+        load_msgs
+            .iter()
+            .any(|lm| *lm == msg || lm.starts_with(&with_ctx))
+    };
     let errors = verrs
         .into_iter()
+        .filter(|err| !is_dup_of_booking(&err.message))
         .map(|err| {
             let mut e = ffi::Error::new(&err.message).validate_phase();
             if let Some(span) = err.span {

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -1494,6 +1494,53 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_balance_wrong_currency() {
+        // #1668: a balance asserted in a currency the account doesn't allow is
+        // flagged with a dedicated diagnostic (not only "Balance failed").
+        let directives = vec![
+            Directive::Open(
+                Open::new(date(2024, 1, 1), "Assets:Cash").with_currencies(vec!["USD".into()]),
+            ),
+            Directive::Balance(Balance::new(
+                date(2024, 3, 1),
+                "Assets:Cash",
+                Amount::new(dec!(100), "EUR"),
+            )),
+        ];
+        let errors = validate(&directives);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == ErrorCode::CurrencyNotAllowed
+                    && e.message.contains("for Balance directive")),
+            "balance in a non-allowed currency should be flagged (#1668); got: {:?}",
+            errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_validate_balance_currency_allowed_when_unconstrained() {
+        // An account opened without a currency constraint allows any balance
+        // currency — no false positive (#1668).
+        let directives = vec![
+            Directive::Open(Open::new(date(2024, 1, 1), "Assets:Cash")),
+            Directive::Balance(Balance::new(
+                date(2024, 3, 1),
+                "Assets:Cash",
+                Amount::new(dec!(0), "EUR"),
+            )),
+        ];
+        let errors = validate(&directives);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.code == ErrorCode::CurrencyNotAllowed),
+            "unconstrained account must not flag balance currency (#1668); got: {:?}",
+            errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_validate_future_date_warning() {
         // Anchor "today" so this test isn't time-dependent. The
         // directive is 30 days after the anchor — unambiguously in

--- a/crates/rustledger-validate/src/validators/balance.rs
+++ b/crates/rustledger-validate/src/validators/balance.rs
@@ -99,6 +99,34 @@ pub fn validate_balance_early(
     errors: &mut Vec<ValidationError>,
 ) {
     require_account_open(state, &bal.account, bal.date, "Account", errors);
+
+    // Flag a balance asserted in a currency the account doesn't allow. Without
+    // this, the only signal is a confusing "Balance failed ... got 0 EUR" (the
+    // account simply holds no EUR); beancount emits a dedicated "invalid
+    // currency for Balance" diagnostic. Only when the account constrains its
+    // currencies (empty set = any currency allowed), matching the transaction
+    // currency check — #1668.
+    if let Some(account_state) = state.accounts.get(&bal.account)
+        && !account_state.currencies.is_empty()
+        && !account_state.currencies.contains(&bal.amount.currency)
+    {
+        let mut allowed: Vec<String> = account_state
+            .currencies
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        allowed.sort();
+        errors.push(ValidationError::new(
+            ErrorCode::CurrencyNotAllowed,
+            format!(
+                "Invalid currency {} for Balance directive on {} (account holds {})",
+                bal.amount.currency,
+                bal.account,
+                allowed.join(", ")
+            ),
+            bal.date,
+        ));
+    }
 }
 
 /// Late-phase balance validation — runs after booking + plugins.


### PR DESCRIPTION
Fixes surfaced by differential-testing rustfava against beancount.

## #1666 — reduction drops the matched lot's label (holdings bug) — Closes #1666
Reducing a **labeled** cost lot emitted the reduction with `label: null`, so it didn't share lot identity with its augmenting lot and left a **phantom unlabeled negative lot** in the holdings view (aggregates stayed correct). Root cause: the **single-lot** reduction path in `book.rs` set `label: None`, while the multi-lot path already preserved it. Fix carries the matched lot's label (as the date already was).

Before: `10 X {lot-a}` + `10 X {lot-b}` + `-5 X {no label}` — After: `10 X {lot-a}` + `5 X {lot-b}` ✓ (matches beancount).

## #1668 #2 — balance directive currency not validated
`balance Assets:Cash 100 EUR` on a USD account only gave a confusing `Balance failed … got 0 EUR`. Added a dedicated **`Invalid currency EUR for Balance directive on Assets:Cash (account holds USD)`** diagnostic in `validate_balance_early`, mirroring the transaction currency check — only when the account constrains its currencies (empty = any).

## #1668 #1 — duplicate "Not enough units" on oversell (FFI)
An oversell reported the error **twice** via the FFI: booking (inside `load_source`) reports it **with** transaction context, and the #1663 validation session re-derives it **context-free** (its reduce-check is a standalone-validation safety net). Now the session's copy is dropped when a load error already conveys it. The **CLI never doubled** — it partitions booking-failed txns out before late validation; this was FFI-only.

## #1668 #3 — duplicate `open` across includes — investigated, **no change needed**
Does **not** reproduce: the CLI already flags it (`E1002 Account … already open`, reproduced), and **#1663 made the FFI `load` path validate** (it now runs the full `ValidationSession`, including `validate_open`), so `load` catches it too. The report reflects the **pre-#1663 non-validating `load`**. Safe to close as resolved in v0.18.0.

## Tests
- Booking: a labeled reduction carries its lot's label and nets (`test_reduction_carries_matched_lot_label`).
- Validate: balance wrong-currency flagged; unconstrained account not falsely flagged.
- FFI parity: oversell reports "Not enough units" **exactly once** via `load`.
- 94 validate + 106 booking + 19 FFI parity pass; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
