### PR TITLE
fix(query,ffi): one-arg value() is type-stable; column datatypes from first non-NULL row

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -659,24 +659,37 @@ pub fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> 
     let mut executor = Executor::new(directives);
     match executor.execute(&parsed) {
         Ok(result) => {
-            // Infer column datatypes from the first row (reusing value_datatype).
-            let columns = if let Some(first) = result.rows.first() {
-                result
-                    .columns
-                    .iter()
-                    .zip(first.iter())
-                    .map(|(name, value)| wit::ColumnInfo {
-                        name: name.clone(),
-                        datatype: value_datatype(value).to_string(),
-                    })
-                    .collect()
-            } else {
+            // Infer each column's datatype from its first NON-NULL value.
+            // First-row-only inference declared "null" for columns whose
+            // first row happened to be NULL, and baked in whichever shape row
+            // one carried for expressions that were type-unstable across rows
+            // (#1701) — the host trusts this declaration when deserializing
+            // every row.
+            let columns = if result.rows.is_empty() {
                 result
                     .columns
                     .iter()
                     .map(|name| wit::ColumnInfo {
                         name: name.clone(),
                         datatype: "str".to_string(),
+                    })
+                    .collect()
+            } else {
+                result
+                    .columns
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| {
+                        let datatype = result
+                            .rows
+                            .iter()
+                            .map(|row| &row[i])
+                            .find(|v| !matches!(v, Value::Null))
+                            .map_or("null", value_datatype);
+                        wit::ColumnInfo {
+                            name: name.clone(),
+                            datatype: datatype.to_string(),
+                        }
                     })
                     .collect()
             };

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1776,6 +1776,17 @@ impl<'a> Executor<'a> {
         explicit_currency: Option<&str>,
         at_date: Option<NaiveDate>,
     ) -> Result<Value, QueryError> {
+        // Column-type stability (#1701): the one-argument form infers the
+        // target currency PER ROW (cost currency, else executor default), so
+        // an Amount-vs-Inventory return that depends on the row's data makes
+        // the column type unstable — the FFI layer declares the type from one
+        // row and other rows then contradict it. The rule:
+        //   - explicit currency (two-arg form): target is constant across the
+        //     query -> Amount for every row (existing behavior, stable);
+        //   - one-arg form over an Inventory: ALWAYS return an Inventory
+        //     (beanquery parity: value(inventory) is inventory-typed), whether
+        //     or not a target currency could be inferred for this row.
+        let inventory_stays_inventory = explicit_currency.is_none();
         // Determine target currency:
         // 1. Explicit argument takes precedence
         // 2. Infer from position's cost currency (beancount compatibility)
@@ -1843,6 +1854,28 @@ impl<'a> Executor<'a> {
                 }
             }
             Value::Inventory(inv) => {
+                if inventory_stays_inventory {
+                    // Convert per position; a position with no available price
+                    // keeps its raw units (matching the Position/Amount arms
+                    // above and beanquery, which never drops positions).
+                    let mut out = rustledger_core::Inventory::new();
+                    for pos in inv.positions() {
+                        let units = if pos.units.currency == target_currency {
+                            pos.units.clone()
+                        } else if let Some(converted) = convert_one(&pos.units) {
+                            converted
+                        } else {
+                            pos.units.clone()
+                        };
+                        out.add(rustledger_core::Position::simple(units));
+                    }
+                    return Ok(Value::Inventory(Box::new(out)));
+                }
+                // Two-arg form: collapse to a single Amount in the explicit
+                // target currency. NOTE (pre-existing beanquery divergence,
+                // out of #1701's scope): positions with no available price are
+                // dropped from the total here; beanquery would keep them as
+                // their original units in an Inventory result.
                 let mut total = Decimal::ZERO;
                 for pos in inv.positions() {
                     if pos.units.currency == target_currency {

--- a/crates/rustledger-query/tests/bql_integration_test.rs
+++ b/crates/rustledger-query/tests/bql_integration_test.rs
@@ -4768,6 +4768,51 @@ fn test_only_null_first_argument_propagates() {
     );
 }
 
+/// The one-argument `value()` form must be TYPE-STABLE over inventories:
+/// always Inventory, whether or not a per-row target currency (cost
+/// currency) could be inferred. Before #1701 costless groups returned the
+/// Inventory as-is while costed groups collapsed to Amount — the FFI layer
+/// declared the column from one row and other rows contradicted it.
+#[test]
+fn test_value_one_arg_inventory_is_type_stable() {
+    let directives = make_holdings_directives();
+    // Two groups: a costed one (Brokerage AAPL lots) and a costless one
+    // (Checking USD cash) — the pre-fix instability pair.
+    let result = execute_query(
+        r"SELECT value(sum(position)) as market_value GROUP BY currency",
+        &directives,
+    );
+
+    assert!(result.len() >= 2, "need both a costed and a costless group");
+    for (i, row) in result.rows.iter().enumerate() {
+        assert!(
+            matches!(&row[0], Value::Inventory(_)),
+            "row {i}: one-arg value() must be Inventory for every row, got {:?}",
+            row[0]
+        );
+    }
+}
+
+/// The two-argument form keeps its Amount contract (explicit target
+/// currency is constant across the query, so it was never unstable).
+#[test]
+fn test_value_two_arg_stays_amount() {
+    let directives = make_holdings_directives();
+    let result = execute_query(
+        r#"SELECT value(sum(position), "USD") as market_value GROUP BY currency"#,
+        &directives,
+    );
+
+    assert!(!result.is_empty());
+    for (i, row) in result.rows.iter().enumerate() {
+        assert!(
+            matches!(&row[0], Value::Amount(_)),
+            "row {i}: two-arg value() must stay Amount, got {:?}",
+            row[0]
+        );
+    }
+}
+
 #[test]
 fn test_filter_currency_function() {
     let directives = make_multi_currency_holdings();


### PR DESCRIPTION
Fixes the second route-smoke finding — two stacked defects (per the #1701 analysis):

## 1. `value()` was type-unstable across rows
The one-arg form inferred the target currency **per row**: Amount when a cost currency existed, the Inventory as-is when none did. Now: one-arg over Inventory → **always Inventory** (beanquery parity — `value(inventory)` is inventory-typed), converting per position with unpriced positions kept at raw units — which also fixes the silent-drop inconsistency vs the Position/Amount arms. The **two-arg form keeps its Amount contract** (explicit target is constant per query, never unstable — and existing tests pin `number(value(sum(position), \"USD\"))`); its pre-existing beanquery divergences are documented at the site rather than silently changed.

## 2. First-row datatype inference in the component
`convert.rs` declared each column's type from row 1 — baking in whichever shape that row had (and \"null\" when row 1 was NULL). Now: first **non-NULL** value per column, so no single row dictates a contract other rows contradict.

Regression tests pin both contracts across costed + costless groups (the exact pre-fix instability pair).

Closes #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)