### PR TITLE
chore: run the python-gated cargo tests with bean-check installed

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1130,17 +1130,24 @@ jobs:
   # Python-gated cargo integration tests.
   #
   # Several cargo test suites compare rledger against Python beancount
-  # directly (Command::new("bean-check")) and SKIP SILENTLY when the
-  # binary is absent — which is every environment except this one. The
-  # use-before-open silent-pass bug (#1742) sat on main behind exactly
-  # that skip: test_account_lifecycle_consistency would have caught it,
-  # but nothing in CI ever ran the test with bean-check on PATH.
+  # tooling directly (Command::new("bean-check") / "bean-price") and SKIP
+  # SILENTLY when the binary is absent — which is every environment except
+  # this one. The use-before-open silent-pass bug (#1742) sat on main
+  # behind exactly that skip: test_account_lifecycle_consistency would
+  # have caught it, but nothing in CI ever ran the test with bean-check
+  # on PATH.
   #
   # This job exists so those tests actually gate PRs:
-  # 1. install beancount and FAIL LOUDLY if bean-check isn't runnable
-  #    (a silent skip here would recreate the hole this job closes);
-  # 2. run the python-gated suites. Keep this list in sync with
-  #    `grep -rl 'Command::new("bean-' crates/*/tests`.
+  # 1. install beancount + beanprice and FAIL LOUDLY if the binaries
+  #    aren't runnable (a silent skip here would recreate the hole this
+  #    job closes);
+  # 2. run the python-gated suites — keep the list in sync with
+  #    `grep -rl 'Command::new("bean-' crates/*/tests` (currently:
+  #    rustledger integration_test + bean_price_compat,
+  #    rustledger-core synthetic_generation);
+  # 3. grep the captured output for every suite's skip marker, so a new
+  #    availability probe (different binary, a container check) can't
+  #    quietly reintroduce the green-skip.
   python-gated-cargo-tests:
     name: Python-gated cargo tests
     runs-on: ubuntu-latest
@@ -1156,28 +1163,31 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
-      - name: Install beancount
-        run: pip install beancount
-      - name: Assert bean-check is runnable (no silent skips)
+      - name: Install beancount and beanprice
+        run: pip install beancount beanprice
+      - name: Assert python tools are runnable (no silent skips)
         run: |
+          # The tests skip when these binaries are missing. This step
+          # guarantees that skip path is dead in CI — if a binary breaks,
+          # the job goes red HERE instead of the tests green-skipping.
           bean-check --version
-          # The tests skip with "Skipping: Python beancount not available"
-          # when this binary is missing. This step guarantees that skip
-          # path is dead in CI — if bean-check breaks, the job goes red
-          # HERE instead of the tests green-skipping.
+          bean-price --version
       - name: Run python-gated test suites
         env:
           CARGO_TERM_COLOR: always
         run: |
-          cargo test -p rustledger --test integration_test -- --nocapture
-          cargo test -p rustledger-core --test synthetic_generation -- --nocapture
+          # tee the output so the skip-marker check below inspects THIS
+          # run (a rerun inside an `if` would mask test failures and
+          # cover only one suite — review catch).
+          set -o pipefail
+          cargo test -p rustledger --test integration_test --test bean_price_compat -- --nocapture 2>&1 | tee /tmp/gated-tests.log
+          cargo test -p rustledger-core --test synthetic_generation -- --nocapture 2>&1 | tee -a /tmp/gated-tests.log
       - name: Fail on silent skips
         run: |
-          # Belt and braces: re-run and grep for the skip marker. The
-          # assert step above should make this unreachable, but if a test
-          # gains a new availability probe (a different binary, a
-          # container) this catches it green-skipping.
-          if cargo test -p rustledger --test integration_test -- --nocapture 2>&1 | grep -q "Skipping: Python beancount not available"; then
-            echo "::error::python-gated tests skipped despite bean-check being installed — availability probe drifted"
+          # Every gated suite prints a recognizable marker when it skips;
+          # any of them appearing means an availability probe drifted
+          # despite the assert step above.
+          if grep -Eq "Skipping: Python beancount not available|bean-check not found, skipping|skipping bean-price compat" /tmp/gated-tests.log; then
+            echo "::error::python-gated tests skipped despite the tools being installed — availability probe drifted"
             exit 1
           fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1126,3 +1126,58 @@ jobs:
         run: |
           echo "::error::${{ steps.compat_test.outputs.regression_count }} check regression(s) vs the previous run — files that matched before and mismatch now. See the 'Run comprehensive compatibility test' log and compat-regressions.txt."
           exit 1
+
+  # Python-gated cargo integration tests.
+  #
+  # Several cargo test suites compare rledger against Python beancount
+  # directly (Command::new("bean-check")) and SKIP SILENTLY when the
+  # binary is absent — which is every environment except this one. The
+  # use-before-open silent-pass bug (#1742) sat on main behind exactly
+  # that skip: test_account_lifecycle_consistency would have caught it,
+  # but nothing in CI ever ran the test with bean-check on PATH.
+  #
+  # This job exists so those tests actually gate PRs:
+  # 1. install beancount and FAIL LOUDLY if bean-check isn't runnable
+  #    (a silent skip here would recreate the hole this job closes);
+  # 2. run the python-gated suites. Keep this list in sync with
+  #    `grep -rl 'Command::new("bean-' crates/*/tests`.
+  python-gated-cargo-tests:
+    name: Python-gated cargo tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
+        with:
+          toolchain: stable
+      # rust-cache intentionally omitted — see the note on the
+      # compatibility-test job (LGPL-3.0 license-check interaction).
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install beancount
+        run: pip install beancount
+      - name: Assert bean-check is runnable (no silent skips)
+        run: |
+          bean-check --version
+          # The tests skip with "Skipping: Python beancount not available"
+          # when this binary is missing. This step guarantees that skip
+          # path is dead in CI — if bean-check breaks, the job goes red
+          # HERE instead of the tests green-skipping.
+      - name: Run python-gated test suites
+        env:
+          CARGO_TERM_COLOR: always
+        run: |
+          cargo test -p rustledger --test integration_test -- --nocapture
+          cargo test -p rustledger-core --test synthetic_generation -- --nocapture
+      - name: Fail on silent skips
+        run: |
+          # Belt and braces: re-run and grep for the skip marker. The
+          # assert step above should make this unreachable, but if a test
+          # gains a new availability probe (a different binary, a
+          # container) this catches it green-skipping.
+          if cargo test -p rustledger --test integration_test -- --nocapture 2>&1 | grep -q "Skipping: Python beancount not available"; then
+            echo "::error::python-gated tests skipped despite bean-check being installed — availability probe drifted"
+            exit 1
+          fi


### PR DESCRIPTION
> Supersedes #1744 — identical commits; recreated because the `ci/` branch prefix is rejected by the branch-name policy (only feat|fix|chore|docs|refactor|perf|release|hotfix).

## What

Adds a `python-gated-cargo-tests` job to the Compatibility workflow so the cargo test suites that compare rledger against Python beancount actually run in CI — instead of silently skipping everywhere, forever.

## Why

Several cargo suites call `Command::new("bean-check")` and skip with an `eprintln!` when it's missing — which is every CI environment today. The use-before-open silent-pass bug (**#1742**) sat on main behind exactly that skip: `test_account_lifecycle_consistency` existed, would have caught the bug, and never ran with `bean-check` on PATH. This was the open question flagged in #1741/#1742.

## How

New job in `compat.yml` (which already runs on push/PR/nightly and owns the Python setup convention):

1. `pip install beancount`, then a dedicated step **asserts `bean-check --version` succeeds** — if the binary ever breaks, the job goes red at the assert rather than the tests green-skipping (a silent skip here would recreate the hole this job closes).
2. Runs the two python-gated suites: `rustledger` `integration_test` and `rustledger-core` `synthetic_generation`. A comment carries the grep (`Command::new("bean-`) that enumerates them, so the list is maintainable.
3. Belt-and-braces final step greps a rerun for the `Skipping: Python beancount not available` marker — so a future availability-probe drift (renamed binary, container-based probe) can't quietly reintroduce the skip.

Follows the existing job's conventions: same pinned action SHAs, same Python version, rust-cache omitted for the same license-check reason (comment cross-references it).

## ⚠️ Merge order

**Land #1742 first.** Verified locally with bean-check available: this job catches exactly the #1742 failure on current main (`integration_test`: 18 passed / 1 failed — `test_account_lifecycle_consistency`; `synthetic_generation`: green). If this merges first, the job is red on arrival — which is the proof the gate works, but red main is red main.

Also worth deciding: whether to add this job to branch protection as a required check (that's a repo-settings change only you can make).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

