### PR TITLE
fix(core): try_reduce is now reduce-on-a-clone — equivalent by construction

### DIFF
--- a/crates/rustledger-core/src/inventory/booking.rs
+++ b/crates/rustledger-core/src/inventory/booking.rs
@@ -51,9 +51,19 @@ fn average_cost_from_positions(
 impl Inventory {
     /// Try reducing positions without modifying the inventory.
     ///
-    /// This is a read-only version of `reduce()` that returns what would be matched
-    /// without actually modifying the inventory. Useful for previewing booking results
-    /// before committing.
+    /// The read-only preview of [`Self::reduce`]: returns exactly what
+    /// `reduce` would return — the same matched lots and cost basis on
+    /// success, the same error otherwise — without mutating `self`.
+    ///
+    /// Implemented as `reduce` on a clone, so it is equivalent BY
+    /// CONSTRUCTION. It previously re-implemented every booking method's
+    /// selection logic in a parallel `try_*` tree, which drifted from the
+    /// mutating path in three places (STRICT ambiguity, NONE shorting, `{*}`
+    /// merge dispatch) — the recurring one-logic-two-paths class (#1648,
+    /// #1663, #1686). The clone is cheap: `positions` is an
+    /// `imbl::Vector`, so cloning is O(1) structural sharing and `reduce`'s
+    /// copy-on-write rebuild touches only the clone. The
+    /// `try_reduce_predicts_reduce` property test pins the equivalence.
     ///
     /// # Arguments
     ///
@@ -61,320 +71,18 @@ impl Inventory {
     /// * `cost_spec` - Optional cost specification for matching lots
     /// * `method` - The booking method to use
     ///
-    /// # Returns
+    /// # Errors
     ///
-    /// Returns a `BookingResult` with the positions that would be matched and cost basis,
-    /// or a `BookingError` if the reduction cannot be performed.
+    /// Exactly the errors [`Self::reduce`] would return for the same input.
     pub fn try_reduce(
         &self,
         units: &Amount,
         cost_spec: Option<&CostSpec>,
         method: BookingMethod,
     ) -> Result<BookingResult, BookingError> {
-        let spec = cost_spec.cloned().unwrap_or_default();
-
-        // {*} merge operator: use average-cost semantics (read-only preview)
-        if spec.merge {
-            return self.try_reduce_average(units);
-        }
-
-        match method {
-            BookingMethod::Strict | BookingMethod::StrictWithSize => {
-                self.try_reduce_strict(units, &spec, method == BookingMethod::StrictWithSize)
-            }
-            BookingMethod::Fifo => self.try_reduce_ordered(units, &spec, false),
-            BookingMethod::Lifo => self.try_reduce_ordered(units, &spec, true),
-            BookingMethod::Hifo => self.try_reduce_hifo(units, &spec),
-            BookingMethod::Average => self.try_reduce_average(units),
-            BookingMethod::None => self.try_reduce_ordered(units, &CostSpec::default(), false),
-        }
+        self.clone().reduce(units, cost_spec, method)
     }
 
-    /// Try `STRICT`/`STRICT_WITH_SIZE` booking without modifying inventory.
-    fn try_reduce_strict(
-        &self,
-        units: &Amount,
-        spec: &CostSpec,
-        with_size: bool,
-    ) -> Result<BookingResult, BookingError> {
-        let matching_indices: Vec<usize> = self
-            .positions
-            .iter()
-            .enumerate()
-            .filter(|(_, p)| {
-                p.units.currency == units.currency
-                    && !p.is_empty()
-                    && p.can_reduce(units)
-                    && p.matches_cost_spec(spec)
-            })
-            .map(|(i, _)| i)
-            .collect();
-
-        match matching_indices.len() {
-            0 => Err(BookingError::NoMatchingLot {
-                currency: units.currency.clone(),
-                cost_spec: spec.clone(),
-            }),
-            1 => {
-                let idx = matching_indices[0];
-                self.try_reduce_from_lot(idx, units)
-            }
-            n => {
-                if with_size {
-                    // Check for exact-size match with any lot
-                    let exact_matches: Vec<usize> = matching_indices
-                        .iter()
-                        .filter(|&&i| self.positions[i].units.number.abs() == units.number.abs())
-                        .copied()
-                        .collect();
-
-                    if exact_matches.is_empty() {
-                        // Total match exception
-                        let total_units: Decimal = matching_indices
-                            .iter()
-                            .map(|&i| self.positions[i].units.number.abs())
-                            .sum();
-                        if total_units == units.number.abs() {
-                            self.try_reduce_ordered(units, spec, false)
-                        } else {
-                            Err(BookingError::AmbiguousMatch {
-                                num_matches: n,
-                                currency: units.currency.clone(),
-                            })
-                        }
-                    } else {
-                        let idx = exact_matches[0];
-                        self.try_reduce_from_lot(idx, units)
-                    }
-                } else {
-                    // STRICT: fall back to FIFO when multiple match
-                    self.try_reduce_ordered(units, spec, false)
-                }
-            }
-        }
-    }
-
-    /// Try ordered (FIFO/LIFO) booking without modifying inventory.
-    fn try_reduce_ordered(
-        &self,
-        units: &Amount,
-        spec: &CostSpec,
-        reverse: bool,
-    ) -> Result<BookingResult, BookingError> {
-        let mut remaining = units.number.abs();
-        let mut matched: MatchedLots = SmallVec::new();
-        let mut cost_basis = Decimal::ZERO;
-        let mut cost_currency = None;
-
-        // Get indices of matching positions
-        let mut indices: Vec<usize> = self
-            .positions
-            .iter()
-            .enumerate()
-            .filter(|(_, p)| {
-                p.units.currency == units.currency
-                    && !p.is_empty()
-                    && p.units.number.signum() != units.number.signum()
-                    && p.matches_cost_spec(spec)
-            })
-            .map(|(i, _)| i)
-            .collect();
-
-        // Sort by date for correct FIFO/LIFO ordering
-        indices.sort_by_key(|&i| self.positions[i].cost.as_ref().and_then(|c| c.date));
-
-        if reverse {
-            indices.reverse();
-        }
-
-        if indices.is_empty() {
-            return Err(BookingError::NoMatchingLot {
-                currency: units.currency.clone(),
-                cost_spec: spec.clone(),
-            });
-        }
-
-        for idx in indices {
-            if remaining.is_zero() {
-                break;
-            }
-
-            let pos = &self.positions[idx];
-            let available = pos.units.number.abs();
-            let take = remaining.min(available);
-
-            // Calculate cost basis for this portion
-            if let Some(cost) = &pos.cost {
-                cost_basis += take * cost.number;
-                cost_currency = Some(cost.currency.clone());
-            }
-
-            // Record what we would match (using split which is read-only)
-            let (taken, _) = pos.split(take * pos.units.number.signum());
-            matched.push(taken);
-
-            remaining -= take;
-        }
-
-        if !remaining.is_zero() {
-            let available = units.number.abs() - remaining;
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested: units.number.abs(),
-                available,
-            });
-        }
-
-        Ok(BookingResult {
-            matched,
-            cost_basis: cost_currency.map(|c| Amount::new(cost_basis, c)),
-        })
-    }
-
-    /// Try HIFO booking without modifying inventory.
-    fn try_reduce_hifo(
-        &self,
-        units: &Amount,
-        spec: &CostSpec,
-    ) -> Result<BookingResult, BookingError> {
-        let mut remaining = units.number.abs();
-        let mut matched: MatchedLots = SmallVec::new();
-        let mut cost_basis = Decimal::ZERO;
-        let mut cost_currency = None;
-
-        // Get matching positions with their costs
-        let mut matching: Vec<(usize, Decimal)> = self
-            .positions
-            .iter()
-            .enumerate()
-            .filter(|(_, p)| {
-                p.units.currency == units.currency
-                    && !p.is_empty()
-                    && p.units.number.signum() != units.number.signum()
-                    && p.matches_cost_spec(spec)
-            })
-            .map(|(i, p)| {
-                let cost = p.cost.as_ref().map_or(Decimal::ZERO, |c| c.number);
-                (i, cost)
-            })
-            .collect();
-
-        if matching.is_empty() {
-            return Err(BookingError::NoMatchingLot {
-                currency: units.currency.clone(),
-                cost_spec: spec.clone(),
-            });
-        }
-
-        // Sort by cost descending (highest first)
-        matching.sort_by_key(|(_, cost)| std::cmp::Reverse(*cost));
-
-        let indices: Vec<usize> = matching.into_iter().map(|(i, _)| i).collect();
-
-        for idx in indices {
-            if remaining.is_zero() {
-                break;
-            }
-
-            let pos = &self.positions[idx];
-            let available = pos.units.number.abs();
-            let take = remaining.min(available);
-
-            // Calculate cost basis for this portion
-            if let Some(cost) = &pos.cost {
-                cost_basis += take * cost.number;
-                cost_currency = Some(cost.currency.clone());
-            }
-
-            // Record what we would match
-            let (taken, _) = pos.split(take * pos.units.number.signum());
-            matched.push(taken);
-
-            remaining -= take;
-        }
-
-        if !remaining.is_zero() {
-            let available = units.number.abs() - remaining;
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested: units.number.abs(),
-                available,
-            });
-        }
-
-        Ok(BookingResult {
-            matched,
-            cost_basis: cost_currency.map(|c| Amount::new(cost_basis, c)),
-        })
-    }
-
-    /// Try AVERAGE booking without modifying inventory.
-    fn try_reduce_average(&self, units: &Amount) -> Result<BookingResult, BookingError> {
-        let matching: Vec<&Position> = self
-            .positions
-            .iter()
-            .filter(|p| p.units.currency == units.currency && !p.is_empty())
-            .collect();
-
-        let total_units: Decimal = matching.iter().map(|p| p.units.number).sum();
-
-        if total_units.is_zero() {
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested: units.number.abs(),
-                available: Decimal::ZERO,
-            });
-        }
-
-        let reduction = units.number.abs();
-        if reduction > total_units.abs() {
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested: reduction,
-                available: total_units.abs(),
-            });
-        }
-
-        let cost_basis = average_cost_from_positions(&matching, total_units)?
-            .map(|(avg_cost, currency)| Amount::new(reduction * avg_cost, currency));
-
-        let matched: MatchedLots = matching.into_iter().cloned().collect();
-
-        Ok(BookingResult {
-            matched,
-            cost_basis,
-        })
-    }
-
-    /// Try reducing from a specific lot without modifying inventory.
-    fn try_reduce_from_lot(
-        &self,
-        idx: usize,
-        units: &Amount,
-    ) -> Result<BookingResult, BookingError> {
-        let pos = &self.positions[idx];
-        let available = pos.units.number.abs();
-        let requested = units.number.abs();
-
-        if requested > available {
-            return Err(BookingError::InsufficientUnits {
-                currency: units.currency.clone(),
-                requested,
-                available,
-            });
-        }
-
-        let cost_basis = pos.cost.as_ref().map(|c| c.total_cost(requested));
-        let (matched, _) = pos.split(requested * pos.units.number.signum());
-
-        Ok(BookingResult {
-            matched: smallvec![matched],
-            cost_basis,
-        })
-    }
-}
-
-impl Inventory {
     /// STRICT booking: require exactly one matching lot, unless either:
     ///
     /// - all matching lots are identical in cost, in which case the choice

--- a/crates/rustledger-core/tests/try_reduce_equivalence.proptest-regressions
+++ b/crates/rustledger-core/tests/try_reduce_equivalence.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4a4360a21c0ae246e09697a4c47e185958a354fe9c376b6283bcf57d030f8b05 # shrinks to positions = [], method = None, spec = None, amount = 1, wrong_currency = false

--- a/crates/rustledger-core/tests/try_reduce_equivalence.rs
+++ b/crates/rustledger-core/tests/try_reduce_equivalence.rs
@@ -1,0 +1,123 @@
+//! `try_reduce` ≅ `reduce` equivalence — the preview must predict the commit.
+//!
+//! [`Inventory::try_reduce`] is the read-only preview of [`Inventory::reduce`]
+//! ("returns what would be matched without actually modifying the
+//! inventory"). It duplicates every booking method's selection logic, which
+//! is exactly the one-logic-two-paths shape behind this codebase's recurring
+//! drift class (#1648, the `@@` price, #1663, #1686) — and it HAD drifted:
+//! before the fix accompanying this test, `try_reduce` under STRICT fell back
+//! to FIFO on any multi-lot match while `reduce` returned `AmbiguousMatch`
+//! unless the lots were financially interchangeable, and `try_reduce` under
+//! NONE/`{*}`-merge routed to entirely different implementations than the
+//! mutating dispatch.
+//!
+//! The obligation, checked here for every booking method against randomized
+//! inventories and satisfiable/unsatisfiable reductions alike:
+//!
+//! ```text
+//! try_reduce(&inv, op) == reduce(&mut inv.clone(), op)
+//! ```
+//!
+//! — identical `Ok` (matched lots AND cost basis) or identical `Err`.
+
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+use rustledger_core::{
+    Amount, BookingMethod, Cost, CostNumber, CostSpec, Inventory, NaiveDate, Position, naive_date,
+};
+
+const CURRENCY: &str = "AAPL";
+const LABELS: [&str; 3] = ["lot-a", "lot-b", "lot-c"];
+
+fn day(d: u32) -> NaiveDate {
+    naive_date(2024, 1, d).expect("valid day")
+}
+
+fn position_strategy() -> impl Strategy<Value = Position> {
+    (
+        1i64..50,
+        1i64..20,
+        1u32..28,
+        proptest::option::of(0usize..LABELS.len()),
+    )
+        .prop_map(|(units, cost, d, label)| {
+            let mut c = Cost::new(Decimal::from(cost), "USD").with_date(day(d));
+            c.label = label.map(|i| LABELS[i].to_string());
+            Position::with_cost(Amount::new(Decimal::from(units), CURRENCY), c)
+        })
+}
+
+fn method_strategy() -> impl Strategy<Value = BookingMethod> {
+    prop_oneof![
+        Just(BookingMethod::Strict),
+        Just(BookingMethod::StrictWithSize),
+        Just(BookingMethod::Fifo),
+        Just(BookingMethod::Lifo),
+        Just(BookingMethod::Hifo),
+        Just(BookingMethod::Average),
+        Just(BookingMethod::None),
+    ]
+}
+
+/// Cost specs spanning the satisfiable and unsatisfiable spectrum: empty,
+/// label match, unknown label, unmatched cost number, and the `{*}` merge
+/// operator (which has its own dispatch arm).
+fn spec_strategy() -> impl Strategy<Value = Option<CostSpec>> {
+    prop_oneof![
+        Just(None),
+        Just(Some(CostSpec::default())),
+        (0usize..LABELS.len()).prop_map(|i| {
+            Some(CostSpec {
+                label: Some(LABELS[i].to_string()),
+                ..CostSpec::default()
+            })
+        }),
+        Just(Some(CostSpec {
+            label: Some("no-such-lot".to_string()),
+            ..CostSpec::default()
+        })),
+        Just(Some(CostSpec::default().with_number(CostNumber::PerUnit {
+            value: Decimal::from(9999),
+        }),)),
+        Just(Some(CostSpec {
+            merge: true,
+            ..CostSpec::default()
+        })),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// For any inventory, method, spec, and (possibly excessive) amount, the
+    /// preview and the commit agree exactly.
+    #[test]
+    fn try_reduce_predicts_reduce(
+        positions in prop::collection::vec(position_strategy(), 0..5),
+        method in method_strategy(),
+        spec in spec_strategy(),
+        amount in 1i64..200,
+        wrong_currency in proptest::bool::weighted(0.15),
+    ) {
+        let mut inv = Inventory::new();
+        for pos in &positions {
+            inv.add(pos.clone());
+        }
+
+        let currency = if wrong_currency { "MSFT" } else { CURRENCY };
+        let units = Amount::new(Decimal::from(-amount), currency);
+
+        let preview = inv.try_reduce(&units, spec.as_ref(), method);
+        let mut committed_inv = inv.clone();
+        let commit = committed_inv.reduce(&units, spec.as_ref(), method);
+
+        prop_assert_eq!(
+            &preview,
+            &commit,
+            "try_reduce diverged from reduce (method {:?}, spec {:?}, amount {})",
+            method,
+            spec,
+            amount
+        );
+    }
+}


### PR DESCRIPTION
FV follow-up #1 (of the improvement menu): the `try_reduce` preview must predict `reduce` exactly — and it didn't.

## The divergences (equivalence property written first, as the oracle)
`try_reduce` re-implemented every booking method's selection logic in a parallel `try_*` tree (~330 lines). The property test caught it drifting in **three** places:
1. **STRICT**: `try_` fell back to FIFO on *any* multi-lot match; `reduce` returns `AmbiguousMatch` unless the lots are financially interchangeable.
2. **NONE**: `try_` routed to ordered reduction (`NoMatchingLot` on an empty inventory); `reduce_none` appends/shorts (oracle's minimal case).
3. **`{*}` merge**: `try_` dispatched to `try_reduce_average`; the mutating path uses the separate `reduce_merge`.

Same one-logic-two-paths class as #1648/#1663/#1686 — a preview surface silently disagreeing with the commit.

## The structural fix
`try_reduce` = **`reduce` on a clone** — equivalent *by construction*, cannot re-drift, and deletes the whole duplicate tree (−326 lines). Cheap: `positions` is an `imbl::Vector` (O(1) structural-sharing clone); `reduce`'s copy-on-write rebuild touches only the clone. (Note: `try_reduce` currently has no in-repo callers — deleting the API entirely is also an option, but keeping it correct + guarded seemed the conservative call; happy to drop it instead.)

## Guard
`tests/try_reduce_equivalence.rs`: 500 randomized cases × 7 methods × satisfiable/unsatisfiable specs (labels, unmatched costs, `{*}`, wrong currency, oversells) — preview == commit exactly (same `Ok` matched+basis or same `Err`).

## Verification
Equivalence property green; core lib 422/422 (no existing test had pinned the divergent preview); replay + TLA proptests green; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)