### PR TITLE
fix: allow path-only wildcard deps in cargo-deny bans

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -63,6 +63,11 @@ multiple-versions = "deny"
 # Forbid `version = "*"` specs in published crates — they bind to whatever
 # happens to resolve at publish time, with no SemVer guard.
 wildcards = "deny"
+# ...except path-only dependencies. Sibling-crate dev-deps are
+# deliberately `path`-only WITHOUT a version (#1758): cargo strips
+# versionless dev-deps at publish, so they can never bind to a
+# published version — but cargo-deny models them as wildcards.
+allow-wildcard-paths = true
 highlight = "all"
 
 # Crates we never want to depend on, even transitively. We use rustls


### PR DESCRIPTION
Cargo Deny is red on main (and therefore on every open PR, e.g. #1760's run): #1758 made `rustledger-wasm`'s sibling dev-deps **path-only without a version** so cargo strips them at publish and the crates.io publish order can never fail on them — but cargo-deny models a versionless path dep as a wildcard, tripping `wildcards = "deny"`.

`allow-wildcard-paths = true` permits exactly this shape and nothing more: a path dep cannot bind to whatever version happens to resolve at publish time, which is what the wildcard ban exists to prevent. `version = "*"` registry specs remain denied.

Local `cargo deny check`: advisories ok, bans ok, licenses ok, sources ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)