### PR TITLE
chore: release v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "agcli",
  "anyhow",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3447,11 +3447,11 @@ dependencies = [
 
 [[package]]
 name = "rustledger-completion"
-version = "0.18.0"
+version = "0.19.0"
 
 [[package]]
 name = "rustledger-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "imbl",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "jiff",
  "rustledger-booking",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component-tests"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "rustledger-ffi-wasi",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.2",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "blake3",
  "glob",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "crossbeam-channel",
  "glob",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-only"
@@ -192,19 +192,19 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.18.0", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.18.0", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.18.0", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.18.0", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.18.0", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.18.0", path = "crates/rustledger-query" }
-rustledger-completion = { version = "0.18.0", path = "crates/rustledger-completion" }
-rustledger-plugin = { version = "0.18.0", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.18.0", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.18.0", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.18.0", path = "crates/rustledger-ops" }
-rustledger-ffi-wasi = { version = "0.18.0", path = "crates/rustledger-ffi-wasi" }
-rustledger-wasm = { version = "0.18.0", path = "crates/rustledger-wasm" }
+rustledger-core = { version = "0.19.0", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.19.0", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.19.0", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.19.0", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.19.0", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.19.0", path = "crates/rustledger-query" }
+rustledger-completion = { version = "0.19.0", path = "crates/rustledger-completion" }
+rustledger-plugin = { version = "0.19.0", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.19.0", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.19.0", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.19.0", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.19.0", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.19.0", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-completion"
 description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Slimmed FFI-support helpers reused by the rustledger WASI component FFI (loader orchestration + WIT-input construction + directive hashing; the wasip1 JSON-RPC surface and Directive-to-JSON DTO were removed in #1419)"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustledger/mcp-server",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustledger/mcp-server",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "MCP server for rustledger - validate, query, and format Beancount ledgers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Minor release carrying the **breaking FFI/WIT change** `rustledger:ledger 3.1.0 → 3.2.0` (#1667 / #1670):

- The component now **imports `host.decrypt`** — encrypted (`.gpg`/`.asc`) ledgers are decrypted by the embedder with its keyring; secret keys never enter the sandbox. ⚠️ **rustfava must provide the import in its wasmtime linker and regenerate bindings.**

Plus the diagnostics/booking fixes from #1669 (#1666, #1668): reductions keep the matched lot's label (no phantom holdings lot), dedicated invalid-currency-for-Balance diagnostic, deduped oversell error.

- `cargo set-version 0.19.0` + `packages/mcp-server` → 0.19.0

On merge: tag `v0.19.0`, drive Build → Publish → Channel Testing, and **verify all three workflows fully green** (incl. Test Nix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)