### PR TITLE
fix(ci): align codeql-action init with the bumped analyze version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0 — MUST match analyze below (mixed versions fail with a config-version error)
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0 — MUST match init above
         with:
           category: "/language:${{ matrix.language }}"
   # Gate job - all CodeQL analyses must pass


### PR DESCRIPTION
Dependabot #1778 bumped only `codeql-action/analyze` to 4.37.0, leaving `init` at 4.36.3. Mixed versions fail every Analyze job — on main and every PR — with:

> Loaded a configuration file for version '4.36.3', but running version '4.37.0'

Pins both steps to the same 4.37.0 SHA, with comments marking the pair as must-match so a future partial bump is visibly wrong. (Second bad artifact from the same dependabot batch as #1787 — the group config can't group across the `init`/`analyze` action paths, so this pair will drift again; the comment is the tripwire.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)