### PR TITLE
feat: expose import over the component boundary (WIT 3.5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,8 +421,18 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Build the wasip2 component
         run: cargo build -p rustledger-ffi-component --target wasm32-wasip2
+      # The parity tests gracefully skip when the component artifact is
+      # missing (so plain `cargo test` works locally without a wasip2
+      # build). In THIS job the build step just produced it, so a skip
+      # means artifact-path drift — fail loudly instead of passing green
+      # on zero assertions (availability-gated-tests rule, CLAUDE.md).
       - name: Run parity tests
-        run: cargo test -p rustledger-ffi-component-tests
+        run: |
+          cargo test -p rustledger-ffi-component-tests -- --nocapture 2>&1 | tee parity-output.log
+          if grep -q "skip: component wasm not built" parity-output.log; then
+            echo "::error::parity tests skipped despite the component being built — artifact path drift"
+            exit 1
+          fi
 
   # Wire-contract version gate (#1395). The Component-Model `world.wit` is the
   # versioned wire contract that replaced the hand-parsed FFI-WASI JSON format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3476,6 +3476,7 @@ dependencies = [
  "rustledger-booking",
  "rustledger-core",
  "rustledger-ffi-wasi",
+ "rustledger-importer",
  "rustledger-loader",
  "rustledger-ops",
  "rustledger-parser",
@@ -3492,6 +3493,7 @@ dependencies = [
  "anyhow",
  "rustledger-core",
  "rustledger-ffi-wasi",
+ "rustledger-importer",
  "tempfile",
  "wasmtime",
  "wasmtime-wasi",
@@ -3537,6 +3539,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
  "wasmtime",
  "wat",
 ]

--- a/crates/rustledger-ffi-component-tests/Cargo.toml
+++ b/crates/rustledger-ffi-component-tests/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1"
 tempfile.workspace = true
 rustledger-core.workspace = true
 rustledger-ffi-wasi.workspace = true
+rustledger-importer = { workspace = true, features = ["toml-config"] }
 
 [lints]
 workspace = true

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -912,3 +912,38 @@ fn load_file_decrypts_via_host_import() -> Result<()> {
     );
     Ok(())
 }
+
+/// The `importer` interface (3.5.0) over the real component: identify a CSV,
+/// infer its mapping, extract with the inferred config, and agree with the
+/// native `rustledger-importer` engine on the result.
+#[test]
+fn importer_extract_matches_native_engine() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    const CSV: &str =
+        "Date,Description,Amount\n2026-07-01,Coffee Shop,-4.50\n2026-07-02,Salary,2500.00\n";
+    let (mut store, inst) = instantiate()?;
+    let importer = inst.rustledger_ledger_importer();
+
+    let names = importer.call_identify(&mut store, "bank.csv", CSV.as_bytes())?;
+    assert_eq!(names, vec!["CSV".to_string()]);
+
+    let config = importer
+        .call_infer(&mut store, "bank.csv", CSV.as_bytes())?
+        .expect("CSV is inferable");
+    let config = format!("{config}account = \"Assets:Bank\"\ncurrency = \"USD\"\n");
+    let result = importer
+        .call_extract(&mut store, "bank.csv", CSV.as_bytes(), &config)?
+        .expect("extraction succeeds");
+
+    // Native engine on the same content + config — the drift guard.
+    let entry = rustledger_importer::toml_entry::ImporterEntry::from_toml_str(&config)?;
+    let native_cfg = rustledger_importer::toml_entry::build_config_from_entry(&entry)?;
+    let native = rustledger_importer::csv_importer::CsvImporter.extract_string(CSV, &native_cfg)?;
+
+    assert_eq!(result.entries.len(), native.directives.len());
+    assert_eq!(result.entries.len(), 2);
+    Ok(())
+}

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -943,7 +943,53 @@ fn importer_extract_matches_native_engine() -> Result<()> {
     let native_cfg = rustledger_importer::toml_entry::build_config_from_entry(&entry)?;
     let native = rustledger_importer::csv_importer::CsvImporter.extract_string(CSV, &native_cfg)?;
 
-    assert_eq!(result.entries.len(), native.directives.len());
-    assert_eq!(result.entries.len(), 2);
+    // Compare the exact observables (date, narration, postings), not just
+    // counts — a count-only guard is decoration per the drift-guard rule.
+    fn wit_shape(
+        d: &rustledger::ledger::types::Directive,
+    ) -> (String, String, Vec<(String, String)>) {
+        let rustledger::ledger::types::Directive::Transaction(t) = d else {
+            panic!("expected transaction, got {d:?}");
+        };
+        (
+            t.date.clone(),
+            t.narration.clone().unwrap_or_default(),
+            t.postings
+                .iter()
+                .map(|p| {
+                    let units = p
+                        .units
+                        .as_ref()
+                        .map(|u| format!("{} {}", u.number, u.currency))
+                        .unwrap_or_default();
+                    (p.account.clone(), units)
+                })
+                .collect(),
+        )
+    }
+    fn native_shape(d: &rustledger_core::Directive) -> (String, String, Vec<(String, String)>) {
+        let rustledger_core::Directive::Transaction(t) = d else {
+            panic!("expected transaction, got {d:?}");
+        };
+        (
+            t.date.to_string(),
+            t.narration.to_string(),
+            t.postings
+                .iter()
+                .map(|p| {
+                    let units = p
+                        .amount()
+                        .map(|a| format!("{} {}", a.number, a.currency))
+                        .unwrap_or_default();
+                    (p.account.to_string(), units)
+                })
+                .collect(),
+        )
+    }
+    let component_shapes: Vec<_> = result.entries.iter().map(wit_shape).collect();
+    let native_shapes: Vec<_> = native.directives.iter().map(native_shape).collect();
+    assert_eq!(component_shapes, native_shapes);
+    assert_eq!(component_shapes.len(), 2);
+    assert_eq!(result.warnings, native.warnings);
     Ok(())
 }

--- a/crates/rustledger-ffi-component/Cargo.toml
+++ b/crates/rustledger-ffi-component/Cargo.toml
@@ -36,6 +36,11 @@ rustledger-validate.workspace = true
 # types. During the dual-ship window both crates coexist; the shared logic
 # moves to a neutral home when the wasip1 surface is retired (Phase 5).
 rustledger-ffi-wasi.workspace = true
+# The `importer` interface (3.5.0): CSV/OFX extraction + inference, with the
+# canonical `importers.toml` entry schema (`toml-config`). Default features
+# only — the `.wasm` plugin-importer runtime (wasmtime host) cannot exist
+# inside a component and stays a host-side concern.
+rustledger-importer = { workspace = true, features = ["toml-config"] }
 
 [lints]
 workspace = true

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -2098,7 +2098,7 @@ pub fn import_infer(_filename: &str, content: &[u8]) -> Result<String, String> {
     let text = std::str::from_utf8(content).map_err(|_| "content is not UTF-8".to_string())?;
     let inferred = rustledger_importer::csv_inference::infer_csv_config(text)
         .ok_or_else(|| "content does not look like parseable CSV".to_string())?;
-    Ok(toml_entry::entry_toml_from_inferred("inferred", &inferred))
+    toml_entry::entry_toml_from_inferred("inferred", &inferred).map_err(|e| e.to_string())
 }
 
 /// Extract directives from statement bytes using a declarative config entry.
@@ -2121,10 +2121,13 @@ pub fn import_extract(
 
     let result = if detect_format(filename, content) == Some(DetectedFormat::Ofx) {
         // OFX needs only account/currency; column mappings don't apply.
-        let mut builder = rustledger_importer::ImporterConfig::csv();
-        if let Some(ref account) = entry.account {
-            builder = builder.account(account);
-        }
+        // `account` is required HERE (not defaulted): the builder would
+        // otherwise silently target Expenses:Unknown, which is wrong for
+        // the asset/liability account a statement belongs to.
+        let Some(ref account) = entry.account else {
+            return Err("OFX extraction requires `account` in the config entry".to_string());
+        };
+        let mut builder = rustledger_importer::ImporterConfig::csv().account(account);
         if let Some(ref currency) = entry.currency {
             builder = builder.currency(currency);
         }
@@ -2226,6 +2229,15 @@ mod importer_tests {
         let config = "name = \"ofx\"\naccount = \"Assets:Checking\"\ncurrency = \"USD\"\n";
         let result = import_extract("bank.ofx", OFX.as_bytes(), config).expect("extracts");
         assert_eq!(result.entries.len(), 1);
+    }
+
+    /// OFX without `account` is an error, not a silent import into the
+    /// builder's Expenses:Unknown default (review comment).
+    #[test]
+    fn extract_ofx_without_account_is_rejected() {
+        let err =
+            import_extract("bank.ofx", OFX.as_bytes(), "name = \"ofx\"").expect_err("rejects");
+        assert!(err.contains("account"), "{err}");
     }
 
     #[test]

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -2078,49 +2078,18 @@ mod tests {
 
 use crate::exports::rustledger::ledger::importer as imp;
 use rustledger_importer::csv_importer::CsvImporter;
-use rustledger_importer::{OfxImporter, toml_entry};
+use rustledger_importer::{DetectedFormat, OfxImporter, detect_format, toml_entry};
 
-/// Sniff OFX content: OFX 1.x starts with an `OFXHEADER` SGML preamble; 2.x
-/// is XML containing an `<OFX>` element. Checked case-insensitively over the
-/// head of the file so a generic `.txt` download is still recognized.
-fn looks_like_ofx(content: &[u8]) -> bool {
-    let head_len = content.len().min(2048);
-    let head = String::from_utf8_lossy(&content[..head_len]).to_uppercase();
-    head.contains("OFXHEADER") || head.contains("<OFX")
-}
-
-/// Filename extension, lowercased.
-fn extension(filename: &str) -> Option<String> {
-    std::path::Path::new(filename)
-        .extension()
-        .map(|e| e.to_string_lossy().to_lowercase())
-}
-
-/// Whether the file should be treated as OFX: extension first, content
-/// sniff as fallback.
-fn is_ofx(filename: &str, content: &[u8]) -> bool {
-    matches!(extension(filename).as_deref(), Some("ofx" | "qfx")) || looks_like_ofx(content)
-}
-
-/// Names of built-in importers that recognize the file. Mirrors the
-/// registry's builtin `identify` heuristics (extension), extended with a
-/// content sniff so bytes-only hosts get an answer for misnamed downloads.
+/// Names of built-in importers that recognize the file. Delegates to the
+/// canonical `rustledger_importer::detect_format` — the extension is
+/// authoritative when recognized; the content sniff only decides for
+/// absent/unrecognized extensions (misnamed downloads).
 pub fn import_identify(filename: &str, content: &[u8]) -> Vec<String> {
-    let mut names = Vec::new();
-    if is_ofx(filename, content) {
-        names.push("OFX/QFX".to_string());
+    match detect_format(filename, content) {
+        Some(DetectedFormat::Ofx) => vec!["OFX/QFX".to_string()],
+        Some(DetectedFormat::Csv) => vec!["CSV".to_string()],
+        None => Vec::new(),
     }
-    let csv_ext = matches!(extension(filename).as_deref(), Some("csv"));
-    if csv_ext
-        || (names.is_empty()
-            && std::str::from_utf8(content)
-                .ok()
-                .and_then(rustledger_importer::csv_inference::infer_csv_config)
-                .is_some())
-    {
-        names.push("CSV".to_string());
-    }
-    names
 }
 
 /// Infer a CSV mapping; returns an `importers.toml` entry (bare TOML table)
@@ -2133,15 +2102,24 @@ pub fn import_infer(_filename: &str, content: &[u8]) -> Result<String, String> {
 }
 
 /// Extract directives from statement bytes using a declarative config entry.
+///
+/// Mirrors the CLI's semantics: `currency` defaults to USD when the entry
+/// omits it (the schema's documented default — the CLI injects it via the
+/// `--currency` flag default), and non-UTF-8 content is decoded lossily so
+/// a Latin-1 OFX 1.x download degrades to replacement characters in text
+/// fields instead of dead-ending a file `identify` just recognized.
 pub fn import_extract(
     filename: &str,
     content: &[u8],
     config: &str,
 ) -> Result<imp::ExtractResult, String> {
-    let entry = toml_entry::ImporterEntry::from_toml_str(config).map_err(|e| e.to_string())?;
-    let text = std::str::from_utf8(content).map_err(|_| "content is not UTF-8".to_string())?;
+    let mut entry = toml_entry::ImporterEntry::from_toml_str(config).map_err(|e| e.to_string())?;
+    if entry.currency.is_none() {
+        entry.currency = Some("USD".to_string());
+    }
+    let text = String::from_utf8_lossy(content);
 
-    let result = if is_ofx(filename, content) {
+    let result = if detect_format(filename, content) == Some(DetectedFormat::Ofx) {
         // OFX needs only account/currency; column mappings don't apply.
         let mut builder = rustledger_importer::ImporterConfig::csv();
         if let Some(ref account) = entry.account {
@@ -2152,12 +2130,12 @@ pub fn import_extract(
         }
         let cfg = builder.build().map_err(|e| e.to_string())?;
         OfxImporter
-            .extract_from_string(text, &cfg)
+            .extract_from_string(&text, &cfg)
             .map_err(|e| e.to_string())?
     } else {
         let cfg = toml_entry::build_config_from_entry(&entry).map_err(|e| e.to_string())?;
         CsvImporter
-            .extract_string(text, &cfg)
+            .extract_string(&text, &cfg)
             .map_err(|e| e.to_string())?
     };
 
@@ -2190,6 +2168,41 @@ mod importer_tests {
         );
         // Headerless junk matches nothing.
         assert!(import_identify("blob.bin", &[0u8, 159, 146, 150]).is_empty());
+    }
+
+    /// The extension is authoritative: a CSV whose narration mentions
+    /// "<OFX" must stay on the CSV path (review finding — the sniff must
+    /// not override an explicit extension).
+    #[test]
+    fn csv_extension_beats_ofx_looking_content() {
+        let csv = "Date,Description,Amount\n2026-07-01,REFUND <OFX PORTAL>,-4.50\n";
+        assert_eq!(import_identify("bank.csv", csv.as_bytes()), vec!["CSV"]);
+        let config = "name = \"x\"\naccount = \"Assets:Bank\"\ndate_column = \"Date\"\nnarration_column = \"Description\"\namount_column = \"Amount\"\n";
+        let result = import_extract("bank.csv", csv.as_bytes(), config).expect("CSV path");
+        assert_eq!(result.entries.len(), 1);
+    }
+
+    /// Currency defaults to USD (the schema's documented default), so an
+    /// entry with only account works over the component exactly like the
+    /// CLI, where the --currency flag default supplies it.
+    #[test]
+    fn currency_defaults_to_usd() {
+        let config = "name = \"ofx\"\naccount = \"Assets:Checking\"\n";
+        let result = import_extract("bank.ofx", OFX.as_bytes(), config).expect("extracts");
+        assert_eq!(result.entries.len(), 1);
+    }
+
+    /// Latin-1 OFX (CHARSET:1252, the OFX 1.x default many banks emit) is
+    /// decoded lossily instead of dead-ending a file identify recognized.
+    #[test]
+    fn latin1_ofx_extracts_lossily() {
+        let mut bytes = OFX.replace("Coffee", "Entr~e").into_bytes();
+        let idx = bytes.iter().position(|&b| b == b'~').expect("marker");
+        bytes[idx] = 0xE9; // \u{e9} in Latin-1 (Entree with an accent) — invalid UTF-8
+        assert_eq!(import_identify("bank.ofx", &bytes), vec!["OFX/QFX"]);
+        let config = "name = \"ofx\"\naccount = \"Assets:Checking\"\ncurrency = \"USD\"\n";
+        let result = import_extract("bank.ofx", &bytes, config).expect("lossy decode extracts");
+        assert_eq!(result.entries.len(), 1);
     }
 
     /// The infer -> extract loop a GUI host runs: infer a mapping, append

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -2065,3 +2065,160 @@ mod tests {
         assert_eq!(session.info().entries.len(), 0);
     }
 }
+
+// ---- importer interface (3.5.0) ------------------------------------------
+//
+// The `rledger extract` engine over the component boundary (roadmap "import
+// over the component boundary"). Content arrives as bytes from the host —
+// there is no file to read — so extraction goes through the importer crate's
+// content-based entry points (`CsvImporter::extract_string`,
+// `OfxImporter::extract_from_string`). The declarative config is ONE
+// `importers.toml` entry parsed by the canonical
+// `rustledger_importer::toml_entry` schema module shared with the CLI.
+
+use crate::exports::rustledger::ledger::importer as imp;
+use rustledger_importer::csv_importer::CsvImporter;
+use rustledger_importer::{OfxImporter, toml_entry};
+
+/// Sniff OFX content: OFX 1.x starts with an `OFXHEADER` SGML preamble; 2.x
+/// is XML containing an `<OFX>` element. Checked case-insensitively over the
+/// head of the file so a generic `.txt` download is still recognized.
+fn looks_like_ofx(content: &[u8]) -> bool {
+    let head_len = content.len().min(2048);
+    let head = String::from_utf8_lossy(&content[..head_len]).to_uppercase();
+    head.contains("OFXHEADER") || head.contains("<OFX")
+}
+
+/// Filename extension, lowercased.
+fn extension(filename: &str) -> Option<String> {
+    std::path::Path::new(filename)
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase())
+}
+
+/// Whether the file should be treated as OFX: extension first, content
+/// sniff as fallback.
+fn is_ofx(filename: &str, content: &[u8]) -> bool {
+    matches!(extension(filename).as_deref(), Some("ofx" | "qfx")) || looks_like_ofx(content)
+}
+
+/// Names of built-in importers that recognize the file. Mirrors the
+/// registry's builtin `identify` heuristics (extension), extended with a
+/// content sniff so bytes-only hosts get an answer for misnamed downloads.
+pub fn import_identify(filename: &str, content: &[u8]) -> Vec<String> {
+    let mut names = Vec::new();
+    if is_ofx(filename, content) {
+        names.push("OFX/QFX".to_string());
+    }
+    let csv_ext = matches!(extension(filename).as_deref(), Some("csv"));
+    if csv_ext
+        || (names.is_empty()
+            && std::str::from_utf8(content)
+                .ok()
+                .and_then(rustledger_importer::csv_inference::infer_csv_config)
+                .is_some())
+    {
+        names.push("CSV".to_string());
+    }
+    names
+}
+
+/// Infer a CSV mapping; returns an `importers.toml` entry (bare TOML table)
+/// that round-trips into [`import_extract`].
+pub fn import_infer(_filename: &str, content: &[u8]) -> Result<String, String> {
+    let text = std::str::from_utf8(content).map_err(|_| "content is not UTF-8".to_string())?;
+    let inferred = rustledger_importer::csv_inference::infer_csv_config(text)
+        .ok_or_else(|| "content does not look like parseable CSV".to_string())?;
+    Ok(toml_entry::entry_toml_from_inferred("inferred", &inferred))
+}
+
+/// Extract directives from statement bytes using a declarative config entry.
+pub fn import_extract(
+    filename: &str,
+    content: &[u8],
+    config: &str,
+) -> Result<imp::ExtractResult, String> {
+    let entry = toml_entry::ImporterEntry::from_toml_str(config).map_err(|e| e.to_string())?;
+    let text = std::str::from_utf8(content).map_err(|_| "content is not UTF-8".to_string())?;
+
+    let result = if is_ofx(filename, content) {
+        // OFX needs only account/currency; column mappings don't apply.
+        let mut builder = rustledger_importer::ImporterConfig::csv();
+        if let Some(ref account) = entry.account {
+            builder = builder.account(account);
+        }
+        if let Some(ref currency) = entry.currency {
+            builder = builder.currency(currency);
+        }
+        let cfg = builder.build().map_err(|e| e.to_string())?;
+        OfxImporter
+            .extract_from_string(text, &cfg)
+            .map_err(|e| e.to_string())?
+    } else {
+        let cfg = toml_entry::build_config_from_entry(&entry).map_err(|e| e.to_string())?;
+        CsvImporter
+            .extract_string(text, &cfg)
+            .map_err(|e| e.to_string())?
+    };
+
+    Ok(imp::ExtractResult {
+        entries: result
+            .directives
+            .iter()
+            .map(|d| directive_from_core(d, 0, filename))
+            .collect(),
+        warnings: result.warnings,
+    })
+}
+
+#[cfg(test)]
+mod importer_tests {
+    use super::*;
+
+    const CSV: &str =
+        "Date,Description,Amount\n2026-07-01,Coffee Shop,-4.50\n2026-07-02,Salary,2500.00\n";
+    const OFX: &str = "OFXHEADER:100\nDATA:OFXSGML\n\n<OFX><BANKMSGSRSV1><STMTTRNRS><STMTRS>\n<CURDEF>USD\n<BANKTRANLIST>\n<STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20260701<TRNAMT>-4.50<FITID>1<NAME>Coffee</STMTTRN>\n</BANKTRANLIST></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>\n";
+
+    #[test]
+    fn identify_by_extension_and_sniff() {
+        assert_eq!(import_identify("bank.csv", CSV.as_bytes()), vec!["CSV"]);
+        assert_eq!(import_identify("bank.qfx", OFX.as_bytes()), vec!["OFX/QFX"]);
+        // Misnamed OFX download: content sniff catches it.
+        assert_eq!(
+            import_identify("statement.txt", OFX.as_bytes()),
+            vec!["OFX/QFX"]
+        );
+        // Headerless junk matches nothing.
+        assert!(import_identify("blob.bin", &[0u8, 159, 146, 150]).is_empty());
+    }
+
+    /// The infer -> extract loop a GUI host runs: infer a mapping, append
+    /// account/currency, extract with it.
+    #[test]
+    fn infer_round_trips_into_extract() {
+        let config = import_infer("bank.csv", CSV.as_bytes()).expect("inferable");
+        let config = format!("{config}account = \"Assets:Bank\"\ncurrency = \"USD\"\n");
+        let result = import_extract("bank.csv", CSV.as_bytes(), &config).expect("extracts");
+        assert_eq!(result.entries.len(), 2);
+        let wit::Directive::Transaction(txn) = &result.entries[0] else {
+            panic!("expected a transaction");
+        };
+        assert!(txn.postings.iter().any(|p| p.account == "Assets:Bank"));
+        // Extracted entries carry the statement filename as provenance.
+        assert_eq!(txn.meta.filename, "bank.csv");
+    }
+
+    #[test]
+    fn extract_ofx_needs_only_account_and_currency() {
+        let config = "name = \"ofx\"\naccount = \"Assets:Checking\"\ncurrency = \"USD\"\n";
+        let result = import_extract("bank.ofx", OFX.as_bytes(), config).expect("extracts");
+        assert_eq!(result.entries.len(), 1);
+    }
+
+    #[test]
+    fn extract_rejects_malformed_config() {
+        assert!(import_extract("bank.csv", CSV.as_bytes(), "not = [valid").is_err());
+        // Missing `name` is a schema violation, same as the CLI.
+        assert!(import_extract("bank.csv", CSV.as_bytes(), "account = \"Assets:Bank\"").is_err());
+    }
+}

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -38,19 +38,21 @@ mod convert;
 
 use exports::rustledger::ledger::builder::{Directive, Guest as BuilderGuest, InputDirective};
 use exports::rustledger::ledger::format::Guest as FormatGuest;
+use exports::rustledger::ledger::importer::{ExtractResult, Guest as ImporterGuest};
 use exports::rustledger::ledger::ledger::{
     BatchResult, Guest as LedgerGuest, GuestSession, LoadResult, QueryResult, Session,
     ValidateResult,
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. 3.2 adds the
-/// `host.decrypt` import so encrypted (`.gpg`/`.asc`) ledgers can be decrypted by
-/// the host — a WASI guest can't reach the keyring (#1667). 3.4 added
-/// `session.from-entries` (hold a directive set, rustfava#173/#249); 3.1 added
-/// the `diff` field on `balance-dir` (#1663); 3.0 was the breaking
+/// The Component-Model api-version this build implements. 3.5 adds the
+/// `importer` interface (identify / infer / extract — the `rledger extract`
+/// engine over the boundary); 3.4 added `session.from-entries` (hold a
+/// directive set, rustfava#173/#249); 3.2 added the `host.decrypt` import so
+/// encrypted (`.gpg`/`.asc`) ledgers can be decrypted by the host (#1667);
+/// 3.1 added the `diff` field on `balance-dir` (#1663); 3.0 was the breaking
 /// `expand-pads` parameter on `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.4";
+const API_VERSION: &str = "3.5";
 
 struct Component;
 
@@ -161,6 +163,22 @@ impl UtilGuest for Component {
     }
     fn get_account_type(account: String) -> String {
         convert::get_account_type(&account)
+    }
+}
+
+impl ImporterGuest for Component {
+    fn identify(filename: String, content: Vec<u8>) -> Vec<String> {
+        convert::import_identify(&filename, &content)
+    }
+    fn infer(filename: String, content: Vec<u8>) -> Result<String, String> {
+        convert::import_infer(&filename, &content)
+    }
+    fn extract(
+        filename: String,
+        content: Vec<u8>,
+        config: String,
+    ) -> Result<ExtractResult, String> {
+        convert::import_extract(&filename, &content, &config)
     }
 }
 

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.4.0;
+package rustledger:ledger@3.5.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -556,6 +556,41 @@ interface format {
   format-entries: func(entries: list<input-directive>) -> result<string, string>;
 }
 
+/// Bank-statement import — the `rledger extract` engine over the component
+/// boundary (added in 3.5.0; roadmap "import over the component boundary").
+/// Covers the NATIVE importers: CSV (with auto-inference) and OFX 1.x/2.x.
+/// Sandboxed `.wasm` plugin importers remain a host-side concern — a
+/// component cannot host nested guests.
+interface importer {
+  use types.{directive};
+
+  /// Extracted directives plus non-fatal diagnostics (skipped rows etc.).
+  /// Entries carry the given statement filename as their source location.
+  record extract-result {
+    entries: list<directive>,
+    warnings: list<string>,
+  }
+
+  /// Names of built-in importers that recognize the file, by filename
+  /// extension with a content sniff as fallback (e.g. an OFX body served
+  /// with a generic extension). Empty when nothing matches.
+  identify: func(filename: string, content: list<u8>) -> list<string>;
+
+  /// Infer a CSV column mapping from content. Returns an `importers.toml`
+  /// entry as a bare TOML table — the same schema `extract` accepts — so
+  /// the host can surface it for editing and pass it straight back.
+  /// Errors when the content doesn't look like confidently-parseable CSV.
+  infer: func(filename: string, content: list<u8>) -> result<string, string>;
+
+  /// Extract directives from statement content. `config` is ONE
+  /// `importers.toml` entry as a bare TOML table (`name = "..."`,
+  /// `date_column = "..."`, ...) — the exact schema documented for the
+  /// CLI; both surfaces share the same canonical parser. OFX content is
+  /// detected via `identify` semantics and needs only `account`/`currency`
+  /// from the config; everything else applies to CSV.
+  extract: func(filename: string, content: list<u8>, config: string) -> result<extract-result, string>;
+}
+
 /// Capabilities the host provides to the component.
 interface host {
   /// Decrypt an encrypted ledger file on the host — e.g. via the user's GPG
@@ -577,4 +612,5 @@ world rustledger {
   export builder;
   export util;
   export format;
+  export importer;
 }

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -589,9 +589,9 @@ interface importer {
   /// `date_column = "..."`, ...) — the exact schema documented for the
   /// CLI; both surfaces share the same canonical parser, and `currency`
   /// defaults to USD exactly like the CLI's --currency flag. OFX content
-  /// is detected via `identify` semantics and needs only
-  /// `account`/`currency` from the config; everything else applies to
-  /// CSV. Non-UTF-8 content (e.g. a Latin-1 OFX 1.x download) is decoded
+  /// is detected via `identify` semantics and needs only `account`
+  /// (required) and `currency` from the config; everything else applies
+  /// to CSV. Non-UTF-8 content (e.g. a Latin-1 OFX 1.x download) is decoded
   /// lossily — unmappable bytes degrade to replacement characters in text
   /// fields rather than failing the extraction.
   extract: func(filename: string, content: list<u8>, config: string) -> result<extract-result, string>;

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -571,9 +571,11 @@ interface importer {
     warnings: list<string>,
   }
 
-  /// Names of built-in importers that recognize the file, by filename
-  /// extension with a content sniff as fallback (e.g. an OFX body served
-  /// with a generic extension). Empty when nothing matches.
+  /// Names of built-in importers that recognize the file. The filename
+  /// extension is AUTHORITATIVE when recognized (.csv is CSV even if the
+  /// content mentions "<OFX"); the content sniff only decides for absent
+  /// or unrecognized extensions (e.g. an OFX body served as .txt). Empty
+  /// when nothing matches.
   identify: func(filename: string, content: list<u8>) -> list<string>;
 
   /// Infer a CSV column mapping from content. Returns an `importers.toml`
@@ -585,9 +587,13 @@ interface importer {
   /// Extract directives from statement content. `config` is ONE
   /// `importers.toml` entry as a bare TOML table (`name = "..."`,
   /// `date_column = "..."`, ...) — the exact schema documented for the
-  /// CLI; both surfaces share the same canonical parser. OFX content is
-  /// detected via `identify` semantics and needs only `account`/`currency`
-  /// from the config; everything else applies to CSV.
+  /// CLI; both surfaces share the same canonical parser, and `currency`
+  /// defaults to USD exactly like the CLI's --currency flag. OFX content
+  /// is detected via `identify` semantics and needs only
+  /// `account`/`currency` from the config; everything else applies to
+  /// CSV. Non-UTF-8 content (e.g. a Latin-1 OFX 1.x download) is decoded
+  /// lossily — unmappable bytes degrade to replacement characters in text
+  /// fields rather than failing the extraction.
   extract: func(filename: string, content: list<u8>, config: string) -> result<extract-result, string>;
 }
 

--- a/crates/rustledger-importer/Cargo.toml
+++ b/crates/rustledger-importer/Cargo.toml
@@ -28,6 +28,10 @@ wasm-importer = [
   "dep:thiserror",
   "dep:rustledger-plugin",
 ]
+# The `importers.toml` entry schema (`toml_entry` module) — the canonical
+# declarative-config parser shared by the CLI and the WASI component's
+# `importer` interface. Off by default so slim builds skip toml/serde.
+toml-config = ["dep:serde", "dep:toml"]
 
 [dependencies]
 rustledger-core.workspace = true
@@ -50,6 +54,7 @@ wasmtime = { workspace = true, optional = true }
 rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -38,6 +38,8 @@ pub mod csv_inference;
 pub mod ofx_importer;
 pub mod registry;
 pub mod test_fixtures;
+#[cfg(feature = "toml-config")]
+pub mod toml_entry;
 #[cfg(feature = "wasm-importer")]
 pub mod wasm;
 

--- a/crates/rustledger-importer/src/lib.rs
+++ b/crates/rustledger-importer/src/lib.rs
@@ -256,6 +256,57 @@ pub trait Importer: Send + Sync {
     }
 }
 
+/// A statement format recognized by [`detect_format`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectedFormat {
+    /// Comma/character-separated values.
+    Csv,
+    /// OFX 1.x (SGML) or 2.x (XML), including QFX.
+    Ofx,
+}
+
+/// Sniff OFX content: OFX 1.x starts with an `OFXHEADER` SGML preamble; 2.x
+/// is XML containing an `<OFX>` element. Checked case-insensitively over the
+/// head of the file so a generic `.txt` download is still recognized.
+fn looks_like_ofx(content: &[u8]) -> bool {
+    let head_len = content.len().min(2048);
+    let head = String::from_utf8_lossy(&content[..head_len]).to_uppercase();
+    head.contains("OFXHEADER") || head.contains("<OFX")
+}
+
+/// Canonical filename+content format dispatch for the built-in importers.
+///
+/// The extension is AUTHORITATIVE when recognized: a `.csv` whose narration
+/// happens to contain `<OFX` must not be routed to the OFX parser, and a
+/// `.ofx` is OFX even if its head looks odd. The content sniff only decides
+/// when the extension is absent or unrecognized (e.g. an OFX body served as
+/// `.txt`, or extensionless uploads). Shared by every bytes-based surface
+/// (the WASI component's `importer` interface) so dispatch policy cannot
+/// drift per-surface.
+#[must_use]
+pub fn detect_format(filename: &str, content: &[u8]) -> Option<DetectedFormat> {
+    let ext = std::path::Path::new(filename)
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase());
+    match ext.as_deref() {
+        Some("csv") => Some(DetectedFormat::Csv),
+        Some("ofx" | "qfx") => Some(DetectedFormat::Ofx),
+        _ => {
+            if looks_like_ofx(content) {
+                Some(DetectedFormat::Ofx)
+            } else if std::str::from_utf8(content)
+                .ok()
+                .and_then(csv_inference::infer_csv_config)
+                .is_some()
+            {
+                Some(DetectedFormat::Csv)
+            } else {
+                None
+            }
+        }
+    }
+}
+
 /// Auto-extract transactions from a file by inferring its format.
 ///
 /// If the file is OFX/QFX, uses the OFX importer directly. Otherwise,

--- a/crates/rustledger-importer/src/toml_entry.rs
+++ b/crates/rustledger-importer/src/toml_entry.rs
@@ -122,6 +122,16 @@ pub fn parse_column_value(value: &toml::Value) -> Option<String> {
     }
 }
 
+/// Like [`parse_column_value`], but a wrong TOML type is an ERROR naming the
+/// field — a mistyped `amount_column = 2.0` must not silently fall back to
+/// the builder's default column (review finding on the 3.5.0 component
+/// surface; previously the CLI silently ignored such values too).
+fn require_column_value(field: &str, value: &toml::Value) -> Result<String> {
+    parse_column_value(value).ok_or_else(|| {
+        anyhow!("`{field}` must be a column name (string) or 0-based index (integer), got: {value}")
+    })
+}
+
 /// Parse an amount-locale name (e.g. `de_DE`, `en_US`) into a [`Locale`].
 ///
 /// Emits a consistent error for an unrecognized name. Shared by the CLI's
@@ -147,9 +157,8 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
     if let Some(ref currency) = entry.currency {
         builder = builder.currency(currency);
     }
-    if let Some(ref val) = entry.date_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.date_column {
+        let col = require_column_value("date_column", val)?;
         builder = apply_column(
             builder,
             &col,
@@ -175,9 +184,8 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
         });
         builder = builder.secondary_date(col, fmt, key);
     }
-    if let Some(ref val) = entry.narration_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.narration_column {
+        let col = require_column_value("narration_column", val)?;
         builder = apply_column(
             builder,
             &col,
@@ -185,9 +193,8 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
             |b, n| b.narration_column(n),
         );
     }
-    if let Some(ref val) = entry.payee_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.payee_column {
+        let col = require_column_value("payee_column", val)?;
         builder = apply_column(
             builder,
             &col,
@@ -195,9 +202,8 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
             |b, n| b.payee_column(n),
         );
     }
-    if let Some(ref val) = entry.amount_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.amount_column {
+        let col = require_column_value("amount_column", val)?;
         builder = apply_column(
             builder,
             &col,
@@ -205,9 +211,8 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
             |b, n| b.amount_column(n),
         );
     }
-    if let Some(ref val) = entry.currency_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.currency_column {
+        let col = require_column_value("currency_column", val)?;
         builder = apply_column(
             builder,
             &col,
@@ -215,14 +220,12 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
             |b, n| b.currency_column(n),
         );
     }
-    if let Some(ref val) = entry.debit_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.debit_column {
+        let col = require_column_value("debit_column", val)?;
         builder = builder.debit_column(&col);
     }
-    if let Some(ref val) = entry.credit_column
-        && let Some(col) = parse_column_value(val)
-    {
+    if let Some(ref val) = entry.credit_column {
+        let col = require_column_value("credit_column", val)?;
         builder = builder.credit_column(&col);
     }
     if let Some(ref locale) = entry.amount_locale {
@@ -322,6 +325,10 @@ pub fn entry_toml_from_inferred(
     if let Some(ref c) = inferred.currency_column {
         t.insert("currency_column".into(), col(c));
     }
+    // Inference only ever produces a Name column here (secondary-date
+    // detection is header-gated — see `csv_inference`'s SecondaryDate
+    // construction), so the Name-only match is lossless. Pinned by
+    // `inferred_secondary_date_is_always_named`.
     if let Some(ref sd) = inferred.secondary_date
         && let ColumnSpec::Name(ref n) = sd.column
     {
@@ -426,6 +433,68 @@ amount_column = 2
         let entry = ImporterEntry::from_toml_str(&toml_str).expect("round-trips");
         assert_eq!(entry.name, "inferred");
         build_config_from_entry(&entry).expect("config builds");
+    }
+
+    /// A mistyped column value is an error, not a silent fallback to the
+    /// default column.
+    #[test]
+    fn wrong_column_type_is_rejected() {
+        let entry = ImporterEntry::from_toml_str(
+            "name = \"bad\"\naccount = \"Assets:Bank\"\namount_column = 2.0",
+        )
+        .expect("parses as TOML");
+        let err = build_config_from_entry(&entry).expect_err("must reject");
+        assert!(err.to_string().contains("amount_column"), "{err}");
+    }
+
+    /// Drift guard: the TOML round-trip path (`entry_toml_from_inferred` →
+    /// `build_config_from_entry`) must agree with the canonical direct
+    /// mapping (`InferredCsvConfig::to_csv_config`) on the same inference.
+    #[test]
+    fn inferred_toml_path_matches_to_csv_config() {
+        let content = "Booking Date,Value Date,Description,Amount\n\
+                       2026-07-01,2026-07-02,Coffee,-4.50\n\
+                       2026-07-03,2026-07-04,Salary,2500.00\n";
+        let inferred = crate::csv_inference::infer_csv_config(content).expect("inferable");
+        let direct = inferred.to_csv_config();
+
+        let toml_str = entry_toml_from_inferred("x", &inferred);
+        let entry = ImporterEntry::from_toml_str(&toml_str).expect("round-trips");
+        let via_toml = build_config_from_entry(&entry).expect("config builds");
+        let ImporterType::Csv(via_toml) = &via_toml.importer_type;
+
+        assert_eq!(
+            format!("{:?}", via_toml.date_column),
+            format!("{:?}", direct.date_column)
+        );
+        assert_eq!(via_toml.date_format, direct.date_format);
+        assert_eq!(
+            format!("{:?}", via_toml.amount_column),
+            format!("{:?}", direct.amount_column)
+        );
+        assert_eq!(
+            format!("{:?}", via_toml.narration_column),
+            format!("{:?}", direct.narration_column)
+        );
+        assert_eq!(via_toml.delimiter, direct.delimiter);
+        assert_eq!(via_toml.has_header, direct.has_header);
+        assert_eq!(
+            format!("{:?}", via_toml.secondary_date),
+            format!("{:?}", direct.secondary_date),
+            "secondary date must survive the TOML round trip"
+        );
+    }
+
+    /// The invariant `entry_toml_from_inferred`'s Name-only secondary-date
+    /// match relies on: inference never emits an Index secondary column.
+    #[test]
+    fn inferred_secondary_date_is_always_named() {
+        let content = "Booking Date,Value Date,Description,Amount\n\
+                       2026-07-01,2026-07-02,Coffee,-4.50\n";
+        let inferred = crate::csv_inference::infer_csv_config(content).expect("inferable");
+        if let Some(sd) = inferred.secondary_date {
+            assert!(matches!(sd.column, crate::config::ColumnSpec::Name(_)));
+        }
     }
 
     /// The Debug form of `Locale` is the locale code and parses back —

--- a/crates/rustledger-importer/src/toml_entry.rs
+++ b/crates/rustledger-importer/src/toml_entry.rs
@@ -1,0 +1,441 @@
+//! The `importers.toml` entry schema and its mapping onto [`ImporterConfig`].
+//!
+//! This is the canonical parser for one `[[importers]]` entry — the schema
+//! documented in `docs/commands/extract.md`. It lives here (not in the CLI)
+//! so every consumer of the declarative config speaks the same dialect: the
+//! `rledger extract` command and the WASI component's `importer` interface
+//! both build their [`ImporterConfig`] through [`build_config_from_entry`].
+//! File *discovery* (search paths, `~` expansion, the `wasm_importer_dir`
+//! setting) stays CLI-side — it is filesystem policy, not schema.
+//!
+//! Gated behind the `toml-config` feature so slim builds don't pull
+//! `toml`/`serde`.
+
+use crate::ImporterConfig;
+use crate::config::CsvConfigBuilder;
+use anyhow::{Result, anyhow};
+use format_num_pattern::Locale;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// A single importer entry in `importers.toml`.
+#[derive(Debug, Deserialize)]
+pub struct ImporterEntry {
+    /// Name used to select this importer via --importer flag.
+    pub name: String,
+    /// Optional glob pattern to auto-identify this importer by filename.
+    pub filename_pattern: Option<String>,
+    /// Target account for imported transactions.
+    pub account: Option<String>,
+    /// Currency (default: USD).
+    pub currency: Option<String>,
+    /// Date column name or 0-based index.
+    pub date_column: Option<toml::Value>,
+    /// Date format (strftime-style).
+    pub date_format: Option<String>,
+    /// Narration/description column name or index.
+    pub narration_column: Option<toml::Value>,
+    /// Payee column name or index.
+    pub payee_column: Option<toml::Value>,
+    /// Amount column name or index.
+    pub amount_column: Option<toml::Value>,
+    /// Per-row currency column name or index.
+    pub currency_column: Option<toml::Value>,
+    /// Debit column name or index.
+    pub debit_column: Option<toml::Value>,
+    /// Credit column name or index.
+    pub credit_column: Option<toml::Value>,
+    /// A second date column (header name) to preserve as transaction metadata
+    /// — e.g. a value date alongside the booking `date_column` (#1623).
+    pub secondary_date_column: Option<String>,
+    /// strftime-style format for `secondary_date_column` (default: `date_format`).
+    pub secondary_date_format: Option<String>,
+    /// Metadata key the secondary date is stored under (default: a slug of the
+    /// column name, e.g. `value_date`).
+    pub secondary_date_key: Option<String>,
+    /// Amount locale for number parsing (e.g. `de_DE` so `21,12` reads as
+    /// 21.12). Mirrors the `--amount-locale` CLI flag.
+    pub amount_locale: Option<String>,
+    /// Amount format pattern (`format_num_pattern` style). Mirrors the
+    /// `--amount-format` CLI flag.
+    pub amount_format: Option<String>,
+    /// CSV delimiter character.
+    pub delimiter: Option<String>,
+    /// Number of rows to skip.
+    pub skip_rows: Option<usize>,
+    /// Whether the CSV has a header row.
+    #[serde(default)]
+    pub skip_header: Option<bool>,
+    /// Whether to invert amount signs.
+    #[serde(default)]
+    pub invert_amounts: Option<bool>,
+    /// Default expense account for unmatched negative-amount (money out) transactions.
+    pub default_expense: Option<String>,
+    /// Default income account for unmatched positive-amount (money in) transactions.
+    pub default_income: Option<String>,
+    /// Account mappings: pattern → account.
+    #[serde(default)]
+    pub mappings: HashMap<String, String>,
+    /// Categorize via the built-in merchant dictionary (off by default).
+    pub use_merchant_dict: Option<bool>,
+}
+
+impl ImporterEntry {
+    /// Parse a single entry from a bare TOML table, e.g.
+    /// `name = "bank"\ndate_column = "Date"`. This is the config shape the
+    /// component's `importer.extract` accepts — one entry, no
+    /// `[[importers]]` wrapper.
+    ///
+    /// # Errors
+    /// Returns an error when the TOML is malformed or missing `name`.
+    pub fn from_toml_str(toml_str: &str) -> Result<Self> {
+        toml::from_str(toml_str).map_err(|e| anyhow!("invalid importer config: {e}"))
+    }
+}
+
+/// Apply a CSV column flag that may be a header name or a bare 0-based index.
+///
+/// CSV column flags are documented as "name or index". A value that parses as a
+/// non-negative integer is treated as a positional index (so headerless CSVs
+/// import correctly); anything else is a column name. Shared by the CLI-argument
+/// and `importers.toml` config paths so both honor numeric columns.
+pub fn apply_column(
+    builder: CsvConfigBuilder,
+    col: &str,
+    by_index: impl FnOnce(CsvConfigBuilder, usize) -> CsvConfigBuilder,
+    by_name: impl FnOnce(CsvConfigBuilder, &str) -> CsvConfigBuilder,
+) -> CsvConfigBuilder {
+    match col.parse::<usize>() {
+        Ok(i) => by_index(builder, i),
+        Err(_) => by_name(builder, col),
+    }
+}
+
+/// Parse a TOML value as a column spec string (either a string name or integer index).
+#[must_use]
+pub fn parse_column_value(value: &toml::Value) -> Option<String> {
+    match value {
+        toml::Value::String(s) => Some(s.clone()),
+        toml::Value::Integer(i) => Some(i.to_string()),
+        _ => None,
+    }
+}
+
+/// Parse an amount-locale name (e.g. `de_DE`, `en_US`) into a [`Locale`].
+///
+/// Emits a consistent error for an unrecognized name. Shared by the CLI's
+/// `--amount-locale` flag and the `amount_locale` config field.
+///
+/// # Errors
+/// Returns an error when `name` is not a recognized locale.
+pub fn parse_amount_locale(name: &str) -> Result<Locale> {
+    Locale::from_str(name).map_err(|_| anyhow!("{name} is not a valid locale"))
+}
+
+/// Build an [`ImporterConfig`] from a named importer entry.
+///
+/// # Errors
+/// Returns an error when a field fails to validate (e.g. an unknown
+/// `amount_locale`) or the assembled config is incomplete.
+pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> {
+    let mut builder = ImporterConfig::csv();
+
+    if let Some(ref account) = entry.account {
+        builder = builder.account(account);
+    }
+    if let Some(ref currency) = entry.currency {
+        builder = builder.currency(currency);
+    }
+    if let Some(ref val) = entry.date_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::date_column_index,
+            |b, n| b.date_column(n),
+        );
+    }
+    if let Some(ref fmt) = entry.date_format {
+        builder = builder.date_format(fmt);
+    }
+    if let Some(ref col) = entry.secondary_date_column {
+        // Format defaults to the primary date format; key defaults to a slug of
+        // the column name (e.g. "Value Date" -> "value_date").
+        let fmt = entry
+            .secondary_date_format
+            .clone()
+            .or_else(|| entry.date_format.clone())
+            .unwrap_or_else(|| "%Y-%m-%d".to_string());
+        let key = entry.secondary_date_key.clone().unwrap_or_else(|| {
+            col.trim()
+                .to_lowercase()
+                .replace(|c: char| !c.is_ascii_alphanumeric(), "_")
+        });
+        builder = builder.secondary_date(col, fmt, key);
+    }
+    if let Some(ref val) = entry.narration_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::narration_column_index,
+            |b, n| b.narration_column(n),
+        );
+    }
+    if let Some(ref val) = entry.payee_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::payee_column_index,
+            |b, n| b.payee_column(n),
+        );
+    }
+    if let Some(ref val) = entry.amount_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::amount_column_index,
+            |b, n| b.amount_column(n),
+        );
+    }
+    if let Some(ref val) = entry.currency_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = apply_column(
+            builder,
+            &col,
+            CsvConfigBuilder::currency_column_index,
+            |b, n| b.currency_column(n),
+        );
+    }
+    if let Some(ref val) = entry.debit_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = builder.debit_column(&col);
+    }
+    if let Some(ref val) = entry.credit_column
+        && let Some(col) = parse_column_value(val)
+    {
+        builder = builder.credit_column(&col);
+    }
+    if let Some(ref locale) = entry.amount_locale {
+        builder = builder.amount_locale(parse_amount_locale(locale)?);
+    }
+    if let Some(ref format) = entry.amount_format {
+        builder = builder.amount_format(format);
+    }
+    if let Some(ref delim) = entry.delimiter
+        && let Some(c) = delim.chars().next()
+    {
+        builder = builder.delimiter(c);
+    }
+    if let Some(skip) = entry.skip_rows {
+        builder = builder.skip_rows(skip);
+    }
+    if let Some(skip_header) = entry.skip_header {
+        builder = builder.has_header(!skip_header);
+    }
+    if let Some(invert) = entry.invert_amounts {
+        builder = builder.invert_sign(invert);
+    }
+    if let Some(ref account) = entry.default_expense {
+        builder = builder.default_expense(account);
+    }
+    if let Some(ref account) = entry.default_income {
+        builder = builder.default_income(account);
+    }
+    if !entry.mappings.is_empty() {
+        let mut mappings: Vec<(String, String)> = entry
+            .mappings
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        mappings.sort_by_key(|a| std::cmp::Reverse(a.0.len()));
+        builder = builder.mappings(mappings);
+    }
+
+    if let Some(enable) = entry.use_merchant_dict {
+        builder = builder.use_merchant_dict(enable);
+    }
+
+    builder.build()
+}
+
+/// Render an inferred CSV mapping as an `importers.toml` entry (bare table).
+///
+/// The output round-trips through [`ImporterEntry::from_toml_str`] +
+/// [`build_config_from_entry`], so a host can show it to the user, let them
+/// edit it, and pass it straight back to an extract call. Only inferred
+/// fields are emitted; account/currency are the caller's to add.
+#[must_use]
+pub fn entry_toml_from_inferred(
+    name: &str,
+    inferred: &crate::csv_inference::InferredCsvConfig,
+) -> String {
+    use crate::config::ColumnSpec;
+    use toml::Value;
+
+    fn col(spec: &ColumnSpec) -> Value {
+        match spec {
+            ColumnSpec::Name(n) => Value::String(n.clone()),
+            #[allow(clippy::cast_possible_wrap)]
+            ColumnSpec::Index(i) => Value::Integer(*i as i64),
+        }
+    }
+
+    let mut t = toml::value::Table::new();
+    t.insert("name".into(), Value::String(name.to_string()));
+    t.insert(
+        "delimiter".into(),
+        Value::String(inferred.delimiter.to_string()),
+    );
+    if !inferred.has_header {
+        t.insert("skip_header".into(), Value::Boolean(true));
+    }
+    t.insert("date_column".into(), col(&inferred.date_column));
+    t.insert(
+        "date_format".into(),
+        Value::String(inferred.date_format.clone()),
+    );
+    if let Some(ref c) = inferred.amount_column {
+        t.insert("amount_column".into(), col(c));
+    }
+    if let Some(ref c) = inferred.debit_column {
+        t.insert("debit_column".into(), col(c));
+    }
+    if let Some(ref c) = inferred.credit_column {
+        t.insert("credit_column".into(), col(c));
+    }
+    if let Some(ref c) = inferred.narration_column {
+        t.insert("narration_column".into(), col(c));
+    }
+    if let Some(ref c) = inferred.payee_column {
+        t.insert("payee_column".into(), col(c));
+    }
+    if let Some(ref c) = inferred.currency_column {
+        t.insert("currency_column".into(), col(c));
+    }
+    if let Some(ref sd) = inferred.secondary_date
+        && let ColumnSpec::Name(ref n) = sd.column
+    {
+        t.insert("secondary_date_column".into(), Value::String(n.clone()));
+        t.insert(
+            "secondary_date_format".into(),
+            Value::String(sd.format.clone()),
+        );
+        t.insert(
+            "secondary_date_key".into(),
+            Value::String(sd.meta_key.clone()),
+        );
+    }
+    if let Some(locale) = inferred.amount_locale {
+        // `Locale`'s variant names ARE the locale codes (`de_DE`, `en_US`),
+        // so the Debug form round-trips through `Locale::from_str` /
+        // `parse_amount_locale`. Pinned by `inferred_locale_round_trips`.
+        t.insert("amount_locale".into(), Value::String(format!("{locale:?}")));
+    }
+    // A table of scalars always serializes.
+    toml::to_string(&Value::Table(t)).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ImporterType;
+
+    #[derive(Debug, Deserialize)]
+    struct EntriesWrapper {
+        importers: Vec<ImporterEntry>,
+    }
+
+    /// Regression for #1133: `amount_locale` / `amount_format` set in
+    /// `importers.toml` were silently ignored — only the matching CLI flags
+    /// (`--amount-locale` / `--amount-format`) applied them.
+    #[test]
+    fn build_config_from_entry_applies_amount_locale_and_format() {
+        let src = r##"
+[[importers]]
+name = "de-locale"
+account = "Assets:Bank"
+amount_locale = "de_DE"
+
+[[importers]]
+name = "de-format"
+account = "Assets:Bank"
+amount_locale = "de_DE"
+amount_format = "#.##0,00"
+"##;
+        let file: EntriesWrapper = toml::from_str(src).expect("toml parses");
+
+        // amount_locale: in de_DE the comma is the decimal separator, so
+        // "21,12" reads as 21.12 (the #1133 bug read it as 2112).
+        let cfg = build_config_from_entry(&file.importers[0]).expect("config builds");
+        let ImporterType::Csv(csv) = &cfg.importer_type;
+        let fmt = csv.compile_amount_format().expect("format compiles");
+        assert_eq!(
+            fmt.parse("21,12").expect("amount parses").to_string(),
+            "21.12"
+        );
+
+        // amount_format also flows through from the toml entry.
+        let cfg = build_config_from_entry(&file.importers[1]).expect("config builds");
+        let ImporterType::Csv(csv) = &cfg.importer_type;
+        assert_eq!(csv.amount_format.as_deref(), Some("#.##0,00"));
+    }
+
+    /// The component's config shape: one bare TOML table, no `[[importers]]`.
+    #[test]
+    fn entry_parses_from_bare_table() {
+        let entry = ImporterEntry::from_toml_str(
+            r#"
+name = "bank"
+account = "Assets:Bank"
+date_column = "Date"
+amount_column = 2
+"#,
+        )
+        .expect("bare table parses");
+        assert_eq!(entry.name, "bank");
+        // Numeric columns survive as indices.
+        assert_eq!(
+            parse_column_value(entry.amount_column.as_ref().expect("set")),
+            Some("2".to_string())
+        );
+        build_config_from_entry(&entry).expect("config builds");
+    }
+
+    #[test]
+    fn entry_without_name_is_rejected() {
+        assert!(ImporterEntry::from_toml_str("account = \"Assets:Bank\"").is_err());
+    }
+
+    /// Inference output round-trips: serialize → parse → build a config.
+    #[test]
+    fn inferred_entry_toml_round_trips() {
+        let content =
+            "Date,Description,Amount\n2026-07-01,Coffee,-4.50\n2026-07-02,Salary,2500.00\n";
+        let inferred = crate::csv_inference::infer_csv_config(content).expect("inferable");
+        let toml_str = entry_toml_from_inferred("inferred", &inferred);
+        let entry = ImporterEntry::from_toml_str(&toml_str).expect("round-trips");
+        assert_eq!(entry.name, "inferred");
+        build_config_from_entry(&entry).expect("config builds");
+    }
+
+    /// The Debug form of `Locale` is the locale code and parses back —
+    /// the contract `entry_toml_from_inferred` relies on.
+    #[test]
+    fn inferred_locale_round_trips() {
+        let locale = parse_amount_locale("de_DE").expect("valid locale");
+        assert_eq!(
+            parse_amount_locale(&format!("{locale:?}")).expect("round-trips"),
+            locale
+        );
+    }
+}

--- a/crates/rustledger-importer/src/toml_entry.rs
+++ b/crates/rustledger-importer/src/toml_entry.rs
@@ -277,11 +277,15 @@ pub fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> 
 /// [`build_config_from_entry`], so a host can show it to the user, let them
 /// edit it, and pass it straight back to an extract call. Only inferred
 /// fields are emitted; account/currency are the caller's to add.
-#[must_use]
+///
+/// # Errors
+/// Serialization of a flat table of scalars should not fail; the error is
+/// still propagated rather than swallowed so a future non-scalar field
+/// can't silently produce an empty config.
 pub fn entry_toml_from_inferred(
     name: &str,
     inferred: &crate::csv_inference::InferredCsvConfig,
-) -> String {
+) -> Result<String> {
     use crate::config::ColumnSpec;
     use toml::Value;
 
@@ -348,8 +352,7 @@ pub fn entry_toml_from_inferred(
         // `parse_amount_locale`. Pinned by `inferred_locale_round_trips`.
         t.insert("amount_locale".into(), Value::String(format!("{locale:?}")));
     }
-    // A table of scalars always serializes.
-    toml::to_string(&Value::Table(t)).unwrap_or_default()
+    toml::to_string(&Value::Table(t)).map_err(|e| anyhow!("serializing inferred config: {e}"))
 }
 
 #[cfg(test)]
@@ -429,7 +432,7 @@ amount_column = 2
         let content =
             "Date,Description,Amount\n2026-07-01,Coffee,-4.50\n2026-07-02,Salary,2500.00\n";
         let inferred = crate::csv_inference::infer_csv_config(content).expect("inferable");
-        let toml_str = entry_toml_from_inferred("inferred", &inferred);
+        let toml_str = entry_toml_from_inferred("inferred", &inferred).expect("serializes");
         let entry = ImporterEntry::from_toml_str(&toml_str).expect("round-trips");
         assert_eq!(entry.name, "inferred");
         build_config_from_entry(&entry).expect("config builds");
@@ -458,7 +461,7 @@ amount_column = 2
         let inferred = crate::csv_inference::infer_csv_config(content).expect("inferable");
         let direct = inferred.to_csv_config();
 
-        let toml_str = entry_toml_from_inferred("x", &inferred);
+        let toml_str = entry_toml_from_inferred("x", &inferred).expect("serializes");
         let entry = ImporterEntry::from_toml_str(&toml_str).expect("round-trips");
         let via_toml = build_config_from_entry(&entry).expect("config builds");
         let ImporterType::Csv(via_toml) = &via_toml.importer_type;

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -87,7 +87,7 @@ rustledger-query.workspace = true
 # importer paths behind that feature. See #1427.
 rustledger-plugin.workspace = true
 rustledger-ops.workspace = true
-rustledger-importer.workspace = true
+rustledger-importer = { workspace = true, features = ["toml-config"] }
 clap.workspace = true
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -1,11 +1,16 @@
 //! Importers TOML configuration for extract command.
 
 use anyhow::{Context, Result, anyhow};
-use rustledger_importer::ImporterConfig;
-use rustledger_importer::config::CsvConfigBuilder;
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::path::Path;
+
+// The `[[importers]]` entry schema and its `ImporterConfig` mapping are the
+// canonical `rustledger_importer::toml_entry` module (shared with the WASI
+// component's `importer` interface); this module keeps only file discovery
+// and the CLI-side `ImportersFile` wrapper.
+pub(super) use rustledger_importer::toml_entry::{
+    ImporterEntry, apply_column, build_config_from_entry,
+};
 #[cfg(feature = "python-plugin-wasm")]
 use std::path::PathBuf;
 
@@ -73,95 +78,6 @@ pub(super) fn expand_tilde(path: &Path) -> PathBuf {
     path.to_path_buf()
 }
 
-/// A single importer entry in importers.toml.
-#[derive(Debug, Deserialize)]
-pub(super) struct ImporterEntry {
-    /// Name used to select this importer via --importer flag.
-    pub(super) name: String,
-    /// Optional glob pattern to auto-identify this importer by filename.
-    pub(super) filename_pattern: Option<String>,
-    /// Target account for imported transactions.
-    pub(super) account: Option<String>,
-    /// Currency (default: USD).
-    pub(super) currency: Option<String>,
-    /// Date column name or 0-based index.
-    pub(super) date_column: Option<toml::Value>,
-    /// Date format (strftime-style).
-    pub(super) date_format: Option<String>,
-    /// Narration/description column name or index.
-    pub(super) narration_column: Option<toml::Value>,
-    /// Payee column name or index.
-    pub(super) payee_column: Option<toml::Value>,
-    /// Amount column name or index.
-    pub(super) amount_column: Option<toml::Value>,
-    /// Per-row currency column name or index.
-    pub(super) currency_column: Option<toml::Value>,
-    /// Debit column name or index.
-    pub(super) debit_column: Option<toml::Value>,
-    /// Credit column name or index.
-    pub(super) credit_column: Option<toml::Value>,
-    /// A second date column (header name) to preserve as transaction metadata
-    /// — e.g. a value date alongside the booking `date_column` (#1623).
-    pub(super) secondary_date_column: Option<String>,
-    /// strftime-style format for `secondary_date_column` (default: `date_format`).
-    pub(super) secondary_date_format: Option<String>,
-    /// Metadata key the secondary date is stored under (default: a slug of the
-    /// column name, e.g. `value_date`).
-    pub(super) secondary_date_key: Option<String>,
-    /// Amount locale for number parsing (e.g. `de_DE` so `21,12` reads as
-    /// 21.12). Mirrors the `--amount-locale` CLI flag.
-    pub(super) amount_locale: Option<String>,
-    /// Amount format pattern (`format_num_pattern` style). Mirrors the
-    /// `--amount-format` CLI flag.
-    pub(super) amount_format: Option<String>,
-    /// CSV delimiter character.
-    pub(super) delimiter: Option<String>,
-    /// Number of rows to skip.
-    pub(super) skip_rows: Option<usize>,
-    /// Whether the CSV has a header row.
-    #[serde(default)]
-    pub(super) skip_header: Option<bool>,
-    /// Whether to invert amount signs.
-    #[serde(default)]
-    pub(super) invert_amounts: Option<bool>,
-    /// Default expense account for unmatched negative-amount (money out) transactions.
-    pub(super) default_expense: Option<String>,
-    /// Default income account for unmatched positive-amount (money in) transactions.
-    pub(super) default_income: Option<String>,
-    /// Account mappings: pattern → account.
-    #[serde(default)]
-    pub(super) mappings: HashMap<String, String>,
-    /// Categorize via the built-in merchant dictionary (off by default).
-    pub(super) use_merchant_dict: Option<bool>,
-}
-
-/// Apply a CSV column flag that may be a header name or a bare 0-based index.
-///
-/// CSV column flags are documented as "name or index". A value that parses as a
-/// non-negative integer is treated as a positional index (so headerless CSVs
-/// import correctly); anything else is a column name. Shared by the CLI-argument
-/// and `importers.toml` config paths so both honor numeric columns.
-pub(super) fn apply_column(
-    builder: CsvConfigBuilder,
-    col: &str,
-    by_index: impl FnOnce(CsvConfigBuilder, usize) -> CsvConfigBuilder,
-    by_name: impl FnOnce(CsvConfigBuilder, &str) -> CsvConfigBuilder,
-) -> CsvConfigBuilder {
-    match col.parse::<usize>() {
-        Ok(i) => by_index(builder, i),
-        Err(_) => by_name(builder, col),
-    }
-}
-
-/// Parse a TOML value as a column spec string (either a string name or integer index).
-pub(super) fn parse_column_value(value: &toml::Value) -> Option<String> {
-    match value {
-        toml::Value::String(s) => Some(s.clone()),
-        toml::Value::Integer(i) => Some(i.to_string()),
-        _ => None,
-    }
-}
-
 /// Find the importers.toml file, searching in standard locations.
 pub(super) fn find_importers_config(
     explicit_path: Option<&Path>,
@@ -199,137 +115,6 @@ pub(super) fn load_importers_config(path: &Path) -> Result<ImportersFile> {
     Ok(config)
 }
 
-/// Build an `ImporterConfig` from a named importer entry.
-pub(super) fn build_config_from_entry(entry: &ImporterEntry) -> Result<ImporterConfig> {
-    let mut builder = ImporterConfig::csv();
-
-    if let Some(ref account) = entry.account {
-        builder = builder.account(account);
-    }
-    if let Some(ref currency) = entry.currency {
-        builder = builder.currency(currency);
-    }
-    if let Some(ref val) = entry.date_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = apply_column(
-            builder,
-            &col,
-            CsvConfigBuilder::date_column_index,
-            |b, n| b.date_column(n),
-        );
-    }
-    if let Some(ref fmt) = entry.date_format {
-        builder = builder.date_format(fmt);
-    }
-    if let Some(ref col) = entry.secondary_date_column {
-        // Format defaults to the primary date format; key defaults to a slug of
-        // the column name (e.g. "Value Date" -> "value_date").
-        let fmt = entry
-            .secondary_date_format
-            .clone()
-            .or_else(|| entry.date_format.clone())
-            .unwrap_or_else(|| "%Y-%m-%d".to_string());
-        let key = entry.secondary_date_key.clone().unwrap_or_else(|| {
-            col.trim()
-                .to_lowercase()
-                .replace(|c: char| !c.is_ascii_alphanumeric(), "_")
-        });
-        builder = builder.secondary_date(col, fmt, key);
-    }
-    if let Some(ref val) = entry.narration_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = apply_column(
-            builder,
-            &col,
-            CsvConfigBuilder::narration_column_index,
-            |b, n| b.narration_column(n),
-        );
-    }
-    if let Some(ref val) = entry.payee_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = apply_column(
-            builder,
-            &col,
-            CsvConfigBuilder::payee_column_index,
-            |b, n| b.payee_column(n),
-        );
-    }
-    if let Some(ref val) = entry.amount_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = apply_column(
-            builder,
-            &col,
-            CsvConfigBuilder::amount_column_index,
-            |b, n| b.amount_column(n),
-        );
-    }
-    if let Some(ref val) = entry.currency_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = apply_column(
-            builder,
-            &col,
-            CsvConfigBuilder::currency_column_index,
-            |b, n| b.currency_column(n),
-        );
-    }
-    if let Some(ref val) = entry.debit_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = builder.debit_column(&col);
-    }
-    if let Some(ref val) = entry.credit_column
-        && let Some(col) = parse_column_value(val)
-    {
-        builder = builder.credit_column(&col);
-    }
-    if let Some(ref locale) = entry.amount_locale {
-        builder = builder.amount_locale(super::parse_amount_locale(locale)?);
-    }
-    if let Some(ref format) = entry.amount_format {
-        builder = builder.amount_format(format);
-    }
-    if let Some(ref delim) = entry.delimiter
-        && let Some(c) = delim.chars().next()
-    {
-        builder = builder.delimiter(c);
-    }
-    if let Some(skip) = entry.skip_rows {
-        builder = builder.skip_rows(skip);
-    }
-    if let Some(skip_header) = entry.skip_header {
-        builder = builder.has_header(!skip_header);
-    }
-    if let Some(invert) = entry.invert_amounts {
-        builder = builder.invert_sign(invert);
-    }
-    if let Some(ref account) = entry.default_expense {
-        builder = builder.default_expense(account);
-    }
-    if let Some(ref account) = entry.default_income {
-        builder = builder.default_income(account);
-    }
-    if !entry.mappings.is_empty() {
-        let mut mappings: Vec<(String, String)> = entry
-            .mappings
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        mappings.sort_by_key(|a| std::cmp::Reverse(a.0.len()));
-        builder = builder.mappings(mappings);
-    }
-
-    if let Some(enable) = entry.use_merchant_dict {
-        builder = builder.use_merchant_dict(enable);
-    }
-
-    builder.build()
-}
-
 /// Check if an importer matches the given filename using its glob pattern.
 pub(super) fn importer_matches_filename(entry: &ImporterEntry, filename: &str) -> bool {
     if let Some(pattern) = &entry.filename_pattern {
@@ -349,45 +134,4 @@ pub(super) fn find_matching_importers<'a>(
         .iter()
         .filter(|imp| importer_matches_filename(imp, filename))
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rustledger_importer::config::ImporterType;
-
-    /// Regression for #1133: `amount_locale` / `amount_format` set in
-    /// `importers.toml` were silently ignored — only the matching CLI flags
-    /// (`--amount-locale` / `--amount-format`) applied them.
-    #[test]
-    fn build_config_from_entry_applies_amount_locale_and_format() {
-        let src = r##"
-[[importers]]
-name = "de-locale"
-account = "Assets:Bank"
-amount_locale = "de_DE"
-
-[[importers]]
-name = "de-format"
-account = "Assets:Bank"
-amount_locale = "de_DE"
-amount_format = "#.##0,00"
-"##;
-        let file: ImportersFile = toml::from_str(src).expect("toml parses");
-
-        // amount_locale: in de_DE the comma is the decimal separator, so
-        // "21,12" reads as 21.12 (the #1133 bug read it as 2112).
-        let cfg = build_config_from_entry(&file.importers[0]).expect("config builds");
-        let ImporterType::Csv(csv) = &cfg.importer_type;
-        let fmt = csv.compile_amount_format().expect("format compiles");
-        assert_eq!(
-            fmt.parse("21,12").expect("amount parses").to_string(),
-            "21.12"
-        );
-
-        // amount_format also flows through from the toml entry.
-        let cfg = build_config_from_entry(&file.importers[1]).expect("config builds");
-        let ImporterType::Csv(csv) = &cfg.importer_type;
-        assert_eq!(csv.amount_format.as_deref(), Some("#.##0,00"));
-    }
 }

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -4,10 +4,10 @@ use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 use std::path::Path;
 
-// The `[[importers]]` entry schema and its `ImporterConfig` mapping are the
-// canonical `rustledger_importer::toml_entry` module (shared with the WASI
-// component's `importer` interface); this module keeps only file discovery
-// and the CLI-side `ImportersFile` wrapper.
+// The `[[importers]]` entry schema and its `ImporterConfig` mapping live in
+// the canonical `rustledger_importer::toml_entry` module (shared with the
+// WASI component's `importer` interface); this module keeps only file
+// discovery and the CLI-side `ImportersFile` wrapper.
 pub(super) use rustledger_importer::toml_entry::{
     ImporterEntry, apply_column, build_config_from_entry,
 };

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -70,7 +70,6 @@ use config::{
 #[cfg(feature = "python-plugin-wasm")]
 use config::expand_tilde;
 use duplicate::load_existing_transactions;
-use format_num_pattern::Locale;
 use rustledger_core::{Directive, FormatConfig};
 use rustledger_importer::config::CsvConfigBuilder;
 use rustledger_importer::{Importer, ImporterConfig, ImporterRegistry, csv_importer::CsvImporter};
@@ -78,7 +77,6 @@ use rustledger_parser::format::canonicalize_directives;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Arc;
 
 /// Extract transactions from bank files.
@@ -463,12 +461,9 @@ fn build_registry(args: &Args) -> Result<ImporterRegistry> {
     Ok(registry)
 }
 
-/// Parse an `--amount-locale` value (e.g. `de_DE`, `en_US`) into a [`Locale`],
-/// with a consistent error for an unrecognized name. Shared by the `--auto`
-/// and raw-CLI config paths.
-fn parse_amount_locale(name: &str) -> Result<Locale> {
-    Locale::from_str(name).map_err(|_| anyhow!("{name} is not a valid locale"))
-}
+// `parse_amount_locale` moved to `rustledger_importer::toml_entry` (the
+// canonical config-schema module, shared with the WASI component).
+use rustledger_importer::toml_entry::parse_amount_locale;
 
 /// Run the extract command with the given arguments, writing extracted
 /// directives to stdout.
@@ -900,9 +895,9 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
 
 #[cfg(test)]
 mod tests {
-    use super::config::{ImporterEntry, parse_column_value};
     use super::*;
     use rustledger_importer::config::ImporterType;
+    use rustledger_importer::toml_entry::{ImporterEntry, parse_column_value};
     use std::collections::HashMap;
 
     fn write_temp_config(content: &str) -> (tempfile::TempDir, PathBuf) {


### PR DESCRIPTION
Implements the top *Now* item from the revised importing roadmap (#1763): the import engine was reachable only through `rledger extract` — rustfava imports via Python beangulp and the component had no import surface, so no GUI user could touch the Rust machinery.

## What

Adds an `importer` interface to the `rustledger:ledger` WIT world (**3.4.0 → 3.5.0**, additive):

- `identify(filename, content)` — builtin recognition by extension, with an OFX/CSV content sniff so misnamed downloads (e.g. an OFX body served as `.txt`) still resolve.
- `infer(filename, content)` — CSV auto-inference returning an **`importers.toml` entry as a bare TOML table** that round-trips into `extract`: the host shows it, the user tweaks it, it goes straight back.
- `extract(filename, content, config)` — CSV/OFX extraction from bytes (no filesystem needed); extracted entries carry the statement filename as their source location.

## Canonical-function discipline

The `[[importers]]` entry schema **moves** from the CLI into `rustledger_importer::toml_entry` (new `toml-config` feature: serde + toml, off by default so slim builds stay slim). The CLI and the component now share one config parser — including `parse_amount_locale` and the #1133 regression test, which moved with it. The `.wasm` plugin-importer runtime stays host-side (a component cannot host nested guests); WIT docs say so explicitly.

## Testing

- `toml_entry`: entry parsing, config building, bare-table shape, inference→TOML→config round-trip, locale Debug-form round-trip.
- Component `convert` unit tests (native): identify by extension + sniff, infer→extract loop, OFX minimal config, malformed-config rejection.
- **Parity suite against the real wasip2 component**: all 21 tests pass locally, including a new `importer_extract_matches_native_engine` drift guard (component result vs native engine on identical input) and the version-lockstep test at "3.5".
- Full `rustledger` CLI suite green; clippy `-D warnings` (all features/targets), fmt, rustdoc clean.

## Follow-up (separate PRs)

rustfava ingest backend consuming this interface (beangulp stays as the escape hatch); enrichment (dedup-against-session, ML suggestions) as a 3.6 addition once the UI flow exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)