### PR TITLE
fix: compound costs mispriced in doctor region and ops clamp

### DIFF
--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -590,10 +590,19 @@ impl CostNumber {
     /// like the `total()`-then-`per_unit()` chain, but `Compound` is
     /// handled instead of silently dropped:
     ///
-    /// - `Total` / `PerUnitFromTotal`: the stored total (precision-exact).
-    /// - `PerUnit`: `value * units`.
-    /// - `Compound { per_unit, total }`: `per_unit * units + total`
+    /// - `Total` / `PerUnitFromTotal`: the stored total (precision-exact),
+    ///   with the sign following `units`.
+    /// - `PerUnit`: `value * units` (sign carries through `units`).
+    /// - `Compound { per_unit, total }`: `per_unit * units + total × sign(units)`
     ///   (the `N·a + b` rule from #1704; `total` is only the lump).
+    ///
+    /// Stored totals and lumps are written as positive magnitudes in
+    /// source, so the sign is taken from `units` for EVERY variant — a
+    /// reduction (negative units) yields a negative total across the
+    /// board, the same sign rule the balance-weight ladder applies.
+    /// (Pre-fix, `Total`/`PerUnitFromTotal` returned the unsigned stored
+    /// total while `PerUnit` was signed through multiplication, so
+    /// reductions costed with opposite signs depending on the spec shape.)
     ///
     /// Consumers computing "what did N units cost" MUST use this rather
     /// than chaining the `total()`/`per_unit()` accessors — both return
@@ -601,11 +610,13 @@ impl CostNumber {
     /// miscost compound lots (the doctor/clamp bug class).
     #[must_use]
     pub fn total_for(&self, units: Decimal) -> Decimal {
+        use rust_decimal::prelude::Signed;
+        let signum = units.signum();
         match self {
-            Self::Total { value } => *value,
-            Self::PerUnitFromTotal(b) => b.total,
+            Self::Total { value } => *value * signum,
+            Self::PerUnitFromTotal(b) => b.total * signum,
             Self::PerUnit { value } => *value * units,
-            Self::Compound { per_unit, total } => *per_unit * units + *total,
+            Self::Compound { per_unit, total } => *per_unit * units + *total * signum,
         }
     }
 }
@@ -874,6 +885,51 @@ mod tests {
             }
             .total_for(n),
             Decimal::new(6000, 2), // 10*5.00 + 10.00 = N*a + b
+        );
+    }
+
+    #[test]
+    fn total_for_signs_reductions_consistently() {
+        // Stored totals/lumps are positive magnitudes in source; the sign
+        // must come from `units` for EVERY variant, or reductions cost
+        // with opposite signs depending on spec shape (review catch on
+        // the original fix: Total/PerUnitFromTotal were unsigned while
+        // PerUnit signed through multiplication).
+        let n = Decimal::from(-10);
+        assert_eq!(
+            CostNumber::PerUnit {
+                value: Decimal::new(500, 2)
+            }
+            .total_for(n),
+            Decimal::new(-5000, 2),
+        );
+        assert_eq!(
+            CostNumber::Total {
+                value: Decimal::new(6000, 2)
+            }
+            .total_for(n),
+            Decimal::new(-6000, 2),
+        );
+        let booked = BookedCost::new(Decimal::new(600, 2), Decimal::new(6000, 2), n.abs());
+        assert_eq!(
+            CostNumber::PerUnitFromTotal(booked).total_for(n),
+            Decimal::new(-6000, 2),
+        );
+        assert_eq!(
+            CostNumber::Compound {
+                per_unit: Decimal::new(500, 2),
+                total: Decimal::new(1000, 2),
+            }
+            .total_for(n),
+            Decimal::new(-6000, 2), // -10*5.00 + 10.00*sign(-10)
+        );
+        // Zero units: everything costs zero.
+        assert_eq!(
+            CostNumber::Total {
+                value: Decimal::new(6000, 2)
+            }
+            .total_for(Decimal::ZERO),
+            Decimal::ZERO,
         );
     }
 

--- a/crates/rustledger-core/src/cost.rs
+++ b/crates/rustledger-core/src/cost.rs
@@ -269,7 +269,7 @@ pub enum CostNumber {
     /// USD}` as `total = 0` — arithmetically exact in both cases.
     ///
     /// Before #1700 the parser folded this form into [`Self::Total`]
-    /// with only the post-`#` value, silently mis-weighing every
+    /// with only the post-`#` value, silently misweighing every
     /// compound spec (valid ledgers errored, invalid ones passed).
     Compound {
         /// Per-unit component (`a` in `{a # b}`); zero when omitted.
@@ -579,9 +579,33 @@ impl CostNumber {
             Self::PerUnitFromTotal(b) => Some(b.total),
             // Compound's `total` field is only the lump component; the
             // whole total (N*per_unit + total) needs units. Exposing the
-            // lump here would mis-weigh callers that treat this as the
+            // lump here would misweigh callers that treat this as the
             // full total — the exact bug class this variant fixes.
             Self::PerUnit { .. } | Self::Compound { .. } => None,
+        }
+    }
+
+    /// The total cost of `units` under this cost number, exhaustive over
+    /// every variant — stored totals are preferred for precision, exactly
+    /// like the `total()`-then-`per_unit()` chain, but `Compound` is
+    /// handled instead of silently dropped:
+    ///
+    /// - `Total` / `PerUnitFromTotal`: the stored total (precision-exact).
+    /// - `PerUnit`: `value * units`.
+    /// - `Compound { per_unit, total }`: `per_unit * units + total`
+    ///   (the `N·a + b` rule from #1704; `total` is only the lump).
+    ///
+    /// Consumers computing "what did N units cost" MUST use this rather
+    /// than chaining the `total()`/`per_unit()` accessors — both return
+    /// `None` for `Compound`, and accessor-chain fallbacks silently
+    /// miscost compound lots (the doctor/clamp bug class).
+    #[must_use]
+    pub fn total_for(&self, units: Decimal) -> Decimal {
+        match self {
+            Self::Total { value } => *value,
+            Self::PerUnitFromTotal(b) => b.total,
+            Self::PerUnit { value } => *value * units,
+            Self::Compound { per_unit, total } => *per_unit * units + *total,
         }
     }
 }
@@ -817,6 +841,41 @@ impl fmt::Display for CostSpec {
 mod tests {
     use super::*;
     use rust_decimal_macros::dec;
+
+    /// `total_for` must be exhaustive: every variant yields the correct
+    /// total for N units, including `Compound` (which the `total()` /
+    /// `per_unit()` accessors both refuse — the doctor/clamp bug class).
+    #[test]
+    fn total_for_covers_all_variants() {
+        let n = Decimal::from(10);
+        assert_eq!(
+            CostNumber::PerUnit {
+                value: Decimal::new(500, 2)
+            }
+            .total_for(n),
+            Decimal::new(5000, 2), // 10 * 5.00
+        );
+        assert_eq!(
+            CostNumber::Total {
+                value: Decimal::new(6000, 2)
+            }
+            .total_for(n),
+            Decimal::new(6000, 2), // stored total, precision-exact
+        );
+        let booked = BookedCost::new(Decimal::new(600, 2), Decimal::new(6000, 2), n);
+        assert_eq!(
+            CostNumber::PerUnitFromTotal(booked).total_for(n),
+            Decimal::new(6000, 2), // stored total preferred
+        );
+        assert_eq!(
+            CostNumber::Compound {
+                per_unit: Decimal::new(500, 2),
+                total: Decimal::new(1000, 2),
+            }
+            .total_for(n),
+            Decimal::new(6000, 2), // 10*5.00 + 10.00 = N*a + b
+        );
+    }
 
     fn date(year: i32, month: u32, day: u32) -> NaiveDate {
         crate::naive_date(year, month, day).unwrap()

--- a/crates/rustledger-ops/src/clamp.rs
+++ b/crates/rustledger-ops/src/clamp.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use rustledger_core::{
-    Amount, Cost, CostNumber, CostSpec, Decimal, Directive, IncompleteAmount, Inventory, Metadata,
+    Amount, CostNumber, CostSpec, Decimal, Directive, IncompleteAmount, Inventory, Metadata,
     NaiveDate, Position, Posting, Span, Spanned, Transaction,
 };
 
@@ -36,32 +36,16 @@ const fn type_priority(d: &Directive) -> u8 {
 }
 
 /// Build a [`Position`] from a booked posting's units + optional cost spec.
-/// Falls back to a cost-less position when the cost is absent or unresolved.
-fn posting_position(units: &Amount, cost: Option<&CostSpec>) -> Position {
-    let Some(spec) = cost else {
-        return Position::simple(units.clone());
-    };
-    let Some(cost_number) = spec.number else {
-        return Position::simple(units.clone());
-    };
-    // Per-unit value: PerUnit / PerUnitFromTotal yield it directly; a residual
-    // Total spec is divided by |units| (matches the old JSON behavior).
-    let per_unit = cost_number.per_unit().or(match cost_number {
-        CostNumber::Total { value } if !units.number.is_zero() => Some(value / units.number.abs()),
-        _ => None,
-    });
-    let (Some(number), Some(currency)) = (per_unit, spec.currency.clone()) else {
-        return Position::simple(units.clone());
-    };
-    Position::with_cost(
-        units.clone(),
-        Cost {
-            number,
-            currency,
-            date: spec.date,
-            label: spec.label.clone(),
-        },
-    )
+///
+/// Delegates to the canonical [`Position::from_posting`] (→
+/// `CostSpec::resolve`), which handles every `CostNumber` variant. The
+/// previous hand-rolled per-unit ladder here had no `Compound` arm and
+/// silently summarized compound-cost lots as cost-less, destroying their
+/// basis in the clamped opening balance (L2). `date` is the posting's
+/// transaction date — `resolve` uses it to fill lot dates the spec omits,
+/// matching how the booking engine, query engine, and reports build lots.
+fn posting_position(units: &Amount, cost: Option<&CostSpec>, date: NaiveDate) -> Position {
+    Position::from_posting(units, cost, date)
 }
 
 /// A synthesized posting (used for summary/earnings transactions).
@@ -211,7 +195,7 @@ pub fn clamp_indexed(
                         let p = &sp.value;
                         if let Some(units) = p.units.as_ref().and_then(IncompleteAmount::as_amount)
                         {
-                            let pos = posting_position(units, p.cost.as_ref());
+                            let pos = posting_position(units, p.cost.as_ref(), t.date);
                             balances.entry(p.account.to_string()).or_default().add(pos);
                         }
                     }
@@ -301,6 +285,45 @@ mod tests {
     fn mentions(dir: &Directive, account: &str) -> bool {
         matches!(dir, Directive::Transaction(t)
             if t.postings.iter().any(|p| p.value.account.to_string() == account))
+    }
+
+    /// L2 regression: a pre-window lot bought at COMPOUND cost
+    /// (`{a # b}`) must keep its cost basis in the clamped opening
+    /// balance. The old hand-rolled per-unit ladder had no `Compound`
+    /// arm and summarized the lot cost-less, destroying the basis.
+    #[test]
+    fn clamp_preserves_compound_cost_basis() {
+        let src = "2024-01-01 open Assets:Broker\n\
+                   2024-01-01 open Assets:Cash\n\n\
+                   2024-01-05 * \"buy\"\n  \
+                   Assets:Broker  10 WIDGET {5.00 # 10.00 USD}\n  \
+                   Assets:Cash  -60.00 USD\n";
+        let directives = dirs(src);
+        let clamped = clamp(&directives, d(2024, 6, 1), d(2024, 12, 31));
+        let summary = clamped
+            .iter()
+            .find(|dd| is_summary(dd) && mentions(dd, "Assets:Broker"))
+            .expect("summary transaction for the pre-window lot");
+        let Directive::Transaction(t) = summary else {
+            unreachable!()
+        };
+        let broker = t
+            .postings
+            .iter()
+            .find(|p| p.value.account.to_string() == "Assets:Broker")
+            .expect("broker posting");
+        let cost = broker
+            .value
+            .cost
+            .as_ref()
+            .and_then(|c| c.number)
+            .expect("compound cost basis must survive clamping (was None pre-fix)");
+        // resolve(): (10*5.00 + 10.00) / 10 = 6.00 per unit.
+        assert_eq!(
+            cost.per_unit(),
+            Some(rust_decimal::Decimal::new(600, 2)),
+            "summarized per-unit must be 6.00, got {cost:?}",
+        );
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/doctor/region.rs
+++ b/crates/rustledger/src/cmd/doctor/region.rs
@@ -83,30 +83,18 @@ pub(super) fn cmd_region<W: Write>(
                     Some(Conversion::Cost) => {
                         // Use cost if available, otherwise fall back to units
                         if let Some(ref cost) = posting.cost {
-                            // Calculate total cost from cost spec. The
-                            // post-#1164 `CostNumber` enum keeps the
-                            // original total when booking derives a
-                            // per-unit (`PerUnitFromTotal`), so the
-                            // `total()` accessor is preferred here for
-                            // precision; the `PerUnit` fallback
-                            // multiplies by units, matching the pre-
-                            // #1164 branch order (total → per-unit →
-                            // none).
-                            let total_cost = if let Some(total) = cost
+                            // Total cost via the exhaustive helper: stored
+                            // totals stay precision-exact (PerUnitFromTotal /
+                            // Total, the post-#1164 preference) and Compound
+                            // costs `N·a + b`. The previous total()/per_unit()
+                            // accessor chain returned None for Compound and
+                            // fell through to bare units mislabeled as the
+                            // cost currency (L3 — this command reads the RAW
+                            // load stream, where Compound survives as-written).
+                            let total_cost = cost
                                 .number
                                 .as_ref()
-                                .and_then(rustledger_core::CostNumber::total)
-                            {
-                                total
-                            } else if let Some(per_unit) = cost
-                                .number
-                                .as_ref()
-                                .and_then(rustledger_core::CostNumber::per_unit)
-                            {
-                                amount.number * per_unit
-                            } else {
-                                amount.number
-                            };
+                                .map_or(amount.number, |n| n.total_for(amount.number));
                             let currency = cost
                                 .currency
                                 .clone()

--- a/crates/rustledger/src/cmd/doctor/region.rs
+++ b/crates/rustledger/src/cmd/doctor/region.rs
@@ -82,7 +82,9 @@ pub(super) fn cmd_region<W: Write>(
                 let (display_number, display_currency) = match conversion {
                     Some(Conversion::Cost) => {
                         // Use cost if available, otherwise fall back to units
-                        if let Some(ref cost) = posting.cost {
+                        if let Some(ref cost) = posting.cost
+                            && let Some(number) = cost.number.as_ref()
+                        {
                             // Total cost via the exhaustive helper: stored
                             // totals stay precision-exact (PerUnitFromTotal /
                             // Total, the post-#1164 preference) and Compound
@@ -91,10 +93,14 @@ pub(super) fn cmd_region<W: Write>(
                             // fell through to bare units mislabeled as the
                             // cost currency (L3 — this command reads the RAW
                             // load stream, where Compound survives as-written).
-                            let total_cost = cost
-                                .number
-                                .as_ref()
-                                .map_or(amount.number, |n| n.total_for(amount.number));
+                            //
+                            // A cost spec WITHOUT a number (`{}`, bare
+                            // `{USD}` lot matching) has no determinable cost
+                            // here, so it falls through to the units display
+                            // below — labeling the unit count with the cost
+                            // currency would be the same mislabel bug in a
+                            // different coat (review catch).
+                            let total_cost = number.total_for(amount.number);
                             let currency = cost
                                 .currency
                                 .clone()

--- a/crates/rustledger/tests/doctor_region_compound_cost_test.rs
+++ b/crates/rustledger/tests/doctor_region_compound_cost_test.rs
@@ -47,9 +47,10 @@ fn doctor_region_costs_compound_lots() {
     assert!(out.status.success(), "doctor region failed");
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("60.00 USD"),
-        "compound cost must total N*a+b = 60.00 USD (pre-fix showed the \
-         bare unit count '10 USD'): {stdout}",
+        stdout.contains("Assets:Broker 60.00 USD"),
+        "compound cost must total N*a+b = 60.00 USD on the Broker line \
+         (a bare \"60.00 USD\" match would be satisfied by the cash leg \
+         and pass even under the pre-fix bug; deep-review catch): {stdout}",
     );
     assert!(
         !stdout.contains("Assets:Broker 10 USD"),

--- a/crates/rustledger/tests/doctor_region_compound_cost_test.rs
+++ b/crates/rustledger/tests/doctor_region_compound_cost_test.rs
@@ -1,0 +1,58 @@
+//! Regression test for L3: `doctor region --conversion cost` must cost
+//! compound (`{a # b}`) lots correctly.
+//!
+//! `doctor region` reads the RAW load stream — before booking rewrites
+//! `Compound` to `PerUnitFromTotal` — so it is the one CLI surface where
+//! `Compound` reaches cost math as-written. Pre-fix, the
+//! `total()`/`per_unit()` accessor chain returned `None` for `Compound`
+//! and fell through to the bare unit count mislabeled with the cost
+//! currency: `10 WIDGET {5.00 # 10.00 USD}` displayed as `10 USD`
+//! instead of `60.00 USD` (N·a + b), and the "net changes" view did not
+//! balance.
+
+mod common;
+
+use std::io::Write;
+
+const COMPOUND_SOURCE: &str = r#"2024-01-01 open Assets:Broker
+2024-01-01 open Assets:Cash
+
+2024-01-05 * "buy with compound cost"
+  Assets:Broker   10 WIDGET {5.00 # 10.00 USD}
+  Assets:Cash   -60.00 USD
+"#;
+
+#[test]
+fn doctor_region_costs_compound_lots() {
+    let bin = require_rledger!();
+    let mut f = tempfile::Builder::new()
+        .prefix("doctor-compound-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(COMPOUND_SOURCE.as_bytes())
+        .expect("write fixture");
+    let out = std::process::Command::new(&bin)
+        .args([
+            "doctor",
+            "region",
+            f.path().to_str().unwrap(),
+            "1",
+            "20",
+            "--conversion",
+            "cost",
+        ])
+        .output()
+        .expect("run doctor region");
+    assert!(out.status.success(), "doctor region failed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("60.00 USD"),
+        "compound cost must total N*a+b = 60.00 USD (pre-fix showed the \
+         bare unit count '10 USD'): {stdout}",
+    );
+    assert!(
+        !stdout.contains("Assets:Broker 10 USD"),
+        "the unit-count-mislabeled-as-cost bug must not reappear: {stdout}",
+    );
+}


### PR DESCRIPTION
Found by the Phase-0 duplication sweep (cost-resolution family, L2/L3) and confirmed empirically. Two consumers computed cost via the `total()`/`per_unit()` accessor chain — **both return `None` for `CostNumber::Compound`**, so both silently miscosted `{a # b}` lots.

## The bugs
- **`doctor region --conversion cost` (L3, trivially reachable)**: reads the RAW load stream where Compound survives as-written. The accessor fallthrough displayed the bare unit count mislabeled with the cost currency — `10 WIDGET {5.00 # 10.00 USD}` showed **"10 USD"** instead of **60.00 USD**, and the net-changes view didn't balance (+10/−60).
- **`ops::clamp` (L2, contract-gated)**: the hand-rolled per-unit ladder in `posting_position` had no Compound arm — a pre-window compound lot was summarized **cost-less**, destroying its basis in the clamped opening balance. Masked on the standard load path (booking rewrites Compound → PerUnitFromTotal first), but `ops::clamp` is a public API and the WIT builder input type explicitly allows Compound from hosts.

## The fixes
- **core**: new `CostNumber::total_for(units)` — exhaustive over all four variants; stored totals stay precision-exact (the post-#1164 preference), Compound = `N·a + b` (the #1704 rule). Doc directs total-cost consumers here instead of accessor chains.
- **doctor region**: accessor chain → `total_for`. Shows 60.00 USD; balances.
- **ops clamp**: `posting_position` delegates to the canonical `Position::from_posting` (→ `CostSpec::resolve`, the only 4-variant-complete path), with the transaction date for lot-date fill — matching booking/query/reports.

## Tests
- core `total_for` unit test (all four variants)
- clamp regression: compound basis survives clamping (summarized per-unit 6.00; was `None`)
- doctor integration: 60.00 USD asserted; the unit-count-mislabel shape pinned against

ops+core suites green, clippy 0, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)