### PR TITLE
ci(release-test): make the AUR from-source smoke test fit its timeout

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -661,7 +661,7 @@ jobs:
     name: Test AUR (rustledger from source)
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 90 # Cold from-source workspace build in the Arch container now exceeds 45m (timed out on v0.18.0 AND v0.19.0 channel runs; the job was cancelled, not failed)
+    timeout-minutes: 90 # Safety margin; with --nocheck + CU=16 (see install step) the build fits well inside this — unmodified it exceeds even 90m
     container: archlinux:latest
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
@@ -697,8 +697,20 @@ jobs:
           done
           echo "Warning: AUR may not be updated, proceeding anyway..."
       - name: Install rustledger (from source)
+        # This smoke test verifies the AUR source package BUILDS AND RUNS —
+        # not the full optimization pipeline or the test suite. Unmodified,
+        # the PKGBUILD build (codegen-units=1 across the whole workspace) plus
+        # its check() (the entire release-mode test suite) exceeds 90 minutes
+        # on a 2-core runner: the job timed out on the v0.18.0 and v0.19.0
+        # channel runs at 45m AND on the v0.19.0 rerun at 90m. So, for CI
+        # only (real AUR users build with the PKGBUILD's full settings):
+        #  - --mflags --nocheck skips check() — the test suite already runs
+        #    in repo CI on every PR (same reasoning as the Nix doCheck=false
+        #    fix, #1661);
+        #  - CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 parallelizes codegen
+        #    (profile `release` keeps its thin LTO).
         run: |
-          su - builder -c 'yay -S --noconfirm rustledger'
+          su - builder -c 'export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16; yay -S --noconfirm --mflags "--nocheck" rustledger'
       - name: Verify version
         run: |
           INSTALLED=$(rledger --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1)


### PR DESCRIPTION
Closes out the last non-green channel job. The v0.19.0 rerun proved #1681's timeout bump insufficient — the job also died at **90m**. Root cause isn't the timeout: the unmodified PKGBUILD build is `codegen-units=1` over the **whole workspace**, and its `check()` then runs the **entire release-mode test suite** — >90 min total on a 2-core runner.

CI-only relaxations (real AUR users keep the PKGBUILD's full settings), mirroring the Nix `doCheck = false` fix (#1661):
- `yay --mflags --nocheck` — skip `check()`; the test suite runs in repo CI on every PR. This smoke test verifies the source package **builds and runs**.
- `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16` — parallel codegen (profile `release` keeps its thin LTO).

The 90m timeout stays as safety margin. Verifiable on the next release's channel run (or a manual `Release Channel Testing` dispatch for 0.19.0 after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)