### PR TITLE
feat: dotted attribute and string subscript access in BQL

### DIFF
--- a/crates/rustledger-query/src/ast.rs
+++ b/crates/rustledger-query/src/ast.rs
@@ -196,6 +196,23 @@ pub enum Expr {
     },
     /// Set literal for IN operator, e.g., `('EUR', 'USD')`.
     Set(Vec<Self>),
+    /// Dotted attribute access on a structured value, e.g. `entry.meta`
+    /// (upstream bql.ebnf: `attribute = operand:primary '.' name:identifier`,
+    /// #1796).
+    Attribute {
+        /// The structured operand.
+        operand: Box<Self>,
+        /// The attribute name.
+        name: String,
+    },
+    /// String-keyed subscript access, e.g. `meta['key']` (upstream
+    /// bql.ebnf: `subscript = operand:primary '[' key:string ']'`, #1796).
+    Subscript {
+        /// The mapping operand.
+        operand: Box<Self>,
+        /// The string key.
+        key: String,
+    },
 }
 
 /// A literal value.
@@ -570,6 +587,8 @@ impl fmt::Display for Expr {
         match self {
             Self::Wildcard => write!(f, "*"),
             Self::Column(name) => write!(f, "{name}"),
+            Self::Attribute { operand, name } => write!(f, "{operand}.{name}"),
+            Self::Subscript { operand, key } => write!(f, "{operand}['{key}']"),
             Self::Literal(lit) => write!(f, "{lit}"),
             Self::Function(func) => {
                 write!(f, "{}(", func.name)?;

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -262,6 +262,12 @@ impl<'a> Executor<'a> {
         group: &[&PostingContext],
     ) -> Result<Value, QueryError> {
         match expr {
+            Expr::Attribute { operand, name } => {
+                Self::eval_attribute(self.evaluate_aggregate_expr(operand, group)?, name)
+            }
+            Expr::Subscript { operand, key } => {
+                Self::eval_subscript(self.evaluate_aggregate_expr(operand, group)?, key)
+            }
             Expr::Function(func) => {
                 match func.name.to_uppercase().as_str() {
                     "COUNT" => {
@@ -598,6 +604,14 @@ impl<'a> Executor<'a> {
         group: &[&PostingContext],
     ) -> Result<Value, QueryError> {
         match expr {
+            Expr::Attribute { operand, name } => Self::eval_attribute(
+                self.evaluate_having_expr(operand, row, col_map, alias_map, group)?,
+                name,
+            ),
+            Expr::Subscript { operand, key } => Self::eval_subscript(
+                self.evaluate_having_expr(operand, row, col_map, alias_map, group)?,
+                key,
+            ),
             Expr::Column(name) => {
                 let upper_name = name.to_uppercase();
                 // Try alias first, then column name
@@ -686,6 +700,14 @@ impl<'a> Executor<'a> {
         column_map: &rustc_hash::FxHashMap<String, usize>,
     ) -> Result<Value, QueryError> {
         match expr {
+            Expr::Attribute { operand, name } => Self::eval_attribute(
+                self.evaluate_aggregate_table_expr(operand, group, column_map)?,
+                name,
+            ),
+            Expr::Subscript { operand, key } => Self::eval_subscript(
+                self.evaluate_aggregate_table_expr(operand, group, column_map)?,
+                key,
+            ),
             Expr::Function(func) => {
                 match func.name.to_uppercase().as_str() {
                     "COUNT" => {
@@ -953,6 +975,18 @@ impl<'a> Executor<'a> {
         column_map: &rustc_hash::FxHashMap<String, usize>,
     ) -> Result<Value, QueryError> {
         match expr {
+            Expr::Attribute { operand, name } => Self::eval_attribute(
+                self.evaluate_having_table_expr(
+                    operand, row, col_map, alias_map, group, column_map,
+                )?,
+                name,
+            ),
+            Expr::Subscript { operand, key } => Self::eval_subscript(
+                self.evaluate_having_table_expr(
+                    operand, row, col_map, alias_map, group, column_map,
+                )?,
+                key,
+            ),
             Expr::Column(name) => {
                 let upper_name = name.to_uppercase();
                 if let Some(&idx) = alias_map.get(&upper_name) {

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -30,6 +30,12 @@ impl<'a> Executor<'a> {
             }
             Expr::UnaryOp(op) => Self::is_aggregate_expr(&op.operand),
             Expr::Paren(inner) => Self::is_aggregate_expr(inner),
+            // A postfix access over an aggregate (first(entry).payee) is
+            // itself aggregate — without this the query is misrouted down
+            // the per-row path and silently returns NULL rows (#1800 review).
+            Expr::Attribute { operand, .. } | Expr::Subscript { operand, .. } => {
+                Self::is_aggregate_expr(operand)
+            }
             _ => false,
         }
     }

--- a/crates/rustledger-query/src/executor/aggregation.rs
+++ b/crates/rustledger-query/src/executor/aggregation.rs
@@ -272,7 +272,7 @@ impl<'a> Executor<'a> {
                 Self::eval_attribute(self.evaluate_aggregate_expr(operand, group)?, name)
             }
             Expr::Subscript { operand, key } => {
-                Self::eval_subscript(self.evaluate_aggregate_expr(operand, group)?, key)
+                Self::eval_subscript(&self.evaluate_aggregate_expr(operand, group)?, key)
             }
             Expr::Function(func) => {
                 match func.name.to_uppercase().as_str() {
@@ -615,7 +615,7 @@ impl<'a> Executor<'a> {
                 name,
             ),
             Expr::Subscript { operand, key } => Self::eval_subscript(
-                self.evaluate_having_expr(operand, row, col_map, alias_map, group)?,
+                &self.evaluate_having_expr(operand, row, col_map, alias_map, group)?,
                 key,
             ),
             Expr::Column(name) => {
@@ -711,7 +711,7 @@ impl<'a> Executor<'a> {
                 name,
             ),
             Expr::Subscript { operand, key } => Self::eval_subscript(
-                self.evaluate_aggregate_table_expr(operand, group, column_map)?,
+                &self.evaluate_aggregate_table_expr(operand, group, column_map)?,
                 key,
             ),
             Expr::Function(func) => {
@@ -988,7 +988,7 @@ impl<'a> Executor<'a> {
                 name,
             ),
             Expr::Subscript { operand, key } => Self::eval_subscript(
-                self.evaluate_having_table_expr(
+                &self.evaluate_having_table_expr(
                     operand, row, col_map, alias_map, group, column_map,
                 )?,
                 key,

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -161,6 +161,12 @@ impl Executor<'_> {
         match expr {
             Expr::Wildcard => Ok(Value::Null), // Wildcard isn't really an expression
             Expr::Column(name) => self.evaluate_column(name, ctx),
+            Expr::Attribute { operand, name } => {
+                Self::eval_attribute(self.evaluate_expr(operand, ctx)?, name)
+            }
+            Expr::Subscript { operand, key } => {
+                Self::eval_subscript(self.evaluate_expr(operand, ctx)?, key)
+            }
             Expr::Literal(lit) => self.evaluate_literal(lit),
             Expr::Function(func) => self.evaluate_function(func, ctx),
             Expr::Window(_) => {
@@ -203,6 +209,74 @@ impl Executor<'_> {
     }
 
     /// Evaluate a column reference.
+    /// The parent transaction as a structured [`Value::Object`] — the
+    /// `entry` column (attribute-accessible via `entry.<field>`, #1796).
+    /// CANONICAL builder: the default-path `entry` column and the
+    /// `#postings` table's `entry` column both call this, so their
+    /// shapes cannot drift.
+    pub(super) fn entry_object(txn: &rustledger_core::Transaction) -> Value {
+        let mut obj = BTreeMap::new();
+        obj.insert("date".to_string(), Value::Date(txn.date));
+        obj.insert("flag".to_string(), Value::String(txn.flag.to_string()));
+        if let Some(ref payee) = txn.payee {
+            obj.insert("payee".to_string(), Value::String(payee.to_string()));
+        }
+        obj.insert(
+            "narration".to_string(),
+            Value::String(txn.narration.to_string()),
+        );
+        obj.insert(
+            "tags".to_string(),
+            Value::StringSet(txn.tags.iter().map(ToString::to_string).collect()),
+        );
+        obj.insert(
+            "links".to_string(),
+            Value::StringSet(txn.links.iter().map(ToString::to_string).collect()),
+        );
+        let mut meta_obj = BTreeMap::new();
+        for (k, v) in &txn.meta {
+            meta_obj.insert(k.clone(), Self::meta_value_to_value(Some(v)));
+        }
+        obj.insert("meta".to_string(), Value::Object(Box::new(meta_obj)));
+        Value::Object(Box::new(obj))
+    }
+
+    /// Dotted attribute access (`entry.meta`, #1796). Upstream compiles
+    /// attributes against structured dtypes and errors on non-structured
+    /// operands; rustledger's structured values are dynamic
+    /// [`Value::Object`]s, so lookup happens here at evaluation time.
+    ///
+    /// Stricter-vs-looser note (Python Compatibility Policy): a MISSING
+    /// attribute returns `NULL`, where upstream distinguishes "field
+    /// exists but is None" (NULL) from "no such attribute" (compile
+    /// error). rustledger's `entry` object omits empty fields (e.g. an
+    /// absent payee), so the two cases are indistinguishable at runtime —
+    /// NULL reproduces upstream for the common case and is lenient for
+    /// typos. Pinned in `bql_attribute_subscript_test.rs`.
+    pub(super) fn eval_attribute(value: Value, name: &str) -> Result<Value, QueryError> {
+        match value {
+            Value::Object(obj) => Ok(obj.get(name).cloned().unwrap_or(Value::Null)),
+            Value::Null => Ok(Value::Null),
+            other => Err(QueryError::Type(format!(
+                "cannot access attribute '{name}': operand {other:?} is not structured"
+            ))),
+        }
+    }
+
+    /// String-keyed subscript access (`meta['key']`, #1796). Mirrors
+    /// GETITEM's metadata/object arms — a missing key is `NULL`, exactly
+    /// like upstream's `getitem`.
+    pub(super) fn eval_subscript(value: Value, key: &str) -> Result<Value, QueryError> {
+        match value {
+            Value::Metadata(meta) => Ok(Self::meta_value_to_value(meta.get(key))),
+            Value::Object(obj) => Ok(obj.get(key).cloned().unwrap_or(Value::Null)),
+            Value::Null => Ok(Value::Null),
+            other => Err(QueryError::Type(format!(
+                "cannot subscript with '{key}': operand {other:?} is not a mapping"
+            ))),
+        }
+    }
+
     pub(super) fn evaluate_column(
         &self,
         name: &str,
@@ -401,34 +475,7 @@ impl Executor<'_> {
             // has_cost - check if posting has cost specification
             "has_cost" => Ok(Value::Boolean(posting.cost.is_some())),
             // entry - parent transaction as structured object
-            "entry" => {
-                let txn = ctx.transaction;
-                let mut obj = BTreeMap::new();
-                obj.insert("date".to_string(), Value::Date(txn.date));
-                obj.insert("flag".to_string(), Value::String(txn.flag.to_string()));
-                if let Some(ref payee) = txn.payee {
-                    obj.insert("payee".to_string(), Value::String(payee.to_string()));
-                }
-                obj.insert(
-                    "narration".to_string(),
-                    Value::String(txn.narration.to_string()),
-                );
-                obj.insert(
-                    "tags".to_string(),
-                    Value::StringSet(txn.tags.iter().map(ToString::to_string).collect()),
-                );
-                obj.insert(
-                    "links".to_string(),
-                    Value::StringSet(txn.links.iter().map(ToString::to_string).collect()),
-                );
-                // Include transaction metadata
-                let mut meta_obj = BTreeMap::new();
-                for (k, v) in &txn.meta {
-                    meta_obj.insert(k.clone(), Self::meta_value_to_value(Some(v)));
-                }
-                obj.insert("meta".to_string(), Value::Object(Box::new(meta_obj)));
-                Ok(Value::Object(Box::new(obj)))
-            }
+            "entry" => Ok(Self::entry_object(ctx.transaction)),
             // type - directive type. bean-query lowercases it (`transaction`),
             // and the `#postings` table already emits lowercase; the default
             // posting source is always a transaction. (Confirmed against the

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -165,7 +165,7 @@ impl Executor<'_> {
                 Self::eval_attribute(self.evaluate_expr(operand, ctx)?, name)
             }
             Expr::Subscript { operand, key } => {
-                Self::eval_subscript(self.evaluate_expr(operand, ctx)?, key)
+                Self::eval_subscript(&self.evaluate_expr(operand, ctx)?, key)
             }
             Expr::Literal(lit) => self.evaluate_literal(lit),
             Expr::Function(func) => self.evaluate_function(func, ctx),
@@ -278,8 +278,8 @@ impl Executor<'_> {
     /// (the first draft re-implemented two of GETITEM's three arms and
     /// `balance['USD']` type-errored where `getitem(balance,'USD')`
     /// worked — #1800 review).
-    pub(super) fn eval_subscript(value: Value, key: &str) -> Result<Value, QueryError> {
-        Self::getitem_lookup(&value, key)
+    pub(super) fn eval_subscript(value: &Value, key: &str) -> Result<Value, QueryError> {
+        Self::getitem_lookup(value, key)
     }
 
     /// CANONICAL container lookup for GETITEM and `[...]` subscripts:

--- a/crates/rustledger-query/src/executor/evaluation.rs
+++ b/crates/rustledger-query/src/executor/evaluation.rs
@@ -214,7 +214,10 @@ impl Executor<'_> {
     /// CANONICAL builder: the default-path `entry` column and the
     /// `#postings` table's `entry` column both call this, so their
     /// shapes cannot drift.
-    pub(super) fn entry_object(txn: &rustledger_core::Transaction) -> Value {
+    pub(super) fn entry_object(
+        txn: &rustledger_core::Transaction,
+        entry_loc: Option<&crate::executor::SourceLocation>,
+    ) -> Value {
         let mut obj = BTreeMap::new();
         obj.insert("date".to_string(), Value::Date(txn.date));
         obj.insert("flag".to_string(), Value::String(txn.flag.to_string()));
@@ -233,8 +236,14 @@ impl Executor<'_> {
             "links".to_string(),
             Value::StringSet(txn.links.iter().map(ToString::to_string).collect()),
         );
+        // Same filename/lineno augmentation the ENTRY_META function and
+        // the posting-level `meta` column apply (via `augmented_meta`), so
+        // `entry.meta['filename']` agrees with `entry_meta('filename')` —
+        // upstream's entry.meta always carries source location (#1800
+        // review).
+        let augmented = Self::augmented_meta(&txn.meta, entry_loc);
         let mut meta_obj = BTreeMap::new();
-        for (k, v) in &txn.meta {
+        for (k, v) in &augmented {
             meta_obj.insert(k.clone(), Self::meta_value_to_value(Some(v)));
         }
         obj.insert("meta".to_string(), Value::Object(Box::new(meta_obj)));
@@ -252,7 +261,7 @@ impl Executor<'_> {
     /// error). rustledger's `entry` object omits empty fields (e.g. an
     /// absent payee), so the two cases are indistinguishable at runtime —
     /// NULL reproduces upstream for the common case and is lenient for
-    /// typos. Pinned in `bql_attribute_subscript_test.rs`.
+    /// typos. Pinned in `attribute_subscript_test.rs`.
     pub(super) fn eval_attribute(value: Value, name: &str) -> Result<Value, QueryError> {
         match value {
             Value::Object(obj) => Ok(obj.get(name).cloned().unwrap_or(Value::Null)),
@@ -263,11 +272,29 @@ impl Executor<'_> {
         }
     }
 
-    /// String-keyed subscript access (`meta['key']`, #1796). Mirrors
-    /// GETITEM's metadata/object arms — a missing key is `NULL`, exactly
-    /// like upstream's `getitem`.
+    /// String-keyed subscript access (`meta['key']`, #1796). Delegates to
+    /// the CANONICAL [`Self::getitem_lookup`] shared with the GETITEM
+    /// function, so the two spellings of the same lookup cannot drift
+    /// (the first draft re-implemented two of GETITEM's three arms and
+    /// `balance['USD']` type-errored where `getitem(balance,'USD')`
+    /// worked — #1800 review).
     pub(super) fn eval_subscript(value: Value, key: &str) -> Result<Value, QueryError> {
-        match value {
+        Self::getitem_lookup(&value, key)
+    }
+
+    /// CANONICAL container lookup for GETITEM and `[...]` subscripts:
+    /// inventory-by-currency, metadata-by-key, object-by-key. A missing
+    /// key (or zero inventory units) is `NULL`, like upstream's `getitem`.
+    pub(super) fn getitem_lookup(container: &Value, key: &str) -> Result<Value, QueryError> {
+        match container {
+            Value::Inventory(inv) => {
+                let amount = inv.units(key);
+                if amount.is_zero() {
+                    Ok(Value::Null)
+                } else {
+                    Ok(Value::Amount(rustledger_core::Amount::new(amount, key)))
+                }
+            }
             Value::Metadata(meta) => Ok(Self::meta_value_to_value(meta.get(key))),
             Value::Object(obj) => Ok(obj.get(key).cloned().unwrap_or(Value::Null)),
             Value::Null => Ok(Value::Null),
@@ -474,8 +501,15 @@ impl Executor<'_> {
             )),
             // has_cost - check if posting has cost specification
             "has_cost" => Ok(Value::Boolean(posting.cost.is_some())),
-            // entry - parent transaction as structured object
-            "entry" => Ok(Self::entry_object(ctx.transaction)),
+            // entry - parent transaction as structured object. The
+            // location is the enclosing DIRECTIVE's (like ENTRY_META),
+            // not the posting's.
+            "entry" => {
+                let entry_loc = ctx
+                    .directive_index
+                    .and_then(|i| self.get_source_location(i).cloned());
+                Ok(Self::entry_object(ctx.transaction, entry_loc.as_ref()))
+            }
             // type - directive type. bean-query lowercases it (`transaction`),
             // and the `#postings` table already emits lowercase; the default
             // posting source is always a transaction. (Confirmed against the

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -734,6 +734,12 @@ impl Executor<'_> {
         column_map: &FxHashMap<String, usize>,
     ) -> Result<Value, QueryError> {
         match expr {
+            Expr::Attribute { operand, name } => {
+                Self::eval_attribute(self.evaluate_subquery_expr(operand, row, column_map)?, name)
+            }
+            Expr::Subscript { operand, key } => {
+                Self::eval_subscript(self.evaluate_subquery_expr(operand, row, column_map)?, key)
+            }
             Expr::Wildcard => Err(QueryError::Evaluation(
                 "Wildcard not allowed in expression context".to_string(),
             )),

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -372,8 +372,12 @@ impl Executor<'_> {
             }
 
             // Evaluate outer targets
-            let outer_row =
-                self.evaluate_subquery_row(&outer_query.targets, inner_row, &inner_column_map)?;
+            let outer_row = self.evaluate_subquery_row(
+                &outer_query.targets,
+                inner_row,
+                &inner_column_map,
+                &inner_result.columns,
+            )?;
 
             if outer_query.distinct {
                 // O(1) hash-based deduplication
@@ -521,7 +525,8 @@ impl Executor<'_> {
             };
 
             // Evaluate targets (including hidden columns)
-            let result_row = self.evaluate_subquery_row(&extended_targets, row, &column_map)?;
+            let result_row =
+                self.evaluate_subquery_row(&extended_targets, row, &column_map, &table.columns)?;
 
             if query.distinct {
                 // DISTINCT should only consider visible columns, not hidden sort columns.
@@ -706,13 +711,29 @@ impl Executor<'_> {
             if let Some(alias) = &target.alias {
                 names.push(alias.clone());
             } else if matches!(target.expr, Expr::Wildcard) {
-                // Expand wildcard to all inner columns
-                names.extend(inner_columns.iter().cloned());
+                // Expand wildcard to all VISIBLE inner columns.
+                names.extend(
+                    inner_columns
+                        .iter()
+                        .filter(|c| !Self::wildcard_hidden(c))
+                        .cloned(),
+                );
             } else {
                 names.push(self.expr_to_name(&target.expr, i));
             }
         }
         Ok(names)
+    }
+
+    /// Whether a table column is hidden from `SELECT *` expansion.
+    ///
+    /// Upstream beanquery's wildcard omits the structured `entry` column,
+    /// and our underscore-prefixed helper columns (`_entry_meta`,
+    /// `_posting_meta`) were ALSO leaking into `SELECT *` before #1800 —
+    /// one rule now covers both. Every hidden column stays addressable by
+    /// explicit name. Pinned by `select_star_hides_structured_and_helper_columns`.
+    fn wildcard_hidden(name: &str) -> bool {
+        name.starts_with('_') || name == "entry"
     }
 
     /// Evaluate a filter expression against a subquery row.
@@ -836,12 +857,20 @@ impl Executor<'_> {
         targets: &[Target],
         inner_row: &[Value],
         column_map: &FxHashMap<String, usize>,
+        inner_columns: &[String],
     ) -> Result<Row, QueryError> {
         let mut row = Vec::new();
         for target in targets {
             if matches!(target.expr, Expr::Wildcard) {
-                // Expand wildcard to all values from inner row
-                row.extend(inner_row.iter().cloned());
+                // Expand wildcard to the VISIBLE inner values, matching the
+                // name expansion above.
+                row.extend(
+                    inner_row
+                        .iter()
+                        .zip(inner_columns)
+                        .filter(|(_, c)| !Self::wildcard_hidden(c))
+                        .map(|(v, _)| v.clone()),
+                );
             } else {
                 row.push(self.evaluate_subquery_expr(&target.expr, inner_row, column_map)?);
             }

--- a/crates/rustledger-query/src/executor/execution.rs
+++ b/crates/rustledger-query/src/executor/execution.rs
@@ -759,7 +759,7 @@ impl Executor<'_> {
                 Self::eval_attribute(self.evaluate_subquery_expr(operand, row, column_map)?, name)
             }
             Expr::Subscript { operand, key } => {
-                Self::eval_subscript(self.evaluate_subquery_expr(operand, row, column_map)?, key)
+                Self::eval_subscript(&self.evaluate_subquery_expr(operand, row, column_map)?, key)
             }
             Expr::Wildcard => Err(QueryError::Evaluation(
                 "Wildcard not allowed in expression context".to_string(),

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -2005,6 +2005,9 @@ impl<'a> Executor<'a> {
 fn expr_references_column(expr: &Expr, name: &str) -> bool {
     match expr {
         Expr::Column(col) => col.eq_ignore_ascii_case(name),
+        Expr::Attribute { operand, .. } | Expr::Subscript { operand, .. } => {
+            expr_references_column(operand, name)
+        }
         Expr::Function(call) => call.args.iter().any(|a| expr_references_column(a, name)),
         Expr::Window(call) => {
             // Function args + the OVER clause's PARTITION BY / ORDER BY

--- a/crates/rustledger-query/src/executor/mod.rs
+++ b/crates/rustledger-query/src/executor/mod.rs
@@ -1473,24 +1473,11 @@ impl<'a> Executor<'a> {
             "GETITEM" | "GET" => {
                 Self::require_args_count(&name_upper, args, 2)?;
                 match (&args[0], &args[1]) {
-                    (Value::Inventory(inv), Value::String(currency)) => {
-                        let amount = inv.units(currency);
-                        if amount.is_zero() {
-                            Ok(Value::Null)
-                        } else {
-                            Ok(Value::Amount(Amount::new(amount, currency.as_str())))
-                        }
-                    }
-                    // Metadata / object lookup — mirror the per-row path
-                    // (`eval_getitem`). Previously only the lazy path handled
-                    // these, so `getitem(meta, key)` errored in the eager /
-                    // `#postings` evaluation path.
-                    (Value::Metadata(meta), Value::String(key)) => {
-                        Ok(Self::meta_value_to_value(meta.get(key)))
-                    }
-                    (Value::Object(obj), Value::String(key)) => {
-                        Ok(obj.get(key).cloned().unwrap_or(Value::Null))
-                    }
+                    // Container lookups delegate to the CANONICAL
+                    // `getitem_lookup`, shared with `[...]` subscript
+                    // expressions so the two spellings cannot drift
+                    // (#1800 review).
+                    (container, Value::String(key)) => Self::getitem_lookup(container, key),
                     (Value::Null, _) => Ok(Value::Null),
                     _ => Err(QueryError::Type(
                         "GETITEM expects (inventory, string), (metadata, string), or (object, string)"
@@ -1949,6 +1936,11 @@ impl<'a> Executor<'a> {
             Expr::Column(name) => name.clone(),
             Expr::Function(func) => func.name.clone(),
             Expr::Window(wf) => wf.name.clone(),
+            // Postfix accesses name themselves by their source spelling so
+            // ORDER BY / PIVOT BY string resolution finds the target (a
+            // bare "colN" broke `SELECT entry.narration ORDER BY
+            // entry.narration`, #1800 review).
+            Expr::Attribute { .. } | Expr::Subscript { .. } => expr.to_string(),
             _ => format!("col{index}"),
         }
     }

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -602,6 +602,12 @@ impl Executor<'_> {
             .expect("scan_postings(None, None, ..) evaluates no predicates, so it cannot fail")
             .postings;
 
+        // Entry objects are per-TRANSACTION; postings of one transaction are
+        // contiguous in the scan, so memoize the last built object instead of
+        // rebuilding (strings, tags/links vectors, full meta conversion) for
+        // every posting (#1800 review).
+        let mut last_entry: Option<(usize, Value)> = None;
+
         for ctx in contexts {
             let txn = ctx.transaction;
             let posting = &txn.postings[ctx.posting_index];
@@ -612,6 +618,15 @@ impl Executor<'_> {
 
             // Transaction-level location — the per-posting fallback below.
             let source_loc = self.get_source_location(dir_idx);
+
+            let entry_val = match &last_entry {
+                Some((idx, value)) if *idx == dir_idx => value.clone(),
+                _ => {
+                    let value = Self::entry_object(txn, source_loc);
+                    last_entry = Some((dir_idx, value.clone()));
+                    value
+                }
+            };
 
             let tags: Vec<String> = txn.tags.iter().map(ToString::to_string).collect();
             let links: Vec<String> = txn.links.iter().map(ToString::to_string).collect();
@@ -756,7 +771,7 @@ impl Executor<'_> {
                     posting_loc.as_ref(),
                 ))),
                 Value::StringSet(all_accounts),
-                Self::entry_object(txn),
+                entry_val,
                 // Hidden metadata columns
                 Self::metadata_to_value(&txn.meta),
                 Self::metadata_to_value(&posting.meta),

--- a/crates/rustledger-query/src/executor/system_tables.rs
+++ b/crates/rustledger-query/src/executor/system_tables.rs
@@ -583,6 +583,9 @@ impl Executor<'_> {
             // Metadata and collection columns
             "meta".to_string(),
             "accounts".to_string(),
+            // Parent transaction as a structured object (entry.meta etc.,
+            // #1796) — same canonical builder as the default-path column.
+            "entry".to_string(),
             // Hidden metadata columns for META/ENTRY_META functions
             "_entry_meta".to_string(),
             "_posting_meta".to_string(),
@@ -753,6 +756,7 @@ impl Executor<'_> {
                     posting_loc.as_ref(),
                 ))),
                 Value::StringSet(all_accounts),
+                Self::entry_object(txn),
                 // Hidden metadata columns
                 Self::metadata_to_value(&txn.meta),
                 Self::metadata_to_value(&posting.meta),

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -673,7 +673,11 @@ fn expr<'a>() -> Boxed<'a, 'a, ParserInput<'a>, Expr, ParserExtra<'a>> {
             Sub(String),
         }
         let postfix = choice((
+            // Whitespace is allowed on BOTH sides of the dot — upstream's
+            // tatsu grammar skips whitespace between tokens, so
+            // `entry . meta` parses there (#1800 review).
             ws().ignore_then(just('.'))
+                .ignore_then(ws())
                 .ignore_then(identifier())
                 .map(Postfix::Attr),
             ws().ignore_then(just('['))

--- a/crates/rustledger-query/src/parser.rs
+++ b/crates/rustledger-query/src/parser.rs
@@ -662,7 +662,39 @@ fn at_function<'a>() -> impl Parser<'a, ParserInput<'a>, String, ParserExtra<'a>
 #[allow(clippy::large_stack_frames)]
 fn expr<'a>() -> Boxed<'a, 'a, ParserInput<'a>, Expr, ParserExtra<'a>> {
     recursive(|expr| {
-        let primary = primary_expr(expr.clone()).boxed();
+        // Postfix attribute/subscript access binds tighter than any
+        // operator (upstream bql.ebnf: `primary = attribute | subscript |
+        // atom`, both left-recursive on primary — here a postfix fold so
+        // `entry.meta['key']` and `a.b.c` chain, #1796). Number literals
+        // are consumed whole by `literal()` first, so `1.5` never reaches
+        // the attribute dot.
+        enum Postfix {
+            Attr(String),
+            Sub(String),
+        }
+        let postfix = choice((
+            ws().ignore_then(just('.'))
+                .ignore_then(identifier())
+                .map(Postfix::Attr),
+            ws().ignore_then(just('['))
+                .ignore_then(ws())
+                .ignore_then(string_literal())
+                .then_ignore(ws())
+                .then_ignore(just(']'))
+                .map(Postfix::Sub),
+        ));
+        let primary = primary_expr(expr.clone())
+            .foldl(postfix.repeated(), |operand, p| match p {
+                Postfix::Attr(name) => Expr::Attribute {
+                    operand: Box::new(operand),
+                    name,
+                },
+                Postfix::Sub(key) => Expr::Subscript {
+                    operand: Box::new(operand),
+                    key,
+                },
+            })
+            .boxed();
 
         // Unary minus
         let unary = just('-')

--- a/crates/rustledger-query/tests/attribute_subscript_test.rs
+++ b/crates/rustledger-query/tests/attribute_subscript_test.rs
@@ -1,0 +1,130 @@
+//! Regression for #1796: dotted attribute access (`entry.meta`) and
+//! string-keyed subscript (`meta['key']`) — upstream bql.ebnf:
+//!
+//! ```text
+//! attribute = operand:primary '.' name:identifier
+//! subscript = operand:primary '[' key:string ']'
+//! ```
+//!
+//! Three gaps closed together: the parser had no postfix `.`/`[`, the
+//! executor had no attribute/subscript evaluation (though `entry` as a
+//! structured object and GETITEM's lookup machinery already existed),
+//! and the `#postings`/`FROM postings` table projection lacked the
+//! `entry` column entirely.
+
+use rust_decimal_macros::dec;
+use rustledger_core::{Amount, Directive, MetaValue, NaiveDate, Open, Posting, Transaction};
+use rustledger_query::{Executor, Value, parse};
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    rustledger_core::naive_date(y, m, d).unwrap()
+}
+
+fn ledger() -> Vec<Directive> {
+    let mut txn = Transaction::new(date(2026, 7, 1), "coffee")
+        .with_synthesized_posting(Posting::new("Assets:Cash", Amount::new(dec!(-1), "USD")))
+        .with_synthesized_posting(Posting::new("Expenses:X", Amount::new(dec!(1), "USD")));
+    txn.payee = Some("Shop".into());
+    txn.meta
+        .insert("note".into(), MetaValue::String("hello".into()));
+    vec![
+        Directive::Open(Open::new(date(2026, 7, 1), "Assets:Cash")),
+        Directive::Open(Open::new(date(2026, 7, 1), "Expenses:X")),
+        Directive::Transaction(txn),
+    ]
+}
+
+fn run(query: &str) -> Vec<Vec<Value>> {
+    let dirs = ledger();
+    let q = parse(query).expect("parse");
+    let mut ex = Executor::new(&dirs);
+    ex.execute(&q).expect("execute").rows
+}
+
+/// The issue's verbatim query shape (mkshp Obsidian plugin's Journal
+/// view), through the `FROM postings` table path.
+#[test]
+fn issue_1796_entry_meta_from_postings() {
+    let rows = run("SELECT id, date, entry.meta as entry_meta FROM postings");
+    assert_eq!(rows.len(), 2);
+    let Value::Object(meta) = &rows[0][2] else {
+        panic!(
+            "entry.meta must be a structured object, got {:?}",
+            rows[0][2]
+        );
+    };
+    assert_eq!(meta.get("note"), Some(&Value::String("hello".into())));
+}
+
+/// Attribute access on the default (no-FROM) path, including chaining
+/// into a subscript: `entry.meta['note']`.
+#[test]
+fn attribute_and_subscript_chain() {
+    let rows = run("SELECT entry.narration, entry.payee, entry.meta['note'] LIMIT 1");
+    assert_eq!(rows[0][0], Value::String("coffee".into()));
+    assert_eq!(rows[0][1], Value::String("Shop".into()));
+    assert_eq!(rows[0][2], Value::String("hello".into()));
+}
+
+/// Subscript on the posting-level `meta` column (a `Value::Metadata`):
+/// the transaction's meta is NOT the posting's, so this is NULL here,
+/// while GETITEM-equivalent lookup works where posting meta exists.
+#[test]
+fn subscript_on_posting_meta() {
+    let rows = run("SELECT meta['note'] LIMIT 1");
+    // `note` lives on the transaction, not the posting — upstream's
+    // getitem returns None for a missing key, i.e. NULL, not an error.
+    assert_eq!(rows[0][0], Value::Null);
+}
+
+/// A missing attribute is NULL. Deliberate divergence nuance (Python
+/// Compatibility Policy): upstream errors at COMPILE time for an unknown
+/// attribute on a structured type but yields None for a present-but-empty
+/// field; rustledger's dynamic `entry` object omits empty fields, making
+/// the two cases indistinguishable — NULL reproduces upstream for the
+/// common case (absent payee) and is lenient for typos.
+#[test]
+fn missing_attribute_is_null() {
+    let mut dirs = ledger();
+    // A transaction without payee: entry.payee must be NULL, not an error.
+    if let Directive::Transaction(t) = &mut dirs[2] {
+        t.payee = None;
+    }
+    let q = parse("SELECT entry.payee LIMIT 1").expect("parse");
+    let mut ex = Executor::new(&dirs);
+    assert_eq!(ex.execute(&q).expect("execute").rows[0][0], Value::Null);
+
+    // Typo'd attribute: also NULL (see divergence note above).
+    let rows = run("SELECT entry.naration LIMIT 1");
+    assert_eq!(rows[0][0], Value::Null);
+}
+
+/// Attribute access on a non-structured operand is a type error,
+/// matching upstream's "column type is not structured".
+#[test]
+fn attribute_on_non_object_errors() {
+    let dirs = ledger();
+    let q = parse("SELECT account.foo LIMIT 1").expect("parse");
+    let mut ex = Executor::new(&dirs);
+    let err = ex.execute(&q).expect_err("must be a type error");
+    assert!(err.to_string().contains("not structured"), "{err}");
+}
+
+/// Number literals keep their decimal point — `1.5` is a decimal, never
+/// `1 . 5` attribute access.
+#[test]
+fn decimal_literals_unaffected() {
+    let rows = run("SELECT 1.5 LIMIT 1");
+    assert_eq!(rows[0][0], Value::Number(dec!(1.5)));
+}
+
+/// Attribute/subscript work in WHERE and aggregate contexts too — every
+/// evaluator path grew the arms.
+#[test]
+fn attribute_in_where_and_group_by() {
+    let rows = run("SELECT count(*) WHERE entry.payee = 'Shop'");
+    assert_eq!(rows[0][0], Value::Integer(2));
+    let rows = run("SELECT entry.narration, count(*) GROUP BY entry.narration");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String("coffee".into()));
+}

--- a/crates/rustledger-query/tests/attribute_subscript_test.rs
+++ b/crates/rustledger-query/tests/attribute_subscript_test.rs
@@ -128,3 +128,112 @@ fn attribute_in_where_and_group_by() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][0], Value::String("coffee".into()));
 }
+
+/// An aggregate wrapped in postfix access is still an aggregate:
+/// `first(entry).payee` must produce ONE aggregated row, not a NULL per
+/// posting (pre-review, is_aggregate_expr didn't recurse into the new
+/// variants and the query was silently misrouted down the per-row path).
+#[test]
+fn aggregate_under_postfix_access() {
+    let rows = run("SELECT first(entry).payee");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0], Value::String("Shop".into()));
+}
+
+/// ORDER BY on a selected attribute expression resolves (pre-review the
+/// target was named "colN" and ORDER BY string lookup missed it), and
+/// the output column is named by its source spelling.
+#[test]
+fn order_by_attribute_and_column_naming() {
+    let dirs = ledger();
+    let q = parse("SELECT entry.narration ORDER BY entry.narration").expect("parse");
+    let mut ex = Executor::new(&dirs);
+    let result = ex.execute(&q).expect("execute");
+    assert_eq!(result.rows.len(), 2);
+    assert_eq!(result.columns[0], "entry.narration");
+}
+
+/// Drift guard: `balance['USD']` and `getitem(balance, 'USD')` are two
+/// spellings of the same canonical lookup and must agree on every row —
+/// including the Inventory arm the first draft omitted.
+#[test]
+fn subscript_agrees_with_getitem_on_inventory() {
+    let rows = run("SELECT balance['USD'], getitem(balance, 'USD')");
+    assert_eq!(rows.len(), 2);
+    for row in &rows {
+        assert_eq!(row[0], row[1], "subscript/getitem drift: {row:?}");
+    }
+    // And at least one row has a real amount (not vacuous agreement).
+    assert!(rows.iter().any(|r| matches!(r[0], Value::Amount(_))));
+}
+
+/// `SELECT * FROM postings` hides the structured `entry` column (matching
+/// upstream's wildcard) and the underscore helper columns — which leaked
+/// into the wildcard before this PR. All stay addressable by name.
+#[test]
+fn select_star_hides_structured_and_helper_columns() {
+    let dirs = ledger();
+    let q = parse("SELECT * FROM postings LIMIT 1").expect("parse");
+    let mut ex = Executor::new(&dirs);
+    let result = ex.execute(&q).expect("execute");
+    for hidden in ["entry", "_entry_meta", "_posting_meta"] {
+        assert!(
+            !result.columns.iter().any(|c| c == hidden),
+            "column '{hidden}' must be hidden from SELECT *: {:?}",
+            result.columns
+        );
+    }
+    // Column names and row width stay in lockstep.
+    assert_eq!(result.columns.len(), result.rows[0].len());
+    // Explicit selection still works.
+    let rows = run("SELECT entry FROM postings LIMIT 1");
+    assert!(matches!(rows[0][0], Value::Object(_)));
+}
+
+/// `entry.meta` carries the filename/lineno augmentation, agreeing with
+/// `entry_meta('lineno')` — the two lookup paths cannot drift. Uses a
+/// source-mapped executor so real locations exist (programmatic
+/// directives have none, which would make the presence assert vacuous).
+#[test]
+fn entry_meta_carries_source_location() {
+    use rustledger_loader::SourceMap;
+    use rustledger_parser::{Span, Spanned};
+    use std::sync::Arc;
+
+    let mut source_map = SourceMap::new();
+    let source: Arc<str> =
+        "2026-07-01 open Assets:Cash\n2026-07-01 * \"Shop\" \"coffee\"\n  Assets:Cash  -1.00 USD\n"
+            .into();
+    let file_id = source_map.add_file("test.beancount".into(), source);
+    let spanned: Vec<Spanned<Directive>> = ledger()
+        .into_iter()
+        .map(|d| Spanned {
+            value: d,
+            // Offset of the transaction line (line 2) — close enough for a
+            // stable, non-zero lineno.
+            span: Span::new(28, 60),
+            file_id: u16::try_from(file_id).expect("single test file"),
+        })
+        .collect();
+
+    let mut ex = rustledger_query::Executor::new_with_sources(&spanned, &source_map);
+    let q = parse("SELECT entry.meta['lineno'], entry_meta('lineno') LIMIT 1").expect("parse");
+    let rows = ex.execute(&q).expect("execute").rows;
+    assert_eq!(rows[0][0], rows[0][1], "entry.meta vs entry_meta drift");
+    assert!(!matches!(rows[0][0], Value::Null), "lineno must be present");
+}
+
+/// Whitespace is allowed around the postfix dot, as in upstream's
+/// whitespace-skipping grammar.
+#[test]
+fn whitespace_around_postfix_dot() {
+    for q in [
+        "SELECT entry.narration LIMIT 1",
+        "SELECT entry .narration LIMIT 1",
+        "SELECT entry. narration LIMIT 1",
+        "SELECT entry . narration LIMIT 1",
+    ] {
+        let rows = run(q);
+        assert_eq!(rows[0][0], Value::String("coffee".into()), "query: {q}");
+    }
+}

--- a/crates/rustledger-query/tests/attribute_subscript_test.rs
+++ b/crates/rustledger-query/tests/attribute_subscript_test.rs
@@ -131,7 +131,7 @@ fn attribute_in_where_and_group_by() {
 
 /// An aggregate wrapped in postfix access is still an aggregate:
 /// `first(entry).payee` must produce ONE aggregated row, not a NULL per
-/// posting (pre-review, is_aggregate_expr didn't recurse into the new
+/// posting (pre-review, `is_aggregate_expr` didn't recurse into the new
 /// variants and the query was silently misrouted down the per-row path).
 #[test]
 fn aggregate_under_postfix_access() {


### PR DESCRIPTION
## What

`SELECT id, date, entry.meta as entry_meta FROM postings` (the mkshp Obsidian plugin's Journal query, working against beanquery 0.2.0) failed at the `.` — and investigating showed **three gaps behind one report**:

1. The parser had no postfix attribute access (`primary '.' identifier` in upstream bql.ebnf).
2. It had no string subscript either (`primary '[' string ']'`) — the sibling rule, and core machinery upstream: beanquery rewrites `meta(key)` into `getitem(entry.meta, key)`.
3. `FROM postings` resolves columns against the `#postings` table projection, which had no `entry` column at all ("column 'entry' not found in subquery result") — even though the default-path `entry` column existed.

## How

- **Parser**: a postfix fold on `primary` so `.name`/`['key']` chain (`entry.meta['note']`, `a.b.c`) and bind tighter than any operator. `literal()` consumes decimals whole, so `1.5` never reaches the attribute dot (pinned).
- **Executor**: shared `eval_attribute`/`eval_subscript` helpers mirroring GETITEM's metadata/object arms — missing key → NULL like upstream's `getitem`; attribute on a non-structured operand is a type error like upstream's compiler. Wired into **every** evaluator path (per-posting, subquery/table rows, aggregate groups, both HAVING flavors, `expr_references_column`), compiler-enforced via the new AST variants.
- **Canonical-function discipline**: the entry-object builder is extracted as `entry_object()`, shared by the default-path column and the new `#postings` `entry` column — the two shapes cannot drift.
- **Documented divergence nuance** (per the compat policy checklist): a typo'd attribute yields NULL where upstream errors at compile time. rustledger's dynamic `entry` object omits empty fields, so "absent payee" and "typo" are indistinguishable at runtime — NULL reproduces upstream for the common case; rationale at `eval_attribute` and pinned in tests.

## Testing

The issue's verbatim query (both rows, structured object contents asserted); attribute+subscript chaining; posting-vs-transaction meta distinction; NULL semantics for absent payee and typo'd attribute; the not-structured type error; decimal-literal non-interference; WHERE and GROUP BY coverage. Full query + CLI suites green; clippy `-D warnings`, fmt, rustdoc clean.

Closes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)