### PR TITLE
spec(tla): pad-directive model + behavior replay against process_pads

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -77,7 +77,7 @@ jobs:
         run: python3 scripts/tla-coverage-check.py
       - name: Model check all specs
         run: |
-          SPECS="Conservation DoubleEntry AccountStateMachine Interpolation \
+          SPECS="Conservation DoubleEntry AccountStateMachine Interpolation PadCorrect \
                  FIFOCorrect LIFOCorrect HIFOCorrect MultiCurrency PriceDB \
                  STRICTCorrect AVERAGECorrect NONECorrect ValidationCorrect \
                  PluginCorrect ConcurrentAccess QueryExecution"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,7 @@ dependencies = [
  "rust_decimal_macros",
  "rustc-hash 2.1.2",
  "rustledger-core",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -21,6 +21,7 @@ thiserror.workspace = true
 rustc-hash.workspace = true
 
 [dev-dependencies]
+serde_json.workspace = true
 proptest.workspace = true
 rust_decimal_macros = "1.40"
 

--- a/crates/rustledger-booking/tests/tla_behavior_replay.rs
+++ b/crates/rustledger-booking/tests/tla_behavior_replay.rs
@@ -1,0 +1,225 @@
+//! Behavior replay for `PadCorrect.tla` against the pad engine.
+//!
+//! Companion to `rustledger-core/tests/tla_behavior_replay.rs` (see its
+//! module docs for the corpus format and regeneration workflow) — this suite
+//! lives in the booking crate because the abstraction target is
+//! [`rustledger_booking::process_pads`].
+//!
+//! The model (`spec/tla/PadCorrect.tla`): a pad directive arms a pending pad
+//! on the account; the next balance assertion absorbs the difference by
+//! synthesizing a padding transaction (`pad amount = asserted − actual`); a
+//! newer pad replaces a pending one; assertions without a pad only occur
+//! when they already hold. Single account, single currency — the
+//! implementation's sub-account summing semantic is out of model scope
+//! (pinned by integration tests instead).
+//!
+//! Conformance per behavior: `process_pads` synthesizes exactly the pads
+//! the model resolved with exactly the model's amounts, and the final
+//! account balance (original transactions + synthesized pads) equals the
+//! model's final `actual`. Behaviors ending with an ARMED pad must produce
+//! exactly the implementation's unused-pad error (beancount-aligned) and
+//! nothing else; all other behaviors must be error-free.
+
+use rust_decimal::Decimal;
+use rustledger_booking::process_pads;
+use rustledger_core::{
+    Amount, Balance, Directive, IncompleteAmount, NaiveDate, Pad, Posting, Spanned, Transaction,
+    naive_date,
+};
+use serde_json::Value;
+
+const ACCOUNT: &str = "Assets:Cash";
+const SOURCE: &str = "Equity:Opening-Balances";
+
+fn load_corpus(spec: &str) -> Option<Value> {
+    let path = match std::env::var("RUSTLEDGER_TLA_BEHAVIORS_DIR") {
+        Ok(dir) => std::path::PathBuf::from(dir).join(format!("{spec}.json")),
+        Err(_) => std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(format!("../../spec/tla/behaviors/{spec}.json")),
+    };
+    // Graceful skip when spec/ is stripped (crane srcFilter, published crates).
+    let raw = std::fs::read_to_string(path).ok()?;
+    let corpus: Value = serde_json::from_str(&raw).expect("corpus is valid JSON");
+    let behaviors = corpus["behaviors"]
+        .as_array()
+        .expect("behaviors array")
+        .len() as u64;
+    let declared = corpus["coverage"]["behaviors"]
+        .as_u64()
+        .expect("coverage.behaviors");
+    assert!(
+        behaviors > 0 && behaviors == declared,
+        "{spec}: corpus has {behaviors} behaviors but declares {declared} — \
+         regenerate with scripts/tla-behaviors.py"
+    );
+    Some(corpus)
+}
+
+fn day(step: usize) -> NaiveDate {
+    naive_date(2024, 1, u32::try_from(step.min(27)).expect("small") + 1).expect("valid day")
+}
+
+fn txn(date: NaiveDate, amount: i64) -> Directive {
+    let leg = |account: &str, number: i64| {
+        Spanned::synthesized(Posting {
+            account: account.into(),
+            units: Some(IncompleteAmount::Complete(Amount::new(
+                Decimal::from(number),
+                "USD",
+            ))),
+            cost: None,
+            price: None,
+            flag: None,
+            comments: Vec::new(),
+            trailing_comments: Vec::new(),
+            meta: Default::default(),
+        })
+    };
+    Directive::Transaction(Transaction {
+        date,
+        flag: '*',
+        payee: None,
+        narration: "replay".into(),
+        tags: vec![],
+        links: vec![],
+        postings: vec![leg(ACCOUNT, amount), leg("Equity:Aux", -amount)],
+        trailing_comments: Vec::new(),
+        meta: Default::default(),
+    })
+}
+
+/// Sum a transaction's postings on ACCOUNT.
+fn account_units(t: &Transaction) -> Decimal {
+    t.postings
+        .iter()
+        .filter(|p| p.account.as_ref() == ACCOUNT)
+        .filter_map(|p| p.amount())
+        .map(|a| a.number)
+        .sum()
+}
+
+#[test]
+fn replay_every_pad_behavior() {
+    let Some(corpus) = load_corpus("PadCorrect") else {
+        eprintln!("skipping: PadCorrect corpus not available");
+        return;
+    };
+    let behaviors = corpus["behaviors"].as_array().expect("behaviors");
+
+    for (bi, behavior) in behaviors.iter().enumerate() {
+        // process_pads only tracks inventories for accounts an Open directive
+        // created (postings to unopened accounts are silently ignored — the
+        // validator owns that error class), so open every account first, as
+        // any real ledger would.
+        let mut directives: Vec<Directive> = [ACCOUNT, SOURCE, "Equity:Aux"]
+            .iter()
+            .map(|account| {
+                Directive::Open(rustledger_core::Open {
+                    date: naive_date(2023, 12, 31).expect("valid"),
+                    account: (*account).into(),
+                    currencies: vec![],
+                    booking: None,
+                    meta: Default::default(),
+                })
+            })
+            .collect();
+        // Model-side bookkeeping to derive the expected synthesized pads.
+        let mut actual: i64 = 0;
+        let mut pad_pending = false;
+        let mut expected_pads: Vec<i64> = Vec::new();
+        let mut txn_sum: i64 = 0;
+
+        for (si, step) in behavior.as_array().expect("steps").iter().enumerate() {
+            let (action, params, state) = (step[0].as_str().expect("action"), &step[1], &step[2]);
+            let date = day(si + 1);
+            match action {
+                "AddTxn" => {
+                    let amount = params["amount"].as_i64().expect("amount");
+                    directives.push(txn(date, amount));
+                    actual += amount;
+                    txn_sum += amount;
+                }
+                "AddPad" => {
+                    directives.push(Directive::Pad(Pad {
+                        date,
+                        account: ACCOUNT.into(),
+                        source_account: SOURCE.into(),
+                        meta: Default::default(),
+                    }));
+                    pad_pending = true;
+                }
+                "AddBalance" => {
+                    let asserted = params["asserted"].as_i64().expect("asserted");
+                    directives.push(Directive::Balance(Balance {
+                        date,
+                        account: ACCOUNT.into(),
+                        amount: Amount::new(Decimal::from(asserted), "USD"),
+                        tolerance: None,
+                        meta: Default::default(),
+                    }));
+                    if pad_pending {
+                        expected_pads.push(asserted - actual);
+                        actual = asserted;
+                        pad_pending = false;
+                    } else {
+                        assert_eq!(asserted, actual, "model emitted an illegal balance");
+                    }
+                }
+                other => panic!("PadCorrect: unknown action {other:?}"),
+            }
+            assert_eq!(
+                actual,
+                state["actual"].as_i64().expect("actual"),
+                "PadCorrect behavior {bi} step {si}: bookkeeping drifted from the corpus"
+            );
+        }
+
+        let result = process_pads(&directives);
+        // A behavior may END with an armed pad; the implementation
+        // (beancount-aligned) reports an unused pad as an error. Assert
+        // EXACTLY that error in exactly that case — any other error, or a
+        // missing unused-pad error, is a divergence.
+        if pad_pending {
+            assert!(
+                result.errors.len() == 1
+                    && result.errors[0]
+                        .message
+                        .contains("no corresponding balance"),
+                "PadCorrect behavior {bi}: expected exactly the unused-pad error, \
+                 got: {:?}",
+                result.errors
+            );
+        } else {
+            assert!(
+                result.errors.is_empty(),
+                "PadCorrect behavior {bi}: model-legal pad sequence errored: {:?}",
+                result.errors
+            );
+        }
+
+        // Zero-difference pads may or may not synthesize a transaction; only
+        // nonzero expected pads are structural.
+        let synthesized: Vec<Decimal> = result
+            .padding_transactions
+            .iter()
+            .map(account_units)
+            .collect();
+        let expected: Vec<Decimal> = expected_pads
+            .iter()
+            .filter(|p| **p != 0)
+            .map(|p| Decimal::from(*p))
+            .collect();
+        assert_eq!(
+            synthesized, expected,
+            "PadCorrect behavior {bi}: synthesized pad amounts diverged"
+        );
+
+        let final_balance = Decimal::from(txn_sum) + synthesized.iter().sum::<Decimal>();
+        assert_eq!(
+            final_balance,
+            Decimal::from(actual),
+            "PadCorrect behavior {bi}: final balance diverged from the model"
+        );
+    }
+    println!("PadCorrect: replayed {} behaviors", behaviors.len());
+}

--- a/scripts/tla-behaviors.py
+++ b/scripts/tla-behaviors.py
@@ -395,6 +395,31 @@ def _derive_price_db(src: dict, dst: dict) -> list:
     raise SystemExit(f"PriceDB: underivable delta {src} -> {dst}")
 
 
+def _derive_pad(src: dict, dst: dict) -> list:
+    """Pad lifecycle: AddTxn (actual moves, pad unchanged), AddPad (pad arms),
+    AddBalance (pad disarms; actual jumps to the asserted value).
+
+    TLA booleans parse as the strings "TRUE"/"FALSE" — normalize before any
+    truthiness check ("FALSE" is truthy in Python)."""
+    src_pad = src["padPending"] == "TRUE"
+    dst_pad = dst["padPending"] == "TRUE"
+    state = {"actual": dst["actual"], "padPending": dst_pad}
+    if dst_pad and not src_pad and dst["actual"] == src["actual"]:
+        return ["AddPad", {}, state]
+    if not dst_pad and src_pad:
+        return ["AddBalance", {"asserted": dst["actual"]}, state]
+    if dst_pad == src_pad and dst["actual"] != src["actual"]:
+        # A transaction; a pending pad (if any) stays armed.
+        return ["AddTxn", {"amount": dst["actual"] - src["actual"]}, state]
+    if not dst_pad and not src_pad and dst["actual"] == src["actual"]:
+        # Self-loop: a no-pad balance assertion of the current value.
+        return ["AddBalance", {"asserted": dst["actual"]}, state]
+    # Remaining self-loop: pad armed while already armed (replacement).
+    if dst_pad and src_pad and dst["actual"] == src["actual"]:
+        return ["AddPad", {}, state]
+    raise SystemExit(f"PadCorrect: underivable delta {src} -> {dst}")
+
+
 SPECS = {
     "Conservation": {
         "required": ("inventory", "totalAdded", "totalReduced"),
@@ -444,6 +469,11 @@ SPECS = {
     "PriceDB": {
         "required": ("prices",),
         "derive": _derive_price_db,
+        "step_format": ["action", "params", "state"],
+    },
+    "PadCorrect": {
+        "required": ("actual", "padPending"),
+        "derive": _derive_pad,
         "step_format": ["action", "params", "state"],
     },
 }

--- a/scripts/tla-coverage-check.py
+++ b/scripts/tla-coverage-check.py
@@ -40,6 +40,7 @@ REPLAY_FILES = [
     REPO / "crates" / "rustledger-core" / "tests" / "tla_behavior_replay.rs",
     REPO / "crates" / "rustledger-validate" / "tests" / "tla_behavior_replay.rs",
     REPO / "crates" / "rustledger-query" / "tests" / "tla_behavior_replay.rs",
+    REPO / "crates" / "rustledger-booking" / "tests" / "tla_behavior_replay.rs",
 ]
 MAPPING = TLA_DIR / "RUST_MAPPING.md"
 GENERATOR = REPO / "scripts" / "tla-behaviors.py"

--- a/scripts/tla-escalated-replay.py
+++ b/scripts/tla-escalated-replay.py
@@ -52,6 +52,7 @@ ESCALATED: dict[str, dict[str, int]] = {
     "MultiCurrency": {"MaxUnits": 5, "MaxOperations": 8},
     "AccountStateMachine": {"MaxBalance": 15},
     "PriceDB": {"MaxPrice": 5},
+    "PadCorrect": {"MaxAmount": 5, "MaxOperations": 6},
 }
 
 

--- a/spec/tla/PadCorrect.cfg
+++ b/spec/tla/PadCorrect.cfg
@@ -1,0 +1,9 @@
+CONSTANTS
+    MaxAmount = 3
+    MaxOperations = 5
+
+INIT Init
+NEXT Next
+
+INVARIANTS
+    TypeOK

--- a/spec/tla/PadCorrect.tla
+++ b/spec/tla/PadCorrect.tla
@@ -1,0 +1,85 @@
+------------------------------ MODULE PadCorrect ------------------------------
+(*
+ * Verify pad-directive semantics (beancount `pad`).
+ *
+ * A pad directive arms a pending pad on an account; the NEXT balance
+ * assertion on that account absorbs the difference by synthesizing a
+ * padding transaction, so the assertion holds exactly:
+ *
+ *   pad amount = asserted - actual   (inserted just before the balance)
+ *
+ * Modeled per the implementation in `rustledger-booking/src/pad.rs`:
+ * - a newer pad REPLACES a still-pending one;
+ * - a balance assertion with no pending pad must simply match (the model
+ *   only emits legal balances — failing unpadded assertions are validator
+ *   territory, not pad-engine semantics);
+ * - single account, single currency. The implementation's sub-account
+ *   summing semantic (a balance assertion covers the account subtree) is
+ *   deliberately OUT of model scope — it is pinned by integration tests.
+ *
+ * The replay (rustledger-booking/tests/tla_behavior_replay.rs) drives the
+ * real `process_pads` with the directive sequence and checks the
+ * synthesized pad amounts and final balances.
+ *)
+
+EXTENDS Integers
+
+CONSTANTS MaxAmount, MaxOperations
+
+VARIABLES
+    actual,         \* True balance including synthesized pads
+    padPending,     \* A pad directive is armed and awaiting a balance
+    opCount
+
+vars == <<actual, padPending, opCount>>
+
+-----------------------------------------------------------------------------
+Init ==
+    /\ actual = 0
+    /\ padPending = FALSE
+    /\ opCount = 0
+
+-----------------------------------------------------------------------------
+(* A transaction posting to the account. *)
+AddTxn(amt) ==
+    /\ amt # 0
+    /\ opCount < MaxOperations
+    /\ actual' = actual + amt
+    /\ UNCHANGED padPending
+    /\ opCount' = opCount + 1
+
+(* Arm a pad. Arming while one is pending replaces it (same observable
+   state — the implementation swaps the pending entry). *)
+AddPad ==
+    /\ opCount < MaxOperations
+    /\ padPending' = TRUE
+    /\ UNCHANGED actual
+    /\ opCount' = opCount + 1
+
+(* A balance assertion. With a pad pending, the pad absorbs the difference
+   and the balance lands exactly on the asserted value; without one, the
+   model only emits assertions that already hold. *)
+AddBalance(asserted) ==
+    /\ opCount < MaxOperations
+    /\ IF padPending
+       THEN actual' = asserted
+       ELSE /\ asserted = actual
+            /\ UNCHANGED actual
+    /\ padPending' = FALSE
+    /\ opCount' = opCount + 1
+
+Next ==
+    \/ \E amt \in (-MaxAmount..MaxAmount) \ {0} : AddTxn(amt)
+    \/ AddPad
+    \/ \E b \in -MaxAmount..MaxAmount : AddBalance(b)
+
+-----------------------------------------------------------------------------
+TypeOK ==
+    /\ actual \in Int
+    /\ padPending \in BOOLEAN
+    /\ opCount \in Nat
+
+-----------------------------------------------------------------------------
+Spec == Init /\ [][Next]_vars
+
+=============================================================================

--- a/spec/tla/RUST_MAPPING.md
+++ b/spec/tla/RUST_MAPPING.md
@@ -44,6 +44,7 @@ Covered specs (≈4,000 behaviors total, all replayed in <1s of `cargo test`):
 | NONECorrect | 396 | balance (shorts allowed) + totals abstraction |
 | MultiCurrency | 10,116 | per-currency inventory over a multi-commodity `Inventory` — every currency asserted after every step, so cross-commodity unit leaks fail |
 | AccountStateMachine | 16,222 | validator lifecycle (in `rustledger-validate/tests/`): each model-legal open/close/post/transfer sequence, converted to directives, must `validate()` with zero errors (the E1001/E1002/E1003 state machine) |
+| PadCorrect | 1,044 | pad engine (in `rustledger-booking/tests/`): model-legal pad/txn/balance sequences run through `process_pads` — zero errors, synthesized pad amounts exactly `asserted − actual`, final balance matches; sub-account summing out of model scope (integration-tested) |
 | PriceDB | 690 | `PriceDatabase` (in `rustledger-query/tests/`): every model-set `(base, quote)` reads back via `get_latest_price`; model-unset entries not asserted (the implementation legitimately derives inverse rates) |
 
 Two specs are deliberately NOT replayed:

--- a/spec/tla/behaviors/PadCorrect.json
+++ b/spec/tla/behaviors/PadCorrect.json
@@ -1,0 +1,43417 @@
+{
+ "spec": "PadCorrect",
+ "state_vars": [
+  "actual",
+  "padPending"
+ ],
+ "step_format": [
+  "action",
+  "params",
+  "state"
+ ],
+ "coverage": {
+  "states": 161,
+  "transitions": 1044,
+  "behaviors": 1044
+ },
+ "behaviors": [
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -11,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 0
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 11,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 0,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -13,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -11,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -13,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -14,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": -12,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": -13,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -14,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -15,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 1,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 4,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 7,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 10,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 13,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 2,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": -1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 5,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 8,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 11,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 13,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 14,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddBalance",
+    {
+     "asserted": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 3,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 2,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 1,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 0,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 6,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 5,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 4,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 9,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 8,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 7,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddPad",
+    {},
+    {
+     "actual": 12,
+     "padPending": true
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -1
+    },
+    {
+     "actual": 11,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -2
+    },
+    {
+     "actual": 10,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": -3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 1
+    },
+    {
+     "actual": 13,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 2
+    },
+    {
+     "actual": 14,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 15,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 12,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 9,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ],
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 6,
+     "padPending": false
+    }
+   ]
+  ],
+  [
+   [
+    "AddTxn",
+    {
+     "amount": 3
+    },
+    {
+     "actual": 3,
+     "padPending": false
+    }
+   ]
+  ]
+ ]
+}


### PR DESCRIPTION
FV backlog (roadmap "Next" item): the pad directive — beancount's subtlest directive — gets a TLA+ model and full behavior-replay conformance.

## Model
`PadCorrect.tla` (161 states, TLC-checked): pad arms → next balance absorbs the difference (`pad = asserted − actual`) → newer pads replace pending ones. Single account/currency; sub-account summing deliberately out of scope (integration-tested).

## Replay — 1,044 behaviors (4,082 escalated) against the real `process_pads`
Synthesized pad amounts must match the model exactly; final balances must match. Building it surfaced **two implementation semantics the suite now pins**:
1. **Unused pad = error**: a behavior ending with an armed pad must produce *exactly* the beancount-aligned unused-pad error — no more, no less.
2. **Opened-accounts precondition**: `process_pads` silently ignores postings to unopened accounts (the validator owns that error class) — the replay opens accounts first, as any real ledger would; the precondition is documented in the test.

## Wiring (all four layers, enforced by the coverage lint)
Generator derive (with TLA boolean normalization — `"FALSE"` is truthy in Python, a trap now documented) · corpus · lint replay-file list · escalation entry · RUST_MAPPING row · tla.yml model-check loop. This PR triggers the TLA workflow: lint + 17-spec model check + corpora lockstep + trace validation all run on it.

Verified locally: TLC clean · both corpus scales green · clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)