### PR TITLE
fix: price sources must honor --date or refuse it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,6 +2026,7 @@ checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
+ "jiff-tzdb",
  "jiff-tzdb-platform",
  "js-sys",
  "log",
@@ -2049,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"

--- a/crates/rustledger/Cargo.toml
+++ b/crates/rustledger/Cargo.toml
@@ -103,7 +103,13 @@ anyhow.workspace = true
 rust_decimal.workspace = true
 format_num_pattern.workspace = true
 glob.workspace = true
-jiff.workspace = true
+# tzdb-bundle-always: the yahoo source classifies quote bars by
+# exchange timezone (meta.exchangeTimezoneName); without a bundled tzdb
+# that silently degrades to the DST-unsafe gmtoffset fallback on any
+# machine lacking /usr/share/zoneinfo (containers, the nix build
+# sandbox), and its regression test would fail only there (round-3
+# deep review of #1801).
+jiff = { workspace = true, features = ["tzdb-bundle-always"] }
 ureq.workspace = true
 sha2.workspace = true
 

--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -22,6 +22,12 @@ pub struct PriceCache {
     ttl: Duration,
     entries: HashMap<String, CachedPrice>,
     dirty: bool,
+    /// The on-disk file belongs to a NEWER schema this binary cannot
+    /// read. All writes are suppressed — this run simply goes uncached —
+    /// so an outdated binary never destroys a newer binary's cache, not
+    /// even when it fetches (round-4 deep review: the round-3 fix only
+    /// protected no-fetch runs).
+    readonly: bool,
 }
 
 /// Current cache schema.
@@ -73,71 +79,100 @@ impl PriceCache {
     fn load_from_path(path: PathBuf, ttl_secs: u64) -> Self {
         let ttl = Duration::from_secs(ttl_secs);
 
-        let (entries, discarded) = if path.exists() {
+        let (entries, dirty, readonly) = if path.exists() {
             match std::fs::read_to_string(&path) {
-                // Versioned envelope: entries from other schema versions are
-                // DISCARDED, not migrated. Pre-#1801 caches hold live quotes
-                // stored under historical dates (the #1794 corruption); the
-                // old bare-map format fails to parse as CacheFile, so those
-                // poisoned entries can never be served again (deep review —
-                // the cache sits ABOVE the sources, bypassing their fixes).
-                // NOTE: a pre-#1801 binary sharing this file cannot read the
-                // v2 envelope and will clobber it on its next fetch; that
-                // downgrade path is accepted — readable-by-old-binaries
-                // would mean keeping the poisoned format alive.
-                Ok(contents) => match serde_json::from_str::<CacheFile>(&contents) {
-                    Ok(file) if file.version == CACHE_SCHEMA_VERSION => (file.entries, false),
-                    // A NEWER schema — this binary is the outdated one.
-                    // Don't serve entries it can't vouch for, but don't
-                    // mark dirty either: a no-fetch run must leave the
-                    // newer binary's cache untouched (round-3 review —
-                    // dirty here made every old-binary run wipe it).
-                    Ok(file) if file.version > CACHE_SCHEMA_VERSION => (HashMap::new(), false),
-                    // Older or unversioned (the pre-#1801 bare map):
-                    // poisoned — discard AND mark dirty so save() rewrites
-                    // the file even when the run fetches nothing, otherwise
-                    // the poisoned file survives on disk for any older
-                    // binary to serve again (round-2 deep review).
-                    _ => (HashMap::new(), true),
-                },
+                Ok(contents) => Self::classify_contents(&contents),
                 // Transient I/O error (EACCES, network home dir): leave the
                 // file alone — it may be perfectly healthy (round-3 review:
                 // marking dirty here let a recoverable read error destroy
                 // the whole cache on save()).
-                Err(_) => (HashMap::new(), false),
+                Err(_) => (HashMap::new(), false, false),
             }
         } else {
-            (HashMap::new(), false)
+            (HashMap::new(), false, false)
         };
 
         Self {
             path,
             ttl,
             entries,
-            dirty: discarded,
+            dirty,
+            readonly,
         }
+    }
+
+    /// Classify on-disk cache contents into `(entries, dirty, readonly)`.
+    ///
+    /// Entries from other schema versions are DISCARDED, not migrated,
+    /// but what happens to the FILE depends on why parsing failed:
+    ///
+    /// - current version: served as-is.
+    /// - NEWER version (parseable or not — a future envelope may change
+    ///   shape entirely, so an unparsable file claiming a newer
+    ///   `version` counts too): this binary is the outdated one; load
+    ///   empty and go READONLY so nothing this run does — not even a
+    ///   fetch — clobbers the newer binary's cache (round-4 review).
+    /// - OLDER version, or the pre-#1801 unversioned bare map: poisoned —
+    ///   those files hold live quotes stored under historical dates (the
+    ///   #1794 corruption) and the cache sits ABOVE the source guards,
+    ///   so mark dirty: `save()` rewrites the file even on a no-fetch run
+    ///   (round-2 review). A pre-#1801 binary sharing the file will
+    ///   still clobber it on its next fetch; that downgrade direction is
+    ///   accepted — readable-by-old-binaries would keep the poisoned
+    ///   format alive.
+    /// - anything else (truncated write, editor damage): plain
+    ///   corruption — not dirty (a no-fetch run leaves it for manual
+    ///   recovery) and not readonly (a run that fetches may overwrite;
+    ///   the data was unreadable anyway) (round-4 review: the old
+    ///   catch-all queued these for destruction).
+    fn classify_contents(contents: &str) -> (HashMap<String, CachedPrice>, bool, bool) {
+        if let Ok(file) = serde_json::from_str::<CacheFile>(contents) {
+            return match file.version.cmp(&CACHE_SCHEMA_VERSION) {
+                std::cmp::Ordering::Equal => (file.entries, false, false),
+                std::cmp::Ordering::Greater => (HashMap::new(), false, true),
+                std::cmp::Ordering::Less => (HashMap::new(), true, false),
+            };
+        }
+        // The pre-#1801 legacy shape: a bare entries map at the top level.
+        if serde_json::from_str::<HashMap<String, CachedPrice>>(contents).is_ok() {
+            return (HashMap::new(), true, false);
+        }
+        // A future envelope whose shape we can't parse but whose version
+        // field is readable and newer — preserve it read-only.
+        if serde_json::from_str::<serde_json::Value>(contents)
+            .ok()
+            .and_then(|v| v.get("version").and_then(serde_json::Value::as_u64))
+            .is_some_and(|v| v > u64::from(CACHE_SCHEMA_VERSION))
+        {
+            return (HashMap::new(), false, true);
+        }
+        (HashMap::new(), false, false)
     }
 
     /// Look up a cached price. Returns `None` if missing or expired.
     ///
-    /// SETTLED historical prices (keyed under a date strictly before
-    /// today) never expire — a past close is immutable. Latest prices
-    /// AND prices keyed under today (or a future date) expire after the
-    /// configured TTL: a `--date <today>` fetch from a latest-only
-    /// source is an intraday quote, and serving the morning's value all
-    /// day from a never-expiring entry would freeze it as the day's
-    /// price of record (round-3 deep review). This matches Python
-    /// bean-price behavior for the settled case.
+    /// SETTLED historical prices never expire — a past close is
+    /// immutable. Whether an entry is settled is decided by the entry's
+    /// OWN fetch time, not the live clock: a quote keyed under date D
+    /// but fetched ON day D is an intraday snapshot, and it stays an
+    /// intraday snapshot after midnight — promoting it to a
+    /// never-expiring "settled" price would freeze it as D's price of
+    /// record and serve it before any source guard runs, resurrecting
+    /// the #1794 corruption through the cache (round-4 deep review;
+    /// round 3's live-clock rule had exactly that hole). Only an entry
+    /// fetched AFTER its keyed day ended is a real close. Latest,
+    /// intraday, and future-dated entries expire with the TTL.
     pub fn get(&self, key: &str) -> Option<PriceResponse> {
         let entry = self.entries.get(key)?;
 
-        // Only strictly-past dated keys are exempt from the TTL.
         let is_settled = !key.ends_with(":latest")
             && key
                 .rsplit(':')
                 .next()
                 .and_then(|s| s.parse::<NaiveDate>().ok())
-                .is_some_and(|d| d < jiff::Zoned::now().date());
+                .is_some_and(|key_date| {
+                    civil_day_of(entry.cached_at).is_some_and(|fetched_day| key_date < fetched_day)
+                });
         if !is_settled {
             let now = now_secs();
             if self.ttl.is_zero() || now.saturating_sub(entry.cached_at) > self.ttl.as_secs() {
@@ -172,8 +207,12 @@ impl PriceCache {
     }
 
     /// Save cache to disk (only if modified). Prunes stale entries.
+    ///
+    /// A no-op when the on-disk file belongs to a newer schema — see
+    /// [`Self::classify_contents`]: this run trades caching away rather
+    /// than destroy a newer binary's data.
     pub fn save(&mut self) {
-        if !self.dirty {
+        if self.readonly || !self.dirty {
             return;
         }
 
@@ -232,6 +271,14 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
+/// The local civil day a unix timestamp falls on. Used to decide
+/// whether a dated cache entry was fetched after its keyed day ended
+/// (settled) or on the day itself (intraday) — see [`PriceCache::get`].
+fn civil_day_of(unix_secs: u64) -> Option<NaiveDate> {
+    let ts = jiff::Timestamp::from_second(i64::try_from(unix_secs).ok()?).ok()?;
+    Some(ts.to_zoned(jiff::tz::TimeZone::system()).date())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,6 +307,7 @@ mod tests {
             ttl: Duration::from_secs(0), // TTL=0 would expire latest prices
             entries: HashMap::new(),
             dirty: false,
+            readonly: false,
         };
 
         let response = PriceResponse {
@@ -282,6 +330,7 @@ mod tests {
             ttl: Duration::from_hours(1),
             entries: HashMap::new(),
             dirty: false,
+            readonly: false,
         };
 
         let response = PriceResponse {
@@ -309,6 +358,7 @@ mod tests {
             ttl: Duration::from_secs(0), // Expire immediately
             entries: HashMap::new(),
             dirty: false,
+            readonly: false,
         };
 
         let response = PriceResponse {
@@ -330,6 +380,7 @@ mod tests {
             ttl: Duration::from_hours(1),
             entries: HashMap::new(),
             dirty: false,
+            readonly: false,
         };
 
         assert!(cache.get("nonexistent").is_none());
@@ -354,6 +405,7 @@ mod tests {
                 ttl: Duration::from_hours(1),
                 entries: HashMap::new(),
                 dirty: false,
+                readonly: false,
             };
             cache.insert("yahoo:AAPL:USD:latest", &response);
             cache.save();
@@ -382,6 +434,7 @@ mod tests {
             ttl: Duration::from_hours(1),
             entries: HashMap::new(),
             dirty: false,
+            readonly: false,
         };
 
         let response = PriceResponse {
@@ -492,6 +545,7 @@ mod tests {
             ttl: Duration::from_secs(0), // everything TTL-subject expires
             entries: HashMap::new(),
             dirty: false,
+            readonly: false,
         };
         let response = PriceResponse {
             price: Decimal::new(15000, 2),
@@ -504,6 +558,156 @@ mod tests {
         assert!(
             cache.get(&key).is_none(),
             "a today-dated entry must expire with the TTL"
+        );
+    }
+
+    /// The newer-schema guarantee must hold through a FETCH, not only a
+    /// no-fetch run: an insert marks the cache dirty, and `save()` must
+    /// still refuse to clobber the newer binary's file (round-4 deep
+    /// review — round 3's fix only covered the no-insert path).
+    #[test]
+    fn newer_version_cache_survives_an_insert_and_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices.json");
+        let future = format!(
+            r#"{{"version":{},"entries":{{}}}}"#,
+            CACHE_SCHEMA_VERSION + 1
+        );
+        std::fs::write(&path, &future).unwrap();
+
+        let mut cache = PriceCache::load_from_path(path.clone(), 3600);
+        cache.insert(
+            "yahoo:AAPL:USD:latest",
+            &PriceResponse {
+                price: Decimal::new(15000, 2),
+                currency: "USD".to_string(),
+                date: rustledger_core::naive_date(2024, 1, 15).unwrap(),
+                source: "yahoo".to_string(),
+            },
+        );
+        cache.save();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            future,
+            "a fetch in an outdated binary must not destroy the newer cache"
+        );
+    }
+
+    /// An unparsable-but-newer envelope (a future schema that changed
+    /// the envelope shape entirely, so the `CacheFile` parse fails) is
+    /// still recognized as newer via its raw `version` field and
+    /// preserved read-only (round-4 deep review — the old catch-all
+    /// queued it for destruction).
+    #[test]
+    fn unparsable_newer_envelope_is_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices.json");
+        let future = format!(
+            r#"{{"version":{},"generations":[{{"entries":{{}}}}]}}"#,
+            CACHE_SCHEMA_VERSION + 1
+        );
+        std::fs::write(&path, &future).unwrap();
+
+        let mut cache = PriceCache::load_from_path(path.clone(), 3600);
+        assert!(cache.entries.is_empty());
+        assert!(!cache.dirty);
+        cache.insert(
+            "yahoo:AAPL:USD:latest",
+            &PriceResponse {
+                price: Decimal::new(15000, 2),
+                currency: "USD".to_string(),
+                date: rustledger_core::naive_date(2024, 1, 15).unwrap(),
+                source: "yahoo".to_string(),
+            },
+        );
+        cache.save();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), future);
+    }
+
+    /// Plain corruption (truncated write, editor damage) is neither
+    /// poisoned nor foreign: a no-fetch run must leave the file for
+    /// manual recovery instead of queuing it for destruction (round-4
+    /// deep review).
+    #[test]
+    fn corrupt_cache_is_not_marked_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices.json");
+        let truncated = r#"{"version":2,"entries":{"yahoo:AAPL:USD:2024-01-15":{"pri"#;
+        std::fs::write(&path, truncated).unwrap();
+
+        let cache = PriceCache::load_from_path(path, 3600);
+        assert!(cache.entries.is_empty());
+        assert!(!cache.dirty, "corruption must not queue a rewrite");
+        assert!(!cache.readonly, "a later fetch MAY overwrite corrupt junk");
+    }
+
+    /// An entry keyed under date D but FETCHED on day D is an intraday
+    /// snapshot forever — crossing midnight must not promote it to a
+    /// settled, never-expiring price (round-4 deep review: that
+    /// promotion re-served stale intraday quotes as the historical
+    /// price of record, before any source guard could run).
+    #[test]
+    fn entry_fetched_on_its_own_day_stays_ttl_bound() {
+        // Simulate "yesterday's --date-today fetch": cached_at is 24h
+        // ago, and the key date is the civil day that instant fell on.
+        let cached_at = now_secs() - 24 * 3600;
+        let key_date = civil_day_of(cached_at).unwrap();
+        let key = format!("coinbase:BTC:USD:{key_date}");
+        let mut entries = HashMap::new();
+        entries.insert(
+            key.clone(),
+            CachedPrice {
+                price: "67000.00".to_string(),
+                currency: "USD".to_string(),
+                date: key_date.to_string(),
+                source: "coinbase".to_string(),
+                cached_at,
+            },
+        );
+        let cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache-intraday.json"),
+            ttl: Duration::from_mins(30),
+            entries,
+            dirty: false,
+            readonly: false,
+        };
+        assert!(
+            cache.get(&key).is_none(),
+            "an intraday-fetched entry must expire with the TTL even after \
+             its keyed day has passed"
+        );
+    }
+
+    /// The settled exemption still applies when the entry was fetched
+    /// AFTER its keyed day — a real close is immutable and never
+    /// expires (pinned so the round-4 fix doesn't overshoot).
+    #[test]
+    fn entry_fetched_after_its_day_never_expires() {
+        let cached_at = now_secs() - 24 * 3600;
+        let fetch_day = civil_day_of(cached_at).unwrap();
+        let key_date = fetch_day.checked_sub(jiff::Span::new().days(3)).unwrap();
+        let key = format!("yahoo:AAPL:USD:{key_date}");
+        let mut entries = HashMap::new();
+        entries.insert(
+            key.clone(),
+            CachedPrice {
+                price: "150.00".to_string(),
+                currency: "USD".to_string(),
+                date: key_date.to_string(),
+                source: "yahoo".to_string(),
+                cached_at,
+            },
+        );
+        let cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache-settled.json"),
+            ttl: Duration::from_secs(0), // TTL 0 would expire anything TTL-bound
+            entries,
+            dirty: false,
+            readonly: false,
+        };
+        assert!(
+            cache.get(&key).is_some(),
+            "a close fetched after its day ended is settled and immortal"
         );
     }
 

--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -209,8 +209,8 @@ impl PriceCache {
     /// Save cache to disk (only if modified). Prunes stale entries.
     ///
     /// A no-op when the on-disk file belongs to a newer schema — see
-    /// [`Self::classify_contents`]: this run trades caching away rather
-    /// than destroy a newer binary's data.
+    /// `classify_contents` (private): this run trades caching away
+    /// rather than destroy a newer binary's data.
     pub fn save(&mut self) {
         if self.readonly || !self.dirty {
             return;

--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -24,11 +24,18 @@ pub struct PriceCache {
     dirty: bool,
 }
 
-/// Current cache schema. Bumped in #1801: version 1 was an unversioned
-/// bare map that could hold live quotes mislabeled with historical dates
-/// (#1794); those entries must never be served, so unversioned or
-/// mismatched files load as empty.
-const CACHE_SCHEMA_VERSION: u32 = 2;
+/// Current cache schema.
+///
+/// Bumped in #1801: version 1 was an unversioned bare map that could
+/// hold live quotes mislabeled with historical dates (#1794); those
+/// entries must never be served, so unversioned or older-versioned
+/// files load as empty (newer-versioned files also load as empty but
+/// are left on disk for the newer binary).
+///
+/// Public so integration tests that pre-write cache fixtures reference
+/// the real constant instead of a literal that silently goes stale on
+/// the next bump (round-3 deep review).
+pub const CACHE_SCHEMA_VERSION: u32 = 2;
 
 /// The on-disk cache envelope.
 #[derive(Debug, Serialize, Deserialize)]
@@ -80,13 +87,24 @@ impl PriceCache {
                 // would mean keeping the poisoned format alive.
                 Ok(contents) => match serde_json::from_str::<CacheFile>(&contents) {
                     Ok(file) if file.version == CACHE_SCHEMA_VERSION => (file.entries, false),
-                    // Discarding marks the cache dirty so save() rewrites
-                    // the file even when the run fetches nothing — otherwise
-                    // the poisoned pre-#1801 file survives on disk for any
-                    // older binary to serve again (round-2 deep review).
+                    // A NEWER schema — this binary is the outdated one.
+                    // Don't serve entries it can't vouch for, but don't
+                    // mark dirty either: a no-fetch run must leave the
+                    // newer binary's cache untouched (round-3 review —
+                    // dirty here made every old-binary run wipe it).
+                    Ok(file) if file.version > CACHE_SCHEMA_VERSION => (HashMap::new(), false),
+                    // Older or unversioned (the pre-#1801 bare map):
+                    // poisoned — discard AND mark dirty so save() rewrites
+                    // the file even when the run fetches nothing, otherwise
+                    // the poisoned file survives on disk for any older
+                    // binary to serve again (round-2 deep review).
                     _ => (HashMap::new(), true),
                 },
-                Err(_) => (HashMap::new(), true),
+                // Transient I/O error (EACCES, network home dir): leave the
+                // file alone — it may be perfectly healthy (round-3 review:
+                // marking dirty here let a recoverable read error destroy
+                // the whole cache on save()).
+                Err(_) => (HashMap::new(), false),
             }
         } else {
             (HashMap::new(), false)
@@ -102,15 +120,25 @@ impl PriceCache {
 
     /// Look up a cached price. Returns `None` if missing or expired.
     ///
-    /// Historical prices (with a specific date in the key) never expire.
-    /// Latest prices expire after the configured TTL.
-    /// This matches Python bean-price behavior.
+    /// SETTLED historical prices (keyed under a date strictly before
+    /// today) never expire — a past close is immutable. Latest prices
+    /// AND prices keyed under today (or a future date) expire after the
+    /// configured TTL: a `--date <today>` fetch from a latest-only
+    /// source is an intraday quote, and serving the morning's value all
+    /// day from a never-expiring entry would freeze it as the day's
+    /// price of record (round-3 deep review). This matches Python
+    /// bean-price behavior for the settled case.
     pub fn get(&self, key: &str) -> Option<PriceResponse> {
         let entry = self.entries.get(key)?;
 
-        // Historical prices never expire; latest prices use TTL
-        let is_latest = key.ends_with(":latest");
-        if is_latest {
+        // Only strictly-past dated keys are exempt from the TTL.
+        let is_settled = !key.ends_with(":latest")
+            && key
+                .rsplit(':')
+                .next()
+                .and_then(|s| s.parse::<NaiveDate>().ok())
+                .is_some_and(|d| d < jiff::Zoned::now().date());
+        if !is_settled {
             let now = now_secs();
             if self.ttl.is_zero() || now.saturating_sub(entry.cached_at) > self.ttl.as_secs() {
                 return None; // Expired or caching disabled
@@ -403,6 +431,79 @@ mod tests {
         assert!(
             rewritten.entries.is_empty(),
             "save() after a discard must replace the poisoned file with an empty v2 envelope"
+        );
+    }
+
+    /// A NEWER-versioned file (downgraded binary) loads as empty but is
+    /// NOT dirty: this binary must not serve entries it can't vouch for,
+    /// and must not destroy the newer binary's cache on `save()` either
+    /// (round-3 deep review — the round-2 discard-marks-dirty fix made
+    /// every old-binary run wipe a newer cache).
+    #[test]
+    fn newer_version_cache_is_ignored_but_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices.json");
+        let future = format!(
+            r#"{{"version":{},"entries":{{"yahoo:AAPL:USD:2024-01-15":{{"price":"150.00","currency":"USD","date":"2024-01-15","source":"yahoo","cached_at":1700000000}}}}}}"#,
+            CACHE_SCHEMA_VERSION + 1
+        );
+        std::fs::write(&path, &future).unwrap();
+
+        let mut cache = PriceCache::load_from_path(path.clone(), 3600);
+        assert!(cache.entries.is_empty(), "newer schema must not be served");
+        assert!(!cache.dirty, "newer schema must not be marked for rewrite");
+
+        cache.save();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            future,
+            "a no-insert run must leave the newer binary's cache untouched"
+        );
+    }
+
+    /// A transient read error must NOT queue the file for destruction —
+    /// it may be perfectly healthy (round-3 deep review: EACCES on a
+    /// network home dir wiped the whole cache on `save()`).
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_cache_is_not_marked_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory at the cache path: exists() is true, read fails.
+        let path = dir.path().join("prices.json");
+        std::fs::create_dir(&path).unwrap();
+
+        let cache = PriceCache::load_from_path(path, 3600);
+        assert!(cache.entries.is_empty());
+        assert!(
+            !cache.dirty,
+            "a read error must leave the on-disk cache alone"
+        );
+    }
+
+    /// A key dated TODAY is an intraday quote, not a settled close — it
+    /// must honor the TTL instead of never expiring (round-3 deep
+    /// review: the first `--date <today>` fetch froze as that day's
+    /// price of record).
+    #[test]
+    fn today_dated_key_honors_ttl() {
+        let today = jiff::Zoned::now().date();
+        let mut cache = PriceCache {
+            path: PathBuf::from("/tmp/test-price-cache-today.json"),
+            ttl: Duration::from_secs(0), // everything TTL-subject expires
+            entries: HashMap::new(),
+            dirty: false,
+        };
+        let response = PriceResponse {
+            price: Decimal::new(15000, 2),
+            currency: "USD".to_string(),
+            date: today,
+            source: "coinbase".to_string(),
+        };
+        let key = format!("coinbase:BTC:USD:{today}");
+        cache.insert(&key, &response);
+        assert!(
+            cache.get(&key).is_none(),
+            "a today-dated entry must expire with the TTL"
         );
     }
 

--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -37,6 +37,14 @@ struct CacheFile {
     entries: HashMap<String, CachedPrice>,
 }
 
+/// Borrowing mirror of [`CacheFile`] for serialization — avoids deep-
+/// cloning every entry on save. Field names must match `CacheFile`.
+#[derive(Serialize)]
+struct CacheFileRef<'a> {
+    version: u32,
+    entries: &'a HashMap<String, CachedPrice>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachedPrice {
     price: String,
@@ -49,10 +57,16 @@ struct CachedPrice {
 impl PriceCache {
     /// Load cache from disk, or create empty if not found.
     pub fn load(ttl_secs: u64) -> Self {
-        let path = cache_file_path();
+        Self::load_from_path(cache_file_path(), ttl_secs)
+    }
+
+    /// Load a cache from an explicit path (injectable for tests — the
+    /// discard-on-mismatch behavior below must be assertable through the
+    /// real load path, not a re-implemented parse).
+    fn load_from_path(path: PathBuf, ttl_secs: u64) -> Self {
         let ttl = Duration::from_secs(ttl_secs);
 
-        let entries = if path.exists() {
+        let (entries, discarded) = if path.exists() {
             match std::fs::read_to_string(&path) {
                 // Versioned envelope: entries from other schema versions are
                 // DISCARDED, not migrated. Pre-#1801 caches hold live quotes
@@ -60,21 +74,29 @@ impl PriceCache {
                 // old bare-map format fails to parse as CacheFile, so those
                 // poisoned entries can never be served again (deep review —
                 // the cache sits ABOVE the sources, bypassing their fixes).
+                // NOTE: a pre-#1801 binary sharing this file cannot read the
+                // v2 envelope and will clobber it on its next fetch; that
+                // downgrade path is accepted — readable-by-old-binaries
+                // would mean keeping the poisoned format alive.
                 Ok(contents) => match serde_json::from_str::<CacheFile>(&contents) {
-                    Ok(file) if file.version == CACHE_SCHEMA_VERSION => file.entries,
-                    _ => HashMap::new(),
+                    Ok(file) if file.version == CACHE_SCHEMA_VERSION => (file.entries, false),
+                    // Discarding marks the cache dirty so save() rewrites
+                    // the file even when the run fetches nothing — otherwise
+                    // the poisoned pre-#1801 file survives on disk for any
+                    // older binary to serve again (round-2 deep review).
+                    _ => (HashMap::new(), true),
                 },
-                Err(_) => HashMap::new(),
+                Err(_) => (HashMap::new(), true),
             }
         } else {
-            HashMap::new()
+            (HashMap::new(), false)
         };
 
         Self {
             path,
             ttl,
             entries,
-            dirty: false,
+            dirty: discarded,
         }
     }
 
@@ -137,9 +159,9 @@ impl PriceCache {
             let _ = std::fs::create_dir_all(parent);
         }
 
-        let file = CacheFile {
+        let file = CacheFileRef {
             version: CACHE_SCHEMA_VERSION,
-            entries: self.entries.clone(),
+            entries: &self.entries,
         };
         if let Ok(json) = serde_json::to_string_pretty(&file)
             && std::fs::write(&self.path, json).is_ok()
@@ -310,17 +332,13 @@ mod tests {
             assert!(!cache.dirty, "dirty should be cleared after save");
         }
 
-        // Load and verify through the versioned envelope.
+        // Load through the REAL load path and verify the entry survives
+        // the versioned envelope round trip.
         {
             let file: CacheFile =
                 serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
             assert_eq!(file.version, CACHE_SCHEMA_VERSION);
-            let cache = PriceCache {
-                path: path.clone(),
-                ttl: Duration::from_hours(1),
-                entries: file.entries,
-                dirty: false,
-            };
+            let cache = PriceCache::load_from_path(path.clone(), 3600);
             let cached = cache.get("yahoo:AAPL:USD:latest");
             assert!(cached.is_some(), "should find cached entry after load");
             assert_eq!(cached.unwrap().price, response.price);
@@ -353,9 +371,14 @@ mod tests {
 
     /// A pre-#1801 cache (unversioned bare map — the format that could
     /// hold live quotes mislabeled with historical dates, #1794) must
-    /// load as EMPTY, never serving its poisoned entries.
+    /// load as EMPTY through the REAL load path, never serving its
+    /// poisoned entries — and the discard must mark the cache dirty so
+    /// the very next `save()` destroys the poisoned file even when the
+    /// run fetched nothing (round-2 deep review: the earlier version of
+    /// this test asserted a re-implemented parse, which a future
+    /// legacy-migration fallback inside `load()` could not trip).
     #[test]
-    fn unversioned_legacy_cache_is_discarded() {
+    fn unversioned_legacy_cache_is_discarded_and_rewritten() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("prices.json");
         // The 0.21.0 on-disk shape: entries map at the top level.
@@ -364,11 +387,50 @@ mod tests {
             r#"{"yahoo:AAPL:USD:2000-01-03":{"price":"317.31","currency":"USD","date":"2000-01-03","source":"yahoo","cached_at":1700000000}}"#,
         )
         .unwrap();
-        let loaded = std::fs::read_to_string(&path).unwrap();
-        let parsed = serde_json::from_str::<CacheFile>(&loaded);
+
+        let mut cache = PriceCache::load_from_path(path.clone(), 3600);
         assert!(
-            parsed.is_err(),
-            "legacy bare-map format must fail the versioned parse"
+            cache.get("yahoo:AAPL:USD:2000-01-03").is_none(),
+            "poisoned legacy entry must never be served"
+        );
+        assert!(cache.entries.is_empty(), "legacy file must load as empty");
+        assert!(cache.dirty, "discard must mark dirty so save() rewrites");
+
+        cache.save();
+        let rewritten: CacheFile =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(rewritten.version, CACHE_SCHEMA_VERSION);
+        assert!(
+            rewritten.entries.is_empty(),
+            "save() after a discard must replace the poisoned file with an empty v2 envelope"
+        );
+    }
+
+    /// A well-formed current-version file loads its entries and is NOT
+    /// dirty — the discard path above must not fire on healthy files.
+    #[test]
+    fn current_version_cache_loads_clean() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices.json");
+        {
+            let mut cache = PriceCache::load_from_path(path.clone(), 3600);
+            assert!(!cache.dirty, "missing file is not a discard");
+            cache.insert(
+                "yahoo:AAPL:USD:2024-01-15",
+                &PriceResponse {
+                    price: Decimal::new(15000, 2),
+                    currency: "USD".to_string(),
+                    date: rustledger_core::naive_date(2024, 1, 15).unwrap(),
+                    source: "yahoo".to_string(),
+                },
+            );
+            cache.save();
+        }
+        let cache = PriceCache::load_from_path(path, 3600);
+        assert!(!cache.dirty, "healthy v2 file must not be marked dirty");
+        assert!(
+            cache.get("yahoo:AAPL:USD:2024-01-15").is_some(),
+            "entries from a healthy v2 file must be served"
         );
     }
 }

--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -24,6 +24,19 @@ pub struct PriceCache {
     dirty: bool,
 }
 
+/// Current cache schema. Bumped in #1801: version 1 was an unversioned
+/// bare map that could hold live quotes mislabeled with historical dates
+/// (#1794); those entries must never be served, so unversioned or
+/// mismatched files load as empty.
+const CACHE_SCHEMA_VERSION: u32 = 2;
+
+/// The on-disk cache envelope.
+#[derive(Debug, Serialize, Deserialize)]
+struct CacheFile {
+    version: u32,
+    entries: HashMap<String, CachedPrice>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CachedPrice {
     price: String,
@@ -41,7 +54,16 @@ impl PriceCache {
 
         let entries = if path.exists() {
             match std::fs::read_to_string(&path) {
-                Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+                // Versioned envelope: entries from other schema versions are
+                // DISCARDED, not migrated. Pre-#1801 caches hold live quotes
+                // stored under historical dates (the #1794 corruption); the
+                // old bare-map format fails to parse as CacheFile, so those
+                // poisoned entries can never be served again (deep review —
+                // the cache sits ABOVE the sources, bypassing their fixes).
+                Ok(contents) => match serde_json::from_str::<CacheFile>(&contents) {
+                    Ok(file) if file.version == CACHE_SCHEMA_VERSION => file.entries,
+                    _ => HashMap::new(),
+                },
                 Err(_) => HashMap::new(),
             }
         } else {
@@ -115,7 +137,11 @@ impl PriceCache {
             let _ = std::fs::create_dir_all(parent);
         }
 
-        if let Ok(json) = serde_json::to_string_pretty(&self.entries)
+        let file = CacheFile {
+            version: CACHE_SCHEMA_VERSION,
+            entries: self.entries.clone(),
+        };
+        if let Ok(json) = serde_json::to_string_pretty(&file)
             && std::fs::write(&self.path, json).is_ok()
         {
             self.dirty = false;
@@ -284,12 +310,15 @@ mod tests {
             assert!(!cache.dirty, "dirty should be cleared after save");
         }
 
-        // Load and verify
+        // Load and verify through the versioned envelope.
         {
+            let file: CacheFile =
+                serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+            assert_eq!(file.version, CACHE_SCHEMA_VERSION);
             let cache = PriceCache {
                 path: path.clone(),
                 ttl: Duration::from_hours(1),
-                entries: serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap(),
+                entries: file.entries,
                 dirty: false,
             };
             let cached = cache.get("yahoo:AAPL:USD:latest");
@@ -320,5 +349,26 @@ mod tests {
         cache.clear();
         assert!(cache.entries.is_empty());
         assert!(cache.get("key").is_none());
+    }
+
+    /// A pre-#1801 cache (unversioned bare map — the format that could
+    /// hold live quotes mislabeled with historical dates, #1794) must
+    /// load as EMPTY, never serving its poisoned entries.
+    #[test]
+    fn unversioned_legacy_cache_is_discarded() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices.json");
+        // The 0.21.0 on-disk shape: entries map at the top level.
+        std::fs::write(
+            &path,
+            r#"{"yahoo:AAPL:USD:2000-01-03":{"price":"317.31","currency":"USD","date":"2000-01-03","source":"yahoo","cached_at":1700000000}}"#,
+        )
+        .unwrap();
+        let loaded = std::fs::read_to_string(&path).unwrap();
+        let parsed = serde_json::from_str::<CacheFile>(&loaded);
+        assert!(
+            parsed.is_err(),
+            "legacy bare-map format must fail the versioned parse"
+        );
     }
 }

--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -201,6 +201,10 @@ impl PriceSource for ExternalCommandSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Deliberately NOT guarded by `reject_historical_date`: the
+        // requested date is forwarded to the external command via
+        // RLEDGER_DATE below, so historical semantics are the external
+        // fetcher's contract, not ours (#1801 review).
         if self.command.is_empty() {
             anyhow::bail!("External command is empty");
         }

--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -204,7 +204,15 @@ impl PriceSource for ExternalCommandSource {
         // Deliberately NOT guarded by `reject_historical_date`: the
         // requested date is forwarded to the external command via
         // RLEDGER_DATE below, so historical semantics are the external
-        // fetcher's contract, not ours (#1801 review).
+        // fetcher's contract, not ours (#1801 review). That contract is
+        // a TRUST contract: output formats that carry no date of their
+        // own (plain number, JSON without a date field) are labeled with
+        // the requested date on the assumption the command honored
+        // RLEDGER_DATE — rledger cannot verify a user-authored command,
+        // so a script that ignores the date and prints its latest quote
+        // WILL be recorded under the requested date. Documented in
+        // docs/commands/price.md; scripts that can't honor RLEDGER_DATE
+        // should emit the dated beancount form instead (round-4 review).
         if self.command.is_empty() {
             anyhow::bail!("External command is empty");
         }
@@ -290,6 +298,9 @@ impl PriceSource for ExternalCommandSource {
                 return Ok(PriceResponse {
                     price,
                     currency,
+                    // No date in the JSON: trust contract — the command is
+                    // assumed to have honored RLEDGER_DATE (see fetch_price
+                    // top comment). Emit a "date" field to override.
                     date: date.unwrap_or_else(|| {
                         request.date.unwrap_or_else(|| jiff::Zoned::now().date())
                     }),
@@ -313,6 +324,10 @@ impl PriceSource for ExternalCommandSource {
             return Ok(PriceResponse {
                 price,
                 currency,
+                // Plain-number output carries no date: trust contract —
+                // the command is assumed to have honored RLEDGER_DATE
+                // (see fetch_price top comment). Use the beancount form
+                // (`<date> price <ticker> <amount> <ccy>`) to override.
                 date: request.date.unwrap_or_else(|| jiff::Zoned::now().date()),
                 source: self.source_name.clone(),
             });

--- a/crates/rustledger/src/cmd/price/mod.rs
+++ b/crates/rustledger/src/cmd/price/mod.rs
@@ -238,7 +238,11 @@ impl PriceSourceRegistry {
     ) -> Result<PriceResponse> {
         let attempts = self.resolve_mapping(commodity, mapping)?;
 
-        let mut last_error = None;
+        // Every failed attempt is kept, not just the last: in a chain
+        // like [yahoo, coinbase] with --date, the trailing source's
+        // "latest quote only" refusal must not mask yahoo's real
+        // (possibly transient) failure (round-2 deep review of #1801).
+        let mut errors: Vec<(String, anyhow::Error)> = Vec::new();
         let mut unknown_sources = Vec::new();
 
         for (source_name, ticker) in &attempts {
@@ -252,7 +256,7 @@ impl PriceSourceRegistry {
                 match source.fetch_price(&request) {
                     Ok(response) => return Ok(response),
                     Err(e) => {
-                        last_error = Some(e);
+                        errors.push((source_name.clone(), e));
                         // Try next source in fallback chain
                     }
                 }
@@ -263,13 +267,29 @@ impl PriceSourceRegistry {
         }
 
         // Build an informative error message
-        let err_msg = if let Some(e) = last_error {
+        let err_msg = if errors.len() == 1 {
+            // A single failure keeps its full error value.
+            let (_, single) = errors.remove(0);
             if unknown_sources.is_empty() {
-                e
+                single
             } else {
                 anyhow::anyhow!(
-                    "{}; note: unknown sources skipped: {}",
-                    e,
+                    "{single:#}; note: unknown sources skipped: {}",
+                    unknown_sources.join(", ")
+                )
+            }
+        } else if !errors.is_empty() {
+            let attempts_report = errors
+                .iter()
+                .map(|(name, e)| format!("{name}: {e:#}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            if unknown_sources.is_empty() {
+                anyhow::anyhow!("all sources failed for {commodity}: {attempts_report}")
+            } else {
+                anyhow::anyhow!(
+                    "all sources failed for {commodity}: {attempts_report}; \
+                     note: unknown sources skipped: {}",
                     unknown_sources.join(", ")
                 )
             }

--- a/crates/rustledger/src/cmd/price/sources/alphavantage.rs
+++ b/crates/rustledger/src/cmd/price/sources/alphavantage.rs
@@ -117,7 +117,13 @@ impl AlphaVantageSource {
         let price = Decimal::from_str(price_str)
             .with_context(|| format!("Failed to parse price: {price_str}"))?;
 
-        let date = jiff::Zoned::now().date();
+        // The quote's OWN trading day when present — a weekend fetch must
+        // date the price Friday, not today (deep review of #1801).
+        let date = quote
+            .get("07. latest trading day")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
+            .unwrap_or_else(|| jiff::Zoned::now().date());
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/alphavantage.rs
+++ b/crates/rustledger/src/cmd/price/sources/alphavantage.rs
@@ -216,6 +216,10 @@ impl PriceSource for AlphaVantageSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let api_key = Self::get_api_key()?;
         self.fetch_internal(request, &api_key)
     }

--- a/crates/rustledger/src/cmd/price/sources/alphavantage.rs
+++ b/crates/rustledger/src/cmd/price/sources/alphavantage.rs
@@ -119,11 +119,11 @@ impl AlphaVantageSource {
 
         // The quote's OWN trading day when present — a weekend fetch must
         // date the price Friday, not today (deep review of #1801).
-        let date = quote
-            .get("07. latest trading day")
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
-            .unwrap_or_else(|| jiff::Zoned::now().date());
+        let date = super::feed_date_or_today(
+            quote
+                .get("07. latest trading day")
+                .and_then(serde_json::Value::as_str),
+        );
 
         Ok(PriceResponse {
             price,
@@ -174,12 +174,11 @@ impl AlphaVantageSource {
         // is "YYYY-MM-DD HH:MM:SS" in UTC) — a weekend FX fetch returns
         // Friday's rate and must be dated Friday, not today (#1794
         // class; round-2 deep review).
-        let date = rate_data
-            .get("6. Last Refreshed")
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| s.get(..10))
-            .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
-            .unwrap_or_else(|| jiff::Zoned::now().date());
+        let date = super::feed_date_or_today(
+            rate_data
+                .get("6. Last Refreshed")
+                .and_then(serde_json::Value::as_str),
+        );
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/alphavantage.rs
+++ b/crates/rustledger/src/cmd/price/sources/alphavantage.rs
@@ -135,8 +135,20 @@ impl AlphaVantageSource {
 
     fn fetch_forex(&self, from: &str, to: &str, api_key: &str) -> Result<PriceResponse> {
         let url = self.build_forex_url(from, to, api_key);
+        self.fetch_exchange_rate(&url, from, to)
+    }
 
-        let mut response = ureq::get(&url)
+    fn fetch_crypto(&self, symbol: &str, market: &str, api_key: &str) -> Result<PriceResponse> {
+        let url = self.build_crypto_url(symbol, market, api_key);
+        self.fetch_exchange_rate(&url, symbol, market)
+    }
+
+    /// Shared `CURRENCY_EXCHANGE_RATE` fetch — forex and crypto hit the
+    /// same endpoint and parse the same response shape (round-2 deep
+    /// review: the two copies had drifted, keeping the local-clock date
+    /// label in both while the stock path was fixed).
+    fn fetch_exchange_rate(&self, url: &str, from: &str, to: &str) -> Result<PriceResponse> {
+        let mut response = ureq::get(url)
             .header("User-Agent", user_agent())
             .call()
             .with_context(|| format!("Failed to fetch rate for {from}/{to}"))?;
@@ -158,46 +170,20 @@ impl AlphaVantageSource {
         let price = Decimal::from_str(price_str)
             .with_context(|| format!("Failed to parse rate: {price_str}"))?;
 
-        let date = jiff::Zoned::now().date();
+        // The quote's OWN refresh day when present ("6. Last Refreshed"
+        // is "YYYY-MM-DD HH:MM:SS" in UTC) — a weekend FX fetch returns
+        // Friday's rate and must be dated Friday, not today (#1794
+        // class; round-2 deep review).
+        let date = rate_data
+            .get("6. Last Refreshed")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|s| s.get(..10))
+            .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
+            .unwrap_or_else(|| jiff::Zoned::now().date());
 
         Ok(PriceResponse {
             price,
             currency: to.to_string(),
-            date,
-            source: self.name().to_string(),
-        })
-    }
-
-    fn fetch_crypto(&self, symbol: &str, market: &str, api_key: &str) -> Result<PriceResponse> {
-        let url = self.build_crypto_url(symbol, market, api_key);
-
-        let mut response = ureq::get(&url)
-            .header("User-Agent", user_agent())
-            .call()
-            .with_context(|| format!("Failed to fetch crypto price for {symbol}"))?;
-
-        let json: serde_json::Value = response
-            .body_mut()
-            .read_json()
-            .with_context(|| "Failed to parse Alpha Vantage response")?;
-
-        let rate_data = json
-            .get("Realtime Currency Exchange Rate")
-            .with_context(|| "Missing crypto price data")?;
-
-        let price_str = rate_data
-            .get("5. Exchange Rate")
-            .and_then(serde_json::Value::as_str)
-            .with_context(|| "Missing crypto price")?;
-
-        let price = Decimal::from_str(price_str)
-            .with_context(|| format!("Failed to parse price: {price_str}"))?;
-
-        let date = jiff::Zoned::now().date();
-
-        Ok(PriceResponse {
-            price,
-            currency: market.to_string(),
             date,
             source: self.name().to_string(),
         })

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -53,6 +53,10 @@ impl PriceSource for CoinbaseSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let url = self.build_url(&request.ticker, &request.currency);
 
         let mut response = ureq::get(&url)

--- a/crates/rustledger/src/cmd/price/sources/coincap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coincap.rs
@@ -72,6 +72,10 @@ impl PriceSource for CoinCapSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let url = self.build_url(&request.ticker);
 
         let mut response = ureq::get(&url)

--- a/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
@@ -64,6 +64,10 @@ impl PriceSource for CoinMarketCapSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let api_key = Self::get_api_key()?;
         let url = self.build_url(&request.ticker, &request.currency);
 

--- a/crates/rustledger/src/cmd/price/sources/eastmoneyfund.rs
+++ b/crates/rustledger/src/cmd/price/sources/eastmoneyfund.rs
@@ -64,6 +64,10 @@ impl PriceSource for EastMoneyFundSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let url = self.build_url(&request.ticker);
 
         let mut response = ureq::get(&url)

--- a/crates/rustledger/src/cmd/price/sources/eastmoneyfund.rs
+++ b/crates/rustledger/src/cmd/price/sources/eastmoneyfund.rs
@@ -6,7 +6,6 @@ use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
-use rustledger_core::NaiveDate;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -93,29 +92,15 @@ impl PriceSource for EastMoneyFundSource {
         let price = Decimal::from_str(price_str)
             .with_context(|| format!("Failed to parse NAV: {price_str}"))?;
 
-        // Get the date from gztime (估算时间) or jzrq (净值日期)
-        let date = json
-            .get("gztime")
-            .or_else(|| json.get("jzrq"))
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| {
-                // Try different date formats
-                s.parse::<NaiveDate>()
-                    .or_else(|_| {
-                        // Try parsing just the date portion (first 10 chars)
-                        // Use char_indices for UTF-8 safety
-                        if let Some((idx, _)) = s.char_indices().nth(10) {
-                            s[..idx].parse::<NaiveDate>()
-                        } else if s.len() >= 10 && s.is_char_boundary(10) {
-                            s[..10].parse::<NaiveDate>()
-                        } else {
-                            // Return an error that will be converted to None by and_then
-                            "".parse::<NaiveDate>()
-                        }
-                    })
-                    .ok()
-            })
-            .unwrap_or_else(|| request.date.unwrap_or_else(|| jiff::Zoned::now().date()));
+        // Get the date from gztime (估算时间) or jzrq (净值日期) — the
+        // feed's own date, never the requested one (#1794; the inline
+        // parse with a request.date fallback was the last un-canonical
+        // copy of this extraction — round-4 deep review).
+        let date = super::feed_date_or_today(
+            json.get("gztime")
+                .or_else(|| json.get("jzrq"))
+                .and_then(serde_json::Value::as_str),
+        );
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -125,6 +125,10 @@ impl PriceSource for EcbSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let ticker = request.ticker.to_uppercase();
         let currency = request.currency.to_uppercase();
 
@@ -152,7 +156,10 @@ impl PriceSource for EcbSource {
             return Ok(PriceResponse {
                 price: rate,
                 currency,
-                date: request.date.unwrap_or(rate_date),
+                // The ECB feed's OWN reference date — never the requested one:
+                // on weekends/holidays the latest rate is Friday's and must
+                // be labeled as such (#1794).
+                date: rate_date,
                 source: self.name().to_string(),
             });
         }
@@ -167,7 +174,10 @@ impl PriceSource for EcbSource {
             return Ok(PriceResponse {
                 price: inverted,
                 currency,
-                date: request.date.unwrap_or(rate_date),
+                // The ECB feed's OWN reference date — never the requested one:
+                // on weekends/holidays the latest rate is Friday's and must
+                // be labeled as such (#1794).
+                date: rate_date,
                 source: self.name().to_string(),
             });
         }
@@ -186,7 +196,8 @@ impl PriceSource for EcbSource {
         Ok(PriceResponse {
             price: cross_rate,
             currency,
-            date: request.date.unwrap_or(ticker_date),
+            // Same rule as the direct branches: the feed's own date.
+            date: ticker_date,
             source: self.name().to_string(),
         })
     }

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -94,7 +94,7 @@ impl EcbSource {
             .with_context(|| format!("Failed to parse rate: {rate_value}"))?;
 
         // Try to get the date from the structure
-        let date = json
+        let date_str = json
             .get("structure")
             .and_then(|s| s.get("dimensions"))
             .and_then(|d| d.get("observation"))
@@ -107,9 +107,8 @@ impl EcbSource {
                 values.get(idx)
             })
             .and_then(|v| v.get("id"))
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| s.parse::<NaiveDate>().ok())
-            .unwrap_or_else(|| jiff::Zoned::now().date());
+            .and_then(serde_json::Value::as_str);
+        let date = super::feed_date_or_today(date_str);
 
         Ok((rate, date))
     }
@@ -191,16 +190,21 @@ impl PriceSource for EcbSource {
         let (currency_rate, currency_date) = self.fetch_rate(&currency)?;
 
         // The two legs are separate fetches of a once-daily feed; if they
-        // straddle the ~16:00 CET publication they reference different
-        // days, and dividing a Monday rate by a Friday rate yields a
-        // number that is not a valid rate for ANY date. Refuse rather
-        // than emit a silently corrupted directive (round-2 deep review —
-        // min() labeling was not sound).
+        // reference different days, dividing a Monday rate by a Friday
+        // rate yields a number that is not a valid rate for ANY date.
+        // Refuse rather than emit a silently corrupted directive
+        // (round-2 deep review — min() labeling was not sound). Two
+        // causes, one transient and one permanent (round-3 review: for a
+        // currency the ECB stopped publishing — HRK, RUB — the feed
+        // returns its frozen final observation forever, so "retry" alone
+        // was misleading advice).
         if ticker_date != currency_date {
             anyhow::bail!(
                 "ECB returned different reference dates for the two legs of \
-                 {ticker}/{currency} ({ticker_date} vs {currency_date}) — the \
-                 fetches straddled a daily publication; retry in a moment"
+                 {ticker}/{currency} ({ticker_date} vs {currency_date}): either \
+                 the fetches straddled the daily ~16:00 CET publication (retry \
+                 shortly), or the leg with the older date is no longer published \
+                 by the ECB and needs a different price source"
             );
         }
 

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -133,17 +133,16 @@ impl PriceSource for EcbSource {
         // 2. ticker=X, currency=EUR: fetch X rate, invert it (EUR per X)
         // 3. ticker=X, currency=Y: fetch both, compute cross-rate (Y per X)
 
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
-
-        // Identity rate: 1.0 is correct for ANY pair and ANY date (the
-        // pre-#1801 cross-rate path answered USD/USD = rate/rate = 1 for
-        // dated requests too), so this branch deliberately sits ABOVE
-        // the latest-only guard — same shape as ratesapi (deep review).
+        // Identity rate: 1.0 is correct for ANY pair and any PAST date
+        // (the pre-#1801 cross-rate path answered USD/USD = rate/rate
+        // = 1 for dated requests too), so this branch deliberately sits
+        // ABOVE the latest-only guard — same shape as ratesapi. Future
+        // labels are refused by identity_label_date (round-4 review).
         if ticker == currency {
             return Ok(PriceResponse {
                 price: Decimal::ONE,
                 currency,
-                date,
+                date: super::identity_label_date(self.name(), request)?,
                 source: self.name().to_string(),
             });
         }
@@ -194,17 +193,31 @@ impl PriceSource for EcbSource {
         // rate yields a number that is not a valid rate for ANY date.
         // Refuse rather than emit a silently corrupted directive
         // (round-2 deep review — min() labeling was not sound). Two
-        // causes, one transient and one permanent (round-3 review: for a
-        // currency the ECB stopped publishing — HRK, RUB — the feed
-        // returns its frozen final observation forever, so "retry" alone
-        // was misleading advice).
+        // causes: a transient publication straddle (gap of a day or a
+        // weekend) and a permanently frozen series — the ECB stops
+        // publishing discontinued currencies (HRK, RUB) but keeps
+        // serving their final observation, so a large gap gets the
+        // permanent diagnosis instead of useless "retry" advice
+        // (rounds 3-4 deep review).
         if ticker_date != currency_date {
+            let (older_date, older_ccy) = if ticker_date < currency_date {
+                (ticker_date, &ticker)
+            } else {
+                (currency_date, &currency)
+            };
+            let gap_days = (ticker_date - currency_date).get_days().abs();
+            if gap_days > 5 {
+                anyhow::bail!(
+                    "ECB's {older_ccy} series is frozen at {older_date} — the ECB \
+                     no longer publishes it (discontinued currency); use a \
+                     different price source for {older_ccy}"
+                );
+            }
             anyhow::bail!(
                 "ECB returned different reference dates for the two legs of \
-                 {ticker}/{currency} ({ticker_date} vs {currency_date}): either \
-                 the fetches straddled the daily ~16:00 CET publication (retry \
-                 shortly), or the leg with the older date is no longer published \
-                 by the ECB and needs a different price source"
+                 {ticker}/{currency} ({ticker_date} vs {currency_date}) — the \
+                 fetches likely straddled the daily ~16:00 CET publication; \
+                 retry shortly"
             );
         }
 

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -125,8 +125,6 @@ impl PriceSource for EcbSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
         let ticker = request.ticker.to_uppercase();
         let currency = request.currency.to_uppercase();
 
@@ -138,10 +136,11 @@ impl PriceSource for EcbSource {
 
         let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
 
-        // Identity rate: 1.0 is correct for ANY date, so this branch
-        // deliberately sits ABOVE the latest-only guard (deep review).
-        if ticker == "EUR" && currency == "EUR" {
-            // EUR to EUR = 1
+        // Identity rate: 1.0 is correct for ANY pair and ANY date (the
+        // pre-#1801 cross-rate path answered USD/USD = rate/rate = 1 for
+        // dated requests too), so this branch deliberately sits ABOVE
+        // the latest-only guard — same shape as ratesapi (deep review).
+        if ticker == currency {
             return Ok(PriceResponse {
                 price: Decimal::ONE,
                 currency,
@@ -191,6 +190,20 @@ impl PriceSource for EcbSource {
         let (ticker_rate, ticker_date) = self.fetch_rate(&ticker)?;
         let (currency_rate, currency_date) = self.fetch_rate(&currency)?;
 
+        // The two legs are separate fetches of a once-daily feed; if they
+        // straddle the ~16:00 CET publication they reference different
+        // days, and dividing a Monday rate by a Friday rate yields a
+        // number that is not a valid rate for ANY date. Refuse rather
+        // than emit a silently corrupted directive (round-2 deep review —
+        // min() labeling was not sound).
+        if ticker_date != currency_date {
+            anyhow::bail!(
+                "ECB returned different reference dates for the two legs of \
+                 {ticker}/{currency} ({ticker_date} vs {currency_date}) — the \
+                 fetches straddled a daily publication; retry in a moment"
+            );
+        }
+
         if ticker_rate.is_zero() {
             anyhow::bail!("Cannot compute cross-rate: zero rate for {ticker}");
         }
@@ -200,11 +213,9 @@ impl PriceSource for EcbSource {
         Ok(PriceResponse {
             price: cross_rate,
             currency,
-            // Same rule as the direct branches: the feed's own date. Both
-            // legs come from the same daily feed, but two fetches can
-            // straddle a publication — the OLDER reference date is the one
-            // both rates are valid for (deep review).
-            date: ticker_date.min(currency_date),
+            // Same rule as the direct branches: the feed's own reference
+            // date (both legs agree — checked above).
+            date: ticker_date,
             source: self.name().to_string(),
         })
     }
@@ -237,5 +248,20 @@ mod tests {
         let response = source.fetch_price(&request).unwrap();
         assert_eq!(response.price, Decimal::ONE);
         assert_eq!(response.currency, "EUR");
+    }
+
+    /// Any identity pair — not just EUR/EUR — answers 1.0 for any
+    /// requested date without network access. The pre-#1801 cross-rate
+    /// path gave dated USD/USD = 1 too; the latest-only guard must not
+    /// remove that (round-2 deep review).
+    #[test]
+    fn dated_non_eur_identity_returns_one() {
+        let source = EcbSource::new(Duration::from_secs(30));
+        let date = rustledger_core::naive_date(2024, 6, 30).unwrap();
+        let mut request = PriceRequest::new("USD", "USD");
+        request.date = Some(date);
+        let response = source.fetch_price(&request).unwrap();
+        assert_eq!(response.price, Decimal::ONE);
+        assert_eq!(response.date, date);
     }
 }

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -127,8 +127,6 @@ impl PriceSource for EcbSource {
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
         // Latest-only source: a historical --date must refuse, not
         // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
         let ticker = request.ticker.to_uppercase();
         let currency = request.currency.to_uppercase();
 
@@ -140,6 +138,8 @@ impl PriceSource for EcbSource {
 
         let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
 
+        // Identity rate: 1.0 is correct for ANY date, so this branch
+        // deliberately sits ABOVE the latest-only guard (deep review).
         if ticker == "EUR" && currency == "EUR" {
             // EUR to EUR = 1
             return Ok(PriceResponse {
@@ -149,6 +149,10 @@ impl PriceSource for EcbSource {
                 source: self.name().to_string(),
             });
         }
+
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
 
         if ticker == "EUR" {
             // EUR -> X: fetch X rate (X per EUR), return as-is
@@ -185,7 +189,7 @@ impl PriceSource for EcbSource {
         // Cross-rate: X -> Y via EUR
         // X per EUR and Y per EUR => Y per X = (Y per EUR) / (X per EUR)
         let (ticker_rate, ticker_date) = self.fetch_rate(&ticker)?;
-        let (currency_rate, _) = self.fetch_rate(&currency)?;
+        let (currency_rate, currency_date) = self.fetch_rate(&currency)?;
 
         if ticker_rate.is_zero() {
             anyhow::bail!("Cannot compute cross-rate: zero rate for {ticker}");
@@ -196,8 +200,11 @@ impl PriceSource for EcbSource {
         Ok(PriceResponse {
             price: cross_rate,
             currency,
-            // Same rule as the direct branches: the feed's own date.
-            date: ticker_date,
+            // Same rule as the direct branches: the feed's own date. Both
+            // legs come from the same daily feed, but two fetches can
+            // straddle a publication — the OLDER reference date is the one
+            // both rates are valid for (deep review).
+            date: ticker_date.min(currency_date),
             source: self.name().to_string(),
         })
     }

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -30,23 +30,25 @@ pub use yahoo::YahooFinanceSource;
 use super::{PriceRequest, PriceResponse};
 use anyhow::Result;
 
-/// Reject a historical `--date` on a source that can only fetch the
+/// Reject an explicit `--date` on a source that can only fetch the
 /// LATEST quote.
 ///
 /// Labeling the latest price with an arbitrary historical date silently
 /// corrupts price archives (#1794 — Yahoo emitted the live quote under
-/// `--date 2000-01-03`). A latest-only source must refuse instead.
-/// Today's date is allowed: the latest quote genuinely belongs to today.
+/// `--date 2000-01-03`). Matching beanprice, a dated fetch requires a
+/// source with real historical support, so latest-only sources refuse
+/// ANY `--date` — including today's, which keeps the rule clock-free
+/// and consistent across a batch that straddles midnight (deep review).
+/// Date-independent identity branches (e.g. EUR→EUR = 1.0) early-return
+/// BEFORE this guard.
 ///
 /// # Errors
-/// Errors when `request.date` names a day other than today.
+/// Errors whenever `request.date` is set.
 pub(super) fn reject_historical_date(
     source: &str,
     request: &crate::cmd::price::PriceRequest,
 ) -> anyhow::Result<()> {
-    if let Some(date) = request.date
-        && date != jiff::Zoned::now().date()
-    {
+    if let Some(date) = request.date {
         anyhow::bail!(
             "the '{source}' source only provides the latest quote and cannot fetch {} \
              for {date}; drop --date, or use a source with historical support \
@@ -113,34 +115,74 @@ mod guard_tests {
         }
     }
 
-    /// Latest-only sources refuse a historical --date instead of
-    /// mislabeling the current quote (#1794). Uses a FIXED past date so
-    /// the assertion is deterministic (never "yesterday", which races
-    /// the midnight rollover — review comment).
+    /// Latest-only sources refuse ANY --date instead of mislabeling the
+    /// current quote (#1794) — including today's, keeping the rule
+    /// clock-free (deep review: a per-fetch clock comparison flips
+    /// behavior mid-batch across midnight).
     #[test]
-    fn historical_date_is_rejected() {
+    fn any_explicit_date_is_rejected() {
         let past = rustledger_core::naive_date(2000, 1, 3).expect("valid date");
         let err = super::reject_historical_date("coinbase", &request(Some(past)))
             .expect_err("must refuse");
         assert!(err.to_string().contains("latest quote"), "{err}");
         assert!(err.to_string().contains("coinbase"), "{err}");
+
+        let today = jiff::Zoned::now().date();
+        assert!(
+            super::reject_historical_date("coinbase", &request(Some(today))).is_err(),
+            "today's date is also refused — dated fetches need historical support"
+        );
     }
 
-    /// Today's date is allowed — the latest quote genuinely belongs to
-    /// today — and no date always passes. The guard reads the clock
-    /// again internally, so re-check that "today" was stable across the
-    /// call and retry if midnight flipped between the two reads.
+    /// No date always passes.
     #[test]
-    fn today_and_absent_date_pass() {
-        loop {
-            let today = jiff::Zoned::now().date();
-            let passed = super::reject_historical_date("coinbase", &request(Some(today))).is_ok();
-            if jiff::Zoned::now().date() == today {
-                assert!(passed, "today's date must pass the guard");
-                break;
-            }
-            // Midnight rolled over mid-test; retry with the new date.
-        }
+    fn absent_date_passes() {
         assert!(super::reject_historical_date("coinbase", &request(None)).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod guard_wiring_tests {
+    use crate::cmd::price::{PriceConfig, PriceRequest, PriceSourceRegistry};
+
+    /// Drift guard (deep review of #1801): every latest-only builtin must
+    /// actually CALL `reject_historical_date` from `fetch_price`. The
+    /// guard fires before any network I/O, so a hermetic dated fetch must
+    /// fail with the guard's message — a source that forgot the guard
+    /// would instead surface a network/parse error (or worse, succeed).
+    /// `yahoo` (real historical support) and `external` (forwards the
+    /// date to the user's command) are exempt by design.
+    #[test]
+    fn every_latest_only_source_rejects_dated_fetches() {
+        let registry = PriceSourceRegistry::new(&PriceConfig::default());
+        let past = rustledger_core::naive_date(2000, 1, 3).expect("valid date");
+        for name in [
+            "alphavantage",
+            "coinbase",
+            "coincap",
+            "coinmarketcap",
+            "eastmoneyfund",
+            "ecb",
+            "oanda",
+            "quandl",
+            "ratesapi",
+            "tsp",
+        ] {
+            let source = registry
+                .get(name)
+                .unwrap_or_else(|| panic!("builtin source '{name}' must exist"));
+            let request = PriceRequest {
+                ticker: "AAPL".to_string(),
+                currency: "USD".to_string(),
+                date: Some(past),
+            };
+            let err = source
+                .fetch_price(&request)
+                .expect_err("dated fetch must be refused before any I/O");
+            assert!(
+                err.to_string().contains("latest quote"),
+                "source '{name}' did not fire the historical-date guard: {err}"
+            );
+        }
     }
 }

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -30,6 +30,33 @@ pub use yahoo::YahooFinanceSource;
 use super::{PriceRequest, PriceResponse};
 use anyhow::Result;
 
+/// Reject a historical `--date` on a source that can only fetch the
+/// LATEST quote.
+///
+/// Labeling the latest price with an arbitrary historical date silently
+/// corrupts price archives (#1794 — Yahoo emitted the live quote under
+/// `--date 2000-01-03`). A latest-only source must refuse instead.
+/// Today's date is allowed: the latest quote genuinely belongs to today.
+///
+/// # Errors
+/// Errors when `request.date` names a day other than today.
+pub(super) fn reject_historical_date(
+    source: &str,
+    request: &crate::cmd::price::PriceRequest,
+) -> anyhow::Result<()> {
+    if let Some(date) = request.date
+        && date != jiff::Zoned::now().date()
+    {
+        anyhow::bail!(
+            "the '{source}' source only provides the latest quote and cannot fetch {} \
+             for {date}; drop --date, or use a source with historical support \
+             (e.g. yahoo)",
+            request.ticker
+        );
+    }
+    Ok(())
+}
+
 /// Trait for price data sources.
 ///
 /// All price sources must implement this trait. The trait is object-safe
@@ -72,4 +99,40 @@ pub trait PriceSource: Send + Sync {
 /// Helper function to build a User-Agent header for HTTP requests.
 pub(crate) const fn user_agent() -> &'static str {
     "Mozilla/5.0 (compatible; rustledger/1.0; +https://github.com/rustledger/rustledger)"
+}
+
+#[cfg(test)]
+mod guard_tests {
+    use crate::cmd::price::PriceRequest;
+
+    fn request(date: Option<rustledger_core::NaiveDate>) -> PriceRequest {
+        PriceRequest {
+            ticker: "AAPL".to_string(),
+            currency: "USD".to_string(),
+            date,
+        }
+    }
+
+    /// Latest-only sources refuse a historical --date instead of
+    /// mislabeling the current quote (#1794).
+    #[test]
+    fn historical_date_is_rejected() {
+        let yesterday = jiff::Zoned::now()
+            .date()
+            .yesterday()
+            .expect("valid yesterday");
+        let err = super::reject_historical_date("coinbase", &request(Some(yesterday)))
+            .expect_err("must refuse");
+        assert!(err.to_string().contains("latest quote"), "{err}");
+        assert!(err.to_string().contains("coinbase"), "{err}");
+    }
+
+    /// Today's date is allowed — the latest quote genuinely belongs to
+    /// today — and no date always passes.
+    #[test]
+    fn today_and_absent_date_pass() {
+        let today = jiff::Zoned::now().date();
+        assert!(super::reject_historical_date("coinbase", &request(Some(today))).is_ok());
+        assert!(super::reject_historical_date("coinbase", &request(None)).is_ok());
+    }
 }

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -30,25 +30,29 @@ pub use yahoo::YahooFinanceSource;
 use super::{PriceRequest, PriceResponse};
 use anyhow::Result;
 
-/// Reject an explicit `--date` on a source that can only fetch the
+/// Reject a past or future `--date` on a source that can only fetch the
 /// LATEST quote.
 ///
 /// Labeling the latest price with an arbitrary historical date silently
 /// corrupts price archives (#1794 — Yahoo emitted the live quote under
 /// `--date 2000-01-03`). Matching beanprice, a dated fetch requires a
-/// source with real historical support, so latest-only sources refuse
-/// ANY `--date` — including today's, which keeps the rule clock-free
-/// and consistent across a batch that straddles midnight (deep review).
-/// Date-independent identity branches (e.g. EUR→EUR = 1.0) early-return
+/// source with real historical support — with one exception: `--date
+/// <today>` is allowed, because the latest quote IS a valid answer for
+/// today and the emitted directive carries the response's own date
+/// anyway (round-2 deep review: nightly `--date $(date +%F)` runs
+/// worked on every source before #1801 and must keep working).
+/// Date-independent identity branches (e.g. USD→USD = 1.0) early-return
 /// BEFORE this guard.
 ///
 /// # Errors
-/// Errors whenever `request.date` is set.
+/// Errors whenever `request.date` is set to any day other than today.
 pub(super) fn reject_historical_date(
     source: &str,
     request: &crate::cmd::price::PriceRequest,
 ) -> anyhow::Result<()> {
-    if let Some(date) = request.date {
+    if let Some(date) = request.date
+        && date != jiff::Zoned::now().date()
+    {
         anyhow::bail!(
             "the '{source}' source only provides the latest quote and cannot fetch {} \
              for {date}; drop --date, or use a source with historical support \
@@ -115,12 +119,13 @@ mod guard_tests {
         }
     }
 
-    /// Latest-only sources refuse ANY --date instead of mislabeling the
-    /// current quote (#1794) — including today's, keeping the rule
-    /// clock-free (deep review: a per-fetch clock comparison flips
-    /// behavior mid-batch across midnight).
+    /// Latest-only sources refuse any past or future --date instead of
+    /// mislabeling the current quote (#1794). Today's date is the one
+    /// exception: the latest quote is a valid answer for today, and
+    /// pre-#1801 nightly `--date $(date +%F)` runs must keep working
+    /// (round-2 deep review).
     #[test]
-    fn any_explicit_date_is_rejected() {
+    fn past_and_future_dates_are_rejected_today_passes() {
         let past = rustledger_core::naive_date(2000, 1, 3).expect("valid date");
         let err = super::reject_historical_date("coinbase", &request(Some(past)))
             .expect_err("must refuse");
@@ -128,9 +133,17 @@ mod guard_tests {
         assert!(err.to_string().contains("coinbase"), "{err}");
 
         let today = jiff::Zoned::now().date();
+        let future = today
+            .checked_add(jiff::Span::new().days(7))
+            .expect("valid date");
         assert!(
-            super::reject_historical_date("coinbase", &request(Some(today))).is_err(),
-            "today's date is also refused — dated fetches need historical support"
+            super::reject_historical_date("coinbase", &request(Some(future))).is_err(),
+            "a future date must be refused — the latest quote is not a quote for next week"
+        );
+
+        assert!(
+            super::reject_historical_date("coinbase", &request(Some(today))).is_ok(),
+            "--date <today> is a valid request for the latest quote"
         );
     }
 

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -30,6 +30,14 @@ pub use yahoo::YahooFinanceSource;
 use super::{PriceRequest, PriceResponse};
 use anyhow::Result;
 
+/// The run's notion of "today", latched at the first guarded fetch.
+///
+/// A `--date $(date +%F)` batch that straddles midnight must not flip
+/// mid-run from accepted to refused — a per-fetch clock read left the
+/// tail of the batch failing with advice to "drop --date" even though
+/// the flag was correct when the run began (round-3 deep review).
+static RUN_TODAY: std::sync::OnceLock<rustledger_core::NaiveDate> = std::sync::OnceLock::new();
+
 /// Reject a past or future `--date` on a source that can only fetch the
 /// LATEST quote.
 ///
@@ -40,7 +48,8 @@ use anyhow::Result;
 /// <today>` is allowed, because the latest quote IS a valid answer for
 /// today and the emitted directive carries the response's own date
 /// anyway (round-2 deep review: nightly `--date $(date +%F)` runs
-/// worked on every source before #1801 and must keep working).
+/// worked on every source before #1801 and must keep working). "Today"
+/// is latched once per process — see [`RUN_TODAY`].
 /// Date-independent identity branches (e.g. USD→USD = 1.0) early-return
 /// BEFORE this guard.
 ///
@@ -51,7 +60,7 @@ pub(super) fn reject_historical_date(
     request: &crate::cmd::price::PriceRequest,
 ) -> anyhow::Result<()> {
     if let Some(date) = request.date
-        && date != jiff::Zoned::now().date()
+        && date != *RUN_TODAY.get_or_init(|| jiff::Zoned::now().date())
     {
         anyhow::bail!(
             "the '{source}' source only provides the latest quote and cannot fetch {} \
@@ -61,6 +70,23 @@ pub(super) fn reject_historical_date(
         );
     }
     Ok(())
+}
+
+/// Parse a feed-supplied date label — either a bare `YYYY-MM-DD` or the
+/// date prefix of a `YYYY-MM-DD HH:MM:SS` timestamp — falling back to
+/// the local today when the field is absent or malformed.
+///
+/// Canonical helper for the "quote's OWN date" rule (#1794): a source
+/// labels its response with the feed's reference date, never the
+/// requested date and never the local clock when the feed says
+/// otherwise. Round-3 deep review: the per-source copies of this
+/// extraction had already drifted once (alphavantage forex/crypto kept
+/// the local-clock label while the stock path was fixed), so the
+/// parsing lives here and the sources pass in the raw field.
+pub(super) fn feed_date_or_today(raw: Option<&str>) -> rustledger_core::NaiveDate {
+    raw.and_then(|s| s.get(..10))
+        .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
+        .unwrap_or_else(|| jiff::Zoned::now().date())
 }
 
 /// Trait for price data sources.
@@ -151,6 +177,32 @@ mod guard_tests {
     #[test]
     fn absent_date_passes() {
         assert!(super::reject_historical_date("coinbase", &request(None)).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod feed_date_tests {
+    use super::feed_date_or_today;
+
+    #[test]
+    fn parses_bare_date_and_timestamp_prefix() {
+        let expected = rustledger_core::naive_date(2024, 1, 15).unwrap();
+        assert_eq!(feed_date_or_today(Some("2024-01-15")), expected);
+        // Alpha Vantage "6. Last Refreshed" shape.
+        assert_eq!(feed_date_or_today(Some("2024-01-15 10:30:00")), expected);
+    }
+
+    /// Absent, short, or malformed fields fall back to today instead of
+    /// erroring — the date label degrades, the price still flows.
+    #[test]
+    fn falls_back_to_today_on_missing_or_malformed() {
+        let today = jiff::Zoned::now().date();
+        assert_eq!(feed_date_or_today(None), today);
+        assert_eq!(feed_date_or_today(Some("")), today);
+        assert_eq!(feed_date_or_today(Some("2024")), today);
+        assert_eq!(feed_date_or_today(Some("not-a-date-at-all")), today);
+        // Multibyte content at the 10-byte boundary must not panic.
+        assert_eq!(feed_date_or_today(Some("2024-01-1é 10:30:00")), today);
     }
 }
 

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -30,13 +30,32 @@ pub use yahoo::YahooFinanceSource;
 use super::{PriceRequest, PriceResponse};
 use anyhow::Result;
 
-/// The run's notion of "today", latched at the first guarded fetch.
+/// The civil day of this process's FIRST guarded fetch.
 ///
-/// A `--date $(date +%F)` batch that straddles midnight must not flip
-/// mid-run from accepted to refused — a per-fetch clock read left the
-/// tail of the batch failing with advice to "drop --date" even though
-/// the flag was correct when the run began (round-3 deep review).
-static RUN_TODAY: std::sync::OnceLock<rustledger_core::NaiveDate> = std::sync::OnceLock::new();
+/// Used only to widen the guard by one day across a midnight straddle —
+/// see [`latest_date_window_ok`]. It deliberately does NOT replace the
+/// live clock (round-4 deep review: an unconditional process-wide latch
+/// froze "today" forever for long-lived library embedders, refusing
+/// every fetch after the first midnight).
+static FIRST_FETCH_DAY: std::sync::OnceLock<rustledger_core::NaiveDate> =
+    std::sync::OnceLock::new();
+
+/// Pure decision for the latest-only guard: `date` is fetchable when it
+/// IS `today`, or when the run started on `date` and midnight has since
+/// passed (`date` is yesterday AND equals the first-fetch day). The
+/// second arm keeps a `--date $(date +%F)` batch working to its end
+/// when it straddles midnight (round-3 review), without letting a
+/// long-lived embedder replay its start day weeks later — the window
+/// never widens past one day (round-4 review).
+fn latest_date_window_ok(
+    date: rustledger_core::NaiveDate,
+    today: rustledger_core::NaiveDate,
+    first_fetch_day: rustledger_core::NaiveDate,
+) -> bool {
+    date == today
+        || (date == first_fetch_day
+            && today.checked_sub(jiff::Span::new().days(1)).ok() == Some(date))
+}
 
 /// Reject a past or future `--date` on a source that can only fetch the
 /// LATEST quote.
@@ -48,28 +67,58 @@ static RUN_TODAY: std::sync::OnceLock<rustledger_core::NaiveDate> = std::sync::O
 /// <today>` is allowed, because the latest quote IS a valid answer for
 /// today and the emitted directive carries the response's own date
 /// anyway (round-2 deep review: nightly `--date $(date +%F)` runs
-/// worked on every source before #1801 and must keep working). "Today"
-/// is latched once per process — see [`RUN_TODAY`].
+/// worked on every source before #1801 and must keep working). A batch
+/// that straddles midnight stays accepted — see
+/// [`latest_date_window_ok`].
 /// Date-independent identity branches (e.g. USD→USD = 1.0) early-return
-/// BEFORE this guard.
+/// BEFORE this guard but refuse future labels via
+/// [`identity_label_date`].
 ///
 /// # Errors
-/// Errors whenever `request.date` is set to any day other than today.
+/// Errors whenever `request.date` is outside the accepted window.
 pub(super) fn reject_historical_date(
     source: &str,
     request: &crate::cmd::price::PriceRequest,
 ) -> anyhow::Result<()> {
-    if let Some(date) = request.date
-        && date != *RUN_TODAY.get_or_init(|| jiff::Zoned::now().date())
-    {
-        anyhow::bail!(
-            "the '{source}' source only provides the latest quote and cannot fetch {} \
-             for {date}; drop --date, or use a source with historical support \
-             (e.g. yahoo)",
-            request.ticker
-        );
+    if let Some(date) = request.date {
+        let today = jiff::Zoned::now().date();
+        let first_fetch_day = *FIRST_FETCH_DAY.get_or_init(|| today);
+        if !latest_date_window_ok(date, today, first_fetch_day) {
+            anyhow::bail!(
+                "the '{source}' source only provides the latest quote and cannot fetch {} \
+                 for {date}; drop --date, or use a source with historical support \
+                 (e.g. yahoo)",
+                request.ticker
+            );
+        }
     }
     Ok(())
+}
+
+/// Date label for a date-independent identity answer (X→X = 1.0).
+///
+/// Identity is numerically correct for any PAST day, which is why the
+/// identity branches sit ABOVE [`reject_historical_date`] — but a
+/// FUTURE label would fabricate a directive for a day that hasn't
+/// happened, which every guarded path refuses; refuse it here too
+/// (round-4 deep review: `--date 2030-01-01` on an ecb/ratesapi
+/// identity pair emitted `2030-01-01 price USD 1 USD` and cached it).
+///
+/// # Errors
+/// Errors when `request.date` is after today.
+pub(super) fn identity_label_date(
+    source: &str,
+    request: &crate::cmd::price::PriceRequest,
+) -> anyhow::Result<rustledger_core::NaiveDate> {
+    let today = jiff::Zoned::now().date();
+    match request.date {
+        Some(date) if date > today => anyhow::bail!(
+            "the '{source}' source cannot label a price with the future date {date}; \
+             use a date on or before today"
+        ),
+        Some(date) => Ok(date),
+        None => Ok(today),
+    }
 }
 
 /// Parse a feed-supplied date label — either a bare `YYYY-MM-DD` or the
@@ -177,6 +226,57 @@ mod guard_tests {
     #[test]
     fn absent_date_passes() {
         assert!(super::reject_historical_date("coinbase", &request(None)).is_ok());
+    }
+
+    /// The acceptance window: today always; yesterday ONLY when the
+    /// run's first fetch happened on it (a genuine midnight straddle).
+    /// A long-lived process can never replay its start day later than
+    /// that, and future dates never pass (round-4 deep review).
+    #[test]
+    fn window_accepts_midnight_straddle_only() {
+        let d = rustledger_core::naive_date(2026, 7, 16).unwrap();
+        let next = d.checked_add(jiff::Span::new().days(1)).unwrap();
+        let much_later = d.checked_add(jiff::Span::new().days(30)).unwrap();
+
+        assert!(super::latest_date_window_ok(d, d, d), "same day");
+        assert!(
+            super::latest_date_window_ok(d, next, d),
+            "midnight straddle: run started on d, clock now d+1"
+        );
+        assert!(
+            !super::latest_date_window_ok(d, much_later, d),
+            "a daemon must not replay its start day weeks later"
+        );
+        assert!(
+            !super::latest_date_window_ok(d, next, next),
+            "yesterday is refused when the run did NOT start on it"
+        );
+        assert!(
+            !super::latest_date_window_ok(much_later, d, d),
+            "future dates never pass"
+        );
+    }
+
+    /// Identity answers accept any past-or-today label but refuse a
+    /// future one — identity bypasses the main guard, so this is its
+    /// own fence (round-4 deep review).
+    #[test]
+    fn identity_label_refuses_future_dates() {
+        let today = jiff::Zoned::now().date();
+        let past = rustledger_core::naive_date(2020, 1, 1).unwrap();
+        let future = today.checked_add(jiff::Span::new().days(7)).unwrap();
+
+        assert_eq!(
+            super::identity_label_date("ecb", &request(Some(past))).unwrap(),
+            past
+        );
+        assert_eq!(
+            super::identity_label_date("ecb", &request(None)).unwrap(),
+            today
+        );
+        let err = super::identity_label_date("ecb", &request(Some(future)))
+            .expect_err("future labels are fabrication");
+        assert!(err.to_string().contains("future"), "{err}");
     }
 }
 

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -114,25 +114,33 @@ mod guard_tests {
     }
 
     /// Latest-only sources refuse a historical --date instead of
-    /// mislabeling the current quote (#1794).
+    /// mislabeling the current quote (#1794). Uses a FIXED past date so
+    /// the assertion is deterministic (never "yesterday", which races
+    /// the midnight rollover — review comment).
     #[test]
     fn historical_date_is_rejected() {
-        let yesterday = jiff::Zoned::now()
-            .date()
-            .yesterday()
-            .expect("valid yesterday");
-        let err = super::reject_historical_date("coinbase", &request(Some(yesterday)))
+        let past = rustledger_core::naive_date(2000, 1, 3).expect("valid date");
+        let err = super::reject_historical_date("coinbase", &request(Some(past)))
             .expect_err("must refuse");
         assert!(err.to_string().contains("latest quote"), "{err}");
         assert!(err.to_string().contains("coinbase"), "{err}");
     }
 
     /// Today's date is allowed — the latest quote genuinely belongs to
-    /// today — and no date always passes.
+    /// today — and no date always passes. The guard reads the clock
+    /// again internally, so re-check that "today" was stable across the
+    /// call and retry if midnight flipped between the two reads.
     #[test]
     fn today_and_absent_date_pass() {
-        let today = jiff::Zoned::now().date();
-        assert!(super::reject_historical_date("coinbase", &request(Some(today))).is_ok());
+        loop {
+            let today = jiff::Zoned::now().date();
+            let passed = super::reject_historical_date("coinbase", &request(Some(today))).is_ok();
+            if jiff::Zoned::now().date() == today {
+                assert!(passed, "today's date must pass the guard");
+                break;
+            }
+            // Midnight rolled over mid-test; retry with the new date.
+        }
         assert!(super::reject_historical_date("coinbase", &request(None)).is_ok());
     }
 }

--- a/crates/rustledger/src/cmd/price/sources/oanda.rs
+++ b/crates/rustledger/src/cmd/price/sources/oanda.rs
@@ -76,6 +76,10 @@ impl PriceSource for OandaSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let api_key = Self::get_api_key()?;
         let instrument = Self::format_instrument(&request.ticker, &request.currency);
         let url = self.build_url(&instrument);

--- a/crates/rustledger/src/cmd/price/sources/quandl.rs
+++ b/crates/rustledger/src/cmd/price/sources/quandl.rs
@@ -78,6 +78,10 @@ impl PriceSource for QuandlSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let api_key = Self::get_api_key()?;
         let (database, dataset) = Self::parse_dataset(&request.ticker);
         let full_dataset = format!("{database}/{dataset}");

--- a/crates/rustledger/src/cmd/price/sources/quandl.rs
+++ b/crates/rustledger/src/cmd/price/sources/quandl.rs
@@ -5,7 +5,6 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
-use rustledger_core::NaiveDate;
 use std::env;
 use std::time::Duration;
 
@@ -149,12 +148,11 @@ impl PriceSource for QuandlSource {
             })
             .with_context(|| "No price column found in dataset")?;
 
-        // Extract date
-        let date = data
-            .get(date_idx)
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| s.parse::<NaiveDate>().ok())
-            .unwrap_or_else(|| request.date.unwrap_or_else(|| jiff::Zoned::now().date()));
+        // The feed's own date, never the requested one (#1794; the old
+        // request.date fallback was the exact mislabeling pattern this
+        // PR removes — round-3 deep review).
+        let date =
+            super::feed_date_or_today(data.get(date_idx).and_then(serde_json::Value::as_str));
 
         // Extract price
         let price_value = data.get(price_idx).with_context(|| "Missing price value")?;

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -42,11 +42,10 @@ impl PriceSource for RatesApiSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
-        // If ticker and currency are the same, return 1.0
+        // Identity rate: 1.0 is correct for ANY date, so this branch
+        // deliberately sits ABOVE the latest-only guard (deep review —
+        // the guard must not remove previously-correct dated identity
+        // answers).
         if request.ticker.to_uppercase() == request.currency.to_uppercase() {
             let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
             return Ok(PriceResponse {
@@ -56,6 +55,10 @@ impl PriceSource for RatesApiSource {
                 source: self.name().to_string(),
             });
         }
+
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
 
         let url = self.build_url(
             &request.ticker.to_uppercase(),
@@ -99,7 +102,14 @@ impl PriceSource for RatesApiSource {
         let price = crate::cmd::price::price_decimal_from_json(rate_value)
             .with_context(|| format!("Invalid rate format: {rate_value}"))?;
 
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
+        // The feed's OWN quote date when present (exchangerate.host
+        // returns a "date" field) — on weekends the latest rate belongs
+        // to Friday and must say so (deep review, same rule as ECB).
+        let date = json
+            .get("date")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
+            .unwrap_or_else(|| jiff::Zoned::now().date());
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -42,6 +42,10 @@ impl PriceSource for RatesApiSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         // If ticker and currency are the same, return 1.0
         if request.ticker.to_uppercase() == request.currency.to_uppercase() {
             let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -42,16 +42,16 @@ impl PriceSource for RatesApiSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Identity rate: 1.0 is correct for ANY date, so this branch
-        // deliberately sits ABOVE the latest-only guard (deep review —
-        // the guard must not remove previously-correct dated identity
-        // answers).
+        // Identity rate: 1.0 is correct for any PAST date, so this
+        // branch deliberately sits ABOVE the latest-only guard (deep
+        // review — the guard must not remove previously-correct dated
+        // identity answers). Future labels are refused by
+        // identity_label_date (round-4 review).
         if request.ticker.to_uppercase() == request.currency.to_uppercase() {
-            let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
             return Ok(PriceResponse {
                 price: Decimal::ONE,
                 currency: request.currency.clone(),
-                date,
+                date: super::identity_label_date(self.name(), request)?,
                 source: self.name().to_string(),
             });
         }

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -105,11 +105,7 @@ impl PriceSource for RatesApiSource {
         // The feed's OWN quote date when present (exchangerate.host
         // returns a "date" field) — on weekends the latest rate belongs
         // to Friday and must say so (deep review, same rule as ECB).
-        let date = json
-            .get("date")
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
-            .unwrap_or_else(|| jiff::Zoned::now().date());
+        let date = super::feed_date_or_today(json.get("date").and_then(serde_json::Value::as_str));
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/tsp.rs
+++ b/crates/rustledger/src/cmd/price/sources/tsp.rs
@@ -5,7 +5,6 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
-use rustledger_core::NaiveDate;
 use std::time::Duration;
 
 /// Thrift Savings Plan price source.
@@ -110,12 +109,11 @@ impl PriceSource for TspSource {
         let price = crate::cmd::price::price_decimal_from_json(price_value)
             .with_context(|| format!("Invalid price format for {fund_name}: {price_value}"))?;
 
-        // Get the date from the response
-        let date = latest
-            .get("date")
-            .and_then(serde_json::Value::as_str)
-            .and_then(|s| s.parse::<NaiveDate>().ok())
-            .unwrap_or_else(|| request.date.unwrap_or_else(|| jiff::Zoned::now().date()));
+        // The feed's own date, never the requested one (#1794; the old
+        // request.date fallback was the exact mislabeling pattern this
+        // PR removes — round-3 deep review).
+        let date =
+            super::feed_date_or_today(latest.get("date").and_then(serde_json::Value::as_str));
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/tsp.rs
+++ b/crates/rustledger/src/cmd/price/sources/tsp.rs
@@ -72,6 +72,10 @@ impl PriceSource for TspSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // Latest-only source: a historical --date must refuse, not
+        // mislabel the current quote (#1794).
+        super::reject_historical_date(self.name(), request)?;
+
         let fund_name = Self::normalize_fund(&request.ticker)
             .with_context(|| format!("Unknown TSP fund: {}", request.ticker))?;
 

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -39,15 +39,20 @@ impl YahooFinanceSource {
     fn build_url(&self, symbol: &str, date: Option<NaiveDate>) -> Result<String> {
         match date {
             Some(d) => {
+                // Window bounds are fetch SLOP, not the classification: a
+                // bar's day is decided by the exchange-local date below, so
+                // the window is padded a day on each side to cover every
+                // UTC offset (deep review of #1801: NZX/ASX sessions cross
+                // UTC midnight).
                 let end = d
-                    .tomorrow()
+                    .checked_add(jiff::Span::new().days(2))
                     .context("date overflow")?
                     .to_zoned(jiff::tz::TimeZone::UTC)
                     .context("date out of range")?
                     .timestamp()
                     .as_second();
                 let begin = d
-                    .checked_sub(jiff::Span::new().days(5))
+                    .checked_sub(jiff::Span::new().days(6))
                     .context("date underflow")?
                     .to_zoned(jiff::tz::TimeZone::UTC)
                     .context("date out of range")?
@@ -99,15 +104,38 @@ impl YahooFinanceSource {
             .and_then(serde_json::Value::as_str)
             .map(ToString::to_string);
 
+        // Quote timestamps are exchange-session times; classify them by
+        // the EXCHANGE's civil date via meta.gmtoffset (what beanprice
+        // does through exchangeTimezoneName). Classifying by UTC date
+        // shifts NZX/ASX bars onto the wrong day — the same wrong-date
+        // class #1794 fixed (deep review).
+        let gmtoffset = result
+            .get("meta")
+            .and_then(|m| m.get("gmtoffset"))
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        let quote_civil_date = |secs: i64| -> Option<NaiveDate> {
+            jiff::Timestamp::from_second(secs.checked_add(gmtoffset)?)
+                .ok()
+                .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date())
+        };
+
         let Some(requested) = requested else {
-            // Latest quote.
-            let price_value = result
-                .get("meta")
+            // Latest quote — labeled with the QUOTE's own trading day
+            // (meta.regularMarketTime) when present, not the local clock:
+            // fetching on a weekend must date the price Friday.
+            let meta = result.get("meta");
+            let price_value = meta
                 .and_then(|m| m.get("regularMarketPrice"))
                 .with_context(|| format!("No price found for {ticker}"))?;
             let price = crate::cmd::price::price_decimal_from_json(price_value)
                 .with_context(|| format!("Invalid price for {ticker}"))?;
-            return Ok((price, currency, jiff::Zoned::now().date()));
+            let date = meta
+                .and_then(|m| m.get("regularMarketTime"))
+                .and_then(serde_json::Value::as_i64)
+                .and_then(quote_civil_date)
+                .unwrap_or_else(|| jiff::Zoned::now().date());
+            return Ok((price, currency, date));
         };
 
         // Historical: walk timestamps/closes in parallel, keep the last
@@ -124,18 +152,23 @@ impl YahooFinanceSource {
             .and_then(serde_json::Value::as_array)
             .with_context(|| format!("No close series for {ticker}"))?;
 
+        // No early break: Yahoo does not guarantee sorted timestamps, so
+        // track the maximum quote date <= requested across the whole
+        // series (deep review).
         let mut best: Option<(rust_decimal::Decimal, NaiveDate)> = None;
         for (ts, close) in timestamps.iter().zip(closes) {
             if close.is_null() {
                 continue;
             }
             let Some(secs) = ts.as_i64() else { continue };
-            let Ok(stamp) = jiff::Timestamp::from_second(secs) else {
+            let Some(quote_date) = quote_civil_date(secs) else {
                 continue;
             };
-            let quote_date = stamp.to_zoned(jiff::tz::TimeZone::UTC).date();
             if quote_date > requested {
-                break;
+                continue;
+            }
+            if best.as_ref().is_some_and(|(_, d)| *d > quote_date) {
+                continue;
             }
             if let Some(price) = crate::cmd::price::price_decimal_from_json(close) {
                 best = Some((price, quote_date));
@@ -205,7 +238,7 @@ mod tests {
         assert!(url.contains("period2="), "{url}");
         assert!(!url.contains("range="), "{url}");
         // period2 is the exclusive end: midnight UTC of the day after.
-        assert!(url.contains("period2=1735862400"), "{url}");
+        assert!(url.contains("period2=1735948800"), "{url}");
     }
 
     /// Fixture-driven historical parsing: Sat 2025-01-04 requested, the
@@ -263,6 +296,51 @@ mod tests {
         let err = YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL")
             .expect_err("must refuse");
         assert!(err.to_string().contains("on or before"), "{err}");
+    }
+
+    /// Exchange-timezone classification (deep review): NZX trades at
+    /// UTC+13, so Tuesday's 10:00 NZST bar is Monday 21:00 UTC. Classified
+    /// by UTC date it would masquerade as Monday and overwrite Monday's
+    /// real close; classified by exchange-local date (meta.gmtoffset) the
+    /// Monday request returns MONDAY's close.
+    #[test]
+    fn parse_chart_classifies_by_exchange_timezone() {
+        // gmtoffset +13h (46800). Monday 2026-07-13 10:00 NZST
+        // = Sunday 2026-07-12 21:00 UTC = 1783976400.
+        // Tuesday 2026-07-14 10:00 NZST = Monday 2026-07-13 21:00 UTC
+        // = 1784062800.
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": { "currency": "NZD", "gmtoffset": 46800 },
+                "timestamp": [1_783_976_400_i64, 1_784_062_800_i64],
+                "indicators": { "quote": [{ "close": [1.11, 2.22] }] }
+            }], "error": null }
+        });
+        let requested = rustledger_core::naive_date(2026, 7, 13).unwrap();
+        let (price, _, date) =
+            YahooFinanceSource::parse_chart(&json, Some(requested), "AIR.NZ").expect("parses");
+        assert_eq!(price.to_string(), "1.11", "Monday's bar, not Tuesday's");
+        assert_eq!(date, rustledger_core::naive_date(2026, 7, 13).unwrap());
+    }
+
+    /// The latest path labels with the quote's own trading day
+    /// (regularMarketTime + gmtoffset), not the local clock.
+    #[test]
+    fn parse_chart_latest_uses_quote_own_date() {
+        // Friday 2026-07-10 16:00 US/Eastern (UTC-4) = 20:00 UTC
+        // = 1783800000; gmtoffset -14400.
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": {
+                    "currency": "USD",
+                    "regularMarketPrice": 243.85,
+                    "regularMarketTime": 1_783_800_000_i64,
+                    "gmtoffset": -14400
+                }
+            }], "error": null }
+        });
+        let (_, _, date) = YahooFinanceSource::parse_chart(&json, None, "AAPL").expect("parses");
+        assert_eq!(date, rustledger_core::naive_date(2026, 7, 10).unwrap());
     }
 
     /// The latest path still reads regularMarketPrice.

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -5,6 +5,7 @@
 use super::{PriceSource, user_agent};
 use crate::cmd::price::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
+use rustledger_core::NaiveDate;
 use std::time::Duration;
 
 /// Yahoo Finance price source.
@@ -28,9 +29,126 @@ impl YahooFinanceSource {
         Self {}
     }
 
-    /// Build the Yahoo Finance API URL.
-    fn build_url(&self, symbol: &str) -> String {
-        format!("https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&range=1d")
+    /// Build the Yahoo Finance chart-API URL.
+    ///
+    /// Latest quote: a one-day range. Historical (#1794): a window of the
+    /// five days up to and including the requested date, via epoch
+    /// `period1`/`period2` — mirroring beanprice's `get_historical_price`,
+    /// which fetches `time - 5d .. time` so weekends/holidays resolve to
+    /// the preceding trading day.
+    fn build_url(&self, symbol: &str, date: Option<NaiveDate>) -> Result<String> {
+        match date {
+            Some(d) => {
+                let end = d
+                    .tomorrow()
+                    .context("date overflow")?
+                    .to_zoned(jiff::tz::TimeZone::UTC)
+                    .context("date out of range")?
+                    .timestamp()
+                    .as_second();
+                let begin = d
+                    .checked_sub(jiff::Span::new().days(5))
+                    .context("date underflow")?
+                    .to_zoned(jiff::tz::TimeZone::UTC)
+                    .context("date out of range")?
+                    .timestamp()
+                    .as_second();
+                Ok(format!(
+                    "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&period1={begin}&period2={end}"
+                ))
+            }
+            None => Ok(format!(
+                "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&range=1d"
+            )),
+        }
+    }
+
+    /// Extract `(price, currency, effective-date)` from a chart response.
+    ///
+    /// Latest mode (`requested = None`): `meta.regularMarketPrice`, dated
+    /// today. Historical mode: the LAST non-null close on or before the
+    /// requested date, dated by its own quote timestamp — never the
+    /// requested date (#1794: a Saturday request must emit Friday's close
+    /// under Friday's date). Errors when the window holds no usable quote,
+    /// instead of mislabeling the latest one.
+    fn parse_chart(
+        json: &serde_json::Value,
+        requested: Option<NaiveDate>,
+        ticker: &str,
+    ) -> Result<(rust_decimal::Decimal, Option<String>, NaiveDate)> {
+        // Check for errors in the response
+        if let Some(chart) = json.get("chart")
+            && let Some(error) = chart.get("error")
+            && !error.is_null()
+        {
+            let description = error
+                .get("description")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("Unknown error");
+            anyhow::bail!("Yahoo Finance error: {description}");
+        }
+
+        let result = json
+            .get("chart")
+            .and_then(|c| c.get("result"))
+            .and_then(|r| r.get(0))
+            .with_context(|| format!("Invalid response structure for {ticker}"))?;
+        let currency = result
+            .get("meta")
+            .and_then(|m| m.get("currency"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string);
+
+        let Some(requested) = requested else {
+            // Latest quote.
+            let price_value = result
+                .get("meta")
+                .and_then(|m| m.get("regularMarketPrice"))
+                .with_context(|| format!("No price found for {ticker}"))?;
+            let price = crate::cmd::price::price_decimal_from_json(price_value)
+                .with_context(|| format!("Invalid price for {ticker}"))?;
+            return Ok((price, currency, jiff::Zoned::now().date()));
+        };
+
+        // Historical: walk timestamps/closes in parallel, keep the last
+        // usable close on or before the requested date.
+        let timestamps = result
+            .get("timestamp")
+            .and_then(serde_json::Value::as_array)
+            .with_context(|| format!("No quotes for {ticker} in the requested window"))?;
+        let closes = result
+            .get("indicators")
+            .and_then(|i| i.get("quote"))
+            .and_then(|q| q.get(0))
+            .and_then(|q| q.get("close"))
+            .and_then(serde_json::Value::as_array)
+            .with_context(|| format!("No close series for {ticker}"))?;
+
+        let mut best: Option<(rust_decimal::Decimal, NaiveDate)> = None;
+        for (ts, close) in timestamps.iter().zip(closes) {
+            if close.is_null() {
+                continue;
+            }
+            let Some(secs) = ts.as_i64() else { continue };
+            let Ok(stamp) = jiff::Timestamp::from_second(secs) else {
+                continue;
+            };
+            let quote_date = stamp.to_zoned(jiff::tz::TimeZone::UTC).date();
+            if quote_date > requested {
+                break;
+            }
+            if let Some(price) = crate::cmd::price::price_decimal_from_json(close) {
+                best = Some((price, quote_date));
+            }
+        }
+
+        let (price, date) = best.with_context(|| {
+            format!(
+                "no Yahoo quote for {ticker} on or before {requested} in the \
+                 fetched window; the market may not have traded that week"
+            )
+        })?;
+        Ok((price, currency, date))
     }
 }
 
@@ -44,7 +162,7 @@ impl PriceSource for YahooFinanceSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        let url = self.build_url(&request.ticker);
+        let url = self.build_url(&request.ticker, request.date)?;
 
         let mut response = ureq::get(&url)
             .header("User-Agent", user_agent())
@@ -56,45 +174,11 @@ impl PriceSource for YahooFinanceSource {
             .read_json()
             .with_context(|| format!("Failed to parse response for {}", request.ticker))?;
 
-        // Check for errors in the response
-        if let Some(chart) = json.get("chart")
-            && let Some(error) = chart.get("error")
-            && !error.is_null()
-        {
-            let description = error
-                .get("description")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("Unknown error");
-            anyhow::bail!("Yahoo Finance error: {description}");
-        }
-
-        // Navigate to the price in the response
-        let meta = json
-            .get("chart")
-            .and_then(|c| c.get("result"))
-            .and_then(|r| r.get(0))
-            .and_then(|r| r.get("meta"))
-            .with_context(|| format!("Invalid response structure for {}", request.ticker))?;
-
-        let price_value = meta
-            .get("regularMarketPrice")
-            .with_context(|| format!("No price found for {}", request.ticker))?;
-
-        let price = crate::cmd::price::price_decimal_from_json(price_value)
-            .with_context(|| format!("Invalid price for {}", request.ticker))?;
-
-        // Get the currency from the response
-        let currency = meta
-            .get("currency")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or(&request.currency)
-            .to_string();
-
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
+        let (price, currency, date) = Self::parse_chart(&json, request.date, &request.ticker)?;
 
         Ok(PriceResponse {
             price,
-            currency,
+            currency: currency.unwrap_or_else(|| request.currency.clone()),
             date,
             source: self.name().to_string(),
         })
@@ -108,9 +192,91 @@ mod tests {
     #[test]
     fn test_build_url() {
         let source = YahooFinanceSource::new(Duration::from_secs(30));
-        let url = source.build_url("AAPL");
+        let url = source.build_url("AAPL", None).expect("latest url");
         assert!(url.contains("AAPL"));
         assert!(url.contains("query1.finance.yahoo.com"));
+        assert!(url.contains("range=1d"));
+
+        // Historical: an epoch window bracketing the requested date, no
+        // range param (#1794 — range=1d was the always-latest bug).
+        let d = rustledger_core::naive_date(2025, 1, 2).unwrap();
+        let url = source.build_url("AAPL", Some(d)).expect("historical url");
+        assert!(url.contains("period1="), "{url}");
+        assert!(url.contains("period2="), "{url}");
+        assert!(!url.contains("range="), "{url}");
+        // period2 is the exclusive end: midnight UTC of the day after.
+        assert!(url.contains("period2=1735862400"), "{url}");
+    }
+
+    /// Fixture-driven historical parsing: Sat 2025-01-04 requested, the
+    /// window holds Thu/Fri closes plus a null (market holiday) — the
+    /// result is FRIDAY's close under FRIDAY's date, never the requested
+    /// Saturday or the latest quote (#1794).
+    #[test]
+    fn parse_chart_historical_picks_last_close_on_or_before_date() {
+        // 2025-01-02 (Thu) 14:30 UTC, 2025-01-03 (Fri), 2025-01-06 (Mon)
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": { "currency": "USD", "regularMarketPrice": 999.99 },
+                "timestamp": [1_735_828_200_i64, 1_735_914_600_i64, 1_736_173_800_i64],
+                "indicators": { "quote": [{ "close": [243.85, 243.36, 245.00] }] }
+            }], "error": null }
+        });
+        let requested = rustledger_core::naive_date(2025, 1, 4).unwrap();
+        let (price, currency, date) =
+            YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL").expect("parses");
+        assert_eq!(price.to_string(), "243.36");
+        assert_eq!(currency.as_deref(), Some("USD"));
+        assert_eq!(date, rustledger_core::naive_date(2025, 1, 3).unwrap());
+    }
+
+    /// Null closes (holidays) are skipped, not treated as zero.
+    #[test]
+    fn parse_chart_skips_null_closes() {
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": { "currency": "USD" },
+                "timestamp": [1_735_828_200_i64, 1_735_914_600_i64],
+                "indicators": { "quote": [{ "close": [243.85, null] }] }
+            }], "error": null }
+        });
+        let requested = rustledger_core::naive_date(2025, 1, 3).unwrap();
+        let (price, _, date) =
+            YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL").expect("parses");
+        assert_eq!(price.to_string(), "243.85");
+        assert_eq!(date, rustledger_core::naive_date(2025, 1, 2).unwrap());
+    }
+
+    /// An empty window is a hard error — never the latest quote under a
+    /// historical label (the exact corruption from #1794).
+    #[test]
+    fn parse_chart_errors_when_no_quote_in_window() {
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": { "currency": "USD", "regularMarketPrice": 999.99 },
+                "timestamp": [1_736_173_800_i64],
+                "indicators": { "quote": [{ "close": [245.00] }] }
+            }], "error": null }
+        });
+        // Requested date precedes every quote in the window.
+        let requested = rustledger_core::naive_date(2025, 1, 4).unwrap();
+        let err = YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL")
+            .expect_err("must refuse");
+        assert!(err.to_string().contains("on or before"), "{err}");
+    }
+
+    /// The latest path still reads regularMarketPrice.
+    #[test]
+    fn parse_chart_latest_uses_regular_market_price() {
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": { "currency": "USD", "regularMarketPrice": 243.85 }
+            }], "error": null }
+        });
+        let (price, currency, _) =
+            YahooFinanceSource::parse_chart(&json, None, "AAPL").expect("parses");
+        assert_eq!(price.to_string(), "243.85");
+        assert_eq!(currency.as_deref(), Some("USD"));
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -306,13 +306,13 @@ mod tests {
     #[test]
     fn parse_chart_classifies_by_exchange_timezone() {
         // gmtoffset +13h (46800). Monday 2026-07-13 10:00 NZST
-        // = Sunday 2026-07-12 21:00 UTC = 1783976400.
+        // = Sunday 2026-07-12 21:00 UTC = 1783890000.
         // Tuesday 2026-07-14 10:00 NZST = Monday 2026-07-13 21:00 UTC
-        // = 1784062800.
+        // = 1783976400 — by UTC date it masquerades as Monday.
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": { "currency": "NZD", "gmtoffset": 46800 },
-                "timestamp": [1_783_976_400_i64, 1_784_062_800_i64],
+                "timestamp": [1_783_890_000_i64, 1_783_976_400_i64],
                 "indicators": { "quote": [{ "close": [1.11, 2.22] }] }
             }], "error": null }
         });
@@ -328,13 +328,13 @@ mod tests {
     #[test]
     fn parse_chart_latest_uses_quote_own_date() {
         // Friday 2026-07-10 16:00 US/Eastern (UTC-4) = 20:00 UTC
-        // = 1783800000; gmtoffset -14400.
+        // = 1783713600; gmtoffset -14400.
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": {
                     "currency": "USD",
                     "regularMarketPrice": 243.85,
-                    "regularMarketTime": 1_783_800_000_i64,
+                    "regularMarketTime": 1_783_713_600_i64,
                     "gmtoffset": -14400
                 }
             }], "error": null }

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -31,11 +31,12 @@ impl YahooFinanceSource {
 
     /// Build the Yahoo Finance chart-API URL.
     ///
-    /// Latest quote: a one-day range. Historical (#1794): a window of the
-    /// five days up to and including the requested date, via epoch
-    /// `period1`/`period2` — mirroring beanprice's `get_historical_price`,
-    /// which fetches `time - 5d .. time` so weekends/holidays resolve to
-    /// the preceding trading day.
+    /// Latest quote: a one-day range. Historical (#1794): an epoch
+    /// `period1`/`period2` window from six days before to two days after
+    /// the requested date (UTC midnights) — beanprice's
+    /// `get_historical_price` window of `time - 5d .. time`, padded a day
+    /// each side so every exchange UTC offset is covered; the bounds are
+    /// fetch slop, classification happens in `parse_chart`.
     fn build_url(&self, symbol: &str, date: Option<NaiveDate>) -> Result<String> {
         match date {
             Some(d) => {
@@ -105,26 +106,39 @@ impl YahooFinanceSource {
             .map(ToString::to_string);
 
         // Quote timestamps are exchange-session times; classify them by
-        // the EXCHANGE's civil date via meta.gmtoffset (what beanprice
-        // does through exchangeTimezoneName). Classifying by UTC date
-        // shifts NZX/ASX bars onto the wrong day — the same wrong-date
-        // class #1794 fixed (deep review).
-        let gmtoffset = result
-            .get("meta")
+        // the EXCHANGE's civil date. Classifying by UTC date shifts
+        // NZX/ASX bars onto the wrong day — the same wrong-date class
+        // #1794 fixed (deep review). Prefer meta.exchangeTimezoneName
+        // (what beanprice uses): a real timezone handles a DST switch
+        // inside the fetch window, where meta.gmtoffset — a single
+        // response-time offset — would misclassify pre-switch
+        // midnight-anchored bars by a day (round-2 deep review). Fall
+        // back to gmtoffset when the name is absent or the tz database
+        // is unavailable.
+        let meta = result.get("meta");
+        let exchange_tz = meta
+            .and_then(|m| m.get("exchangeTimezoneName"))
+            .and_then(serde_json::Value::as_str)
+            .and_then(|name| jiff::tz::TimeZone::get(name).ok());
+        let gmtoffset = meta
             .and_then(|m| m.get("gmtoffset"))
             .and_then(serde_json::Value::as_i64)
             .unwrap_or(0);
-        let quote_civil_date = |secs: i64| -> Option<NaiveDate> {
-            jiff::Timestamp::from_second(secs.checked_add(gmtoffset)?)
-                .ok()
-                .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date())
+        let quote_civil_date = move |secs: i64| -> Option<NaiveDate> {
+            match &exchange_tz {
+                Some(tz) => jiff::Timestamp::from_second(secs)
+                    .ok()
+                    .map(|t| t.to_zoned(tz.clone()).date()),
+                None => jiff::Timestamp::from_second(secs.checked_add(gmtoffset)?)
+                    .ok()
+                    .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date()),
+            }
         };
 
         let Some(requested) = requested else {
             // Latest quote — labeled with the QUOTE's own trading day
             // (meta.regularMarketTime) when present, not the local clock:
             // fetching on a weekend must date the price Friday.
-            let meta = result.get("meta");
             let price_value = meta
                 .and_then(|m| m.get("regularMarketPrice"))
                 .with_context(|| format!("No price found for {ticker}"))?;
@@ -299,20 +313,22 @@ mod tests {
     }
 
     /// Exchange-timezone classification (deep review): NZX trades at
-    /// UTC+13, so Tuesday's 10:00 NZST bar is Monday 21:00 UTC. Classified
-    /// by UTC date it would masquerade as Monday and overwrite Monday's
-    /// real close; classified by exchange-local date (meta.gmtoffset) the
-    /// Monday request returns MONDAY's close.
+    /// UTC+12 in July (NZST), so Tuesday's 10:00 NZST bar is Monday
+    /// 22:00 UTC. Classified by UTC date it would masquerade as Monday
+    /// and overwrite Monday's real close; classified by exchange-local
+    /// date (meta.gmtoffset — no exchangeTimezoneName in this fixture,
+    /// exercising the fallback) the Monday request returns MONDAY's
+    /// close.
     #[test]
     fn parse_chart_classifies_by_exchange_timezone() {
-        // gmtoffset +13h (46800). Monday 2026-07-13 10:00 NZST
-        // = Sunday 2026-07-12 21:00 UTC = 1783890000.
-        // Tuesday 2026-07-14 10:00 NZST = Monday 2026-07-13 21:00 UTC
-        // = 1783976400 — by UTC date it masquerades as Monday.
+        // gmtoffset +12h (43200). Monday 2026-07-13 10:00 NZST
+        // = Sunday 2026-07-12 22:00 UTC = 1783893600.
+        // Tuesday 2026-07-14 10:00 NZST = Monday 2026-07-13 22:00 UTC
+        // = 1783980000 — by UTC date it masquerades as Monday.
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
-                "meta": { "currency": "NZD", "gmtoffset": 46800 },
-                "timestamp": [1_783_890_000_i64, 1_783_976_400_i64],
+                "meta": { "currency": "NZD", "gmtoffset": 43200 },
+                "timestamp": [1_783_893_600_i64, 1_783_980_000_i64],
                 "indicators": { "quote": [{ "close": [1.11, 2.22] }] }
             }], "error": null }
         });
@@ -321,6 +337,36 @@ mod tests {
             YahooFinanceSource::parse_chart(&json, Some(requested), "AIR.NZ").expect("parses");
         assert_eq!(price.to_string(), "1.11", "Monday's bar, not Tuesday's");
         assert_eq!(date, rustledger_core::naive_date(2026, 7, 13).unwrap());
+    }
+
+    /// A DST switch inside the fetch window (round-2 deep review):
+    /// meta.gmtoffset is the offset at RESPONSE time, so applying it to
+    /// a bar from before the switch shifts midnight-anchored bars by an
+    /// hour — a full civil day for FX bars stamped at local 00:00.
+    /// exchangeTimezoneName resolves each bar with the offset in force
+    /// at ITS OWN instant.
+    #[test]
+    fn parse_chart_handles_dst_transition_via_timezone_name() {
+        // America/New_York, DST ends 2025-11-02.
+        // Fri 2025-10-31 00:00 EDT (UTC-4) = 04:00 UTC = 1761883200 —
+        //   post-switch gmtoffset -18000 would misdate it 2025-10-30.
+        // Tue 2025-11-04 00:00 EST (UTC-5) = 05:00 UTC = 1762232400.
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": {
+                    "currency": "USD",
+                    "exchangeTimezoneName": "America/New_York",
+                    "gmtoffset": -18000
+                },
+                "timestamp": [1_761_883_200_i64, 1_762_232_400_i64],
+                "indicators": { "quote": [{ "close": [1.11, 2.22] }] }
+            }], "error": null }
+        });
+        let requested = rustledger_core::naive_date(2025, 10, 31).unwrap();
+        let (price, _, date) =
+            YahooFinanceSource::parse_chart(&json, Some(requested), "EURUSD=X").expect("parses");
+        assert_eq!(price.to_string(), "1.11", "Friday's pre-switch bar");
+        assert_eq!(date, requested, "classified by its own instant's offset");
     }
 
     /// The latest path labels with the quote's own trading day

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -458,13 +458,13 @@ pub fn run_with_writer<W: Write>(
                         // Also store under the default source key for fast lookup.
                         // Trade-off: if a user later changes their `price:`
                         // source for (symbol, currency) — e.g. yahoo→google —
-                        // a historical-date lookup (no TTL) under the global
-                        // default key will return the OLD source's payload
-                        // until the user runs `--clear-cache`. "Latest" lookups
-                        // are protected by the 30-min TTL on `:latest` keys
-                        // (cache.rs:64-74). Documented limitation; honors the
-                        // perf goal of not re-attempting failed-fallback sources
-                        // on every run.
+                        // a settled historical-date lookup (no TTL) under the
+                        // global default key will return the OLD source's
+                        // payload until the user runs `--clear-cache`. Latest
+                        // and today-dated lookups are protected by the TTL
+                        // (see `PriceCache::get`). Documented limitation;
+                        // honors the perf goal of not re-attempting
+                        // failed-fallback sources on every run.
                         if actual_key != key {
                             c.insert(&key, &response);
                         }

--- a/crates/rustledger/tests/price_clobber_post_fetch.rs
+++ b/crates/rustledger/tests/price_clobber_post_fetch.rs
@@ -187,7 +187,13 @@ fn clobber_cache_hit_skips_when_cached_date_matches_existing() {
             "cached_at": cached_at,
         }),
     );
-    std::fs::write(&cache_file, serde_json::to_string(&entries).unwrap()).unwrap();
+    // The CURRENT versioned envelope (cache.rs CACHE_SCHEMA_VERSION) — a
+    // bare map is the pre-#1801 legacy format, which load() discards,
+    // silently turning this test into a guard-error no-op (round-2 deep
+    // review). The stderr assertion below pins that the cache path
+    // actually ran.
+    let envelope = serde_json::json!({ "version": 2, "entries": entries });
+    std::fs::write(&cache_file, serde_json::to_string(&envelope).unwrap()).unwrap();
 
     let fixture = "\
 2024-01-01 commodity AAPL
@@ -216,6 +222,9 @@ fn clobber_cache_hit_skips_when_cached_date_matches_existing() {
             "coinbase",
             "--date",
             "2024-01-15",
+            // --verbose so the cache-hit skip announces itself on stderr —
+            // the assertion below needs it to prove which path ran.
+            "--verbose",
         ])
         .output()
         .expect("rledger price should execute");
@@ -226,6 +235,15 @@ fn clobber_cache_hit_skips_when_cached_date_matches_existing() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // The skip must come from the CACHE-HIT branch specifically — an
+    // empty stdout alone is also satisfied by the fetch erroring (e.g.
+    // the historical-date guard on a cache MISS), which is exactly how
+    // this test went vacuous once (round-2 deep review).
+    assert!(
+        stderr.contains("skipped from cache"),
+        "the cache-hit dedup branch must be the path taken. stderr was:\n{stderr}"
+    );
     let new_directive_count = stdout.lines().filter(|l| l.contains("price AAPL")).count();
     assert_eq!(
         new_directive_count, 0,

--- a/crates/rustledger/tests/price_clobber_post_fetch.rs
+++ b/crates/rustledger/tests/price_clobber_post_fetch.rs
@@ -187,12 +187,16 @@ fn clobber_cache_hit_skips_when_cached_date_matches_existing() {
             "cached_at": cached_at,
         }),
     );
-    // The CURRENT versioned envelope (cache.rs CACHE_SCHEMA_VERSION) — a
-    // bare map is the pre-#1801 legacy format, which load() discards,
-    // silently turning this test into a guard-error no-op (round-2 deep
-    // review). The stderr assertion below pins that the cache path
-    // actually ran.
-    let envelope = serde_json::json!({ "version": 2, "entries": entries });
+    // The CURRENT versioned envelope — a bare map is the pre-#1801
+    // legacy format, which load() discards, silently turning this test
+    // into a guard-error no-op (round-2 deep review). The stderr
+    // assertion below pins that the cache path actually ran; referencing
+    // the real constant keeps the fixture from going stale on the next
+    // schema bump (round-3 deep review).
+    let envelope = serde_json::json!({
+        "version": rustledger::cmd::price::cache::CACHE_SCHEMA_VERSION,
+        "entries": entries
+    });
     std::fs::write(&cache_file, serde_json::to_string(&envelope).unwrap()).unwrap();
 
     let fixture = "\

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -24,7 +24,7 @@ rledger price [OPTIONS] [SYMBOL]...
 |--------|-------------|
 | `-f, --file <FILE>` | Beancount file to discover commodities from |
 | `-c, --currency <CURRENCY>` | Base currency for price quotes [default: USD] |
-| `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today) |
+| `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today). Historical dates need a source with historical support: `yahoo`, or an external `--source-cmd` that honors `RLEDGER_DATE`. Latest-only sources (coinbase, ecb, ratesapi, alphavantage, …) accept only today's date and refuse past or future dates instead of mislabeling the current quote (#1794). |
 | `-b, --beancount` | Output as beancount price directives |
 | `--source-meta` | With `-b`, also write a `source:` metadata line on each price directive recording which provider produced the quote (opt-in provenance — see note below). Requires `-b`. |
 | `-s, --source <SOURCE>` | Use specific source (overrides mapping) |
@@ -178,7 +178,13 @@ use_default_source = true
 Prices are cached to disk to reduce API calls. By default, cached prices expire after **30 minutes** (matching Python `bean-price` behavior).
 
 - **Latest prices** (no `--date`) expire after the configured TTL
-- **Historical prices** (with `--date`) don't expire via TTL, but are pruned after 7 days of inactivity
+- **Settled historical prices** (a `--date` strictly before the day the
+  quote was fetched) don't expire via TTL — a past close is immutable —
+  but are pruned after 7 days of inactivity
+- **Same-day prices** (`--date <today>`) are intraday quotes, not
+  closes: they expire with the TTL like latest prices, so a re-run
+  after the TTL refetches. Raise `cache_ttl` if you re-run same-day
+  batches against rate-limited sources
 - Cache file location: platform cache directory (e.g., `~/.cache/rledger/prices.json` on Linux)
 
 ### Configuration
@@ -267,6 +273,15 @@ rledger price PROP --currency AUD \
 The shell expands `$RLEDGER_*` so `bean-price` sees its own argument convention. No rledger-specific glue required.
 
 `RLEDGER_DATE` is set to the empty string (not unset) when no date is requested, so `${RLEDGER_DATE:-today}` shell idioms work.
+
+> **Trust contract for dated fetches:** when the command's output carries
+> no date of its own (a plain number, or JSON without a `date` field),
+> rledger labels the price with the *requested* date, trusting that the
+> command honored `RLEDGER_DATE`. A script that ignores `RLEDGER_DATE`
+> and prints its latest quote will have that quote recorded under
+> whatever `--date` was passed. If your fetcher can't honor the date,
+> emit the dated beancount form (`<date> price <ticker> <amount>
+> <currency>`) or a JSON `date` field so the true date wins.
 
 #### Legacy: appended CLI arguments
 

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -280,8 +280,9 @@ The shell expands `$RLEDGER_*` so `bean-price` sees its own argument convention.
 > command honored `RLEDGER_DATE`. A script that ignores `RLEDGER_DATE`
 > and prints its latest quote will have that quote recorded under
 > whatever `--date` was passed. If your fetcher can't honor the date,
-> emit the dated beancount form (`<date> price <ticker> <amount>
-> <currency>`) or a JSON `date` field so the true date wins.
+> emit the dated beancount form
+> (`<date> price <ticker> <amount> <currency>`)
+> or a JSON `date` field so the true date wins.
 
 #### Legacy: appended CLI arguments
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -471,10 +471,6 @@ criteria = "safe-to-deploy"
 version = "0.31.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-conv]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.num-format]]
 version = "0.4.4"
 criteria = "safe-to-deploy"
@@ -785,10 +781,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.49"
-criteria = "safe-to-deploy"
-
-[[exemptions.time-core]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -563,8 +563,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.jiff-tzdb]]
-version = "0.1.6"
-when = "2026-03-03"
+version = "0.1.8"
+when = "2026-07-09"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -2282,6 +2282,12 @@ criteria = "safe-to-deploy"
 delta = "0.50.1 -> 0.50.3"
 notes = "CI changes, Rust changes, nothing out of the ordinary."
 
+[[audits.bytecode-alliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
+
 [[audits.bytecode-alliance.audits.num-traits]]
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
@@ -3617,6 +3623,23 @@ criteria = "safe-to-deploy"
 delta = "0.25.1 -> 0.26.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.oorandom]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-run"
@@ -3891,6 +3914,37 @@ criteria = "safe-to-deploy"
 delta = "1.0.43 -> 1.0.69"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.tinyvec_macros]]
 who = "Drew Willcoxon <adw@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -4029,6 +4083,13 @@ A new unsafe trait method `SockaddrLike::set_length` is added; it's impls look f
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[[audits.zcash.audits.num-conv]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "No changes to unsafe code, straightforward refactoring and cleanup."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.rand_xorshift]]
 who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
@@ -4075,6 +4136,13 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.1.8 -> 1.1.9"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.time-core]]
+who = "Kris Nuttycombe <kris@nutty.land>"
+criteria = "safe-to-deploy"
+delta = "0.1.8 -> 0.1.9"
+notes = "No unsafe code; macro additions are straightforward refactoring changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.valuable]]
 who = "Jack Grigg <jack@electriccoin.co>"


### PR DESCRIPTION
## What

#1794 reported the Yahoo source ignoring `--date` and stamping the LIVE quote with the requested historical date — silent corruption of price archives (the report's repro: identical prices for `2000-01-03` and `2025-01-02`). Auditing all 11 sources showed it's a **class**: most stamp `request.date` onto a latest quote, and ECB even overrides the real rate date it already parsed.

## Two-tier fix

**Yahoo gets real historical support**, mirroring beanprice's `get_historical_price`:
- `--date` → a five-day `period1`/`period2` epoch window ending at the requested date (weekends/holidays resolve to the preceding trading day).
- Emits the **last non-null close on or before the date, under the quote's own date** — a Saturday request yields Friday's close dated Friday, exactly like upstream.
- **Hard error** when the window holds no usable quote — never the latest price under a historical label.
- Parsing extracted into a pure `parse_chart()` unit-tested against fixture JSON: weekend resolution, null-close holidays skipped, empty-window refusal, latest path unchanged.

**Every latest-only source refuses a historical `--date`** via a shared `reject_historical_date` guard (alphavantage, coinbase, coincap, coinmarketcap, eastmoneyfund, ecb, oanda, quandl, ratesapi, tsp) with an actionable message pointing at yahoo. Today's date passes — the latest quote genuinely belongs to today. This stops the corruption class everywhere immediately; per-source historical support where the provider APIs allow it (Coinbase `?date=`, exchangerate.host historical endpoints, quandl `start_date`/`end_date`) is tracked in the follow-up issue.

**ECB** additionally now labels rates with the feed's **own** reference date in all three branches (direct/inverted/cross) — on weekends the latest rate is Friday's and must say so.

## Testing

Yahoo: URL construction both modes (epoch window pinned), four fixture-JSON parse tests. Guard: rejects yesterday with a source-naming error, passes today/absent. Full crate suite, clippy `-D warnings`, fmt clean. (Provider correctness remains untestable in CI without a mock-HTTP harness — noted in the follow-up issue.)

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)