### PR TITLE
test(tla): implementation-trace validation — the dual refinement direction

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -11,6 +11,8 @@ on:
       - 'crates/rustledger-booking/src/**'
       - 'scripts/tla-trace-to-test.py'
       - 'scripts/tla-behaviors.py'
+      - 'scripts/tla-trace-validate.py'
+      - 'crates/rustledger-core/examples/conservation_trace_gen.rs'
       - 'spec/tla/behaviors/**'
       - '.github/workflows/tla.yml'
   pull_request:
@@ -23,6 +25,8 @@ on:
       - 'crates/rustledger-booking/src/**'
       - 'scripts/tla-trace-to-test.py'
       - 'scripts/tla-behaviors.py'
+      - 'scripts/tla-trace-validate.py'
+      - 'crates/rustledger-core/examples/conservation_trace_gen.rs'
       - 'spec/tla/behaviors/**'
       - '.github/workflows/tla.yml'
 permissions:
@@ -55,6 +59,12 @@ jobs:
             -O ~/tla2tools.jar
       - name: Verify TLA+ Tools
         run: java -jar ~/tla2tools.jar -help | head -5
+      # Rust toolchain for the implementation-trace generator (dual-direction
+      # validation below).
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       # One loop instead of 16 uniform steps: every spec is checked even when
       # an earlier one fails (previously fail-fast masked later spec failures),
       # and each TLC output is teed to tlc-logs/<Spec>.log so counterexamples
@@ -114,6 +124,21 @@ jobs:
             echo "::error::stale behavior corpora:${STALE} — regenerate (see scripts/tla-behaviors.py docstring)"
             exit 1
           fi
+      # Dual-direction refinement check: the behavior-replay suite verifies
+      # model -> implementation (every model behavior is implemented
+      # correctly, exhaustively); this step verifies implementation -> model
+      # (sampled): random op sequences are driven through the REAL Inventory
+      # and TLC checks that every recorded transition satisfies
+      # Conservation.tla's Next relation. A transition the model forbids
+      # fails the ConformsToConservation action property. The seed varies per
+      # run (continuous sampling) and is printed for exact reproduction; the
+      # validator self-test first proves the harness rejects violations.
+      - name: Validate implementation traces against the spec
+        env:
+          TLC_CMD: java -XX:+UseParallelGC -Xmx2g -jar /home/runner/tla2tools.jar
+        run: |
+          python3 scripts/tla-trace-validate.py --self-test
+          cargo run -q -p rustledger-core --example conservation_trace_gen --             --count 24 --max-units 3 --max-ops 8 --seed "${{ github.run_id }}"             | python3 scripts/tla-trace-validate.py
       # The counterexample-driven workflow from the formal-verification
       # roadmap: every TLC error trace becomes a pinned Rust regression-test
       # skeleton (the process that produced tla_fifo_bug_test.rs). Skeletons

--- a/crates/rustledger-core/examples/conservation_trace_gen.rs
+++ b/crates/rustledger-core/examples/conservation_trace_gen.rs
@@ -1,0 +1,135 @@
+//! Generate implementation traces of [`Inventory`] for TLA+ trace validation.
+//!
+//! The behavior-replay suite checks the model→implementation direction
+//! (every model behavior is implemented correctly). This generator serves the
+//! DUAL direction: drive the real `Inventory` through random Add/Reduce
+//! sequences, record the abstract state after every operation, and let TLC
+//! verify that each recorded transition satisfies `Conservation.tla`'s `Next`
+//! relation (`scripts/tla-trace-validate.py` builds the trace modules and
+//! runs TLC). An implementation transition the model forbids fails the
+//! action property.
+//!
+//! Deterministic by construction (seeded LCG, no clocks), so CI failures
+//! reproduce exactly from the printed seed.
+//!
+//! Usage:
+//!   `cargo run -p rustledger-core --example conservation_trace_gen -- \
+//!       --count 32 --max-units 3 --max-ops 8 --seed 1 [--corrupt]`
+//!
+//! Output (stdout): one line per trace — a JSON array of
+//! `[inventory, totalAdded, totalReduced, opCount]` states, starting at the
+//! initial all-zero state. `--corrupt` flips one unit in the final state of
+//! each trace (used by the validator's self-test to prove TLC catches
+//! violations).
+
+use rust_decimal::Decimal;
+use rustledger_core::{Amount, BookingMethod, Cost, Inventory, Position};
+
+/// Minimal deterministic PRNG (LCG, Numerical Recipes constants) — avoids a
+/// rand dependency and any ambient nondeterminism.
+struct Lcg(u64);
+
+impl Lcg {
+    const fn next(&mut self, bound: u64) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (self.0 >> 33) % bound
+    }
+}
+
+fn main() {
+    let mut count = 32u64;
+    let mut max_units = 3u64;
+    let mut max_ops = 8u64;
+    let mut seed = 1u64;
+    let mut corrupt = false;
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--count" => {
+                count = args[i + 1].parse().expect("--count takes a number");
+                i += 2;
+            }
+            "--max-units" => {
+                max_units = args[i + 1].parse().expect("--max-units takes a number");
+                i += 2;
+            }
+            "--max-ops" => {
+                max_ops = args[i + 1].parse().expect("--max-ops takes a number");
+                i += 2;
+            }
+            "--seed" => {
+                seed = args[i + 1].parse().expect("--seed takes a number");
+                i += 2;
+            }
+            "--corrupt" => {
+                corrupt = true;
+                i += 1;
+            }
+            other => panic!("unknown argument {other:?}"),
+        }
+    }
+    eprintln!(
+        "conservation_trace_gen: count={count} max_units={max_units} \
+         max_ops={max_ops} seed={seed} corrupt={corrupt}"
+    );
+
+    let cost = Cost::new(Decimal::ONE, "USD")
+        .with_date(rustledger_core::naive_date(2024, 1, 1).expect("valid date"));
+
+    for t in 0..count {
+        let mut rng = Lcg(seed.wrapping_add(t).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        let mut inv = Inventory::new();
+        let mut total_added: i64 = 0;
+        let mut total_reduced: i64 = 0;
+        let mut op_count: i64 = 0;
+        let mut states: Vec<[i64; 4]> = vec![[0, 0, 0, 0]];
+
+        while op_count < max_ops as i64 {
+            let amount = i64::try_from(rng.next(max_units) + 1).expect("small");
+            if rng.next(2) == 0 {
+                // Add — always enabled in the model.
+                inv.add(Position::with_cost(
+                    Amount::new(Decimal::from(amount), "AAPL"),
+                    cost.clone(),
+                ));
+                total_added += amount;
+            } else {
+                // Reduce — the model guard is `units <= inventory`; a failed
+                // implementation reduce corresponds to a disabled action and
+                // must be a stutter, so it is not recorded.
+                match inv.reduce(
+                    &Amount::new(Decimal::from(-amount), "AAPL"),
+                    None,
+                    BookingMethod::Fifo,
+                ) {
+                    Ok(_) => total_reduced += amount,
+                    Err(_) => continue,
+                }
+            }
+            op_count += 1;
+            let inventory: i64 = inv
+                .units("AAPL")
+                .try_into()
+                .expect("integer-valued inventory");
+            states.push([inventory, total_added, total_reduced, op_count]);
+        }
+
+        if corrupt {
+            // Break conservation in the final state so the validator can
+            // prove TLC detects an illegal implementation transition.
+            let last = states.len() - 1;
+            states[last][0] += 1;
+        }
+
+        let rendered: Vec<String> = states
+            .iter()
+            .map(|s| format!("[{},{},{},{}]", s[0], s[1], s[2], s[3]))
+            .collect();
+        println!("[{}]", rendered.join(","));
+    }
+}

--- a/scripts/tla-trace-validate.py
+++ b/scripts/tla-trace-validate.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Validate implementation traces against a TLA+ spec (dual-direction MBT).
+
+The behavior-replay suite checks model → implementation: every model behavior
+is implemented correctly. This tool checks the DUAL, implementation → model:
+traces produced by driving the REAL `Inventory` (see
+`crates/rustledger-core/examples/conservation_trace_gen.rs`) are checked by
+TLC against `Conservation.tla`'s transition relation — each recorded step must
+satisfy `[][Conservation!Next]_vars`. An implementation transition the model
+forbids fails the property. Together the two directions give two-sided
+refinement checking (exhaustive model-side, sampled implementation-side).
+
+Input (stdin or --traces FILE): one trace per line — a JSON array of
+`[inventory, totalAdded, totalReduced, opCount]` states.
+
+For each trace this script writes a small trace-following spec that drives
+the spec variables through the recorded states and asserts the conformance
+property, then runs TLC on it.
+
+Usage:
+    cargo run -q -p rustledger-core --example conservation_trace_gen -- \\
+        --count 24 --seed 7 | python3 scripts/tla-trace-validate.py
+
+    python3 scripts/tla-trace-validate.py --self-test   # incl. a negative check
+
+TLC discovery: $TLC_CMD if set, else `tlc` on PATH, else
+`java -jar ~/tla2tools.jar`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPEC = REPO_ROOT / "spec" / "tla" / "Conservation.tla"
+
+MODULE_TEMPLATE = """---- MODULE {name} ----
+EXTENDS Integers, Sequences
+CONSTANTS MaxUnits, MaxOperations
+VARIABLES inventory, totalAdded, totalReduced, opCount, idx
+
+specVars == <<inventory, totalAdded, totalReduced, opCount>>
+vars == <<inventory, totalAdded, totalReduced, opCount, idx>>
+
+C == INSTANCE Conservation
+
+Trace == <<{trace}>>
+
+Init ==
+    /\\ idx = 1
+    /\\ inventory = Trace[1].inventory
+    /\\ totalAdded = Trace[1].totalAdded
+    /\\ totalReduced = Trace[1].totalReduced
+    /\\ opCount = Trace[1].opCount
+
+Next ==
+    /\\ idx < Len(Trace)
+    /\\ idx' = idx + 1
+    /\\ inventory' = Trace[idx'].inventory
+    /\\ totalAdded' = Trace[idx'].totalAdded
+    /\\ totalReduced' = Trace[idx'].totalReduced
+    /\\ opCount' = Trace[idx'].opCount
+
+Spec == Init /\\ [][Next]_vars
+
+(* Every recorded implementation transition must be a legal step of the
+   Conservation model (or a stutter on its variables). *)
+ConformsToConservation == [][C!Next]_specVars
+====
+"""
+
+CFG_TEMPLATE = """CONSTANTS
+    MaxUnits = {max_units}
+    MaxOperations = {max_ops}
+SPECIFICATION Spec
+PROPERTY ConformsToConservation
+"""
+
+
+def tlc_command() -> list[str]:
+    if os.environ.get("TLC_CMD"):
+        return os.environ["TLC_CMD"].split()
+    if shutil.which("tlc"):
+        return ["tlc"]
+    jar = Path.home() / "tla2tools.jar"
+    if jar.exists():
+        return ["java", "-XX:+UseParallelGC", "-Xmx2g", "-jar", str(jar)]
+    raise SystemExit("no TLC found: set TLC_CMD, or provide `tlc` / ~/tla2tools.jar")
+
+
+def state_record(s: list[int]) -> str:
+    return (
+        f"[inventory |-> {s[0]}, totalAdded |-> {s[1]}, "
+        f"totalReduced |-> {s[2]}, opCount |-> {s[3]}]"
+    )
+
+
+def validate_trace(states: list[list[int]], workdir: Path, name: str) -> bool:
+    """Write the trace spec + cfg and TLC-check it. True = conforms."""
+    deltas = [1]
+    for prev, cur in zip(states, states[1:]):
+        deltas.append(cur[1] - prev[1])
+        deltas.append(cur[2] - prev[2])
+    max_units = max(deltas)
+    max_ops = max(1, states[-1][3])
+
+    trace = ", ".join(state_record(s) for s in states)
+    (workdir / f"{name}.tla").write_text(
+        MODULE_TEMPLATE.format(name=name, trace=trace)
+    )
+    (workdir / f"{name}.cfg").write_text(
+        CFG_TEMPLATE.format(max_units=max_units, max_ops=max_ops)
+    )
+    proc = subprocess.run(
+        [*tlc_command(), "-deadlock", "-config", f"{name}.cfg", f"{name}.tla"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    ok = proc.returncode == 0 and "Error:" not in proc.stdout
+    if not ok:
+        print(f"--- {name}: NON-CONFORMING trace ---", file=sys.stderr)
+        print(json.dumps(states), file=sys.stderr)
+        for line in proc.stdout.splitlines():
+            if "Error" in line or "violated" in line or line.startswith("State"):
+                print(f"  {line}", file=sys.stderr)
+    return ok
+
+
+def run(traces: list[list[list[int]]]) -> int:
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        shutil.copy(SPEC, workdir / "Conservation.tla")
+        for i, states in enumerate(traces):
+            if not validate_trace(states, workdir, f"Trace{i}"):
+                failures += 1
+    print(
+        f"trace validation: {len(traces) - failures}/{len(traces)} traces conform",
+        file=sys.stderr,
+    )
+    return 1 if failures else 0
+
+
+# A hand-checked legal trace: Add 2, Reduce 1.
+SELF_TEST_LEGAL = [[0, 0, 0, 0], [2, 2, 0, 1], [1, 2, 1, 2]]
+# Conservation broken in the final state (inventory 2 ≠ 3 added − 1 reduced
+# ... actually inventory jumps without a matching total change).
+SELF_TEST_ILLEGAL = [[0, 0, 0, 0], [2, 2, 0, 1], [2, 2, 1, 2]]
+
+
+def self_test() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        workdir = Path(tmp)
+        shutil.copy(SPEC, workdir / "Conservation.tla")
+        assert validate_trace(SELF_TEST_LEGAL, workdir, "SelfLegal"), (
+            "a legal implementation trace must conform"
+        )
+        assert not validate_trace(SELF_TEST_ILLEGAL, workdir, "SelfIllegal"), (
+            "TLC must REJECT a trace whose step violates the model — the "
+            "harness would otherwise pass vacuously"
+        )
+    print("self-test: OK (legal trace accepted, illegal trace rejected)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--traces", help="file of trace lines (default: stdin)")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    text = Path(args.traces).read_text() if args.traces else sys.stdin.read()
+    traces = [json.loads(line) for line in text.splitlines() if line.strip()]
+    if not traces:
+        raise SystemExit("no traces on input")
+    return run(traces)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spec/tla/RUST_MAPPING.md
+++ b/spec/tla/RUST_MAPPING.md
@@ -53,6 +53,22 @@ Extending to another spec = a `derive` entry in `scripts/tla-behaviors.py`'s
 SPECS registry + a replay interpreter in `tla_behavior_replay.rs` + the
 corpus file, all guarded by the CI lockstep check.
 
+## Dual-Direction Trace Validation
+
+The behavior replay above checks **model → implementation** exhaustively. The
+dual direction — **implementation → model**, i.e. the implementation never
+takes a transition the model forbids — is checked by trace validation:
+`crates/rustledger-core/examples/conservation_trace_gen.rs` drives the real
+`Inventory` through seeded-random Add/Reduce sequences and records the
+abstract state after every operation; `scripts/tla-trace-validate.py` turns
+each trace into a trace-following TLA+ spec and has TLC verify the
+`[][Conservation!Next]_vars` action property over it. The TLA+ CI workflow
+runs this on every triggering change with a fresh seed (printed for exact
+reproduction), after a self-test that proves the harness rejects a corrupted
+trace. Together the two directions give two-sided refinement checking —
+exhaustive on the model side, continuously sampled on the implementation
+side.
+
 ## Refinement Obligations
 
 The specs model **atomic** actions: when a guard (e.g. `Conservation.tla`'s


### PR DESCRIPTION
FV follow-up #2 (of the improvement menu), companion to #1690. Closes the remaining conceptual gap in the MBT layer.

## The gap
The behavior-replay suite (#1685/#1688) checks **model → implementation**: every model behavior is implemented correctly, exhaustively up to the bound. The dual — **implementation → model**, i.e. the implementation never takes a transition the model forbids — was unchecked.

## The mechanism (MongoDB/etcd-style trace validation)
1. `examples/conservation_trace_gen.rs` drives the **real `Inventory`** through seeded-random Add/Reduce sequences (deterministic LCG — no clocks, no deps; failed reduces = disabled actions = stutters, not recorded) and emits the abstract state after every operation.
2. `scripts/tla-trace-validate.py` wraps each trace in a trace-following TLA+ spec (`C == INSTANCE Conservation`) and has **TLC verify the `[][C!Next]_specVars` action property** — every recorded transition must be a legal model step.
3. `tla.yml` runs the validator's self-test, then validates **24 fresh traces per run** (seed = `github.run_id`, printed for exact reproduction — continuous sampling of the dual direction).

## Trustworthiness of the harness itself
The self-test proves both directions: a hand-checked legal trace is **accepted** and an illegal one is **rejected** (`Action property ConformsToConservation is violated`) — plus the generator's `--corrupt` mode is verified to fail the pipeline. A vacuously-green harness is the failure mode to fear; this one demonstrably detects violations.

Together with #1685/#1688: **two-sided refinement checking** — exhaustive on the model side, continuously sampled on the implementation side. Extension to other specs follows the same template (documented in `RUST_MAPPING.md`).

## Verified locally with real TLC
Self-test OK · 8/8 real implementation traces conform · corrupted traces fail · clippy `-D warnings` + fmt clean. This PR triggers the TLA workflow itself, so the new step runs on this very PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)