### PR TITLE
fix: dedupe Cargo.lock after conflicting dependabot merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,16 +4921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.253.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.253.0",
-]
-
-[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,17 +4967,6 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.253.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
-dependencies = [
- "bitflags 2.13.0",
- "indexmap",
- "semver",
 ]
 
 [[package]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1108,11 +1108,6 @@ version = "0.253.0"
 when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
-[[publisher.wasm-encoder]]
-version = "0.253.0"
-when = "2026-07-07"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-
 [[publisher.wasm-metadata]]
 version = "0.236.0"
 when = "2025-07-28"
@@ -1132,11 +1127,6 @@ trusted-publisher = "github:bytecodealliance/wasm-tools"
 [[publisher.wasmparser]]
 version = "0.251.0"
 when = "2026-05-28"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
-
-[[publisher.wasmparser]]
-version = "0.253.0"
-when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]


### PR DESCRIPTION
**Main is currently broken for every cargo command** — `failed to parse lock file: package wasm-encoder is specified twice`. Dependabot #1783 (rust-dependencies group) and #1784 (wit-bindgen 0.59) merged in quick succession and the textual lockfile merge duplicated two entries (each PR was green against its own stale base; the combination broke — the required checks are non-strict, so nothing forced a re-run on the final base).

Deduplicated by (name, version); `cargo check --workspace` passes. All open PRs (e.g. #1786, where this surfaced as 25 simultaneous failures) are blocked until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)