### PR TITLE
feat(cli): rledger explain — describe validation error codes

### DIFF
--- a/crates/rustledger-validate/src/error.rs
+++ b/crates/rustledger-validate/src/error.rs
@@ -189,6 +189,227 @@ impl ErrorCode {
         matches!(self, Self::AccountCloseNotEmpty)
     }
 
+    /// Parse a user-supplied code string (`"E2001"`, `"e2001"`, or bare
+    /// `"2001"`) into its variant. Backs `rledger explain`.
+    #[must_use]
+    pub fn from_code(code: &str) -> Option<Self> {
+        let digits = code
+            .trim()
+            .strip_prefix(['E', 'e'])
+            .unwrap_or_else(|| code.trim());
+        let normalized = format!("E{digits}");
+        Self::ALL.iter().find(|c| c.code() == normalized).copied()
+    }
+
+    /// A short human title for the code (one line). Backs `rledger explain`.
+    #[must_use]
+    pub const fn title(&self) -> &'static str {
+        match self {
+            Self::AccountNotOpen => "Account used before it was opened",
+            Self::AccountAlreadyOpen => "Duplicate open directive for an account",
+            Self::AccountClosed => "Account used after it was closed",
+            Self::AccountCloseNotEmpty => "Account closed with a non-zero balance",
+            Self::InvalidAccountName => "Invalid account name",
+            Self::BalanceAssertionFailed => "Balance assertion failed",
+            Self::BalanceToleranceExceeded => "Balance exceeds explicit tolerance",
+            Self::PadWithoutBalance => "Pad without a subsequent balance assertion",
+            Self::MultiplePadForBalance => "Multiple pads for the same balance assertion",
+            Self::TransactionUnbalanced => "Transaction does not balance",
+            Self::MultipleInterpolation => "Multiple postings missing amounts for one currency",
+            Self::NoPostings => "Transaction has no postings",
+            Self::SinglePosting => "Transaction has a single posting",
+            Self::NoMatchingLot => "No matching lot for reduction",
+            Self::InsufficientUnits => "Not enough units in matching lots",
+            Self::AmbiguousLotMatch => "Ambiguous lot match under STRICT booking",
+            Self::NegativeCost => "Negative cost",
+            Self::UndeclaredCurrency => "Currency used without a commodity declaration",
+            Self::CurrencyNotAllowed => "Currency not allowed in this account",
+            Self::InvalidPrecisionMetadata => "Invalid precision metadata on commodity",
+            Self::UnknownOption => "Unknown option name",
+            Self::InvalidOptionValue => "Invalid option value",
+            Self::DuplicateOption => "Non-repeatable option given more than once",
+            Self::DocumentNotFound => "Document file not found",
+            Self::DateOutOfOrder => "Directive date out of order",
+            Self::FutureDate => "Directive dated in the future",
+        }
+    }
+
+    /// A detailed explanation of the code — what it means, its common cause,
+    /// and how to fix it. Backs `rledger explain`, mirroring
+    /// `rustc --explain`.
+    ///
+    /// Kept as code constants (not `include_str!` from `spec/core/`) so the
+    /// binary is self-contained: published crates don't package `spec/`, and
+    /// the Nix flake's source filter strips it. The exhaustive match means
+    /// adding a variant forces adding its explanation, and the
+    /// `error_codes_documented_in_spec` test guards that every code is also
+    /// documented in the spec.
+    #[must_use]
+    pub const fn explanation(&self) -> &'static str {
+        match self {
+            Self::AccountNotOpen => {
+                "A posting or directive references an account with no prior `open` \
+                 directive.\n\nEvery account must be opened on or before the date it is \
+                 first used:\n\n    2024-01-01 open Assets:Bank:Checking USD\n\nFix: add \
+                 an `open` directive dated on or before the first use, or correct a \
+                 misspelled account name."
+            }
+            Self::AccountAlreadyOpen => {
+                "An `open` directive targets an account that is already open.\n\nThis \
+                 is usually a duplicated line — often the same `open` appearing in both \
+                 a main file and an `include`d file.\n\nFix: remove the duplicate \
+                 `open` (keep the earliest one)."
+            }
+            Self::AccountClosed => {
+                "A posting or directive references an account after its `close` \
+                 directive.\n\nFix: move the transaction before the close date, remove \
+                 the `close`, or use a different account."
+            }
+            Self::AccountCloseNotEmpty => {
+                "A `close` directive targets an account that still holds a non-zero \
+                 balance.\n\nAdvisory only: `check` stays silent to match `bean-check`; \
+                 surface it on demand with `rledger lint closed-nonempty`.\n\nFix: zero \
+                 the account (transfer the residual) before closing it."
+            }
+            Self::InvalidAccountName => {
+                "An account name does not match the required pattern.\n\nAccount names \
+                 are colon-separated capitalized components rooted at one of the five \
+                 account types (Assets, Liabilities, Equity, Income, Expenses — \
+                 renameable via `option \"name_assets\"` etc.), e.g. \
+                 `Assets:Bank:Checking`.\n\nFix: rename the account to match the \
+                 pattern."
+            }
+            Self::BalanceAssertionFailed => {
+                "A `balance` assertion does not match the computed balance of the \
+                 account (including its sub-accounts) at that date.\n\nThe comparison \
+                 uses a tolerance inferred from the asserted amount's precision.\n\n\
+                 Fix: correct the asserted amount, add the missing transactions, or \
+                 insert a `pad` directive to absorb the difference. The reported \
+                 difference is the exact discrepancy."
+            }
+            Self::BalanceToleranceExceeded => {
+                "A `balance` assertion with an explicit tolerance, e.g. \
+                 `balance Assets:Cash 100.00 ~ 0.05 USD`, differs from the computed \
+                 balance by more than that tolerance.\n\nFix: correct the amount, \
+                 widen the explicit tolerance, or add the missing transactions."
+            }
+            Self::PadWithoutBalance => {
+                "A `pad` directive is never consumed by a later `balance` assertion \
+                 for that account and currency.\n\nA pad means \"insert whatever \
+                 amount makes the NEXT balance assertion true\" — without that \
+                 balance it does nothing.\n\nFix: add the `balance` assertion after \
+                 the pad, or delete the pad."
+            }
+            Self::MultiplePadForBalance => {
+                "More than one `pad` directive is pending for the same account and \
+                 currency before a single `balance` assertion — it is ambiguous which \
+                 pad should absorb the difference.\n\nFix: keep one pad per \
+                 account/currency between consecutive balance assertions."
+            }
+            Self::TransactionUnbalanced => {
+                "The weights of a transaction's postings do not sum to zero per \
+                 currency (beyond the inferred tolerance).\n\nA posting's weight is \
+                 its amount, converted through its cost (`{...}`) or price \
+                 (`@`/`@@`) when present.\n\nFix: correct the amounts, or leave \
+                 exactly one posting's amount blank and rustledger will interpolate \
+                 it. The reported residual is the exact imbalance."
+            }
+            Self::MultipleInterpolation => {
+                "More than one posting in the same currency has no amount — only one \
+                 blank posting per currency can be interpolated from the others.\n\n\
+                 Fix: fill in amounts so at most one posting per currency is elided."
+            }
+            Self::NoPostings => {
+                "Reserved for a transaction with zero postings.\n\nNever emitted in \
+                 practice: rustledger (like Python beancount) treats a posting-less \
+                 transaction as a structurally-valid no-op."
+            }
+            Self::SinglePosting => {
+                "A transaction has exactly one posting, which cannot balance on its \
+                 own (warning).\n\nFix: add the offsetting posting(s), or elide the \
+                 second amount to interpolate it."
+            }
+            Self::NoMatchingLot => {
+                "A cost reduction (e.g. a sale, `Assets:Stock -5 X {...}`) specifies \
+                 a cost, date, or label that matches no lot held in the account's \
+                 inventory.\n\nFix: check the cost spec against the actual holdings; \
+                 `rledger query` with `cost_label`/`cost_date` columns shows the \
+                 lots."
+            }
+            Self::InsufficientUnits => {
+                "A reduction requests more units than the matching lots hold (e.g. \
+                 selling 10 when 5 are held).\n\nA failed reduction leaves the \
+                 inventory untouched.\n\nFix: reduce the sold quantity, or check for \
+                 a missing purchase transaction."
+            }
+            Self::AmbiguousLotMatch => {
+                "Under STRICT booking (the default), a reduction's cost spec matches \
+                 more than one lot, and rustledger refuses to guess.\n\nFix: \
+                 disambiguate with the lot's cost `{10.00 USD}`, date `{2024-01-02}`, \
+                 or label `{\"lot-a\"}` — or open the account with a non-strict \
+                 method: `2024-01-01 open Assets:Stock \"FIFO\"`."
+            }
+            Self::NegativeCost => {
+                "A posting's cost amount is negative — a cost basis must be \
+                 non-negative.\n\nFix: check the sign of the cost (the units carry \
+                 the sign of a sale, not the cost)."
+            }
+            Self::UndeclaredCurrency => {
+                "A currency is used but never declared with a `commodity` directive, \
+                 and commodity declarations are required (strict commodity mode).\n\n\
+                 Fix: add `YYYY-MM-DD commodity CUR`, or disable the strict \
+                 requirement."
+            }
+            Self::CurrencyNotAllowed => {
+                "A posting or `balance` assertion uses a currency outside the list \
+                 the account was opened with (`open Assets:Cash USD` constrains the \
+                 account to USD).\n\nFix: use an allowed currency, or extend the \
+                 currency list on the `open` directive. An `open` with no currencies \
+                 allows all."
+            }
+            Self::InvalidPrecisionMetadata => {
+                "A `commodity` directive carries a `precision:` metadata value that \
+                 does not parse as a non-negative integer (warning). The declaration \
+                 is ignored; display precision falls back to \
+                 `option \"display_precision\"`, then to inference.\n\nFix: use e.g. \
+                 `precision: 2`."
+            }
+            Self::UnknownOption => {
+                "An `option` directive names an option rustledger does not recognize \
+                 (warning; the option is ignored).\n\nFix: check the option name \
+                 against the options documentation — it may be misspelled or \
+                 unsupported."
+            }
+            Self::InvalidOptionValue => {
+                "An `option` directive has a value that does not parse for that \
+                 option's type (e.g. a non-numeric \
+                 `inferred_tolerance_multiplier`).\n\nFix: correct the value per the \
+                 options documentation."
+            }
+            Self::DuplicateOption => {
+                "A non-repeatable option is specified more than once (warning; the \
+                 last value wins).\n\nFix: keep a single occurrence."
+            }
+            Self::DocumentNotFound => {
+                "A `document` directive references a file that does not exist. \
+                 Relative paths resolve against the directory of the source file \
+                 containing the directive (matching `include`).\n\nFix: correct the \
+                 path, or remove the directive."
+            }
+            Self::DateOutOfOrder => {
+                "A directive's date is earlier than the preceding directive's date \
+                 in the same file (informational only — directives are sorted before \
+                 processing, so this never changes results).\n\nFix: reorder the \
+                 file chronologically if you care about source order."
+            }
+            Self::FutureDate => {
+                "A directive is dated in the future relative to today (warning).\n\n\
+                 Fix: correct the date — or ignore the warning if the future dating \
+                 is intentional (e.g. scheduled entries)."
+            }
+        }
+    }
+
     /// Get the severity level.
     #[must_use]
     pub const fn severity(&self) -> Severity {

--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -141,6 +141,12 @@ enum Commands {
         action: CompatAction,
     },
 
+    /// Explain a validation error code (e.g. E2001), or list all codes
+    Explain {
+        #[command(flatten)]
+        args: rustledger::cmd::explain::Args,
+    },
+
     /// Non-fatal advisory passes — e.g., detect inter-account transfer pairs
     Lint {
         #[command(flatten)]
@@ -482,6 +488,13 @@ fn main() -> ExitCode {
                 }
             }
         }
+        Commands::Explain { args } => match rustledger::cmd::explain::run(&args) {
+            Ok(code) => code,
+            Err(e) => {
+                eprintln!("error: {e:#}");
+                ExitCode::from(1)
+            }
+        },
         Commands::Lint { args } => match rustledger::cmd::lint::run(&args) {
             Ok(code) => code,
             Err(e) => {

--- a/crates/rustledger/src/cmd/explain.rs
+++ b/crates/rustledger/src/cmd/explain.rs
@@ -1,0 +1,131 @@
+//! `rledger explain` — describe a validation error code, `rustc --explain`
+//! style.
+//!
+//! `rledger explain E2001` prints what the code means, its common cause, and
+//! how to fix it; bare `rledger explain` lists every code with its title. The
+//! text lives on [`ErrorCode`] itself (`title`/`explanation`), so the binary
+//! is self-contained and the exhaustive match keeps it in lockstep with the
+//! enum.
+
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::Parser;
+use rustledger_validate::ErrorCode;
+
+/// Arguments for `rledger explain`.
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// The error code to explain (e.g. `E2001`, `e2001`, or `2001`).
+    /// Omit to list all codes.
+    pub code: Option<String>,
+}
+
+/// Run `rledger explain`.
+///
+/// # Errors
+///
+/// Returns an error if writing to stdout fails.
+pub fn run(args: &Args) -> Result<ExitCode> {
+    let status = run_with_writer(args, &mut std::io::stdout().lock())?;
+    Ok(ExitCode::from(status))
+}
+
+/// [`run`], writing to `out` and returning the process status as a plain
+/// `u8` (0 = success) so tests can assert on it (`std::process::ExitCode`
+/// has no `PartialEq`).
+///
+/// # Errors
+///
+/// Returns an error if writing to `out` fails.
+pub fn run_with_writer<W: std::io::Write>(args: &Args, out: &mut W) -> Result<u8> {
+    match &args.code {
+        None => {
+            writeln!(out, "Validation error codes (rledger explain <CODE>):\n")?;
+            for code in ErrorCode::ALL {
+                writeln!(
+                    out,
+                    "  {:<7} {:<9} {}",
+                    code.code(),
+                    format!("[{:?}]", code.severity()).to_lowercase(),
+                    code.title()
+                )?;
+            }
+            Ok(0)
+        }
+        Some(raw) => {
+            if let Some(code) = ErrorCode::from_code(raw) {
+                writeln!(out, "{}: {}", code.code(), code.title())?;
+                writeln!(out, "severity: {:?}\n", code.severity())?;
+                writeln!(out, "{}", code.explanation())?;
+                Ok(0)
+            } else {
+                writeln!(
+                    out,
+                    "unknown error code `{raw}` — run `rledger explain` to list all codes"
+                )?;
+                Ok(1)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn output(args: &Args) -> (String, u8) {
+        let mut buf = Vec::new();
+        let status = run_with_writer(args, &mut buf).expect("write to Vec cannot fail");
+        (String::from_utf8(buf).expect("output is UTF-8"), status)
+    }
+
+    #[test]
+    fn explains_a_known_code_in_any_spelling() {
+        for spelling in ["E2001", "e2001", "2001", " E2001 "] {
+            let (text, status) = output(&Args {
+                code: Some(spelling.to_string()),
+            });
+            assert_eq!(status, 0, "spelling {spelling:?}");
+            assert!(text.contains("E2001: Balance assertion failed"));
+            assert!(text.contains("Fix:"), "explanation has a fix section");
+        }
+    }
+
+    #[test]
+    fn lists_every_code_without_an_argument() {
+        let (text, status) = output(&Args { code: None });
+        assert_eq!(status, 0);
+        for ec in ErrorCode::ALL {
+            assert!(text.contains(ec.code()), "listing includes {}", ec.code());
+        }
+    }
+
+    #[test]
+    fn unknown_code_exits_nonzero_with_pointer() {
+        let (text, status) = output(&Args {
+            code: Some("E9999".to_string()),
+        });
+        assert_eq!(status, 1);
+        assert!(text.contains("unknown error code"));
+        assert!(text.contains("rledger explain"));
+    }
+
+    #[test]
+    fn every_code_roundtrips_and_has_title_and_explanation() {
+        for ec in ErrorCode::ALL {
+            assert_eq!(
+                ErrorCode::from_code(ec.code()),
+                Some(*ec),
+                "{} must parse back to its variant",
+                ec.code()
+            );
+            assert!(!ec.title().is_empty());
+            assert!(
+                ec.explanation().len() > 40,
+                "{} explanation should be substantive",
+                ec.code()
+            );
+        }
+    }
+}

--- a/crates/rustledger/src/cmd/mod.rs
+++ b/crates/rustledger/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod compat;
 pub mod completions;
 pub mod config_cmd;
 pub mod doctor;
+pub mod explain;
 pub mod extract_cmd;
 pub mod format;
 pub mod lint;


### PR DESCRIPTION
Implements improvement idea #6 — `rustc --explain` for rledger's E-codes.

```
$ rledger explain E2001
E2001: Balance assertion failed
severity: Error

A balance assertion does not match the computed balance of the account
(including its sub-accounts) at that date. ... Fix: ...

$ rledger explain            # lists all 26 codes with severities
$ rledger explain 2001       # bare digits + lowercase accepted
```

## Design notes
- Explanations are **code constants on `ErrorCode`** (`title()`/`explanation()` via exhaustive match) — adding a variant forces adding its explanation at compile time. New `ErrorCode::from_code`.
- Deliberately **not** `include_str!` from `spec/core/validation.md`: published crates don't package `spec/`, and the Nix flake's crane source filter strips it (the v0.17.x channel-test lesson). The existing `error_codes_documented_in_spec` test still guards code↔spec drift; explanations were sourced from the spec's per-code Condition/Severity sections.
- Unknown codes exit non-zero with a pointer to the listing.

## Verification
366 CLI + 94 validate tests pass (4 new: spelling roundtrip, full listing, unknown-code exit, every-code-has-substantive-explanation); smoke-tested `explain E2001` / bare / `E9999`; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)