### PR TITLE
fix: honor name_* account-root renames in reports and BQL (beanquery parity)

### DIFF
--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -391,7 +391,9 @@ impl AccountTypes {
     /// Returns `None` for roots matching none of the five (custom types).
     #[must_use]
     pub fn kind(&self, account: &str) -> Option<AccountTypeKind> {
-        let root = account.split(':').next().unwrap_or(account);
+        // Root segment before the first ':', or the whole name when there
+        // is no colon (`split_once` makes the two cases explicit).
+        let root = account.split_once(':').map_or(account, |(root, _)| root);
         if root == self.assets {
             Some(AccountTypeKind::Assets)
         } else if root == self.liabilities {

--- a/crates/rustledger-core/src/identifiers.rs
+++ b/crates/rustledger-core/src/identifiers.rs
@@ -333,6 +333,123 @@ pub fn is_subaccount_or_equal(child: &str, parent: &str) -> bool {
 /// classify accounts in a config-aware context.
 pub const ACCOUNT_TYPES: [&str; 5] = ["Assets", "Liabilities", "Equity", "Income", "Expenses"];
 
+/// The five beancount account-type kinds, independent of their configured
+/// root names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountTypeKind {
+    /// Assets (debit-normal, balance sheet).
+    Assets,
+    /// Liabilities (credit-normal, balance sheet).
+    Liabilities,
+    /// Equity (credit-normal, balance sheet).
+    Equity,
+    /// Income (credit-normal, income statement).
+    Income,
+    /// Expenses (debit-normal, income statement).
+    Expenses,
+}
+
+/// Config-aware account-type classifier.
+///
+/// beancount lets a ledger rename its five root accounts via the `name_*`
+/// options (e.g. `option "name_income" "Revenue"`). Any consumer that
+/// classifies accounts by root — report section routing, BQL `POSSIGN` /
+/// `ACCOUNT_SORTKEY`, sign conventions — must classify against the
+/// *configured* names, not the [`ACCOUNT_TYPES`] defaults, or renamed
+/// ledgers silently misroute (empty income statements, unflipped signs —
+/// the L5 class). Construct via `Default` for standard names or from the
+/// loader's `Options`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountTypes {
+    /// Configured root name for Assets.
+    pub assets: String,
+    /// Configured root name for Liabilities.
+    pub liabilities: String,
+    /// Configured root name for Equity.
+    pub equity: String,
+    /// Configured root name for Income.
+    pub income: String,
+    /// Configured root name for Expenses.
+    pub expenses: String,
+}
+
+impl Default for AccountTypes {
+    fn default() -> Self {
+        Self {
+            assets: "Assets".to_string(),
+            liabilities: "Liabilities".to_string(),
+            equity: "Equity".to_string(),
+            income: "Income".to_string(),
+            expenses: "Expenses".to_string(),
+        }
+    }
+}
+
+impl AccountTypes {
+    /// Classify `account` by its root segment against the configured names.
+    ///
+    /// Returns `None` for roots matching none of the five (custom types).
+    #[must_use]
+    pub fn kind(&self, account: &str) -> Option<AccountTypeKind> {
+        let root = account.split(':').next().unwrap_or(account);
+        if root == self.assets {
+            Some(AccountTypeKind::Assets)
+        } else if root == self.liabilities {
+            Some(AccountTypeKind::Liabilities)
+        } else if root == self.equity {
+            Some(AccountTypeKind::Equity)
+        } else if root == self.income {
+            Some(AccountTypeKind::Income)
+        } else if root == self.expenses {
+            Some(AccountTypeKind::Expenses)
+        } else {
+            None
+        }
+    }
+
+    /// Balance-sheet account (Assets / Liabilities / Equity)?
+    #[must_use]
+    pub fn is_balance_sheet(&self, account: &str) -> bool {
+        matches!(
+            self.kind(account),
+            Some(AccountTypeKind::Assets | AccountTypeKind::Liabilities | AccountTypeKind::Equity)
+        )
+    }
+
+    /// Income-statement account (Income / Expenses)?
+    #[must_use]
+    pub fn is_income_statement(&self, account: &str) -> bool {
+        matches!(
+            self.kind(account),
+            Some(AccountTypeKind::Income | AccountTypeKind::Expenses)
+        )
+    }
+
+    /// Credit-normal account (Liabilities / Equity / Income) — the set whose
+    /// sign `POSSIGN` flips, matching beancount `get_account_sign` == -1.
+    #[must_use]
+    pub fn is_credit_normal(&self, account: &str) -> bool {
+        matches!(
+            self.kind(account),
+            Some(AccountTypeKind::Liabilities | AccountTypeKind::Equity | AccountTypeKind::Income)
+        )
+    }
+
+    /// Python-parity sort index for `ACCOUNT_SORTKEY`: Assets=0,
+    /// Liabilities=1, Equity=2, Income=3, Expenses=4, custom roots=5.
+    #[must_use]
+    pub fn sort_index(&self, account: &str) -> u8 {
+        match self.kind(account) {
+            Some(AccountTypeKind::Assets) => 0,
+            Some(AccountTypeKind::Liabilities) => 1,
+            Some(AccountTypeKind::Equity) => 2,
+            Some(AccountTypeKind::Income) => 3,
+            Some(AccountTypeKind::Expenses) => 4,
+            None => 5,
+        }
+    }
+}
+
 /// The lowercased root account type for `account` — the segment before the
 /// first `:` — or `"unknown"` if it is not one of [`ACCOUNT_TYPES`].
 #[must_use]

--- a/crates/rustledger-core/src/lib.rs
+++ b/crates/rustledger-core/src/lib.rs
@@ -80,7 +80,8 @@ pub use format::{
     format_posting_line, posting_format_line, render_lines, resolve_alignment,
 };
 pub use identifiers::{
-    ACCOUNT_TYPES, Account, Currency, Link, Tag, account_type, is_subaccount_or_equal,
+    ACCOUNT_TYPES, Account, AccountTypeKind, AccountTypes, Currency, Link, Tag, account_type,
+    is_subaccount_or_equal,
 };
 pub use implicit_prices::extract_per_unit_price;
 pub use intern::{InternedStr, StringInterner};

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -644,11 +644,30 @@ fn query_loaded(loaded: &ffi::helpers::LoadResult, query_str: &str) -> out::Quer
         };
     }
     let directives = rustledger_booking::merge_with_padding(&loaded.directives);
-    run_query(&directives, query_str)
+    run_query(&directives, query_str, account_types_from(&loaded.options))
 }
 
 /// Run one query against already-loaded, pad-expanded directives.
-pub fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> out::QueryResult {
+/// Build the config-aware account-type classifier from loaded ledger
+/// options, so BQL `POSSIGN`/`ACCOUNT_SORTKEY` honor `name_*` renames the
+/// way beanquery does (L5).
+fn account_types_from(
+    options: &rustledger_ffi_wasi::LedgerOptions,
+) -> rustledger_core::AccountTypes {
+    rustledger_core::AccountTypes {
+        assets: options.name_assets.clone(),
+        liabilities: options.name_liabilities.clone(),
+        equity: options.name_equity.clone(),
+        income: options.name_income.clone(),
+        expenses: options.name_expenses.clone(),
+    }
+}
+
+pub fn run_query(
+    directives: &[rustledger_core::Directive],
+    query_str: &str,
+    account_types: rustledger_core::AccountTypes,
+) -> out::QueryResult {
     let parsed = match parse_query(query_str) {
         Ok(q) => q,
         Err(e) => {
@@ -660,6 +679,7 @@ pub fn run_query(directives: &[rustledger_core::Directive], query_str: &str) -> 
         }
     };
     let mut executor = Executor::new(directives);
+    executor.set_account_types(account_types);
     match executor.execute(&parsed) {
         Ok(result) => {
             // Infer each column's datatype from its first NON-NULL value.
@@ -722,7 +742,10 @@ pub fn batch(source: &str, queries: &[String]) -> out::BatchResult {
     let loaded = ffi::helpers::load_source(source);
     let query_results: Vec<out::QueryResult> = if loaded.errors.is_empty() {
         let directives = rustledger_booking::merge_with_padding(&loaded.directives);
-        queries.iter().map(|q| run_query(&directives, q)).collect()
+        queries
+            .iter()
+            .map(|q| run_query(&directives, q, account_types_from(&loaded.options)))
+            .collect()
     } else {
         queries
             .iter()
@@ -1427,7 +1450,15 @@ pub fn query_entries(entries: &[wit::Directive], query_str: &str) -> out::QueryR
         .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok())
         .collect();
     let directives = rustledger_booking::merge_with_padding(&core);
-    run_query(&directives, query_str)
+    // The `query-entries` WIT contract carries no ledger options, so the
+    // classifier defaults to the standard five roots. Renamed-root ledgers
+    // queried via host-provided entries won't POSSIGN-flip custom names —
+    // extending the contract with options is a WIT-version decision (L5 note).
+    run_query(
+        &directives,
+        query_str,
+        rustledger_core::AccountTypes::default(),
+    )
 }
 
 // ---- stateful ledger handle (`resource session`, #1421) -------------------
@@ -1569,7 +1600,17 @@ impl SessionState {
         let directives = self
             .padded
             .get_or_init(|| rustledger_booking::merge_with_padding(&self.directives));
-        run_query(directives, query_str)
+        run_query(
+            directives,
+            query_str,
+            rustledger_core::AccountTypes {
+                assets: self.options.name_assets.clone(),
+                liabilities: self.options.name_liabilities.clone(),
+                equity: self.options.name_equity.clone(),
+                income: self.options.name_income.clone(),
+                expenses: self.options.name_expenses.clone(),
+            },
+        )
     }
 
     /// Keep only directives within `[begin, end)`. Reuses the free `filter`'s

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -599,6 +599,20 @@ impl Options {
         self.custom.get(key).map(String::as_str)
     }
 
+    /// Config-aware [`rustledger_core::AccountTypes`] classifier honoring the
+    /// `name_*` renames. Consumers that route or sign accounts by root type
+    /// must use this, not the rename-blind `ACCOUNT_TYPES` defaults.
+    #[must_use]
+    pub fn to_account_types(&self) -> rustledger_core::AccountTypes {
+        rustledger_core::AccountTypes {
+            assets: self.name_assets.clone(),
+            liabilities: self.name_liabilities.clone(),
+            equity: self.name_equity.clone(),
+            income: self.name_income.clone(),
+            expenses: self.name_expenses.clone(),
+        }
+    }
+
     /// Get all account type prefixes.
     #[must_use]
     pub fn account_types(&self) -> [&str; 5] {

--- a/crates/rustledger-query/src/executor/functions/account.rs
+++ b/crates/rustledger-query/src/executor/functions/account.rs
@@ -12,14 +12,10 @@ impl Executor<'_> {
     /// - Income = 3
     /// - Expenses = 4
     /// - Other = 5 (for custom account types)
-    pub(crate) fn account_type_index(account: &str) -> u8 {
-        // Extract the first component (root account type) and look it up in the
-        // canonical root list (`rustledger_core::ACCOUNT_TYPES`); custom types
-        // (not in the list) sort last.
-        let root = account.split(':').next().unwrap_or(account);
-        rustledger_core::ACCOUNT_TYPES
-            .iter()
-            .position(|t| *t == root)
-            .map_or(5, |i| i as u8)
+    pub(crate) fn account_type_index(&self, account: &str) -> u8 {
+        // Classify against the CONFIGURED account types (honors `name_*`
+        // renames — beanquery's account_sortkey does too; the previous
+        // ACCOUNT_TYPES-const lookup sorted renamed roots as "custom"/5).
+        self.account_types.sort_index(account)
     }
 }

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -94,6 +94,12 @@ pub struct Executor<'a> {
     target_currency: Option<String>,
     /// Query date for price lookups (defaults to today).
     query_date: rustledger_core::NaiveDate,
+    /// Config-aware account-type classifier (honors `name_*` renames).
+    /// `POSSIGN` and `ACCOUNT_SORTKEY` must classify against this — hardcoded
+    /// roots diverge from beanquery on renamed ledgers (L5). Defaults to
+    /// the standard five; hosts with a loaded `Ledger` set it via
+    /// [`Executor::set_account_types`].
+    account_types: rustledger_core::AccountTypes,
     /// Cache for compiled regex patterns (`RwLock` for thread-safe parallel execution).
     // `Arc<Regex>`, not `Regex`: the `~`/`!~` operators look the regex up per
     // row, and cloning a `Regex` gives the clone a fresh, empty lazy-DFA cache
@@ -168,12 +174,20 @@ impl<'a> Executor<'a> {
             price_db,
             target_currency: None,
             query_date: jiff::Zoned::now().date(),
+            account_types: rustledger_core::AccountTypes::default(),
             regex_cache: RwLock::new(FxHashMap::default()),
             account_info,
             source_locations: None,
             source_map: None,
             tables: FxHashMap::default(),
         }
+    }
+
+    /// Set the config-aware account types (from the loaded ledger's
+    /// `name_*` options) so `POSSIGN` / `ACCOUNT_SORTKEY` classify renamed
+    /// roots the way beanquery does.
+    pub fn set_account_types(&mut self, account_types: rustledger_core::AccountTypes) {
+        self.account_types = account_types;
     }
 
     /// Create a new executor with source location support.
@@ -245,6 +259,7 @@ impl<'a> Executor<'a> {
             price_db,
             target_currency: None,
             query_date: jiff::Zoned::now().date(),
+            account_types: rustledger_core::AccountTypes::default(),
             regex_cache: RwLock::new(FxHashMap::default()),
             account_info,
             source_locations: Some(source_locations),
@@ -972,7 +987,7 @@ impl<'a> Executor<'a> {
                 Self::require_args_count(&name_upper, args, 1)?;
                 match &args[0] {
                     Value::String(s) => {
-                        let type_index = Self::account_type_index(s);
+                        let type_index = self.account_type_index(s);
                         Ok(Value::String(format!("{type_index}-{s}")))
                     }
                     Value::Null => Ok(Value::Null),
@@ -1193,9 +1208,9 @@ impl<'a> Executor<'a> {
                         ));
                     }
                 };
-                let first_component = account_str.split(':').next().unwrap_or("");
-                let is_credit_normal =
-                    matches!(first_component, "Liabilities" | "Equity" | "Income");
+                // Configured credit-normal set (honors `name_*` renames) —
+                // beanquery flips for a renamed Income root too (L5).
+                let is_credit_normal = self.account_types.is_credit_normal(&account_str);
                 match &args[0] {
                     Value::Amount(a) => {
                         let mut amt = a.clone();

--- a/crates/rustledger-wasm/src/api.rs
+++ b/crates/rustledger-wasm/src/api.rs
@@ -161,6 +161,11 @@ pub fn query(source: &str, query_str: &str) -> Result<JsValue, JsError> {
     // (#1300) correctly by construction via `process_pads`.
     let directives = merge_with_padding(&load.directives);
     let mut executor = Executor::new(&directives);
+    // Config-aware classification (POSSIGN/ACCOUNT_SORTKEY honor name_*
+    // renames) — same wiring as the CLI query path.
+    executor.set_account_types(crate::helpers::account_types_from_raw(
+        &load.parse_result.options,
+    ));
     match executor.execute(&query) {
         Ok(result) => {
             let rows: Vec<Vec<_>> = result
@@ -743,6 +748,8 @@ pub fn query_multi_file(
     // Merge pad-synthesized transactions into the directive stream
     // (matching CLI query pipeline). See `wasm::query` above for the
     // architectural rule.
+    // Grab the configured account types before `ledger` fields are moved.
+    let account_types = ledger.options.to_account_types();
     let booked_directives: Vec<_> = ledger.directives.into_iter().map(|s| s.value).collect();
     let directives = merge_with_padding(&booked_directives);
 
@@ -761,6 +768,7 @@ pub fn query_multi_file(
 
     // Execute query
     let mut executor = Executor::new(&directives);
+    executor.set_account_types(account_types);
     match executor.execute(&query) {
         Ok(result) => {
             let rows: Vec<Vec<_>> = result

--- a/crates/rustledger-wasm/src/cache.rs
+++ b/crates/rustledger-wasm/src/cache.rs
@@ -28,8 +28,8 @@ use crate::types::{Error, LedgerOptions};
 ///
 /// v2 (#1597): `Error` gained `code`/`phase`/`hint`/`file`/`end_line`/
 /// `end_column`, changing its rkyv archived layout — a v1 blob must be rejected
-/// and re-parsed rather than mis-read under the new layout.
-pub const CACHE_VERSION: u32 = 2;
+/// and re-parsed rather than misread under the new layout.
+pub const CACHE_VERSION: u32 = 3;
 
 /// Magic bytes for [`ParsedLedgerPayload`] cache blobs.
 pub const MAGIC_PARSED: &[u8; 8] = b"WLPARSED";
@@ -58,6 +58,12 @@ pub struct ParsedLedgerPayload {
 pub struct LedgerPayload {
     pub directives: Vec<Directive>,
     pub options: LedgerOptions,
+    /// Configured account-type roots as `[assets, liabilities, equity,
+    /// income, expenses]` — `name_*` renames must survive the cache or
+    /// `fromCache` ledgers silently misclassify in BQL (the L5 class).
+    /// Plain strings rather than `rustledger_core::AccountTypes` so the
+    /// rkyv derive stays local to this crate.
+    pub account_type_names: Vec<String>,
     pub errors: Vec<Error>,
 }
 
@@ -165,6 +171,13 @@ mod tests {
                 operating_currencies: vec!["USD".to_string()],
                 title: Some("Test".to_string()),
             },
+            account_type_names: vec![
+                "Assets".to_string(),
+                "Liabilities".to_string(),
+                "Equity".to_string(),
+                "Revenue".to_string(),
+                "Expenses".to_string(),
+            ],
             errors: vec![Error::new("a warning")],
         };
         let bytes = serialize_ledger(&payload).expect("serialize");
@@ -212,6 +225,7 @@ option "operating_currency" "USD"
         let mut bytes = serialize_ledger(&LedgerPayload {
             directives: Vec::new(),
             options: LedgerOptions::default(),
+            account_type_names: Vec::new(),
             errors: Vec::new(),
         })
         .unwrap();
@@ -233,6 +247,7 @@ option "operating_currency" "USD"
         let mut bytes = serialize_ledger(&LedgerPayload {
             directives: Vec::new(),
             options: LedgerOptions::default(),
+            account_type_names: Vec::new(),
             errors: Vec::new(),
         })
         .unwrap();
@@ -272,6 +287,7 @@ option "operating_currency" "USD"
         let bytes = serialize_ledger(&LedgerPayload {
             directives: Vec::new(),
             options: LedgerOptions::default(),
+            account_type_names: Vec::new(),
             errors: Vec::new(),
         })
         .unwrap();

--- a/crates/rustledger-wasm/src/helpers.rs
+++ b/crates/rustledger-wasm/src/helpers.rs
@@ -226,6 +226,31 @@ pub fn to_js<T: serde::Serialize>(value: &T) -> Result<JsValue, JsError> {
 }
 
 /// Extract [`LedgerOptions`] from parsed option directives (parser format).
+/// Derive the configured [`rustledger_core::AccountTypes`] from raw parsed
+/// option tuples (`name_assets` etc. over the standard defaults).
+///
+/// The wasm wire `LedgerOptions` deliberately carries only title/currencies,
+/// so query surfaces must NOT go through it for classification — they take
+/// the account types from here (single-file paths) or from the loader's
+/// `Options::to_account_types` (multi-file), or `POSSIGN`/`ACCOUNT_SORTKEY`
+/// silently misclassify renamed ledgers (the L5 bug class).
+pub fn account_types_from_raw(
+    options: &[(String, String, rustledger_parser::Span)],
+) -> rustledger_core::AccountTypes {
+    let mut at = rustledger_core::AccountTypes::default();
+    for (key, value, _span) in options {
+        match key.as_str() {
+            "name_assets" => at.assets.clone_from(value),
+            "name_liabilities" => at.liabilities.clone_from(value),
+            "name_equity" => at.equity.clone_from(value),
+            "name_income" => at.income.clone_from(value),
+            "name_expenses" => at.expenses.clone_from(value),
+            _ => {}
+        }
+    }
+    at
+}
+
 pub fn extract_options(options: &[(String, String, rustledger_parser::Span)]) -> LedgerOptions {
     let mut ledger_options = LedgerOptions::default();
 
@@ -335,5 +360,24 @@ mod warning_severity_tests {
         assert_eq!(warn.severity, Severity::Warning);
         let err = validation_error_to_wasm(&mk(ErrorCode::AccountNotOpen), &lookup, None, Some(1));
         assert_eq!(err.severity, Severity::Error);
+    }
+}
+
+#[cfg(test)]
+mod account_types_tests {
+    use super::account_types_from_raw;
+
+    #[test]
+    fn raw_options_override_defaults() {
+        let span = rustledger_parser::Span::ZERO;
+        let opts = vec![
+            ("name_income".to_string(), "Revenue".to_string(), span),
+            ("title".to_string(), "x".to_string(), span),
+        ];
+        let at = account_types_from_raw(&opts);
+        assert_eq!(at.income, "Revenue");
+        assert_eq!(at.assets, "Assets"); // untouched types keep defaults
+        assert!(at.is_credit_normal("Revenue:Sales"));
+        assert!(!at.is_credit_normal("Income:Sales")); // renamed away
     }
 }

--- a/crates/rustledger-wasm/src/lib.rs
+++ b/crates/rustledger-wasm/src/lib.rs
@@ -891,6 +891,7 @@ option "operating_currency" "EUR"
         let payload = cache::LedgerPayload {
             directives: processed.directives.clone(),
             options: processed.options.clone(),
+            account_type_names: Vec::new(),
             errors: Vec::new(),
         };
 

--- a/crates/rustledger-wasm/src/parsed_ledger.rs
+++ b/crates/rustledger-wasm/src/parsed_ledger.rs
@@ -23,7 +23,11 @@ use crate::types::{Error, FormatResult, LedgerOptions, PadResult, QueryResult};
 // Shared query/directive logic (used by both ParsedLedger and Ledger)
 // =============================================================================
 
-fn execute_query(directives: &[Directive], query_str: &str) -> Result<JsValue, JsError> {
+fn execute_query(
+    directives: &[Directive],
+    query_str: &str,
+    account_types: rustledger_core::AccountTypes,
+) -> Result<JsValue, JsError> {
     use crate::convert::value_to_cell;
     use rustledger_query::{Executor, parse as parse_query};
 
@@ -48,6 +52,10 @@ fn execute_query(directives: &[Directive], query_str: &str) -> Result<JsValue, J
     // included.
     let expanded = rustledger_booking::merge_with_padding(directives);
     let mut executor = Executor::new(&expanded);
+    // Config-aware classification (POSSIGN/ACCOUNT_SORTKEY honor name_*
+    // renames) — the wasm wire LedgerOptions deliberately lacks name_*,
+    // so callers supply core AccountTypes from their construction source.
+    executor.set_account_types(account_types);
     match executor.execute(&query) {
         Ok(result) => {
             let rows: Vec<Vec<_>> = result
@@ -271,7 +279,11 @@ impl ParsedLedger {
             };
             return to_js(&result);
         }
-        execute_query(&self.directives, query_str)
+        execute_query(
+            &self.directives,
+            query_str,
+            crate::helpers::account_types_from_raw(&self.parse_result.options),
+        )
     }
 
     /// Get account balances (shorthand for query("BALANCES")).
@@ -482,6 +494,11 @@ pub struct Ledger {
     directives: Vec<Directive>,
     /// Ledger options.
     options: LedgerOptions,
+    /// Configured account-type roots (`name_*` renames) for query
+    /// classification. Not part of the wire `LedgerOptions` (deliberate);
+    /// persisted in the cache payload so `fromCache` ledgers classify
+    /// identically.
+    account_types: rustledger_core::AccountTypes,
     /// Processing errors (load, booking, validation).
     errors: Vec<Error>,
     /// Editor cache for cross-file completions.
@@ -526,6 +543,7 @@ impl Ledger {
                 return Ok(Self {
                     directives: Vec::new(),
                     options: LedgerOptions::default(),
+                    account_types: rustledger_core::AccountTypes::default(),
                     errors: vec![Error::new(format!("Load error: {e}"))],
                     editor_cache: editor::EditorCache::from_directives(&[]),
                 });
@@ -536,6 +554,7 @@ impl Ledger {
             title: load_result.options.title.clone(),
             operating_currencies: load_result.options.operating_currency.clone(),
         };
+        let account_types = load_result.options.to_account_types();
 
         let load_options = LoadOptions {
             validate: true,
@@ -557,6 +576,7 @@ impl Ledger {
                 Ok(Self {
                     directives,
                     options,
+                    account_types,
                     errors,
                     editor_cache,
                 })
@@ -564,6 +584,7 @@ impl Ledger {
             Err(e) => Ok(Self {
                 directives: Vec::new(),
                 options,
+                account_types,
                 errors: vec![Error::new(format!("Processing error: {e}"))],
                 editor_cache: editor::EditorCache::from_directives(&[]),
             }),
@@ -604,7 +625,7 @@ impl Ledger {
     /// Run a BQL query on this ledger.
     #[wasm_bindgen]
     pub fn query(&self, query_str: &str) -> Result<JsValue, JsError> {
-        execute_query(&self.directives, query_str)
+        execute_query(&self.directives, query_str, self.account_types.clone())
     }
 
     /// Get account balances (shorthand for query("BALANCES")).
@@ -654,6 +675,13 @@ impl Ledger {
         let payload = cache::LedgerPayload {
             directives: self.directives.clone(),
             options: self.options.clone(),
+            account_type_names: vec![
+                self.account_types.assets.clone(),
+                self.account_types.liabilities.clone(),
+                self.account_types.equity.clone(),
+                self.account_types.income.clone(),
+                self.account_types.expenses.clone(),
+            ],
             errors: self.errors.clone(),
         };
         cache::serialize_ledger(&payload).map_err(|e| JsError::new(&e))
@@ -674,9 +702,24 @@ impl Ledger {
 
         let editor_cache = editor::EditorCache::from_directives(&payload.directives);
 
+        let account_types = match <[String; 5]>::try_from(payload.account_type_names) {
+            Ok([assets, liabilities, equity, income, expenses]) => rustledger_core::AccountTypes {
+                assets,
+                liabilities,
+                equity,
+                income,
+                expenses,
+            },
+            // Wrong arity can only come from a hand-built blob (the version
+            // header already gates format changes); fall back to defaults
+            // rather than erroring on an otherwise-valid payload.
+            Err(_) => rustledger_core::AccountTypes::default(),
+        };
+
         Ok(Self {
             directives: payload.directives,
             options: payload.options,
+            account_types,
             errors: payload.errors,
             editor_cache,
         })

--- a/crates/rustledger/src/cmd/query/interactive.rs
+++ b/crates/rustledger/src/cmd/query/interactive.rs
@@ -43,6 +43,7 @@ pub(super) fn run_interactive(
     directives: &[Spanned<Directive>],
     source_map: &SourceMap,
     display_context: &DisplayContext,
+    account_types: &rustledger_core::AccountTypes,
     args: &Args,
 ) -> Result<()> {
     let mut rl: Editor<(), DefaultHistory> = DefaultEditor::new()?;
@@ -76,7 +77,8 @@ pub(super) fn run_interactive(
     );
     println!();
 
-    let mut settings = ShellSettings::from_args(args, display_context.clone());
+    let mut settings =
+        ShellSettings::from_args(args, display_context.clone(), account_types.clone());
 
     loop {
         let readline = rl.readline("beanquery> ");

--- a/crates/rustledger/src/cmd/query/mod.rs
+++ b/crates/rustledger/src/cmd/query/mod.rs
@@ -214,13 +214,15 @@ pub fn run_with_writer<W: io::Write>(args: &Args, out: &mut W) -> Result<()> {
             &directives,
             &source_map,
             &display_context,
+            &ledger.options.to_account_types(),
             args,
         );
     };
 
     // Batch query: no pager (matching Python bean-query behavior).
     // Pager is only used in interactive REPL mode.
-    let settings = ShellSettings::from_args(args, display_context);
+    let settings =
+        ShellSettings::from_args(args, display_context, ledger.options.to_account_types());
     if let Some(ref output_path) = settings.output_file {
         let mut file = fs::File::create(output_path)
             .with_context(|| format!("failed to create output file {}", output_path.display()))?;
@@ -237,16 +239,24 @@ struct ShellSettings {
     pager: bool,
     output_file: Option<PathBuf>,
     display_context: DisplayContext,
+    /// Config-aware account types from the loaded ledger (L5: `POSSIGN` /
+    /// `ACCOUNT_SORTKEY` must honor `name_*` renames like beanquery).
+    account_types: rustledger_core::AccountTypes,
 }
 
 impl ShellSettings {
-    fn from_args(args: &Args, display_context: DisplayContext) -> Self {
+    fn from_args(
+        args: &Args,
+        display_context: DisplayContext,
+        account_types: rustledger_core::AccountTypes,
+    ) -> Self {
         Self {
             format: args.format.unwrap_or(OutputFormat::Text),
             numberify: args.numberify,
             pager: true,
             output_file: args.output.clone(),
             display_context,
+            account_types,
         }
     }
 }

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -31,6 +31,7 @@ pub(super) fn execute_query<W: Write>(
     // columns (and `meta`-derived location lookups) resolve to real source
     // positions instead of NULL.
     let mut executor = Executor::new_with_sources(directives, source_map);
+    executor.set_account_types(settings.account_types.clone());
     let result = executor
         .execute(&query)
         .with_context(|| "failed to execute query")?;

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 /// Generate a balance sheet report (Assets, Liabilities, Equity).
 pub(super) fn report_balsheet<W: Write>(
     directives: &[Directive],
+    account_types: &rustledger_core::AccountTypes,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
@@ -20,16 +21,16 @@ pub(super) fn report_balsheet<W: Write>(
     // Partition the single source-of-truth balances (see
     // `super::account_balances`) into the three balance-sheet sections by
     // account prefix. No balance re-derivation here.
+    // Route by CONFIGURED account type (honors `name_*` renames — L5: a
+    // ledger with `option "name_assets" "Activa"` must still fill the
+    // balance sheet), never by hardcoded root prefixes.
+    use rustledger_core::AccountTypeKind as K;
     for (account, inv) in super::account_balances(directives) {
-        let account_str: &str = &account;
-        let section = if account_str.starts_with("Assets:") {
-            &mut assets
-        } else if account_str.starts_with("Liabilities:") {
-            &mut liabilities
-        } else if account_str.starts_with("Equity:") {
-            &mut equity
-        } else {
-            continue;
+        let section = match account_types.kind(&account) {
+            Some(K::Assets) => &mut assets,
+            Some(K::Liabilities) => &mut liabilities,
+            Some(K::Equity) => &mut equity,
+            _ => continue,
         };
         section.insert(account, inv);
     }

--- a/crates/rustledger/src/cmd/report_cmd/holdings.rs
+++ b/crates/rustledger/src/cmd/report_cmd/holdings.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 /// Generate a holdings report with cost basis.
 pub(super) fn report_holdings<W: Write>(
     directives: &[Directive],
+    account_types: &rustledger_core::AccountTypes,
     account_filter: Option<&str>,
     format: &OutputFormat,
     writer: &mut W,
@@ -30,7 +31,9 @@ pub(super) fn report_holdings<W: Write>(
                 }
 
                 let account_str: &str = &posting.account;
-                if !account_str.starts_with("Assets:") {
+                // Configured Assets root, not a hardcoded prefix (L5).
+                if account_types.kind(account_str) != Some(rustledger_core::AccountTypeKind::Assets)
+                {
                     continue;
                 }
 

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 /// Generate an income statement report (Income and Expenses).
 pub(super) fn report_income<W: Write>(
     directives: &[Directive],
+    account_types: &rustledger_core::AccountTypes,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
@@ -19,14 +20,15 @@ pub(super) fn report_income<W: Write>(
     // Partition the single source-of-truth balances (see
     // `super::account_balances`) into income and expense sections by prefix.
     // No balance re-derivation here.
+    // Route by CONFIGURED account type (honors `name_*` renames — L5: a
+    // ledger with `option "name_income" "Revenue"` previously rendered an
+    // EMPTY income statement here).
+    use rustledger_core::AccountTypeKind as K;
     for (account, inv) in super::account_balances(directives) {
-        let account_str: &str = &account;
-        let section = if account_str.starts_with("Income:") {
-            &mut income
-        } else if account_str.starts_with("Expenses:") {
-            &mut expenses
-        } else {
-            continue;
+        let section = match account_types.kind(&account) {
+            Some(K::Income) => &mut income,
+            Some(K::Expenses) => &mut expenses,
+            _ => continue,
         };
         section.insert(account, inv);
     }

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -241,6 +241,11 @@ struct LoadedReport {
     /// Source-faithful directive stream (pads remain `Pad`). Used by
     /// reports that count/list source directive kinds.
     directives: Vec<rustledger_core::Directive>,
+    /// Config-aware account-type classifier (honors `name_*` renames).
+    /// Reports must route/sign accounts through this, never by hardcoded
+    /// root-prefix matching — renamed ledgers otherwise misroute (L5:
+    /// empty income statement under `option "name_income" "Revenue"`).
+    account_types: rustledger_core::AccountTypes,
     /// Pad-expanded view, present only when the ledger has pads AND the
     /// report is balance-computing. `None` means "use `directives`".
     balance_view: Option<Vec<rustledger_core::Directive>>,
@@ -322,10 +327,12 @@ fn load(file: &PathBuf, report: &Report, verbose: bool, no_cache: bool) -> Resul
     } else {
         None
     };
+    let account_types = ledger.options.to_account_types();
     let directives: Vec<_> = ledger.directives.into_iter().map(|s| s.value).collect();
 
     Ok(LoadedReport {
         directives,
+        account_types,
         balance_view,
     })
 }
@@ -361,16 +368,22 @@ fn render<W: io::Write>(
             balances::report_balances(balance_input, account.as_deref(), format, writer)?;
         }
         Report::Balsheet => {
-            balsheet::report_balsheet(balance_input, format, writer)?;
+            balsheet::report_balsheet(balance_input, &loaded.account_types, format, writer)?;
         }
         Report::Income => {
-            income::report_income(balance_input, format, writer)?;
+            income::report_income(balance_input, &loaded.account_types, format, writer)?;
         }
         Report::Journal { account, limit } => {
             journal::report_journal(directives, account.as_deref(), *limit, format, writer)?;
         }
         Report::Holdings { account } => {
-            holdings::report_holdings(balance_input, account.as_deref(), format, writer)?;
+            holdings::report_holdings(
+                balance_input,
+                &loaded.account_types,
+                account.as_deref(),
+                format,
+                writer,
+            )?;
         }
         Report::Networth {
             period,
@@ -380,6 +393,7 @@ fn render<W: io::Write>(
         } => {
             networth::report_networth(
                 balance_input,
+                &loaded.account_types,
                 period,
                 currency.as_deref(),
                 account.as_deref(),

--- a/crates/rustledger/src/cmd/report_cmd/networth.rs
+++ b/crates/rustledger/src/cmd/report_cmd/networth.rs
@@ -19,6 +19,7 @@ use std::io::Write;
 /// * `writer` - Output writer
 pub(super) fn report_networth<W: Write>(
     directives: &[Directive],
+    account_types: &rustledger_core::AccountTypes,
     period: &str,
     currency_filter: Option<&str>,
     account_filter: Option<&str>,
@@ -104,9 +105,15 @@ pub(super) fn report_networth<W: Write>(
                     }
                 }
 
-                if account_str.starts_with("Assets:") && account_matches(account_str) {
+                // Configured roots, not hardcoded prefixes (L5).
+                use rustledger_core::AccountTypeKind as K;
+                if account_types.kind(account_str) == Some(K::Assets)
+                    && account_matches(account_str)
+                {
                     *asset_balance.entry(amount.currency.clone()).or_default() += amount.number;
-                } else if account_str.starts_with("Liabilities:") && account_matches(account_str) {
+                } else if account_types.kind(account_str) == Some(K::Liabilities)
+                    && account_matches(account_str)
+                {
                     *liability_balance
                         .entry(amount.currency.clone())
                         .or_default() += amount.number;

--- a/crates/rustledger/tests/report_account_rename_test.rs
+++ b/crates/rustledger/tests/report_account_rename_test.rs
@@ -1,0 +1,119 @@
+//! Regression tests for L5: report routing and BQL classification must honor
+//! the `name_*` root-rename options (a documented beancount feature), not
+//! hardcoded "Assets:"/"Income:" prefixes.
+//!
+//! Pre-fix, `option "name_income" "Revenue"` produced an EMPTY income
+//! statement, and `POSSIGN` failed to flip renamed credit-normal roots
+//! (diverging from beanquery, which returns +100.00 for the fixture below).
+
+mod common;
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+const RENAMED_SOURCE: &str = r#"option "name_income" "Revenue"
+option "name_assets" "Activa"
+
+2024-01-01 open Activa:Cash
+2024-01-01 open Revenue:Sales
+
+2024-03-01 * "sale"
+  Activa:Cash    100.00 USD
+  Revenue:Sales -100.00 USD
+"#;
+
+fn write_fixture() -> tempfile::NamedTempFile {
+    let mut f = tempfile::Builder::new()
+        .prefix("report-rename-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(RENAMED_SOURCE.as_bytes())
+        .expect("write fixture");
+    f
+}
+
+fn run(binary: &PathBuf, args: &[&str]) -> String {
+    let out = Command::new(binary)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("run rledger {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "rledger {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn income_report_includes_renamed_income_root() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let path = f.path().to_str().unwrap();
+    let stdout = run(&bin, &["report", path, "income", "--no-pager"]);
+    assert!(
+        stdout.contains("Revenue:Sales"),
+        "renamed income root must appear in the income statement \
+         (pre-fix: empty statement): {stdout}",
+    );
+    assert!(
+        stdout.contains("Total Income"),
+        "income section must total the renamed accounts: {stdout}",
+    );
+}
+
+#[test]
+fn balsheet_includes_renamed_assets_root() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let path = f.path().to_str().unwrap();
+    let stdout = run(&bin, &["report", path, "balsheet", "--no-pager"]);
+    assert!(
+        stdout.contains("Activa:Cash"),
+        "renamed assets root must appear on the balance sheet: {stdout}",
+    );
+}
+
+#[test]
+fn possign_flips_renamed_income_root_like_beanquery() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let path = f.path().to_str().unwrap();
+    let stdout = run(
+        &bin,
+        &[
+            "query",
+            path,
+            "SELECT account, possign(number, account) WHERE account ~ \"Revenue\"",
+        ],
+    );
+    // beanquery 3.2.3 on this fixture: Revenue:Sales -100.00 -> +100.00
+    assert!(
+        stdout.contains("100.00") && !stdout.contains("-100.00"),
+        "POSSIGN must flip the renamed credit-normal root (beanquery \
+         parity; pre-fix returned -100.00): {stdout}",
+    );
+}
+
+#[test]
+fn account_sortkey_classifies_renamed_root_like_beanquery() {
+    let bin = require_rledger!();
+    let f = write_fixture();
+    let path = f.path().to_str().unwrap();
+    let stdout = run(
+        &bin,
+        &[
+            "query",
+            path,
+            "SELECT account_sortkey(account) WHERE account ~ \"Revenue\"",
+        ],
+    );
+    // beanquery: renamed Income root sorts with index 3, not custom/5.
+    assert!(
+        stdout.contains("3-Revenue"),
+        "ACCOUNT_SORTKEY must classify the renamed Income root as index 3 \
+         (beanquery parity; pre-fix sorted it as custom): {stdout}",
+    );
+}


### PR DESCRIPTION
Found by the Phase-0 duplication sweep (L5). beancount ledgers can rename their five root accounts (`option "name_income" "Revenue"`) — both engines accept them at check-time, but every rledger consumer classified accounts against hardcoded prefixes. Two user-visible bugs, verified against beanquery 3.2.3:

- **`report income` rendered an EMPTY income statement** under a renamed Income root; same class in balsheet/holdings/networth routing.
- **BQL `POSSIGN` diverged from beanquery** (-100.00 vs +100.00 on a renamed credit-normal root); `ACCOUNT_SORTKEY` sorted renamed roots as custom where beanquery classifies them.

## Fix: one config-aware classifier, threaded everywhere
- **core**: new `AccountTypes` + `AccountTypeKind` — `kind()` / `is_balance_sheet()` / `is_income_statement()` / `is_credit_normal()` / `sort_index()` against the *configured* names.
- **loader**: `Options::to_account_types()`.
- **reports**: `LoadedReport` carries it; balsheet/income/holdings/networth route by `kind()` — no hardcoded prefixes remain in report routing.
- **query**: `Executor` holds it (`set_account_types`); POSSIGN + ACCOUNT_SORTKEY classify through it. Threaded via ShellSettings (CLI batch + interactive) and the ffi-component (`query`/`batch`/session). `query-entries` keeps defaults — its WIT contract carries no options (documented inline).

## Verified
- Renamed fixture vs beanquery 3.2.3: POSSIGN **+100.00** and ACCOUNT_SORTKEY **`3-Revenue:Sales`** match exactly; income statement shows Revenue:Sales → Net Income 100.00.
- New `report_account_rename_test.rs` pins all four surfaces (4 tests).
- Default-name behavior unchanged: report/CLI (57+8+3), query (12 suites), core/loader green; clippy 0; fmt clean.

Follow-ups (registry, not this PR): remaining cosmetic raw-prefix sites (~9), wasm executor default (wasm LedgerOptions lacks name_* fields today), possible WIT option-passing for `query-entries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)