### PR TITLE
fix: one canonical account-name rule; validate FFI ingress; warn on bad name_* roots

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1393,10 +1393,17 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
     // Convert inputs to core directives, remembering each one's position in
     // `entries` so a `clamp_indexed` source index can map an output back to the
     // exact original WIT directive. These are already-loaded WIT directives, so
-    // conversion is not expected to fail; if one ever does it is skipped — this
-    // surface returns `Vec<wit::Directive>` with no error channel (matching the
-    // unparsable-bounds early return above) — and `orig_index` keeps the
-    // surviving cores aligned to their WIT source.
+    // conversion normally succeeds — with one known exception since the
+    // account-name ingress gate: a held directive whose account is not a
+    // lexable account name (possible via plugin-synthesized or
+    // embedder-constructed directives; parser-produced accounts always
+    // re-lex) now FAILS conversion and is dropped from the result. This
+    // surface returns `Vec<wit::Directive>` with no error channel (matching
+    // the unparsable-bounds early return above), so the drop is silent —
+    // acceptable because such a directive could never round-trip through
+    // text anyway; if that trade stops being acceptable, add a warnings
+    // channel to the WIT signature. `orig_index` keeps the surviving cores
+    // aligned to their WIT source.
     let mut core: Vec<rustledger_core::Directive> = Vec::with_capacity(entries.len());
     let mut orig_index: Vec<usize> = Vec::with_capacity(entries.len());
     for (i, d) in entries.iter().enumerate() {
@@ -1421,6 +1428,10 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
 /// The typed counterpart to `filter`/`clamp`: converts the WIT directives to
 /// core, expands pads (as the source-based query does), then runs the query —
 /// so the embedder queries the directives it holds with no re-parse/re-render.
+///
+/// Like `clamp`, a held directive that fails conversion is silently dropped
+/// (`filter_map(..ok())`) — since the account-name ingress gate this includes
+/// directives with un-lexable account names; see the note in [`clamp`].
 pub fn query_entries(entries: &[wit::Directive], query_str: &str) -> out::QueryResult {
     let core: Vec<rustledger_core::Directive> = entries
         .iter()

--- a/crates/rustledger-ffi-wasi/src/types/input.rs
+++ b/crates/rustledger-ffi-wasi/src/types/input.rs
@@ -247,6 +247,26 @@ pub fn json_map_to_metadata(map: &HashMap<String, serde_json::Value>) -> Metadat
         .collect()
 }
 
+/// Validate a wire-supplied account name and convert it, rejecting names the
+/// parser could never read back. The builder path (`entry.create` /
+/// `entry.createBatch`) bypasses the loader pipeline entirely, so without
+/// this gate it admitted arbitrary strings as accounts — weaker than any
+/// surface in the system, and the resulting directives could not round-trip
+/// through text. The rule is the canonical
+/// [`rustledger_parser::is_valid_account_name`] (the lexer itself).
+fn parse_account(context: &str, value: &str) -> Result<rustledger_core::Account, String> {
+    if rustledger_parser::is_valid_account_name(value) {
+        Ok(value.to_string().into())
+    } else {
+        Err(format!(
+            "invalid {context} account {value:?}: not a valid beancount account \
+             name (expected Type:Component[:Component...] — components start \
+             with an uppercase or caseless letter, sub-components may start \
+             with a digit; letters, digits, and hyphens only)"
+        ))
+    }
+}
+
 /// Convert `InputEntry` to core Directive.
 pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String> {
     match entry {
@@ -359,7 +379,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                         .map(rustledger_core::PriceAnnotation::unit);
 
                     Ok::<_, String>(rustledger_core::Spanned::synthesized(rustledger_core::Posting {
-                        account: p.account.clone().into(),
+                        account: parse_account("posting", &p.account)?,
                         units,
                         cost,
                         price,
@@ -395,7 +415,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 .map_err(|e| format!("Invalid date '{date}': {e}"))?;
             Ok(Directive::Open(rustledger_core::Open {
                 date,
-                account: account.clone().into(),
+                account: parse_account("open", account)?,
                 currencies: currencies.iter().map(|c| c.clone().into()).collect(),
                 booking: booking.clone(),
                 meta: json_map_to_metadata(meta),
@@ -411,7 +431,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 .map_err(|e| format!("Invalid date '{date}': {e}"))?;
             Ok(Directive::Close(rustledger_core::Close {
                 date,
-                account: account.clone().into(),
+                account: parse_account("close", account)?,
                 meta: json_map_to_metadata(meta),
             }))
         }
@@ -426,7 +446,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 .map_err(|e| format!("Invalid date '{date}': {e}"))?;
             Ok(Directive::Balance(rustledger_core::Balance {
                 date,
-                account: account.clone().into(),
+                account: parse_account("balance", account)?,
                 amount: parse_input_amount("balance amount", amount)?,
                 tolerance: None,
                 meta: json_map_to_metadata(meta),
@@ -443,8 +463,8 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 .map_err(|e| format!("Invalid date '{date}': {e}"))?;
             Ok(Directive::Pad(rustledger_core::Pad {
                 date,
-                account: account.clone().into(),
-                source_account: source_account.clone().into(),
+                account: parse_account("pad", account)?,
+                source_account: parse_account("pad source", source_account)?,
                 meta: json_map_to_metadata(meta),
             }))
         }
@@ -505,7 +525,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 .map_err(|e| format!("Invalid date '{date}': {e}"))?;
             Ok(Directive::Note(rustledger_core::Note {
                 date,
-                account: account.clone().into(),
+                account: parse_account("note", account)?,
                 comment: comment.clone(),
                 meta: json_map_to_metadata(meta),
             }))
@@ -523,7 +543,7 @@ pub fn input_entry_to_directive(entry: &InputEntry) -> Result<Directive, String>
                 .map_err(|e| format!("Invalid date '{date}': {e}"))?;
             Ok(Directive::Document(rustledger_core::Document {
                 date,
-                account: account.clone().into(),
+                account: parse_account("document", account)?,
                 path: path.clone(),
                 tags: tags.iter().map(|t| t.clone().into()).collect(),
                 links: links.iter().map(|l| l.clone().into()).collect(),
@@ -875,5 +895,47 @@ mod tests {
             result.is_err(),
             "PerUnitFromTotal without units must reject (post-booking shape requires units)"
         );
+    }
+
+    // ===== Builder ingress account validation (L4) =====
+
+    #[test]
+    fn create_rejects_unparsable_account() {
+        // The create/batch path bypasses the loader pipeline; accounts must
+        // still be held to the canonical lexer rule or unroundtrippable
+        // directives enter programmatically.
+        let entry = InputEntry::Open {
+            date: "2024-01-01".to_string(),
+            account: "assets:cash".to_string(), // lowercase root
+            currencies: vec![],
+            booking: None,
+            meta: Default::default(),
+        };
+        let err = input_entry_to_directive(&entry).unwrap_err();
+        assert!(err.contains("invalid open account"), "{err}");
+
+        let entry = InputEntry::Close {
+            date: "2024-01-01".to_string(),
+            account: "Assets:Ca sh".to_string(),
+            meta: Default::default(),
+        };
+        let err = input_entry_to_directive(&entry).unwrap_err();
+        assert!(err.contains("invalid close account"), "{err}");
+    }
+
+    #[test]
+    fn create_accepts_valid_unicode_account() {
+        let entry = InputEntry::Open {
+            date: "2024-01-01".to_string(),
+            account: "資産:現金".to_string(),
+            currencies: vec![],
+            booking: None,
+            meta: Default::default(),
+        };
+        let d = input_entry_to_directive(&entry).expect("valid unicode account");
+        match d {
+            Directive::Open(o) => assert_eq!(o.account.as_str(), "資産:現金"),
+            other => panic!("expected Open, got {other:?}"),
+        }
     }
 }

--- a/crates/rustledger-loader/src/options.rs
+++ b/crates/rustledger-loader/src/options.rs
@@ -55,7 +55,7 @@ const READONLY_OPTIONS: &[&str] = &["filename"];
 /// Option validation warning.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptionWarning {
-    /// Warning code (E7001 through E7007).
+    /// Warning code (E7001 through E7008).
     pub code: &'static str,
     /// Warning message.
     pub message: String,
@@ -269,11 +269,26 @@ impl Options {
         match key {
             "title" => self.title = Some(value.to_string()),
             "operating_currency" => self.operating_currency.push(value.to_string()),
-            "name_assets" => self.name_assets = value.to_string(),
-            "name_liabilities" => self.name_liabilities = value.to_string(),
-            "name_equity" => self.name_equity = value.to_string(),
-            "name_income" => self.name_income = value.to_string(),
-            "name_expenses" => self.name_expenses = value.to_string(),
+            "name_assets" => {
+                self.warn_if_invalid_root("name_assets", value);
+                self.name_assets = value.to_string();
+            }
+            "name_liabilities" => {
+                self.warn_if_invalid_root("name_liabilities", value);
+                self.name_liabilities = value.to_string();
+            }
+            "name_equity" => {
+                self.warn_if_invalid_root("name_equity", value);
+                self.name_equity = value.to_string();
+            }
+            "name_income" => {
+                self.warn_if_invalid_root("name_income", value);
+                self.name_income = value.to_string();
+            }
+            "name_expenses" => {
+                self.warn_if_invalid_root("name_expenses", value);
+                self.name_expenses = value.to_string();
+            }
             "account_rounding" => {
                 if !Self::is_valid_account(value) {
                     self.warnings.push(OptionWarning {
@@ -611,32 +626,45 @@ impl Options {
         ]
     }
 
+    /// Warn (E7008) when a `name_*` account-type rename is not a lexable
+    /// account root: every account under such a root is unparsable (both
+    /// rledger and Python beancount fail at parse time with "unexpected
+    /// NUMBER"-style errors), so the rename can only produce a broken
+    /// ledger. Accepted anyway for option-handling parity — the warning
+    /// makes the failure mode visible at the option site instead of at
+    /// every account mention. The `account_*` options get the analogous
+    /// E7002 guard; `name_*` used to be the unguarded exception.
+    fn warn_if_invalid_root(&mut self, key: &str, value: &str) {
+        if !Self::is_valid_account_root(value) {
+            self.warnings.push(OptionWarning {
+                code: "E7008",
+                message: format!(
+                    "Invalid account type name: '{value}' cannot begin an \
+                     account name (accounts under it will never parse)"
+                ),
+                option: key.to_string(),
+                value: value.to_string(),
+            });
+        }
+    }
+
     /// Check if a value looks like a valid account name.
     ///
-    /// Valid accounts have format "Type:Subaccount:..." where each component
-    /// starts with an uppercase letter (any script) or a non-ASCII letter
-    /// without case (CJK, etc.), and components are colon-separated.
+    /// Delegates to the canonical [`rustledger_parser::is_valid_account_name`]
+    /// (the lexer itself), so option values are held to exactly the rule the
+    /// parser applies to account tokens. The old hand-written check here was a
+    /// third, divergent variant (it accepted lowercase-adjacent first chars the
+    /// lexer rejects and had no per-character rule at all).
     fn is_valid_account(value: &str) -> bool {
-        // Must contain at least one colon
-        if !value.contains(':') {
-            return false;
-        }
+        rustledger_parser::is_valid_account_name(value)
+    }
 
-        // Check each component
-        for part in value.split(':') {
-            if let Some(first) = part.chars().next() {
-                // Accept: uppercase (any script), non-ASCII alphabetic (CJK, etc.)
-                let valid = first.is_uppercase() || (!first.is_ascii() && first.is_alphabetic());
-                if !valid {
-                    return false;
-                }
-            } else {
-                // Empty component
-                return false;
-            }
-        }
-
-        true
+    /// Check if a value is usable as an account TYPE root (a `name_*` option
+    /// value): a single component (no `:`) such that accounts under it are
+    /// lexable. Checked by running the canonical account predicate on
+    /// `value:X` — a root is valid exactly when it can head a real account.
+    fn is_valid_account_root(value: &str) -> bool {
+        !value.contains(':') && rustledger_parser::is_valid_account_name(&format!("{value}:X"))
     }
 }
 
@@ -1018,6 +1046,55 @@ mod tests {
         assert_eq!(opts.warnings[0].code, "E7002");
         assert!(opts.warnings[0].message.contains("CURRENCY:EXAMPLE"));
         assert!(opts.display_precision.is_empty());
+    }
+
+    #[test]
+    fn test_name_option_invalid_root_warns_e7008() {
+        // Digit-start root: every account under it is unparsable (both
+        // rledger and Python fail at parse time) — the option site now
+        // says so up front instead of the ledger erroring at every mention.
+        let mut opts = Options::new();
+        opts.set("name_assets", "1Assets");
+        assert_eq!(opts.warnings.len(), 1);
+        assert_eq!(opts.warnings[0].code, "E7008");
+        assert!(opts.warnings[0].message.contains("1Assets"));
+        // Accepted anyway (option-handling parity).
+        assert_eq!(opts.name_assets, "1Assets");
+
+        // Colon inside a root can never match a root component.
+        let mut opts = Options::new();
+        opts.set("name_income", "In:Come");
+        assert_eq!(opts.warnings.len(), 1);
+        assert_eq!(opts.warnings[0].code, "E7008");
+    }
+
+    #[test]
+    fn test_name_option_valid_roots_no_warning() {
+        let mut opts = Options::new();
+        opts.set("name_income", "Revenue");
+        opts.set("name_assets", "Activa");
+        opts.set("name_expenses", "Ausgaben");
+        opts.set("name_liabilities", "負債"); // caseless (\p{Lo}) root
+        assert!(
+            opts.warnings.is_empty(),
+            "lexable renames must not warn: {:?}",
+            opts.warnings
+        );
+    }
+
+    #[test]
+    fn test_account_option_uses_canonical_rule() {
+        // The old hand-written is_valid_account had no per-character rule:
+        // 'Equity:Ro unding' style values with invalid chars slipped through
+        // as long as first chars looked right. The canonical predicate
+        // rejects what the lexer rejects.
+        let mut opts = Options::new();
+        opts.set("account_current_conversions", "Equity:Conv ersions");
+        assert!(opts.warnings.iter().any(|w| w.code == "E7002"));
+
+        let mut opts = Options::new();
+        opts.set("account_current_conversions", "Equity:Conversions:Current");
+        assert!(opts.warnings.is_empty(), "{:?}", opts.warnings);
     }
 
     #[test]

--- a/crates/rustledger-parser/src/lib.rs
+++ b/crates/rustledger-parser/src/lib.rs
@@ -94,6 +94,7 @@ pub use cst::{
 // changes any of these will require a coordinated bump of this
 // crate so the re-export contract holds at THIS crate's semver.
 pub use error::{ParseError, ParseErrorKind};
+pub use logos_lexer::is_valid_account_name;
 pub use rowan::{Direction, NodeOrToken, TextRange, TextSize, TokenAtOffset, WalkEvent};
 pub use rustledger_core::{InternedStr, SYNTHESIZED_FILE_ID, Span, Spanned};
 

--- a/crates/rustledger-parser/src/logos_lexer.rs
+++ b/crates/rustledger-parser/src/logos_lexer.rs
@@ -524,6 +524,34 @@ fn apply_err_layout_transparency(
     }
 }
 
+/// Whether `name` is a valid beancount account name.
+///
+/// This is the CANONICAL account-name rule, shared by every surface that
+/// admits account names (the validator's Open check, the loader's
+/// `account_*`/`name_*` option guards, the FFI directive builder).
+///
+/// Implemented by running the actual lexer and requiring that `name` lex
+/// to exactly one [`Token::Account`] spanning the whole input, so this
+/// predicate CANNOT drift from what the parser accepts: an account name
+/// is valid if and only if it round-trips through the language. (Before
+/// this existed, the validator and loader each hand-implemented the rule
+/// with different accepted character sets, and accounts that could never
+/// be parsed back could enter through synthesized-directive surfaces.)
+///
+/// The rule, per the `Account` token regex: two or more `:`-separated
+/// components; the root starts with an uppercase (`\p{Lu}`), caseless
+/// (`\p{Lo}`), or titlecase (`\p{Lt}`) letter; sub-components may also
+/// start with an ASCII digit; remaining characters are Unicode letters,
+/// ASCII digits, or `-`.
+#[must_use]
+pub fn is_valid_account_name(name: &str) -> bool {
+    let mut lexer = Token::lexer(name);
+    let Some(Ok(Token::Account(_))) = lexer.next() else {
+        return false;
+    };
+    lexer.span() == (0..name.len()) && lexer.next().is_none()
+}
+
 /// Tokenize source code into a vector of (Token, Span) pairs for the
 /// AST-style parser.
 ///
@@ -1273,5 +1301,40 @@ mod tests {
         assert!(token_types.contains(&Token::AtAt));
         assert!(token_types.contains(&Token::Comma));
         assert!(token_types.contains(&Token::Tilde));
+    }
+
+    #[test]
+    fn is_valid_account_name_matches_lexer_rule() {
+        use super::is_valid_account_name as ok;
+        // Valid: standard, unicode roots/components, digit-start SUB-component,
+        // hyphens, deep nesting.
+        assert!(ok("Assets:Cash"));
+        assert!(ok("Assets:US:BofA:Checking"));
+        assert!(ok("Assets:2024-Bonus"));
+        assert!(ok("Активы:Наличные")); // Cyrillic (\p{Lu} root)
+        assert!(ok("資産:現金")); // CJK (\p{Lo} root)
+        assert!(ok("Assets:Ægir")); // non-ASCII uppercase start
+        // Invalid: single component (roots alone are not accounts).
+        assert!(!ok("Assets"));
+        // Invalid: digit-start ROOT (sub-components may, roots may not).
+        assert!(!ok("1Assets:Cash"));
+        // Invalid: lowercase starts (ASCII and non-ASCII).
+        assert!(!ok("assets:Cash"));
+        assert!(!ok("Assets:cash"));
+        assert!(!ok("Assets:\u{e9}cash")); // é — lowercase letter start
+        // Invalid: characters outside letters/digits/hyphen.
+        assert!(!ok("Assets:Ca sh"));
+        assert!(!ok("Assets:Cash!"));
+        assert!(!ok("Assets:N\u{2116}1")); // № (numero sign, So)
+        assert!(!ok("Assets:Cash\u{1F600}")); // emoji
+        assert!(!ok("Assets:Ca_sh")); // underscore is currency-only
+        // Invalid: structural.
+        assert!(!ok(""));
+        assert!(!ok("Assets:"));
+        assert!(!ok(":Cash"));
+        assert!(!ok("Assets::Cash"));
+        assert!(!ok(" Assets:Cash"));
+        assert!(!ok("Assets:Cash "));
+        assert!(!ok("Assets:Cash\nAssets:Two"));
     }
 }

--- a/crates/rustledger-validate/src/validators/helpers.rs
+++ b/crates/rustledger-validate/src/validators/helpers.rs
@@ -49,19 +49,21 @@ pub fn require_account_open(
 /// The `account_types` parameter specifies valid account type prefixes (from options
 /// like `name_assets`, `name_liabilities`, etc.). Defaults are: Assets, Liabilities,
 /// Equity, Income, Expenses.
+///
+/// The character-level rule delegates to the canonical
+/// [`rustledger_parser::is_valid_account_name`] (the lexer itself), so the
+/// validator accepts exactly the set of names that can round-trip through
+/// the parser — no more (the old hand-written check here admitted digit-start
+/// roots and arbitrary non-ASCII characters mid-component, which the parser
+/// rejects), and no less. The root-type membership check on top is ledger
+/// semantics, not lexing, and stays here.
 pub fn validate_account_name(account: &str, account_types: &[String]) -> Option<String> {
     if account.is_empty() {
         return Some("account name is empty".to_string());
     }
 
-    // Iterate components without allocating a Vec
-    let mut components = account.split(':');
-
-    // Check root account type (first component)
-    let root = components.next()?;
-    if root.is_empty() {
-        return Some("component 1 is empty".to_string());
-    }
+    // Check root account type (first component) — ledger semantics.
+    let root = account.split(':').next()?;
     if !account_types.iter().any(|t| t == root) {
         return Some(format!(
             "account must start with one of: {}. To use a different root name, \
@@ -70,41 +72,71 @@ pub fn validate_account_name(account: &str, account_types: &[String]) -> Option<
         ));
     }
 
-    // Check each component (starting from root)
-    // We already validated root's content will be checked below
-    for (i, part) in std::iter::once(root).chain(components).enumerate() {
-        if part.is_empty() {
-            return Some(format!("component {} is empty", i + 1));
-        }
-
-        // First character must be an uppercase letter (any script) or digit.
-        // Unicode uppercase (\p{Lu}) covers Latin A-Z, Cyrillic А-Я, etc.
-        // Non-ASCII non-letter characters (CJK ideographs, etc.) are also
-        // accepted as they have no case distinction.
-        let Some(first_char) = part.chars().next() else {
-            return Some(format!("component {} is empty", i + 1));
-        };
-        // Accept: uppercase letters (any script), digits, or non-ASCII
-        // letters without case (CJK ideographs, etc.). Matches the lexer
-        // regex [\p{Lu}\p{Lo}\p{Lt}0-9].
-        let is_valid_start = first_char.is_uppercase()
-            || first_char.is_ascii_digit()
-            || (!first_char.is_ascii() && first_char.is_alphabetic());
-        if !is_valid_start {
-            return Some(format!(
-                "component '{part}' must start with uppercase letter or digit"
-            ));
-        }
-
-        // Remaining characters: letters (any script), digits, or hyphens.
-        for c in part.chars().skip(1) {
-            if !c.is_ascii_alphanumeric() && c != '-' && c.is_ascii() {
-                return Some(format!(
-                    "component '{part}' contains invalid character '{c}'"
-                ));
-            }
-        }
+    // Character/structure rule — the canonical parser predicate.
+    if !rustledger_parser::is_valid_account_name(account) {
+        return Some(format!(
+            "'{account}' is not a valid account name: expected two or more \
+             colon-separated components, each starting with an uppercase or \
+             caseless letter (sub-components may start with a digit), \
+             containing only letters, digits, and hyphens"
+        ));
     }
 
     None // Valid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_account_name;
+
+    fn types() -> Vec<String> {
+        ["Assets", "Liabilities", "Equity", "Income", "Expenses"]
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn accepts_parser_valid_names() {
+        let t = types();
+        assert_eq!(validate_account_name("Assets:Cash", &t), None);
+        assert_eq!(validate_account_name("Assets:2024-Bonus", &t), None);
+        assert_eq!(validate_account_name("Assets:US:BofA:Checking", &t), None);
+    }
+
+    #[test]
+    fn respects_renamed_roots() {
+        let t = vec!["Activa".to_string(), "Revenue".to_string()];
+        assert_eq!(validate_account_name("Activa:Kas", &t), None);
+        assert!(validate_account_name("Assets:Cash", &t).is_some());
+    }
+
+    #[test]
+    fn rejects_what_the_lexer_rejects() {
+        // Pre-L4 this validator hand-implemented the character rule and
+        // accepted all of these; none can round-trip through the parser.
+        // The rule now IS the lexer (rustledger_parser::is_valid_account_name).
+        let t = types();
+        // Single component: an account is Type:Component+.
+        assert!(validate_account_name("Assets", &t).is_some());
+        // Arbitrary non-ASCII characters mid-component (the old check only
+        // rejected invalid ASCII).
+        assert!(validate_account_name("Assets:N\u{2116}1", &t).is_some()); // №
+        assert!(validate_account_name("Assets:Cash\u{1F600}", &t).is_some()); // emoji
+        // Lowercase sub-component start.
+        assert!(validate_account_name("Assets:cash", &t).is_some());
+        // Empty / structural.
+        assert!(validate_account_name("", &t).is_some());
+        assert!(validate_account_name("Assets:", &t).is_some());
+        assert!(validate_account_name("Assets::Cash", &t).is_some());
+    }
+
+    #[test]
+    fn digit_start_root_rejected_even_if_renamed() {
+        // A digit-start root can never begin an Account token, so even a
+        // matching renamed type is unusable (the loader warns E7008 at the
+        // option site; this is the same rule seen from the validator).
+        let t = vec!["1Assets".to_string()];
+        assert!(validate_account_name("1Assets:Cash", &t).is_some());
+    }
 }


### PR DESCRIPTION
## What

Establishes ONE canonical account-name rule — the lexer itself — and makes every surface that admits account names use it: the validator's Open check, the loader's option guards, and (new) the FFI directive-builder ingress. Also adds an `E7008` warning for `name_*` account-type renames that can never head a parsable account.

## Why

Phase-1 correctness sweep, finding L4: three hand-written validators accepted **three different character sets**:

| Surface | Rule |
|---|---|
| lexer (`Account` token regex) | `[\p{Lu}\p{Lo}\p{Lt}]` roots, sub-components may start with a digit, letters/digits/hyphens, ≥2 components |
| validator (`validate_account_name`) | digit-start **roots** allowed; **any non-ASCII char** allowed mid-component (the reject condition required `c.is_ascii()` — `№`, emoji passed) |
| loader (`is_valid_account`) | a third first-char rule, no per-character check at all |

Parsed ledgers were safe (the lexer gates them). The live holes were the synthesized surfaces:

- **FFI builder** (`entry.create`/`createBatch`) bypasses the loader pipeline and took raw `account: String` with **no validation whatsoever** — directives whose accounts can never round-trip through text could enter programmatically.
- **`name_*` renames** were the one unguarded option family: `option "name_assets" "1Assets"` was accepted silently even though every account under a digit-start root is unparsable (in both rledger and Python beancount — verified during the probe), while `account_rounding` etc. always had the E7002 guard.

## How

- **`rustledger_parser::is_valid_account_name`** — the canonical predicate, implemented by **running the lexer** and requiring exactly one `Account` token spanning the whole input. Drift from the parser is impossible by construction; there is no second encoding of the rule to keep in sync.
- **Validator** keeps its root-type membership check (ledger semantics, knows about renamed roots) and delegates the character/structure rule. This *tightens* it — digit-start roots, `№`/emoji mid-component, and single-component names are now rejected, matching the parser and Python.
- **Loader** `is_valid_account` delegates. `name_*` roots are checked by running the predicate on `"{root}:X"` (a root is valid exactly when it can head a real account) → `E7008` warning, value still accepted for option-handling parity.
- **FFI builder** validates all eight account ingress sites (posting, open, close, balance, pad + source, note, document) with a typed error naming the field — same pattern as the existing date/cost-invariant checks in `input_entry_to_directive` (review B-3.1 precedent).

All three consumers already depended on `rustledger-parser`; no new edges in the crate graph.

## Testing

- Predicate unit tests: Cyrillic/CJK roots, digit-start sub-components, hyphens; rejection classes (single component, digit-start root, lowercase starts incl. non-ASCII `é`, `№`/emoji/underscore/space, structural `::`/trailing colon/whitespace).
- Validator tests pin the tightening and that renamed roots still work; loader tests pin E7008 (digit-start, embedded colon) and no-warning for valid unicode renames; FFI tests pin rejection (lowercase root, embedded space) and acceptance (`資産:現金`).
- Full suites green: parser, validate, loader, ffi-wasi, ffi-component. Clippy `--all-features --all-targets -D warnings`, fmt, rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
