### PR TITLE
fix(ci): probe bean-price with --help, not --version

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1171,7 +1171,9 @@ jobs:
           # guarantees that skip path is dead in CI — if a binary breaks,
           # the job goes red HERE instead of the tests green-skipping.
           bean-check --version
-          bean-price --version
+          # bean-price has no --version flag (it errors demanding sources);
+          # --help is the probe bean_price_compat.rs itself uses.
+          bean-price --help > /dev/null
       - name: Run python-gated test suites
         env:
           CARGO_TERM_COLOR: always


### PR DESCRIPTION
One-line fix for the python-gated compat job: `bean-price` has no `--version` flag (it prints usage and exits non-zero demanding `sources`), so the assert step introduced in #1746 fails on every run before any test executes. `--help` is the exact probe `bean_price_compat.rs` itself uses (line 31-36). Verified locally: `bean-price --help` exits 0, `bean-price --version` exits 2.

My miss — the deep-review agent even flagged that the test uses `--help` and I wrote `--version` anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)