### PR TITLE
ci(release-test): raise AUR from-source timeout to 90m

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -661,7 +661,7 @@ jobs:
     name: Test AUR (rustledger from source)
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 45 # Rust compilation can take 15-30 minutes
+    timeout-minutes: 90 # Cold from-source workspace build in the Arch container now exceeds 45m (timed out on v0.18.0 AND v0.19.0 channel runs; the job was cancelled, not failed)
     container: archlinux:latest
     env:
       VERSION: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
`Test AUR (rustledger from source)` hit its 45-minute timeout on **both** the v0.18.0 and v0.19.0 channel runs (job `cancelled`, run reported `cancelled`) — the cold from-source workspace build in the `archlinux:latest` container has outgrown the limit. Every other channel job passed on both runs (0 failures).

One-line bump 45m → 90m with an explanatory comment. (A cargo cache inside the container would be the deeper fix, but this restores an honest green/red signal immediately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)