### PR TITLE
feat(ffi): session.from-entries — hold a directive set across calls (WIT 3.4.0)

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1516,6 +1516,34 @@ impl SessionState {
         }
     }
 
+    /// Hold an already-loaded directive set (WIT 3.4.0, `from-entries`).
+    /// The typed counterpart to `builder.query-entries`'s conversion step:
+    /// wire directives convert to core ONCE here, and every subsequent
+    /// method call runs against the held core list with no re-marshaling.
+    /// Conversion failures (e.g. un-lexable accounts, see the note on
+    /// `clamp`) drop the directive, mirroring `query-entries`.
+    pub fn from_entries(entries: &[wit::Directive]) -> Self {
+        let directives: Vec<rustledger_core::Directive> = entries
+            .iter()
+            .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok())
+            .collect();
+        let n = directives.len();
+        Self {
+            directives,
+            lines: vec![0; n],
+            files: vec!["<entries>".to_string(); n],
+            errors: vec![],
+            // Held entries carry no ledger options (they were stripped at
+            // the original load); defaults here match what a stand-alone
+            // directive set implies. Embedders holding options should keep
+            // consulting their load-time `info()`.
+            options: options(ffi::LedgerOptions::default()),
+            plugins: vec![],
+            includes: vec![],
+            padded: std::cell::OnceCell::new(),
+        }
+    }
+
     /// Parse + book from a file path. Mirrors the free `load_file`'s handling
     /// (path-security flag inversion, requested-plugin pass, per-directive
     /// file provenance); a load failure becomes an empty ledger whose single
@@ -1989,5 +2017,45 @@ mod tests {
                 (case, got) => panic!("WIT {case:?} raised to wrong variant: {got:?}"),
             }
         }
+    }
+
+    /// WIT 3.4.0 `session.from-entries`: a held directive set answers
+    /// queries with no per-call marshaling, and conversion-failing
+    /// directives (un-lexable accounts) are dropped like
+    /// `builder.query-entries` — observable via `info()`.
+    #[test]
+    fn session_from_entries_holds_and_queries() {
+        use super::SessionState;
+        // Round-trip the comprehensive LEDGER through the real load path
+        // (parse + book) into WIT directives, then hold them in a session
+        // built from that WIT list.
+        let loaded = ffi::helpers::load_source(LEDGER);
+        let wit_dirs: Vec<wit::Directive> = loaded
+            .directives
+            .iter()
+            .map(|d| directive_from_core(d, 0, "<test>"))
+            .collect();
+        let n = wit_dirs.len();
+        let session = SessionState::from_entries(&wit_dirs);
+        assert_eq!(
+            session.info().entries.len(),
+            n,
+            "all well-formed directives must survive the hold"
+        );
+        let result = session.query("SELECT account, sum(position) GROUP BY account");
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+        assert!(!result.rows.is_empty());
+
+        // An un-lexable account drops its directive (mirrors query-entries).
+        let bad = directive_from_core(
+            &rustledger_core::Directive::Open(rustledger_core::Open::new(
+                rustledger_core::naive_date(2024, 1, 1).unwrap(),
+                "bad account name",
+            )),
+            0,
+            "<test>",
+        );
+        let session = SessionState::from_entries(&[bad]);
+        assert_eq!(session.info().entries.len(), 0);
     }
 }

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1523,10 +1523,16 @@ impl SessionState {
     /// Conversion failures (e.g. un-lexable accounts, see the note on
     /// `clamp`) drop the directive, mirroring `query-entries`.
     pub fn from_entries(entries: &[wit::Directive]) -> Self {
-        let directives: Vec<rustledger_core::Directive> = entries
-            .iter()
-            .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok())
-            .collect();
+        // The one-time conversion is this API's whole reason to exist —
+        // reserve up front so a large ledger doesn't reallocate through
+        // the collect (review catch; drops are rare, over-reserving by
+        // the dropped count is fine).
+        let mut directives: Vec<rustledger_core::Directive> = Vec::with_capacity(entries.len());
+        directives.extend(
+            entries
+                .iter()
+                .filter_map(|d| ffi::input_entry_to_directive(&loaded_directive_to_input(d)).ok()),
+        );
         let n = directives.len();
         Self {
             directives,

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -46,9 +46,10 @@ use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
 /// The Component-Model api-version this build implements. 3.2 adds the
 /// `host.decrypt` import so encrypted (`.gpg`/`.asc`) ledgers can be decrypted by
-/// the host — a WASI guest can't reach the keyring (#1667). 3.1 added the `diff`
-/// field on `balance-dir` (#1663); 3.0 was the breaking `expand-pads` parameter
-/// on `load`/`load-file` (#1628).
+/// the host — a WASI guest can't reach the keyring (#1667). 3.4 added
+/// `session.from-entries` (hold a directive set, rustfava#173/#249); 3.1 added
+/// the `diff` field on `balance-dir` (#1663); 3.0 was the breaking
+/// `expand-pads` parameter on `load`/`load-file` (#1628).
 const API_VERSION: &str = "3.4";
 
 struct Component;

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -104,6 +104,12 @@ impl GuestSession for LedgerSession {
         }
     }
 
+    fn from_entries(entries: Vec<Directive>) -> Session {
+        Session::new(Self {
+            state: convert::SessionState::from_entries(&entries),
+        })
+    }
+
     fn from_file(path: String, allow_unrestricted_includes: bool, plugins: Vec<String>) -> Session {
         Session::new(Self {
             state: convert::SessionState::from_file(&path, allow_unrestricted_includes, &plugins),

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -49,7 +49,7 @@ use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 /// the host — a WASI guest can't reach the keyring (#1667). 3.1 added the `diff`
 /// field on `balance-dir` (#1663); 3.0 was the breaking `expand-pads` parameter
 /// on `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.3";
+const API_VERSION: &str = "3.4";
 
 struct Component;
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.3.0;
+package rustledger:ledger@3.4.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -462,6 +462,15 @@ interface ledger {
     /// `allow-unrestricted-includes` / `plugins` semantics match `load-file`;
     /// load failures are surfaced via `info().errors`, not a trap.
     from-file: static func(path: string, allow-unrestricted-includes: bool, plugins: list<string>) -> session;
+    /// Hold an already-loaded directive set (added in 3.4.0 for the
+    /// rustfava filtered-query path — rustfava#173). The embedder pays the
+    /// directive marshaling ONCE per entry set (e.g. per filter change)
+    /// and subsequent `query`/`filter`/`clamp` calls run against the held
+    /// core directives with no per-call shuttling. Directives that fail
+    /// conversion (e.g. un-lexable accounts) are dropped, mirroring
+    /// `builder.query-entries`; the drop count is observable as
+    /// `info().entries` length vs what was sent.
+    from-entries: static func(entries: list<directive>) -> session;
 
     /// Everything the host needs at load time: entries, errors, options,
     /// plugins, and the resolved include graph.


### PR DESCRIPTION
## What

Adds `session.from-entries: static func(entries: list<directive>) -> session` to the component contract (WIT **3.3.0 → 3.4.0**), so an embedder can hold an already-loaded directive set inside the component and run `query`/`filter`/`clamp` against it with **no per-call marshaling**.

## Why (the missing piece of rustfava#173)

The stateful `session` landed in #1421 but has **zero adopters** — and investigating why surfaced an architectural mismatch: rustfava's query endpoint runs against **filtered** entries (`g.filtered.entries_with_all_prices`, fava's Python-side filter engine), while a session could only be constructed from source or a file path. Result: every BQL query from the fava UI ships the full filtered directive list across the wire (`builder.query-entries`) and re-converts it, per query.

`from-entries` fits fava's model exactly: pay the marshaling once per filter change, cache the session keyed on the filter state, and every subsequent query on that view is wire-free.

## Semantics

- Conversion-failing directives (e.g. un-lexable accounts) are **dropped**, mirroring `query-entries`' established behavior; survivors are observable via `info().entries`.
- Held entries carry no ledger options (they were stripped at original load) — `info().options` returns defaults, documented; embedders keep consulting their load-time `info()`.
- Provenance for held entries is `<entries>`/line 0, matching the `<stdin>` convention for the source constructor.

## Verification

- New unit test: comprehensive test ledger → real load path → WIT directives → `from_entries` → BQL `GROUP BY` query (rows returned, zero errors), plus the un-lexable-drop mirror (bad-account Open → 0 held entries).
- `check-wit-version-bump.sh`: interface changed + version bumped, OK.
- ffi-component + component-parity suites green; clippy clean on 1.96 and 1.97.

## Follow-up (rustfava side)

Adopting this in rustfava — `ComponentSession.from_entries` in the engine, and a session cache keyed on filter identity in `RLConnection` — is the downstream half; filing there with the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)