### PR TITLE
feat(report): balances/balsheet show lots at cost, like beancount

### DIFF
--- a/crates/rustledger-booking/src/book.rs
+++ b/crates/rustledger-booking/src/book.rs
@@ -156,6 +156,19 @@ impl BookingEngine {
         self.inventories.get(account)
     }
 
+    /// Consume the engine and return its realized per-account inventories.
+    ///
+    /// After [`apply`](Self::apply)ing a booked directive stream, this is the
+    /// canonical realization — each account's `Inventory` carries its lots at
+    /// cost, with reductions already matched (FIFO/LIFO/etc. per the account's
+    /// booking method). Callers that render balances (reports, holdings) read
+    /// this rather than re-summing postings, so cost is retained and lot
+    /// matching is the engine's, not a re-implementation.
+    #[must_use]
+    pub fn into_inventories(self) -> FxHashMap<rustledger_core::Account, Inventory> {
+        self.inventories
+    }
+
     /// Book a transaction: fill in empty cost specs and calculate gains.
     ///
     /// This does NOT modify the internal inventories - call `apply` for that.

--- a/crates/rustledger/src/cmd/report_cmd/balances.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balances.rs
@@ -17,8 +17,9 @@ pub(super) fn report_balances<W: Write>(
     // `super::account_balances`); no report re-derives them itself.
     let balances = super::account_balances(directives);
 
-    // Collect data for output
-    let mut rows: Vec<(&str, Decimal, &str)> = Vec::new();
+    // Collect data for output. `cost` is the beancount-style lot annotation
+    // (e.g. ` {150.00 USD}`) for held commodities, empty for plain currency.
+    let mut rows: Vec<(&str, Decimal, &str, String)> = Vec::new();
     for (account, inventory) in &balances {
         if let Some(filter) = account_filter
             && !account.starts_with(filter)
@@ -29,27 +30,45 @@ pub(super) fn report_balances<W: Write>(
             continue;
         }
         for position in inventory.positions() {
-            rows.push((account, position.units.number, &position.units.currency));
+            let cost = position
+                .cost
+                .as_ref()
+                .map(|c| format!("{c}"))
+                .unwrap_or_default();
+            rows.push((
+                account,
+                position.units.number,
+                &position.units.currency,
+                cost,
+            ));
         }
     }
 
     match format {
         OutputFormat::Csv => {
-            writeln!(writer, "account,amount,currency")?;
-            for (account, amount, currency) in &rows {
-                writeln!(writer, "{},{},{}", csv_escape(account), amount, currency)?;
+            writeln!(writer, "account,amount,currency,cost")?;
+            for (account, amount, currency, cost) in &rows {
+                writeln!(
+                    writer,
+                    "{},{},{},{}",
+                    csv_escape(account),
+                    amount,
+                    currency,
+                    csv_escape(cost)
+                )?;
             }
         }
         OutputFormat::Json => {
             writeln!(writer, "[")?;
-            for (i, (account, amount, currency)) in rows.iter().enumerate() {
+            for (i, (account, amount, currency, cost)) in rows.iter().enumerate() {
                 let comma = if i < rows.len() - 1 { "," } else { "" };
                 writeln!(
                     writer,
-                    r#"  {{"account": "{}", "amount": "{}", "currency": "{}"}}{}"#,
+                    r#"  {{"account": "{}", "amount": "{}", "currency": "{}", "cost": "{}"}}{}"#,
                     json_escape(account),
                     amount,
                     currency,
+                    json_escape(cost),
                     comma
                 )?;
             }
@@ -60,12 +79,16 @@ pub(super) fn report_balances<W: Write>(
             writeln!(writer, "{}", "=".repeat(60))?;
             writeln!(writer)?;
             let mut current_account = "";
-            for (account, amount, currency) in &rows {
+            for (account, amount, currency, cost) in &rows {
                 if *account != current_account {
                     writeln!(writer, "{account}")?;
                     current_account = account;
                 }
-                writeln!(writer, "  {amount:>15} {currency}")?;
+                if cost.is_empty() {
+                    writeln!(writer, "  {amount:>15} {currency}")?;
+                } else {
+                    writeln!(writer, "  {amount:>15} {currency} {cost}")?;
+                }
             }
         }
     }

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -52,18 +52,24 @@ pub(super) fn report_balsheet<W: Write>(
     fn collect_rows(
         section: &str,
         balances: &BTreeMap<rustledger_core::Account, Inventory>,
-    ) -> Vec<(String, String, Decimal, String)> {
+    ) -> Vec<(String, String, Decimal, String, String)> {
         let mut rows = Vec::new();
         for (account, inventory) in balances {
             if inventory.is_empty() {
                 continue;
             }
             for position in inventory.positions() {
+                let cost = position
+                    .cost
+                    .as_ref()
+                    .map(|c| format!("{c}"))
+                    .unwrap_or_default();
                 rows.push((
                     section.to_string(),
                     account.to_string(),
                     position.units.number,
                     position.units.currency.to_string(),
+                    cost,
                 ));
             }
         }
@@ -85,15 +91,16 @@ pub(super) fn report_balsheet<W: Write>(
 
     match format {
         OutputFormat::Csv => {
-            writeln!(writer, "section,account,amount,currency")?;
-            for (section, account, amount, currency) in &all_rows {
+            writeln!(writer, "section,account,amount,currency,cost")?;
+            for (section, account, amount, currency, cost) in &all_rows {
                 writeln!(
                     writer,
-                    "{},{},{},{}",
+                    "{},{},{},{},{}",
                     section,
                     csv_escape(account),
                     amount,
-                    currency
+                    currency,
+                    csv_escape(cost)
                 )?;
             }
             // Add net worth rows
@@ -104,15 +111,16 @@ pub(super) fn report_balsheet<W: Write>(
         OutputFormat::Json => {
             writeln!(writer, "{{")?;
             writeln!(writer, r#"  "accounts": ["#)?;
-            for (i, (section, account, amount, currency)) in all_rows.iter().enumerate() {
+            for (i, (section, account, amount, currency, cost)) in all_rows.iter().enumerate() {
                 let comma = if i < all_rows.len() - 1 { "," } else { "" };
                 writeln!(
                     writer,
-                    r#"    {{"section": "{}", "account": "{}", "amount": "{}", "currency": "{}"}}{}"#,
+                    r#"    {{"section": "{}", "account": "{}", "amount": "{}", "currency": "{}", "cost": "{}"}}{}"#,
                     section,
                     json_escape(account),
                     amount,
                     currency,
+                    json_escape(cost),
                     comma
                 )?;
             }
@@ -139,10 +147,15 @@ pub(super) fn report_balsheet<W: Write>(
                         continue;
                     }
                     for position in inventory.positions() {
+                        let cost = position
+                            .cost
+                            .as_ref()
+                            .map(|c| format!(" {c}"))
+                            .unwrap_or_default();
                         writeln!(
                             writer,
-                            "  {:>12} {:>4}  {}",
-                            position.units.number, position.units.currency, account
+                            "  {:>12} {:>4}{}  {}",
+                            position.units.number, position.units.currency, cost, account
                         )?;
                     }
                 }

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -409,44 +409,39 @@ fn render<W: io::Write>(
 ///
 /// Every balance-computing report (`balances`, `balsheet`, `income`, …) is a
 /// *view* over this map — none re-derives balances itself. That is the whole
-/// point: the same "sum the postings per account" logic used to live copied
+/// point: the same "what does each account hold" logic used to live copied
 /// across each report, and the copies drifted (reductions failing to net in
-/// `balances`/`balsheet` while `income` summed cost-less — #1726). One
+/// `balances`/`balsheet` while `income` summed differently — #1726). One
 /// function, one behavior, no drift.
 ///
-/// Positions are summed by commodity **cost-less** on purpose: these reports
-/// render only units, never cost, so a held commodity is a single running
-/// total per account+currency. (Trade-off: two lots at different costs merge,
-/// e.g. `10 AAPL {150}` + `10 AAPL {200}` → `20 AAPL`, rather than showing as
-/// separate lots the way beancount does — acceptable because cost is not
-/// displayed. If cost-accurate holdings reporting is ever wanted, this is the
-/// one place to teach lot-tracking, and every report inherits it.)
+/// Realization goes through the **booking engine** ([`apply`]), so held
+/// commodities keep their lots at cost and reductions are matched against
+/// those lots by the account's booking method — the same machinery the
+/// loader's book phase uses. Each `Inventory` therefore carries cost, and
+/// reports render `5 AAPL {150.00 USD}` like beancount rather than a
+/// cost-less `5 AAPL`. Two lots at different costs stay separate
+/// (`10 AAPL {150}` + `10 AAPL {200}`), matching beancount.
 ///
-/// `Open` directives seed a zero balance so opened accounts are represented;
-/// callers skip empty inventories on render, so this never changes output.
+/// [`apply`]: rustledger_booking::BookingEngine::apply
 pub(super) fn account_balances(
     directives: &[rustledger_core::Directive],
 ) -> std::collections::BTreeMap<rustledger_core::Account, rustledger_core::Inventory> {
     use rustledger_core::Directive;
-    let mut balances = std::collections::BTreeMap::new();
+    // Realize via the booking engine so held commodities carry their lots at
+    // cost and reductions match those lots (FIFO/LIFO/etc. per each account's
+    // booking method) — the same logic the loader's book phase uses, not a
+    // re-implementation. The input directives are already booked (costs
+    // resolved, interpolations applied), which is `apply`'s precondition.
+    let mut engine = rustledger_booking::BookingEngine::new();
+    engine.register_account_methods(directives.iter());
     for directive in directives {
-        match directive {
-            Directive::Open(open) => {
-                balances.entry(open.account.clone()).or_default();
-            }
-            Directive::Transaction(txn) => {
-                for posting in &txn.postings {
-                    if let Some(amount) = posting.amount() {
-                        let inv: &mut rustledger_core::Inventory =
-                            balances.entry(posting.account.clone()).or_default();
-                        inv.add(rustledger_core::Position::simple(amount.clone()));
-                    }
-                }
-            }
-            _ => {}
+        if let Directive::Transaction(txn) = directive {
+            engine.apply(txn);
         }
     }
-    balances
+    // FxHashMap has non-deterministic order; collect into a BTreeMap so report
+    // rows come out account-sorted and stable across runs.
+    engine.into_inventories().into_iter().collect()
 }
 
 /// Escape a string for CSV output.

--- a/crates/rustledger/tests/report_reduction_netting_test.rs
+++ b/crates/rustledger/tests/report_reduction_netting_test.rs
@@ -5,9 +5,14 @@
 //! Before the fix, a buy of `10 AAPL {150}` followed by a sell of
 //! `-5 AAPL {150} @ 180` printed two rows (`10 AAPL` and `-5 AAPL`) —
 //! the reduction resolved to a different lot-key than the augmentation,
-//! so `Inventory.add` could not cancel them. These reports render only
-//! units (never cost), so the correct output is a single `5 AAPL` row.
-//! Verified against beancount 3.2.3: `sum(position)` = `5 AAPL {150.00 USD}`.
+//! so `Inventory.add` could not cancel them. The correct result is a
+//! single netted holding of `5 AAPL {150.00 USD}` — verified against
+//! beancount 3.2.3: `sum(position)` = `5 AAPL {150.00 USD}`.
+//!
+//! Realization now goes through the booking engine, so the reports also
+//! render the lot at cost (`5 AAPL { 150.00 USD, <date>}`) like beancount
+//! rather than a cost-less `5 AAPL`; these tests assert both the netted
+//! units and the cost annotation.
 
 mod common;
 
@@ -119,6 +124,15 @@ fn report_balances_nets_reduction() {
     let f = write_fixture();
     let stdout = run_report(&bin, f.path(), "balances");
     assert_netted_to_5(&stdout, "balances");
+    // The netted holding renders its lot at cost, beancount-style.
+    let aapl_line = stdout
+        .lines()
+        .find(|l| l.contains("AAPL"))
+        .unwrap_or_else(|| panic!("no AAPL row: {stdout}"));
+    assert!(
+        aapl_line.contains("150.00 USD"),
+        "balances must render the lot cost (5 AAPL {{150.00 USD}}), got: {aapl_line:?}",
+    );
 }
 
 /// The AAPL number on the single line that contains all of `needles`.


### PR DESCRIPTION
#1727 made `account_balances` the single source of truth but realized **cost-less** (a held commodity showed `5 AAPL`). This realizes through the **booking engine** so reports match beancount: `5 AAPL {150.00 USD}`.

## What changed
- `account_balances` drives a `BookingEngine` over the already-booked directive stream and returns its realized per-account inventories — the *same* lot-matching the loader's book phase uses, not a re-implementation. Reductions net against lots by the account's booking method (FIFO/LIFO/…).
- **Supersedes #1727's trade-off**: different-cost lots no longer merge — `10 AAPL {150}` + `10 AAPL {200}` show separately, like beancount.
- `rustledger-booking`: new `BookingEngine::into_inventories()` exposes the realized map.
- balances/balsheet render lot cost in text/CSV/JSON (new `cost` column/field; empty for plain currency → cash/income rows unchanged).

## Verified vs beancount 3.2.3
- reduction (buy 10 / sell 5) → `5 AAPL { 150.00 USD, 2024-01-05}`, matching `sum(position)` (rledger also shows the lot date like beancount's `Position` str)
- two lots → shown separately
- report + CLI suites pass, clippy 0, fmt clean
- the one failing integration test (`test_account_lifecycle_consistency`) is **pre-existing on main**, unrelated (bean-check validation)

`holdings` (own cost-basis path) and `income` (no cost) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)