### PR TITLE
chore(ci): dependabot coverage for npm packages (mcp-server, vscode)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,27 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+  # npm — MCP server. The MCP spec moves fast (2026-07-28 restructures the
+  # protocol core); without this entry the @modelcontextprotocol/sdk pin
+  # never gets update PRs and spec adoption stalls silently (issue #1767).
+  - package-ecosystem: "npm"
+    directory: "/packages/mcp-server"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+  # npm — VS Code extension.
+  - package-ecosystem: "npm"
+    directory: "/packages/vscode"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Companion to #1767 (MCP 2026-07-28 spec adoption). Dependabot watched cargo and github-actions but no npm ecosystem — `packages/mcp-server`'s `@modelcontextprotocol/sdk` (locked at 1.29.0, March 2026) and the vscode extension's deps never received update PRs, so the spec-supporting SDK release would have arrived silently never.

Adds weekly npm entries for both package directories with the same conventions as the existing ecosystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)