### PR TITLE
refactor: single-source the booking-order comparator (LSP + validator)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -138,7 +138,17 @@ pub struct PluginContext<'a> {
 /// model. As a result the LSP may report a slightly different error set
 /// than `rledger check` in edge cases that depend on synth plugins'
 /// interaction with Early validation; the canonical behavior is the
-/// loader's. Running plugins after booking (rather than before) keeps
+/// loader's (`rustledger_loader::process`, the
+/// sort → synth → Early → book → regular → Late → finalize pipeline).
+///
+/// Reviewed 2026-07 (duplication sweep, "finalize consumers" family):
+/// keeping this approximation is deliberate — the overlay model swaps
+/// per-buffer directive sets that `process()` (which starts from a raw
+/// `LoadResult`) cannot ingest, and `finalize`'s only current step that
+/// touches directive VALUES (`normalize_prices`, `@@`→`@`) runs AFTER
+/// Late validation in the loader too, so its absence here does not
+/// change diagnostics. If `finalize` ever gains a step that feeds
+/// validation, this function must mirror it — grep for this comment. Running plugins after booking (rather than before) keeps
 /// plugin-transformed directives (e.g., `effective_date` splitting
 /// transactions across dates) visible to validation (#793).
 ///
@@ -168,15 +178,10 @@ pub fn validation_errors_to_diagnostics(
     let line_index = LineIndex::new(source, encoding);
     let mut extra_diagnostics = Vec::new();
 
-    // Sort directives by date, type priority, then cost-basis reductions last
-    // (required for correct lot matching during booking).
-    booked_directives.sort_by_cached_key(|d| {
-        (
-            d.value.date(),
-            d.value.priority(),
-            d.value.has_cost_reduction(),
-        )
-    });
+    // Booking order via the canonical comparator — the SINGLE source for
+    // (date, priority, cost-reduction-last), shared with the loader and
+    // booking engine so the LSP cannot drift from `rledger check`'s order.
+    booked_directives.sort_by_cached_key(|d| rustledger_core::booking_sort_key(&d.value));
 
     // Run booking/interpolation on transactions before validation.
     // This fills in missing amounts (auto-balancing) so validation sees the complete picture.

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -148,7 +148,9 @@ pub struct PluginContext<'a> {
 /// touches directive VALUES (`normalize_prices`, `@@`→`@`) runs AFTER
 /// Late validation in the loader too, so its absence here does not
 /// change diagnostics. If `finalize` ever gains a step that feeds
-/// validation, this function must mirror it — grep for this comment. Running plugins after booking (rather than before) keeps
+/// validation, this function must mirror it — grep for this comment.
+///
+/// Running plugins after booking (rather than before) keeps
 /// plugin-transformed directives (e.g., `effective_date` splitting
 /// transactions across dates) visible to validation (#793).
 ///

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -560,13 +560,11 @@ fn validate_phase_inner<D: ValidatableDirective>(
     // otherwise).
     let mut sorted: Vec<&D> = Vec::with_capacity(directives.len());
     sorted.extend(directives.iter());
+    // Booking order via the canonical comparator (single source shared
+    // with the loader, booking engine, and LSP).
     let sort_fn = |a: &&D, b: &&D| {
-        let ad = a.directive();
-        let bd = b.directive();
-        ad.date()
-            .cmp(&bd.date())
-            .then_with(|| ad.priority().cmp(&bd.priority()))
-            .then_with(|| ad.has_cost_reduction().cmp(&bd.has_cost_reduction()))
+        rustledger_core::booking_sort_key(a.directive())
+            .cmp(&rustledger_core::booking_sort_key(b.directive()))
     };
     if sorted.len() >= PARALLEL_SORT_THRESHOLD {
         sorted.par_sort_by(sort_fn);

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -560,21 +560,23 @@ fn validate_phase_inner<D: ValidatableDirective>(
     // `booking_sort_key` tuple, shared with the loader, booking engine,
     // and LSP. Parallel sort only for large collections (threading
     // overhead otherwise).
-    let mut sorted: Vec<&D> = Vec::with_capacity(directives.len());
-    sorted.extend(directives.iter());
-    // Booking order via the canonical comparator (single source shared
-    // with the loader, booking engine, and LSP).
-    let sort_fn = |a: &&D, b: &&D| {
-        rustledger_core::booking_sort_key(a.directive())
-            .cmp(&rustledger_core::booking_sort_key(b.directive()))
-    };
-    if sorted.len() >= PARALLEL_SORT_THRESHOLD {
-        sorted.par_sort_by(sort_fn);
+    // Decorate-sort-undecorate: compute the canonical key ONCE per
+    // directive (O(n)) instead of per comparison (O(n log n)) — the key's
+    // cost-reduction component walks a transaction's postings, and a
+    // comparator recomputes it eagerly even on date mismatches where the
+    // old hand-rolled `then_with` chain short-circuited. Both sorts are
+    // stable, so equal-key directives keep source order exactly as before.
+    let mut keyed: Vec<(_, &D)> = directives
+        .iter()
+        .map(|d| (rustledger_core::booking_sort_key(d.directive()), d))
+        .collect();
+    if keyed.len() >= PARALLEL_SORT_THRESHOLD {
+        keyed.par_sort_by(|a, b| a.0.cmp(&b.0));
     } else {
-        sorted.sort_by(sort_fn);
+        keyed.sort_by(|a, b| a.0.cmp(&b.0));
     }
 
-    for d in sorted {
+    for (_, d) in keyed {
         let directive = d.directive();
         let date = directive.date();
 

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -554,10 +554,12 @@ fn validate_phase_inner<D: ValidatableDirective>(
 
     let mut errors = Vec::new();
 
-    // Sort directives by date, then by type priority
-    // (e.g., balance assertions before transactions on the same day).
-    // Parallel sort only for large collections (threading overhead
-    // otherwise).
+    // Sort directives into canonical booking order: date, then type
+    // priority (e.g., balance assertions before transactions on the same
+    // day), then the cost-reduction-last tiebreak — the full
+    // `booking_sort_key` tuple, shared with the loader, booking engine,
+    // and LSP. Parallel sort only for large collections (threading
+    // overhead otherwise).
     let mut sorted: Vec<&D> = Vec::with_capacity(directives.len());
     sorted.extend(directives.iter());
     // Booking order via the canonical comparator (single source shared

--- a/crates/rustledger-validate/src/lib.rs
+++ b/crates/rustledger-validate/src/lib.rs
@@ -571,9 +571,9 @@ fn validate_phase_inner<D: ValidatableDirective>(
         .map(|d| (rustledger_core::booking_sort_key(d.directive()), d))
         .collect();
     if keyed.len() >= PARALLEL_SORT_THRESHOLD {
-        keyed.par_sort_by(|a, b| a.0.cmp(&b.0));
+        keyed.par_sort_by_key(|k| k.0);
     } else {
-        keyed.sort_by(|a, b| a.0.cmp(&b.0));
+        keyed.sort_by_key(|k| k.0);
     }
 
     for (_, d) in keyed {


### PR DESCRIPTION
From the Phase-0 duplication sweep (P1, finalize-consumers family) — **right-sized after investigation**.

## What the sweep flagged vs what investigation found
The sweep flagged the LSP as "re-implements the loader pipeline inline" (the #1648 pattern). Investigation showed the LSP's single-pass pipeline is a **deliberate, documented approximation** — the overlay model swaps per-buffer directive sets that `process()` (which ingests a raw `LoadResult`) cannot accept, and `finalize`'s only value-touching step (`normalize_prices`) runs **after Late validation in the loader too**, so its absence from the LSP does not change diagnostics. Wholesale pipeline replacement would be a risky rewrite of an engineered trade-off for zero diagnostic delta — deliberately not done.

## What WAS real duplication (fixed)
The booking-order comparator `(date, priority, cost-reduction-last)` existed **three times**: canonical `rustledger_core::booking_sort_key`, an inline tuple closure in LSP diagnostics, and a chained-cmp closure in the validator's sort (the sweep undercounted — the validator copy was found during implementation). Both copies now delegate to the canonical fn — booking-order changes can no longer silently skew LSP diagnostics or validation relative to the loader/booking engine.

## Also
The LSP approximation doc now records the review verdict, names the canonical pipeline, and states the exact condition requiring revisit (any future finalize step that feeds validation) — greppable at the site.

## Verified
- Behavior identical (comparators were value-equal; this removes *future* drift, not present drift)
- LSP 261 unit + protocol suites green, validator suites green, clippy 0, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)