### PR TITLE
feat(ffi)!: decrypt encrypted ledgers via a host capability (#1667, WIT 3.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,7 @@ dependencies = [
  "rustledger-booking",
  "rustledger-core",
  "rustledger-ffi-wasi",
+ "rustledger-loader",
  "rustledger-ops",
  "rustledger-parser",
  "rustledger-query",

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -39,6 +39,22 @@ impl WasiView for Host {
     }
 }
 
+/// A fixed "decrypted" ledger the test host returns for any ciphertext — this
+/// exercises the `host.decrypt` import plumbing (#1667) without depending on a
+/// real gpg binary or keyring in the test environment.
+const DECRYPTED_LEDGER: &str = "\
+2024-01-01 open Assets:Secret USD
+2024-01-02 * \"decrypted-by-host\"
+  Assets:Secret  42 USD
+  Equity:Opening-Balances
+";
+
+impl rustledger::ledger::host::Host for Host {
+    fn decrypt(&mut self, _ciphertext: Vec<u8>) -> Result<String, String> {
+        Ok(DECRYPTED_LEDGER.to_string())
+    }
+}
+
 fn component_path() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../target/wasm32-wasip2/debug/rustledger_ffi_component.wasm")
@@ -49,6 +65,10 @@ fn instantiate() -> Result<(Store<Host>, Rustledger)> {
     let component = Component::from_file(&engine, component_path())?;
     let mut linker = Linker::<Host>::new(&engine);
     wasmtime_wasi::p2::add_to_linker_sync(&mut linker)?;
+    rustledger::ledger::host::add_to_linker::<_, wasmtime::component::HasSelf<Host>>(
+        &mut linker,
+        |h| h,
+    )?;
     let mut store = Store::new(
         &engine,
         Host {
@@ -67,6 +87,10 @@ fn instantiate_in(host_dir: &std::path::Path) -> Result<(Store<Host>, Rustledger
     let component = Component::from_file(&engine, component_path())?;
     let mut linker = Linker::<Host>::new(&engine);
     wasmtime_wasi::p2::add_to_linker_sync(&mut linker)?;
+    rustledger::ledger::host::add_to_linker::<_, wasmtime::component::HasSelf<Host>>(
+        &mut linker,
+        |h| h,
+    )?;
     let wasi = WasiCtxBuilder::new()
         .preopened_dir(host_dir, "/work", DirPerms::READ, FilePerms::READ)?
         .build();
@@ -834,6 +858,52 @@ fn load_oversell_reports_single_error() -> Result<()> {
         n,
         1,
         "oversell must report 'Not enough units' exactly once (#1668); got {n}: {:?}",
+        loaded
+            .errors
+            .iter()
+            .map(|e| e.message.clone())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// #1667: an encrypted (`.gpg`) ledger loads through the component by delegating
+/// decryption to the `host.decrypt` import — the WASI sandbox can neither spawn
+/// `gpg` nor reach the keyring. The test host returns `DECRYPTED_LEDGER` for any
+/// ciphertext; we assert that plaintext is what gets parsed.
+#[test]
+fn load_file_decrypts_via_host_import() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let dir = tempfile::tempdir()?;
+    // Content is irrelevant — the `.gpg` extension marks the file as encrypted,
+    // and the test host returns a fixed plaintext for any bytes.
+    std::fs::write(
+        dir.path().join("ledger.beancount.gpg"),
+        b"not-really-gpg-ciphertext",
+    )?;
+    let (mut store, inst) = instantiate_in(dir.path())?;
+    let loaded = inst.rustledger_ledger_ledger().call_load_file(
+        &mut store,
+        "/work/ledger.beancount.gpg",
+        false,
+        &[],
+        false,
+    )?;
+    // The host-decrypted ledger opens Assets:Secret — proof the plaintext from
+    // `host.decrypt` is what got parsed (versus the old `failed to decrypt`).
+    let has_secret = loaded.entries.iter().any(|d| {
+        matches!(
+            d,
+            rustledger::ledger::types::Directive::Open(o) if o.account == "Assets:Secret"
+        )
+    });
+    assert!(
+        has_secret,
+        "encrypted ledger must load via host.decrypt (#1667); {} entries, errors: {:?}",
+        loaded.entries.len(),
         loaded
             .errors
             .iter()

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 jiff.workspace = true
 rustledger-booking.workspace = true
 rustledger-core.workspace = true
+rustledger-loader.workspace = true
 rustledger-ops.workspace = true
 rustledger-parser.workspace = true
 rustledger-query.workspace = true

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -738,6 +738,66 @@ fn read_file(path: &str) -> Result<String, String> {
 /// `allow_unrestricted_includes == true` lifts that path-traversal protection
 /// (so the safe state is the `false`/zero default). The flag is negated into
 /// the loader's `path_security` at the boundary.
+/// A filesystem that reads from the WASI-preopened disk but delegates GPG
+/// decryption to the **host** via the `host.decrypt` import.
+///
+/// A WASI guest can neither spawn `gpg` nor reach the user's keyring, so
+/// `.gpg`/`.asc` inputs can't be decrypted in the sandbox. The embedder (which
+/// runs natively and holds that authority) satisfies the import — the
+/// capability-passing pattern the WASI/component model is built around (#1667).
+#[derive(Debug)]
+struct HostDecryptFs(rustledger_loader::DiskFileSystem);
+
+impl rustledger_loader::FileSystem for HostDecryptFs {
+    fn read(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<std::sync::Arc<str>, rustledger_loader::LoadError> {
+        self.0.read(path)
+    }
+
+    fn exists(&self, path: &std::path::Path) -> bool {
+        self.0.exists(path)
+    }
+
+    fn is_encrypted(&self, path: &std::path::Path) -> bool {
+        self.0.is_encrypted(path)
+    }
+
+    fn normalize(&self, path: &std::path::Path) -> std::path::PathBuf {
+        self.0.normalize(path)
+    }
+
+    fn supports_parallel_read(&self) -> bool {
+        self.0.supports_parallel_read()
+    }
+
+    fn glob(&self, pattern: &str) -> Result<Vec<std::path::PathBuf>, String> {
+        self.0.glob(pattern)
+    }
+
+    fn decrypt(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<std::sync::Arc<str>, rustledger_loader::LoadError> {
+        // Read the ciphertext from the sandbox, then hand it to the host to
+        // decrypt with its keyring (the guest cannot) — #1667.
+        let ciphertext =
+            std::fs::read(path).map_err(|e| rustledger_loader::LoadError::Decryption {
+                path: path.to_path_buf(),
+                message: format!("failed to read encrypted file: {e}"),
+            })?;
+        let plaintext =
+            crate::rustledger::ledger::host::decrypt(&ciphertext).map_err(|message| {
+                rustledger_loader::LoadError::Decryption {
+                    path: path.to_path_buf(),
+                    message,
+                }
+            })?;
+        Ok(std::sync::Arc::from(plaintext))
+    }
+}
+
 pub fn load_file(
     path: &str,
     allow_unrestricted_includes: bool,
@@ -747,7 +807,10 @@ pub fn load_file(
     // The loader takes `path_security` (true = confine includes); the WIT flag
     // is inverted so the safe state is the `false`/zero default.
     let path_security = !allow_unrestricted_includes;
-    match ffi::helpers::load_file(std::path::Path::new(path), path_security) {
+    // Inject a filesystem that routes GPG decryption to the `host.decrypt`
+    // import — the sandbox can't run gpg or read the keyring (#1667).
+    let fs = Box::new(HostDecryptFs(rustledger_loader::DiskFileSystem));
+    match ffi::helpers::load_file_with_fs(std::path::Path::new(path), path_security, Some(fs)) {
         Ok(fl) => {
             let mut errors = fl.errors;
             let opts = fl.options;

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -44,11 +44,12 @@ use exports::rustledger::ledger::ledger::{
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. 3.1 adds the `diff`
-/// field on `balance-dir` (computed − asserted) so consumers can render
-/// per-assertion pass/fail (#1663); 3.0 was the breaking `expand-pads` parameter
-/// added to `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.1";
+/// The Component-Model api-version this build implements. 3.2 adds the
+/// `host.decrypt` import so encrypted (`.gpg`/`.asc`) ledgers can be decrypted by
+/// the host — a WASI guest can't reach the keyring (#1667). 3.1 added the `diff`
+/// field on `balance-dir` (#1663); 3.0 was the breaking `expand-pads` parameter
+/// on `load`/`load-file` (#1628).
+const API_VERSION: &str = "3.2";
 
 struct Component;
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.1.0;
+package rustledger:ledger@3.2.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -542,8 +542,23 @@ interface format {
   format-entries: func(entries: list<input-directive>) -> result<string, string>;
 }
 
+/// Capabilities the host provides to the component.
+interface host {
+  /// Decrypt an encrypted ledger file on the host — e.g. via the user's GPG
+  /// keyring. A WASI guest can neither spawn `gpg` nor reach the keyring, so
+  /// decryption of `.gpg`/`.asc` inputs is delegated to the host (#1667). Given
+  /// the file's ciphertext bytes, returns the decrypted UTF-8 text, or an error
+  /// message on failure. Added in 3.2.0.
+  ///
+  /// A host that does not support encrypted ledgers may return an error; the
+  /// component only calls this when loading a file it detects as encrypted.
+  decrypt: func(ciphertext: list<u8>) -> result<string, string>;
+}
+
 /// The component a host instantiates.
 world rustledger {
+  import host;
+
   export ledger;
   export builder;
   export util;

--- a/crates/rustledger-ffi-wasi/src/helpers.rs
+++ b/crates/rustledger-ffi-wasi/src/helpers.rs
@@ -340,6 +340,25 @@ pub fn expand_pads<T: Clone>(
 ///
 /// Returns the loader error string if the entry file cannot be read/parsed.
 pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad, String> {
+    load_file_with_fs(path, path_security, None)
+}
+
+/// Like [`load_file`], but with an optional caller-provided
+/// [`FileSystem`](rustledger_loader::FileSystem).
+///
+/// The WASI component passes a filesystem whose `decrypt` delegates to a host
+/// capability, so GPG-encrypted ledgers load in the sandbox (the guest can
+/// neither spawn `gpg` nor reach the keyring) — #1667. `None` uses the default
+/// on-disk filesystem (gpg via subprocess), matching the native path.
+///
+/// # Errors
+///
+/// Returns a message if loading fails.
+pub fn load_file_with_fs(
+    path: &std::path::Path,
+    path_security: bool,
+    fs: Option<Box<dyn rustledger_loader::FileSystem>>,
+) -> Result<FileLoad, String> {
     // Route through the single canonical pipeline (`process::load`:
     // sort → synth → book → regular → finalize) rather than re-implementing a
     // partial loader here. This keeps the FFI surface in lock-step with the
@@ -356,8 +375,11 @@ pub fn load_file(path: &std::path::Path, path_security: bool) -> Result<FileLoad
         validate: false,
         ..Default::default()
     };
-    let ledger =
-        rustledger_loader::load(path, &options).map_err(|e| format!("Failed to load file: {e}"))?;
+    let ledger = match fs {
+        Some(fs) => rustledger_loader::load_with_fs(path, &options, fs),
+        None => rustledger_loader::load(path, &options),
+    }
+    .map_err(|e| format!("Failed to load file: {e}"))?;
 
     // Directives + their line numbers / originating files (multi-file).
     // Synth-generated directives carry a `file_id` absent from the source map,

--- a/crates/rustledger-loader/src/lib.rs
+++ b/crates/rustledger-loader/src/lib.rs
@@ -83,7 +83,7 @@ pub fn is_glob_pattern(path: &str) -> bool {
 #[cfg(any(feature = "booking", feature = "plugins", feature = "validation"))]
 pub use process::{
     ErrorLocation, ErrorSeverity, ExtraPlugin, Ledger, LedgerError, LoadOptions, ProcessError,
-    load, load_raw, process,
+    load, load_raw, load_with_fs, process,
 };
 #[cfg(feature = "plugins")]
 pub use process::{PluginPass, run_plugins};
@@ -244,7 +244,7 @@ pub struct Plugin {
 ///
 /// This uses `gpg --batch --decrypt` which will use the user's
 /// GPG keyring and gpg-agent for passphrase handling.
-fn decrypt_gpg_file(path: &Path) -> Result<String, LoadError> {
+pub(crate) fn decrypt_gpg_file(path: &Path) -> Result<String, LoadError> {
     let output = Command::new("gpg")
         .args(["--batch", "--decrypt"])
         .arg(path)
@@ -480,7 +480,10 @@ impl Loader {
             pre
         } else {
             let src: std::sync::Arc<str> = if self.fs.is_encrypted(path) {
-                decrypt_gpg_file(path)?.into()
+                // Route decryption through the filesystem so a sandboxed fs (the
+                // WASI component) can delegate to a host capability (#1667); the
+                // default impl shells out to gpg.
+                self.fs.decrypt(path)?
             } else {
                 self.fs.read(path)?
             };

--- a/crates/rustledger-loader/src/process.rs
+++ b/crates/rustledger-loader/src/process.rs
@@ -1465,6 +1465,31 @@ pub fn load(path: &Path, options: &LoadOptions) -> Result<Ledger, ProcessError> 
     process(raw, options)
 }
 
+/// Like [`load`], but with a caller-provided [`FileSystem`](crate::FileSystem).
+///
+/// Lets the WASI component inject a filesystem whose
+/// [`decrypt`](crate::FileSystem::decrypt) delegates to a host capability, so
+/// GPG-encrypted ledgers load in the sandbox (a WASI guest can neither spawn
+/// `gpg` nor reach the keyring) — #1667.
+///
+/// # Errors
+///
+/// Returns a [`ProcessError`] if loading or processing fails.
+pub fn load_with_fs(
+    path: &Path,
+    options: &LoadOptions,
+    fs: Box<dyn crate::FileSystem>,
+) -> Result<Ledger, ProcessError> {
+    let mut loader = crate::Loader::new().with_filesystem(fs);
+
+    if options.path_security {
+        loader = loader.with_path_security(true);
+    }
+
+    let raw = loader.load(path)?;
+    process(raw, options)
+}
+
 /// Load a beancount file without processing.
 ///
 /// This returns raw directives without sorting, booking, or plugins.

--- a/crates/rustledger-loader/src/vfs.rs
+++ b/crates/rustledger-loader/src/vfs.rs
@@ -56,6 +56,22 @@ pub trait FileSystem: Send + Sync + std::fmt::Debug {
         let _ = pattern;
         Err("glob is not supported by this filesystem".to_string())
     }
+
+    /// Decrypt an encrypted file at `path`, returning its plaintext.
+    ///
+    /// The default implementation shells out to `gpg --batch --decrypt` — the
+    /// native path, which uses the user's keyring and gpg-agent. Sandboxed
+    /// filesystems (the WASI component) override this to delegate to a host
+    /// capability, since a WASI guest can neither spawn `gpg` nor reach the
+    /// keyring (#1667). Only called when [`is_encrypted`](Self::is_encrypted)
+    /// returned `true`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoadError::Decryption`] if decryption fails.
+    fn decrypt(&self, path: &Path) -> Result<Arc<str>, LoadError> {
+        crate::decrypt_gpg_file(path).map(Arc::from)
+    }
 }
 
 /// Default filesystem that reads from disk.


### PR DESCRIPTION
Closes #1667. **Breaking WIT change: `rustledger:ledger` 3.1.0 → 3.2.0** — adds the `host.decrypt` import; embedders (rustfava) must provide it.

## Problem
GPG-encrypted ledgers (`.gpg`/`.asc`) were *detected* but couldn't be *decrypted* through the WASI component — decryption shells out to `gpg` (`Command::new`), which a WASI guest can't do (no process spawn, no keyring). Load failed with `failed to decrypt`, so encrypted ledgers were unusable via the component (rustfava).

## Approach — decryption as a host capability (b2)
Grounded in prior art + best practice (see the #1667 discussion): the WASI capability model says the host mediates authority **including secrets**, and beancount itself decrypts on the host (`gpg --batch --decrypt`) then loads the plaintext. So decryption belongs to the host, not the sandbox — and secret keys should never enter the guest.

This implements the clean component-model idiom: the component **imports** a `decrypt` capability the host satisfies.

- **loader**: `FileSystem::decrypt` trait method — **default shells out to gpg**, so the native CLI path is unchanged. New `process::load_with_fs` for filesystem injection.
- **wit** (`3.2.0`): `interface host { decrypt: func(ciphertext: list<u8>) -> result<string, string> }` + `import host`.
- **ffi-component**: `HostDecryptFs` reads the ciphertext in-sandbox (WASI fs) and calls `host.decrypt`; `load_file` injects it.
- **ffi-wasi**: `load_file_with_fs` threads the caller-provided filesystem.

`load-file` keeps handling encryption transparently — the keyring authority just lives in the host now.

## Breaking host-contract change
The component now **imports** `host.decrypt`, so an embedder must provide it in its wasmtime linker — e.g.:
```rust
rustledger::ledger::host::add_to_linker::<_, HasSelf<Host>>(&mut linker, |h| h)?;
// impl Host { fn decrypt(&mut self, ct: Vec<u8>) -> Result<String,String> { /* gpg / gpgme */ } }
```
rustfava must add this to load encrypted ledgers. **The native CLI is unaffected** (it uses the loader's default gpg path).

## Tests
- An encrypted `.gpg` file loads via a host-provided `decrypt` (the test host returns a fixed plaintext — no real gpg/keyring needed in CI).
- 92 loader + 19 FFI parity tests pass; clippy `-D warnings` + fmt clean; the `version_matches_wit_package` gate confirms `API_VERSION 3.2` ↔ WIT `3.2.0`.

## Release
Breaking FFI/WIT → wants a **0.19.0**; rustfava then adds the `host.decrypt` provider and regenerates bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
