### PR TITLE
fix(booking): infer augmenting empty-{} cost from the residual (completes #1706)

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -1115,6 +1115,59 @@ mod tests {
         assert!(results[1].is_ok());
     }
 
+    /// Issue #1705: an augmenting `{}` lot gets its cost inferred from the
+    /// residual, and a later `{}` reduction of that lot then books cleanly
+    /// (previously the reduction hit a spurious "2 unknowns" error because
+    /// the augmenting lot carried no cost basis to match).
+    #[test]
+    fn test_augmenting_empty_cost_then_reduce() {
+        // buy: 1000 USD {} against -900 EUR  → lot booked at 0.90 EUR/unit
+        let buy = Transaction::new(date(2024, 1, 2), "buy USD")
+            .with_synthesized_posting(
+                Posting::new("Assets:Broker", Amount::new(dec!(1000), "USD"))
+                    .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-900), "EUR")));
+
+        // sell: -100 USD {} + 95 EUR + PnL residual  → reduce at 0.90, PnL = -5 EUR
+        let sell = Transaction::new(date(2024, 1, 5), "sell part")
+            .with_synthesized_posting(
+                Posting::new("Assets:Broker", Amount::new(dec!(-100.00), "USD"))
+                    .with_cost(CostSpec::empty()),
+            )
+            .with_synthesized_posting(Posting::new("Expenses:Misc", Amount::new(dec!(95), "EUR")))
+            .with_synthesized_posting(Posting::auto("Income:Trading:PnL"));
+
+        let results = book_transactions(&[buy, sell], BookingMethod::Fifo);
+        assert_eq!(results.len(), 2);
+
+        let buy_txn = &results[0].as_ref().expect("buy should book").transaction;
+        let buy_cost = buy_txn.postings[0].cost.as_ref().expect("cost present");
+        assert_eq!(
+            buy_cost
+                .number
+                .as_ref()
+                .and_then(rustledger_core::CostNumber::per_unit),
+            Some(dec!(0.90))
+        );
+        assert_eq!(buy_cost.currency.as_deref(), Some("EUR"));
+
+        // The `{}` reduction booked cleanly and the PnL residual solved to -5 EUR.
+        let sell_txn = &results[1].as_ref().expect("sell should book").transaction;
+        let pnl = sell_txn
+            .postings
+            .iter()
+            .find(|p| p.account.as_str() == "Income:Trading:PnL")
+            .expect("PnL posting present");
+        let pnl_amount = pnl
+            .units
+            .as_ref()
+            .and_then(|u| u.as_amount())
+            .expect("PnL filled");
+        assert_eq!(pnl_amount.number, dec!(-5));
+        assert_eq!(pnl_amount.currency.as_str(), "EUR");
+    }
+
     #[test]
     fn test_book_augmentation_not_reduction() {
         let mut engine = BookingEngine::new();

--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -45,23 +45,6 @@ pub enum BookingError {
     /// Interpolation failed after booking.
     #[error("interpolation failed: {0}")]
     Interpolation(#[from] InterpolationError),
-    /// An AUGMENTING posting carries a cost spec with no number (`{}`,
-    /// `{USD}`, `{2024-01-02}`): the lot's cost basis cannot be
-    /// determined, and booking it uncosted silently corrupts every
-    /// downstream cost read (#1705). Beancount infers the number from
-    /// the transaction residual — until rustledger implements that
-    /// (book-first-interpolate-after), this is a loud error instead of
-    /// a silent wrong booking. Reductions with `{}` (wildcard lot
-    /// match) and `{*}` merge specs are unaffected.
-    #[error(
-        "cost spec on augmenting posting to {account} has no cost amount; \
-         write the cost explicitly (e.g. {{0.90 EUR}}) — inferring it from \
-         the transaction balance is not supported yet (#1705)"
-    )]
-    EmptyCostAugmentation {
-        /// The augmented account.
-        account: rustledger_core::Account,
-    },
 }
 
 /// Result of booking a single transaction.
@@ -432,27 +415,6 @@ impl BookingEngine {
                     }
                 }
 
-                // Guard (#1705): an augmentation whose cost spec has no
-                // number books an UNCOSTED lot via resolve() -> None —
-                // silent corruption of every downstream cost read. Beancount
-                // infers the number from the residual; until that lands,
-                // fail loudly. Reductions never reach here (booked above,
-                // wildcard {} is their lot-match syntax) and merge specs
-                // legitimately carry no number.
-                if !booked_indices.contains(&idx)
-                    && cost_spec.number.is_none()
-                    && !cost_spec.merge
-                    && units.number > rustledger_core::Decimal::ZERO
-                {
-                    // Positive units only: a negative-units `{}` posting that
-                    // didn't classify as a reduction (e.g. empty inventory)
-                    // is reduction INTENT — the Late validator's independent
-                    // lot-matching pass reports those as missing lots, per
-                    // the two-phase design. The silent case is the BUY.
-                    return Err(BookingError::EmptyCostAugmentation {
-                        account: posting.account.clone(),
-                    });
-                }
                 // Fill in dates and currencies for augmentations (not already booked)
                 if !booked_indices.contains(&idx) && cost_spec.number.is_some() {
                     // Cost spec has a number but may be missing date or currency
@@ -1202,14 +1164,16 @@ mod tests {
                 Amount::new(dec!(-750.00), "USD"),
             ));
 
-        // Pre-#1705 this pinned "should not error - just skip lot
-        // matching", which booked the lot UNCOSTED and silently corrupted
-        // every downstream cost read. The interim guard makes it a loud
-        // error until cost-from-residual interpolation lands.
-        let err = engine.book(&another_buy).unwrap_err();
+        // History: originally pinned "should not error - just skip lot
+        // matching" (booked the lot UNCOSTED — silent corruption); the
+        // #1708 interim guard made it a loud error; the #1705 solver now
+        // books it at the residual-inferred cost like beancount. The
+        // engine-level book() leaves the {} spec for interpolation, so
+        // this remains not-an-error with no booked indices.
+        let booked = engine.book(&another_buy).unwrap();
         assert!(
-            err.to_string().contains("no cost amount"),
-            "empty-cost augmentation must error loudly (#1705), got: {err}"
+            booked.booked_indices.is_empty(),
+            "augmentation books via interpolation, not lot matching"
         );
     }
 

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -4,7 +4,9 @@
 
 use rust_decimal::Decimal;
 use rust_decimal::prelude::Signed;
-use rustledger_core::{Amount, Currency, IncompleteAmount, Transaction};
+use rustledger_core::{
+    Amount, BookedCost, CostNumber, CostSpec, Currency, IncompleteAmount, Transaction,
+};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -178,6 +180,15 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
     // interpolation rule allows.
     let mut cost_unknowns_by_currency: HashMap<Currency, usize> = HashMap::with_capacity(2);
 
+    // Augmenting `{}` postings whose per-unit cost beancount infers from the
+    // balance residual (issue #1705): `(posting index, cost currency, units)`.
+    // Only empty-`{}`, price-less postings qualify — a reduction's `{}` is
+    // already cost-filled by the booking pass (so it never reaches the empty
+    // branch below), and a priced `{}` defers to booking-time lot matching.
+    // Each is solved post-loop, but only when it is the SOLE unknown in its
+    // cost currency group (else the group already errored on the count rule).
+    let mut inferable_cost: Vec<(usize, Currency, Decimal)> = Vec::new();
+
     for (i, posting) in transaction.postings.iter().enumerate() {
         match &posting.units {
             Some(IncompleteAmount::Complete(amount)) => {
@@ -225,7 +236,14 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                         get_inferred_currency(&mut inferred_cost_currency)
                     });
                     if let Some(curr) = cost_currency {
-                        *cost_unknowns_by_currency.entry(curr).or_default() += 1;
+                        *cost_unknowns_by_currency.entry(curr.clone()).or_default() += 1;
+                        // An empty `{}` with NO price annotation reaching here is
+                        // an augmentation (a reduction's `{}` is filled by the
+                        // booking pass first). Beancount infers its per-unit cost
+                        // from the residual — record it for post-loop solving.
+                        if posting.price.is_none() {
+                            inferable_cost.push((i, curr, amount.number));
+                        }
                     }
                 } else if let Some(price) = &posting.price {
                     // Price annotation: converts units to price currency.
@@ -376,6 +394,51 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                 count: count + unassigned_missing.len(),
             });
         }
+    }
+
+    // Infer the per-unit cost of augmenting `{}` postings from the residual
+    // (issue #1705). Beancount books first, then interpolates the single
+    // remaining unknown; an augmenting lot written `1000 USD {}` with one
+    // balancing cash leg has its cost inferred from that leg (`-900 EUR` →
+    // 0.90 EUR/unit). rledger left such a lot with no cost basis, which also
+    // broke later reductions of it (the `{}` reduction could no longer match a
+    // cost-bearing lot, surfacing as a spurious "2 unknowns" error).
+    //
+    // Runs BEFORE missing-amount filling so a filled cost balances its
+    // currency before any elided amount absorbs that currency's residual. Each
+    // entry is guaranteed the sole unknown in its cost currency group: the
+    // count-rule check above rejected any group with >1 unknown, and the
+    // unassigned-missing check rejected any unassigned + cost-unknown combo.
+    for (idx, currency, units_number) in inferable_cost {
+        if units_number.is_zero() {
+            continue; // BookedCost is undefined for zero units.
+        }
+        let residual = residuals.get(&currency).copied().unwrap_or(Decimal::ZERO);
+        // The posting's cost weight must cancel the residual. For
+        // `PerUnitFromTotal` the weight is `total * signum(units)`, so pick
+        // `total = -residual * signum(units)` and `per_unit = total / |units|`.
+        let signum = units_number.signum();
+        let total = -residual * signum;
+        let per_unit = total / units_number.abs();
+
+        let existing = result.postings[idx]
+            .cost
+            .take()
+            .unwrap_or_else(CostSpec::empty);
+        result.postings[idx].cost = Some(CostSpec {
+            number: Some(CostNumber::PerUnitFromTotal(BookedCost::new(
+                per_unit,
+                total,
+                units_number,
+            ))),
+            currency: Some(currency.clone()),
+            date: existing.date.or(Some(transaction.date)),
+            label: existing.label,
+            merge: existing.merge,
+        });
+        // Fold the now-known cost weight into the residual so downstream
+        // missing-amount solving sees a balanced cost currency.
+        *residuals.entry(currency).or_default() += total * signum;
     }
 
     // Fill in known-currency missing postings
@@ -1479,6 +1542,45 @@ mod tests {
         assert!(
             matches!(result, Err(InterpolationError::MultipleMissing { .. })),
             "two empty cost specs in same currency should error; got {result:?}"
+        );
+    }
+
+    /// Issue #1705: an augmenting `{}` posting with one balancing leg has
+    /// its per-unit cost inferred from the residual (like beancount), not
+    /// left with an empty cost basis. `1000 USD {}` + `-900 EUR` → the lot
+    /// is booked at 0.90 EUR/unit.
+    #[test]
+    fn test_interpolate_augmenting_empty_cost_inferred_from_residual() {
+        use rustledger_core::{CostNumber, CostSpec};
+
+        let txn = Transaction::new(date(2024, 1, 2), "buy USD")
+            .with_synthesized_posting(
+                Posting::new("Assets:Broker", Amount::new(dec!(1000), "USD"))
+                    .with_cost(CostSpec::empty()), // augmenting `{}` — no price
+            )
+            .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-900), "EUR")));
+
+        let result = interpolate(&txn).expect("augmenting `{}` should interpolate its cost");
+        let cost = result.transaction.postings[0]
+            .cost
+            .as_ref()
+            .expect("cost spec should be present");
+        assert_eq!(cost.currency.as_deref(), Some("EUR"));
+        match cost.number {
+            Some(CostNumber::PerUnitFromTotal(b)) => {
+                assert_eq!(b.per_unit, dec!(0.90), "per-unit cost");
+                assert_eq!(b.total, dec!(900), "preserved total");
+            }
+            other => panic!("expected PerUnitFromTotal, got {other:?}"),
+        }
+        // Cost currency now balances.
+        assert_eq!(
+            result
+                .residuals
+                .get("EUR")
+                .copied()
+                .unwrap_or(Decimal::ZERO),
+            Decimal::ZERO
         );
     }
 

--- a/crates/rustledger-booking/src/interpolate.rs
+++ b/crates/rustledger-booking/src/interpolate.rs
@@ -34,6 +34,31 @@ pub enum InterpolationError {
         /// booking-time lot matching.
         count: usize,
     },
+    /// The residual-solved cost for an empty `{}` augmentation came out
+    /// negative — beancount rejects this ("Cost is negative") rather than
+    /// booking a negative-cost lot (#1705 edge e14).
+    #[error(
+        "inferred cost for {currency} posting is negative ({per_unit} per unit); \
+         a lot cannot be acquired at a negative cost"
+    )]
+    NegativeInferredCost {
+        /// The cost currency the negative value was solved in.
+        currency: Currency,
+        /// The (negative) solved per-unit value.
+        per_unit: Decimal,
+    },
+    /// An empty `{}` cost spec names no currency and the transaction's
+    /// other postings span more than one currency, so the cost currency
+    /// (and therefore the residual to solve from) is ambiguous — beancount
+    /// rejects this ("Failed to categorize posting") (#1705 edge e15).
+    #[error(
+        "cannot infer the cost currency for the {{}} cost spec: candidates \
+         {candidates}; name it explicitly (e.g. {{EUR}})"
+    )]
+    AmbiguousInferredCostCurrency {
+        /// Comma-joined candidate currencies observed.
+        candidates: String,
+    },
 
     /// Cannot infer currency for a posting.
     #[error("cannot infer currency for posting to account {account}")]
@@ -237,13 +262,81 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
                     });
                     if let Some(curr) = cost_currency {
                         *cost_unknowns_by_currency.entry(curr.clone()).or_default() += 1;
-                        // An empty `{}` with NO price annotation reaching here is
-                        // an augmentation (a reduction's `{}` is filled by the
-                        // booking pass first). Beancount infers its per-unit cost
-                        // from the residual — record it for post-loop solving.
-                        if posting.price.is_none() {
-                            inferable_cost.push((i, curr, amount.number));
+                        // An empty `{}` reaching here is an augmentation (a
+                        // reduction's `{}` is filled by the booking pass
+                        // first). Beancount infers its per-unit cost from the
+                        // residual — INCLUDING when a price annotation is
+                        // present, and even when the two disagree (verified
+                        // against bean-check 3.2.3: `{} @ 0.90` with a 0.95
+                        // residual books {0.95}; the price feeds implicit
+                        // price directives only). #1705 edges e07/e16.
+                        //
+                        // The cost currency must be unambiguous when the spec
+                        // does not name one: with candidates from more than
+                        // one non-cost posting, beancount fails to categorize
+                        // the posting (edge e15).
+                        if posting.cost.as_ref().is_some_and(|c| c.currency.is_none()) {
+                            // Candidates are currencies of COMPLETE cost-less
+                            // postings, excluding any currency that already
+                            // has its own missing-amount posting: that group
+                            // owns its unknown, so the {} cannot also belong
+                            // to it (the per-group at-most-one rule) — which
+                            // is what disambiguates "cost-unknown in USD +
+                            // missing amount in EUR" (fine, disjoint groups)
+                            // from two complete foreign currencies (e15,
+                            // beancount: "Failed to categorize").
+                            let mut complete: Vec<String> = Vec::new();
+                            let mut incomplete: Vec<String> = Vec::new();
+                            for p in &transaction.postings {
+                                if p.cost.is_some() {
+                                    continue;
+                                }
+                                let curr_of = crate::price_currency_of(p).or_else(|| {
+                                    p.units.as_ref().and_then(|u| match u {
+                                        IncompleteAmount::Complete(a) => Some(a.currency.clone()),
+                                        IncompleteAmount::CurrencyOnly(c) => Some(c.clone()),
+                                        IncompleteAmount::NumberOnly(_) => None,
+                                    })
+                                });
+                                let complete_units =
+                                    matches!(p.units.as_ref(), Some(IncompleteAmount::Complete(_)));
+                                if let Some(c) = curr_of {
+                                    if complete_units {
+                                        complete.push(c.as_str().to_owned());
+                                    } else {
+                                        incomplete.push(c.as_str().to_owned());
+                                    }
+                                }
+                            }
+                            // A fully-unassigned missing posting (no currency
+                            // context at all) makes the whole transaction
+                            // reject via the post-scan unassigned+cost-unknown
+                            // check with a more specific diagnosis — defer to
+                            // it rather than reporting ambiguity.
+                            let has_unassigned = transaction.postings.iter().any(|p| {
+                                p.cost.is_none()
+                                    && crate::price_currency_of(p).is_none()
+                                    && !matches!(
+                                        p.units.as_ref(),
+                                        Some(
+                                            IncompleteAmount::Complete(_)
+                                                | IncompleteAmount::CurrencyOnly(_)
+                                        )
+                                    )
+                            });
+                            let mut candidates: Vec<String> = complete
+                                .into_iter()
+                                .filter(|c| !incomplete.contains(c))
+                                .collect();
+                            candidates.sort_unstable();
+                            candidates.dedup();
+                            if !has_unassigned && candidates.len() > 1 {
+                                return Err(InterpolationError::AmbiguousInferredCostCurrency {
+                                    candidates: candidates.join(", "),
+                                });
+                            }
                         }
+                        inferable_cost.push((i, curr, amount.number));
                     }
                 } else if let Some(price) = &posting.price {
                     // Price annotation: converts units to price currency.
@@ -420,6 +513,11 @@ pub fn interpolate(transaction: &Transaction) -> Result<InterpolationResult, Int
         let signum = units_number.signum();
         let total = -residual * signum;
         let per_unit = total / units_number.abs();
+        if per_unit < Decimal::ZERO {
+            // Beancount: "Cost is negative" — a lot cannot be acquired at a
+            // negative cost (#1705 edge e14).
+            return Err(InterpolationError::NegativeInferredCost { currency, per_unit });
+        }
 
         let existing = result.postings[idx]
             .cost

--- a/tests/compatibility/files/.gitignore
+++ b/tests/compatibility/files/.gitignore
@@ -29,3 +29,11 @@
 !costs/**/
 !costs/**/*.beancount
 !costs/*.beancount
+
+# In-tree interpolation differential fixtures (#1705): empty-{} cost
+# solving edge matrix, cross-checked against bean-check 3.2.3. Same
+# recursion note as above.
+!interpolation/
+!interpolation/**/
+!interpolation/**/*.beancount
+!interpolation/*.beancount

--- a/tests/compatibility/files/interpolation/e01_augment_empty.beancount
+++ b/tests/compatibility/files/interpolation/e01_augment_empty.beancount
@@ -1,0 +1,9 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {}
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e02_reduce_empty_auto.beancount
+++ b/tests/compatibility/files/interpolation/e02_reduce_empty_auto.beancount
@@ -1,0 +1,14 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {0.90 EUR}
+  Assets:Cash  -900 EUR
+
+2024-01-05 * "sell"
+  Assets:Broker  -100 USD {}
+  Expenses:Misc  95 EUR
+  Income:PnL

--- a/tests/compatibility/files/interpolation/e03_augment_currency_only.beancount
+++ b/tests/compatibility/files/interpolation/e03_augment_currency_only.beancount
@@ -1,0 +1,9 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {EUR}
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e04_augment_date_only.beancount
+++ b/tests/compatibility/files/interpolation/e04_augment_date_only.beancount
@@ -1,0 +1,9 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {2024-01-02}
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e05_two_empty_augments.beancount
+++ b/tests/compatibility/files/interpolation/e05_two_empty_augments.beancount
@@ -1,0 +1,10 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy2"
+  Assets:Broker  500 USD {}
+  Assets:Broker  500 USD {}
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e06_empty_plus_auto.beancount
+++ b/tests/compatibility/files/interpolation/e06_empty_plus_auto.beancount
@@ -1,0 +1,9 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {}
+  Assets:Cash

--- a/tests/compatibility/files/interpolation/e07_empty_plus_price.beancount
+++ b/tests/compatibility/files/interpolation/e07_empty_plus_price.beancount
@@ -1,0 +1,9 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {} @ 0.90 EUR
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e08_none_augment_empty.beancount
+++ b/tests/compatibility/files/interpolation/e08_none_augment_empty.beancount
@@ -1,0 +1,8 @@
+option "operating_currency" "EUR"
+option "booking_method" "NONE"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {}
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e09_none_reduce_empty.beancount
+++ b/tests/compatibility/files/interpolation/e09_none_reduce_empty.beancount
@@ -1,0 +1,14 @@
+option "operating_currency" "EUR"
+option "booking_method" "NONE"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {0.90 EUR}
+  Assets:Cash  -900 EUR
+
+2024-01-05 * "sell"
+  Assets:Broker  -100 USD {}
+  Assets:Cash  95 EUR
+  Income:PnL

--- a/tests/compatibility/files/interpolation/e10_strict_reduce_empty_ambiguous.beancount
+++ b/tests/compatibility/files/interpolation/e10_strict_reduce_empty_ambiguous.beancount
@@ -1,0 +1,18 @@
+option "operating_currency" "EUR"
+option "booking_method" "STRICT"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:PnL
+
+2024-01-02 * "b1"
+  Assets:Broker  100 USD {0.90 EUR}
+  Assets:Cash  -90 EUR
+
+2024-01-03 * "b2"
+  Assets:Broker  100 USD {0.95 EUR}
+  Assets:Cash  -95 EUR
+
+2024-01-05 * "sell"
+  Assets:Broker  -50 USD {}
+  Assets:Cash  46 EUR
+  Income:PnL

--- a/tests/compatibility/files/interpolation/e11_fifo_reduce_empty_two_lots.beancount
+++ b/tests/compatibility/files/interpolation/e11_fifo_reduce_empty_two_lots.beancount
@@ -1,0 +1,18 @@
+option "operating_currency" "EUR"
+option "booking_method" "FIFO"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:PnL
+
+2024-01-02 * "b1"
+  Assets:Broker  100 USD {0.90 EUR}
+  Assets:Cash  -90 EUR
+
+2024-01-03 * "b2"
+  Assets:Broker  100 USD {0.95 EUR}
+  Assets:Cash  -95 EUR
+
+2024-01-05 * "sell"
+  Assets:Broker  -150 USD {}
+  Assets:Cash  140 EUR
+  Income:PnL

--- a/tests/compatibility/files/interpolation/e12_double_broken.beancount
+++ b/tests/compatibility/files/interpolation/e12_double_broken.beancount
@@ -1,0 +1,10 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "both broken"
+  Assets:Broker  1000 USD {}
+  Assets:Broker  -50 GLD {}
+  Assets:Cash  -900 EUR

--- a/tests/compatibility/files/interpolation/e13_missing_units.beancount
+++ b/tests/compatibility/files/interpolation/e13_missing_units.beancount
@@ -1,0 +1,13 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {0.90 EUR}
+  Assets:Cash  -900 EUR
+
+2024-01-05 * "sell all"
+  Assets:Broker
+  Assets:Cash  900 EUR

--- a/tests/compatibility/files/interpolation/e14_negative_residual.beancount
+++ b/tests/compatibility/files/interpolation/e14_negative_residual.beancount
@@ -1,0 +1,9 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-02 * "weird"
+  Assets:Broker  1000 USD {}
+  Assets:Cash  900 EUR

--- a/tests/compatibility/files/interpolation/e15_multicurrency_residual.beancount
+++ b/tests/compatibility/files/interpolation/e15_multicurrency_residual.beancount
@@ -1,0 +1,12 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Expenses:Misc
+2024-01-01 open Income:PnL
+
+2024-01-01 open Assets:Cash2
+
+2024-01-02 * "buy"
+  Assets:Broker  1000 USD {}
+  Assets:Cash  -500 EUR
+  Assets:Cash2  -100 GBP

--- a/tests/compatibility/files/interpolation/e16_price_vs_residual.beancount
+++ b/tests/compatibility/files/interpolation/e16_price_vs_residual.beancount
@@ -1,0 +1,7 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+
+2024-01-02 * "conflict"
+  Assets:Broker  1000 USD {} @ 0.90 EUR
+  Assets:Cash  -950 EUR

--- a/tests/compatibility/files/interpolation/e17_price_plus_auto.beancount
+++ b/tests/compatibility/files/interpolation/e17_price_plus_auto.beancount
@@ -1,0 +1,7 @@
+option "operating_currency" "EUR"
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+
+2024-01-02 * "price drives"
+  Assets:Broker  1000 USD {} @ 0.90 EUR
+  Assets:Cash


### PR DESCRIPTION
Builds directly on @yurenju's #1706 — **the solver core is their work** (parent commit preserved; Co-Authored-By carried through the squash) — finishing the four review items so this ships now rather than round-tripping:

1. **#1708 guard removed** — it fired in `book()` before interpolation ran, making the solver dead code post-rebase (all 11 augmentation fixtures verified dying in the guard on a trial merge).
2. **Price annotations don't block solving** — bean-check 3.2.3: `{} @ 0.90` with a 0.95 residual books **`{0.95}`, silently** (verified). The `price.is_none()` skip re-opened the silent-corruption path for annotated postings.
3. **Negative solved cost rejects** (bean: "Cost is negative") instead of booking a `{-0.90}` lot.
4. **Ambiguous cost currency rejects** (bean: "Failed to categorize") — candidates exclude currencies owning their own missing-amount unknown (disjoint groups stay legal, pinned by existing unit tests), and the check defers to the more specific unassigned+cost-unknown rejection.

## Validation
17-fixture matrix (committed as `tests/compatibility/files/interpolation/`, every row cross-checked against real bean-check 3.2.3 in the compat container): **17/17 accept/reject parity**, solved values match to the cent, the issue's original file passes end-to-end. Full methodology + ground-truth table in the #1705 plan comments. 108/108 booking suite · clippy `-D warnings` · fmt.

Closes #1705
Closes #1706 — @yurenju thank you for the report AND the fix; the maintainer preferred to land it immediately, so review items were applied directly rather than requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)