### PR TITLE
fix(booking): reject empty-cost augmentations loudly (interim for #1705)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -45,6 +45,23 @@ pub enum BookingError {
     /// Interpolation failed after booking.
     #[error("interpolation failed: {0}")]
     Interpolation(#[from] InterpolationError),
+    /// An AUGMENTING posting carries a cost spec with no number (`{}`,
+    /// `{USD}`, `{2024-01-02}`): the lot's cost basis cannot be
+    /// determined, and booking it uncosted silently corrupts every
+    /// downstream cost read (#1705). Beancount infers the number from
+    /// the transaction residual — until rustledger implements that
+    /// (book-first-interpolate-after), this is a loud error instead of
+    /// a silent wrong booking. Reductions with `{}` (wildcard lot
+    /// match) and `{*}` merge specs are unaffected.
+    #[error(
+        "cost spec on augmenting posting to {account} has no cost amount; \
+         write the cost explicitly (e.g. {{0.90 EUR}}) — inferring it from \
+         the transaction balance is not supported yet (#1705)"
+    )]
+    EmptyCostAugmentation {
+        /// The augmented account.
+        account: rustledger_core::Account,
+    },
 }
 
 /// Result of booking a single transaction.
@@ -415,6 +432,27 @@ impl BookingEngine {
                     }
                 }
 
+                // Guard (#1705): an augmentation whose cost spec has no
+                // number books an UNCOSTED lot via resolve() -> None —
+                // silent corruption of every downstream cost read. Beancount
+                // infers the number from the residual; until that lands,
+                // fail loudly. Reductions never reach here (booked above,
+                // wildcard {} is their lot-match syntax) and merge specs
+                // legitimately carry no number.
+                if !booked_indices.contains(&idx)
+                    && cost_spec.number.is_none()
+                    && !cost_spec.merge
+                    && units.number > rustledger_core::Decimal::ZERO
+                {
+                    // Positive units only: a negative-units `{}` posting that
+                    // didn't classify as a reduction (e.g. empty inventory)
+                    // is reduction INTENT — the Late validator's independent
+                    // lot-matching pass reports those as missing lots, per
+                    // the two-phase design. The silent case is the BUY.
+                    return Err(BookingError::EmptyCostAugmentation {
+                        account: posting.account.clone(),
+                    });
+                }
                 // Fill in dates and currencies for augmentations (not already booked)
                 if !booked_indices.contains(&idx) && cost_spec.number.is_some() {
                     // Cost spec has a number but may be missing date or currency
@@ -1111,11 +1149,14 @@ mod tests {
                 Amount::new(dec!(-750.00), "USD"),
             ));
 
-        // Should not error - just skip lot matching for augmentation
-        let booked = engine.book(&another_buy).unwrap();
+        // Pre-#1705 this pinned "should not error - just skip lot
+        // matching", which booked the lot UNCOSTED and silently corrupted
+        // every downstream cost read. The interim guard makes it a loud
+        // error until cost-from-residual interpolation lands.
+        let err = engine.book(&another_buy).unwrap_err();
         assert!(
-            booked.booked_indices.is_empty(),
-            "Augmentation should not have booked indices"
+            err.to_string().contains("no cost amount"),
+            "empty-cost augmentation must error loudly (#1705), got: {err}"
         );
     }
 

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "rmp-serde",
  "serde",


### PR DESCRIPTION
The interim guard from the #1705 review: converts the SILENT half of the bug (an augmenting `{}` posting booking an **uncosted lot**, corrupting every downstream cost read) into a loud, actionable diagnostic:

```
error[BOOK]: cost spec on augmenting posting to Assets:Broker has no cost amount;
write the cost explicitly (e.g. {0.90 EUR}) — inferring it from the transaction
balance is not supported yet (#1705)
```

Scoping (the subtle part):
- **positive units only** — a negative-units `{}` posting that didn't classify as a reduction (e.g. empty inventory) is reduction *intent*, which the Late validator's independent lot-matching pass already reports; the two-phase engine-lenient/validator-diagnoses design is preserved (`test_book_no_inventory_for_account` still passes unchanged).
- Reductions with `{}` (wildcard lot-match syntax) and `{*}` merge specs unaffected.
- `test_book_augmentation_not_reduction` previously pinned the silent booking — flipped with history documented.

The real fix (book-first-interpolate-after, per the #1705 analysis) is planned separately; this guard makes the interim safe. E2E: the issue's file now fails on the **buy** with the message above instead of silently mis-booking and failing one transaction later.

Refs #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)