### PR TITLE
chore: release v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+
+### 🐛 Bug Fixes
+
+- *(parser)* Green compound-cost conversion retries unparsable numbers like red (#1714)
+- *(query)* Typed scalar functions propagate NULL (beanquery parity) (#1711)
 # Changelog
 
 Shipped work, by area. Forward-looking plans live in [docs/roadmap/](docs/roadmap/index.md); completed items land here so the roadmaps stay forward-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [unreleased]
-
-### 🐛 Bug Fixes
-
-- *(parser)* Green compound-cost conversion retries unparsable numbers like red (#1714)
-- *(query)* Typed scalar functions propagate NULL (beanquery parity) (#1711)
 # Changelog
 
 Shipped work, by area. Forward-looking plans live in [docs/roadmap/](docs/roadmap/index.md); completed items land here so the roadmaps stay forward-only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "agcli",
  "anyhow",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-booking"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bigdecimal",
  "proptest",
@@ -3448,11 +3448,11 @@ dependencies = [
 
 [[package]]
 name = "rustledger-completion"
-version = "0.20.1"
+version = "0.20.2"
 
 [[package]]
 name = "rustledger-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "criterion",
  "imbl",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "jiff",
  "rustledger-booking",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-component-tests"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "rustledger-core",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ffi-wasi"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "jiff",
  "rustc-hash 2.1.2",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-importer"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "csv",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-loader"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "blake3",
  "glob",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-lsp"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "crossbeam-channel",
  "glob",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-ops"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "blake3",
  "jiff",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-parser"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "blake3",
  "criterion",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-query"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "chumsky",
  "criterion",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-validate"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bigdecimal",
  "criterion",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-wasm"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 edition = "2024"
 rust-version = "1.96"
 license = "GPL-3.0-only"
@@ -192,19 +192,19 @@ crossbeam-channel = "0.5"
 parking_lot = "0.12"
 
 # Internal crates
-rustledger-core = { version = "0.20.1", path = "crates/rustledger-core" }
-rustledger-parser = { version = "0.20.1", path = "crates/rustledger-parser" }
-rustledger-loader = { version = "0.20.1", path = "crates/rustledger-loader" }
-rustledger-booking = { version = "0.20.1", path = "crates/rustledger-booking" }
-rustledger-validate = { version = "0.20.1", path = "crates/rustledger-validate" }
-rustledger-query = { version = "0.20.1", path = "crates/rustledger-query" }
-rustledger-completion = { version = "0.20.1", path = "crates/rustledger-completion" }
-rustledger-plugin = { version = "0.20.1", path = "crates/rustledger-plugin", default-features = false }
-rustledger-plugin-types = { version = "0.20.1", path = "crates/rustledger-plugin-types" }
-rustledger-importer = { version = "0.20.1", path = "crates/rustledger-importer" }
-rustledger-ops = { version = "0.20.1", path = "crates/rustledger-ops" }
-rustledger-ffi-wasi = { version = "0.20.1", path = "crates/rustledger-ffi-wasi" }
-rustledger-wasm = { version = "0.20.1", path = "crates/rustledger-wasm" }
+rustledger-core = { version = "0.20.2", path = "crates/rustledger-core" }
+rustledger-parser = { version = "0.20.2", path = "crates/rustledger-parser" }
+rustledger-loader = { version = "0.20.2", path = "crates/rustledger-loader" }
+rustledger-booking = { version = "0.20.2", path = "crates/rustledger-booking" }
+rustledger-validate = { version = "0.20.2", path = "crates/rustledger-validate" }
+rustledger-query = { version = "0.20.2", path = "crates/rustledger-query" }
+rustledger-completion = { version = "0.20.2", path = "crates/rustledger-completion" }
+rustledger-plugin = { version = "0.20.2", path = "crates/rustledger-plugin", default-features = false }
+rustledger-plugin-types = { version = "0.20.2", path = "crates/rustledger-plugin-types" }
+rustledger-importer = { version = "0.20.2", path = "crates/rustledger-importer" }
+rustledger-ops = { version = "0.20.2", path = "crates/rustledger-ops" }
+rustledger-ffi-wasi = { version = "0.20.2", path = "crates/rustledger-ffi-wasi" }
+rustledger-wasm = { version = "0.20.2", path = "crates/rustledger-wasm" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/rustledger-booking/Cargo.toml
+++ b/crates/rustledger-booking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-booking"
 description = "Beancount booking engine with 7 lot matching methods and interpolation"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-completion/Cargo.toml
+++ b/crates/rustledger-completion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-completion"
 description = "Editor-agnostic completion logic for Beancount sources (shared by LSP and WASM)"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-core/Cargo.toml
+++ b/crates/rustledger-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-core"
 description = "Core types for rustledger: Amount, Position, Inventory, and all directive types"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-ffi-wasi/Cargo.toml
+++ b/crates/rustledger-ffi-wasi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ffi-wasi"
 description = "Slimmed FFI-support helpers reused by the rustledger WASI component FFI (loader orchestration + WIT-input construction + directive hashing; the wasip1 JSON-RPC surface and Directive-to-JSON DTO were removed in #1419)"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-importer"
 description = "Import framework for rustledger - extract transactions from bank files"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-importer/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-loader/Cargo.toml
+++ b/crates/rustledger-loader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-loader"
 description = "Beancount file loader with include resolution and options parsing"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-lsp/Cargo.toml
+++ b/crates/rustledger-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustledger-lsp"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/rustledger-ops/Cargo.toml
+++ b/crates/rustledger-ops/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-ops"
 description = "Pure operations on beancount directives — dedup, categorize, reconcile"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-parser/Cargo.toml
+++ b/crates/rustledger-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-parser"
 description = "Beancount parser with error recovery and full syntax support"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin-types/Cargo.toml
+++ b/crates/rustledger-plugin-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin-types"
 description = "WASM plugin interface types for rustledger - use in your plugin crate"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/Cargo.toml
+++ b/crates/rustledger-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-plugin"
 description = "Beancount plugin system with 30 native plugins and WASM support"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
+++ b/crates/rustledger-plugin/tests/fixtures/sample_stub/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "rustledger-plugin-types"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "rmp-serde",
  "serde",

--- a/crates/rustledger-query/Cargo.toml
+++ b/crates/rustledger-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-query"
 description = "Beancount query engine (BQL) with SQL-like syntax for ledger queries"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-validate/Cargo.toml
+++ b/crates/rustledger-validate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-validate"
 description = "Beancount validation with 26 error codes for ledger correctness"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger-wasm"
 description = "Beancount WebAssembly bindings for JavaScript/TypeScript"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustledger"
 description = "Drop-in replacement for Beancount. Pure Rust, 10-30x faster."
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Patch release:
- **#1711**: typed scalar functions propagate NULL (beanquery parity) — un-gaps rustfava's Holdings queries
- **#1714**: green compound-cost conversion retries unparsable numbers like red (closes the #1713 fuzz divergence); CACHE_VERSION 13→14

Also regenerates the sample_stub fixture lockfiles with the bump (the v0.20.1 miss broke prek pre-push stash handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)