### PR TITLE
fix: make pager and config tests hermetic under a TTY

### DIFF
--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -1469,10 +1469,8 @@ t = "check"
         let native = Some(PathBuf::from("/home/u/.config/rledger/config.toml"));
         assert_eq!(resolve_user_config_path(None, native.clone()), native);
 
-        // An empty override is treated as unset (filtered by the caller),
-        // so the native default is used.
-        let other = Some(PathBuf::from("/native/rledger/config.toml"));
-        assert_eq!(resolve_user_config_path(None, other.clone()), other);
+        // No override and no native location: nothing to resolve.
+        assert_eq!(resolve_user_config_path(None, None), None);
     }
 
     #[test]

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -1450,20 +1450,29 @@ t = "check"
         // `~` in the override is expanded to the home dir.
         if let Some(home) = dirs::home_dir() {
             assert_eq!(
-                resolve_user_config_path(Some("~/dots/rledger.toml".to_string()), native.clone()),
+                resolve_user_config_path(Some("~/dots/rledger.toml".to_string()), native),
                 Some(home.join("dots/rledger.toml"))
             );
         }
-        // An empty override is treated as unset (filtered by the caller), so the
-        // native default is used.
-        assert_eq!(resolve_user_config_path(None, native.clone()), native);
     }
 
+    /// The no-override → native case is only assertable off macOS: the
+    /// macOS XDG fallback (#1616) probes the REAL filesystem for
+    /// `~/.config/rledger/config.toml` when the (fake) native path does
+    /// not exist, so on any macOS machine with an actual rledger config
+    /// the sentinel loses to the user's file and the assertion fails
+    /// (#1729 — this exact assertion previously lived in the env-override
+    /// test above and broke `cargo test` for macOS users).
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn resolve_user_config_path_no_override_uses_native_on_non_macos() {
         let native = Some(PathBuf::from("/home/u/.config/rledger/config.toml"));
         assert_eq!(resolve_user_config_path(None, native.clone()), native);
+
+        // An empty override is treated as unset (filtered by the caller),
+        // so the native default is used.
+        let other = Some(PathBuf::from("/native/rledger/config.toml"));
+        assert_eq!(resolve_user_config_path(None, other.clone()), other);
     }
 
     #[test]

--- a/crates/rustledger/src/pager.rs
+++ b/crates/rustledger/src/pager.rs
@@ -82,20 +82,51 @@ pub fn is_broken_pipe(err: &anyhow::Error) -> bool {
 ///
 /// Falls back to stdout otherwise.
 pub fn create_pager(config_pager: Option<&str>) -> PagerWriter {
+    create_pager_in(&PagerEnv::from_process(), config_pager)
+}
+
+/// The process-environment inputs to the paging decision, separated from
+/// [`create_pager`] so the decision is TESTABLE: the old tests asserted the
+/// non-TTY branch by ASSUMING test stdout is never a terminal, which is
+/// false under `cargo test` in a real terminal (libtest captures the
+/// thread-local print handles, not fd 1) — the tests then failed AND
+/// actually spawned `less` on the developer's machine (#1729). Tests now
+/// construct this struct directly and never consult (or mutate — parallel
+/// tests race on `set_var`) the real environment.
+struct PagerEnv {
+    /// Whether fd 1 is a terminal (`io::stdout().is_terminal()`).
+    is_tty: bool,
+    /// Whether `NO_PAGER` is set.
+    no_pager: bool,
+    /// `$PAGER`, if set.
+    pager: Option<String>,
+}
+
+impl PagerEnv {
+    fn from_process() -> Self {
+        Self {
+            is_tty: io::stdout().is_terminal(),
+            no_pager: std::env::var_os("NO_PAGER").is_some(),
+            pager: std::env::var("PAGER").ok(),
+        }
+    }
+}
+
+fn create_pager_in(env: &PagerEnv, config_pager: Option<&str>) -> PagerWriter {
     // Don't page if stdout is not a TTY (piped, redirected, etc.)
-    if !io::stdout().is_terminal() {
+    if !env.is_tty {
         return PagerWriter::Stdout(io::stdout().lock());
     }
 
     // Check NO_PAGER env var
-    if std::env::var_os("NO_PAGER").is_some() {
+    if env.no_pager {
         return PagerWriter::Stdout(io::stdout().lock());
     }
 
     // Resolve pager command: config → $PAGER → "less"
     let pager_cmd = config_pager
         .map(String::from)
-        .or_else(|| std::env::var("PAGER").ok())
+        .or_else(|| env.pager.clone())
         .unwrap_or_else(|| "less".to_string());
 
     if pager_cmd.is_empty() {
@@ -157,17 +188,63 @@ mod tests {
         assert!(!is_broken_pipe(&err));
     }
 
+    /// Hermetic environment for pager-decision tests: every field is
+    /// explicit, so outcomes cannot depend on the terminal, `NO_PAGER`,
+    /// or `$PAGER` of whoever runs the tests (#1729).
+    fn env(is_tty: bool, no_pager: bool, pager: Option<&str>) -> PagerEnv {
+        PagerEnv {
+            is_tty,
+            no_pager,
+            pager: pager.map(String::from),
+        }
+    }
+
     #[test]
     fn test_create_pager_non_tty() {
-        // In CI/tests, stdout is not a TTY — should always return Stdout variant
-        let writer = create_pager(None);
+        // Non-TTY stdout never pages, with or without config.
+        let writer = create_pager_in(&env(false, false, None), None);
         assert!(matches!(writer, PagerWriter::Stdout(_)));
     }
 
     #[test]
     fn test_create_pager_with_config_non_tty() {
-        // Even with config, non-TTY should return Stdout
-        let writer = create_pager(Some("less -R"));
+        let writer = create_pager_in(&env(false, false, Some("less")), Some("less -R"));
+        assert!(matches!(writer, PagerWriter::Stdout(_)));
+    }
+
+    #[test]
+    fn test_create_pager_tty_no_pager_wins() {
+        // NO_PAGER suppresses paging even on a TTY with a configured pager.
+        let writer = create_pager_in(&env(true, true, Some("less")), Some("less -R"));
+        assert!(matches!(writer, PagerWriter::Stdout(_)));
+    }
+
+    #[test]
+    fn test_create_pager_tty_empty_command_falls_back() {
+        // An explicitly empty pager command means "don't page".
+        let writer = create_pager_in(&env(true, false, None), Some(""));
+        assert!(matches!(writer, PagerWriter::Stdout(_)));
+        // Same via $PAGER.
+        let writer = create_pager_in(&env(true, false, Some("")), None);
+        assert!(matches!(writer, PagerWriter::Stdout(_)));
+    }
+
+    #[test]
+    fn test_create_pager_tty_unparsable_command_falls_back() {
+        // shell_words can't split an unterminated quote — fall back, don't panic.
+        let writer = create_pager_in(&env(true, false, None), Some("less '"));
+        assert!(matches!(writer, PagerWriter::Stdout(_)));
+    }
+
+    #[test]
+    fn test_create_pager_tty_spawn_failure_falls_back() {
+        // A pager binary that doesn't exist must fall back to stdout rather
+        // than erroring. (Spawn-SUCCESS on a TTY is deliberately untested:
+        // it would launch a real process from the test suite.)
+        let writer = create_pager_in(
+            &env(true, false, None),
+            Some("/nonexistent/rledger-test-pager-binary"),
+        );
         assert!(matches!(writer, PagerWriter::Stdout(_)));
     }
 


### PR DESCRIPTION
## What

Makes the three tests from #1729 hermetic, so `cargo test` passes in TTY environments (macOS Terminal, ghostty, tmux) and with real user config files on disk. Two distinct causes, per the triage on the issue:

**Pager (the TTY half).** `create_pager()` read process-global `io::stdout().is_terminal()`; libtest captures the thread-local print handles, not fd 1, so under a real terminal the tests asserting the non-TTY branch failed — and `create_pager` actually **spawned `less`** mid-test-run on the developer's machine. The paging decision's inputs (`is_tty`, `NO_PAGER`, `$PAGER`) now live in a small `PagerEnv` struct: the public `create_pager()` fills it from the process, tests construct it directly.

Bonus: the previously-untestable TTY side is now covered — `NO_PAGER`-wins, empty pager command (via config and via `$PAGER`), unparsable command, and spawn-failure fallback. None of the tests consult **or mutate** the real environment (parallel tests race on `set_var`), and none can spawn a process (spawn-success on a TTY is deliberately untested — it would launch a real pager from the suite; the comment says so).

**Config (the filesystem half — not TTY).** The `None`-override assertion in `resolve_user_config_path_env_override_wins` collided with the macOS XDG fallback (#1616), which probes the real filesystem for `~/.config/rledger/config.toml` when the fake `/native/...` sentinel doesn't exist — so it failed for any macOS user with an actual rledger config, terminal or not. The assertion moved into the already-`cfg(not(target_os = "macos"))` sibling test, with a comment naming the trap so it isn't reintroduced.

No production behavior changes — `create_pager`'s public signature and decision logic are unchanged; the config resolver is untouched.

## Verification

- Full `rustledger` lib suite (370 tests) green **both** normally and **under a PTY** (`script -qec "cargo test …"`), the reporter's environment shape.
- The PTY harness is proven non-vacuous: pre-fix code under the same PTY reproduces the reported failures (2 pager tests fail).
- clippy `--all-features --all-targets -D warnings` clean on both 1.96 (nix) and 1.97 (CI's stable); fmt clean.

Closes #1729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
