### PR TITLE
feat(report): render numbers through the ledger DisplayContext (U4)

### DIFF
--- a/crates/rustledger/src/cmd/report_cmd/balances.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balances.rs
@@ -2,14 +2,14 @@
 
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
-use rust_decimal::Decimal;
-use rustledger_core::Directive;
+use rustledger_core::{Directive, DisplayContext};
 use std::io::Write;
 
 /// Generate a balances report.
 pub(super) fn report_balances<W: Write>(
     directives: &[Directive],
     account_filter: Option<&str>,
+    ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
@@ -19,7 +19,11 @@ pub(super) fn report_balances<W: Write>(
 
     // Collect data for output. `cost` is the beancount-style lot annotation
     // (e.g. ` {150.00 USD}`) for held commodities, empty for plain currency.
-    let mut rows: Vec<(&str, Decimal, &str, String)> = Vec::new();
+    // Numbers render through the ledger's DisplayContext (per-currency
+    // inferred precision, `display_precision` overrides, `render_commas`)
+    // — the same context BQL output uses — so `100 USD` in a 2dp ledger
+    // prints as `100.00 USD` regardless of booking-arithmetic scale (U4).
+    let mut rows: Vec<(&str, String, &str, String)> = Vec::new();
     for (account, inventory) in &balances {
         if let Some(filter) = account_filter
             && !account.starts_with(filter)
@@ -37,7 +41,7 @@ pub(super) fn report_balances<W: Write>(
                 .unwrap_or_default();
             rows.push((
                 account,
-                position.units.number,
+                ctx.format_amount_number(position.units.number, &position.units.currency),
                 &position.units.currency,
                 cost,
             ));

--- a/crates/rustledger/src/cmd/report_cmd/balances.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balances.rs
@@ -52,11 +52,13 @@ pub(super) fn report_balances<W: Write>(
         OutputFormat::Csv => {
             writeln!(writer, "account,amount,currency,cost")?;
             for (account, amount, currency, cost) in &rows {
+                // `csv_escape(amount)`: with `render_commas` the formatted
+                // number contains thousands separators (review catch).
                 writeln!(
                     writer,
                     "{},{},{},{}",
                     csv_escape(account),
-                    amount,
+                    csv_escape(amount),
                     currency,
                     csv_escape(cost)
                 )?;

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -96,20 +96,24 @@ pub(super) fn report_balsheet<W: Write>(
         OutputFormat::Csv => {
             writeln!(writer, "section,account,amount,currency,cost")?;
             for (section, account, amount, currency, cost) in &all_rows {
+                // `csv_escape(amount)`: with `render_commas` the formatted
+                // number contains thousands separators (review catch).
                 writeln!(
                     writer,
                     "{},{},{},{},{}",
                     section,
                     csv_escape(account),
-                    amount,
+                    csv_escape(amount),
                     currency,
                     csv_escape(cost)
                 )?;
             }
             // Add net worth rows
             for (currency, total) in &net_worth {
-                let total = ctx.format_amount_number(*total, currency);
-                writeln!(writer, "Net Worth,TOTAL,{total},{currency}")?;
+                let total = csv_escape(&ctx.format_amount_number(*total, currency));
+                // Trailing comma: empty `cost` field keeps the row at the
+                // header's five columns (review catch — was four wide).
+                writeln!(writer, "Net Worth,TOTAL,{total},{currency},")?;
             }
         }
         OutputFormat::Json => {

--- a/crates/rustledger/src/cmd/report_cmd/balsheet.rs
+++ b/crates/rustledger/src/cmd/report_cmd/balsheet.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, Inventory};
+use rustledger_core::{Directive, DisplayContext, Inventory};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -11,6 +11,7 @@ use std::io::Write;
 pub(super) fn report_balsheet<W: Write>(
     directives: &[Directive],
     account_types: &rustledger_core::AccountTypes,
+    ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
@@ -49,11 +50,12 @@ pub(super) fn report_balsheet<W: Write>(
         totals
     }
 
-    // Collect rows: (section, account, amount, currency)
+    // Collect rows: (section, account, formatted amount, currency)
     fn collect_rows(
         section: &str,
         balances: &BTreeMap<rustledger_core::Account, Inventory>,
-    ) -> Vec<(String, String, Decimal, String, String)> {
+        ctx: &DisplayContext,
+    ) -> Vec<(String, String, String, String, String)> {
         let mut rows = Vec::new();
         for (account, inventory) in balances {
             if inventory.is_empty() {
@@ -68,7 +70,7 @@ pub(super) fn report_balsheet<W: Write>(
                 rows.push((
                     section.to_string(),
                     account.to_string(),
-                    position.units.number,
+                    ctx.format_amount_number(position.units.number, &position.units.currency),
                     position.units.currency.to_string(),
                     cost,
                 ));
@@ -78,9 +80,9 @@ pub(super) fn report_balsheet<W: Write>(
     }
 
     let mut all_rows = Vec::new();
-    all_rows.extend(collect_rows("Assets", &assets));
-    all_rows.extend(collect_rows("Liabilities", &liabilities));
-    all_rows.extend(collect_rows("Equity", &equity));
+    all_rows.extend(collect_rows("Assets", &assets, ctx));
+    all_rows.extend(collect_rows("Liabilities", &liabilities, ctx));
+    all_rows.extend(collect_rows("Equity", &equity, ctx));
 
     // Net worth = Assets - Liabilities
     let asset_totals = sum_by_currency(&assets);
@@ -106,6 +108,7 @@ pub(super) fn report_balsheet<W: Write>(
             }
             // Add net worth rows
             for (currency, total) in &net_worth {
+                let total = ctx.format_amount_number(*total, currency);
                 writeln!(writer, "Net Worth,TOTAL,{total},{currency}")?;
             }
         }
@@ -130,6 +133,7 @@ pub(super) fn report_balsheet<W: Write>(
             let nw_vec: Vec<_> = net_worth.iter().collect();
             for (i, (currency, total)) in nw_vec.iter().enumerate() {
                 let comma = if i < nw_vec.len() - 1 { "," } else { "" };
+                let total = ctx.format_amount_number(**total, currency);
                 writeln!(writer, r#"    "{currency}": "{total}"{comma}"#)?;
             }
             writeln!(writer, "  }}")?;
@@ -140,6 +144,7 @@ pub(super) fn report_balsheet<W: Write>(
                 writer: &mut W,
                 title: &str,
                 balances: &BTreeMap<rustledger_core::Account, Inventory>,
+                ctx: &DisplayContext,
             ) -> Result<BTreeMap<rustledger_core::Currency, Decimal>> {
                 writeln!(writer, "{title}")?;
                 writeln!(writer, "{}", "-".repeat(60))?;
@@ -156,7 +161,13 @@ pub(super) fn report_balsheet<W: Write>(
                         writeln!(
                             writer,
                             "  {:>12} {:>4}{}  {}",
-                            position.units.number, position.units.currency, cost, account
+                            ctx.format_amount_number(
+                                position.units.number,
+                                &position.units.currency
+                            ),
+                            position.units.currency,
+                            cost,
+                            account
                         )?;
                     }
                 }
@@ -168,6 +179,7 @@ pub(super) fn report_balsheet<W: Write>(
                 }
                 writeln!(writer)?;
                 for (currency, total) in &totals {
+                    let total = ctx.format_amount_number(*total, currency);
                     writeln!(writer, "  {total:>12} {currency:>4}  Total {title}")?;
                 }
                 writeln!(writer)?;
@@ -178,13 +190,14 @@ pub(super) fn report_balsheet<W: Write>(
             writeln!(writer, "{}", "=".repeat(60))?;
             writeln!(writer)?;
 
-            write_section(writer, "Assets", &assets)?;
-            write_section(writer, "Liabilities", &liabilities)?;
-            write_section(writer, "Equity", &equity)?;
+            write_section(writer, "Assets", &assets, ctx)?;
+            write_section(writer, "Liabilities", &liabilities, ctx)?;
+            write_section(writer, "Equity", &equity, ctx)?;
 
             writeln!(writer, "Net Worth")?;
             writeln!(writer, "{}", "-".repeat(60))?;
             for (currency, total) in &net_worth {
+                let total = ctx.format_amount_number(*total, currency);
                 writeln!(writer, "  {total:>12} {currency:>4}")?;
             }
         }

--- a/crates/rustledger/src/cmd/report_cmd/holdings.rs
+++ b/crates/rustledger/src/cmd/report_cmd/holdings.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::Directive;
+use rustledger_core::{Directive, DisplayContext};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -12,6 +12,7 @@ pub(super) fn report_holdings<W: Write>(
     directives: &[Directive],
     account_types: &rustledger_core::AccountTypes,
     account_filter: Option<&str>,
+    ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
@@ -61,8 +62,10 @@ pub(super) fn report_holdings<W: Write>(
         }
     }
 
-    // Collect rows: (account, units, currency, cost_basis, cost_currency)
-    let mut rows: Vec<(String, Decimal, String, Decimal, String)> = Vec::new();
+    // Collect rows: (account, units, currency, cost basis, cost currency).
+    // Units and cost basis render through the ledger's DisplayContext so
+    // precision follows ledger convention, not booking-arithmetic scale (U4).
+    let mut rows: Vec<(String, String, String, String, String)> = Vec::new();
     for (account, currencies) in &holdings {
         for (currency, (units, cost_basis, cost_currency)) in currencies {
             if *units == Decimal::ZERO {
@@ -70,9 +73,9 @@ pub(super) fn report_holdings<W: Write>(
             }
             rows.push((
                 account.to_string(),
-                *units,
+                ctx.format_amount_number(*units, currency),
                 currency.clone(),
-                *cost_basis,
+                ctx.format_amount_number(*cost_basis, cost_currency),
                 cost_currency.clone(),
             ));
         }

--- a/crates/rustledger/src/cmd/report_cmd/holdings.rs
+++ b/crates/rustledger/src/cmd/report_cmd/holdings.rs
@@ -85,13 +85,15 @@ pub(super) fn report_holdings<W: Write>(
         OutputFormat::Csv => {
             writeln!(writer, "account,units,currency,cost_basis,cost_currency")?;
             for (account, units, currency, cost_basis, cost_currency) in &rows {
+                // `csv_escape` on the numeric fields: with `render_commas`
+                // they contain thousands separators (review catch).
                 writeln!(
                     writer,
                     "{},{},{},{},{}",
                     csv_escape(account),
-                    units,
+                    csv_escape(units),
                     currency,
-                    cost_basis,
+                    csv_escape(cost_basis),
                     cost_currency
                 )?;
             }

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -3,7 +3,7 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
-use rustledger_core::{Directive, Inventory};
+use rustledger_core::{Directive, DisplayContext, Inventory};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -11,6 +11,7 @@ use std::io::Write;
 pub(super) fn report_income<W: Write>(
     directives: &[Directive],
     account_types: &rustledger_core::AccountTypes,
+    ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
 ) -> Result<()> {
@@ -48,7 +49,8 @@ pub(super) fn report_income<W: Write>(
     fn collect_rows(
         section: &str,
         balances: &BTreeMap<rustledger_core::Account, Inventory>,
-    ) -> Vec<(String, String, Decimal, String)> {
+        ctx: &DisplayContext,
+    ) -> Vec<(String, String, String, String)> {
         let mut rows = Vec::new();
         for (account, inventory) in balances {
             if inventory.is_empty() {
@@ -58,7 +60,7 @@ pub(super) fn report_income<W: Write>(
                 rows.push((
                     section.to_string(),
                     account.to_string(),
-                    position.units.number,
+                    ctx.format_amount_number(position.units.number, &position.units.currency),
                     position.units.currency.to_string(),
                 ));
             }
@@ -67,8 +69,8 @@ pub(super) fn report_income<W: Write>(
     }
 
     let mut all_rows = Vec::new();
-    all_rows.extend(collect_rows("Income", &income));
-    all_rows.extend(collect_rows("Expenses", &expenses));
+    all_rows.extend(collect_rows("Income", &income, ctx));
+    all_rows.extend(collect_rows("Expenses", &expenses, ctx));
 
     // Net income = -(Income) - Expenses (income is negative in double-entry)
     let income_totals = sum_by_currency(&income);
@@ -95,6 +97,7 @@ pub(super) fn report_income<W: Write>(
                 )?;
             }
             for (currency, total) in &net_income {
+                let total = ctx.format_amount_number(*total, currency);
                 writeln!(writer, "Net Income,TOTAL,{total},{currency}")?;
             }
         }
@@ -118,6 +121,7 @@ pub(super) fn report_income<W: Write>(
             let ni_vec: Vec<_> = net_income.iter().collect();
             for (i, (currency, total)) in ni_vec.iter().enumerate() {
                 let comma = if i < ni_vec.len() - 1 { "," } else { "" };
+                let total = ctx.format_amount_number(**total, currency);
                 writeln!(writer, r#"    "{currency}": "{total}"{comma}"#)?;
             }
             writeln!(writer, "  }}")?;
@@ -128,6 +132,7 @@ pub(super) fn report_income<W: Write>(
                 writer: &mut W,
                 title: &str,
                 balances: &BTreeMap<rustledger_core::Account, Inventory>,
+                ctx: &DisplayContext,
             ) -> Result<BTreeMap<rustledger_core::Currency, Decimal>> {
                 writeln!(writer, "{title}")?;
                 writeln!(writer, "{}", "-".repeat(60))?;
@@ -139,7 +144,12 @@ pub(super) fn report_income<W: Write>(
                         writeln!(
                             writer,
                             "  {:>12} {:>4}  {}",
-                            position.units.number, position.units.currency, account
+                            ctx.format_amount_number(
+                                position.units.number,
+                                &position.units.currency
+                            ),
+                            position.units.currency,
+                            account
                         )?;
                     }
                 }
@@ -151,6 +161,7 @@ pub(super) fn report_income<W: Write>(
                 }
                 writeln!(writer)?;
                 for (currency, total) in &totals {
+                    let total = ctx.format_amount_number(*total, currency);
                     writeln!(writer, "  {total:>12} {currency:>4}  Total {title}")?;
                 }
                 writeln!(writer)?;
@@ -161,12 +172,13 @@ pub(super) fn report_income<W: Write>(
             writeln!(writer, "{}", "=".repeat(60))?;
             writeln!(writer)?;
 
-            write_section(writer, "Income", &income)?;
-            write_section(writer, "Expenses", &expenses)?;
+            write_section(writer, "Income", &income, ctx)?;
+            write_section(writer, "Expenses", &expenses, ctx)?;
 
             writeln!(writer, "Net Income")?;
             writeln!(writer, "{}", "-".repeat(60))?;
             for (currency, total) in &net_income {
+                let total = ctx.format_amount_number(*total, currency);
                 writeln!(writer, "  {total:>12} {currency:>4}")?;
             }
         }

--- a/crates/rustledger/src/cmd/report_cmd/income.rs
+++ b/crates/rustledger/src/cmd/report_cmd/income.rs
@@ -87,17 +87,19 @@ pub(super) fn report_income<W: Write>(
         OutputFormat::Csv => {
             writeln!(writer, "section,account,amount,currency")?;
             for (section, account, amount, currency) in &all_rows {
+                // `csv_escape(amount)`: with `render_commas` the formatted
+                // number contains thousands separators (review catch).
                 writeln!(
                     writer,
                     "{},{},{},{}",
                     section,
                     csv_escape(account),
-                    amount,
+                    csv_escape(amount),
                     currency
                 )?;
             }
             for (currency, total) in &net_income {
-                let total = ctx.format_amount_number(*total, currency);
+                let total = csv_escape(&ctx.format_amount_number(*total, currency));
                 writeln!(writer, "Net Income,TOTAL,{total},{currency}")?;
             }
         }

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -249,6 +249,12 @@ struct LoadedReport {
     /// Pad-expanded view, present only when the ledger has pads AND the
     /// report is balance-computing. `None` means "use `directives`".
     balance_view: Option<Vec<rustledger_core::Directive>>,
+    /// Per-currency display precision inferred by the loader (plus
+    /// `display_precision` overrides and `render_commas`). Balance-style
+    /// reports render numbers through this — the same context BQL output
+    /// uses — instead of raw `Decimal` `Display`, whose precision is an
+    /// artifact of booking arithmetic rather than ledger convention (U4).
+    display_context: rustledger_core::DisplayContext,
 }
 
 /// Load and fully process the file (parse → book → plugins), producing the
@@ -328,12 +334,14 @@ fn load(file: &PathBuf, report: &Report, verbose: bool, no_cache: bool) -> Resul
         None
     };
     let account_types = ledger.options.to_account_types();
+    let display_context = ledger.display_context.clone();
     let directives: Vec<_> = ledger.directives.into_iter().map(|s| s.value).collect();
 
     Ok(LoadedReport {
         directives,
         account_types,
         balance_view,
+        display_context,
     })
 }
 
@@ -365,13 +373,31 @@ fn render<W: io::Write>(
     // stream); source-faithful reports get `&directives`.
     match report {
         Report::Balances { account } => {
-            balances::report_balances(balance_input, account.as_deref(), format, writer)?;
+            balances::report_balances(
+                balance_input,
+                account.as_deref(),
+                &loaded.display_context,
+                format,
+                writer,
+            )?;
         }
         Report::Balsheet => {
-            balsheet::report_balsheet(balance_input, &loaded.account_types, format, writer)?;
+            balsheet::report_balsheet(
+                balance_input,
+                &loaded.account_types,
+                &loaded.display_context,
+                format,
+                writer,
+            )?;
         }
         Report::Income => {
-            income::report_income(balance_input, &loaded.account_types, format, writer)?;
+            income::report_income(
+                balance_input,
+                &loaded.account_types,
+                &loaded.display_context,
+                format,
+                writer,
+            )?;
         }
         Report::Journal { account, limit } => {
             journal::report_journal(directives, account.as_deref(), *limit, format, writer)?;
@@ -381,6 +407,7 @@ fn render<W: io::Write>(
                 balance_input,
                 &loaded.account_types,
                 account.as_deref(),
+                &loaded.display_context,
                 format,
                 writer,
             )?;
@@ -394,6 +421,7 @@ fn render<W: io::Write>(
             networth::report_networth(
                 balance_input,
                 &loaded.account_types,
+                &loaded.display_context,
                 period,
                 currency.as_deref(),
                 account.as_deref(),

--- a/crates/rustledger/src/cmd/report_cmd/networth.rs
+++ b/crates/rustledger/src/cmd/report_cmd/networth.rs
@@ -1,6 +1,6 @@
 //! Net worth report - Net worth over time.
 
-use super::OutputFormat;
+use super::{OutputFormat, csv_escape};
 use anyhow::Result;
 use rust_decimal::Decimal;
 use rustledger_core::Directive;
@@ -150,7 +150,9 @@ pub(super) fn report_networth<W: Write>(
             writeln!(writer, "period,currency,amount")?;
             for (period_label, net_worth) in &period_results {
                 for (currency, amount) in net_worth {
-                    let amount = ctx.format_amount_number(*amount, currency);
+                    // Escaped: `render_commas` puts separators in the number
+                    // (review catch).
+                    let amount = csv_escape(&ctx.format_amount_number(*amount, currency));
                     writeln!(writer, "{period_label},{currency},{amount}")?;
                 }
             }

--- a/crates/rustledger/src/cmd/report_cmd/networth.rs
+++ b/crates/rustledger/src/cmd/report_cmd/networth.rs
@@ -17,9 +17,15 @@ use std::io::Write;
 /// * `no_zero` - If true, hide zero balances from output
 /// * `format` - Output format (text, csv, json)
 /// * `writer` - Output writer
+// Nine parameters: the report's five filters/knobs plus the four
+// threading params every balance report takes (directives, account
+// types, display context, writer). Bundling them into a struct would
+// obscure the call site more than it helps — allowed deliberately.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn report_networth<W: Write>(
     directives: &[Directive],
     account_types: &rustledger_core::AccountTypes,
+    ctx: &rustledger_core::DisplayContext,
     period: &str,
     currency_filter: Option<&str>,
     account_filter: Option<&str>,
@@ -144,6 +150,7 @@ pub(super) fn report_networth<W: Write>(
             writeln!(writer, "period,currency,amount")?;
             for (period_label, net_worth) in &period_results {
                 for (currency, amount) in net_worth {
+                    let amount = ctx.format_amount_number(*amount, currency);
                     writeln!(writer, "{period_label},{currency},{amount}")?;
                 }
             }
@@ -156,6 +163,7 @@ pub(super) fn report_networth<W: Write>(
                 for (currency, amount) in net_worth {
                     entry_idx += 1;
                     let comma = if entry_idx < total_entries { "," } else { "" };
+                    let amount = ctx.format_amount_number(*amount, currency);
                     writeln!(
                         writer,
                         r#"  {{"period": "{period_label}", "currency": "{currency}", "amount": "{amount}"}}{comma}"#
@@ -172,6 +180,7 @@ pub(super) fn report_networth<W: Write>(
             for (period_label, net_worth) in &period_results {
                 write!(writer, "{period_label:12}")?;
                 for (currency, amount) in net_worth {
+                    let amount = ctx.format_amount_number(*amount, currency);
                     write!(writer, "  {amount:>12} {currency}")?;
                 }
                 writeln!(writer)?;

--- a/crates/rustledger/tests/report_display_context_test.rs
+++ b/crates/rustledger/tests/report_display_context_test.rs
@@ -1,0 +1,103 @@
+//! U4: balance-style reports render numbers through the ledger's
+//! `DisplayContext` (per-currency inferred precision), not raw `Decimal`
+//! `Display` — whose scale is an artifact of booking arithmetic.
+//!
+//! The pinned case: a ledger whose USD amounts are conventionally 2dp
+//! contains one integer-written posting (`-100 USD`). Pre-U4,
+//! `report balances` printed that account's balance as `100 USD` while
+//! `bean-query BALANCES` (and our own BQL output, which has used the
+//! context since #961/#985) printed `100.00 USD`. The fixture output
+//! below was verified byte-identical against beancount 3.2.3's
+//! bean-query rendering.
+
+mod common;
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+// USD samples: four 2dp amounts and two integer-written ones, so the
+// per-currency mode (`Precision::MostCommon`, matching bean-query) is 2dp
+// and the integer-written transfer must be padded to `100.00`.
+const MIXED_PRECISION: &str = r#"2024-01-01 open Assets:Bank
+2024-01-01 open Assets:Broker
+2024-01-01 open Income:Salary
+2024-01-01 open Expenses:Food
+
+2024-01-15 * "salary"
+  Assets:Bank    2500.00 USD
+  Income:Salary -2500.00 USD
+
+2024-02-01 * "groceries"
+  Assets:Bank     -42.35 USD
+  Expenses:Food    42.35 USD
+
+2024-02-10 * "integer-written transfer"
+  Assets:Bank      -100 USD
+  Assets:Broker     100 USD
+"#;
+
+fn run_report(binary: &PathBuf, path: &str, args: &[&str]) -> String {
+    let out = Command::new(binary)
+        .arg("report")
+        .arg(path)
+        .args(args)
+        .arg("--no-pager")
+        .output()
+        .expect("run rledger report");
+    assert!(
+        out.status.success(),
+        "report failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn balances_render_at_ledger_precision() {
+    let bin = require_rledger!();
+    let mut f = tempfile::Builder::new()
+        .prefix("display-ctx-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(MIXED_PRECISION.as_bytes()).expect("write");
+    let path = f.path().to_str().unwrap().to_owned();
+
+    let text = run_report(&bin, &path, &["balances"]);
+    assert!(
+        text.contains("100.00 USD"),
+        "integer-written USD amounts must render at the ledger's 2dp \
+         convention (bean-query parity), got: {text}",
+    );
+    assert!(
+        !text.contains(" 100 USD"),
+        "raw booking-scale rendering must not leak through: {text}",
+    );
+
+    // CSV carries the same formatted numbers (one rendering per report,
+    // not per output format).
+    let csv = run_report(&bin, &path, &["balances", "--format", "csv"]);
+    assert!(
+        csv.contains(",100.00,USD"),
+        "CSV must use the same context-formatted numbers: {csv}",
+    );
+}
+
+#[test]
+fn income_totals_render_at_ledger_precision() {
+    let bin = require_rledger!();
+    let mut f = tempfile::Builder::new()
+        .prefix("display-ctx-income-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(MIXED_PRECISION.as_bytes()).expect("write");
+    let path = f.path().to_str().unwrap().to_owned();
+
+    let text = run_report(&bin, &path, &["income"]);
+    assert!(
+        text.contains("-2500.00 USD") && text.contains("2500.00 USD"),
+        "income statement must render at ledger precision: {text}",
+    );
+}

--- a/crates/rustledger/tests/report_display_context_test.rs
+++ b/crates/rustledger/tests/report_display_context_test.rs
@@ -101,3 +101,47 @@ fn income_totals_render_at_ledger_precision() {
         "income statement must render at ledger precision: {text}",
     );
 }
+
+#[test]
+fn csv_amounts_with_render_commas_are_quoted() {
+    // `option "render_commas" "TRUE"` puts thousands separators in
+    // formatted numbers; CSV fields containing commas must be quoted
+    // (RFC-4180) or the row grows extra columns (review catch on U4).
+    let bin = require_rledger!();
+    let source = format!("option \"render_commas\" \"TRUE\"\n{MIXED_PRECISION}");
+    let mut f = tempfile::Builder::new()
+        .prefix("display-ctx-commas-")
+        .suffix(".beancount")
+        .tempfile()
+        .expect("tempfile");
+    f.write_all(source.as_bytes()).expect("write");
+    let path = f.path().to_str().unwrap().to_owned();
+
+    let csv = run_report(&bin, &path, &["balances", "--format", "csv"]);
+    assert!(
+        csv.contains("\"2,357.65\""),
+        "comma-bearing amounts must be CSV-quoted: {csv}",
+    );
+    // Every data row must still have exactly the header's 4 columns when
+    // parsed with quote-awareness — approximate by checking no row has a
+    // bare (unquoted) thousands comma.
+    for line in csv.lines().skip(1) {
+        let quoted_stripped: String = {
+            let mut out = String::new();
+            let mut in_q = false;
+            for c in line.chars() {
+                match c {
+                    '\"' => in_q = !in_q,
+                    ',' if in_q => out.push('_'),
+                    c => out.push(c),
+                }
+            }
+            out
+        };
+        assert_eq!(
+            quoted_stripped.matches(',').count(),
+            3,
+            "row must have 4 columns outside quotes: {line}",
+        );
+    }
+}


### PR DESCRIPTION
## What

Balance-style reports (`balances`, `balsheet`, `income`, `holdings`, `networth`) now render numbers through the ledger's `DisplayContext` — per-currency inferred precision (MostCommon policy), `option "display_precision"` overrides, and `render_commas` — instead of raw `Decimal` `Display`. This is U4, the last deferred item from the Phase-1 sweep.

## Why

Raw `Display` precision is an artifact of booking arithmetic, not ledger convention. An integer-written posting in a 2dp ledger rendered as `100 USD` in reports where **bean-query prints `100.00 USD`** — and where our own BQL output has been context-aware since #961/#985. Reports were the one CLI surface where the precision/locale machinery didn't reach.

## How

`LoadedReport` carries the loader's `DisplayContext` (same threading pattern as `account_types` in #1731); the five reports format every units number and total via `format_amount_number`. **One rendering per report** — text, CSV, and JSON arms print the same formatted string. Lot-cost annotations keep their existing `Display` form (pinned to bean-query's `Position` string in #1728/#1733) — only units and totals change.

## User-visible change (flagged like #1728)

Numbers in report output can change: integer-scale amounts pad to the ledger's conventional precision (`100` → `100.00` in a 2dp ledger), over-scale outliers quantize to the mode, and `display_precision`/`render_commas` options now take effect in reports. CSV/JSON consumers see the same formatted strings as text.

## Verification

- **Byte-identical to beancount 3.2.3 `bean-query BALANCES`** on a mixed-precision fixture — in *both* directions of the MostCommon policy: a 2dp-dominant ledger pads the integer transfer to `100.00`; an integer-dominant ledger renders `2400` (my first test fixture got this wrong and the implementation matched bean-query, not the test — the mode wins, exactly as upstream).
- New integration test pins the padded rendering and text/CSV consistency.
- Full CLI suite green, **including the #1733 `query == report` realization-parity guard** — which now compares two context-formatted surfaces instead of one formatted and one raw.
- clippy clean on 1.96 and 1.97; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
