### PR TITLE
fix(release): path-only dev-deps in rustledger-wasm so publish never needs them

### DIFF
--- a/crates/rustledger-wasm/Cargo.toml
+++ b/crates/rustledger-wasm/Cargo.toml
@@ -95,9 +95,15 @@ schemars = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # Cross-mirror wire-parity test (tests/cost_number_wire_parity.rs) —
 # native-only, compares this crate's CostNumberJson against the other
-# CostNumber wire mirrors.
-rustledger-plugin-types.workspace = true
-rustledger-ffi-wasi.workspace = true
+# CostNumber wire mirrors. Path-ONLY (not `workspace = true`): the
+# workspace dep carries a `version = "X.Y.Z"` requirement, which cargo
+# bakes into the published package's dev-deps — making `cargo publish`
+# of THIS crate fail whenever the sibling isn't on crates.io yet at that
+# exact version (broke the v0.21.0 publish: wasm was ordered before
+# ffi-wasi). Path-only dev-deps are stripped at publish, which is
+# exactly right for test-only siblings.
+rustledger-plugin-types = { path = "../rustledger-plugin-types" }
+rustledger-ffi-wasi = { path = "../rustledger-ffi-wasi" }
 serde_json.workspace = true
 
 # `getrandom` 0.3 (pulled in transitively via `imbl` → `rand_xoshiro`


### PR DESCRIPTION
The #1740 parity-test dev-deps used `workspace = true`, which carries the workspace's `version = "X.Y.Z"` requirement into the published package's dev-dependencies — so `cargo publish -p rustledger-wasm` fails whenever the sibling isn't on crates.io at that exact version yet. This broke the v0.21.0 crates.io publish (the script orders wasm before ffi-wasi; recovered by rerun once ffi-wasi@0.21.0 indexed).

Path-only dev-deps are **stripped at publish** — exactly right for test-only sibling deps. Verified: the parity test still runs (2 passed) and `cargo publish --dry-run` packages cleanly with no registry requirement.

Alternative considered: reordering the publish script — rejected, since any future test-only sibling edge would re-create the trap; version-free dev-deps kill the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)