### PR TITLE
fix: pick price rates by date across both pair directions

### DIFF
--- a/crates/rustledger-query/src/price.rs
+++ b/crates/rustledger-query/src/price.rs
@@ -35,13 +35,48 @@ pub struct PriceEntry {
 
 /// Database of currency prices.
 ///
-/// Stores prices as a map from base currency to a list of (date, price, quote currency).
-/// Prices are kept sorted by date for efficient lookup.
+/// Two structures with distinct jobs, mirroring Python beancount's
+/// split between Price *directives* and the *price map* built from
+/// them:
+///
+/// - `prices` — the raw provenance store: every entry as declared (or
+///   extracted from a transaction), with its `explicit` flag. Feeds
+///   the `#prices` BQL table, `len()`, and the two-pass dedup gating
+///   (#1006). Never mirrored or deduplicated.
+/// - `lookup` — the conversion index every price lookup reads, built
+///   from the raw entries by a faithful port of beancount's
+///   `build_price_map` merge (see `rebuild_lookup`). Both
+///   directions of every pair are materialized, so lookups pick the
+///   most recent rate *regardless of which direction it was written
+///   in* (issue #1759 — an older direct rate must not shadow a newer
+///   inverse one).
 #[derive(Debug, Default)]
 pub struct PriceDatabase {
     /// Prices indexed by base currency.
     /// Each base currency maps to a list of price entries sorted by date.
     prices: HashMap<rustledger_core::Currency, Vec<PriceEntry>>,
+    /// Every raw entry in insertion (ledger) order. The lookup-index
+    /// build consumes this instead of `prices`: beancount's merge
+    /// tie-breaks depend on Python dict insertion order, which a hash
+    /// map cannot preserve.
+    raw_seq: Vec<RawPrice>,
+    /// The conversion index: base → quote → date-sorted rates, one
+    /// rate per date, both directions of every pair present. Rebuilt
+    /// by [`Self::sort_prices`].
+    lookup: HashMap<
+        rustledger_core::Currency,
+        HashMap<rustledger_core::Currency, Vec<(NaiveDate, Decimal)>>,
+    >,
+}
+
+/// One raw price observation in ledger order — input to the
+/// conversion-index build.
+#[derive(Debug, Clone)]
+struct RawPrice {
+    base: rustledger_core::Currency,
+    quote: rustledger_core::Currency,
+    date: NaiveDate,
+    rate: Decimal,
 }
 
 impl PriceDatabase {
@@ -49,6 +84,8 @@ impl PriceDatabase {
     pub fn new() -> Self {
         Self {
             prices: HashMap::default(),
+            raw_seq: Vec::new(),
+            lookup: HashMap::default(),
         }
     }
 
@@ -121,12 +158,116 @@ impl PriceDatabase {
         db
     }
 
-    /// Sort all price entries by date.
+    /// Sort all price entries by date and rebuild the conversion
+    /// index.
     ///
     /// Call this after adding prices to ensure lookups work correctly.
     pub fn sort_prices(&mut self) {
         for entries in self.prices.values_mut() {
             entries.sort_by_key(|e| e.date);
+        }
+        self.rebuild_lookup();
+    }
+
+    /// Rebuild the conversion index from the raw entries.
+    ///
+    /// A faithful port of Python beancount's `build_price_map` merge
+    /// (`beancount/core/prices.py`), whose observable semantics are
+    /// emergent from the build order and cannot be reproduced by
+    /// per-lookup rules (issue #1759):
+    ///
+    /// 1. Group raw entries per `(base, quote)` pair, preserving
+    ///    first-seen pair order and per-pair entry order (Python
+    ///    dicts are insertion-ordered; the tie-breaks below depend
+    ///    on it).
+    /// 2. When both directions of a pair exist, invert the one with
+    ///    fewer rates and merge it into the other ("swallow"). Zero
+    ///    rates are dropped on inversion (zero-cost postings, e.g.
+    ///    gifted options). On equal counts Python removes
+    ///    `(quote, base)`, keeping whichever direction is reached
+    ///    first in insertion order.
+    /// 3. Sort each pair's list by date (stable, so same-date order
+    ///    stays originals-then-inverted) and collapse to one rate per
+    ///    date keeping the LAST — Python's
+    ///    `sorted_uniquify(..., last=True)`.
+    /// 4. Materialize the inverse of every surviving pair, so the
+    ///    index is direction-blind at lookup time.
+    fn rebuild_lookup(&mut self) {
+        type Pair = (rustledger_core::Currency, rustledger_core::Currency);
+
+        // Step 1: group per pair in insertion order.
+        let mut order: Vec<Pair> = Vec::new();
+        let mut index: HashMap<Pair, usize> = HashMap::default();
+        let mut lists: Vec<Option<Vec<(NaiveDate, Decimal)>>> = Vec::new();
+        for raw in &self.raw_seq {
+            let key = (raw.base.clone(), raw.quote.clone());
+            let i = *index.entry(key.clone()).or_insert_with(|| {
+                order.push(key);
+                lists.push(Some(Vec::new()));
+                lists.len() - 1
+            });
+            if let Some(list) = &mut lists[i] {
+                list.push((raw.date, raw.rate));
+            }
+        }
+
+        // Step 2: swallow the direction with fewer rates.
+        for i in 0..order.len() {
+            let inv_key = (order[i].1.clone(), order[i].0.clone());
+            let Some(&j) = index.get(&inv_key) else {
+                continue;
+            };
+            if lists[i].is_none() || lists[j].is_none() {
+                // Already swallowed when its inverse was visited —
+                // matches Python's second visit being a no-op.
+                continue;
+            }
+            let len_i = lists[i].as_ref().map_or(0, Vec::len);
+            let len_j = lists[j].as_ref().map_or(0, Vec::len);
+            let (keep, remove) = if len_i < len_j { (j, i) } else { (i, j) };
+            let removed = lists[remove].take().unwrap_or_default();
+            if let Some(target) = lists[keep].as_mut() {
+                target.extend(
+                    removed
+                        .iter()
+                        .filter(|(_, rate)| !rate.is_zero())
+                        .map(|&(d, rate)| (d, Decimal::ONE / rate)),
+                );
+            }
+        }
+
+        // Step 3: stable date sort + one rate per date (last wins).
+        let mut merged: Vec<(Pair, Vec<(NaiveDate, Decimal)>)> = Vec::new();
+        for (i, key) in order.into_iter().enumerate() {
+            let Some(mut list) = lists[i].take() else {
+                continue;
+            };
+            list.sort_by_key(|entry| entry.0);
+            let mut deduped: Vec<(NaiveDate, Decimal)> = Vec::with_capacity(list.len());
+            for (d, rate) in list {
+                match deduped.last_mut() {
+                    Some(last) if last.0 == d => last.1 = rate,
+                    _ => deduped.push((d, rate)),
+                }
+            }
+            merged.push((key, deduped));
+        }
+
+        // Step 4: materialize all inverses. After step 2 at most one
+        // direction per pair survives, so these inserts cannot
+        // collide with a surviving forward list.
+        self.lookup = HashMap::default();
+        for ((base, quote), list) in merged {
+            let inverted: Vec<(NaiveDate, Decimal)> = list
+                .iter()
+                .filter(|(_, rate)| !rate.is_zero())
+                .map(|&(d, rate)| (d, Decimal::ONE / rate))
+                .collect();
+            self.lookup
+                .entry(quote.clone())
+                .or_default()
+                .insert(base.clone(), inverted);
+            self.lookup.entry(base).or_default().insert(quote, list);
         }
     }
 
@@ -142,6 +283,12 @@ impl PriceDatabase {
             explicit: true,
         };
 
+        self.raw_seq.push(RawPrice {
+            base: price.currency.clone(),
+            quote: price.amount.currency.clone(),
+            date: price.date,
+            rate: price.amount.number,
+        });
         self.prices
             .entry(price.currency.clone())
             .or_default()
@@ -256,6 +403,12 @@ impl PriceDatabase {
             explicit: false,
         };
 
+        self.raw_seq.push(RawPrice {
+            base: base_currency.clone(),
+            quote: quote_currency.clone(),
+            date,
+            rate: price,
+        });
         self.prices
             .entry(base_currency.clone())
             .or_default()
@@ -264,191 +417,105 @@ impl PriceDatabase {
 
     /// Get the price of a currency on or before a given date.
     ///
-    /// Returns the most recent price for the base currency in terms of the quote currency.
-    /// Tries direct lookup, inverse lookup, and chained lookup (A→B→C).
+    /// Returns the most recent rate for the pair from the conversion
+    /// index — which holds both directions of every pair, so a rate
+    /// declared as `quote → base` is found (inverted) exactly like a
+    /// direct one, with date recency deciding between them (#1759).
+    /// Falls back to a chained lookup (A→B→C) when the pair has no
+    /// rates at all.
     pub fn get_price(&self, base: &str, quote: &str, date: NaiveDate) -> Option<Decimal> {
         // Same currency = price of 1
         if base == quote {
             return Some(Decimal::ONE);
         }
 
-        // Try direct price lookup
-        if let Some(price) = self.get_direct_price(base, quote, date) {
-            return Some(price);
-        }
-
-        // Try inverse price lookup
-        if let Some(price) = self.get_direct_price(quote, base, date)
-            && price != Decimal::ZERO
-        {
-            return Some(Decimal::ONE / price);
+        if let Some(rate) = self.lookup_rate_at(base, quote, date) {
+            return Some(rate);
         }
 
         // Try chained lookup (A→B→C where B is an intermediate currency)
         self.get_chained_price(base, quote, date)
     }
 
-    /// Get direct price (base currency priced in quote currency).
-    fn get_direct_price(&self, base: &str, quote: &str, date: NaiveDate) -> Option<Decimal> {
-        if let Some(entries) = self.prices.get(base) {
-            for entry in entries.iter().rev() {
-                if entry.date <= date && entry.currency == quote {
-                    return Some(entry.price);
-                }
-            }
-        }
-        None
+    /// Most recent rate for the pair on or before `date`, from the
+    /// conversion index.
+    fn lookup_rate_at(&self, base: &str, quote: &str, date: NaiveDate) -> Option<Decimal> {
+        let list = self.lookup.get(base)?.get(quote)?;
+        let idx = list.partition_point(|entry| entry.0 <= date);
+        (idx > 0).then(|| list[idx - 1].1)
+    }
+
+    /// Latest rate for the pair, from the conversion index.
+    fn lookup_rate_latest(&self, base: &str, quote: &str) -> Option<Decimal> {
+        self.lookup
+            .get(base)?
+            .get(quote)?
+            .last()
+            .map(|entry| entry.1)
     }
 
     /// Try to find a price through an intermediate currency.
     /// For A→C, try to find A→B and B→C for some intermediate B.
+    ///
+    /// This is a rustledger extension — beancount's price map has no
+    /// transitive lookups. One hop only; both legs read the
+    /// bidirectional index, so no per-leg inverse handling is needed.
+    /// Intermediates are tried in sorted order so the result is
+    /// deterministic when several paths exist.
     fn get_chained_price(&self, base: &str, quote: &str, date: NaiveDate) -> Option<Decimal> {
-        // Collect all currencies that have prices from 'base'
-        let intermediates: Vec<rustledger_core::Currency> =
-            if let Some(entries) = self.prices.get(base) {
-                entries
-                    .iter()
-                    .filter(|e| e.date <= date)
-                    .map(|e| e.currency.clone())
-                    .collect()
-            } else {
-                Vec::new()
-            };
+        let inner = self.lookup.get(base)?;
+        let mut intermediates: Vec<&rustledger_core::Currency> = inner.keys().collect();
+        intermediates.sort_unstable_by_key(|c| c.as_str());
 
-        // Try each intermediate currency
         for intermediate in intermediates {
-            if intermediate == quote {
+            if intermediate.as_str() == quote {
                 continue; // Already tried direct
             }
-
-            // Get price base→intermediate
-            if let Some(price1) = self.get_direct_price(base, &intermediate, date) {
-                // Get price intermediate→quote (try direct, inverse, but not chained to avoid loops)
-                if let Some(price2) = self.get_direct_price(&intermediate, quote, date) {
-                    return Some(price1 * price2);
-                }
-                // Try inverse for second leg
-                if let Some(price2) = self.get_direct_price(quote, &intermediate, date)
-                    && price2 != Decimal::ZERO
-                {
-                    return Some(price1 / price2);
-                }
+            let Some(rate1) = self.lookup_rate_at(base, intermediate.as_str(), date) else {
+                continue;
+            };
+            if let Some(rate2) = self.lookup_rate_at(intermediate.as_str(), quote, date) {
+                return Some(rate1 * rate2);
             }
         }
-
-        // Also try currencies that price TO base (inverse first leg)
-        for (currency, entries) in &self.prices {
-            for entry in entries.iter().rev() {
-                if entry.date <= date && entry.currency == base && entry.price != Decimal::ZERO {
-                    // We have currency→base, so base→currency = 1/price
-                    let price1 = Decimal::ONE / entry.price;
-
-                    // Now try currency→quote
-                    if let Some(price2) = self.get_direct_price(currency, quote, date) {
-                        return Some(price1 * price2);
-                    }
-                    if let Some(price2) = self.get_direct_price(quote, currency, date)
-                        && price2 != Decimal::ZERO
-                    {
-                        return Some(price1 / price2);
-                    }
-                }
-            }
-        }
-
         None
     }
 
     /// Get the latest price of a currency (most recent date).
     ///
-    /// Supports direct lookup, inverse lookup, and chained lookup (A→B→C).
+    /// Same direction-blind semantics as [`Self::get_price`], using
+    /// each pair's most recent rate.
     pub fn get_latest_price(&self, base: &str, quote: &str) -> Option<Decimal> {
         // Same currency = price of 1
         if base == quote {
             return Some(Decimal::ONE);
         }
 
-        // Try direct price lookup
-        if let Some(price) = self.get_direct_latest_price(base, quote) {
-            return Some(price);
-        }
-
-        // Try inverse price lookup
-        if let Some(price) = self.get_direct_latest_price(quote, base)
-            && price != Decimal::ZERO
-        {
-            return Some(Decimal::ONE / price);
+        if let Some(rate) = self.lookup_rate_latest(base, quote) {
+            return Some(rate);
         }
 
         // Try chained lookup (A→B→C where B is an intermediate currency)
         self.get_chained_latest_price(base, quote)
     }
 
-    /// Get direct latest price (base currency priced in quote currency).
-    fn get_direct_latest_price(&self, base: &str, quote: &str) -> Option<Decimal> {
-        if let Some(entries) = self.prices.get(base) {
-            // Find the most recent price in the target currency
-            for entry in entries.iter().rev() {
-                if entry.currency == quote {
-                    return Some(entry.price);
-                }
-            }
-        }
-        None
-    }
-
-    /// Try to find the latest price through an intermediate currency.
-    /// For A→C, try to find A→B and B→C for some intermediate B.
+    /// Latest-rate variant of [`Self::get_chained_price`].
     fn get_chained_latest_price(&self, base: &str, quote: &str) -> Option<Decimal> {
-        // Collect all currencies that have prices from 'base'
-        let intermediates: Vec<rustledger_core::Currency> =
-            if let Some(entries) = self.prices.get(base) {
-                entries.iter().map(|e| e.currency.clone()).collect()
-            } else {
-                Vec::new()
-            };
+        let inner = self.lookup.get(base)?;
+        let mut intermediates: Vec<&rustledger_core::Currency> = inner.keys().collect();
+        intermediates.sort_unstable_by_key(|c| c.as_str());
 
-        // Try each intermediate currency
         for intermediate in intermediates {
-            if intermediate == quote {
+            if intermediate.as_str() == quote {
                 continue; // Already tried direct
             }
-
-            // Get price base→intermediate
-            if let Some(price1) = self.get_direct_latest_price(base, &intermediate) {
-                // Get price intermediate→quote (try direct, inverse, but not chained to avoid loops)
-                if let Some(price2) = self.get_direct_latest_price(&intermediate, quote) {
-                    return Some(price1 * price2);
-                }
-                // Try inverse for second leg
-                if let Some(price2) = self.get_direct_latest_price(quote, &intermediate)
-                    && price2 != Decimal::ZERO
-                {
-                    return Some(price1 / price2);
-                }
+            let Some(rate1) = self.lookup_rate_latest(base, intermediate.as_str()) else {
+                continue;
+            };
+            if let Some(rate2) = self.lookup_rate_latest(intermediate.as_str(), quote) {
+                return Some(rate1 * rate2);
             }
         }
-
-        // Also try currencies that price TO base (inverse first leg)
-        for (currency, entries) in &self.prices {
-            for entry in entries.iter().rev() {
-                if entry.currency == base && entry.price != Decimal::ZERO {
-                    // We have currency→base, so base→currency = 1/price
-                    let price1 = Decimal::ONE / entry.price;
-
-                    // Now try currency→quote
-                    if let Some(price2) = self.get_direct_latest_price(currency, quote) {
-                        return Some(price1 * price2);
-                    }
-                    if let Some(price2) = self.get_direct_latest_price(quote, currency)
-                        && price2 != Decimal::ZERO
-                    {
-                        return Some(price1 / price2);
-                    }
-                }
-            }
-        }
-
         None
     }
 
@@ -544,9 +611,7 @@ mod tests {
         });
 
         // Sort after adding
-        for entries in db.prices.values_mut() {
-            entries.sort_by_key(|e| e.date);
-        }
+        db.sort_prices();
 
         // Lookup on exact date
         assert_eq!(
@@ -583,9 +648,7 @@ mod tests {
         });
 
         // Sort
-        for entries in db.prices.values_mut() {
-            entries.sort_by_key(|e| e.date);
-        }
+        db.sort_prices();
 
         // Can lookup USD->EUR
         assert_eq!(
@@ -610,9 +673,7 @@ mod tests {
             meta: Default::default(),
         });
 
-        for entries in db.prices.values_mut() {
-            entries.sort_by_key(|e| e.date);
-        }
+        db.sort_prices();
 
         let shares = Amount::new(dec!(10), "AAPL");
         let usd = db.convert(&shares, "USD", date(2024, 1, 1)).unwrap();
@@ -676,9 +737,7 @@ mod tests {
         });
 
         // Sort
-        for entries in db.prices.values_mut() {
-            entries.sort_by_key(|e| e.date);
-        }
+        db.sort_prices();
 
         // Direct lookup AAPL -> USD works
         assert_eq!(
@@ -719,9 +778,7 @@ mod tests {
         });
 
         // Sort
-        for entries in db.prices.values_mut() {
-            entries.sort_by_key(|e| e.date);
-        }
+        db.sort_prices();
 
         // BTC -> EUR should work via BTC -> USD -> EUR
         // BTC -> USD = 40000
@@ -753,9 +810,7 @@ mod tests {
         });
 
         // Sort
-        for entries in db.prices.values_mut() {
-            entries.sort_by_key(|e| e.date);
-        }
+        db.sort_prices();
 
         // No path from AAPL to GBP
         assert_eq!(db.get_price("AAPL", "GBP", date(2024, 1, 1)), None);
@@ -1116,6 +1171,198 @@ mod tests {
         assert_eq!(
             db.get_price("BAM", "EUR", date(2017, 12, 15)),
             Some(dec!(0.5113))
+        );
+    }
+
+    // ============================================================================
+    // Issue #1759 regressions — direction-blind date recency
+    // ============================================================================
+    //
+    // Beancount's `build_price_map` materializes both directions of
+    // every pair, so a lookup picks the most recent rate regardless
+    // of which direction it was declared in. Pre-fix, rustledger
+    // returned any direct entry before consulting the inverse
+    // direction, so an OLDER direct rate shadowed a NEWER inverse
+    // one.
+
+    fn price(date_: NaiveDate, base: &str, number: Decimal, quote: &str) -> PriceDirective {
+        PriceDirective {
+            date: date_,
+            currency: base.into(),
+            amount: Amount::new(number, quote),
+            meta: Default::default(),
+        }
+    }
+
+    /// The core #1759 shape: USD→GBP declared on the 12th, GBP→USD
+    /// declared on the 13th. The newer inverse must win for USD→GBP.
+    #[test]
+    fn test_newer_inverse_beats_older_direct() {
+        let mut db = PriceDatabase::new();
+        db.add_price(&price(date(2026, 7, 12), "USD", dec!(0.7472), "GBP"));
+        db.add_price(&price(date(2026, 7, 13), "GBP", dec!(1.2655), "USD"));
+        db.sort_prices();
+
+        // Latest USD→GBP is the 13th's inverted GBP→USD rate.
+        assert_eq!(
+            db.get_latest_price("USD", "GBP"),
+            Some(Decimal::ONE / dec!(1.2655))
+        );
+        assert_eq!(
+            db.get_price("USD", "GBP", date(2026, 7, 13)),
+            Some(Decimal::ONE / dec!(1.2655))
+        );
+        // On the 12th the direct rate is still the most recent.
+        assert_eq!(
+            db.get_price("USD", "GBP", date(2026, 7, 12)),
+            Some(dec!(0.7472))
+        );
+        // And the other direction mirrors it.
+        assert_eq!(db.get_latest_price("GBP", "USD"), Some(dec!(1.2655)));
+        assert_eq!(
+            db.get_price("GBP", "USD", date(2026, 7, 12)),
+            Some(Decimal::ONE / dec!(0.7472))
+        );
+    }
+
+    /// Symmetric sanity: when the DIRECT rate is newer it still wins.
+    #[test]
+    fn test_newer_direct_beats_older_inverse() {
+        let mut db = PriceDatabase::new();
+        db.add_price(&price(date(2026, 7, 12), "GBP", dec!(1.2655), "USD"));
+        db.add_price(&price(date(2026, 7, 13), "USD", dec!(0.7472), "GBP"));
+        db.sort_prices();
+
+        assert_eq!(db.get_latest_price("USD", "GBP"), Some(dec!(0.7472)));
+    }
+
+    /// The swallow rule: the direction with fewer rates is inverted
+    /// into the one with more, and date recency is decided on the
+    /// merged list.
+    #[test]
+    fn test_swallow_smaller_direction_into_larger() {
+        let mut db = PriceDatabase::new();
+        db.add_price(&price(date(2026, 7, 10), "USD", dec!(0.75), "GBP"));
+        db.add_price(&price(date(2026, 7, 12), "USD", dec!(0.7472), "GBP"));
+        db.add_price(&price(date(2026, 7, 13), "GBP", dec!(1.2655), "USD"));
+        db.sort_prices();
+
+        // Merged USD→GBP list: 10th direct, 12th direct, 13th inverted.
+        assert_eq!(
+            db.get_price("USD", "GBP", date(2026, 7, 11)),
+            Some(dec!(0.75))
+        );
+        assert_eq!(
+            db.get_price("USD", "GBP", date(2026, 7, 12)),
+            Some(dec!(0.7472))
+        );
+        assert_eq!(
+            db.get_latest_price("USD", "GBP"),
+            Some(Decimal::ONE / dec!(1.2655))
+        );
+    }
+
+    /// Same-date tie between a direct and an inverse rate: Python's
+    /// `sorted_uniquify(..., last=True)` keeps ONE rate per date, and
+    /// with equal counts the first-seen direction survives the
+    /// swallow, so its list is [direct, appended-inverted] and the
+    /// inverted rate wins the stable sort's last position.
+    #[test]
+    fn test_same_date_direct_and_inverse_last_wins() {
+        let mut db = PriceDatabase::new();
+        db.add_price(&price(date(2026, 7, 12), "USD", dec!(0.75), "GBP"));
+        db.add_price(&price(date(2026, 7, 12), "GBP", dec!(1.25), "USD"));
+        db.sort_prices();
+
+        // 1/1.25 = 0.8 — the inverted entry replaces the direct one.
+        assert_eq!(
+            db.get_price("USD", "GBP", date(2026, 7, 12)),
+            Some(dec!(0.8))
+        );
+        assert_eq!(db.get_latest_price("GBP", "USD"), Some(dec!(1.25)));
+    }
+
+    /// Zero rates (zero-cost postings, e.g. gifted options) stay in
+    /// their declared direction but are never inverted — no division
+    /// by zero, and the reverse direction simply has no rate.
+    #[test]
+    fn test_zero_rate_not_inverted() {
+        let mut db = PriceDatabase::new();
+        db.add_price(&price(date(2026, 7, 12), "OPT", Decimal::ZERO, "USD"));
+        db.sort_prices();
+
+        assert_eq!(
+            db.get_price("OPT", "USD", date(2026, 7, 12)),
+            Some(Decimal::ZERO)
+        );
+        assert_eq!(db.get_price("USD", "OPT", date(2026, 7, 12)), None);
+    }
+
+    /// End-to-end #1759 shape via `from_directives`: implicit prices
+    /// from transaction postings in BOTH directions, newest declared
+    /// as the inverse (`-18.68 GBP @ 1.2655 USD`), exactly like the
+    /// issue's Format C / Format D pair.
+    #[test]
+    fn test_implicit_inverse_price_wins_by_date() {
+        use rustledger_core::{Posting, PriceAnnotation, Transaction};
+
+        let directives = vec![
+            // Format C: 12.70 USD @@ 9.49 GBP → USD→GBP on the 12th.
+            Directive::Transaction(
+                Transaction::new(date(2026, 7, 12), "Format C")
+                    .with_synthesized_posting(Posting::new(
+                        "Assets:Checking",
+                        Amount::new(dec!(-9.49), "GBP"),
+                    ))
+                    .with_synthesized_posting(
+                        Posting::new("Expenses:Test", Amount::new(dec!(12.70), "USD"))
+                            .with_price(PriceAnnotation::total(Amount::new(dec!(9.49), "GBP"))),
+                    ),
+            ),
+            // Format D: -18.68 GBP @ 1.2655 USD → GBP→USD on the 13th.
+            Directive::Transaction(
+                Transaction::new(date(2026, 7, 13), "Format D")
+                    .with_synthesized_posting(
+                        Posting::new("Assets:Checking", Amount::new(dec!(-18.68), "GBP"))
+                            .with_price(PriceAnnotation::unit(Amount::new(dec!(1.2655), "USD"))),
+                    )
+                    .with_synthesized_posting(Posting::new(
+                        "Expenses:Test",
+                        Amount::new(dec!(23.64), "USD"),
+                    )),
+            ),
+        ];
+        let db = PriceDatabase::from_directives(&directives);
+
+        // Beancount converts 100 USD to 79.02 GBP using the 13th's
+        // inverted rate, not 74.72 GBP from the 12th's direct one.
+        let converted = db
+            .convert_latest(&Amount::new(dec!(100.00), "USD"), "GBP")
+            .expect("USD→GBP rate available");
+        assert_eq!(converted.number.round_dp(2), dec!(79.02));
+
+        // The raw provenance store is untouched by the index build:
+        // both extracted entries remain, in their declared directions.
+        assert_eq!(db.len(), 2);
+    }
+
+    /// Chained lookups go through the bidirectional index too: an
+    /// inverse-declared leg participates in an A→B→C path with the
+    /// same date-recency rule per leg.
+    #[test]
+    fn test_chained_lookup_uses_newest_rate_per_leg() {
+        let mut db = PriceDatabase::new();
+        // AAPL→USD.
+        db.add_price(&price(date(2026, 7, 10), "AAPL", dec!(150.00), "USD"));
+        // USD→EUR twice: old direct, newer inverse.
+        db.add_price(&price(date(2026, 7, 11), "USD", dec!(0.92), "EUR"));
+        db.add_price(&price(date(2026, 7, 12), "EUR", dec!(1.10), "USD"));
+        db.sort_prices();
+
+        // AAPL→EUR = 150 × (1/1.10), not 150 × 0.92.
+        assert_eq!(
+            db.get_latest_price("AAPL", "EUR"),
+            Some(dec!(150.00) * (Decimal::ONE / dec!(1.10)))
         );
     }
 }

--- a/crates/rustledger-query/tests/tla_behavior_replay.rs
+++ b/crates/rustledger-query/tests/tla_behavior_replay.rs
@@ -8,10 +8,13 @@
 //! Mapping: each model `SetPrice(base, quote, price)` becomes an
 //! `add_price` of a price directive at a strictly-later date, so the model's
 //! overwrite semantics ("the price is the last one set") corresponds to
-//! `get_latest_price`. Conformance is checked on every entry the MODEL has
-//! set: `get_latest_price(base, quote) == prices[base][quote]`. Entries the
-//! model has NOT set (0) are not asserted — the implementation legitimately
-//! derives inverse rates the model doesn't track.
+//! `get_latest_price`. The model clears the opposite direction on every set
+//! (direction supersession, #1759 — a pair has ONE rate timeline, like
+//! beancount's `build_price_map`), so conformance is checked both ways on
+//! every entry the model holds: `get_latest_price(base, quote) ==
+//! prices[base][quote]` AND `get_latest_price(quote, base)` is its
+//! reciprocal (the implementation derives inverses; the model stores 0
+//! there, which is why zero entries are never asserted as absent).
 
 use rust_decimal::Decimal;
 use rustledger_core::{Amount, NaiveDate, Price as PriceDirective, naive_date};
@@ -68,8 +71,18 @@ fn replay_every_price_db_behavior() {
                 amount: Amount::new(Decimal::from(price), quote),
                 meta: Default::default(),
             });
+            // Finalize before reading — lookups go through the
+            // conversion index, built by `sort_prices`.
+            db.sort_prices();
 
-            // Every model-set entry must read back as the latest price.
+            // Every model-held entry must read back as the latest
+            // price, and its derived inverse as the reciprocal.
+            // Compared at 20 decimal places: the build may invert a
+            // swallowed rate twice (1/(1/r)), leaving a residue in
+            // the 28th significant digit — Python beancount's
+            // build_price_map performs the same double inversion
+            // with its own last-digit artifacts, so exactness at
+            // full precision is not part of the modeled contract.
             for entry in state["prices"].as_array().expect("prices") {
                 let (b, q, p) = (
                     entry[0].as_str().expect("base"),
@@ -77,9 +90,14 @@ fn replay_every_price_db_behavior() {
                     entry[2].as_i64().expect("price"),
                 );
                 assert_eq!(
-                    db.get_latest_price(b, q),
-                    Some(Decimal::from(p)),
+                    db.get_latest_price(b, q).map(|r| r.round_dp(20)),
+                    Some(Decimal::from(p).round_dp(20)),
                     "PriceDB behavior {bi} step {si}: latest {b}/{q} diverged"
+                );
+                assert_eq!(
+                    db.get_latest_price(q, b).map(|r| r.round_dp(20)),
+                    Some((Decimal::ONE / Decimal::from(p)).round_dp(20)),
+                    "PriceDB behavior {bi} step {si}: inverse {q}/{b} diverged"
                 );
             }
         }

--- a/crates/rustledger-query/tests/tla_proptest.rs
+++ b/crates/rustledger-query/tests/tla_proptest.rs
@@ -91,6 +91,7 @@ proptest! {
         };
 
         db.add_price(&price_directive);
+        db.sort_prices();
 
         // Even after adding a "self-price", get_price should return 1.0
         let result = db.get_price(currency, currency, date);
@@ -124,6 +125,7 @@ proptest! {
             amount: Amount::new(price_val, quote),
             meta: Default::default(),
         });
+        db.sort_prices();
 
         // Direct lookup
         let direct = db.get_price(base, quote, date);
@@ -170,7 +172,9 @@ proptest! {
             meta: Default::default(),
         });
 
-        // Sort (normally done by from_directives)
+        // Finalize (normally done by from_directives)
+        db.sort_prices();
+
         // Chained lookup: AAPL -> EUR = AAPL -> USD * USD -> EUR = 150 * 0.92 = 138
         let chained = db.get_price("AAPL", "EUR", date);
 

--- a/scripts/tla-behaviors.py
+++ b/scripts/tla-behaviors.py
@@ -374,7 +374,10 @@ def _derive_account_state_machine(src: dict, dst: dict) -> list:
 
 
 def _derive_price_db(src: dict, dst: dict) -> list:
-    """Price database: the single changed [base][quote] entry."""
+    """Price database: SetPrice(base, quote, price) writes [base][quote]
+    AND clears [quote][base] (direction supersession, #1759), so a delta
+    may touch two entries. The action is the changed entry whose new
+    value is NONZERO; the zero-change is its implied inverse clear."""
     nonzero = sorted(
         [b, q, dst["prices"][b][q]]
         for b in dst["prices"]
@@ -384,10 +387,11 @@ def _derive_price_db(src: dict, dst: dict) -> list:
     state = {"prices": nonzero}
     for b in sorted(dst["prices"]):
         for q in sorted(dst["prices"][b]):
-            if dst["prices"][b][q] != src["prices"][b][q]:
+            if dst["prices"][b][q] != src["prices"][b][q] and dst["prices"][b][q] != 0:
                 return ["SetPrice", {"base": b, "quote": q, "price": dst["prices"][b][q]}, state]
     # Same-value overwrite: SetPrice re-setting an existing entry leaves
-    # `prices` unchanged (only opCount moves). Any nonzero entry replays
+    # `prices` unchanged (only opCount moves; the inverse was already
+    # cleared by the earlier set). Any nonzero entry replays
     # identically; pick the smallest for determinism.
     if nonzero:
         b, q, price = nonzero[0]

--- a/spec/tla/PriceDB.cfg
+++ b/spec/tla/PriceDB.cfg
@@ -8,3 +8,4 @@ NEXT Next
 INVARIANTS
     SelfPricesNeverSet
     TypeOK
+    OneDirectionPerPair

--- a/spec/tla/PriceDB.tla
+++ b/spec/tla/PriceDB.tla
@@ -4,6 +4,14 @@
  *
  * Simple model of price database for currency conversion.
  * Verifies identity price property: price of X in X is always 1.
+ *
+ * Direction supersession (#1759): the two directions of a currency
+ * pair share ONE rate timeline, exactly like Python beancount's
+ * build_price_map (which materializes both directions of every price
+ * and picks by date recency). Setting base->quote therefore CLEARS
+ * quote->base: the newer write is authoritative for the pair, and
+ * the implementation derives the opposite direction as the
+ * reciprocal.
  *)
 
 EXTENDS Integers, FiniteSets
@@ -30,14 +38,17 @@ Init ==
 -----------------------------------------------------------------------------
 (* Actions *)
 
-(* Set a price between two currencies *)
+(* Set a price between two currencies. The pair has one timeline:
+   the newer write supersedes the opposite direction (#1759), so the
+   inverse entry is cleared — the implementation derives it as the
+   reciprocal of this rate. *)
 SetPrice(base, quote, price) ==
     /\ base # quote
     /\ base \in Currencies
     /\ quote \in Currencies
     /\ price \in 1..MaxPrice
     /\ opCount < MaxOps
-    /\ prices' = [prices EXCEPT ![base][quote] = price]
+    /\ prices' = [prices EXCEPT ![base][quote] = price, ![quote][base] = 0]
     /\ opCount' = opCount + 1
 
 Next ==
@@ -55,6 +66,12 @@ SelfPricesNeverSet ==
 TypeOK ==
     /\ \A b, q \in Currencies : prices[b][q] \in 0..MaxPrice
     /\ opCount \in Nat
+
+(* At most one direction of a pair holds a rate: every SetPrice
+   clears its inverse, so both-nonzero states are unreachable. *)
+OneDirectionPerPair ==
+    \A b, q \in Currencies :
+        (b # q /\ prices[b][q] # 0) => prices[q][b] = 0
 
 -----------------------------------------------------------------------------
 Spec == Init /\ [][Next]_vars

--- a/spec/tla/behaviors/PriceDB.json
+++ b/spec/tla/behaviors/PriceDB.json
@@ -9,9 +9,9 @@
   "state"
  ],
  "coverage": {
-  "states": 142,
-  "transitions": 762,
-  "behaviors": 690
+  "states": 61,
+  "transitions": 330,
+  "behaviors": 330
  },
  "behaviors": [
   [
@@ -694,11 +694,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
        "EUR",
        1
@@ -870,11 +865,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -1048,11 +1038,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
        "EUR",
        3
@@ -1895,11 +1880,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -2073,11 +2053,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
        "EUR",
        2
@@ -2249,11 +2224,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -3098,11 +3068,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
        "EUR",
        1
@@ -3274,11 +3239,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -3452,11 +3412,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
        "EUR",
        3
@@ -3766,11 +3721,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -3792,11 +3742,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -3948,11 +3893,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -3974,11 +3914,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -4130,11 +4065,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -4156,11 +4086,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -4312,11 +4237,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -4329,20 +4249,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -4495,11 +4410,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
        "EUR",
        1
@@ -4511,20 +4421,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -4676,11 +4581,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -4688,26 +4588,26 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -4830,9 +4730,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -4840,11 +4740,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -4852,21 +4747,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -5018,11 +4908,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -5035,7 +4920,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -5043,12 +4928,7 @@
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -5200,11 +5080,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -5217,7 +5092,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -5225,11 +5100,6 @@
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
        2
       ]
      ]
@@ -5382,11 +5252,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -5398,21 +5263,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -5564,11 +5424,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -5581,20 +5436,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -5747,10 +5597,22 @@
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
-      ],
+       "EUR",
+       2
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
       [
        "USD",
        "EUR",
@@ -5901,20 +5763,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -5922,17 +5779,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -6083,42 +5935,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
        "EUR",
-       "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -6270,11 +6095,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -6287,7 +6107,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -6295,12 +6115,7 @@
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -6452,11 +6267,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -6468,21 +6278,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       2
       ]
      ]
     }
@@ -6634,11 +6439,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -6650,21 +6450,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -6817,14 +6612,26 @@
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
-      ],
+       "EUR",
+       3
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -6966,22 +6773,20 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -6989,20 +6794,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -7092,7 +6899,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7100,7 +6907,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -7121,9 +6928,7 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -7144,16 +6949,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -7161,20 +6966,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -7247,7 +7054,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7255,7 +7062,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -7264,7 +7071,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7272,13 +7079,11 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -7316,20 +7121,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -7402,7 +7209,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7410,7 +7217,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -7419,7 +7226,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7427,13 +7234,11 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -7467,7 +7272,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -7557,7 +7364,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7565,7 +7372,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -7573,20 +7380,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -7596,7 +7398,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -7604,18 +7406,11 @@
       [
        "EUR",
        "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
+       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -7632,7 +7427,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -7739,7 +7536,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -7747,7 +7544,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -7755,9 +7552,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -7765,11 +7562,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -7787,11 +7579,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -7937,28 +7724,6 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
      "base": "EUR",
      "price": 3,
      "quote": "USD"
@@ -7969,11 +7734,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -8125,37 +7885,10 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -8302,51 +8035,24 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
      "base": "EUR",
      "price": 1,
      "quote": "USD"
@@ -8484,20 +8190,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -8627,58 +8328,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
      "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -8809,37 +8466,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -8848,20 +8483,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -8991,37 +8621,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -9030,19 +8638,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -9173,37 +8776,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -9211,21 +8792,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -9355,37 +8931,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -9394,20 +8948,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -9537,7 +9086,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -9545,7 +9094,7 @@
       [
        "EUR",
        "USD",
-       2
+       3
       ]
      ]
     }
@@ -9560,11 +9109,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
        "EUR",
        2
@@ -9697,7 +9241,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -9705,7 +9249,7 @@
       [
        "EUR",
        "USD",
-       2
+       3
       ]
      ]
     }
@@ -9720,18 +9264,15 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
        "EUR",
        3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -9745,17 +9286,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -9862,7 +9396,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -9870,16 +9404,18 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -9887,7 +9423,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -9895,21 +9431,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -9918,26 +9449,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -10000,7 +9524,24 @@
      "prices": [
       [
        "EUR",
+       "USD",
+       1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -10022,7 +9563,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -10061,7 +9604,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -10069,7 +9612,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -10077,21 +9620,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -10100,26 +9638,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -10148,12 +9679,48 @@
      "prices": [
       [
        "EUR",
+       "USD",
+       1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
        "USD",
+       "EUR",
        1
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
+    },
+    {
+     "prices": [
+      [
+       "EUR",
+       "USD",
+       2
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -10243,7 +9810,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -10251,7 +9818,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -10259,21 +9826,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -10288,25 +9850,18 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
        "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -10314,11 +9869,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -10425,7 +9982,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -10433,7 +9990,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -10442,20 +9999,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -10464,20 +10016,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -10606,16 +10153,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       1
       ]
      ]
     }
@@ -10624,20 +10171,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -10766,39 +10308,39 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -10905,7 +10447,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -10913,7 +10455,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -10921,15 +10463,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -11059,16 +10601,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
+       "EUR",
+       2
       ]
      ]
     }
@@ -11077,7 +10619,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -11085,7 +10627,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -11214,16 +10756,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
+       "EUR",
+       2
       ]
      ]
     }
@@ -11232,7 +10774,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -11240,7 +10782,7 @@
       [
        "EUR",
        "USD",
-       3
+       2
       ]
      ]
     }
@@ -11369,16 +10911,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
+       "EUR",
+       2
       ]
      ]
     }
@@ -11386,9 +10928,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -11396,15 +10938,12 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -11418,30 +10957,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
       ]
      ]
     }
@@ -11544,23 +11059,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -11569,20 +11067,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -11590,17 +11083,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -11726,23 +11214,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -11751,20 +11222,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -11772,21 +11238,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -11908,23 +11369,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -11933,20 +11377,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -11955,20 +11394,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -12082,52 +11516,13 @@
     {
      "base": "EUR",
      "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -12137,20 +11532,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -12279,15 +11669,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -12296,20 +11686,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -12432,23 +11817,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -12457,20 +11825,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -12479,19 +11842,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -12614,23 +11972,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -12639,20 +11980,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -12661,20 +11997,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -12803,15 +12134,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -12821,42 +12152,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -12985,15 +12289,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -13008,37 +12312,10 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
        2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -13160,23 +12437,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -13185,20 +12445,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -13212,11 +12467,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -13342,23 +12592,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
       ]
      ]
     }
@@ -13367,20 +12600,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -13505,12 +12733,14 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -13518,7 +12748,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -13526,21 +12756,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -13558,17 +12783,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -13624,7 +12842,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -13632,7 +12850,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -13653,7 +12871,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -13692,7 +12912,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -13700,7 +12920,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -13708,21 +12928,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -13731,7 +12946,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -13739,18 +12954,11 @@
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -13772,7 +12980,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -13780,7 +12988,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -13789,7 +12997,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -13797,11 +13005,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -13874,7 +13084,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -13882,7 +13092,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -13890,21 +13100,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -13913,7 +13118,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -13921,23 +13126,16 @@
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -13945,11 +13143,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -14056,37 +13256,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
@@ -14100,11 +13278,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -14221,7 +13394,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -14229,7 +13402,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -14237,38 +13410,35 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -14276,27 +13446,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -14369,7 +13532,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -14377,7 +13540,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -14385,20 +13548,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -14420,7 +13585,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -14428,7 +13593,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -14436,27 +13601,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -14512,7 +13670,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -14520,11 +13678,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -14580,7 +13740,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -14588,13 +13748,11 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -14633,7 +13791,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -14641,7 +13799,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -14662,7 +13820,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -14717,20 +13877,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -14747,19 +13902,12 @@
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -14781,7 +13929,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -14789,7 +13937,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -14798,7 +13946,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -14806,11 +13954,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -14882,20 +14032,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -14905,7 +14050,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -14913,23 +14058,16 @@
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -14937,7 +14075,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -14946,7 +14084,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -14954,11 +14092,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -15047,9 +14187,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
@@ -15057,11 +14197,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -15079,34 +14214,29 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -15212,21 +14342,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -15240,11 +14365,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -15361,37 +14481,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -15405,11 +14503,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -15526,7 +14619,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -15534,35 +14627,30 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -15651,55 +14739,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -15717,34 +14766,12 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
@@ -15851,20 +14878,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -15880,12 +14902,7 @@
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -15893,23 +14910,6 @@
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
@@ -16016,20 +15016,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -16047,34 +15042,12 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
@@ -16181,20 +15154,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -16208,11 +15176,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -16328,15 +15291,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -16351,37 +15314,10 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
        2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -16493,15 +15429,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -16511,20 +15447,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -16636,26 +15567,28 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -16663,11 +15596,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -16685,17 +15613,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -16767,16 +15688,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -16797,7 +15718,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -16818,9 +15741,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -16828,11 +15751,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -16841,26 +15759,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -16915,16 +15826,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -16933,7 +15844,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -16941,13 +15852,15 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
-   [
-    "SetPrice",
+   ]
+  ],
+  [
+   [
+    "SetPrice",
     {
      "base": "EUR",
      "price": 1,
@@ -16983,9 +15896,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -16993,11 +15906,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -17006,26 +15914,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -17056,6 +15957,23 @@
        "EUR",
        "USD",
        1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       2
       ]
      ]
     }
@@ -17064,7 +15982,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -17072,11 +15990,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -17148,9 +16068,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -17158,11 +16078,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -17170,9 +16085,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
@@ -17180,34 +16095,46 @@
        "EUR",
        "USD",
        1
-      ],
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -17314,20 +16241,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -17341,11 +16263,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -17461,16 +16378,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -17484,11 +16401,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -17604,16 +16516,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -17725,16 +16637,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       3
       ]
      ]
     }
@@ -17863,16 +16775,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       3
       ]
      ]
     }
@@ -18001,16 +16913,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       3
       ]
      ]
     }
@@ -18132,23 +17044,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
       ]
      ]
     }
@@ -18157,20 +17052,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -18178,17 +17068,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -18297,23 +17182,6 @@
        "EUR",
        "USD",
        1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
       ]
      ]
     }
@@ -18322,20 +17190,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -18343,21 +17206,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 2,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -18469,16 +17327,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       3
       ]
      ]
     }
@@ -18487,48 +17345,38 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -18617,25 +17465,27 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -18643,7 +17493,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -18651,20 +17501,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -18673,27 +17518,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -18744,7 +17582,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -18800,7 +17640,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -18808,7 +17648,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -18816,20 +17656,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -18838,9 +17673,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -18848,17 +17683,10 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -18875,7 +17703,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -18981,9 +17811,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -18991,11 +17821,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -19091,7 +17916,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -19099,7 +17924,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -19108,7 +17933,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -19116,29 +17941,26 @@
       [
        "EUR",
        "USD",
-       2
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -19156,17 +17978,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -19222,7 +18037,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -19230,7 +18045,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -19238,20 +18053,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -19273,7 +18090,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -19281,7 +18098,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -19289,21 +18106,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -19312,26 +18124,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -19353,7 +18158,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -19361,11 +18166,30 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       2
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -19438,7 +18262,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -19446,7 +18270,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -19454,20 +18278,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -19476,21 +18295,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -19586,7 +18400,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -19594,16 +18408,18 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -19611,7 +18427,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -19619,21 +18435,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -19641,27 +18452,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -19700,7 +18504,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -19708,7 +18512,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -19729,7 +18533,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -19768,7 +18574,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -19776,7 +18582,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -19784,21 +18590,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -19806,32 +18607,25 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -19839,7 +18633,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -19848,7 +18642,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -19856,11 +18650,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -19933,7 +18729,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -19941,7 +18737,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -19949,32 +18745,25 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -19982,11 +18771,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -20076,7 +18867,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -20084,7 +18875,7 @@
       [
        "EUR",
        "USD",
-       2
+       3
       ]
      ]
     }
@@ -20093,42 +18884,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
        "EUR",
-       "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -20224,7 +18988,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -20232,7 +18996,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -20240,38 +19004,35 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 2,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -20280,26 +19041,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -20355,7 +19109,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -20363,7 +19117,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -20371,20 +19125,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -20406,7 +19162,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -20414,7 +19170,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -20422,21 +19178,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -20445,26 +19196,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -20486,7 +19230,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -20494,11 +19238,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -20571,7 +19317,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -20579,7 +19325,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -20588,20 +19334,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -20609,20 +19350,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -20718,15 +19454,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -20748,25 +19484,22 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -20774,27 +19507,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -20849,15 +19575,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -20867,7 +19593,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -20875,11 +19601,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -20901,7 +19629,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -20909,35 +19637,11 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
    ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
    [
     "SetPrice",
     {
@@ -20992,15 +19696,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -21009,20 +19713,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -21044,7 +19750,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21052,13 +19758,11 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -21113,15 +19817,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -21130,20 +19834,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -21165,7 +19871,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21173,7 +19879,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -21194,9 +19900,7 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -21234,15 +19938,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -21251,20 +19955,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -21303,7 +20009,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21311,7 +20017,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -21320,7 +20026,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21328,13 +20034,11 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -21355,20 +20059,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -21441,7 +20147,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21449,7 +20155,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -21457,35 +20163,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
        "EUR",
-       "USD",
-       1
+       2
       ]
      ]
     }
@@ -21506,7 +20193,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -21579,7 +20268,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21587,7 +20276,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -21596,20 +20285,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -21618,7 +20302,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -21626,12 +20310,7 @@
       [
        "EUR",
        "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
+       2
       ]
      ]
     }
@@ -21726,16 +20405,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -21756,24 +20435,21 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
@@ -21783,26 +20459,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -21857,16 +20526,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -21874,20 +20543,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -21909,7 +20580,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21917,7 +20588,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -21925,20 +20596,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -21948,7 +20614,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -21956,18 +20622,11 @@
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -21988,16 +20647,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -22005,20 +20664,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -22074,7 +20735,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -22082,7 +20743,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -22090,20 +20751,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -22118,11 +20774,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -22130,26 +20781,26 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -22238,37 +20889,34 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -22277,27 +20925,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -22352,16 +20993,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -22382,7 +21023,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -22404,7 +21047,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -22412,7 +21055,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -22420,27 +21063,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -22478,16 +21114,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -22496,7 +21132,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -22504,11 +21140,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -22547,7 +21185,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -22555,7 +21193,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -22563,21 +21201,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -22595,30 +21228,23 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -22627,7 +21253,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -22635,11 +21261,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -22712,7 +21340,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -22720,7 +21348,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -22729,20 +21357,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -22750,44 +21373,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
@@ -22876,15 +21477,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -22896,36 +21497,9 @@
      "base": "USD",
      "price": 2,
      "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -23024,16 +21598,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -23041,38 +21615,35 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -23080,27 +21651,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -23155,20 +21719,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -23207,7 +21773,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -23215,7 +21781,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -23223,21 +21789,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -23245,21 +21806,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -23338,7 +21894,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -23346,7 +21902,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -23367,12 +21923,14 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -23380,7 +21938,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -23388,27 +21946,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -23447,7 +21998,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -23455,11 +22006,30 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
+    },
+    {
+     "prices": [
+      [
+       "EUR",
+       "USD",
+       2
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -23515,7 +22085,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -23523,7 +22093,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -23531,21 +22101,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
@@ -23554,19 +22119,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        3
       ]
      ]
@@ -23646,7 +22206,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -23654,7 +22214,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -23662,25 +22222,27 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -23688,7 +22250,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -23696,21 +22258,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -23719,26 +22276,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -23760,7 +22310,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -23768,7 +22318,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -23776,20 +22326,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -23845,7 +22397,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -23853,7 +22405,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -23861,21 +22413,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
@@ -23883,17 +22430,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -23976,7 +22518,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -23984,11 +22526,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -24010,7 +22554,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -24018,7 +22562,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -24026,49 +22570,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -24090,7 +22605,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -24098,7 +22613,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -24119,7 +22634,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -24175,7 +22692,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -24183,7 +22700,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -24191,20 +22708,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 3,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        3
       ]
      ]
@@ -24213,20 +22725,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -24306,7 +22813,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -24314,7 +22821,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -24323,7 +22830,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -24331,16 +22838,18 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -24348,7 +22857,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -24356,27 +22865,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -24415,7 +22917,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -24423,7 +22925,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -24431,20 +22933,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -24483,7 +22987,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -24491,13 +22995,11 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -24519,7 +23021,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -24527,7 +23029,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -24535,20 +23037,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -24603,20 +23107,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -24626,43 +23125,38 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -24735,7 +23229,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -24743,28 +23237,25 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -24774,26 +23265,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -24831,15 +23315,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -24861,7 +23345,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -24899,20 +23385,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -24922,38 +23403,31 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -24963,7 +23437,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -24971,11 +23445,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -25053,11 +23529,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -25069,21 +23540,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -25161,15 +23627,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -25178,37 +23644,34 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
@@ -25217,9 +23680,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -25227,17 +23690,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -25266,12 +23722,48 @@
      "prices": [
       [
        "EUR",
+       "USD",
+       1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
        "USD",
+       "EUR",
        1
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       2
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -25350,14 +23842,26 @@
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
-      ],
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -25435,20 +23939,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -25469,9 +23975,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -25479,11 +23985,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -25501,17 +24002,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -25525,6 +24019,23 @@
        "EUR",
        "USD",
        1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       2
       ]
      ]
     }
@@ -25545,7 +24056,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -25623,11 +24136,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -25649,11 +24157,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -25731,16 +24234,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -25749,7 +24252,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -25757,17 +24260,19 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -25775,11 +24280,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -25788,26 +24288,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -25845,16 +24338,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -25862,20 +24355,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -25913,9 +24408,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -25923,11 +24418,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -25935,40 +24425,33 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -25976,20 +24459,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -26067,11 +24552,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -26089,11 +24569,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -26175,20 +24650,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -26209,9 +24686,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -26219,17 +24696,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -26267,16 +24737,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -26297,7 +24767,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -26335,9 +24807,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -26345,11 +24817,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -26367,30 +24834,23 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -26399,7 +24859,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -26407,11 +24867,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -26489,11 +24951,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -26506,19 +24963,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        3
       ]
      ]
@@ -26597,16 +25049,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -26614,26 +25066,28 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -26641,11 +25095,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -26654,26 +25103,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -26711,16 +25153,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -26728,20 +25170,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -26779,9 +25223,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -26789,11 +25233,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -26801,40 +25240,33 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -26842,20 +25274,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -26933,11 +25367,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -26945,13 +25374,15 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -26959,17 +25390,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -27020,7 +25444,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -27075,27 +25501,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -27112,7 +25531,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -27168,7 +25589,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27176,7 +25597,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -27185,7 +25606,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27193,7 +25614,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -27255,7 +25676,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27263,7 +25684,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -27272,7 +25693,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -27280,16 +25701,18 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -27297,7 +25720,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -27318,9 +25741,7 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -27342,7 +25763,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27350,7 +25771,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -27358,20 +25779,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -27410,7 +25833,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -27418,7 +25841,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -27439,26 +25862,26 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -27514,7 +25937,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27522,7 +25945,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -27530,25 +25953,27 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -27556,13 +25981,11 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -27601,7 +26024,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27609,11 +26032,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -27652,7 +26077,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -27660,7 +26085,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -27668,21 +26093,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -27699,11 +26119,6 @@
       [
        "EUR",
        "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
@@ -27766,7 +26181,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -27774,7 +26189,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -27783,7 +26198,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -27791,16 +26206,18 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -27808,7 +26225,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -27816,20 +26233,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
@@ -27839,31 +26251,24 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -27871,7 +26276,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -27880,7 +26285,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -27888,11 +26293,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -27948,7 +26355,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -27956,7 +26363,7 @@
       [
        "EUR",
        "USD",
-       2
+       3
       ]
      ]
     }
@@ -27970,11 +26377,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -27982,12 +26384,14 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -27995,18 +26399,11 @@
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -28045,7 +26442,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -28053,11 +26450,30 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       2
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28096,7 +26512,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -28104,7 +26520,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -28112,21 +26528,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -28135,20 +26546,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -28210,7 +26616,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -28218,11 +26624,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28244,7 +26652,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -28252,7 +26660,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -28260,20 +26668,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -28283,26 +26686,19 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -28319,7 +26715,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28374,15 +26772,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -28404,31 +26802,26 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -28466,20 +26859,39 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
+    },
+    {
+     "prices": [
+      [
+       "EUR",
+       "USD",
+       3
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28518,7 +26930,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -28526,7 +26938,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -28535,20 +26947,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -28556,21 +26963,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -28622,12 +27024,48 @@
      "prices": [
       [
        "EUR",
+       "USD",
+       1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
        "USD",
+       "EUR",
        1
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       2
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28666,7 +27104,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -28674,7 +27112,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -28683,20 +27121,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -28704,21 +27137,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -28779,20 +27207,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28814,7 +27244,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -28822,7 +27252,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -28830,21 +27260,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -28852,17 +27277,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -28870,9 +27290,7 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -28889,7 +27307,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -28944,16 +27364,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -28974,25 +27394,22 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
@@ -29000,27 +27417,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -29041,16 +27451,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -29059,7 +27469,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -29067,11 +27477,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -29110,7 +27522,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -29118,7 +27530,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -29132,11 +27544,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -29149,20 +27556,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -29223,16 +27625,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -29240,25 +27642,27 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
+    },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -29266,7 +27670,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -29274,27 +27678,20 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -29315,16 +27712,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -29332,20 +27729,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -29384,7 +27783,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -29392,7 +27791,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -29401,24 +27800,21 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -29432,17 +27828,10 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -29473,6 +27862,23 @@
        "EUR",
        "USD",
        1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       3
       ]
      ]
     }
@@ -29493,7 +27899,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -29532,7 +27940,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -29540,7 +27948,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -29554,11 +27962,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -29580,11 +27983,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -29645,16 +28043,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -29663,7 +28061,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -29671,46 +28069,26 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -29719,26 +28097,19 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -29759,16 +28130,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -29776,20 +28147,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -29828,7 +28201,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -29836,7 +28209,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -29851,11 +28224,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
        "EUR",
        3
@@ -29867,20 +28235,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -29941,20 +28304,39 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
    ],
+   [
+    "SetPrice",
+    {
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
+    },
+    {
+     "prices": [
+      [
+       "USD",
+       "EUR",
+       3
+      ]
+     ]
+    }
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -29976,7 +28358,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -29984,7 +28366,7 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
@@ -29992,21 +28374,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -30015,20 +28392,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -30085,7 +28457,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30140,21 +28514,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -30199,7 +28568,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30207,7 +28576,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -30216,7 +28585,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30224,11 +28593,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30250,7 +28621,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -30258,18 +28629,16 @@
       [
        "EUR",
        "USD",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30277,7 +28646,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -30286,7 +28655,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -30294,11 +28663,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30337,7 +28708,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30345,7 +28716,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -30353,20 +28724,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       3
+       "EUR",
+       1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30383,9 +28756,7 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -30407,7 +28778,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30415,7 +28786,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -30423,20 +28794,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30475,7 +28848,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30483,7 +28856,7 @@
       [
        "EUR",
        "USD",
-       3
+       2
       ]
      ]
     }
@@ -30491,16 +28864,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       2
+       "EUR",
+       3
       ]
      ]
     }
@@ -30545,7 +28918,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30553,11 +28926,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30613,7 +28988,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -30621,7 +28996,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -30666,7 +29041,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -30674,7 +29049,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -30683,7 +29058,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -30691,11 +29066,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30717,7 +29094,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -30725,7 +29102,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -30733,9 +29110,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -30743,11 +29120,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -30756,20 +29128,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
-       1
+       3
       ]
      ]
     }
@@ -30814,7 +29181,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -30822,7 +29189,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -30830,20 +29197,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -30865,7 +29234,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -30873,7 +29242,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -30881,9 +29250,9 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
@@ -30891,11 +29260,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -30903,21 +29267,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 2,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -30962,7 +29321,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -30970,7 +29329,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -30978,20 +29337,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31013,36 +29374,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -31061,11 +29400,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
       ]
      ]
     }
@@ -31109,15 +29443,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -31139,7 +29473,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31161,7 +29497,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -31169,7 +29505,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -31183,11 +29519,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -31199,20 +29530,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -31257,15 +29583,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -31275,7 +29601,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -31283,11 +29609,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31309,7 +29637,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -31317,7 +29645,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -31331,11 +29659,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -31348,20 +29671,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -31405,15 +29723,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -31422,20 +29740,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31457,7 +29777,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -31465,7 +29785,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -31479,11 +29799,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -31491,26 +29806,26 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31548,20 +29863,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31583,7 +29900,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -31591,7 +29908,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -31605,11 +29922,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -31631,11 +29943,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -31679,16 +29986,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -31697,7 +30004,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -31705,11 +30012,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31731,7 +30040,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -31739,7 +30048,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -31754,11 +30063,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
        "EUR",
        2
@@ -31770,20 +30074,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       2
+       3
       ]
      ]
     }
@@ -31827,16 +30126,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -31844,20 +30143,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -31879,7 +30180,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -31887,7 +30188,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -31901,11 +30202,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -31917,17 +30213,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -31975,16 +30266,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -31992,20 +30283,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32027,7 +30320,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -32035,7 +30328,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -32049,11 +30342,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -32061,31 +30349,26 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -32106,16 +30389,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -32136,7 +30419,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32174,15 +30459,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -32191,49 +30476,39 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
        "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -32254,16 +30529,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -32272,7 +30547,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -32280,11 +30555,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32322,15 +30599,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -32340,20 +30617,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
@@ -32397,16 +30669,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
@@ -32414,20 +30686,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32449,7 +30723,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -32457,7 +30731,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -32471,11 +30745,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -32487,17 +30756,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -32545,20 +30809,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 3,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32592,12 +30858,14 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
@@ -32605,7 +30873,7 @@
       [
        "EUR",
        "USD",
-       3
+       1
       ]
      ]
     }
@@ -32613,21 +30881,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
@@ -32636,20 +30899,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -32677,7 +30935,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -32685,7 +30943,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -32694,7 +30952,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -32702,11 +30960,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32728,7 +30988,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -32736,7 +30996,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -32757,25 +31017,22 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -32784,43 +31041,38 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32842,7 +31094,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -32850,7 +31102,7 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
@@ -32858,20 +31110,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32893,7 +31147,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -32901,7 +31155,7 @@
       [
        "EUR",
        "USD",
-       3
+       2
       ]
      ]
     }
@@ -32915,11 +31169,6 @@
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
@@ -32927,36 +31176,31 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -32964,11 +31208,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -32990,7 +31236,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -32998,7 +31244,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -33019,7 +31265,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33057,69 +31305,25 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
      "base": "EUR",
      "price": 1,
      "quote": "USD"
@@ -33138,7 +31342,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -33146,7 +31350,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -33155,7 +31359,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -33163,11 +31367,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33206,20 +31412,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -33247,7 +31448,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -33255,7 +31456,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -33263,20 +31464,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33298,7 +31501,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -33306,7 +31509,7 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
@@ -33314,15 +31517,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 3,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        3
       ]
      ]
@@ -33351,7 +31554,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -33359,11 +31562,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33384,15 +31589,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -33414,24 +31619,21 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
@@ -33440,17 +31642,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
@@ -33458,14 +31655,12 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 2,
      "quote": "USD"
     },
     {
@@ -33473,11 +31668,13 @@
       [
        "EUR",
        "USD",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33498,15 +31695,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -33516,7 +31713,7 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
@@ -33524,11 +31721,13 @@
       [
        "EUR",
        "USD",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33556,11 +31755,6 @@
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
        "EUR",
        1
@@ -33571,17 +31765,12 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
+     "base": "USD",
+     "price": 1,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
@@ -33612,15 +31801,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -33629,20 +31818,22 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33663,15 +31854,15 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
@@ -33681,65 +31872,57 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 1,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
+       "EUR",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33760,16 +31943,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -33790,7 +31973,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -33812,20 +31997,15 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -33833,20 +32013,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -33874,16 +32049,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "EUR",
        "USD",
-       1
+       "EUR",
+       2
       ]
      ]
     }
@@ -33892,43008 +32067,14 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 3,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       3
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
-     "price": 2,
-     "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "EUR",
      "price": 3,
      "quote": "USD"
-    },
-    {
-     "prices": [
-      [
-       "EUR",
-       "USD",
-       3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       2
-      ]
-     ]
-    }
-   ]
-  ],
-  [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       2
-      ]
-     ]
-    }
-   ],
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
        "USD",
-       "EUR",
        3
       ]
      ]
@@ -76901,35 +32082,18 @@
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -76951,9 +32115,7 @@
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -76970,19 +32132,21 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -76992,7 +32156,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
@@ -77000,7 +32164,7 @@
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -77008,21 +32172,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
-     "price": 1,
-     "quote": "USD"
+     "base": "USD",
+     "price": 2,
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       1
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -77032,15 +32191,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -77050,7 +32209,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
@@ -77058,7 +32217,7 @@
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
@@ -77079,36 +32238,31 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 2,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
@@ -77116,23 +32270,25 @@
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -77159,20 +32315,15 @@
     "SetPrice",
     {
      "base": "EUR",
-     "price": 3,
+     "price": 1,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
-       3
+       1
       ]
      ]
     }
@@ -77182,15 +32333,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -77200,7 +32351,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
@@ -77208,7 +32359,7 @@
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -77216,44 +32367,44 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       3
+       "USD",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
@@ -77261,7 +32412,7 @@
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -77269,33 +32420,35 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       3
+       "USD",
+       1
       ]
      ]
     }
@@ -77304,7 +32457,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
@@ -77312,13 +32465,11 @@
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -77335,19 +32486,21 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -77374,7 +32527,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
@@ -77382,7 +32535,7 @@
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -77392,15 +32545,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -77410,7 +32563,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
@@ -77418,7 +32571,7 @@
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -77445,15 +32598,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
@@ -77463,7 +32616,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 3,
      "quote": "EUR"
     },
     {
@@ -77471,7 +32624,7 @@
       [
        "USD",
        "EUR",
-       1
+       3
       ]
      ]
     }
@@ -77481,32 +32634,34 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 1,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        2
       ]
      ]
@@ -77525,46 +32680,24 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        2
       ]
      ]
@@ -77581,12 +32714,7 @@
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -77594,35 +32722,18 @@
    ]
   ],
   [
-   [
-    "SetPrice",
-    {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
-    },
-    {
-     "prices": [
-      [
-       "USD",
-       "EUR",
-       1
-      ]
-     ]
-    }
-   ],
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        2
       ]
      ]
@@ -77641,11 +32752,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -77655,16 +32761,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       2
       ]
      ]
     }
@@ -77673,7 +32779,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
@@ -77681,35 +32787,35 @@
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       2
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
      "base": "USD",
-     "price": 1,
+     "price": 2,
      "quote": "EUR"
     },
     {
@@ -77717,23 +32823,25 @@
       [
        "USD",
        "EUR",
-       1
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        2
       ]
      ]
@@ -77743,7 +32851,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 3,
      "quote": "EUR"
     },
     {
@@ -77751,7 +32859,7 @@
       [
        "USD",
        "EUR",
-       2
+       3
       ]
      ]
     }
@@ -77761,33 +32869,35 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       2
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 2,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       2
+       "USD",
+       3
       ]
      ]
     }
@@ -77795,16 +32905,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       3
+       "USD",
+       1
       ]
      ]
     }
@@ -77814,16 +32924,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       3
       ]
      ]
     }
@@ -77831,15 +32941,15 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 2,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        2
       ]
      ]
@@ -77850,16 +32960,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       3
       ]
      ]
     }
@@ -77867,44 +32977,39 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 3,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "EUR",
-     "price": 1,
+     "price": 3,
      "quote": "USD"
     },
     {
      "prices": [
       [
        "EUR",
-       "USD",
-       1
-      ],
-      [
        "USD",
-       "EUR",
        3
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -77921,19 +33026,21 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 3,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        3
       ]
      ]
@@ -77942,21 +33049,16 @@
    [
     "SetPrice",
     {
-     "base": "EUR",
+     "base": "USD",
      "price": 2,
-     "quote": "USD"
+     "quote": "EUR"
     },
     {
      "prices": [
-      [
-       "EUR",
-       "USD",
-       2
-      ],
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -77966,16 +33068,16 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 1,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 3,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       1
+       "USD",
+       3
       ]
      ]
     }
@@ -77996,7 +33098,9 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -78010,11 +33114,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -78041,20 +33140,22 @@
    [
     "SetPrice",
     {
-     "base": "USD",
-     "price": 3,
-     "quote": "EUR"
+     "base": "EUR",
+     "price": 1,
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
-       3
+       "USD",
+       1
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
@@ -78068,6 +33169,23 @@
        "USD",
        "EUR",
        1
+      ]
+     ]
+    }
+   ],
+   [
+    "SetPrice",
+    {
+     "base": "EUR",
+     "price": 2,
+     "quote": "USD"
+    },
+    {
+     "prices": [
+      [
+       "EUR",
+       "USD",
+       2
       ]
      ]
     }
@@ -78094,25 +33212,27 @@
    [
     "SetPrice",
     {
-     "base": "USD",
+     "base": "EUR",
      "price": 3,
-     "quote": "EUR"
+     "quote": "USD"
     },
     {
      "prices": [
       [
-       "USD",
        "EUR",
+       "USD",
        3
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "USD",
-     "price": 2,
+     "price": 1,
      "quote": "EUR"
     },
     {
@@ -78120,13 +33240,11 @@
       [
        "USD",
        "EUR",
-       2
+       1
       ]
      ]
     }
-   ]
-  ],
-  [
+   ],
    [
     "SetPrice",
     {
@@ -78143,12 +33261,14 @@
       ]
      ]
     }
-   ],
+   ]
+  ],
+  [
    [
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 1,
      "quote": "EUR"
     },
     {
@@ -78156,7 +33276,7 @@
       [
        "USD",
        "EUR",
-       3
+       1
       ]
      ]
     }
@@ -78165,7 +33285,7 @@
     "SetPrice",
     {
      "base": "USD",
-     "price": 3,
+     "price": 2,
      "quote": "EUR"
     },
     {
@@ -78173,7 +33293,7 @@
       [
        "USD",
        "EUR",
-       3
+       2
       ]
      ]
     }
@@ -78265,11 +33385,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -78304,12 +33419,7 @@
      "prices": [
       [
        "EUR",
-       "USD",
-       2
-      ],
-      [
        "USD",
-       "EUR",
        2
       ]
      ]
@@ -78347,11 +33457,6 @@
        "EUR",
        "USD",
        3
-      ],
-      [
-       "USD",
-       "EUR",
-       2
       ]
      ]
     }
@@ -78515,11 +33620,6 @@
        "EUR",
        "USD",
        1
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -78556,11 +33656,6 @@
        "EUR",
        "USD",
        2
-      ],
-      [
-       "USD",
-       "EUR",
-       3
       ]
      ]
     }
@@ -78595,12 +33690,7 @@
      "prices": [
       [
        "EUR",
-       "USD",
-       3
-      ],
-      [
        "USD",
-       "EUR",
        3
       ]
      ]


### PR DESCRIPTION
## What

`convert()`/`value()` in BQL preferred any direct `(base, quote)` price entry over the inverse direction, so an **older** direct rate silently shadowed a **newer** rate declared the other way round (`-18.68 GBP @ 1.2655 USD`). On the issue's ledger, four of five `convert(sum(position), 'GBP')` rows diverged from bean-query; all five now match exactly.

## Why a build-time port, not a lookup-time fix

Python beancount's `build_price_map` materializes both directions of every price and picks purely by date recency. Its tie-breaks are **emergent from the build algorithm** and unanswerable per-lookup:

- which direction survives a merge depends on *global entry counts per pair* (the direction with fewer rates is inverted and swallowed into the other);
- which same-date rate wins depends on list order after that swallow (`sorted_uniquify(..., last=True)`).

Simulating that at lookup time is exactly the re-derivation anti-pattern from the Phase-3 canonical-function discipline. So `PriceDatabase` now holds **two structures**: the raw provenance store (unchanged — `#prices` table, `len()`, the #1006 dedup gating all read it) and a **conversion index** built by a line-by-line port of `build_price_map`'s merge, auditable by diffing against the Python source. The transaction-derived extension prices (#567/#593) feed the same merge, making them behave exactly as if `implicit_prices` had materialized them.

Bonus: the chained lookup's four per-leg inverse branches collapse to direct legs (every pair is bidirectional by construction), and intermediates are tried in sorted order, making multi-path chains deterministic.

## Spec update

`PriceDB.tla` modeled the old directed-independent semantics, so the model itself needed the fix: `SetPrice` now clears the opposite direction (one rate timeline per pair), a `OneDirectionPerPair` invariant pins it, the behavior corpus is regenerated (330 behaviors, TLC clean), and the replay asserts both the held rate and its derived reciprocal at 20 dp — the build may invert a swallowed rate twice, exactly like Python, leaving last-digit artifacts on both sides.

## Testing

- 7 new unit regressions: newer-inverse-wins (the issue shape), newer-direct-wins, swallow-smaller-into-larger, same-date last-wins tie-break, zero-rate never inverted, end-to-end `from_directives` with the issue's Format C/D transactions (asserts the 79.02 GBP conversion), chained-leg recency.
- Full `rustledger-query` suite: 12 suites green (TLA replay + proptests updated to honor the documented `sort_prices()` contract — they previously read the raw store incidentally).
- Issue ledger verified against the reported bean-query output: all five rows match.
- clippy `-D warnings`, fmt, rustdoc `-D warnings` clean.

Closes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)