### PR TITLE
chore(ci): pin the CI toolchain to 1.97.0 instead of floating stable

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           cache-on-failure: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           cache-on-failure: true
@@ -560,7 +560,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           cache-on-failure: true

--- a/.github/workflows/cargo-vet-auto.yml
+++ b/.github/workflows/cargo-vet-auto.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Install cargo-vet
         uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           components: rustfmt
       - run: cargo fmt --all -- --check
   # Release hygiene: the crates.io publish list in release-publish.yml must
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Verify release-publish CRATES array matches publishable crates
         run: python3 scripts/check-publish-crates.py
   # Wire-format bindings freshness gate (ADR-0004, #1218 + #1232).
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       # Node for the prettier pass in `scripts/regen-bindings.sh`
       # (#1226). Read from `.nvmrc` to keep the version in one place --
       # matches the convention in `wasm.yml` (single source of truth).
@@ -286,7 +286,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           components: ${{ matrix.components }}
           # wasm32 needed by rustledger-importer's build.rs (which
           # compiles the sample_stub fixture for the wasm_importer_e2e
@@ -322,7 +322,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Run doctests
@@ -337,7 +337,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Build rledger
@@ -369,7 +369,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       # `cargo bench` compiles the lib WITHOUT its `#[test]` fns (only `#[bench]`
@@ -396,7 +396,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Forbid wasmtime in --no-default-features build
         run: ./scripts/check-slim-no-wasmtime.sh
@@ -415,7 +415,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-wasip2
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       # Note: rust-cache intentionally omitted to avoid LGPL-3.0 license check failure.
       # The dependency-review workflow runs from the base branch, so adding LGPL-3.0 to
       # allow-licenses in this PR won't take effect until merged. Nightly builds don't
@@ -1156,7 +1156,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       # rust-cache intentionally omitted — see the note on the
       # compatibility-test job (LGPL-3.0 license-check interaction).
       - name: Set up Python

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-wasip2
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -53,7 +53,7 @@ jobs:
       # 2026-01-16); only the action wrapper is dormant.
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Relax the MSRV gate for Kani's bundled toolchain
         run: |
           # Kani vendors its own nightly (v0.67 ships nightly-2025-11-21 =

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           prefix-key: mutants-${{ matrix.package }}

--- a/.github/workflows/parser-baselines.yml
+++ b/.github/workflows/parser-baselines.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       # Share the corpus cache with the Compatibility workflow so the

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
       - name: Generate workload ledger
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           components: llvm-tools-preview
           # wasm32 needed by rustledger-importer's build.rs for the
           # wasm_importer_e2e fixture. Without it, the test detects the

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Validate tag matches rustledger crate version
         run: |
           # Extract version from tag (strip 'v' prefix)
@@ -116,7 +116,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: ${{ matrix.target }}
           components: llvm-tools-preview
       - name: Install cross
@@ -334,7 +334,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-unknown-unknown
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -364,7 +364,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-wasip2
       - name: Build FFI-Component binary
         # wasm32-wasip2 emits the WASI Preview 2 component directly from the

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Authenticate with crates.io (trusted publishing)
         id: crates-auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
@@ -138,7 +138,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-unknown-unknown
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -461,7 +461,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Install cargo-binstall
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Wait for binstall availability

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Install cargo-vet
         run: cargo install cargo-vet
       - name: Run cargo vet
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx
       - name: Generate SBOM (CycloneDX)

--- a/.github/workflows/tla-escalated.yml
+++ b/.github/workflows/tla-escalated.yml
@@ -51,7 +51,7 @@ jobs:
             -O ~/tla2tools.jar
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Generate escalated corpora
         env:

--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -65,7 +65,7 @@ jobs:
       # validation below).
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       # One loop instead of 16 uniform steps: every spec is checked even when
       # an earlier one fails (previously fail-fast masked later spec failures),

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # stable
         with:
-          toolchain: stable
+          toolchain: 1.97.0 # pinned stable — bump deliberately (see #1745 for why floating broke)
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:


### PR DESCRIPTION
Floating `@stable` let Rust 1.97.0 land in CI overnight and redden every open PR on untouched code (new lints + the BQL parse-stack SIGABRT — #1745 has the story; it cost a working day across 15 PRs). All 36 floating `toolchain: stable` sites are pinned to **1.97.0** — the version everything on main is verified against — with an inline comment pointing at the incident so future bumps are deliberate. Nightly and MSRV pins untouched.

Trade-off acknowledged: pinning means staleness until someone bumps; the incident showed surprise breakage is the worse failure mode for this repo's 15-PR-wide review cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)