### PR TITLE
chore: consolidate utility copies (CSV/JSON escaping, account-type checks, quarter math)

### DIFF
--- a/crates/rustledger-core/src/format/helpers.rs
+++ b/crates/rustledger-core/src/format/helpers.rs
@@ -20,6 +20,22 @@ pub fn format_meta_value(value: &MetaValue) -> String {
     }
 }
 
+/// Escape a string for CSV output (RFC-4180 style): values containing a
+/// comma, double quote, or newline are wrapped in double quotes with inner
+/// quotes doubled; everything else passes through unchanged.
+///
+/// The single implementation behind every CSV surface (`rledger report
+/// --format csv`, BQL CSV output) — these previously carried byte-identical
+/// private copies.
+#[must_use]
+pub fn escape_csv(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
 /// Escape a string for output (handle quotes and backslashes).
 pub fn escape_string(s: &str) -> String {
     let mut out = String::with_capacity(s.len());

--- a/crates/rustledger-core/src/format/helpers.rs
+++ b/crates/rustledger-core/src/format/helpers.rs
@@ -21,8 +21,10 @@ pub fn format_meta_value(value: &MetaValue) -> String {
 }
 
 /// Escape a string for CSV output (RFC-4180 style): values containing a
-/// comma, double quote, or newline are wrapped in double quotes with inner
-/// quotes doubled; everything else passes through unchanged.
+/// comma, double quote, or line feed (`\n` — carriage returns do NOT
+/// trigger quoting, matching the prior copies byte-for-byte) are wrapped
+/// in double quotes with inner quotes doubled; everything else passes
+/// through unchanged.
 ///
 /// The single implementation behind every CSV surface (`rledger report
 /// --format csv`, BQL CSV output) — these previously carried byte-identical

--- a/crates/rustledger-core/src/format/helpers.rs
+++ b/crates/rustledger-core/src/format/helpers.rs
@@ -20,11 +20,12 @@ pub fn format_meta_value(value: &MetaValue) -> String {
     }
 }
 
-/// Escape a string for CSV output (RFC-4180 style): values containing a
-/// comma, double quote, or line feed (`\n` — carriage returns do NOT
-/// trigger quoting, matching the prior copies byte-for-byte) are wrapped
-/// in double quotes with inner quotes doubled; everything else passes
-/// through unchanged.
+/// Escape a string for CSV output (RFC-4180 style).
+///
+/// Values containing a comma, double quote, or line feed (`\n` — carriage
+/// returns do NOT trigger quoting, matching the prior copies
+/// byte-for-byte) are wrapped in double quotes with inner quotes doubled;
+/// everything else passes through unchanged.
 ///
 /// The single implementation behind every CSV surface (`rledger report
 /// --format csv`, BQL CSV output) — these previously carried byte-identical

--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -16,8 +16,8 @@ use directives::{
     format_document_lines, format_event_lines, format_note_lines, format_open_lines,
     format_pad_lines, format_price_lines, format_query_lines,
 };
-pub use helpers::escape_string;
 pub(crate) use helpers::format_meta_value;
+pub use helpers::{escape_csv, escape_string};
 pub(crate) use transaction::{format_incomplete_amount, format_transaction_lines};
 pub use transaction::{format_posting_line, posting_format_line};
 
@@ -193,6 +193,15 @@ mod tests {
         let config = FormatConfig::default();
         let formatted = format_open(&open, &config);
         assert_eq!(formatted, "2024-01-01 open Assets:Bank:Checking USD,EUR\n");
+    }
+
+    #[test]
+    fn test_escape_csv() {
+        assert_eq!(escape_csv("plain"), "plain");
+        assert_eq!(escape_csv("a,b"), "\"a,b\"");
+        assert_eq!(escape_csv("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(escape_csv("line1\nline2"), "\"line1\nline2\"");
+        assert_eq!(escape_csv(""), "");
     }
 
     #[test]

--- a/crates/rustledger-lsp/src/handlers/on_type_formatting.rs
+++ b/crates/rustledger-lsp/src/handlers/on_type_formatting.rs
@@ -197,13 +197,13 @@ fn is_transaction_header(line: &str) -> bool {
 fn is_posting_line(line: &str) -> bool {
     let trimmed = line.trim();
 
-    // Posting lines are indented and start with an account type
+    // Posting lines are indented and start with an account type. The
+    // deliberately colon-less prefix match (mid-typing heuristic) reads the
+    // type list from core so a sixth type can't silently miss this site.
     line.starts_with("  ")
-        && (trimmed.starts_with("Assets")
-            || trimmed.starts_with("Liabilities")
-            || trimmed.starts_with("Equity")
-            || trimmed.starts_with("Income")
-            || trimmed.starts_with("Expenses"))
+        && rustledger_core::ACCOUNT_TYPES
+            .iter()
+            .any(|t| trimmed.starts_with(t))
 }
 
 #[cfg(test)]

--- a/crates/rustledger-lsp/src/handlers/utils.rs
+++ b/crates/rustledger-lsp/src/handlers/utils.rs
@@ -468,11 +468,9 @@ pub fn is_word_char(c: char) -> bool {
 /// Account names start with a standard account type and contain colons.
 pub fn is_account_like(s: &str) -> bool {
     s.contains(':')
-        && (s.starts_with("Assets")
-            || s.starts_with("Liabilities")
-            || s.starts_with("Equity")
-            || s.starts_with("Income")
-            || s.starts_with("Expenses"))
+        && rustledger_core::ACCOUNT_TYPES
+            .iter()
+            .any(|t| s.starts_with(t))
 }
 
 /// Check if a string is a standard root account type.

--- a/crates/rustledger-plugin/src/native/plugins/check_drained.rs
+++ b/crates/rustledger-plugin/src/native/plugins/check_drained.rs
@@ -67,13 +67,15 @@ impl NativePlugin for CheckDrainedPlugin {
             ops.push(PluginOp::Keep(i));
 
             if let DirectiveData::Close(data) = &wrapper.data {
-                // Only generate for balance sheet accounts (Assets, Liabilities, Equity)
-                let is_balance_sheet = data.account.starts_with("Assets:")
-                    || data.account.starts_with("Liabilities:")
-                    || data.account.starts_with("Equity:")
-                    || data.account == "Assets"
-                    || data.account == "Liabilities"
-                    || data.account == "Equity";
+                // Only generate for balance sheet accounts (Assets,
+                // Liabilities, Equity). `account_type` classifies by the
+                // root component, so both `Assets:...` and a bare `Assets`
+                // land in the same arm (the old hand-written check needed
+                // six clauses for that).
+                let is_balance_sheet = matches!(
+                    rustledger_core::account_type(&data.account),
+                    "assets" | "liabilities" | "equity"
+                );
 
                 if !is_balance_sheet {
                     continue;

--- a/crates/rustledger-plugin/src/native/plugins/split_expenses.rs
+++ b/crates/rustledger-plugin/src/native/plugins/split_expenses.rs
@@ -97,8 +97,11 @@ impl NativePlugin for SplitExpensesPlugin {
                 let mut new_postings = Vec::new();
 
                 for posting in &txn.postings {
-                    // Check if this is an expense account
-                    let is_expense = posting.account.starts_with("Expenses:");
+                    // Check if this is an expense account (root-component
+                    // classification via core; identical to the old
+                    // `starts_with("Expenses:")` for any parsable account,
+                    // which always has >= 2 components).
+                    let is_expense = rustledger_core::account_type(&posting.account) == "expenses";
 
                     // Check if account already contains a member name
                     let has_member = members.iter().any(|m| posting.account.contains(m.as_str()));

--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -456,10 +456,12 @@ impl Executor<'_> {
 }
 
 /// Zero-based quarter index for a 1-based month (0 => Q1). The single
-/// quarter formula for this module — `DATE_TRUNC`, `QUARTER()`, and the
-/// `DATE_BIN` quarter arm all derive from it rather than re-deriving
-/// `(month - 1) / 3` inline (the sweep found the formula written twice
-/// here, diverging only in off-by-one framing).
+/// `(month - 1) / 3` formula for this module — `DATE_TRUNC` and
+/// `QUARTER()` both derive from it rather than re-deriving it inline
+/// (the sweep found it written twice, diverging only in off-by-one
+/// framing). `DATE_BIN`'s quarter arm is NOT a user of this formula:
+/// it buckets by months-elapsed-since-origin (`months_diff / (3 * amt)`),
+/// which is origin- and width-relative, not calendar-quarter indexing.
 ///
 /// `month1` must be 1-based (`Zoned`/`Date::month()` guarantees 1..=12);
 /// 0 would wrap in release builds, so debug builds assert.

--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -455,6 +455,19 @@ impl Executor<'_> {
     }
 }
 
+/// Zero-based quarter index for a 1-based month (0 => Q1). The single
+/// quarter formula for this module — `DATE_TRUNC`, `QUARTER()`, and the
+/// `DATE_BIN` quarter arm all derive from it rather than re-deriving
+/// `(month - 1) / 3` inline (the sweep found the formula written twice
+/// here, diverging only in off-by-one framing).
+///
+/// `month1` must be 1-based (`Zoned`/`Date::month()` guarantees 1..=12);
+/// 0 would wrap in release builds, so debug builds assert.
+const fn quarter_index0(month1: u32) -> u32 {
+    debug_assert!(month1 >= 1);
+    (month1 - 1) / 3
+}
+
 /// Add `days` to `date`, returning a graceful error instead of panicking when
 /// `days` is out of range.
 ///
@@ -463,15 +476,6 @@ impl Executor<'_> {
 /// `date.checked_add(jiff::ToSpan::days(days)).unwrap()` aborted the process on
 /// a large offset. Build the span fallibly and propagate overflow as a
 /// `QueryError` (beanquery raises a catchable `OverflowError` here).
-/// Zero-based quarter index for a 1-based month (0 => Q1). The single
-/// quarter formula for this module — `DATE_TRUNC`, `QUARTER()`, and the
-/// `DATE_BIN` quarter arm all derive from it rather than re-deriving
-/// `(month - 1) / 3` inline (the sweep found the formula written twice
-/// here, diverging only in off-by-one framing).
-const fn quarter_index0(month1: u32) -> u32 {
-    (month1 - 1) / 3
-}
-
 fn add_days(date: NaiveDate, days: i64) -> Result<NaiveDate, QueryError> {
     let span = jiff::Span::new()
         .try_days(days)

--- a/crates/rustledger-query/src/executor/functions/date.rs
+++ b/crates/rustledger-query/src/executor/functions/date.rs
@@ -216,7 +216,7 @@ impl Executor<'_> {
         let result = match field.as_str() {
             "YEAR" => rustledger_core::naive_date(i32::from(date.year()), 1, 1),
             "QUARTER" => {
-                let quarter = (date.month() as u32 - 1) / 3;
+                let quarter = quarter_index0(date.month() as u32);
                 rustledger_core::naive_date(i32::from(date.year()), quarter * 3 + 1, 1)
             }
             "MONTH" => rustledger_core::naive_date(i32::from(date.year()), date.month() as u32, 1),
@@ -263,7 +263,7 @@ impl Executor<'_> {
             "YEAR" => i64::from(date.year()),
             "MONTH" => i64::from(date.month()),
             "DAY" => i64::from(date.day()),
-            "QUARTER" => i64::from((date.month() - 1) / 3 + 1),
+            "QUARTER" => i64::from(quarter_index0(date.month() as u32) + 1),
             "WEEK" => {
                 // ISO week number via strftime %V
                 let week_str = jiff::fmt::strtime::format("%V", date).unwrap_or_default();
@@ -463,6 +463,15 @@ impl Executor<'_> {
 /// `date.checked_add(jiff::ToSpan::days(days)).unwrap()` aborted the process on
 /// a large offset. Build the span fallibly and propagate overflow as a
 /// `QueryError` (beanquery raises a catchable `OverflowError` here).
+/// Zero-based quarter index for a 1-based month (0 => Q1). The single
+/// quarter formula for this module — `DATE_TRUNC`, `QUARTER()`, and the
+/// `DATE_BIN` quarter arm all derive from it rather than re-deriving
+/// `(month - 1) / 3` inline (the sweep found the formula written twice
+/// here, diverging only in off-by-one framing).
+const fn quarter_index0(month1: u32) -> u32 {
+    (month1 - 1) / 3
+}
+
 fn add_days(date: NaiveDate, days: i64) -> Result<NaiveDate, QueryError> {
     let span = jiff::Span::new()
         .try_days(days)

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -671,13 +671,7 @@ fn value_to_json(value: &Value) -> serde_json::Value {
     }
 }
 
-fn escape_csv(s: &str) -> String {
-    if s.contains(',') || s.contains('"') || s.contains('\n') {
-        format!("\"{}\"", s.replace('"', "\"\""))
-    } else {
-        s.to_string()
-    }
-}
+use rustledger_core::format::escape_csv;
 
 #[cfg(test)]
 mod tests {

--- a/crates/rustledger/src/cmd/query/output.rs
+++ b/crates/rustledger/src/cmd/query/output.rs
@@ -2,6 +2,7 @@
 
 use super::ShellSettings;
 use anyhow::{Context, Result};
+use rustledger_core::format::escape_csv;
 use rustledger_core::{Directive, DisplayContext, Spanned};
 use rustledger_loader::SourceMap;
 use rustledger_query::{Executor, Value, parse as parse_query};
@@ -670,8 +671,6 @@ fn value_to_json(value: &Value) -> serde_json::Value {
         Value::Null => serde_json::Value::Null,
     }
 }
-
-use rustledger_core::format::escape_csv;
 
 #[cfg(test)]
 mod tests {

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -444,23 +444,11 @@ pub(super) fn account_balances(
     engine.into_inventories().into_iter().collect()
 }
 
-/// Escape a string for CSV output.
-pub(super) fn csv_escape(s: &str) -> String {
-    if s.contains(',') || s.contains('"') || s.contains('\n') {
-        format!("\"{}\"", s.replace('"', "\"\""))
-    } else {
-        s.to_string()
-    }
-}
-
-/// Escape a string for JSON output.
-pub(super) fn json_escape(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
-}
+// CSV/JSON escaping: single-sourced in core. `escape_string` escapes the
+// exact set the old hand-chained `json_escape` did (backslash, quote, \n,
+// \r, \t), so the alias is behavior-identical.
+pub(super) use rustledger_core::format::escape_csv as csv_escape;
+pub(super) use rustledger_core::format::escape_string as json_escape;
 
 #[derive(Default)]
 pub(super) struct LedgerStats {


### PR DESCRIPTION
## What

The utility-census batch from the Phase-1 sweep (U1/U2/U5): consolidates four families of copy-pasted utility code into the core helpers. Behavior-identical throughout; no user-visible output changes.

## Changes

- **CSV escaping (U2)**: `report_cmd::csv_escape` and BQL `output::escape_csv` were byte-identical private copies. Now `rustledger_core::format::escape_csv` (unit-tested); both CLI sites delegate — report_cmd via a `pub(super) use` alias so its 26 call sites are untouched.
- **JSON escaping (U2)**: `report_cmd::json_escape` hand-chained `replace()` over exactly the set core's `format::escape_string` handles (backslash, quote, `\n`, `\r`, `\t`). Aliased to the core fn; hand chain deleted.
- **Account-type checks (U1)**: four production sites re-derived account types from raw string prefixes; they now use core's `ACCOUNT_TYPES`/`account_type`, so a sixth type or a rule change has one home:
  - LSP `on_type_formatting` + `utils::is_account_like` — the deliberately colon-less mid-typing heuristics iterate `ACCOUNT_TYPES` (same matching, single-sourced list);
  - `check_drained` plugin — six hand-written clauses (three `starts_with` + three bare-root equalities) collapse to a three-arm match on `account_type`, which classifies by root component;
  - `split_expenses` plugin — `is_expense` via `account_type` (identical for any parsable account, which always has ≥ 2 components per #1739's rule).
- **Quarter math (U5-lite)**: `(month − 1) / 3` appeared twice within query `functions/date.rs`, diverging only in off-by-one framing (`DATE_TRUNC` zero-based vs `QUARTER()` one-based). A single `const quarter_index0` now feeds both.

## Deliberately out of scope

- **Report-section routing** (balsheet/income/networth/holdings raw prefixes): already rewritten config-aware by open **#1731** — touching them here would conflict.
- **U5 full (networth on query `IntervalUnit`)**: networth's buckets are label-string equality (ISO `%V` weeks); switching bucketing machinery risks silent period-boundary changes for purely cosmetic dedup. Rejected, on record.
- **U4 (reports adopt DisplayContext)**: user-visible output change — needs its own PR with bean-compat verification, like #1728.

## ⚠️ Pre-existing failure found while testing (not from this PR)

`test_account_lifecycle_consistency` (`crates/rustledger/tests/integration_test.rs`) **fails on clean main**: `rledger check` passes a ledger where `Assets:Bank` is posted on 2020-01-15 but opened 2020-02-01 — Python rejects it, and `rustledger-validate` has a unit test for exactly this rule (`lifecycle_posting_before_open_errors`), so the check is being lost somewhere between the validator and the CLI pipeline. Verified with a manual `rledger check` on main: `✓ No errors found`. Tracking separately — this looks like a real silent-pass correctness bug.

## Testing

core/query/plugin/LSP suites green; CLI suite green except the pre-existing failure above (fails identically with this diff stashed). clippy `--all-features --all-targets -D warnings`, fmt, rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
