### PR TITLE
feat(config): add RLEDGER_CONFIG_DIR and deprecate RLEDGER_CONFIG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ date_format = "%m/%d/%Y"
 rledger extract --importer chase chase-statement.csv
 ```
 
-Config is searched in: current directory, `~/.config/rledger/importers.toml`, or via `--config`.
+Config is searched in: current directory, the user config directory (`$RLEDGER_CONFIG_DIR` if set, else `~/.config/rledger/importers.toml`), or via `--config`.
 
 ### Transaction Categorization
 

--- a/crates/rustledger/src/bin/rledger.rs
+++ b/crates/rustledger/src/bin/rledger.rs
@@ -18,7 +18,7 @@
 //!
 //! If no file is specified, rledger will use the default file from config:
 //! ```bash
-//! rledger check  # Uses file from ~/.config/rledger/config.toml
+//! rledger check  # Uses file from the user config
 //! ```
 //!
 //! # Aliases

--- a/crates/rustledger/src/cmd/config_cmd.rs
+++ b/crates/rustledger/src/cmd/config_cmd.rs
@@ -112,18 +112,13 @@ fn run_show<W: Write>(raw: bool, format: &str, out: &mut W) -> Result<()> {
                 }
                 config::ConfigSource::Environment => {
                     writeln!(out, "# === Environment Variables ===")?;
-                    if let Ok(file) = std::env::var("RLEDGER_FILE") {
-                        writeln!(out, "RLEDGER_FILE={file}")?;
-                    }
-                    if let Ok(format) = std::env::var("RLEDGER_FORMAT") {
-                        writeln!(out, "RLEDGER_FORMAT={format}")?;
-                    }
+                    write_non_empty_env(out, "RLEDGER_CONFIG_DIR")?;
+                    write_non_empty_env(out, "RLEDGER_FILE")?;
+                    write_non_empty_env(out, "RLEDGER_FORMAT")?;
                     if std::env::var("NO_COLOR").is_ok() {
                         writeln!(out, "NO_COLOR=1")?;
                     }
-                    if let Ok(profile) = std::env::var("RLEDGER_PROFILE") {
-                        writeln!(out, "RLEDGER_PROFILE={profile}")?;
-                    }
+                    write_non_empty_env(out, "RLEDGER_PROFILE")?;
                     writeln!(out)?;
                 }
                 _ => {}
@@ -134,6 +129,13 @@ fn run_show<W: Write>(raw: bool, format: &str, out: &mut W) -> Result<()> {
         print_config(&loaded, format, out)?;
     }
 
+    Ok(())
+}
+
+fn write_non_empty_env<W: Write>(out: &mut W, name: &str) -> Result<()> {
+    if let Some(value) = std::env::var_os(name).filter(|v| !v.is_empty()) {
+        writeln!(out, "{name}={}", value.to_string_lossy())?;
+    }
     Ok(())
 }
 
@@ -198,12 +200,12 @@ fn run_path<W: Write>(out: &mut W) -> Result<()> {
     writeln!(out, "Environment variables:")?;
     writeln!(
         out,
-        "  RLEDGER_CONFIG   Path to the config file (overrides the default location)"
+        "  RLEDGER_CONFIG_DIR  Config directory holding config.toml and importers.toml"
     )?;
-    writeln!(out, "  RLEDGER_FILE     Default beancount file")?;
-    writeln!(out, "  RLEDGER_FORMAT   Output format (text, csv, json)")?;
-    writeln!(out, "  RLEDGER_PROFILE  Active profile name")?;
-    writeln!(out, "  NO_COLOR         Disable colored output")?;
+    writeln!(out, "  RLEDGER_FILE        Default beancount file")?;
+    writeln!(out, "  RLEDGER_FORMAT      Output format (text, csv, json)")?;
+    writeln!(out, "  RLEDGER_PROFILE     Active profile name")?;
+    writeln!(out, "  NO_COLOR            Disable colored output")?;
 
     Ok(())
 }

--- a/crates/rustledger/src/cmd/extract_cmd/config.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/config.rs
@@ -96,11 +96,10 @@ pub(super) fn find_importers_config(
         }
     }
 
-    if let Some(config_dir) = dirs::config_dir() {
-        let user_path = config_dir.join("rledger").join("importers.toml");
-        if user_path.exists() {
-            return Ok(Some(user_path));
-        }
+    if let Some(user_path) = crate::config::user_config_file("importers.toml")
+        && user_path.exists()
+    {
+        return Ok(Some(user_path));
     }
 
     Ok(None)

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -331,9 +331,10 @@ fn select_importer(registry: &ImporterRegistry, file: &Path, args: &Args) -> Arc
 }
 
 fn importers_config_not_found_message() -> anyhow::Error {
-    let user_path = crate::config::user_config_file("importers.toml")
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| "the user config directory".to_string());
+    let user_path = crate::config::user_config_file("importers.toml").map_or_else(
+        || "the user config directory".to_string(),
+        |p| p.display().to_string(),
+    );
     anyhow!("No importers.toml found. Create one in the current directory or at {user_path}")
 }
 

--- a/crates/rustledger/src/cmd/extract_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/extract_cmd/mod.rs
@@ -31,9 +31,9 @@
 //! ```
 //!
 //! The file is searched for in the following locations (first found wins):
-//! 1. Path specified via `--importers-config`
+//! 1. Path specified via `--config` / `--importers-config`
 //! 2. `importers.toml` in the current directory
-//! 3. `~/.config/rledger/importers.toml`
+//! 3. `importers.toml` in the user config directory
 //!
 //! # WASM importers (wave 2.3c+)
 //!
@@ -330,6 +330,13 @@ fn select_importer(registry: &ImporterRegistry, file: &Path, args: &Args) -> Arc
     }
 }
 
+fn importers_config_not_found_message() -> anyhow::Error {
+    let user_path = crate::config::user_config_file("importers.toml")
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "the user config directory".to_string());
+    anyhow!("No importers.toml found. Create one in the current directory or at {user_path}")
+}
+
 /// Resolve the list of directories to scan for WASM importers.
 ///
 /// Top-level dispatcher; the two real branches are
@@ -366,7 +373,7 @@ fn resolve_scan_dirs_explicit(path: &Path) -> Result<Vec<PathBuf>> {
 }
 
 /// No `--config` flag — soft-discover in default locations
-/// (cwd `importers.toml` then `~/.config/rledger/importers.toml`).
+/// (cwd `importers.toml` then the user config directory).
 /// A missing file is expected; a malformed file is unusual but not
 /// fatal (the user didn't explicitly point at it). Print a warning
 /// for the malformed case so the user can find their mistake.
@@ -532,9 +539,7 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
         let config = if let Some(ref importer_name) = args.importer {
             // Explicit --importer: require config file, find named entry
             let config_path = find_importers_config(args.config.as_deref())?
-                .ok_or_else(|| anyhow!(
-                    "No importers.toml found. Create one in the current directory or at ~/.config/rledger/importers.toml"
-                ))?;
+                .ok_or_else(importers_config_not_found_message)?;
 
             let importers_file = load_importers_config(&config_path)?;
 
@@ -565,9 +570,7 @@ pub fn run_with_writer<W: Write>(args: &Args, file: &Path, out: &mut W) -> Resul
         } else if args.config.is_some() {
             // Explicit --config without --importer: try auto-identification by filename
             let config_path = find_importers_config(args.config.as_deref())?
-                .ok_or_else(|| anyhow!(
-                    "No importers.toml found. Create one in the current directory or at ~/.config/rledger/importers.toml"
-                ))?;
+                .ok_or_else(importers_config_not_found_message)?;
 
             let importers_file = load_importers_config(&config_path)?;
 
@@ -1416,13 +1419,13 @@ default_expense = "Expenses:Uncategorized"
     #[test]
     #[cfg(feature = "python-plugin-wasm")]
     fn resolve_scan_dirs_soft_fails_for_implicit_missing_config() {
-        // No --config provided, no importers.toml in cwd/XDG → empty
+        // No --config provided, no importers.toml in cwd/user config dir → empty
         // scan dirs, no error. This is the right behavior because
         // the user didn't ask for any config; absence is expected.
         let args = Args::parse_from(["extract"]);
         let dirs = resolve_scan_dirs(&args).expect("implicit missing is soft-fail");
         // Could be empty or non-empty depending on whether a real
-        // ~/.config/rledger/importers.toml exists in this test env.
+        // user importers.toml exists in this test env.
         // What we're asserting is that it didn't error.
         let _ = dirs;
     }

--- a/crates/rustledger/src/cmd/query/interactive.rs
+++ b/crates/rustledger/src/cmd/query/interactive.rs
@@ -14,11 +14,20 @@ use std::io;
 use std::path::PathBuf;
 
 /// Get the history file path.
+///
+/// Lives under the shared `…/beanquery/` app directory (NOT rledger's own
+/// config dir), matching the Python `beanquery` REPL so the two tools share a
+/// history/init. This is deliberately OUTSIDE `RLEDGER_CONFIG_DIR` — do not
+/// relocate it into rledger's config dir in a future config-relocation pass.
 fn get_history_path() -> Option<PathBuf> {
     dirs::config_dir().map(|p| p.join("beanquery").join("history"))
 }
 
 /// Get the init file path.
+///
+/// See [`get_history_path`]: the `…/beanquery/` location is shared with the
+/// Python `beanquery` REPL on purpose and is intentionally not covered by
+/// `RLEDGER_CONFIG_DIR`.
 fn get_init_path() -> Option<PathBuf> {
     dirs::config_dir().map(|p| p.join("beanquery").join("init"))
 }

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -776,6 +776,11 @@ fn warn_if_rledger_config_set() {
 
 /// Pure resolution of a user config file from the platform-native default —
 /// separated from the env/`dirs` reads so it is unit-testable. See [`user_config_path`].
+// Not a `const fn`: on macOS the body queries the filesystem (`Path::exists`)
+// for the XDG fallback. clippy only sees the non-macOS body (which reduces to
+// returning `native`) and suggests `const`, but that would fail to compile on
+// macOS, so allow the lint rather than cfg-splitting the signature.
+#[allow(clippy::missing_const_for_fn)]
 fn resolve_user_config_path(native: Option<PathBuf>, filename: &str) -> Option<PathBuf> {
     // macOS: honor an XDG-style config when the native location is absent, so a
     // shared `~/.config/rledger/<filename>` works there too (#1616).

--- a/crates/rustledger/src/config.rs
+++ b/crates/rustledger/src/config.rs
@@ -34,6 +34,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -350,6 +351,35 @@ pub struct LoadedConfig {
     pub sources: Vec<ConfigSource>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct EnvironmentConfig {
+    config_dir: Option<OsString>,
+    file: Option<String>,
+    format: Option<String>,
+    no_color: bool,
+    profile: Option<OsString>,
+}
+
+impl EnvironmentConfig {
+    fn load() -> Self {
+        Self {
+            config_dir: non_empty_os_var("RLEDGER_CONFIG_DIR"),
+            file: env::var("RLEDGER_FILE").ok(),
+            format: env::var("RLEDGER_FORMAT").ok(),
+            no_color: env::var("NO_COLOR").is_ok(),
+            profile: non_empty_os_var("RLEDGER_PROFILE"),
+        }
+    }
+
+    const fn has_source(&self) -> bool {
+        self.config_dir.is_some()
+            || self.file.is_some()
+            || self.format.is_some()
+            || self.no_color
+            || self.profile.is_some()
+    }
+}
+
 impl Config {
     /// Load configuration from all sources.
     ///
@@ -362,6 +392,9 @@ impl Config {
     pub fn load() -> Result<LoadedConfig> {
         let mut merged = Self::default();
         let mut sources = Vec::new();
+        let environment = EnvironmentConfig::load();
+
+        warn_if_rledger_config_set();
 
         // Load system config (lowest priority)
         if let Some(path) = system_config_path()
@@ -372,8 +405,11 @@ impl Config {
             sources.push(ConfigSource::System(path));
         }
 
+        let user_path =
+            user_config_file_with_override(environment.config_dir.clone(), "config.toml");
+
         // Load user config
-        if let Some(path) = user_config_path()
+        if let Some(path) = user_path
             && path.exists()
         {
             let config = Self::load_from_file(&path)?;
@@ -389,11 +425,8 @@ impl Config {
         }
 
         // Apply environment variables (higher than files)
-        merged = merged.apply_env();
-        if env::var("RLEDGER_FILE").is_ok()
-            || env::var("RLEDGER_FORMAT").is_ok()
-            || env::var("NO_COLOR").is_ok()
-        {
+        merged = merged.apply_env_config(&environment);
+        if environment.has_source() {
             sources.push(ConfigSource::Environment);
         }
 
@@ -454,14 +487,18 @@ impl Config {
 
     /// Apply environment variables to the config.
     #[must_use]
-    pub fn apply_env(mut self) -> Self {
-        if let Ok(file) = env::var("RLEDGER_FILE") {
-            self.default.file = Some(file);
+    pub fn apply_env(self) -> Self {
+        self.apply_env_config(&EnvironmentConfig::load())
+    }
+
+    fn apply_env_config(mut self, environment: &EnvironmentConfig) -> Self {
+        if let Some(file) = &environment.file {
+            self.default.file = Some(file.clone());
         }
-        if let Ok(format) = env::var("RLEDGER_FORMAT") {
-            self.output.format = Some(format);
+        if let Some(format) = &environment.format {
+            self.output.format = Some(format.clone());
         }
-        if env::var("NO_COLOR").is_ok() {
+        if environment.no_color {
             self.output.color = Some(false);
         }
         self
@@ -653,63 +690,120 @@ impl PriceConfig {
 }
 
 /// Get the user config directory path.
+///
+/// Checks `$RLEDGER_CONFIG_DIR` first (an empty value is treated as unset).
+/// The override names the application config directory.
+/// Without an override, this falls back to `dirs::config_dir()/rledger`.
+///
+/// The override moves the whole application directory, including `config.toml`
+/// and `importers.toml`.
+#[must_use]
 pub fn user_config_dir() -> Option<PathBuf> {
+    user_config_dir_with_override(non_empty_os_var("RLEDGER_CONFIG_DIR"))
+}
+
+/// Pure resolution of the user config directory from the `$RLEDGER_CONFIG_DIR`
+/// override — env is read by the caller so this is unit-testable.
+fn user_config_dir_with_override(override_dir: Option<OsString>) -> Option<PathBuf> {
+    if let Some(dir) = override_dir.filter(|d| !d.is_empty()) {
+        return Some(expand_os_path(dir));
+    }
     dirs::config_dir().map(|p| p.join("rledger"))
 }
 
 /// Get the user config file path.
 ///
 /// Precedence:
-/// 1. `$RLEDGER_CONFIG` — an explicit config file path (`~` and `$VAR` expanded).
-///    Highest precedence; ideal for cross-platform dotfile managers
-///    (chezmoi / home-manager) that want one canonical location (discussion #1616).
+/// 1. `$RLEDGER_CONFIG_DIR/config.toml` — an explicit config directory, used
+///    verbatim (also moves `importers.toml`; see [`user_config_dir`]). The
+///    macOS XDG fallback below does not apply: the directory was named
+///    explicitly.
 /// 2. The platform-native location `dirs::config_dir()/rledger/config.toml`
 ///    (`~/.config` on Linux, `~/Library/Application Support` on macOS).
 /// 3. macOS only: an XDG-style `$XDG_CONFIG_HOME`/`~/.config/rledger/config.toml`
 ///    when it exists — `dirs` ignores `XDG_CONFIG_HOME` on macOS, so we check it
 ///    here, letting a single `~/.config/rledger/config.toml` work on Linux *and*
 ///    macOS without any env var.
+#[must_use]
 pub fn user_config_path() -> Option<PathBuf> {
-    resolve_user_config_path(
-        env::var("RLEDGER_CONFIG").ok().filter(|s| !s.is_empty()),
-        user_config_dir().map(|p| p.join("config.toml")),
-    )
+    user_config_file("config.toml")
 }
 
-/// Pure resolution of the user config path from the `$RLEDGER_CONFIG` override
-/// and the platform-native default — env is read by the caller so this is
-/// unit-testable. See [`user_config_path`].
-fn resolve_user_config_path(
-    env_override: Option<String>,
-    native: Option<PathBuf>,
+/// Resolve a file in the user config directory.
+#[must_use]
+pub fn user_config_file(filename: &str) -> Option<PathBuf> {
+    user_config_file_with_override(non_empty_os_var("RLEDGER_CONFIG_DIR"), filename)
+}
+
+fn user_config_file_with_override(
+    dir_override: Option<OsString>,
+    filename: &str,
 ) -> Option<PathBuf> {
-    if let Some(p) = env_override {
-        return Some(Config::expand_path(&p));
+    let has_dir_override = dir_override.is_some();
+    let native = user_config_dir_with_override(dir_override).map(|p| p.join(filename));
+
+    // An explicit config dir disables the macOS XDG fallback.
+    if has_dir_override {
+        return native;
     }
+    resolve_user_config_path(native, filename)
+}
+
+fn expand_os_path(path: OsString) -> PathBuf {
+    match path.into_string() {
+        Ok(path) => Config::expand_path(&path),
+        // Preserve `~`/`$VAR` expansion even for non-UTF-8 paths.
+        Err(path) => Config::expand_path(&path.to_string_lossy()),
+    }
+}
+
+fn non_empty_os_var(name: &str) -> Option<OsString> {
+    env::var_os(name).filter(|value| !value.is_empty())
+}
+
+/// `RLEDGER_CONFIG` (a single-file override) was replaced by `RLEDGER_CONFIG_DIR`
+/// (a directory override covering both `config.toml` and `importers.toml`).
+/// It is now inert; warn so users relying on it notice instead of silently
+/// losing their override.
+fn warn_if_rledger_config_set() {
+    if non_empty_os_var("RLEDGER_CONFIG").is_some() {
+        eprintln!(
+            "warning: RLEDGER_CONFIG is no longer supported and has no effect; \
+             set RLEDGER_CONFIG_DIR to the directory containing config.toml instead"
+        );
+    }
+}
+
+/// Pure resolution of a user config file from the platform-native default —
+/// separated from the env/`dirs` reads so it is unit-testable. See [`user_config_path`].
+fn resolve_user_config_path(native: Option<PathBuf>, filename: &str) -> Option<PathBuf> {
     // macOS: honor an XDG-style config when the native location is absent, so a
-    // shared `~/.config/rledger/config.toml` works there too (#1616).
+    // shared `~/.config/rledger/<filename>` works there too (#1616).
     #[cfg(target_os = "macos")]
     if native.as_ref().is_none_or(|n| !n.exists())
-        && let Some(xdg) = macos_xdg_config_path()
+        && let Some(xdg) = macos_xdg_config_path(filename)
         && xdg.exists()
     {
         return Some(xdg);
     }
+    #[cfg(not(target_os = "macos"))]
+    let _ = filename;
     native
 }
 
-/// macOS XDG-style config path: `$XDG_CONFIG_HOME/rledger/config.toml`, else
-/// `~/.config/rledger/config.toml`. (On Linux this is already `user_config_dir`.)
+/// macOS XDG-style config path: `$XDG_CONFIG_HOME/rledger/<filename>`, else
+/// `~/.config/rledger/<filename>`. (On Linux this is already `user_config_dir`.)
 #[cfg(target_os = "macos")]
-fn macos_xdg_config_path() -> Option<PathBuf> {
+fn macos_xdg_config_path(filename: &str) -> Option<PathBuf> {
     env::var_os("XDG_CONFIG_HOME")
         .filter(|v| !v.is_empty())
         .map(PathBuf::from)
         .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
-        .map(|c| c.join("rledger").join("config.toml"))
+        .map(|c| c.join("rledger").join(filename))
 }
 
 /// Get the system config file path.
+#[must_use]
 pub fn system_config_path() -> Option<PathBuf> {
     #[cfg(unix)]
     {
@@ -728,12 +822,14 @@ pub fn system_config_path() -> Option<PathBuf> {
 }
 
 /// Find project config by searching upward from current directory.
+#[must_use]
 pub fn find_project_config() -> Option<PathBuf> {
     let cwd = env::current_dir().ok()?;
     find_project_config_from(&cwd)
 }
 
 /// Find project config by searching upward from a given directory.
+#[must_use]
 pub fn find_project_config_from(start: &Path) -> Option<PathBuf> {
     let mut current = start.to_path_buf();
 
@@ -1430,8 +1526,8 @@ t = "check"
     }
 
     #[test]
-    fn test_user_config_path() {
-        let path = user_config_path();
+    fn test_user_config_path_uses_platform_default_without_override() {
+        let path = user_config_file_with_override(None, "config.toml");
         // Should return Some on most platforms
         if let Some(p) = path {
             assert!(p.to_string_lossy().contains("rledger"));
@@ -1440,20 +1536,17 @@ t = "check"
     }
 
     #[test]
-    fn resolve_user_config_path_env_override_wins() {
-        let native = Some(PathBuf::from("/native/rledger/config.toml"));
-        // An explicit RLEDGER_CONFIG path takes precedence over the native default.
+    fn resolve_user_config_path_uses_existing_native() {
+        // The native file must actually exist here: on macOS the XDG fallback
+        // fires for an absent native path, so a fake path would make this
+        // assertion depend on the developer's real ~/.config/rledger/config.toml.
+        let dir = tempfile::tempdir().unwrap();
+        let existing_native = dir.path().join("config.toml");
+        std::fs::write(&existing_native, "").unwrap();
         assert_eq!(
-            resolve_user_config_path(Some("/custom/my.toml".to_string()), native.clone()),
-            Some(PathBuf::from("/custom/my.toml"))
+            resolve_user_config_path(Some(existing_native.clone()), "config.toml"),
+            Some(existing_native)
         );
-        // `~` in the override is expanded to the home dir.
-        if let Some(home) = dirs::home_dir() {
-            assert_eq!(
-                resolve_user_config_path(Some("~/dots/rledger.toml".to_string()), native),
-                Some(home.join("dots/rledger.toml"))
-            );
-        }
     }
 
     /// The no-override → native case is only assertable off macOS: the
@@ -1465,12 +1558,42 @@ t = "check"
     /// test above and broke `cargo test` for macOS users).
     #[cfg(not(target_os = "macos"))]
     #[test]
-    fn resolve_user_config_path_no_override_uses_native_on_non_macos() {
+    fn resolve_user_config_path_uses_native_on_non_macos() {
         let native = Some(PathBuf::from("/home/u/.config/rledger/config.toml"));
-        assert_eq!(resolve_user_config_path(None, native.clone()), native);
+        assert_eq!(
+            resolve_user_config_path(native.clone(), "config.toml"),
+            native
+        );
+    }
 
-        // No override and no native location: nothing to resolve.
-        assert_eq!(resolve_user_config_path(None, None), None);
+    #[test]
+    fn test_user_config_dir_override_used_verbatim() {
+        // The override names the app directory itself — no `rledger` is
+        // appended (app-specific vars work like GNUPGHOME / CARGO_HOME).
+        let dir = user_config_dir_with_override(Some("/custom/config".into()));
+        assert_eq!(dir, Some(PathBuf::from("/custom/config")));
+    }
+
+    #[test]
+    fn test_user_config_dir_override_expands_tilde() {
+        if let Some(home) = dirs::home_dir() {
+            let dir = user_config_dir_with_override(Some("~/dots/rledger".into()));
+            assert_eq!(dir, Some(home.join("dots/rledger")));
+        }
+    }
+
+    #[test]
+    fn test_user_config_path_dir_override_joins_config_file() {
+        let path = user_config_file_with_override(Some("/custom/config".into()), "config.toml");
+        assert_eq!(path, Some(PathBuf::from("/custom/config/config.toml")));
+    }
+
+    #[test]
+    fn test_user_config_dir_empty_or_absent_override_uses_platform_default() {
+        // An empty RLEDGER_CONFIG_DIR is treated as unset.
+        let expected = dirs::config_dir().map(|p| p.join("rledger"));
+        assert_eq!(user_config_dir_with_override(Some("".into())), expected);
+        assert_eq!(user_config_dir_with_override(None), expected);
     }
 
     #[test]

--- a/crates/rustledger/tests/config_dir_env_override.rs
+++ b/crates/rustledger/tests/config_dir_env_override.rs
@@ -99,3 +99,48 @@ default_expense = "Expenses:Unknown"
          stdout: {stdout}\nstderr: {stderr}"
     );
 }
+
+/// The deprecated `RLEDGER_CONFIG` must be INERT (its config is never loaded)
+/// and must emit a deprecation warning — the core behavior of this breaking
+/// change (#1795). Without this, a future refactor could silently make
+/// `RLEDGER_CONFIG` load again with nothing failing.
+#[test]
+fn deprecated_rledger_config_is_inert_and_warns() {
+    let bin = require_rledger!();
+
+    // A config.toml carrying a distinctive marker, pointed at by the OLD
+    // `RLEDGER_CONFIG` var. If the var were still honored, the marker would
+    // appear in `config show`.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let old_config = dir.path().join("config.toml");
+    std::fs::write(
+        &old_config,
+        "[default]\nfile = \"ZZ_INERT_MARKER.beancount\"\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(bin)
+        .args(["config", "show", "--raw"])
+        // Neither cwd nor RLEDGER_CONFIG_DIR provides the marker; PROGRAMDATA
+        // shields the Windows system-config path. The marker can ONLY leak in
+        // if the deprecated RLEDGER_CONFIG were (wrongly) honored.
+        .current_dir(dir.path())
+        .env("PROGRAMDATA", dir.path())
+        .env("RLEDGER_CONFIG", &old_config)
+        .env_remove("RLEDGER_CONFIG_DIR")
+        .output()
+        .expect("run rledger config show");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("ZZ_INERT_MARKER"),
+        "RLEDGER_CONFIG must be inert — its config.toml must NOT load.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("RLEDGER_CONFIG is no longer supported"),
+        "setting RLEDGER_CONFIG must print a deprecation warning.\n\
+         stderr: {stderr}"
+    );
+}

--- a/crates/rustledger/tests/config_dir_env_override.rs
+++ b/crates/rustledger/tests/config_dir_env_override.rs
@@ -1,0 +1,101 @@
+//! End-to-end coverage for the `RLEDGER_CONFIG_DIR` env-var wiring.
+//!
+//! The public `user_config_path()` wrapper reads `RLEDGER_CONFIG_DIR` and its
+//! pure `*_with_override` helper does the resolution. The unit tests exercise
+//! the helper directly, so they would still pass if the env-var name were
+//! typo'd or dropped in the public wrapper. This subprocess test pins the real
+//! wiring: set the var, and the config in that directory must actually load.
+
+mod common;
+
+use std::process::Command;
+
+#[test]
+fn config_dir_env_var_loads_config_from_that_directory() {
+    let bin = require_rledger!();
+
+    // A config.toml with a distinctive marker in a directory that is neither
+    // the platform default nor the cwd — it can only be found via the env var.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("config.toml"),
+        "[default]\nfile = \"ZZ_ENV_OVERRIDE_MARKER.beancount\"\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(bin)
+        .args(["config", "show", "--raw"])
+        // cwd holds no `.rledger.toml`, so the marker can only come from the
+        // RLEDGER_CONFIG_DIR user config. PROGRAMDATA shields the Windows
+        // system-config path from ambient state.
+        .current_dir(dir.path())
+        .env("PROGRAMDATA", dir.path())
+        .env("RLEDGER_CONFIG_DIR", dir.path())
+        .output()
+        .expect("run rledger config show");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("ZZ_ENV_OVERRIDE_MARKER"),
+        "config.toml under RLEDGER_CONFIG_DIR must load via the public wrapper.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn config_dir_env_var_loads_importers_from_that_directory() {
+    let bin = require_rledger!();
+
+    let config_dir = tempfile::tempdir().expect("config tempdir");
+    std::fs::write(
+        config_dir.path().join("importers.toml"),
+        r#"
+[[importers]]
+name = "envbank"
+account = "Assets:Bank:Env"
+currency = "USD"
+date_column = "Date"
+narration_column = "Description"
+amount_column = "Amount"
+default_expense = "Expenses:Unknown"
+"#,
+    )
+    .expect("write importers config");
+
+    let work_dir = tempfile::tempdir().expect("work tempdir");
+    let csv_path = work_dir.path().join("statement.csv");
+    std::fs::write(
+        &csv_path,
+        "Date,Description,Amount\n2024-01-15,COFFEE,-4.25\n",
+    )
+    .expect("write statement");
+
+    let output = Command::new(bin)
+        .args([
+            "extract",
+            csv_path.to_str().expect("utf-8 path"),
+            "--importer",
+            "envbank",
+        ])
+        // cwd holds no importers.toml, so the importer can only come from
+        // RLEDGER_CONFIG_DIR/importers.toml.
+        .current_dir(work_dir.path())
+        .env("PROGRAMDATA", work_dir.path())
+        .env("RLEDGER_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("run rledger extract");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "extract should succeed with importers.toml under RLEDGER_CONFIG_DIR.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Assets:Bank:Env"),
+        "configured importer account should appear in extracted output.\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+}

--- a/crates/rustledger/tests/config_load_error_surfaced.rs
+++ b/crates/rustledger/tests/config_load_error_surfaced.rs
@@ -29,17 +29,12 @@ fn malformed_config_surfaces_parse_error_instead_of_silent_default() {
     let output = Command::new(bin)
         .args(["price", "hy"])
         // Run inside the tempdir so its `.rledger.toml` is the project
-        // config, and point every config-dir source at the (empty)
-        // tempdir so no real user/system config is loaded first. HOME +
-        // XDG_CONFIG_HOME cover Unix; APPDATA / PROGRAMDATA / USERPROFILE
-        // cover the Windows paths `dirs::config_dir()` consults, keeping
-        // the test hermetic across platforms.
+        // config. RLEDGER_CONFIG_DIR shields the user-config lookup from
+        // ambient developer state; PROGRAMDATA shields the Windows system
+        // config path.
         .current_dir(dir.path())
-        .env("HOME", dir.path())
-        .env("XDG_CONFIG_HOME", dir.path())
-        .env("APPDATA", dir.path())
         .env("PROGRAMDATA", dir.path())
-        .env("USERPROFILE", dir.path())
+        .env("RLEDGER_CONFIG_DIR", dir.path())
         .output()
         .expect("run rledger price");
 
@@ -82,11 +77,8 @@ fn malformed_config_does_not_block_help() {
     let output = Command::new(bin)
         .arg("--help")
         .current_dir(dir.path())
-        .env("HOME", dir.path())
-        .env("XDG_CONFIG_HOME", dir.path())
-        .env("APPDATA", dir.path())
         .env("PROGRAMDATA", dir.path())
-        .env("USERPROFILE", dir.path())
+        .env("RLEDGER_CONFIG_DIR", dir.path())
         .output()
         .expect("run rledger --help");
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -65,10 +65,11 @@ Configuration file search paths:
   system   (not found)  /etc/rledger/config.toml
 
 Environment variables:
-  RLEDGER_FILE     Default beancount file
-  RLEDGER_FORMAT   Output format (text, csv, json)
-  RLEDGER_PROFILE  Active profile name
-  NO_COLOR         Disable colored output
+  RLEDGER_CONFIG_DIR  Config directory holding config.toml and importers.toml
+  RLEDGER_FILE        Default beancount file
+  RLEDGER_FORMAT      Output format (text, csv, json)
+  RLEDGER_PROFILE     Active profile name
+  NO_COLOR            Disable colored output
 ```
 
 ### Create Default Config
@@ -77,7 +78,7 @@ Environment variables:
 rledger config init
 ```
 
-Creates `~/.config/rledger/config.toml` with default settings.
+Creates the user `config.toml` with default settings. If `RLEDGER_CONFIG_DIR` is set, the file is created there.
 
 ### Edit Config
 

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -1,4 +1,4 @@
----
+______________________________________________________________________
 
 ## title: rledger extract description: Import transactions from bank statements
 

--- a/docs/commands/extract.md
+++ b/docs/commands/extract.md
@@ -1,4 +1,4 @@
-______________________________________________________________________
+---
 
 ## title: rledger extract description: Import transactions from bank statements
 
@@ -14,64 +14,64 @@ rledger extract [OPTIONS] [FILE]
 
 ## Arguments
 
-| Argument | Description |
-|----------|-------------|
-| `FILE` | CSV or OFX file to import (required unless using `--list-importers`) |
+| Argument | Description                                                          |
+| -------- | -------------------------------------------------------------------- |
+| `FILE`   | CSV or OFX file to import (required unless using `--list-importers`) |
 
 ## Options
 
 ### Config-based Import
 
-| Option | Description |
-|--------|-------------|
-| `-i, --importer <NAME>` | Use a named importer from config |
-| `--config <FILE>` | Path to importers.toml configuration file |
-| `--list-importers` | List available importers from config file and exit |
+| Option                  | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `-i, --importer <NAME>` | Use a named importer from config                   |
+| `--config <FILE>`       | Path to importers.toml configuration file          |
+| `--list-importers`      | List available importers from config file and exit |
 
 ### Auto-Detection
 
-| Option | Description |
-|--------|-------------|
+| Option   | Description                                                                                     |
+| -------- | ----------------------------------------------------------------------------------------------- |
 | `--auto` | Auto-detect CSV format (delimiter, columns, date format). Conflicts with manual column options. |
 
 ### Direct CLI Import
 
-| Option | Description |
-|--------|-------------|
-| `-a, --account <ACCOUNT>` | Target account [default: Assets:Bank:Checking] |
-| `-c, --currency <CURRENCY>` | Currency for amounts [default: USD] |
-| `--date-column <COL>` | Date column name or index [default: Date] |
-| `--date-format <FMT>` | Date format (strftime-style) [default: %Y-%m-%d] |
-| `--narration-column <COL>` | Narration/description column [default: Description] |
-| `--payee-column <COL>` | Payee column name (optional) |
-| `--amount-column <COL>` | Amount column name or index [default: Amount] |
-| `--amount-locale <LOCALE>` | Locale for parsing amounts (e.g., `en_US`) |
-| `--amount-format <FMT>` | Custom format for parsing amounts |
-| `--debit-column <COL>` | Debit column (for separate debit/credit) |
-| `--credit-column <COL>` | Credit column (for separate debit/credit) |
-| `--delimiter <CHAR>` | CSV delimiter [default: ,] |
-| `--skip-rows <N>` | Number of header rows to skip [default: 0] |
-| `--invert-sign` | Invert sign of amounts |
-| `--no-header` | CSV has no header row |
-| `--include-zero-amounts` | Preserve rows whose amount is exactly zero (default drops them; bank "status filler" rows) |
+| Option                      | Description                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `-a, --account <ACCOUNT>`   | Target account [default: Assets:Bank:Checking]                                             |
+| `-c, --currency <CURRENCY>` | Currency for amounts [default: USD]                                                        |
+| `--date-column <COL>`       | Date column name or index [default: Date]                                                  |
+| `--date-format <FMT>`       | Date format (strftime-style) [default: %Y-%m-%d]                                           |
+| `--narration-column <COL>`  | Narration/description column [default: Description]                                        |
+| `--payee-column <COL>`      | Payee column name (optional)                                                               |
+| `--amount-column <COL>`     | Amount column name or index [default: Amount]                                              |
+| `--amount-locale <LOCALE>`  | Locale for parsing amounts (e.g., `en_US`)                                                 |
+| `--amount-format <FMT>`     | Custom format for parsing amounts                                                          |
+| `--debit-column <COL>`      | Debit column (for separate debit/credit)                                                   |
+| `--credit-column <COL>`     | Credit column (for separate debit/credit)                                                  |
+| `--delimiter <CHAR>`        | CSV delimiter [default: ,]                                                                 |
+| `--skip-rows <N>`           | Number of header rows to skip [default: 0]                                                 |
+| `--invert-sign`             | Invert sign of amounts                                                                     |
+| `--no-header`               | CSV has no header row                                                                      |
+| `--include-zero-amounts`    | Preserve rows whose amount is exactly zero (default drops them; bank "status filler" rows) |
 
 ### Output Options
 
-| Option | Description |
-|--------|-------------|
-| `-o, --output <FILE>` | Write output to file instead of stdout |
-| `--existing <FILE>` | Existing ledger file for duplicate detection |
-| `--suggest-categories` | Use ML (Naive Bayes on the `--existing` ledger) to suggest accounts for transactions the rules engine didn't categorize. Requires `--existing`. |
-| `--balance <AMOUNT>` | Append a balance assertion directive with the given amount (e.g., `1234.56`) |
-| `--balance-date <DATE>` | Date for the balance assertion (defaults to today) |
+| Option                  | Description                                                                                                                                     |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-o, --output <FILE>`   | Write output to file instead of stdout                                                                                                          |
+| `--existing <FILE>`     | Existing ledger file for duplicate detection                                                                                                    |
+| `--suggest-categories`  | Use ML (Naive Bayes on the `--existing` ledger) to suggest accounts for transactions the rules engine didn't categorize. Requires `--existing`. |
+| `--balance <AMOUNT>`    | Append a balance assertion directive with the given amount (e.g., `1234.56`)                                                                    |
+| `--balance-date <DATE>` | Date for the balance assertion (defaults to today)                                                                                              |
 
 ### WASM Importers
 
 Third-party importers ship as sandboxed `.wasm` modules. Flags below override `wasm_importer_dir` from `importers.toml`.
 
-| Option | Description |
-|--------|-------------|
-| `--wasm-importer <PATH>` | Register a specific `.wasm` importer ahead of built-ins. Repeatable. User-specified modules take precedence over discovered ones and built-ins. |
+| Option                      | Description                                                                                                                                          |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--wasm-importer <PATH>`    | Register a specific `.wasm` importer ahead of built-ins. Repeatable. User-specified modules take precedence over discovered ones and built-ins.      |
 | `--wasm-importer-dir <DIR>` | Scan a directory for `*.wasm` importer modules at startup. Repeatable. Subdirectories are not recursed into; non-`.wasm` files are silently skipped. |
 
 ## Examples
@@ -178,10 +178,10 @@ default_expense = "Expenses:Unknown"
 The importer library supports additional enrichment features via the
 `CsvConfigBuilder` API:
 
-| Builder Method | Description |
-|----------------|-------------|
-| `use_merchant_dict(true)` | Enable the built-in merchant dictionary (75 common patterns) as a low-priority fallback for account categorization |
-| `regex_mappings(vec)` | Add regex-based account mappings (case-insensitive, compiled at load time) |
+| Builder Method            | Description                                                                                                         |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `use_merchant_dict(true)` | Enable the built-in merchant dictionary (75 common patterns) as a low-priority fallback for account categorization  |
+| `regex_mappings(vec)`     | Add regex-based account mappings (case-insensitive, compiled at load time)                                          |
 
 These options are available in the Rust library API but are not yet exposed as
 fields in `importers.toml` configuration. Substring-based mappings in
@@ -208,7 +208,8 @@ Use with:
 rledger extract --importer checking statement.csv
 ```
 
-The `importers.toml` file is auto-discovered from the current directory or `~/.config/rledger/`. To specify a custom path:
+The `importers.toml` file is auto-discovered from the current directory or the user config directory
+(`$RLEDGER_CONFIG_DIR` if set, otherwise the platform default such as `~/.config/rledger/`). To specify a custom path:
 
 ```bash
 rledger extract --config path/to/importers.toml --importer checking statement.csv

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,4 +1,4 @@
----
+______________________________________________________________________
 
 ## title: Configuration description: Configure rustledger with profiles and options
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,4 +1,4 @@
-______________________________________________________________________
+---
 
 ## title: Configuration description: Configure rustledger with profiles and options
 
@@ -8,11 +8,12 @@ rustledger can be configured via environment variables, config files, and comman
 
 ## Environment Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `RLEDGER_FILE` | Default beancount file | `~/ledger.beancount` |
-| `RLEDGER_PROFILE` | Active profile name | `business` |
-| `NO_COLOR` | Disable colored output | `1` |
+| Variable             | Description                                                             | Example              |
+| -------------------- | ----------------------------------------------------------------------- | -------------------- |
+| `RLEDGER_CONFIG_DIR` | Config directory, used as-is (holds `config.toml` and `importers.toml`) | `~/dots/rledger`     |
+| `RLEDGER_FILE`       | Default beancount file                                                  | `~/ledger.beancount` |
+| `RLEDGER_PROFILE`    | Active profile name                                                     | `business`           |
+| `NO_COLOR`           | Disable colored output                                                  | `1`                  |
 
 Set in your shell profile (`~/.bashrc`, `~/.zshrc`):
 
@@ -25,8 +26,19 @@ export RLEDGER_FILE="$HOME/finances/main.beancount"
 rustledger looks for configuration in these locations (highest to lowest priority):
 
 1. `.rledger.toml` in the current directory (searching upward)
-1. `~/.config/rledger/config.toml` (user config)
+1. The user config, resolved as:
+   - `$RLEDGER_CONFIG_DIR/config.toml` if set — an explicit config directory,
+     used as-is (this also relocates `importers.toml`)
+   - Otherwise the platform default:
+     - Linux: `$XDG_CONFIG_HOME/rledger/config.toml` (usually `~/.config/rledger/config.toml`)
+     - macOS: `~/Library/Application Support/rledger/config.toml`, falling back to
+       an XDG-style `~/.config/rledger/config.toml` when only that exists
+     - Windows: `%APPDATA%\rledger\config.toml`
 1. `/etc/rledger/config.toml` (system config, Unix only)
+
+```bash
+export RLEDGER_CONFIG_DIR="$HOME/dots/rledger"
+```
 
 Higher priority configs override lower ones. You can also generate a default config with:
 
@@ -93,14 +105,14 @@ option "booking_method" "FIFO"
 
 ### Common Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `title` | Ledger title | (none) |
-| `operating_currency` | Main currency | (none) |
-| `booking_method` | FIFO, LIFO, AVERAGE, etc. | STRICT |
-| `account_previous_balances` | Retained earnings account | `Equity:Opening-Balances` |
-| `account_current_earnings` | Current earnings account | `Equity:Earnings:Current` |
-| `inferred_tolerance_default` | Per-currency balance tolerance (e.g. `USD:0.005`) | (none) |
+| Option                       | Description                                       | Default                   |
+| ---------------------------- | ------------------------------------------------- | ------------------------- |
+| `title`                      | Ledger title                                      | (none)                    |
+| `operating_currency`         | Main currency                                     | (none)                    |
+| `booking_method`             | FIFO, LIFO, AVERAGE, etc.                         | STRICT                    |
+| `account_previous_balances`  | Retained earnings account                         | `Equity:Opening-Balances` |
+| `account_current_earnings`   | Current earnings account                          | `Equity:Earnings:Current` |
+| `inferred_tolerance_default` | Per-currency balance tolerance (e.g. `USD:0.005`) | (none)                    |
 
 ### Booking Methods
 

--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -67,7 +67,10 @@ The `importers.toml` file is searched for automatically in these locations (firs
 
 1. Path specified via `--config path/to/importers.toml` (the legacy spelling `--importers-config` is still accepted as an alias)
 1. `importers.toml` in the current directory
-1. `~/.config/rledger/importers.toml`
+1. `$RLEDGER_CONFIG_DIR/importers.toml` if set
+1. The platform default (`~/.config/rledger/importers.toml` on Linux,
+   `~/Library/Application Support/rledger/importers.toml` on macOS)
+1. Fallback on macOS (`~/.config/rledger/importers.toml`)
 
 ### Preserving a second date column
 


### PR DESCRIPTION
## Summary

Adds RLEDGER_CONFIG_DIR, an env var that relocates the entire user config directory (both config.toml and importers.toml) to an arbitrary path, replacing the narrower RLEDGER_CONFIG (which only relocated config.toml and never affected importers.toml discovery). This closes the gap where a dotfile manager (chezmoi/home-manager) could only relocate half of rledger's config. In the future when we have more configs like `report.config` etc setting the directory once is cleaner. Setting RLEDGER_CONFIG now prints a deprecation warning instead of silently doing nothing. We can remove that after a few weeks to make sure no one else has adopted that feature. 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (changes to docs and some alignment in markdown to make it easy to read)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

I have selected breaking, but it should be okay because the feature that it breaks was only added a few days back and this PR extends that and makes it future proof.

## Changes


-

## Testing

<!-- How did you test these changes? -->

- [x] `cargo test` 
- [x] `cargo clippy` passes
- [ ] Tested manually with a beancount file
- [x] Added new tests for the changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings

## Review Focus

- [x] Please review the algorithm/logic
- [ ] Please review for beancount compatibility
- [ ] Please review for performance
- [x] Please review test coverage
- [ ] General review is fine
