### PR TITLE
fix(query): only() propagates NULL in its first argument

### DIFF
--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1047,6 +1047,12 @@ impl<'a> Executor<'a> {
                 Self::require_args_count(&name_upper, args, 2)?;
                 let currency = match &args[0] {
                     Value::String(s) => s.clone(),
+                    // NULL propagates (beanquery parity): `first(cost_currency)`
+                    // is NULL for groups without costs, and fava's Holdings
+                    // by_currency query feeds exactly that into only() — see
+                    // #1699. The second-argument match below already
+                    // propagates; the asymmetry was the bug.
+                    Value::Null => return Ok(Value::Null),
                     _ => {
                         return Err(QueryError::Type(
                             "ONLY: first argument must be a currency string".to_string(),

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -4746,6 +4746,28 @@ fn test_only_function_with_inventory() {
     }
 }
 
+/// `only()` must propagate NULL in its first argument (beanquery parity).
+/// `first(cost_currency)` is NULL for groups without costs — fava's Holdings
+/// `by_currency` query feeds that into `only()` on any ledger with a costless
+/// commodity group, which 500'd the page before #1699.
+#[test]
+fn test_only_null_first_argument_propagates() {
+    let directives = make_holdings_directives();
+    let result = execute_query(
+        r#"SELECT only(first(cost_currency), cost(sum(position))) as avg_cost_ccy
+           WHERE account ~ "Cash"
+           GROUP BY currency"#,
+        &directives,
+    );
+
+    assert_eq!(result.len(), 1);
+    assert!(
+        matches!(&result.rows[0][0], Value::Null),
+        "only(NULL, ...) must be NULL, got {:?}",
+        result.rows[0][0]
+    );
+}
+
 #[test]
 fn test_filter_currency_function() {
     let directives = make_multi_currency_holdings();


### PR DESCRIPTION
Fixes the first of the three route-smoke findings: `only(NULL, inv)` now returns NULL (beanquery parity) instead of `type error: ONLY: first argument must be a currency string`.

Root cause (from the #1699 analysis): the first-arg match sent everything non-String — including `Value::Null` from `first(cost_currency)` on costless groups — to the error branch. The second-arg match already propagated; the asymmetry was the bug. **User impact fixed: fava's Holdings → by currency page 500'd on ordinary ledgers.**

Regression test drives the exact Holdings expression shape (`only(first(cost_currency), cost(sum(position)))` over a costless group → NULL row, not an error).

The broader NULL-propagation sweep across typed scalar functions (also suggested in #1699) is left as a follow-up — this PR is the minimal user-facing fix.

Closes #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)