### PR TITLE
refactor(report): single source of truth for account balances (#1726)

### DIFF
--- a/crates/rustledger/src/cmd/report_cmd/balances.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balances.rs
@@ -3,8 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, Inventory};
-use std::collections::BTreeMap;
+use rustledger_core::Directive;
 use std::io::Write;
 
 /// Generate a balances report.
@@ -14,25 +13,9 @@ pub(super) fn report_balances<W: Write>(
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
-    let mut balances: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
-
-    for directive in directives {
-        match directive {
-            Directive::Open(open) => {
-                balances.entry(open.account.clone()).or_default();
-            }
-            Directive::Transaction(txn) => {
-                for posting in &txn.postings {
-                    if let Some(amount) = posting.amount() {
-                        let inv = balances.entry(posting.account.clone()).or_default();
-                        let position = rustledger_core::Position::simple(amount.clone());
-                        inv.add(position);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
+    // Single source of truth for per-account balances (see
+    // `super::account_balances`); no report re-derives them itself.
+    let balances = super::account_balances(directives);
 
     // Collect data for output
     let mut rows: Vec<(&str, Decimal, &str)> = Vec::new();

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -17,27 +17,21 @@ pub(super) fn report_balsheet<W: Write>(
     let mut liabilities: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
     let mut equity: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
 
-    for directive in directives {
-        if let Directive::Transaction(txn) = directive {
-            for posting in &txn.postings {
-                if let Some(amount) = posting.amount() {
-                    let account_str: &str = &posting.account;
-                    let balances = if account_str.starts_with("Assets:") {
-                        &mut assets
-                    } else if account_str.starts_with("Liabilities:") {
-                        &mut liabilities
-                    } else if account_str.starts_with("Equity:") {
-                        &mut equity
-                    } else {
-                        continue;
-                    };
-
-                    let inv = balances.entry(posting.account.clone()).or_default();
-                    let position = rustledger_core::Position::simple(amount.clone());
-                    inv.add(position);
-                }
-            }
-        }
+    // Partition the single source-of-truth balances (see
+    // `super::account_balances`) into the three balance-sheet sections by
+    // account prefix. No balance re-derivation here.
+    for (account, inv) in super::account_balances(directives) {
+        let account_str: &str = &account;
+        let section = if account_str.starts_with("Assets:") {
+            &mut assets
+        } else if account_str.starts_with("Liabilities:") {
+            &mut liabilities
+        } else if account_str.starts_with("Equity:") {
+            &mut equity
+        } else {
+            continue;
+        };
+        section.insert(account, inv);
     }
 
     // Helper to sum inventory by currency, keyed by the Currency newtype

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -16,25 +16,19 @@ pub(super) fn report_income<W: Write>(
     let mut income: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
     let mut expenses: BTreeMap<rustledger_core::Account, Inventory> = BTreeMap::new();
 
-    for directive in directives {
-        if let Directive::Transaction(txn) = directive {
-            for posting in &txn.postings {
-                if let Some(amount) = posting.amount() {
-                    let account_str: &str = &posting.account;
-                    let balances = if account_str.starts_with("Income:") {
-                        &mut income
-                    } else if account_str.starts_with("Expenses:") {
-                        &mut expenses
-                    } else {
-                        continue;
-                    };
-
-                    let inv = balances.entry(posting.account.clone()).or_default();
-                    let position = rustledger_core::Position::simple(amount.clone());
-                    inv.add(position);
-                }
-            }
-        }
+    // Partition the single source-of-truth balances (see
+    // `super::account_balances`) into income and expense sections by prefix.
+    // No balance re-derivation here.
+    for (account, inv) in super::account_balances(directives) {
+        let account_str: &str = &account;
+        let section = if account_str.starts_with("Income:") {
+            &mut income
+        } else if account_str.starts_with("Expenses:") {
+            &mut expenses
+        } else {
+            continue;
+        };
+        section.insert(account, inv);
     }
 
     fn sum_by_currency(

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -405,6 +405,50 @@ fn render<W: io::Write>(
     Ok(())
 }
 
+/// The single source of truth for "what does each account hold".
+///
+/// Every balance-computing report (`balances`, `balsheet`, `income`, …) is a
+/// *view* over this map — none re-derives balances itself. That is the whole
+/// point: the same "sum the postings per account" logic used to live copied
+/// across each report, and the copies drifted (reductions failing to net in
+/// `balances`/`balsheet` while `income` summed cost-less — #1726). One
+/// function, one behavior, no drift.
+///
+/// Positions are summed by commodity **cost-less** on purpose: these reports
+/// render only units, never cost, so a held commodity is a single running
+/// total per account+currency. (Trade-off: two lots at different costs merge,
+/// e.g. `10 AAPL {150}` + `10 AAPL {200}` → `20 AAPL`, rather than showing as
+/// separate lots the way beancount does — acceptable because cost is not
+/// displayed. If cost-accurate holdings reporting is ever wanted, this is the
+/// one place to teach lot-tracking, and every report inherits it.)
+///
+/// `Open` directives seed a zero balance so opened accounts are represented;
+/// callers skip empty inventories on render, so this never changes output.
+pub(super) fn account_balances(
+    directives: &[rustledger_core::Directive],
+) -> std::collections::BTreeMap<rustledger_core::Account, rustledger_core::Inventory> {
+    use rustledger_core::Directive;
+    let mut balances = std::collections::BTreeMap::new();
+    for directive in directives {
+        match directive {
+            Directive::Open(open) => {
+                balances.entry(open.account.clone()).or_default();
+            }
+            Directive::Transaction(txn) => {
+                for posting in &txn.postings {
+                    if let Some(amount) = posting.amount() {
+                        let inv: &mut rustledger_core::Inventory =
+                            balances.entry(posting.account.clone()).or_default();
+                        inv.add(rustledger_core::Position::simple(amount.clone()));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    balances
+}
+
 /// Escape a string for CSV output.
 pub(super) fn csv_escape(s: &str) -> String {
     if s.contains(',') || s.contains('"') || s.contains('\n') {

--- a/crates/rustledger/tests/report_reduction_netting_test.rs
+++ b/crates/rustledger/tests/report_reduction_netting_test.rs
@@ -1,0 +1,130 @@
+//! Regression tests for #1726: `report balances` and `report balsheet`
+//! must NET a held-commodity reduction against its augmentation, rather
+//! than listing the augmenting and reducing positions as separate rows.
+//!
+//! Before the fix, a buy of `10 AAPL {150}` followed by a sell of
+//! `-5 AAPL {150} @ 180` printed two rows (`10 AAPL` and `-5 AAPL`) —
+//! the reduction resolved to a different lot-key than the augmentation,
+//! so `Inventory.add` could not cancel them. These reports render only
+//! units (never cost), so the correct output is a single `5 AAPL` row.
+//! Verified against beancount 3.2.3: `sum(position)` = `5 AAPL {150.00 USD}`.
+
+mod common;
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Buy 10 AAPL at cost, then sell 5 back at a price. Net holding is 5.
+const REDUCTION_SOURCE: &str = r#"option "operating_currency" "USD"
+
+2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+2024-01-01 open Income:PnL
+
+2024-01-05 * "buy"
+  Assets:Broker   10 AAPL {150.00 USD}
+  Assets:Cash  -1500.00 USD
+
+2024-06-10 * "sell half"
+  Assets:Broker   -5 AAPL {150.00 USD} @ 180.00 USD
+  Assets:Cash    900.00 USD
+  Income:PnL    -150.00 USD
+"#;
+
+fn write_fixture() -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("report-reduction-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(REDUCTION_SOURCE.as_bytes())
+        .expect("write fixture");
+    f
+}
+
+fn run_report(binary: &PathBuf, file: &std::path::Path, report: &str) -> String {
+    let out = Command::new(binary)
+        .args(["report", file.to_str().unwrap(), report, "--no-pager"])
+        .output()
+        .unwrap_or_else(|e| panic!("run rledger report {report}: {e}"));
+    assert!(
+        out.status.success(),
+        "rledger report {report} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Every AAPL figure must be the netted `5` — never the pre-fix split of
+/// a `10 AAPL` augmentation row and a separate `-5 AAPL` reduction row.
+/// (`balsheet` legitimately repeats the holding across the account line,
+/// the assets total, and net worth; all must agree on 5.)
+fn assert_netted_to_5(stdout: &str, report: &str) {
+    let aapl_numbers: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.contains("AAPL"))
+        .filter_map(|l| l.split_whitespace().find(|t| t.parse::<f64>().is_ok()))
+        .collect();
+    assert!(
+        !aapl_numbers.is_empty(),
+        "report {report} shows no AAPL holding at all: {stdout}",
+    );
+    for n in &aapl_numbers {
+        assert_eq!(
+            *n, "5",
+            "report {report} must net the reduction to 5 AAPL everywhere; \
+             pre-fix showed separate 10 and -5 rows. Got {n:?} in: {stdout}",
+        );
+    }
+}
+
+/// Pull the first number that appears on the line mentioning `needle`.
+fn number_on_line_with<'a>(stdout: &'a str, needle: &str) -> Option<&'a str> {
+    stdout
+        .lines()
+        .find(|l| l.contains(needle))
+        .and_then(|l| l.split_whitespace().find(|t| t.parse::<f64>().is_ok()))
+}
+
+/// The drift guard: `balances` and `balsheet` read one shared source
+/// (`report_cmd::account_balances`), so they must report the *same* figure
+/// for the same account. If a future change re-forks the balance
+/// computation, this fails. (This is the invariant the #1726 class violated:
+/// the reports each re-derived balances and disagreed.)
+#[test]
+fn balances_and_balsheet_agree_per_account() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let bal = run_report(&bin, f.path(), "balances");
+    let bs = run_report(&bin, f.path(), "balsheet");
+    // The netted holding must read identically in both reports.
+    let bal_aapl = bal
+        .lines()
+        .filter(|l| l.contains("AAPL"))
+        .find_map(|l| l.split_whitespace().find(|t| t.parse::<f64>().is_ok()));
+    let bs_aapl = number_on_line_with(&bs, "AAPL");
+    assert_eq!(
+        bal_aapl, bs_aapl,
+        "balances and balsheet must agree on Assets:Broker AAPL \
+         (single source of truth); balances={bal_aapl:?} balsheet={bs_aapl:?}",
+    );
+    assert_eq!(bal_aapl, Some("5"), "both must show the netted 5 AAPL");
+}
+
+#[test]
+fn report_balances_nets_reduction() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let stdout = run_report(&bin, f.path(), "balances");
+    assert_netted_to_5(&stdout, "balances");
+}
+
+#[test]
+fn report_balsheet_nets_reduction() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let stdout = run_report(&bin, f.path(), "balsheet");
+    assert_netted_to_5(&stdout, "balsheet");
+}

--- a/crates/rustledger/tests/report_reduction_netting_test.rs
+++ b/crates/rustledger/tests/report_reduction_netting_test.rs
@@ -121,10 +121,38 @@ fn report_balances_nets_reduction() {
     assert_netted_to_5(&stdout, "balances");
 }
 
+/// The AAPL number on the single line that contains all of `needles`.
+fn aapl_number_on_line_with<'a>(stdout: &'a str, needles: &[&str]) -> Option<&'a str> {
+    stdout
+        .lines()
+        .filter(|l| l.contains("AAPL"))
+        .find(|l| needles.iter().all(|n| l.contains(n)))
+        .and_then(|l| l.split_whitespace().find(|t| t.parse::<f64>().is_ok()))
+}
+
 #[test]
 fn report_balsheet_nets_reduction() {
     let bin = require_rledger!();
     let f = write_fixture();
     let stdout = run_report(&bin, f.path(), "balsheet");
+    // Every AAPL figure is the netted 5 (never the pre-fix 10 / -5 split)...
     assert_netted_to_5(&stdout, "balsheet");
+    // ...AND the holding must actually propagate into the assets total and
+    // net worth, not just the account row. A regression that dropped AAPL
+    // from the totals could otherwise still print a lone `5 AAPL` account
+    // row and pass assert_netted_to_5 (Copilot review on #1727).
+    assert_eq!(
+        aapl_number_on_line_with(&stdout, &["Total Assets"]),
+        Some("5"),
+        "balsheet must carry the 5 AAPL holding into Total Assets: {stdout}",
+    );
+    // Net Worth section: the AAPL figure appears after the "Net Worth"
+    // header. Take the tail of the output and find its AAPL line.
+    let net_worth_tail = stdout.split_once("Net Worth").map_or("", |(_, tail)| tail);
+    assert!(
+        net_worth_tail
+            .lines()
+            .any(|l| l.contains("AAPL") && l.split_whitespace().any(|t| t == "5")),
+        "balsheet must carry the 5 AAPL holding into Net Worth: {stdout}",
+    );
 }


### PR DESCRIPTION
Root-cause follow-up to #1726 (@weslem's fix, merged). #1726 closed the specific hole; this closes the **class**.

## What went wrong
Three balance-computing reports — `balances`, `balsheet`, `income` — each re-derived per-account balances from raw postings with their own copy of the accumulation logic. The copies had already drifted: `income` summed cost-less, while `balances`/`balsheet` used a cost lot-key that silently failed to net a reduction against its augmentation (the #1726 bug: buy 10 AAPL / sell 5 → showed `10` and `-5` instead of `5`). Same question, three implementations, two answers. #1726 converged them by making `balances`/`balsheet` cost-less too — correct, but it left three copies that can drift again.

## The fix
`report_cmd::account_balances(directives)` is now the **single source of truth** for "what does each account hold". Every balance-computing report is a *view* over it — the three reports just partition its output by account prefix; none re-derives balances. One implementation ⇒ they cannot disagree.

- New shared `account_balances` in `report_cmd/mod.rs`, with the deliberate cost-less sum-by-commodity behavior + trade-off documented in the one place it lives.
- `balances`/`balsheet`/`income` rewritten to consume it (**−61 lines** of duplicated accumulation, +44 for the shared fn).
- Regression tests: buy(10 AAPL {150})/sell(-5 AAPL {150} @ 180) must net to a single `5 AAPL` in `balances` and `balsheet`. **Verified they fail on pre-#1726 code and pass now**; matches beancount 3.2.3 `sum(position)`.

## Verified
- Output identical to post-#1726 on balances/balsheet/income (full multi-account fixture)
- `cargo test -p rustledger` report/CLI suites: 69 pass (report_parse_cache, cli_commands, pad_expansion, reduction_netting)
- clippy `0 issues`, fmt clean

Cost-accurate lot tracking, if ever wanted, now has exactly **one** place to live — the deeper `pipeline-finalize-invariants` direction (reports/BQL/FFI all reading a booked realization) can build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)