### PR TITLE
ci(downstream): pin bytecodealliance/actions to a commit SHA

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -82,7 +82,7 @@ jobs:
           cache-dependency-glob: "rustfava/uv.lock"
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
       - name: Install wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
+        uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
 
       - name: Run rustfava's Python tests against the PR component
         working-directory: rustfava


### PR DESCRIPTION
Fixes [code-scanning alert #200](https://github.com/rustledger/rustledger/security/code-scanning/200) (`actions/unpinned-tag`, medium): `downstream.yml`'s wasmtime setup step used the mutable `@v1` tag — copied from rustfava's own `test.yml`, which doesn't enforce this repo's pin-by-SHA convention. Now pinned to the commit `v1` resolves to (`9152e71`), matching every other action in the repo.

Verified: this is the only open `unpinned-tag` alert; YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)