### PR TITLE
fix: stop stripping backslashes from BQL string literals

### DIFF
--- a/crates/rustledger-query/src/completions.rs
+++ b/crates/rustledger-query/src/completions.rs
@@ -142,6 +142,15 @@ pub fn complete(partial_query: &str, cursor_pos: usize) -> CompletionResult {
 }
 
 /// Simple tokenizer for BQL.
+///
+/// DELIBERATE divergence from the parser's [`crate::parser`] string
+/// lexing (#1797 review): this is a heuristic completion-context
+/// tokenizer — it only recognizes double-quoted strings and knows
+/// nothing of single quotes or `''` continuation. Tokenizing an
+/// unusual literal wrongly costs at worst an odd completion suggestion, never a
+/// wrong query result. Revisit if completions ever gate on string
+/// VALUES rather than token boundaries; the parser-side counterpart
+/// note lives on `nesting_exceeds_limit`.
 fn tokenize_bql(text: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut current = String::new();

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -1072,14 +1072,16 @@ fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<
 
     // Single-quoted string (SQL-style): `''` continues the string (and
     // stays as-is in the value); anything else ends at the first `'`.
+    // The body is captured as one input slice (`to_slice`) — the value
+    // is verbatim anyway, so no per-piece assembly is needed.
     let single_quoted = just('\'')
         .ignore_then(
             just("''")
-                .to("''".to_string())
-                .or(none_of("'").map(String::from))
+                .ignored()
+                .or(none_of("'").ignored())
                 .repeated()
-                .collect::<Vec<String>>()
-                .map(|parts| parts.concat()),
+                .to_slice()
+                .map(ToString::to_string),
         )
         .then_ignore(just('\''));
 

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -57,20 +57,26 @@ const PARSE_STACK_SIZE: usize = 16 * 1024 * 1024;
 /// Byte offset at which parenthesis nesting first exceeds
 /// [`MAX_NESTING_DEPTH`], or `None` if the input stays within the bound.
 ///
-/// Parens inside string literals (`"..."` / `'...'`, with `\` escapes)
-/// are skipped so they don't count — matching the grammar, which treats
-/// them as opaque string bytes rather than expression delimiters.
+/// Parens inside string literals (`"..."` / `'...'`) are skipped so they
+/// don't count — matching the grammar, which treats them as opaque string
+/// bytes rather than expression delimiters. String lexing here MUST agree
+/// with [`string_literal`] (upstream semantics, #1797): backslash is an
+/// ordinary byte (never an escape), and `''` continues a single-quoted
+/// string. Pinned by `nesting_scan_agrees_with_string_literal_lexing`.
 fn nesting_exceeds_limit(source: &str) -> Option<usize> {
     let mut depth: usize = 0;
-    let mut chars = source.char_indices();
+    let mut chars = source.char_indices().peekable();
     while let Some((i, c)) = chars.next() {
         match c {
             '"' | '\'' => {
                 // Consume the string body so its parens don't count.
                 while let Some((_, sc)) = chars.next() {
-                    if sc == '\\' {
-                        chars.next(); // skip the escaped char
-                    } else if sc == c {
+                    if sc == c {
+                        // `''` continues a single-quoted string.
+                        if c == '\'' && chars.peek().is_some_and(|&(_, n)| n == '\'') {
+                            chars.next();
+                            continue;
+                        }
                         break;
                     }
                 }
@@ -1044,24 +1050,36 @@ fn table_identifier<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtr
 }
 
 /// Parse a string literal.
+///
+/// Upstream beanquery's grammar is quote-stripping ONLY (#1797):
+///
+/// ```text
+/// string = /\"[^\"]*\"|\'(?:[^\']|\'\')*\'/    (bql.ebnf)
+/// def string(value): return value[1:-1]        (parser semantics)
+/// ```
+///
+/// A backslash is an ordinary byte — `'\)'` must reach `subst()` as the
+/// two characters `\)`, not be collapsed to `)` (which turns a valid
+/// regex into "unopened group"). A doubled `''` lets a single-quoted
+/// string continue past a quote but is kept VERBATIM — upstream's own
+/// `parser_test.py` pins `'rainy''day'` -> `rainy''day`. Double-quoted
+/// strings have no escapes at all and end at the first `"`.
 fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<'a>> + Clone {
-    // Double-quoted string
+    // Double-quoted string: body is everything up to the first `"`.
     let double_quoted = just('"')
-        .ignore_then(
-            none_of("\"\\")
-                .or(just('\\').ignore_then(any()))
-                .repeated()
-                .collect::<String>(),
-        )
+        .ignore_then(none_of("\"").repeated().collect::<String>())
         .then_ignore(just('"'));
 
-    // Single-quoted string (SQL-style)
+    // Single-quoted string (SQL-style): `''` continues the string (and
+    // stays as-is in the value); anything else ends at the first `'`.
     let single_quoted = just('\'')
         .ignore_then(
-            none_of("'\\")
-                .or(just('\\').ignore_then(any()))
+            just("''")
+                .to("''".to_string())
+                .or(none_of("'").map(String::from))
                 .repeated()
-                .collect::<String>(),
+                .collect::<Vec<String>>()
+                .map(|parts| parts.concat()),
         )
         .then_ignore(just('\''));
 

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -62,7 +62,11 @@ const PARSE_STACK_SIZE: usize = 16 * 1024 * 1024;
 /// bytes rather than expression delimiters. String lexing here MUST agree
 /// with [`string_literal`] (upstream semantics, #1797): backslash is an
 /// ordinary byte (never an escape), and `''` continues a single-quoted
-/// string. Pinned by `nesting_scan_agrees_with_string_literal_lexing`.
+/// string. Pinned by the MAX_NESTING_DEPTH-straddling guards in
+/// `string_literal_escapes_test.rs`. (A third, DELIBERATELY divergent
+/// string scanner exists: `completions::tokenize_bql`, a heuristic
+/// completion-context tokenizer that only understands double quotes —
+/// see its doc comment for the divergence rationale.)
 fn nesting_exceeds_limit(source: &str) -> Option<usize> {
     let mut depth: usize = 0;
     let mut chars = source.char_indices().peekable();
@@ -1065,9 +1069,16 @@ fn table_identifier<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtr
 /// `parser_test.py` pins `'rainy''day'` -> `rainy''day`. Double-quoted
 /// strings have no escapes at all and end at the first `"`.
 fn string_literal<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<'a>> + Clone {
-    // Double-quoted string: body is everything up to the first `"`.
+    // Double-quoted string: body is everything up to the first `"`,
+    // captured as one input slice like the single-quoted arm.
     let double_quoted = just('"')
-        .ignore_then(none_of("\"").repeated().collect::<String>())
+        .ignore_then(
+            none_of("\"")
+                .ignored()
+                .repeated()
+                .to_slice()
+                .map(ToString::to_string),
+        )
         .then_ignore(just('"'));
 
     // Single-quoted string (SQL-style): `''` continues the string (and

--- a/crates/rustledger-query/tests/string_literal_escapes_test.rs
+++ b/crates/rustledger-query/tests/string_literal_escapes_test.rs
@@ -76,20 +76,60 @@ fn doubled_quote_continues_single_quoted_string_verbatim() {
     );
 }
 
-/// Drift guard: the paren-nesting pre-scan must lex strings identically
-/// to the parser — a string whose body pre-fix "escaped" the closing
-/// quote (trailing `\`) followed by deep parens must parse fine, and a
-/// `''`-continued string containing parens must not count them.
+/// The quote-run edge family of the upstream regex
+/// `\'(?:[^\']|\'\')*\'`: empty string, a body that is ONLY a doubled
+/// quote, and a trailing `''` right before the closing quote. These are
+/// the inputs where a PEG re-encoding is fragile (alternation order,
+/// laziness, or an "unescape" step would silently change them).
 #[test]
-fn nesting_scan_agrees_with_string_literal_lexing() {
-    // A trailing-backslash string followed by real parens: the OLD
-    // pre-scan treated `\` as escaping the closing quote and swallowed
-    // the rest of the query as string body, desynchronizing its paren
-    // count from the parser's.
+fn quote_run_edges_match_upstream_regex() {
+    assert_eq!(eval_scalar("''"), Value::String(String::new()));
+    assert_eq!(eval_scalar("''''"), Value::String("''".into()));
+    assert_eq!(eval_scalar("'a'''"), Value::String("a''".into()));
+    // Three bare quotes cannot form a complete string in the upstream
+    // grammar either (it lexes as empty-string + stray quote there);
+    // both implementations reject the query.
+    assert!(parse("SELECT '''").is_err());
+}
+
+/// Drift guards: the paren-nesting pre-scan must lex strings identically
+/// to the parser. Its ONLY observable is the `MAX_NESTING_DEPTH` (128)
+/// rejection, so each guard straddles that limit — a scanner that
+/// disagrees with the parser about where a string ends flips the
+/// outcome (per the review of #1798: a guard that a divergence cannot
+/// trip is decoration).
+#[test]
+fn nesting_scan_counts_real_parens_after_trailing_backslash_string() {
+    // `'\'` is a complete one-character string; the 150 parens after it
+    // are REAL and must trip the nesting cap. A scanner that regresses
+    // to backslash-escaping swallows the rest of the query as string
+    // body, skips the cap, and hands the parser 150-deep recursion —
+    // on wasm32 the pre-scan is the only stack protection.
+    let deep = "(".repeat(150);
+    let query = format!(r"SELECT length('\') {deep}");
+    let err = parse(&query).expect_err("must hit the nesting cap");
+    assert!(
+        err.to_string().contains("nesting"),
+        "expected the nesting-depth error, got: {err}"
+    );
+}
+
+#[test]
+fn nesting_scan_ignores_parens_inside_doubled_quote_string() {
+    // 150 `(` inside a ''-continued single-quoted string are opaque
+    // bytes. A scanner that ends the string at the first quote of the
+    // `''` sees them as code and falsely rejects a legitimate query.
+    let parens = "(".repeat(150);
+    assert_eq!(
+        eval_scalar(&format!("length('{parens}''{parens}')")),
+        Value::Integer(302)
+    );
+}
+
+/// The pre-fix user-visible shapes stay covered end-to-end.
+#[test]
+fn strings_with_escapes_evaluate_through_parenthesized_args() {
     assert_eq!(eval_scalar(r"length(('\'))"), Value::Integer(1));
-    // Parens inside a ''-continued string body are opaque bytes, and a
-    // `\)` regex escape deletes a literal paren from a parenthesized
-    // string argument.
     assert_eq!(
         eval_scalar(r"subst('\)', '', ('y)'))"),
         Value::String("y".into())

--- a/crates/rustledger-query/tests/string_literal_escapes_test.rs
+++ b/crates/rustledger-query/tests/string_literal_escapes_test.rs
@@ -1,0 +1,98 @@
+//! Regression for #1797: BQL string literals must match upstream
+//! beanquery's quote-stripping-ONLY semantics.
+//!
+//! Upstream's grammar (`bql.ebnf`) is
+//! `string = /\"[^\"]*\"|\'(?:[^\']|\'\')*\'/` with semantics
+//! `value[1:-1]` — a backslash is an ordinary byte, and a doubled `''`
+//! continues a single-quoted string while staying VERBATIM in the value
+//! (pinned by upstream's own `parser_test.py`: `'rainy''day'` →
+//! `rainy''day`). rustledger's parser used to consume `\` as a C-style
+//! escape introducer, so `subst('[ ,]*\)$', …)` reached the regex engine
+//! as `[ ,]*)$` — "unopened group" on a regex that works in beanquery.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+fn ledger() -> Vec<Directive> {
+    vec![
+        Directive::Open(Open::new(date(2026, 7, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2026, 7, 1), "Expenses:X")),
+        Directive::Transaction(
+            Transaction::new(date(2026, 7, 1), "t")
+                .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1), "USD")))
+                .with_synthesized_posting(Posting::new("Expenses:X", Amount::new(dec!(1), "USD"))),
+        ),
+    ]
+}
+
+fn eval_scalar(expr: &str) -> Value {
+    let dirs = ledger();
+    let q = parse(&format!("SELECT {expr} LIMIT 1")).expect("parse");
+    let mut ex = Executor::new(&dirs);
+    let r = ex.execute(&q).expect("execute");
+    r.rows[0][0].clone()
+}
+
+/// The issue's minimal repro: `\)` must survive to the regex engine as a
+/// literal-paren escape instead of collapsing to an unbalanced `)`.
+#[test]
+fn backslash_survives_into_subst_regex() {
+    assert_eq!(
+        eval_scalar(r"subst('[ ,]*\)$', ')', 'foo   )')"),
+        Value::String("foo)".into())
+    );
+}
+
+/// The real-world template from #1797 (mkshp's Obsidian plugin): three
+/// nested `subst()` calls with `\(`/`\)` escapes over a converted balance.
+#[test]
+fn issue_1797_multi_currency_formatting_template() {
+    let expr = r"subst('^\([ ,]*', '(', subst('[ ,]*\)$', ')', subst(', *[-.0-9]+ GBP|[-.0-9]+ GBP *,?', '', '(10.00 USD, 5.00 GBP)')))";
+    assert_eq!(eval_scalar(expr), Value::String("(10.00 USD)".into()));
+}
+
+/// Backslash is an ordinary byte in BOTH quote styles — `'\n'` is the two
+/// characters backslash-n, not a newline.
+#[test]
+fn backslash_is_a_literal_byte() {
+    assert_eq!(eval_scalar(r"'a\nb'"), Value::String(r"a\nb".into()));
+    assert_eq!(eval_scalar(r#""a\nb""#), Value::String(r"a\nb".into()));
+    // A lone trailing backslash is a complete, one-character string —
+    // pre-fix it consumed the closing quote and broke the parse.
+    assert_eq!(eval_scalar(r"'\'"), Value::String(r"\".into()));
+}
+
+/// Upstream-pinned `''` behavior: continues the string, kept verbatim.
+#[test]
+fn doubled_quote_continues_single_quoted_string_verbatim() {
+    assert_eq!(
+        eval_scalar("'rainy''day'"),
+        Value::String("rainy''day".into())
+    );
+}
+
+/// Drift guard: the paren-nesting pre-scan must lex strings identically
+/// to the parser — a string whose body pre-fix "escaped" the closing
+/// quote (trailing `\`) followed by deep parens must parse fine, and a
+/// `''`-continued string containing parens must not count them.
+#[test]
+fn nesting_scan_agrees_with_string_literal_lexing() {
+    // A trailing-backslash string followed by real parens: the OLD
+    // pre-scan treated `\` as escaping the closing quote and swallowed
+    // the rest of the query as string body, desynchronizing its paren
+    // count from the parser's.
+    assert_eq!(eval_scalar(r"length(('\'))"), Value::Integer(1));
+    // Parens inside a ''-continued string body are opaque bytes, and a
+    // `\)` regex escape deletes a literal paren from a parenthesized
+    // string argument.
+    assert_eq!(
+        eval_scalar(r"subst('\)', '', ('y)'))"),
+        Value::String("y".into())
+    );
+    assert_eq!(eval_scalar("length('(((''((( ')"), Value::Integer(9));
+}


### PR DESCRIPTION
## What

`subst('[ ,]*\)$', ...)` failed with "unopened group" because the BQL string-literal parser treated `\` as a C-style escape introducer and **dropped it** (`just('\\').ignore_then(any())`) — the regex engine received `[ ,]*)$`. Reported with a real-world query template from the mkshp Obsidian plugin that works against beanquery 0.2.0.

## The upstream contract

beanquery's grammar is quote-stripping ONLY:

```
string = /\"[^\"]*\"|\'(?:[^\']|\'\')*\'/     (bql.ebnf)
def string(value): return value[1:-1]           (parser semantics)
```

A backslash is an ordinary byte. The only structural escape is SQL-style `''` in single-quoted strings — which continues the string but stays **verbatim** in the value (upstream's own `parser_test.py` pins `'rainy''day'` → `rainy''day`). Double-quoted strings have no escapes at all.

## Changes

- `string_literal()` reimplements exactly that grammar, with the upstream rules quoted in its doc comment.
- The paren-nesting pre-scan (`nesting_exceeds_limit`) lexed strings with the OLD backslash rule — its lexing must agree with the parser's (canonical-discipline drift rule), so it now uses the same semantics, and a drift-guard test pins the historically-breaking shape (a lone trailing backslash used to make the scan swallow the closing quote and desynchronize its paren count).
- The completions tokenizer already terminated `"..."` at the first quote, so it becomes *more* consistent, not less.

## Compatibility

Strictly compat-improving: no existing test relied on the invented escapes (full query + LSP suites pass unchanged), and `\"`-style escapes never worked in beanquery either, so no real query used them.

## Tests

The issue's minimal repro; the full 3-level Obsidian template; backslash-as-literal in both quote styles including lone trailing backslash; the upstream `''` verbatim pin; scan/parser lexing agreement.

Closes #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)