### PR TITLE
fix(ci): channel-only rust-toolchain.toml — kill the implicit component sync

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -17,8 +17,10 @@
 # declare what they need explicitly via the dtolnay action's
 # `components:`/`targets:` inputs, so the sync must have nothing to do.
 #
-# Developers without nix: add what you need once —
-#   rustup component add clippy rustfmt rust-src llvm-tools-preview
-#   rustup target add wasm32-unknown-unknown
+# Developers without nix: add what you need once, onto THIS pinned
+# toolchain (a bare `rustup component add` targets whatever toolchain is
+# default, which may differ) —
+#   rustup component add --toolchain 1.97.0 clippy rustfmt rust-src llvm-tools-preview
+#   rustup target add --toolchain 1.97.0 wasm32-unknown-unknown
 [toolchain]
 channel = "1.97.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,14 +8,17 @@
 # of sync, cargo runs under this channel's install while wasm targets were
 # added to the pinned one, and every wasip2/wasm job fails with
 # "can't find crate for `std`" (the #1750 Component Parity failure).
+# CHANNEL ONLY — no components/targets here. Listing them makes rustup's
+# implicit override sync (first cargo invocation in every CI job) download
+# and install them transactionally, and that transaction intermittently
+# fails on hosted runners with "failed to install component:
+# 'clippy-preview…', detected conflict: 'bin/cargo-clippy'" (#1754 hit it
+# twice; identical green runs exist — it's a per-runner dice roll). CI jobs
+# declare what they need explicitly via the dtolnay action's
+# `components:`/`targets:` inputs, so the sync must have nothing to do.
+#
+# Developers without nix: add what you need once —
+#   rustup component add clippy rustfmt rust-src llvm-tools-preview
+#   rustup target add wasm32-unknown-unknown
 [toolchain]
 channel = "1.97.0"
-components = [
-  "cargo",
-  "clippy",
-  "rust-src",
-  "rustc",
-  "rustfmt",
-  "llvm-tools-preview",
-]
-targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## What

Trims `rust-toolchain.toml` to **channel only**, removing the `components`/`targets` lists.

## Why (#1754's blocking failure, twice)

With components listed, rustup implicitly syncs them on the **first cargo invocation of every CI job** — a transactional install that intermittently fails on hosted runners: `failed to install component: 'clippy-preview…', detected conflict: 'bin/cargo-clippy'`, then `rolling back changes`. #1754 hit it on two consecutive runs while byte-identical syncs succeeded on main minutes earlier (same runner-image version, same toolchain point release) — a per-runner dice roll, and re-rolling per run isn't acceptable CI.

Every CI job already declares what it needs via the dtolnay action's `components:`/`targets:` inputs (verified: clippy job passes `clippy`, fmt passes `rustfmt`, wasm/downstream jobs pass their targets, quality/release pass `llvm-tools-preview`) — nothing relies on the file's sync. Channel-only, the sync has nothing to install and the failure class is structurally dead.

Non-nix developer setup is documented in the file (`rustup component add …` once).

## Sequencing

Merge before #1754/#1755 re-run; their branches pick this up via update-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)