### PR TITLE
feat: window-primitive price source architecture (#1802)

### DIFF
--- a/crates/rustledger/src/cmd/price/cache.rs
+++ b/crates/rustledger/src/cmd/price/cache.rs
@@ -254,7 +254,12 @@ pub fn cache_key(source: &str, ticker: &str, currency: &str, date: Option<NaiveD
         Some(d) => d.to_string(),
         None => "latest".to_string(),
     };
-    format!("{source}:{ticker}:{currency}:{date_part}")
+    // The currency segment is uppercased so `-c usd` and `-c USD` share
+    // one cache identity, matching `dedup_key` in price_cmd.rs (see the
+    // paired comment there; round-4 deep review of #1803). The TICKER
+    // stays raw: provider tickers can be case-significant (external
+    // command sources define their own ticker namespace).
+    format!("{source}:{ticker}:{}:{date_part}", currency.to_uppercase())
 }
 
 fn cache_file_path() -> PathBuf {

--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -3,7 +3,7 @@
 //! This module provides a price source that executes an external command
 //! to fetch prices. This allows users to integrate custom price fetchers.
 
-use super::sources::PriceSource;
+use super::sources::{PricePair, PriceSource};
 use super::{PriceRequest, PriceResponse};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
@@ -200,19 +200,34 @@ impl PriceSource for ExternalCommandSource {
         "External command price source"
     }
 
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        self.fetch_price(&PriceRequest {
+            ticker: pair.ticker.clone(),
+            currency: pair.currency.clone(),
+            date: None,
+        })
+    }
+
+    fn historical_coverage(&self) -> super::sources::HistoricalCoverage {
+        // The date is forwarded to the user's command via RLEDGER_DATE;
+        // whatever history the command can serve, this source can.
+        super::sources::HistoricalCoverage::Full
+    }
+
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Deliberately NOT guarded by `reject_historical_date`: the
-        // requested date is forwarded to the external command via
-        // RLEDGER_DATE below, so historical semantics are the external
-        // fetcher's contract, not ours (#1801 review). That contract is
-        // a TRUST contract: output formats that carry no date of their
-        // own (plain number, JSON without a date field) are labeled with
-        // the requested date on the assumption the command honored
-        // RLEDGER_DATE — rledger cannot verify a user-authored command,
-        // so a script that ignores the date and prints its latest quote
-        // WILL be recorded under the requested date. Documented in
-        // docs/commands/price.md; scripts that can't honor RLEDGER_DATE
-        // should emit the dated beancount form instead (round-4 review).
+        // The ONE sanctioned override of the trait's canonical dispatch
+        // (see `PriceSource::fetch_price`): the requested date is
+        // forwarded to the external command via RLEDGER_DATE below, so
+        // historical semantics are the external fetcher's contract, not
+        // ours (#1801 review). That contract is a TRUST contract: output
+        // formats that carry no date of their own (plain number, JSON
+        // without a date field) are labeled with the requested date on
+        // the assumption the command honored RLEDGER_DATE — rledger
+        // cannot verify a user-authored command, so a script that
+        // ignores the date and prints its latest quote WILL be recorded
+        // under the requested date. Documented in docs/commands/price.md;
+        // scripts that can't honor RLEDGER_DATE should emit the dated
+        // beancount form instead (round-4 review).
         if self.command.is_empty() {
             anyhow::bail!("External command is empty");
         }

--- a/crates/rustledger/src/cmd/price/external.rs
+++ b/crates/rustledger/src/cmd/price/external.rs
@@ -201,7 +201,14 @@ impl PriceSource for ExternalCommandSource {
     }
 
     fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
-        self.fetch_price(&PriceRequest {
+        // Delegates to the INHERENT run_command, not the trait's
+        // fetch_price: routing through the trait would be mutual
+        // recursion held together only by this type's fetch_price
+        // override existing — deleting that override in a future
+        // refactor would turn every undated fetch into unbounded
+        // recursion with no compiler warning (round-5 deep review of
+        // #1803).
+        self.run_command(&PriceRequest {
             ticker: pair.ticker.clone(),
             currency: pair.currency.clone(),
             date: None,
@@ -215,6 +222,15 @@ impl PriceSource for ExternalCommandSource {
     }
 
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        self.run_command(request)
+    }
+}
+
+impl ExternalCommandSource {
+    /// Invoke the external command and parse its output — the shared
+    /// core behind both trait methods (see `fetch_latest`'s comment on
+    /// why they must not call each other through the trait).
+    fn run_command(&self, request: &PriceRequest) -> Result<PriceResponse> {
         // The ONE sanctioned override of the trait's canonical dispatch
         // (see `PriceSource::fetch_price`): the requested date is
         // forwarded to the external command via RLEDGER_DATE below, so

--- a/crates/rustledger/src/cmd/price/sources/alphavantage.rs
+++ b/crates/rustledger/src/cmd/price/sources/alphavantage.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches stock, forex, and crypto prices from Alpha Vantage.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use std::env;
@@ -62,12 +62,12 @@ impl AlphaVantageSource {
     }
 
     /// Determine the type of request and fetch accordingly.
-    fn fetch_internal(&self, request: &PriceRequest, api_key: &str) -> Result<PriceResponse> {
-        let ticker = &request.ticker;
+    fn fetch_internal(&self, pair: &PricePair, api_key: &str) -> Result<PriceResponse> {
+        let ticker = &pair.ticker;
 
         // Check for crypto prefix
         if let Some(symbol) = ticker.strip_prefix("CRYPTO:") {
-            return self.fetch_crypto(symbol, &request.currency, api_key);
+            return self.fetch_crypto(symbol, &pair.currency, api_key);
         }
 
         // Check for forex format (contains /)
@@ -79,7 +79,7 @@ impl AlphaVantageSource {
         }
 
         // Default to stock
-        self.fetch_stock(ticker, &request.currency, api_key)
+        self.fetch_stock(ticker, &pair.currency, api_key)
     }
 
     fn fetch_stock(&self, symbol: &str, currency: &str, api_key: &str) -> Result<PriceResponse> {
@@ -206,13 +206,9 @@ impl PriceSource for AlphaVantageSource {
         Some("ALPHAVANTAGE_API_KEY")
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
         let api_key = Self::get_api_key()?;
-        self.fetch_internal(request, &api_key)
+        self.fetch_internal(pair, &api_key)
     }
 }
 

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -125,10 +125,25 @@ impl PriceSource for CoinbaseSource {
     }
 
     fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
+        // Parity with main for a same-day request: the dated endpoint
+        // serves that day's reference price, while --date <today>
+        // historically hit the LIVE spot endpoint — keep it that way
+        // (deep review of #1803).
+        if window.end == jiff::Zoned::now().date() {
+            let response = self.fetch_latest(pair)?;
+            return Ok(vec![PricePoint {
+                date: response.date,
+                price: response.price,
+                currency: Some(response.currency),
+            }]);
+        }
+
         // Crypto trades every day, so the exact-date spot endpoint
-        // answers for any day: a single point at the window's end
+        // answers for any past day: a single point at the window's end
         // satisfies the dispatch's on-or-before selection without
-        // burning one request per day of the window.
+        // burning one request per day of the window. The dispatch
+        // refuses future dates before this can run, so window.end is a
+        // real, completed day.
         let url = self.build_url(&pair.ticker, &pair.currency, Some(window.end));
         let (price, currency) = self.fetch_spot(&url, pair)?;
         Ok(vec![PricePoint {

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -52,8 +52,12 @@ impl CoinbaseSource {
     }
 
     /// Shared fetch + parse for the spot endpoint (dated or not).
-    /// Returns `(price, currency)`.
-    fn fetch_spot(&self, url: &str, pair: &PricePair) -> Result<(Decimal, String)> {
+    /// Returns `(price, currency)` — currency is `None` when the feed
+    /// omits the field, so callers (and the dispatch's canonical
+    /// uppercase fallback) can distinguish feed truth from the raw
+    /// request value (round-5 deep review of #1803: wrapping the raw
+    /// fallback in `Some` shadowed the dispatch's normalization).
+    fn fetch_spot(&self, url: &str, pair: &PricePair) -> Result<(Decimal, Option<String>)> {
         let mut response = ureq::get(url)
             .header("User-Agent", user_agent())
             .call()
@@ -90,8 +94,7 @@ impl CoinbaseSource {
         let currency = data
             .get("currency")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or(&pair.currency)
-            .to_string();
+            .map(ToString::to_string);
 
         Ok((price, currency))
     }
@@ -119,7 +122,7 @@ impl PriceSource for CoinbaseSource {
 
         Ok(PriceResponse {
             price,
-            currency,
+            currency: currency.unwrap_or_else(|| pair.currency.clone()),
             date,
             source: self.name().to_string(),
         })
@@ -152,7 +155,9 @@ impl PriceSource for CoinbaseSource {
         Ok(vec![PricePoint {
             date: window.end,
             price,
-            currency: Some(currency),
+            // None when the feed omits it — the dispatch substitutes
+            // the request currency, uppercased.
+            currency,
         }])
     }
 }

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -132,13 +132,10 @@ impl PriceSource for CoinbaseSource {
     }
 
     fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
-        // Parity with main for a same-day request: --date <today>
-        // historically hit the LIVE spot endpoint — the canonical
-        // delegation keeps it that way (round-2 review of #1803).
-        if let Some(result) = super::same_day_latest_point(self, pair, window) {
-            return result;
-        }
-
+        // The dispatch routes requested==today to fetch_latest before
+        // the window path, so window.end here is always a COMPLETED
+        // day (round-3 review of #1803 removed the per-source same-day
+        // delegations along with the straddle).
         // Crypto trades every day, so the exact-date spot endpoint
         // answers for any past day: a single point at the window's end
         // satisfies the dispatch's on-or-before selection without

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -121,21 +121,22 @@ impl PriceSource for CoinbaseSource {
     }
 
     fn historical_coverage(&self) -> HistoricalCoverage {
-        HistoricalCoverage::Full
+        // Coinbase the exchange launched in January 2015; earlier dated
+        // requests get the clean capability refusal instead of a raw
+        // provider error (round-2 review of #1803). Per-pair listing
+        // dates vary — later-listed pairs still surface provider errors
+        // for their pre-listing gap.
+        HistoricalCoverage::Since(
+            rustledger_core::naive_date(2015, 1, 1).expect("static date is valid"),
+        )
     }
 
     fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
-        // Parity with main for a same-day request: the dated endpoint
-        // serves that day's reference price, while --date <today>
-        // historically hit the LIVE spot endpoint — keep it that way
-        // (deep review of #1803).
-        if window.end == jiff::Zoned::now().date() {
-            let response = self.fetch_latest(pair)?;
-            return Ok(vec![PricePoint {
-                date: response.date,
-                price: response.price,
-                currency: Some(response.currency),
-            }]);
+        // Parity with main for a same-day request: --date <today>
+        // historically hit the LIVE spot endpoint — the canonical
+        // delegation keeps it that way (round-2 review of #1803).
+        if let Some(result) = super::same_day_latest_point(self, pair, window) {
+            return result;
         }
 
         // Crypto trades every day, so the exact-date spot endpoint

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches cryptocurrency prices from Coinbase.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{DateWindow, HistoricalCoverage, PricePair, PricePoint, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use std::str::FromStr;
@@ -30,8 +30,14 @@ impl CoinbaseSource {
         Self {}
     }
 
-    /// Build the Coinbase API URL.
-    fn build_url(&self, ticker: &str, currency: &str) -> String {
+    /// Build the Coinbase API URL. A date adds `?date=YYYY-MM-DD`,
+    /// which the spot endpoint answers with that day's price.
+    fn build_url(
+        &self,
+        ticker: &str,
+        currency: &str,
+        date: Option<rustledger_core::NaiveDate>,
+    ) -> String {
         // If the ticker already contains a dash, use it directly
         // Otherwise, append the currency
         let pair = if ticker.contains('-') {
@@ -39,35 +45,24 @@ impl CoinbaseSource {
         } else {
             format!("{ticker}-{currency}")
         };
-        format!("https://api.coinbase.com/v2/prices/{pair}/spot")
-    }
-}
-
-impl PriceSource for CoinbaseSource {
-    fn name(&self) -> &'static str {
-        "coinbase"
+        match date {
+            Some(d) => format!("https://api.coinbase.com/v2/prices/{pair}/spot?date={d}"),
+            None => format!("https://api.coinbase.com/v2/prices/{pair}/spot"),
+        }
     }
 
-    fn description(&self) -> &'static str {
-        "Coinbase - cryptocurrency spot prices"
-    }
-
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
-        let url = self.build_url(&request.ticker, &request.currency);
-
-        let mut response = ureq::get(&url)
+    /// Shared fetch + parse for the spot endpoint (dated or not).
+    /// Returns `(price, currency)`.
+    fn fetch_spot(&self, url: &str, pair: &PricePair) -> Result<(Decimal, String)> {
+        let mut response = ureq::get(url)
             .header("User-Agent", user_agent())
             .call()
-            .with_context(|| format!("Failed to fetch price for {}", request.ticker))?;
+            .with_context(|| format!("Failed to fetch price for {}", pair.ticker))?;
 
         let json: serde_json::Value = response
             .body_mut()
             .read_json()
-            .with_context(|| format!("Failed to parse response for {}", request.ticker))?;
+            .with_context(|| format!("Failed to parse response for {}", pair.ticker))?;
 
         // Check for errors
         if let Some(errors) = json.get("errors")
@@ -95,17 +90,52 @@ impl PriceSource for CoinbaseSource {
         let currency = data
             .get("currency")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or(&request.currency)
+            .unwrap_or(&pair.currency)
             .to_string();
 
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
+        Ok((price, currency))
+    }
+}
+
+impl PriceSource for CoinbaseSource {
+    fn name(&self) -> &'static str {
+        "coinbase"
+    }
+
+    fn description(&self) -> &'static str {
+        "Coinbase - cryptocurrency spot prices"
+    }
+
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let url = self.build_url(&pair.ticker, &pair.currency, None);
+        let (price, currency) = self.fetch_spot(&url, pair)?;
 
         Ok(PriceResponse {
             price,
             currency,
-            date,
+            // The spot endpoint carries no date field; a dateless spot
+            // quote is a live quote for today.
+            date: jiff::Zoned::now().date(),
             source: self.name().to_string(),
         })
+    }
+
+    fn historical_coverage(&self) -> HistoricalCoverage {
+        HistoricalCoverage::Full
+    }
+
+    fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
+        // Crypto trades every day, so the exact-date spot endpoint
+        // answers for any day: a single point at the window's end
+        // satisfies the dispatch's on-or-before selection without
+        // burning one request per day of the window.
+        let url = self.build_url(&pair.ticker, &pair.currency, Some(window.end));
+        let (price, currency) = self.fetch_spot(&url, pair)?;
+        Ok(vec![PricePoint {
+            date: window.end,
+            price,
+            currency: Some(currency),
+        }])
     }
 }
 
@@ -117,11 +147,19 @@ mod tests {
     fn test_build_url() {
         let source = CoinbaseSource::new(Duration::from_secs(30));
 
-        let url = source.build_url("BTC", "USD");
+        let url = source.build_url("BTC", "USD", None);
         assert_eq!(url, "https://api.coinbase.com/v2/prices/BTC-USD/spot");
 
-        let url = source.build_url("BTC-EUR", "USD");
+        let url = source.build_url("BTC-EUR", "USD", None);
         assert_eq!(url, "https://api.coinbase.com/v2/prices/BTC-EUR/spot");
+
+        // Historical (#1802): the spot endpoint takes an exact date.
+        let d = rustledger_core::naive_date(2024, 1, 15).unwrap();
+        let url = source.build_url("BTC", "USD", Some(d));
+        assert_eq!(
+            url,
+            "https://api.coinbase.com/v2/prices/BTC-USD/spot?date=2024-01-15"
+        );
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/price/sources/coinbase.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinbase.rs
@@ -107,15 +107,20 @@ impl PriceSource for CoinbaseSource {
     }
 
     fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        // Label read BEFORE the network fetch: the spot endpoint
+        // carries no date field, and a live quote must carry the day
+        // the request was made — not a day the clock rolled to during
+        // network I/O (round-4 deep review of #1803: the post-fetch
+        // read could poison the settled cache with a D+1-labeled
+        // entry under a D key).
+        let date = jiff::Zoned::now().date();
         let url = self.build_url(&pair.ticker, &pair.currency, None);
         let (price, currency) = self.fetch_spot(&url, pair)?;
 
         Ok(PriceResponse {
             price,
             currency,
-            // The spot endpoint carries no date field; a dateless spot
-            // quote is a live quote for today.
-            date: jiff::Zoned::now().date(),
+            date,
             source: self.name().to_string(),
         })
     }

--- a/crates/rustledger/src/cmd/price/sources/coincap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coincap.rs
@@ -72,6 +72,11 @@ impl PriceSource for CoinCapSource {
     }
 
     fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        // Label read BEFORE the network fetch: a quote labeled with the
+        // local day must carry the day the request was made, not a day
+        // the clock rolled to during network I/O (round-4 deep review
+        // of #1803 — the post-fetch read could poison the settled cache
+        // with a D+1-labeled entry under a D key).
         let url = self.build_url(&pair.ticker);
 
         let mut response = ureq::get(&url)

--- a/crates/rustledger/src/cmd/price/sources/coincap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coincap.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches cryptocurrency prices from `CoinCap`.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use std::str::FromStr;
@@ -71,22 +71,18 @@ impl PriceSource for CoinCapSource {
         "CoinCap - cryptocurrency prices"
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
-        let url = self.build_url(&request.ticker);
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let url = self.build_url(&pair.ticker);
 
         let mut response = ureq::get(&url)
             .header("User-Agent", user_agent())
             .call()
-            .with_context(|| format!("Failed to fetch price for {}", request.ticker))?;
+            .with_context(|| format!("Failed to fetch price for {}", pair.ticker))?;
 
         let json: serde_json::Value = response
             .body_mut()
             .read_json()
-            .with_context(|| format!("Failed to parse response for {}", request.ticker))?;
+            .with_context(|| format!("Failed to parse response for {}", pair.ticker))?;
 
         // Check for errors
         if let Some(error) = json.get("error") {
@@ -106,7 +102,7 @@ impl PriceSource for CoinCapSource {
         let price = Decimal::from_str(price_str)
             .with_context(|| format!("Failed to parse price: {price_str}"))?;
 
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
+        let date = jiff::Zoned::now().date();
 
         // CoinCap only provides USD prices
         Ok(PriceResponse {

--- a/crates/rustledger/src/cmd/price/sources/coincap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coincap.rs
@@ -76,7 +76,9 @@ impl PriceSource for CoinCapSource {
         // local day must carry the day the request was made, not a day
         // the clock rolled to during network I/O (round-4 deep review
         // of #1803 — the post-fetch read could poison the settled cache
-        // with a D+1-labeled entry under a D key).
+        // with a D+1-labeled entry under a D key; round-5 review: the
+        // round-4 edit had moved only this comment, not the read).
+        let date = jiff::Zoned::now().date();
         let url = self.build_url(&pair.ticker);
 
         let mut response = ureq::get(&url)
@@ -106,8 +108,6 @@ impl PriceSource for CoinCapSource {
 
         let price = Decimal::from_str(price_str)
             .with_context(|| format!("Failed to parse price: {price_str}"))?;
-
-        let date = jiff::Zoned::now().date();
 
         // CoinCap only provides USD prices
         Ok(PriceResponse {

--- a/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
@@ -64,6 +64,11 @@ impl PriceSource for CoinMarketCapSource {
     }
 
     fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        // Label read BEFORE the network fetch: a quote labeled with the
+        // local day must carry the day the request was made, not a day
+        // the clock rolled to during network I/O (round-4 deep review
+        // of #1803 — the post-fetch read could poison the settled cache
+        // with a D+1-labeled entry under a D key).
         let api_key = Self::get_api_key()?;
         let url = self.build_url(&pair.ticker, &pair.currency);
 

--- a/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches cryptocurrency prices from `CoinMarketCap`.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use std::env;
 use std::time::Duration;
@@ -63,20 +63,16 @@ impl PriceSource for CoinMarketCapSource {
         Some("CMC_API_KEY")
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
         let api_key = Self::get_api_key()?;
-        let url = self.build_url(&request.ticker, &request.currency);
+        let url = self.build_url(&pair.ticker, &pair.currency);
 
         let mut response = ureq::get(&url)
             .header("User-Agent", user_agent())
             .header("X-CMC_PRO_API_KEY", &api_key)
             .header("Accept", "application/json")
             .call()
-            .with_context(|| format!("Failed to fetch price for {}", request.ticker))?;
+            .with_context(|| format!("Failed to fetch price for {}", pair.ticker))?;
 
         let json: serde_json::Value = response
             .body_mut()
@@ -103,7 +99,7 @@ impl PriceSource for CoinMarketCapSource {
             .and_then(serde_json::Value::as_object)
             .with_context(|| "Missing data in response")?;
 
-        let symbol_upper = request.ticker.to_uppercase();
+        let symbol_upper = pair.ticker.to_uppercase();
         let coin_data = data
             .get(&symbol_upper)
             .with_context(|| format!("No data for symbol: {symbol_upper}"))?;
@@ -113,7 +109,7 @@ impl PriceSource for CoinMarketCapSource {
             .and_then(serde_json::Value::as_object)
             .with_context(|| "Missing quote data")?;
 
-        let currency_upper = request.currency.to_uppercase();
+        let currency_upper = pair.currency.to_uppercase();
         let currency_quote = quote
             .get(&currency_upper)
             .with_context(|| format!("No quote for currency: {currency_upper}"))?;
@@ -125,11 +121,11 @@ impl PriceSource for CoinMarketCapSource {
         let price = crate::cmd::price::price_decimal_from_json(price_value)
             .with_context(|| format!("Invalid price format: {price_value}"))?;
 
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
+        let date = jiff::Zoned::now().date();
 
         Ok(PriceResponse {
             price,
-            currency: request.currency.to_uppercase(),
+            currency: pair.currency.to_uppercase(),
             date,
             source: self.name().to_string(),
         })

--- a/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
+++ b/crates/rustledger/src/cmd/price/sources/coinmarketcap.rs
@@ -68,7 +68,9 @@ impl PriceSource for CoinMarketCapSource {
         // local day must carry the day the request was made, not a day
         // the clock rolled to during network I/O (round-4 deep review
         // of #1803 — the post-fetch read could poison the settled cache
-        // with a D+1-labeled entry under a D key).
+        // with a D+1-labeled entry under a D key; round-5 review: the
+        // round-4 edit had moved only this comment, not the read).
+        let date = jiff::Zoned::now().date();
         let api_key = Self::get_api_key()?;
         let url = self.build_url(&pair.ticker, &pair.currency);
 
@@ -125,8 +127,6 @@ impl PriceSource for CoinMarketCapSource {
 
         let price = crate::cmd::price::price_decimal_from_json(price_value)
             .with_context(|| format!("Invalid price format: {price_value}"))?;
-
-        let date = jiff::Zoned::now().date();
 
         Ok(PriceResponse {
             price,

--- a/crates/rustledger/src/cmd/price/sources/eastmoneyfund.rs
+++ b/crates/rustledger/src/cmd/price/sources/eastmoneyfund.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches Chinese mutual fund prices from East Money (天天基金).
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use std::str::FromStr;
@@ -62,18 +62,14 @@ impl PriceSource for EastMoneyFundSource {
         "East Money Fund - Chinese mutual fund NAVs (天天基金)"
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
-        let url = self.build_url(&request.ticker);
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let url = self.build_url(&pair.ticker);
 
         let mut response = ureq::get(&url)
             .header("User-Agent", user_agent())
             .header("Referer", "https://fund.eastmoney.com/")
             .call()
-            .with_context(|| format!("Failed to fetch fund {}", request.ticker))?;
+            .with_context(|| format!("Failed to fetch fund {}", pair.ticker))?;
 
         let body = response
             .body_mut()

--- a/crates/rustledger/src/cmd/price/sources/ecb.rs
+++ b/crates/rustledger/src/cmd/price/sources/ecb.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches currency exchange rates from the ECB.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use rustledger_core::NaiveDate;
@@ -123,33 +123,17 @@ impl PriceSource for EcbSource {
         "European Central Bank - currency exchange rates"
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        let ticker = request.ticker.to_uppercase();
-        let currency = request.currency.to_uppercase();
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let ticker = pair.ticker.to_uppercase();
+        let currency = pair.currency.to_uppercase();
 
         // ECB provides rates as "X per 1 EUR"
-        // We need to handle three cases:
+        // We need to handle three cases (identity pairs and dated
+        // requests never reach here — the trait's canonical dispatch
+        // handles both, #1802):
         // 1. ticker=EUR, currency=X: fetch X rate, return as-is (X per EUR)
         // 2. ticker=X, currency=EUR: fetch X rate, invert it (EUR per X)
         // 3. ticker=X, currency=Y: fetch both, compute cross-rate (Y per X)
-
-        // Identity rate: 1.0 is correct for ANY pair and any PAST date
-        // (the pre-#1801 cross-rate path answered USD/USD = rate/rate
-        // = 1 for dated requests too), so this branch deliberately sits
-        // ABOVE the latest-only guard — same shape as ratesapi. Future
-        // labels are refused by identity_label_date (round-4 review).
-        if ticker == currency {
-            return Ok(PriceResponse {
-                price: Decimal::ONE,
-                currency,
-                date: super::identity_label_date(self.name(), request)?,
-                source: self.name().to_string(),
-            });
-        }
-
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
 
         if ticker == "EUR" {
             // EUR -> X: fetch X rate (X per EUR), return as-is
@@ -259,7 +243,9 @@ mod tests {
 
     #[test]
     fn test_eur_to_eur_returns_one() {
-        // EUR to EUR should always return 1.0 without network access
+        // EUR to EUR should always return 1.0 without network access —
+        // served by the trait's canonical identity arm (#1802).
+        use crate::cmd::price::PriceRequest;
         let source = EcbSource::new(Duration::from_secs(30));
         let request = PriceRequest::new("EUR", "EUR");
         let response = source.fetch_price(&request).unwrap();
@@ -269,10 +255,11 @@ mod tests {
 
     /// Any identity pair — not just EUR/EUR — answers 1.0 for any
     /// requested date without network access. The pre-#1801 cross-rate
-    /// path gave dated USD/USD = 1 too; the latest-only guard must not
-    /// remove that (round-2 deep review).
+    /// path gave dated USD/USD = 1 too; the dispatch must keep that
+    /// (round-2 deep review, hoisted into the trait in #1802).
     #[test]
     fn dated_non_eur_identity_returns_one() {
+        use crate::cmd::price::PriceRequest;
         let source = EcbSource::new(Duration::from_secs(30));
         let date = rustledger_core::naive_date(2024, 6, 30).unwrap();
         let mut request = PriceRequest::new("USD", "USD");

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -311,9 +311,15 @@ pub trait PriceSource: Send + Sync {
             currency: request.currency.clone(),
         };
 
-        // 2. Undated → latest.
+        // 2. Undated → latest. The response currency is uppercased on
+        // the way out, like every other arm: feeds return uppercase,
+        // but sources that echo the raw request currency would let a
+        // lowercase `-c` value flow into an unparsable directive
+        // (round-5 deep review of #1803).
         let Some(requested) = request.date else {
-            return self.fetch_latest(&pair);
+            let mut response = self.fetch_latest(&pair)?;
+            response.currency = response.currency.to_uppercase();
+            return Ok(response);
         };
 
         let today = jiff::Zoned::now().date();
@@ -348,7 +354,9 @@ pub trait PriceSource: Send + Sync {
         // sources refuse the completed day honestly, and their refusal
         // names the alternative.
         if requested == today {
-            return self.fetch_latest(&pair);
+            let mut response = self.fetch_latest(&pair)?;
+            response.currency = response.currency.to_uppercase();
+            return Ok(response);
         }
 
         // 5. Covered past date → window + canonical selection.

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -182,9 +182,23 @@ fn identity_label_date(
 /// the local-clock label while the stock path was fixed), so the
 /// parsing lives here and the sources pass in the raw field.
 pub(super) fn feed_date_or_today(raw: Option<&str>) -> rustledger_core::NaiveDate {
+    feed_date_or(raw, jiff::Zoned::now().date())
+}
+
+/// [`feed_date_or_today`] with an explicit fallback.
+///
+/// A LATEST fetch falls back to today; a DATED fetch must fall back to
+/// the requested/window date instead — falling back to today there
+/// labels a historical rate with the fetch day, which the dispatch's
+/// on-or-before selection then discards, turning a served rate into a
+/// spurious "no quote" error (deep review of #1803).
+pub(super) fn feed_date_or(
+    raw: Option<&str>,
+    fallback: rustledger_core::NaiveDate,
+) -> rustledger_core::NaiveDate {
     raw.and_then(|s| s.get(..10))
         .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
-        .unwrap_or_else(|| jiff::Zoned::now().date())
+        .unwrap_or(fallback)
 }
 
 /// Trait for price data sources.
@@ -303,11 +317,13 @@ pub trait PriceSource: Send + Sync {
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
         // 1. Identity: X priced in X is 1.0 on any past-or-today date,
         // source-independent (hoisted out of per-source branches by the
-        // #1801 reviews; future labels refuse).
+        // #1801 reviews; future labels refuse). The currency is
+        // uppercased — beancount commodities are uppercase, and main's
+        // ecb identity branch normalized (deep review of #1803).
         if request.ticker.eq_ignore_ascii_case(&request.currency) {
             return Ok(PriceResponse {
                 price: Decimal::ONE,
-                currency: request.currency.clone(),
+                currency: request.currency.to_uppercase(),
                 date: identity_label_date(self.name(), request)?,
                 source: self.name().to_string(),
             });
@@ -323,15 +339,50 @@ pub trait PriceSource: Send + Sync {
             return self.fetch_latest(&pair);
         };
 
+        // The midnight-straddle latch initializes on the FIRST dated
+        // fetch of ANY kind — covered sources included — so a batch
+        // whose pre-midnight fetches all hit window-capable sources
+        // still latches its start day for the uncovered sources it
+        // reaches after midnight (deep review of #1803; the latch
+        // previously sat inside the uncovered arm only).
+        let today = jiff::Zoned::now().date();
+        let first_fetch_day = *FIRST_FETCH_DAY.get_or_init(|| today);
+
+        // A price for a day that hasn't happened cannot exist: refuse
+        // FUTURE dates on every source, before any coverage routing.
+        // Without this, Full/Since coverage "covers" the future and the
+        // dated provider endpoints get asked for it — a provider that
+        // answers or clamps would have its response labeled with the
+        // fabricated future date (#1794 class; deep review of #1803).
+        // The straddle window is not future: it only ever looks back.
+        if requested > today {
+            anyhow::bail!(
+                "the '{}' source cannot fetch {} for the future date {requested}; \
+                 prices for days that have not happened do not exist",
+                self.name(),
+                request.ticker
+            );
+        }
+
         // 3. Covered date → window + canonical selection. Today is
         // routed here too for window-capable sources (a same-day
         // request returns the freshest daily bar — yahoo's
-        // pre-existing behavior).
+        // pre-existing behavior; coinbase/ratesapi delegate the
+        // end==today case to their latest endpoints internally for
+        // parity with main).
         let coverage = self.historical_coverage();
         if coverage.covers(requested) {
-            let start = requested
+            let mut start = requested
                 .checked_sub(jiff::Span::new().days(HISTORICAL_LOOKBACK_DAYS))
                 .context("date underflow")?;
+            // Never ask a source for days before its declared epoch —
+            // the DateWindow contract requires consistency with
+            // historical_coverage (deep review of #1803).
+            if let HistoricalCoverage::Since(epoch) = coverage
+                && start < epoch
+            {
+                start = epoch;
+            }
             let window = DateWindow {
                 start,
                 end: requested,
@@ -354,12 +405,22 @@ pub trait PriceSource: Send + Sync {
         }
 
         // 4. Uncovered date, but it is today (or a midnight straddle):
-        // the latest quote IS a valid answer for today, and the
-        // response carries the quote's own date anyway (#1801).
-        let today = jiff::Zoned::now().date();
-        let first_fetch_day = *FIRST_FETCH_DAY.get_or_init(|| today);
+        // the latest quote IS a valid answer for today (#1801). A
+        // response the source labeled AFTER the requested day — the
+        // straddle minute, where a local-clock label has already
+        // rolled to the new day — is clamped back to the requested
+        // day, matching main's request-date labeling for the accepted
+        // window without giving sources date access (deep review of
+        // #1803: a 00:01 straddle fetch was labeled the NEW day,
+        // shifting the archive entry and colliding with the next
+        // night's run). Feed-supplied dates on or before the request
+        // (ECB's Friday on a weekend) pass through untouched.
         if latest_date_window_ok(requested, today, first_fetch_day) {
-            return self.fetch_latest(&pair);
+            let mut response = self.fetch_latest(&pair)?;
+            if response.date > requested {
+                response.date = requested;
+            }
+            return Ok(response);
         }
 
         // 5. Refuse: mislabeling the latest quote with this date is the
@@ -607,6 +668,117 @@ mod dispatch_tests {
         assert!(err.to_string().contains("future"), "{err}");
     }
 
+    /// A future date refuses on EVERY source — including window-capable
+    /// ones, whose coverage would otherwise "cover" it and forward the
+    /// fabricated date to the provider's dated endpoint (deep review of
+    /// #1803; #1794 class).
+    #[test]
+    fn future_dates_refuse_even_on_covered_sources() {
+        struct PanicWindow;
+        impl PriceSource for PanicWindow {
+            fn name(&self) -> &'static str {
+                "mock-covered"
+            }
+            fn description(&self) -> &'static str {
+                "full coverage, panics on any fetch"
+            }
+            fn fetch_latest(&self, _p: &PricePair) -> Result<PriceResponse> {
+                panic!("future date must refuse before any fetch");
+            }
+            fn historical_coverage(&self) -> HistoricalCoverage {
+                HistoricalCoverage::Full
+            }
+            fn fetch_window(&self, _p: &PricePair, _w: DateWindow) -> Result<Vec<PricePoint>> {
+                panic!("future date must refuse before any fetch");
+            }
+        }
+        let future = jiff::Zoned::now()
+            .date()
+            .checked_add(jiff::Span::new().days(7))
+            .unwrap();
+        let err = PanicWindow
+            .fetch_price(&request(Some(future)))
+            .expect_err("refuse");
+        assert!(err.to_string().contains("future"), "{err}");
+    }
+
+    /// The straddle-minute clamp: a latest response the source labeled
+    /// AFTER the requested day is clamped back to the requested day —
+    /// a 00:01 fetch in a batch that started before midnight must not
+    /// shift the archive entry onto the new day (deep review of #1803).
+    /// Feed dates on or before the request pass through untouched
+    /// (asserted by `latest_only_refuses_past_and_future_but_serves_today`).
+    #[test]
+    fn straddle_accepted_latest_is_clamped_to_requested_day() {
+        struct LabelsTomorrow;
+        impl PriceSource for LabelsTomorrow {
+            fn name(&self) -> &'static str {
+                "mock-tomorrow"
+            }
+            fn description(&self) -> &'static str {
+                "labels its quote with the next civil day"
+            }
+            fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+                Ok(PriceResponse {
+                    price: Decimal::new(100, 2),
+                    currency: pair.currency.clone(),
+                    date: jiff::Zoned::now()
+                        .date()
+                        .checked_add(jiff::Span::new().days(1))
+                        .unwrap(),
+                    source: self.name().to_string(),
+                })
+            }
+        }
+        let today = jiff::Zoned::now().date();
+        let response = LabelsTomorrow
+            .fetch_price(&request(Some(today)))
+            .expect("today is accepted");
+        assert_eq!(
+            response.date, today,
+            "a label after the requested day is clamped to it"
+        );
+    }
+
+    /// The window handed to a Since source never starts before its
+    /// declared epoch — the dispatch clamps the look-back (deep review
+    /// of #1803: the `DateWindow` contract requires consistency with
+    /// `historical_coverage`).
+    #[test]
+    fn since_window_start_is_clamped_to_epoch() {
+        use std::sync::Mutex;
+        struct CapturesWindow(Mutex<Option<DateWindow>>);
+        impl PriceSource for CapturesWindow {
+            fn name(&self) -> &'static str {
+                "mock-capture"
+            }
+            fn description(&self) -> &'static str {
+                "records the window it is asked for"
+            }
+            fn fetch_latest(&self, _p: &PricePair) -> Result<PriceResponse> {
+                panic!("covered date must use the window path");
+            }
+            fn historical_coverage(&self) -> HistoricalCoverage {
+                HistoricalCoverage::Since(rustledger_core::naive_date(2020, 1, 6).unwrap())
+            }
+            fn fetch_window(&self, _p: &PricePair, w: DateWindow) -> Result<Vec<PricePoint>> {
+                *self.0.lock().unwrap() = Some(w);
+                Ok(vec![PricePoint {
+                    date: w.end,
+                    price: Decimal::ONE,
+                    currency: None,
+                }])
+            }
+        }
+        let src = CapturesWindow(Mutex::new(None));
+        let epoch = rustledger_core::naive_date(2020, 1, 6).unwrap();
+        let requested = epoch.checked_add(jiff::Span::new().days(1)).unwrap();
+        src.fetch_price(&request(Some(requested))).expect("fetch");
+        let window = src.0.lock().unwrap().expect("window captured");
+        assert_eq!(window.start, epoch, "look-back clamped to the epoch");
+        assert_eq!(window.end, requested);
+    }
+
     /// The selection helper itself: greatest date <= requested, order
     /// independent, currency carried through.
     #[test]
@@ -687,6 +859,21 @@ mod feed_date_tests {
         assert_eq!(feed_date_or_today(Some("2024-01-15")), expected);
         // Alpha Vantage "6. Last Refreshed" shape.
         assert_eq!(feed_date_or_today(Some("2024-01-15 10:30:00")), expected);
+    }
+
+    /// An explicit fallback is honored — a DATED fetch must fall back
+    /// to the requested day, not today (deep review of #1803: a
+    /// today-fallback on a historical response gets discarded by the
+    /// on-or-before selection).
+    #[test]
+    fn explicit_fallback_is_used_for_missing_fields() {
+        let fallback = rustledger_core::naive_date(2015, 8, 14).unwrap();
+        assert_eq!(super::feed_date_or(None, fallback), fallback);
+        assert_eq!(super::feed_date_or(Some("garbage"), fallback), fallback);
+        assert_eq!(
+            super::feed_date_or(Some("2015-08-14 16:00:00"), fallback),
+            fallback
+        );
     }
 
     /// Absent, short, or malformed fields fall back to today instead of

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -117,31 +117,62 @@ fn select_on_or_before(points: Vec<PricePoint>, requested: NaiveDate) -> Option<
         .max_by_key(|p| p.date)
 }
 
-/// The civil day of this process's FIRST guarded fetch.
+/// The civil day and instant of this process's FIRST dated fetch —
+/// identity and covered fetches included (round-2 review of #1803: an
+/// all-identity or all-covered pre-midnight prefix must still latch for
+/// the uncovered sources the batch reaches after midnight).
 ///
 /// Used only to widen the guard by one day across a midnight straddle —
 /// see [`latest_date_window_ok`]. It deliberately does NOT replace the
-/// live clock (round-4 deep review: an unconditional process-wide latch
-/// froze "today" forever for long-lived library embedders, refusing
-/// every fetch after the first midnight).
-static FIRST_FETCH_DAY: std::sync::OnceLock<rustledger_core::NaiveDate> =
+/// live clock (#1801 round-4 review: an unconditional process-wide
+/// latch froze "today" forever for long-lived library embedders).
+static FIRST_DATED_FETCH: std::sync::OnceLock<(rustledger_core::NaiveDate, jiff::Timestamp)> =
     std::sync::OnceLock::new();
 
+/// How long after its first dated fetch a run keeps the midnight
+/// straddle open. A batch that crosses midnight finishes within
+/// minutes; six hours is generous slack — while a long-lived embedder
+/// that latched yesterday must NOT have yesterday's date re-accepted a
+/// day later (round-2 review of #1803: the day-granular latch let a
+/// day-old covered fetch unlock live quotes recorded under the old
+/// date).
+const STRADDLE_MAX_SECS: i64 = 6 * 3600;
+
 /// Pure decision for the latest-only guard: `date` is fetchable when it
-/// IS `today`, or when the run started on `date` and midnight has since
-/// passed (`date` is yesterday AND equals the first-fetch day). The
-/// second arm keeps a `--date $(date +%F)` batch working to its end
-/// when it straddles midnight (round-3 review), without letting a
-/// long-lived embedder replay its start day weeks later — the window
-/// never widens past one day (round-4 review).
+/// IS `today`, or during a midnight straddle — `date` is yesterday AND
+/// the run's first dated fetch happened on it AND that first fetch was
+/// recent ([`STRADDLE_MAX_SECS`]). The straddle keeps a
+/// `--date $(date +%F)` batch working to its end across midnight
+/// without letting a long-lived embedder replay its latch day later.
 fn latest_date_window_ok(
     date: rustledger_core::NaiveDate,
     today: rustledger_core::NaiveDate,
     first_fetch_day: rustledger_core::NaiveDate,
+    secs_since_first_fetch: i64,
 ) -> bool {
     date == today
         || (date == first_fetch_day
-            && today.checked_sub(jiff::Span::new().days(1)).ok() == Some(date))
+            && today.checked_sub(jiff::Span::new().days(1)).ok() == Some(date)
+            && secs_since_first_fetch <= STRADDLE_MAX_SECS)
+}
+
+/// The straddle-minute label clamp, pure for testability: a latest
+/// response labeled with the CURRENT local day while the request was
+/// for an earlier (straddle-accepted) day keeps the requested day —
+/// the local clock rolled mid-batch, not the feed. A feed label ahead
+/// of the LOCAL clock (eastmoneyfund's China civil day from a US
+/// evening) is genuine feed information and passes through untouched
+/// (round-2 review of #1803: the unconditional clamp rewrote those).
+fn clamp_local_label(
+    response_date: rustledger_core::NaiveDate,
+    requested: rustledger_core::NaiveDate,
+    today: rustledger_core::NaiveDate,
+) -> rustledger_core::NaiveDate {
+    if response_date > requested && response_date == today {
+        requested
+    } else {
+        response_date
+    }
 }
 
 /// Date label for a date-independent identity answer (X→X = 1.0).
@@ -199,6 +230,34 @@ pub(super) fn feed_date_or(
     raw.and_then(|s| s.get(..10))
         .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
         .unwrap_or(fallback)
+}
+
+/// Canonical same-day delegation for single-point window providers:
+/// when the window ends TODAY, answer from the latest endpoint instead
+/// of the dated one (parity with main's `--date <today>` behavior),
+/// returned as a window point. `None` means "not a same-day window —
+/// take the dated path".
+///
+/// The point's date is clamped to `window.end` so a midnight race
+/// between the dispatch's clock and this one cannot label the point
+/// after the requested day and get it discarded by the on-or-before
+/// selection as a spurious "no quote" error (round-2 review of #1803;
+/// the two per-source copies of this delegation had already drifted).
+pub(super) fn same_day_latest_point<S: PriceSource + ?Sized>(
+    source: &S,
+    pair: &PricePair,
+    window: DateWindow,
+) -> Option<Result<Vec<PricePoint>>> {
+    if window.end != jiff::Zoned::now().date() {
+        return None;
+    }
+    Some(source.fetch_latest(pair).map(|response| {
+        vec![PricePoint {
+            date: response.date.min(window.end),
+            price: response.price,
+            currency: Some(response.currency),
+        }]
+    }))
 }
 
 /// Trait for price data sources.
@@ -315,6 +374,17 @@ pub trait PriceSource: Send + Sync {
     /// requests the source cannot serve; "no quote on or before" when
     /// the fetched window is empty.
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // The midnight-straddle latch initializes on the FIRST dated
+        // fetch of ANY kind — identity and covered fetches included —
+        // so a batch whose pre-midnight fetches are all identities or
+        // window-capable sources still latches its start day for the
+        // uncovered sources it reaches after midnight (round-1 and
+        // round-2 reviews of #1803 each caught a narrower latch).
+        if request.date.is_some() {
+            let _ = FIRST_DATED_FETCH
+                .get_or_init(|| (jiff::Zoned::now().date(), jiff::Timestamp::now()));
+        }
+
         // 1. Identity: X priced in X is 1.0 on any past-or-today date,
         // source-independent (hoisted out of per-source branches by the
         // #1801 reviews; future labels refuse). The currency is
@@ -339,14 +409,9 @@ pub trait PriceSource: Send + Sync {
             return self.fetch_latest(&pair);
         };
 
-        // The midnight-straddle latch initializes on the FIRST dated
-        // fetch of ANY kind — covered sources included — so a batch
-        // whose pre-midnight fetches all hit window-capable sources
-        // still latches its start day for the uncovered sources it
-        // reaches after midnight (deep review of #1803; the latch
-        // previously sat inside the uncovered arm only).
         let today = jiff::Zoned::now().date();
-        let first_fetch_day = *FIRST_FETCH_DAY.get_or_init(|| today);
+        let (first_fetch_day, first_fetch_at) =
+            *FIRST_DATED_FETCH.get_or_init(|| (today, jiff::Timestamp::now()));
 
         // A price for a day that hasn't happened cannot exist: refuse
         // FUTURE dates on every source, before any coverage routing.
@@ -406,20 +471,18 @@ pub trait PriceSource: Send + Sync {
 
         // 4. Uncovered date, but it is today (or a midnight straddle):
         // the latest quote IS a valid answer for today (#1801). A
-        // response the source labeled AFTER the requested day — the
-        // straddle minute, where a local-clock label has already
-        // rolled to the new day — is clamped back to the requested
-        // day, matching main's request-date labeling for the accepted
-        // window without giving sources date access (deep review of
-        // #1803: a 00:01 straddle fetch was labeled the NEW day,
-        // shifting the archive entry and colliding with the next
-        // night's run). Feed-supplied dates on or before the request
-        // (ECB's Friday on a weekend) pass through untouched.
-        if latest_date_window_ok(requested, today, first_fetch_day) {
+        // response the source labeled with the CURRENT local day while
+        // the request was for the straddle's earlier day is clamped
+        // back — the local clock rolled mid-batch, not the feed.
+        // Genuine feed labels — ECB's Friday on a weekend, or a feed
+        // already on the NEXT civil day (eastmoneyfund's China dates
+        // from a US evening) — pass through untouched (round-2 review
+        // of #1803: the unconditional clamp rewrote those).
+        let secs_since_first_fetch =
+            jiff::Timestamp::now().as_second() - first_fetch_at.as_second();
+        if latest_date_window_ok(requested, today, first_fetch_day, secs_since_first_fetch) {
             let mut response = self.fetch_latest(&pair)?;
-            if response.date > requested {
-                response.date = requested;
-            }
+            response.date = clamp_local_label(response.date, requested, today);
             return Ok(response);
         }
 
@@ -702,14 +765,14 @@ mod dispatch_tests {
         assert!(err.to_string().contains("future"), "{err}");
     }
 
-    /// The straddle-minute clamp: a latest response the source labeled
-    /// AFTER the requested day is clamped back to the requested day —
-    /// a 00:01 fetch in a batch that started before midnight must not
-    /// shift the archive entry onto the new day (deep review of #1803).
-    /// Feed dates on or before the request pass through untouched
-    /// (asserted by `latest_only_refuses_past_and_future_but_serves_today`).
+    /// A feed genuinely ahead of the local clock (labels tomorrow's
+    /// civil day) passes through the dispatch UNTOUCHED — the clamp is
+    /// scoped to local-clock labels only (round-2 deep review of #1803:
+    /// the first clamp rewrote eastmoneyfund's China-day labels). The
+    /// clamp's positive case is pinned by the pure-function test
+    /// `clamp_only_rewrites_current_day_labels`.
     #[test]
-    fn straddle_accepted_latest_is_clamped_to_requested_day() {
+    fn feed_ahead_of_local_clock_passes_through() {
         struct LabelsTomorrow;
         impl PriceSource for LabelsTomorrow {
             fn name(&self) -> &'static str {
@@ -731,12 +794,13 @@ mod dispatch_tests {
             }
         }
         let today = jiff::Zoned::now().date();
+        let tomorrow = today.checked_add(jiff::Span::new().days(1)).unwrap();
         let response = LabelsTomorrow
             .fetch_price(&request(Some(today)))
             .expect("today is accepted");
         assert_eq!(
-            response.date, today,
-            "a label after the requested day is clamped to it"
+            response.date, tomorrow,
+            "a genuine ahead-of-clock feed label is preserved"
         );
     }
 
@@ -797,33 +861,59 @@ mod dispatch_tests {
         assert!(select_on_or_before(vec![], d(12)).is_none());
     }
 
-    /// The acceptance window: today always; yesterday ONLY when the
-    /// run's first fetch happened on it (a genuine midnight straddle).
-    /// A long-lived process can never replay its start day later than
-    /// that, and future dates never pass (round-4 deep review).
+    /// The acceptance window: today always; yesterday ONLY during a
+    /// genuine midnight straddle — the run's first dated fetch happened
+    /// on it AND recently. A long-lived process can never replay its
+    /// latch day later (round-2 deep review of #1803: a day-granular
+    /// latch let a day-old covered fetch unlock live quotes recorded
+    /// under the old date), and future dates never pass.
     #[test]
     fn window_accepts_midnight_straddle_only() {
+        const RECENT: i64 = 1800; // 30 minutes into the batch
+        const DAY_OLD: i64 = 24 * 3600;
         let d = rustledger_core::naive_date(2026, 7, 16).unwrap();
         let next = d.checked_add(jiff::Span::new().days(1)).unwrap();
         let much_later = d.checked_add(jiff::Span::new().days(30)).unwrap();
 
-        assert!(super::latest_date_window_ok(d, d, d), "same day");
+        assert!(super::latest_date_window_ok(d, d, d, RECENT), "same day");
         assert!(
-            super::latest_date_window_ok(d, next, d),
-            "midnight straddle: run started on d, clock now d+1"
+            super::latest_date_window_ok(d, next, d, RECENT),
+            "midnight straddle: run started on d minutes ago, clock now d+1"
         );
         assert!(
-            !super::latest_date_window_ok(d, much_later, d),
+            !super::latest_date_window_ok(d, next, d, DAY_OLD),
+            "a latch from a day-old fetch must not reopen yesterday"
+        );
+        assert!(
+            !super::latest_date_window_ok(d, much_later, d, RECENT),
             "a daemon must not replay its start day weeks later"
         );
         assert!(
-            !super::latest_date_window_ok(d, next, next),
+            !super::latest_date_window_ok(d, next, next, RECENT),
             "yesterday is refused when the run did NOT start on it"
         );
         assert!(
-            !super::latest_date_window_ok(much_later, d, d),
+            !super::latest_date_window_ok(much_later, d, d, RECENT),
             "future dates never pass"
         );
+    }
+
+    /// The label clamp is scoped to local-clock labels: only a response
+    /// dated with the CURRENT day gets clamped down to the straddle's
+    /// requested day. A feed genuinely ahead of the local clock
+    /// (eastmoneyfund's China civil day from a US evening) passes
+    /// through (round-2 deep review of #1803).
+    #[test]
+    fn clamp_only_rewrites_current_day_labels() {
+        let d = |day| rustledger_core::naive_date(2026, 7, day).unwrap();
+        // Straddle minute: local clock rolled to the 17th mid-batch.
+        assert_eq!(super::clamp_local_label(d(17), d(16), d(17)), d(16));
+        // Feed ahead of the local clock: China's 18th from a US 17th.
+        assert_eq!(super::clamp_local_label(d(18), d(17), d(17)), d(18));
+        // Feed behind the request (ECB Friday on a weekend): untouched.
+        assert_eq!(super::clamp_local_label(d(15), d(17), d(17)), d(15));
+        // Label equals the request: untouched.
+        assert_eq!(super::clamp_local_label(d(17), d(17), d(17)), d(17));
     }
 
     /// Identity answers accept any past-or-today label but refuse a
@@ -939,15 +1029,23 @@ mod capability_wiring_tests {
         }
     }
 
-    /// The capable builtins declare their coverage as data — the
-    /// introspection callers (dry-run validation, fallback-chain
-    /// skipping) rely on these declarations being truthful.
+    /// The capable builtins declare their coverage as data. Today the
+    /// only consumer is the trait's canonical dispatch (refusal before
+    /// network I/O); future introspection callers — dry-run validation,
+    /// fallback-chain skipping — can rely on the same declarations once
+    /// wired (they are NOT wired yet; round-2 review of #1803 caught
+    /// this comment overclaiming).
     #[test]
     fn historical_capable_builtins_declare_coverage() {
         let registry = PriceSourceRegistry::new(&PriceConfig::default());
         let coverage = |name: &str| registry.get(name).expect(name).historical_coverage();
         assert_eq!(coverage("yahoo"), HistoricalCoverage::Full);
-        assert_eq!(coverage("coinbase"), HistoricalCoverage::Full);
+        // Coinbase launched January 2015; earlier dates get the clean
+        // capability refusal instead of a raw provider error.
+        assert_eq!(
+            coverage("coinbase"),
+            HistoricalCoverage::Since(rustledger_core::naive_date(2015, 1, 1).unwrap())
+        );
         // exchangerate.host serves EU-reference history from 1999-01-04.
         assert_eq!(
             coverage("ratesapi"),

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -380,7 +380,13 @@ pub trait PriceSource: Send + Sync {
             })?;
             return Ok(PriceResponse {
                 price: point.price,
-                currency: point.currency.unwrap_or_else(|| pair.currency.clone()),
+                // Uppercased like the identity arm: beancount
+                // commodities are uppercase, and a lowercase -c value
+                // must not flow into the emitted directive (round-4
+                // deep review of #1803).
+                currency: point
+                    .currency
+                    .unwrap_or_else(|| pair.currency.to_uppercase()),
                 date: point.date,
                 source: self.name().to_string(),
             });
@@ -389,10 +395,11 @@ pub trait PriceSource: Send + Sync {
         // 6. Refuse: mislabeling the latest quote with this date is the
         // #1794 corruption. The wording tracks the coverage — a Since
         // source is NOT latest-only, its history just starts later than
-        // the requested date (Copilot review). Neither message suggests
-        // a specific alternative source for Since refusals: which
-        // source covers a given asset/date pair is asset-specific
-        // (round-3 review: yahoo has no 2012 crypto either).
+        // the requested date (Copilot review). Only the None arm names
+        // an example alternative (yahoo); the Since arm deliberately
+        // does not, because which source covers a given asset/date pair
+        // is asset-specific (round-3 review: yahoo has no 2012 crypto
+        // either).
         match coverage {
             HistoricalCoverage::Since(s) => anyhow::bail!(
                 "the '{}' source has no history before {s} and cannot fetch {} for \
@@ -417,6 +424,12 @@ pub(crate) const fn user_agent() -> &'static str {
 }
 
 #[cfg(test)]
+// NOTE on clocks: the dispatch reads the wall clock internally (no
+// injection seam), so each today-arm test computes "today" separately
+// from the dispatch's own read. A CI run crossing local midnight
+// between the two reads can flake — a known, accepted sub-second
+// window (round-4 deep review of #1803); injecting a clock would
+// change the public trait for a test-only concern.
 mod dispatch_tests {
     use super::{
         DateWindow, HistoricalCoverage, PricePair, PricePoint, PriceSource, select_on_or_before,
@@ -669,11 +682,11 @@ mod dispatch_tests {
     }
 
     /// A feed genuinely ahead of the local clock (labels tomorrow's
-    /// civil day) passes through the dispatch UNTOUCHED — the clamp is
-    /// scoped to local-clock labels only (round-2 deep review of #1803:
-    /// the first clamp rewrote eastmoneyfund's China-day labels). The
-    /// clamp's positive case is pinned by the pure-function test
-    /// `clamp_only_rewrites_current_day_labels`.
+    /// civil day) passes through the dispatch UNTOUCHED: the response
+    /// always carries the quote's own claimed day — no clamping of any
+    /// kind exists since round 3 of the #1803 review deleted the
+    /// straddle machinery (round-2's scoped clamp had rewritten
+    /// eastmoneyfund's China-day labels).
     #[test]
     fn feed_ahead_of_local_clock_passes_through() {
         struct LabelsTomorrow;

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -734,7 +734,10 @@ mod dispatch_tests {
     /// `historical_coverage`).
     #[test]
     fn since_window_start_is_clamped_to_epoch() {
-        use std::sync::Mutex;
+        // Sync interior mutability for a cfg(test) mock capture; Cell/RefCell
+        // fail the trait's Sync bound and parking_lot is not a dependency of
+        // this crate.
+        use std::sync::Mutex; // ratchet-allow: std-sync cfg(test) mock capture, not library code
         struct CapturesWindow(Mutex<Option<DateWindow>>);
         impl PriceSource for CapturesWindow {
             fn name(&self) -> &'static str {

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -363,18 +363,24 @@ pub trait PriceSource: Send + Sync {
         }
 
         // 5. Refuse: mislabeling the latest quote with this date is the
-        // #1794 corruption.
-        let coverage_note = match coverage {
-            HistoricalCoverage::Since(s) => format!(" (its history begins {s})"),
-            _ => String::new(),
-        };
-        anyhow::bail!(
-            "the '{}' source only provides the latest quote{coverage_note} and cannot \
-             fetch {} for {requested}; drop --date, or use a source with historical \
-             support (e.g. yahoo)",
-            self.name(),
-            request.ticker
-        );
+        // #1794 corruption. The wording tracks the coverage — a Since
+        // source is NOT latest-only, its history just starts later than
+        // the requested date (Copilot review).
+        match coverage {
+            HistoricalCoverage::Since(s) => anyhow::bail!(
+                "the '{}' source has no history before {s} and cannot fetch {} for \
+                 {requested}; use a source with deeper history (e.g. yahoo)",
+                self.name(),
+                request.ticker
+            ),
+            _ => anyhow::bail!(
+                "the '{}' source only provides the latest quote and cannot fetch {} \
+                 for {requested}; drop --date, or use a source with historical \
+                 support (e.g. yahoo)",
+                self.name(),
+                request.ticker
+            ),
+        }
     }
 }
 
@@ -574,8 +580,12 @@ mod dispatch_tests {
         let err = SinceSource
             .fetch_price(&request(Some(too_early)))
             .expect_err("refuse");
+        assert!(err.to_string().contains("no history before"), "{err}");
         assert!(err.to_string().contains("1999-01-04"), "{err}");
-        assert!(err.to_string().contains("latest quote"), "{err}");
+        assert!(
+            !err.to_string().contains("latest quote"),
+            "a Since source is not latest-only; the message must not claim it is: {err}"
+        );
     }
 
     /// Identity pairs answer 1.0 for any past-or-today date without any

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -28,7 +28,94 @@ pub use tsp::TspSource;
 pub use yahoo::YahooFinanceSource;
 
 use super::{PriceRequest, PriceResponse};
-use anyhow::Result;
+use anyhow::{Context, Result};
+use rust_decimal::Decimal;
+use rustledger_core::NaiveDate;
+
+/// A `(ticker, quote-currency)` pair — the date-free fetch target.
+///
+/// Sources take this instead of [`PriceRequest`] so an implementation
+/// cannot even see a requested date, let alone label a quote with it
+/// (#1794): all date handling lives in the provided
+/// [`PriceSource::fetch_price`] dispatch.
+#[derive(Debug, Clone)]
+pub struct PricePair {
+    /// Ticker symbol.
+    pub ticker: String,
+    /// Quote currency.
+    pub currency: String,
+}
+
+/// One dated quote from a source's historical series.
+#[derive(Debug, Clone)]
+pub struct PricePoint {
+    /// The quote's OWN civil date (exchange-local where applicable).
+    pub date: NaiveDate,
+    /// The settled price for that date.
+    pub price: Decimal,
+    /// Quote currency when the feed reports one; the request's currency
+    /// is used otherwise.
+    pub currency: Option<String>,
+}
+
+/// An inclusive civil-date range for a historical window fetch.
+#[derive(Debug, Clone, Copy)]
+pub struct DateWindow {
+    /// First day (inclusive).
+    pub start: NaiveDate,
+    /// Last day (inclusive).
+    pub end: NaiveDate,
+}
+
+/// How far back a source can serve dated quotes.
+///
+/// Declared as DATA rather than probed via errors — the ccxt
+/// `has`-dictionary / pricehist `types()`+`start()` pattern: the
+/// dispatch refuses an uncoverable dated request before any network
+/// I/O, and callers can inspect capability up front. beanprice's
+/// `None`-return signaling is the documented counterexample (its own
+/// `TODO(blais)` calls the capability/failure conflation a flaw).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistoricalCoverage {
+    /// Latest quote only — dated fetches (other than today's) refuse.
+    None,
+    /// Dated quotes available from this day onward.
+    Since(NaiveDate),
+    /// Full history, as far back as the provider goes.
+    Full,
+}
+
+impl HistoricalCoverage {
+    /// Whether a quote for `date` can be requested under this coverage.
+    #[must_use]
+    pub fn covers(self, date: NaiveDate) -> bool {
+        match self {
+            Self::None => false,
+            Self::Since(start) => date >= start,
+            Self::Full => true,
+        }
+    }
+}
+
+/// Days of look-back slop when turning a point request into a window:
+/// the window `requested - LOOKBACK ..= requested` spans weekends plus
+/// multi-day market holidays (beanprice uses a 5-day window for the
+/// same purpose; ours matches the pre-existing yahoo behavior).
+const HISTORICAL_LOOKBACK_DAYS: i64 = 6;
+
+/// Canonical on-or-before selection over a fetched window: the point
+/// with the greatest date `<= requested`.
+///
+/// Ownership sits HERE — in the dispatch, not in each source — so the
+/// #1794 invariant (a dated answer is labeled with the quote's own
+/// date, never the requested one) is enforced in exactly one place.
+/// Input order is irrelevant; providers do not guarantee sorted series.
+fn select_on_or_before(points: Vec<PricePoint>, requested: NaiveDate) -> Option<PricePoint> {
+    points
+        .into_iter()
+        .filter(|p| p.date <= requested)
+        .max_by_key(|p| p.date)
+}
 
 /// The civil day of this process's FIRST guarded fetch.
 ///
@@ -57,56 +144,18 @@ fn latest_date_window_ok(
             && today.checked_sub(jiff::Span::new().days(1)).ok() == Some(date))
 }
 
-/// Reject a past or future `--date` on a source that can only fetch the
-/// LATEST quote.
-///
-/// Labeling the latest price with an arbitrary historical date silently
-/// corrupts price archives (#1794 — Yahoo emitted the live quote under
-/// `--date 2000-01-03`). Matching beanprice, a dated fetch requires a
-/// source with real historical support — with one exception: `--date
-/// <today>` is allowed, because the latest quote IS a valid answer for
-/// today and the emitted directive carries the response's own date
-/// anyway (round-2 deep review: nightly `--date $(date +%F)` runs
-/// worked on every source before #1801 and must keep working). A batch
-/// that straddles midnight stays accepted — see
-/// [`latest_date_window_ok`].
-/// Date-independent identity branches (e.g. USD→USD = 1.0) early-return
-/// BEFORE this guard but refuse future labels via
-/// [`identity_label_date`].
-///
-/// # Errors
-/// Errors whenever `request.date` is outside the accepted window.
-pub(super) fn reject_historical_date(
-    source: &str,
-    request: &crate::cmd::price::PriceRequest,
-) -> anyhow::Result<()> {
-    if let Some(date) = request.date {
-        let today = jiff::Zoned::now().date();
-        let first_fetch_day = *FIRST_FETCH_DAY.get_or_init(|| today);
-        if !latest_date_window_ok(date, today, first_fetch_day) {
-            anyhow::bail!(
-                "the '{source}' source only provides the latest quote and cannot fetch {} \
-                 for {date}; drop --date, or use a source with historical support \
-                 (e.g. yahoo)",
-                request.ticker
-            );
-        }
-    }
-    Ok(())
-}
-
 /// Date label for a date-independent identity answer (X→X = 1.0).
 ///
 /// Identity is numerically correct for any PAST day, which is why the
-/// identity branches sit ABOVE [`reject_historical_date`] — but a
-/// FUTURE label would fabricate a directive for a day that hasn't
-/// happened, which every guarded path refuses; refuse it here too
-/// (round-4 deep review: `--date 2030-01-01` on an ecb/ratesapi
+/// identity arm sits at the top of the [`PriceSource::fetch_price`]
+/// dispatch — but a FUTURE label would fabricate a directive for a day
+/// that hasn't happened, which every other dated path refuses; refuse
+/// it here too (round-4 deep review of #1801: `--date 2030-01-01` on an
 /// identity pair emitted `2030-01-01 price USD 1 USD` and cached it).
 ///
 /// # Errors
 /// Errors when `request.date` is after today.
-pub(super) fn identity_label_date(
+fn identity_label_date(
     source: &str,
     request: &crate::cmd::price::PriceRequest,
 ) -> anyhow::Result<rustledger_core::NaiveDate> {
@@ -143,6 +192,21 @@ pub(super) fn feed_date_or_today(raw: Option<&str>) -> rustledger_core::NaiveDat
 /// All price sources must implement this trait. The trait is object-safe
 /// to allow dynamic dispatch through `Arc<dyn PriceSource>`.
 ///
+/// # Architecture (#1802)
+///
+/// Sources implement the date-free [`Self::fetch_latest`] and, when the
+/// provider has a history API, [`Self::fetch_window`] plus a
+/// [`Self::historical_coverage`] declaration. All date SEMANTICS —
+/// identity pairs, refusing uncoverable dates, on-or-before selection,
+/// and labeling the answer with the quote's own date — live in the
+/// provided [`Self::fetch_price`] dispatch, so they cannot drift per
+/// source (every defect in #1801's four review rounds was a per-source
+/// date-labeling mistake). Grounded in a survey of beanprice (split
+/// point methods, capability signaled by an ambiguous `None` its author
+/// flags as a flaw), pricehist (a single series primitive subsuming the
+/// point protocols, capability as data), and ccxt (`has` capability
+/// dictionary); see issue #1802.
+///
 /// # Implementation Notes
 ///
 /// Source implementations store a `timeout` field for future use. Currently,
@@ -165,7 +229,12 @@ pub trait PriceSource: Send + Sync {
         None
     }
 
-    /// Fetch a price for the given request.
+    /// Fetch the LATEST quote for a pair. Every provider has a latest
+    /// endpoint, so this is the one mandatory fetch method.
+    ///
+    /// The response's `date` must be the quote's own trading day
+    /// (`feed_date_or_today` is the canonical extraction helper) — a
+    /// caller-chosen date is inexpressible here by design.
     ///
     /// # Errors
     ///
@@ -174,7 +243,139 @@ pub trait PriceSource: Send + Sync {
     /// - The response cannot be parsed
     /// - The ticker is not found
     /// - The API key is missing (for sources that require it)
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse>;
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse>;
+
+    /// How far back this source can serve dated quotes. Latest-only
+    /// sources keep the default.
+    fn historical_coverage(&self) -> HistoricalCoverage {
+        HistoricalCoverage::None
+    }
+
+    /// Fetch the daily points the provider has in (or near) `window` —
+    /// the single historical primitive (the pricehist model).
+    ///
+    /// Sources return RAW dated points; on-or-before selection and
+    /// response labeling happen in the provided [`Self::fetch_price`]
+    /// dispatch. Points outside the window are permitted (timezone
+    /// slop, single-point providers) — the dispatch filters. An EMPTY
+    /// vec means "the provider has no quotes there" and becomes the
+    /// dispatch's no-quote error. Implementations must be consistent
+    /// with [`Self::historical_coverage`].
+    ///
+    /// # Errors
+    ///
+    /// The default refuses (latest-only source); implementations error
+    /// on network/parse/auth failures.
+    fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
+        let _ = window;
+        anyhow::bail!(
+            "the '{}' source only provides the latest quote and has no historical window \
+             fetch for {}",
+            self.name(),
+            pair.ticker
+        )
+    }
+
+    /// Fetch a price — the canonical dispatch.
+    ///
+    /// Do NOT override this: implement [`Self::fetch_latest`] /
+    /// [`Self::fetch_window`] instead, so the date semantics stay in
+    /// one place. The single sanctioned override is
+    /// `ExternalCommandSource`, whose trust-contract divergence is
+    /// documented at both sites.
+    ///
+    /// Dispatch order:
+    /// 1. Identity pair (X→X = 1.0 for any past-or-today date).
+    /// 2. No date → [`Self::fetch_latest`].
+    /// 3. Date covered by [`Self::historical_coverage`] →
+    ///    [`Self::fetch_window`] over the trailing look-back window,
+    ///    then canonical on-or-before selection, labeled with the
+    ///    point's own date (#1794).
+    /// 4. Uncovered date that is today (or a midnight straddle, see
+    ///    `latest_date_window_ok`) → [`Self::fetch_latest`].
+    /// 5. Anything else → refusal naming the source and its coverage.
+    ///
+    /// # Errors
+    ///
+    /// Fetch failures from the underlying methods; a refusal for dated
+    /// requests the source cannot serve; "no quote on or before" when
+    /// the fetched window is empty.
+    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
+        // 1. Identity: X priced in X is 1.0 on any past-or-today date,
+        // source-independent (hoisted out of per-source branches by the
+        // #1801 reviews; future labels refuse).
+        if request.ticker.eq_ignore_ascii_case(&request.currency) {
+            return Ok(PriceResponse {
+                price: Decimal::ONE,
+                currency: request.currency.clone(),
+                date: identity_label_date(self.name(), request)?,
+                source: self.name().to_string(),
+            });
+        }
+
+        let pair = PricePair {
+            ticker: request.ticker.clone(),
+            currency: request.currency.clone(),
+        };
+
+        // 2. Undated → latest.
+        let Some(requested) = request.date else {
+            return self.fetch_latest(&pair);
+        };
+
+        // 3. Covered date → window + canonical selection. Today is
+        // routed here too for window-capable sources (a same-day
+        // request returns the freshest daily bar — yahoo's
+        // pre-existing behavior).
+        let coverage = self.historical_coverage();
+        if coverage.covers(requested) {
+            let start = requested
+                .checked_sub(jiff::Span::new().days(HISTORICAL_LOOKBACK_DAYS))
+                .context("date underflow")?;
+            let window = DateWindow {
+                start,
+                end: requested,
+            };
+            let points = self.fetch_window(&pair, window)?;
+            let point = select_on_or_before(points, requested).with_context(|| {
+                format!(
+                    "no {} quote for {} on or before {requested} in the fetched window; \
+                     the market may not have traded that week",
+                    self.name(),
+                    pair.ticker
+                )
+            })?;
+            return Ok(PriceResponse {
+                price: point.price,
+                currency: point.currency.unwrap_or_else(|| pair.currency.clone()),
+                date: point.date,
+                source: self.name().to_string(),
+            });
+        }
+
+        // 4. Uncovered date, but it is today (or a midnight straddle):
+        // the latest quote IS a valid answer for today, and the
+        // response carries the quote's own date anyway (#1801).
+        let today = jiff::Zoned::now().date();
+        let first_fetch_day = *FIRST_FETCH_DAY.get_or_init(|| today);
+        if latest_date_window_ok(requested, today, first_fetch_day) {
+            return self.fetch_latest(&pair);
+        }
+
+        // 5. Refuse: mislabeling the latest quote with this date is the
+        // #1794 corruption.
+        let coverage_note = match coverage {
+            HistoricalCoverage::Since(s) => format!(" (its history begins {s})"),
+            _ => String::new(),
+        };
+        anyhow::bail!(
+            "the '{}' source only provides the latest quote{coverage_note} and cannot \
+             fetch {} for {requested}; drop --date, or use a source with historical \
+             support (e.g. yahoo)",
+            self.name(),
+            request.ticker
+        );
+    }
 }
 
 /// Helper function to build a User-Agent header for HTTP requests.
@@ -183,10 +384,16 @@ pub(crate) const fn user_agent() -> &'static str {
 }
 
 #[cfg(test)]
-mod guard_tests {
-    use crate::cmd::price::PriceRequest;
+mod dispatch_tests {
+    use super::{
+        DateWindow, HistoricalCoverage, PricePair, PricePoint, PriceSource, select_on_or_before,
+    };
+    use crate::cmd::price::{PriceRequest, PriceResponse};
+    use anyhow::Result;
+    use rust_decimal::Decimal;
+    use rustledger_core::NaiveDate;
 
-    fn request(date: Option<rustledger_core::NaiveDate>) -> PriceRequest {
+    fn request(date: Option<NaiveDate>) -> PriceRequest {
         PriceRequest {
             ticker: "AAPL".to_string(),
             currency: "USD".to_string(),
@@ -194,38 +401,218 @@ mod guard_tests {
         }
     }
 
-    /// Latest-only sources refuse any past or future --date instead of
-    /// mislabeling the current quote (#1794). Today's date is the one
-    /// exception: the latest quote is a valid answer for today, and
-    /// pre-#1801 nightly `--date $(date +%F)` runs must keep working
-    /// (round-2 deep review).
+    /// A latest-only source whose feed labels its quote with a fixed
+    /// (non-today) trading day, as a weekend feed would.
+    struct LatestOnly;
+    const FEED_DAY: (i32, u32, u32) = (2026, 7, 10);
+    impl PriceSource for LatestOnly {
+        fn name(&self) -> &'static str {
+            "mock-latest"
+        }
+        fn description(&self) -> &'static str {
+            "latest-only mock"
+        }
+        fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+            Ok(PriceResponse {
+                price: Decimal::new(4200, 2),
+                currency: pair.currency.clone(),
+                date: rustledger_core::naive_date(FEED_DAY.0, FEED_DAY.1, FEED_DAY.2).unwrap(),
+                source: self.name().to_string(),
+            })
+        }
+    }
+
+    /// A window-capable source returning a fixed unsorted series,
+    /// including a point AFTER any plausible requested date.
+    struct Windowed;
+    impl PriceSource for Windowed {
+        fn name(&self) -> &'static str {
+            "mock-window"
+        }
+        fn description(&self) -> &'static str {
+            "window mock"
+        }
+        fn fetch_latest(&self, _pair: &PricePair) -> Result<PriceResponse> {
+            panic!("dated dispatch on a covered date must use fetch_window");
+        }
+        fn historical_coverage(&self) -> HistoricalCoverage {
+            HistoricalCoverage::Full
+        }
+        fn fetch_window(&self, _pair: &PricePair, _window: DateWindow) -> Result<Vec<PricePoint>> {
+            let d = |y, m, day| rustledger_core::naive_date(y, m, day).unwrap();
+            Ok(vec![
+                PricePoint {
+                    date: d(2026, 7, 6),
+                    price: Decimal::new(300, 2),
+                    currency: Some("USD".to_string()),
+                },
+                // Deliberately after the tested request date: selection
+                // must skip it (unsorted input, no early break).
+                PricePoint {
+                    date: d(2026, 7, 13),
+                    price: Decimal::new(999, 2),
+                    currency: Some("USD".to_string()),
+                },
+                PricePoint {
+                    date: d(2026, 7, 10),
+                    price: Decimal::new(500, 2),
+                    currency: Some("USD".to_string()),
+                },
+            ])
+        }
+    }
+
+    /// A source that panics on ANY fetch — proves identity answers
+    /// never touch the network.
+    struct NeverFetch;
+    impl PriceSource for NeverFetch {
+        fn name(&self) -> &'static str {
+            "mock-never"
+        }
+        fn description(&self) -> &'static str {
+            "panics on fetch"
+        }
+        fn fetch_latest(&self, _pair: &PricePair) -> Result<PriceResponse> {
+            panic!("identity must not fetch");
+        }
+    }
+
+    /// Latest-only: past and future dates refuse with the latest-quote
+    /// message; today routes to `fetch_latest`, and the answer carries
+    /// the FEED's day, not the requested one (#1794/#1801 semantics,
+    /// now enforced by the shared dispatch instead of per-source
+    /// guards).
     #[test]
-    fn past_and_future_dates_are_rejected_today_passes() {
-        let past = rustledger_core::naive_date(2000, 1, 3).expect("valid date");
-        let err = super::reject_historical_date("coinbase", &request(Some(past)))
-            .expect_err("must refuse");
+    fn latest_only_refuses_past_and_future_but_serves_today() {
+        let src = LatestOnly;
+        let past = rustledger_core::naive_date(2000, 1, 3).unwrap();
+        let err = src.fetch_price(&request(Some(past))).expect_err("refuse");
         assert!(err.to_string().contains("latest quote"), "{err}");
-        assert!(err.to_string().contains("coinbase"), "{err}");
+        assert!(err.to_string().contains("mock-latest"), "{err}");
 
         let today = jiff::Zoned::now().date();
-        let future = today
-            .checked_add(jiff::Span::new().days(7))
-            .expect("valid date");
-        assert!(
-            super::reject_historical_date("coinbase", &request(Some(future))).is_err(),
-            "a future date must be refused — the latest quote is not a quote for next week"
+        let future = today.checked_add(jiff::Span::new().days(7)).unwrap();
+        assert!(src.fetch_price(&request(Some(future))).is_err());
+
+        let response = src.fetch_price(&request(Some(today))).expect("today ok");
+        assert_eq!(
+            response.date,
+            rustledger_core::naive_date(FEED_DAY.0, FEED_DAY.1, FEED_DAY.2).unwrap(),
+            "the response carries the feed's own day, not the requested one"
         );
 
-        assert!(
-            super::reject_historical_date("coinbase", &request(Some(today))).is_ok(),
-            "--date <today> is a valid request for the latest quote"
+        assert!(src.fetch_price(&request(None)).is_ok(), "undated passes");
+    }
+
+    /// Covered dates go through the window primitive: the dispatch
+    /// selects the greatest point `<= requested` from unsorted input
+    /// and labels the response with THAT point's date.
+    #[test]
+    fn covered_date_selects_on_or_before_and_labels_with_point_date() {
+        let src = Windowed;
+        let requested = rustledger_core::naive_date(2026, 7, 12).unwrap();
+        let response = src.fetch_price(&request(Some(requested))).expect("fetch");
+        assert_eq!(response.price.to_string(), "5.00", "Friday's close");
+        assert_eq!(
+            response.date,
+            rustledger_core::naive_date(2026, 7, 10).unwrap(),
+            "labeled with the point's own date, never the requested one"
         );
     }
 
-    /// No date always passes.
+    /// An empty window is a hard error, never a mislabeled latest quote.
     #[test]
-    fn absent_date_passes() {
-        assert!(super::reject_historical_date("coinbase", &request(None)).is_ok());
+    fn empty_window_is_a_no_quote_error() {
+        struct Empty;
+        impl PriceSource for Empty {
+            fn name(&self) -> &'static str {
+                "mock-empty"
+            }
+            fn description(&self) -> &'static str {
+                "empty window"
+            }
+            fn fetch_latest(&self, _p: &PricePair) -> Result<PriceResponse> {
+                panic!("must not fall back to latest");
+            }
+            fn historical_coverage(&self) -> HistoricalCoverage {
+                HistoricalCoverage::Full
+            }
+            fn fetch_window(&self, _p: &PricePair, _w: DateWindow) -> Result<Vec<PricePoint>> {
+                Ok(vec![])
+            }
+        }
+        let requested = rustledger_core::naive_date(2026, 7, 12).unwrap();
+        let err = Empty
+            .fetch_price(&request(Some(requested)))
+            .expect_err("must refuse");
+        assert!(err.to_string().contains("on or before"), "{err}");
+    }
+
+    /// `Since` coverage: a date before the epoch refuses and the
+    /// message names where history begins.
+    #[test]
+    fn since_coverage_refuses_earlier_dates_with_epoch_in_message() {
+        struct SinceSource;
+        impl PriceSource for SinceSource {
+            fn name(&self) -> &'static str {
+                "mock-since"
+            }
+            fn description(&self) -> &'static str {
+                "since mock"
+            }
+            fn fetch_latest(&self, _p: &PricePair) -> Result<PriceResponse> {
+                panic!("uncovered past date must refuse, not fetch latest");
+            }
+            fn historical_coverage(&self) -> HistoricalCoverage {
+                HistoricalCoverage::Since(rustledger_core::naive_date(1999, 1, 4).unwrap())
+            }
+            fn fetch_window(&self, _p: &PricePair, _w: DateWindow) -> Result<Vec<PricePoint>> {
+                panic!("uncovered date must not reach fetch_window");
+            }
+        }
+        let too_early = rustledger_core::naive_date(1980, 1, 1).unwrap();
+        let err = SinceSource
+            .fetch_price(&request(Some(too_early)))
+            .expect_err("refuse");
+        assert!(err.to_string().contains("1999-01-04"), "{err}");
+        assert!(err.to_string().contains("latest quote"), "{err}");
+    }
+
+    /// Identity pairs answer 1.0 for any past-or-today date without any
+    /// fetch, on EVERY source; future identity labels refuse.
+    #[test]
+    fn identity_answers_without_fetching_and_refuses_future() {
+        let src = NeverFetch;
+        let past = rustledger_core::naive_date(2024, 6, 30).unwrap();
+        let mut req = PriceRequest::new("USD", "USD");
+        req.date = Some(past);
+        let response = src.fetch_price(&req).expect("identity");
+        assert_eq!(response.price, Decimal::ONE);
+        assert_eq!(response.date, past);
+
+        let today = jiff::Zoned::now().date();
+        let future = today.checked_add(jiff::Span::new().days(7)).unwrap();
+        req.date = Some(future);
+        let err = src.fetch_price(&req).expect_err("future identity refuses");
+        assert!(err.to_string().contains("future"), "{err}");
+    }
+
+    /// The selection helper itself: greatest date <= requested, order
+    /// independent, currency carried through.
+    #[test]
+    fn select_on_or_before_picks_max_not_first() {
+        let d = |day| rustledger_core::naive_date(2026, 7, day).unwrap();
+        let point = |day, cents| PricePoint {
+            date: d(day),
+            price: Decimal::new(cents, 2),
+            currency: None,
+        };
+        let picked =
+            select_on_or_before(vec![point(10, 500), point(6, 300), point(13, 999)], d(12))
+                .expect("some");
+        assert_eq!(picked.date, d(10));
+        assert!(select_on_or_before(vec![point(13, 999)], d(12)).is_none());
+        assert!(select_on_or_before(vec![], d(12)).is_none());
     }
 
     /// The acceptance window: today always; yesterday ONLY when the
@@ -307,35 +694,39 @@ mod feed_date_tests {
 }
 
 #[cfg(test)]
-mod guard_wiring_tests {
+mod capability_wiring_tests {
+    use super::HistoricalCoverage;
     use crate::cmd::price::{PriceConfig, PriceRequest, PriceSourceRegistry};
 
-    /// Drift guard (deep review of #1801): every latest-only builtin must
-    /// actually CALL `reject_historical_date` from `fetch_price`. The
-    /// guard fires before any network I/O, so a hermetic dated fetch must
-    /// fail with the guard's message — a source that forgot the guard
-    /// would instead surface a network/parse error (or worse, succeed).
-    /// `yahoo` (real historical support) and `external` (forwards the
-    /// date to the user's command) are exempt by design.
+    /// Drift guard (#1801 reviews, rearchitected in #1802): every
+    /// builtin that declares NO historical coverage must refuse a dated
+    /// fetch through the shared dispatch, before any network I/O — a
+    /// hermetic dated fetch fails with the refusal message. A source
+    /// that wrongly declared coverage would instead surface a
+    /// network/parse error here.
     #[test]
-    fn every_latest_only_source_rejects_dated_fetches() {
+    fn latest_only_builtins_refuse_dated_fetches() {
         let registry = PriceSourceRegistry::new(&PriceConfig::default());
         let past = rustledger_core::naive_date(2000, 1, 3).expect("valid date");
         for name in [
             "alphavantage",
-            "coinbase",
             "coincap",
             "coinmarketcap",
             "eastmoneyfund",
             "ecb",
             "oanda",
             "quandl",
-            "ratesapi",
             "tsp",
         ] {
             let source = registry
                 .get(name)
                 .unwrap_or_else(|| panic!("builtin source '{name}' must exist"));
+            assert_eq!(
+                source.historical_coverage(),
+                HistoricalCoverage::None,
+                "'{name}' is expected to be latest-only; if it grew historical \
+                 support, move it to the capable list below"
+            );
             let request = PriceRequest {
                 ticker: "AAPL".to_string(),
                 currency: "USD".to_string(),
@@ -346,8 +737,24 @@ mod guard_wiring_tests {
                 .expect_err("dated fetch must be refused before any I/O");
             assert!(
                 err.to_string().contains("latest quote"),
-                "source '{name}' did not fire the historical-date guard: {err}"
+                "source '{name}' did not refuse through the dispatch: {err}"
             );
         }
+    }
+
+    /// The capable builtins declare their coverage as data — the
+    /// introspection callers (dry-run validation, fallback-chain
+    /// skipping) rely on these declarations being truthful.
+    #[test]
+    fn historical_capable_builtins_declare_coverage() {
+        let registry = PriceSourceRegistry::new(&PriceConfig::default());
+        let coverage = |name: &str| registry.get(name).expect(name).historical_coverage();
+        assert_eq!(coverage("yahoo"), HistoricalCoverage::Full);
+        assert_eq!(coverage("coinbase"), HistoricalCoverage::Full);
+        // exchangerate.host serves EU-reference history from 1999-01-04.
+        assert_eq!(
+            coverage("ratesapi"),
+            HistoricalCoverage::Since(rustledger_core::naive_date(1999, 1, 4).unwrap())
+        );
     }
 }

--- a/crates/rustledger/src/cmd/price/sources/mod.rs
+++ b/crates/rustledger/src/cmd/price/sources/mod.rs
@@ -117,64 +117,6 @@ fn select_on_or_before(points: Vec<PricePoint>, requested: NaiveDate) -> Option<
         .max_by_key(|p| p.date)
 }
 
-/// The civil day and instant of this process's FIRST dated fetch —
-/// identity and covered fetches included (round-2 review of #1803: an
-/// all-identity or all-covered pre-midnight prefix must still latch for
-/// the uncovered sources the batch reaches after midnight).
-///
-/// Used only to widen the guard by one day across a midnight straddle —
-/// see [`latest_date_window_ok`]. It deliberately does NOT replace the
-/// live clock (#1801 round-4 review: an unconditional process-wide
-/// latch froze "today" forever for long-lived library embedders).
-static FIRST_DATED_FETCH: std::sync::OnceLock<(rustledger_core::NaiveDate, jiff::Timestamp)> =
-    std::sync::OnceLock::new();
-
-/// How long after its first dated fetch a run keeps the midnight
-/// straddle open. A batch that crosses midnight finishes within
-/// minutes; six hours is generous slack — while a long-lived embedder
-/// that latched yesterday must NOT have yesterday's date re-accepted a
-/// day later (round-2 review of #1803: the day-granular latch let a
-/// day-old covered fetch unlock live quotes recorded under the old
-/// date).
-const STRADDLE_MAX_SECS: i64 = 6 * 3600;
-
-/// Pure decision for the latest-only guard: `date` is fetchable when it
-/// IS `today`, or during a midnight straddle — `date` is yesterday AND
-/// the run's first dated fetch happened on it AND that first fetch was
-/// recent ([`STRADDLE_MAX_SECS`]). The straddle keeps a
-/// `--date $(date +%F)` batch working to its end across midnight
-/// without letting a long-lived embedder replay its latch day later.
-fn latest_date_window_ok(
-    date: rustledger_core::NaiveDate,
-    today: rustledger_core::NaiveDate,
-    first_fetch_day: rustledger_core::NaiveDate,
-    secs_since_first_fetch: i64,
-) -> bool {
-    date == today
-        || (date == first_fetch_day
-            && today.checked_sub(jiff::Span::new().days(1)).ok() == Some(date)
-            && secs_since_first_fetch <= STRADDLE_MAX_SECS)
-}
-
-/// The straddle-minute label clamp, pure for testability: a latest
-/// response labeled with the CURRENT local day while the request was
-/// for an earlier (straddle-accepted) day keeps the requested day —
-/// the local clock rolled mid-batch, not the feed. A feed label ahead
-/// of the LOCAL clock (eastmoneyfund's China civil day from a US
-/// evening) is genuine feed information and passes through untouched
-/// (round-2 review of #1803: the unconditional clamp rewrote those).
-fn clamp_local_label(
-    response_date: rustledger_core::NaiveDate,
-    requested: rustledger_core::NaiveDate,
-    today: rustledger_core::NaiveDate,
-) -> rustledger_core::NaiveDate {
-    if response_date > requested && response_date == today {
-        requested
-    } else {
-        response_date
-    }
-}
-
 /// Date label for a date-independent identity answer (X→X = 1.0).
 ///
 /// Identity is numerically correct for any PAST day, which is why the
@@ -230,34 +172,6 @@ pub(super) fn feed_date_or(
     raw.and_then(|s| s.get(..10))
         .and_then(|s| s.parse::<rustledger_core::NaiveDate>().ok())
         .unwrap_or(fallback)
-}
-
-/// Canonical same-day delegation for single-point window providers:
-/// when the window ends TODAY, answer from the latest endpoint instead
-/// of the dated one (parity with main's `--date <today>` behavior),
-/// returned as a window point. `None` means "not a same-day window —
-/// take the dated path".
-///
-/// The point's date is clamped to `window.end` so a midnight race
-/// between the dispatch's clock and this one cannot label the point
-/// after the requested day and get it discarded by the on-or-before
-/// selection as a spurious "no quote" error (round-2 review of #1803;
-/// the two per-source copies of this delegation had already drifted).
-pub(super) fn same_day_latest_point<S: PriceSource + ?Sized>(
-    source: &S,
-    pair: &PricePair,
-    window: DateWindow,
-) -> Option<Result<Vec<PricePoint>>> {
-    if window.end != jiff::Zoned::now().date() {
-        return None;
-    }
-    Some(source.fetch_latest(pair).map(|response| {
-        vec![PricePoint {
-            date: response.date.min(window.end),
-            price: response.price,
-            currency: Some(response.currency),
-        }]
-    }))
 }
 
 /// Trait for price data sources.
@@ -360,13 +274,17 @@ pub trait PriceSource: Send + Sync {
     /// Dispatch order:
     /// 1. Identity pair (X→X = 1.0 for any past-or-today date).
     /// 2. No date → [`Self::fetch_latest`].
-    /// 3. Date covered by [`Self::historical_coverage`] →
+    /// 3. Future date → refusal on every source.
+    /// 4. Requested date is TODAY → [`Self::fetch_latest`] on every
+    ///    source, uniformly: a day in progress has no close yet, and
+    ///    the response carries the quote's own date. There is
+    ///    deliberately no midnight-straddle acceptance for a completed
+    ///    day (round-3 review of #1803).
+    /// 5. Covered past date ([`Self::historical_coverage`]) →
     ///    [`Self::fetch_window`] over the trailing look-back window,
     ///    then canonical on-or-before selection, labeled with the
     ///    point's own date (#1794).
-    /// 4. Uncovered date that is today (or a midnight straddle, see
-    ///    `latest_date_window_ok`) → [`Self::fetch_latest`].
-    /// 5. Anything else → refusal naming the source and its coverage.
+    /// 6. Anything else → refusal naming the source and its coverage.
     ///
     /// # Errors
     ///
@@ -374,17 +292,6 @@ pub trait PriceSource: Send + Sync {
     /// requests the source cannot serve; "no quote on or before" when
     /// the fetched window is empty.
     fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // The midnight-straddle latch initializes on the FIRST dated
-        // fetch of ANY kind — identity and covered fetches included —
-        // so a batch whose pre-midnight fetches are all identities or
-        // window-capable sources still latches its start day for the
-        // uncovered sources it reaches after midnight (round-1 and
-        // round-2 reviews of #1803 each caught a narrower latch).
-        if request.date.is_some() {
-            let _ = FIRST_DATED_FETCH
-                .get_or_init(|| (jiff::Zoned::now().date(), jiff::Timestamp::now()));
-        }
-
         // 1. Identity: X priced in X is 1.0 on any past-or-today date,
         // source-independent (hoisted out of per-source branches by the
         // #1801 reviews; future labels refuse). The currency is
@@ -410,16 +317,14 @@ pub trait PriceSource: Send + Sync {
         };
 
         let today = jiff::Zoned::now().date();
-        let (first_fetch_day, first_fetch_at) =
-            *FIRST_DATED_FETCH.get_or_init(|| (today, jiff::Timestamp::now()));
 
-        // A price for a day that hasn't happened cannot exist: refuse
-        // FUTURE dates on every source, before any coverage routing.
-        // Without this, Full/Since coverage "covers" the future and the
-        // dated provider endpoints get asked for it — a provider that
-        // answers or clamps would have its response labeled with the
-        // fabricated future date (#1794 class; deep review of #1803).
-        // The straddle window is not future: it only ever looks back.
+        // 3. A price for a day that hasn't happened cannot exist:
+        // refuse FUTURE dates on every source, before any coverage
+        // routing. Without this, Full/Since coverage "covers" the
+        // future and the dated provider endpoints get asked for it — a
+        // provider that answers or clamps would have its response
+        // labeled with the fabricated future date (#1794 class; deep
+        // review of #1803).
         if requested > today {
             anyhow::bail!(
                 "the '{}' source cannot fetch {} for the future date {requested}; \
@@ -429,12 +334,24 @@ pub trait PriceSource: Send + Sync {
             );
         }
 
-        // 3. Covered date → window + canonical selection. Today is
-        // routed here too for window-capable sources (a same-day
-        // request returns the freshest daily bar — yahoo's
-        // pre-existing behavior; coinbase/ratesapi delegate the
-        // end==today case to their latest endpoints internally for
-        // parity with main).
+        // 4. Requested TODAY → latest, uniformly, on every source: the
+        // latest quote IS the freshest answer for a day that is still
+        // in progress, and the response carries the quote's own date —
+        // never the requested one. There is deliberately NO midnight
+        // "straddle" acceptance for a completed day: three review
+        // rounds showed every straddle mechanism (labels clamped by
+        // heuristics, process-wide latches, elapsed-time bounds) trades
+        // one #1794-class mislabel for another, and the straddle only
+        // ever existed as a workaround for missing historical support.
+        // A batch that crosses midnight keeps working on every
+        // window-capable source through the dated path; latest-only
+        // sources refuse the completed day honestly, and their refusal
+        // names the alternative.
+        if requested == today {
+            return self.fetch_latest(&pair);
+        }
+
+        // 5. Covered past date → window + canonical selection.
         let coverage = self.historical_coverage();
         if coverage.covers(requested) {
             let mut start = requested
@@ -469,31 +386,17 @@ pub trait PriceSource: Send + Sync {
             });
         }
 
-        // 4. Uncovered date, but it is today (or a midnight straddle):
-        // the latest quote IS a valid answer for today (#1801). A
-        // response the source labeled with the CURRENT local day while
-        // the request was for the straddle's earlier day is clamped
-        // back — the local clock rolled mid-batch, not the feed.
-        // Genuine feed labels — ECB's Friday on a weekend, or a feed
-        // already on the NEXT civil day (eastmoneyfund's China dates
-        // from a US evening) — pass through untouched (round-2 review
-        // of #1803: the unconditional clamp rewrote those).
-        let secs_since_first_fetch =
-            jiff::Timestamp::now().as_second() - first_fetch_at.as_second();
-        if latest_date_window_ok(requested, today, first_fetch_day, secs_since_first_fetch) {
-            let mut response = self.fetch_latest(&pair)?;
-            response.date = clamp_local_label(response.date, requested, today);
-            return Ok(response);
-        }
-
-        // 5. Refuse: mislabeling the latest quote with this date is the
+        // 6. Refuse: mislabeling the latest quote with this date is the
         // #1794 corruption. The wording tracks the coverage — a Since
         // source is NOT latest-only, its history just starts later than
-        // the requested date (Copilot review).
+        // the requested date (Copilot review). Neither message suggests
+        // a specific alternative source for Since refusals: which
+        // source covers a given asset/date pair is asset-specific
+        // (round-3 review: yahoo has no 2012 crypto either).
         match coverage {
             HistoricalCoverage::Since(s) => anyhow::bail!(
                 "the '{}' source has no history before {s} and cannot fetch {} for \
-                 {requested}; use a source with deeper history (e.g. yahoo)",
+                 {requested}; use a source whose history covers that date",
                 self.name(),
                 request.ticker
             ),
@@ -861,59 +764,41 @@ mod dispatch_tests {
         assert!(select_on_or_before(vec![], d(12)).is_none());
     }
 
-    /// The acceptance window: today always; yesterday ONLY during a
-    /// genuine midnight straddle — the run's first dated fetch happened
-    /// on it AND recently. A long-lived process can never replay its
-    /// latch day later (round-2 deep review of #1803: a day-granular
-    /// latch let a day-old covered fetch unlock live quotes recorded
-    /// under the old date), and future dates never pass.
+    /// Requested TODAY routes to `fetch_latest` on EVERY source — window
+    /// capable ones included (round-3 review of #1803: uniform today
+    /// semantics replaced the per-source same-day delegations and the
+    /// straddle machinery; a day in progress has no close, so the
+    /// latest quote labeled with its own day is the honest answer).
     #[test]
-    fn window_accepts_midnight_straddle_only() {
-        const RECENT: i64 = 1800; // 30 minutes into the batch
-        const DAY_OLD: i64 = 24 * 3600;
-        let d = rustledger_core::naive_date(2026, 7, 16).unwrap();
-        let next = d.checked_add(jiff::Span::new().days(1)).unwrap();
-        let much_later = d.checked_add(jiff::Span::new().days(30)).unwrap();
-
-        assert!(super::latest_date_window_ok(d, d, d, RECENT), "same day");
-        assert!(
-            super::latest_date_window_ok(d, next, d, RECENT),
-            "midnight straddle: run started on d minutes ago, clock now d+1"
-        );
-        assert!(
-            !super::latest_date_window_ok(d, next, d, DAY_OLD),
-            "a latch from a day-old fetch must not reopen yesterday"
-        );
-        assert!(
-            !super::latest_date_window_ok(d, much_later, d, RECENT),
-            "a daemon must not replay its start day weeks later"
-        );
-        assert!(
-            !super::latest_date_window_ok(d, next, next, RECENT),
-            "yesterday is refused when the run did NOT start on it"
-        );
-        assert!(
-            !super::latest_date_window_ok(much_later, d, d, RECENT),
-            "future dates never pass"
-        );
-    }
-
-    /// The label clamp is scoped to local-clock labels: only a response
-    /// dated with the CURRENT day gets clamped down to the straddle's
-    /// requested day. A feed genuinely ahead of the local clock
-    /// (eastmoneyfund's China civil day from a US evening) passes
-    /// through (round-2 deep review of #1803).
-    #[test]
-    fn clamp_only_rewrites_current_day_labels() {
-        let d = |day| rustledger_core::naive_date(2026, 7, day).unwrap();
-        // Straddle minute: local clock rolled to the 17th mid-batch.
-        assert_eq!(super::clamp_local_label(d(17), d(16), d(17)), d(16));
-        // Feed ahead of the local clock: China's 18th from a US 17th.
-        assert_eq!(super::clamp_local_label(d(18), d(17), d(17)), d(18));
-        // Feed behind the request (ECB Friday on a weekend): untouched.
-        assert_eq!(super::clamp_local_label(d(15), d(17), d(17)), d(15));
-        // Label equals the request: untouched.
-        assert_eq!(super::clamp_local_label(d(17), d(17), d(17)), d(17));
+    fn today_routes_to_latest_even_on_covered_sources() {
+        struct CoveredLatest;
+        impl PriceSource for CoveredLatest {
+            fn name(&self) -> &'static str {
+                "mock-covered-latest"
+            }
+            fn description(&self) -> &'static str {
+                "full coverage; today must still use latest"
+            }
+            fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+                Ok(PriceResponse {
+                    price: Decimal::new(700, 2),
+                    currency: pair.currency.clone(),
+                    date: jiff::Zoned::now().date(),
+                    source: self.name().to_string(),
+                })
+            }
+            fn historical_coverage(&self) -> HistoricalCoverage {
+                HistoricalCoverage::Full
+            }
+            fn fetch_window(&self, _p: &PricePair, _w: DateWindow) -> Result<Vec<PricePoint>> {
+                panic!("requested==today must route to fetch_latest, not the window");
+            }
+        }
+        let today = jiff::Zoned::now().date();
+        let response = CoveredLatest
+            .fetch_price(&request(Some(today)))
+            .expect("today serves the latest quote");
+        assert_eq!(response.price.to_string(), "7.00");
     }
 
     /// Identity answers accept any past-or-today label but refuse a

--- a/crates/rustledger/src/cmd/price/sources/oanda.rs
+++ b/crates/rustledger/src/cmd/price/sources/oanda.rs
@@ -48,6 +48,28 @@ impl OandaSource {
         )
     }
 
+    /// The trading day an OANDA D-granularity candle represents.
+    ///
+    /// The candle's `time` field is its OPEN, and daily candles align
+    /// to the 17:00 `America/New_York` session boundary — so a candle's
+    /// open timestamp falls on the civil day BEFORE the trading day it
+    /// represents (Friday's candle opens Thursday 17:00 NY = 21:00Z or
+    /// 22:00Z). Labeling from the raw time field dated every quote one
+    /// trading day early (round-5 deep review of #1803): convert to New
+    /// York time and roll forward past the session boundary instead.
+    /// `None` when the timestamp or the tz database is unavailable —
+    /// the caller falls back to the pre-fetch local day.
+    fn candle_trading_day(time_rfc3339: &str) -> Option<rustledger_core::NaiveDate> {
+        let ts: jiff::Timestamp = time_rfc3339.parse().ok()?;
+        let ny = jiff::tz::TimeZone::get("America/New_York").ok()?;
+        let zoned = ts.to_zoned(ny);
+        if zoned.hour() >= 17 {
+            zoned.date().checked_add(jiff::Span::new().days(1)).ok()
+        } else {
+            Some(zoned.date())
+        }
+    }
+
     /// Format currency pair for OANDA.
     fn format_instrument(ticker: &str, currency: &str) -> String {
         if ticker.contains('_') {
@@ -76,6 +98,10 @@ impl PriceSource for OandaSource {
     }
 
     fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        // Fallback label read BEFORE the network fetch (round-5 deep
+        // review of #1803: a post-fetch read can label with a day the
+        // clock rolled to during I/O).
+        let fallback_date = jiff::Zoned::now().date();
         let api_key = Self::get_api_key()?;
         let instrument = Self::format_instrument(&pair.ticker, &pair.currency);
         let url = self.build_url(&instrument);
@@ -119,15 +145,15 @@ impl PriceSource for OandaSource {
         let price = Decimal::from_str(close_str)
             .with_context(|| format!("Failed to parse price: {close_str}"))?;
 
-        // The candle's OWN day, never the local fetch day: OANDA's
-        // latest D-granularity candle on a weekend is Friday's, and the
-        // RFC3339 "time" field (requested via Accept-Datetime-Format)
-        // says so — its first 10 bytes are the date (round-4 deep
-        // review of #1803; the local-day label was the #1794 class).
-        let date = super::feed_date_or(
-            candle.get("time").and_then(serde_json::Value::as_str),
-            jiff::Zoned::now().date(),
-        );
+        // The candle's OWN trading day, never the local fetch day
+        // (rounds 4-5 deep review of #1803; the local-day label was
+        // the #1794 class, and the raw time field is one day early —
+        // see candle_trading_day).
+        let date = candle
+            .get("time")
+            .and_then(serde_json::Value::as_str)
+            .and_then(Self::candle_trading_day)
+            .unwrap_or(fallback_date);
 
         let target_currency = if instrument.contains('_') {
             instrument.split('_').next_back().unwrap_or(&pair.currency)
@@ -147,6 +173,32 @@ impl PriceSource for OandaSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Candle open times roll forward past the 17:00 New-York session
+    /// boundary onto the trading day the candle represents — in both
+    /// DST regimes — while intraday times stay on their own day
+    /// (round-5 deep review of #1803: the raw open time labeled every
+    /// quote one trading day early).
+    #[test]
+    fn candle_trading_day_rolls_past_session_open() {
+        // Thu 2026-07-16 21:00Z = Thu 17:00 EDT → Friday's candle.
+        assert_eq!(
+            OandaSource::candle_trading_day("2026-07-16T21:00:00.000000000Z"),
+            Some(rustledger_core::naive_date(2026, 7, 17).unwrap())
+        );
+        // Thu 2026-01-15 22:00Z = Thu 17:00 EST (winter) → Friday's.
+        assert_eq!(
+            OandaSource::candle_trading_day("2026-01-15T22:00:00.000000000Z"),
+            Some(rustledger_core::naive_date(2026, 1, 16).unwrap())
+        );
+        // Fri 14:00Z = Fri 10:00 EDT (before the boundary) → Friday.
+        assert_eq!(
+            OandaSource::candle_trading_day("2026-07-17T14:00:00.000000000Z"),
+            Some(rustledger_core::naive_date(2026, 7, 17).unwrap())
+        );
+        // Garbage → None (caller falls back to the pre-fetch day).
+        assert_eq!(OandaSource::candle_trading_day("not-a-time"), None);
+    }
 
     #[test]
     fn test_format_instrument() {

--- a/crates/rustledger/src/cmd/price/sources/oanda.rs
+++ b/crates/rustledger/src/cmd/price/sources/oanda.rs
@@ -119,7 +119,15 @@ impl PriceSource for OandaSource {
         let price = Decimal::from_str(close_str)
             .with_context(|| format!("Failed to parse price: {close_str}"))?;
 
-        let date = jiff::Zoned::now().date();
+        // The candle's OWN day, never the local fetch day: OANDA's
+        // latest D-granularity candle on a weekend is Friday's, and the
+        // RFC3339 "time" field (requested via Accept-Datetime-Format)
+        // says so — its first 10 bytes are the date (round-4 deep
+        // review of #1803; the local-day label was the #1794 class).
+        let date = super::feed_date_or(
+            candle.get("time").and_then(serde_json::Value::as_str),
+            jiff::Zoned::now().date(),
+        );
 
         let target_currency = if instrument.contains('_') {
             instrument.split('_').next_back().unwrap_or(&pair.currency)

--- a/crates/rustledger/src/cmd/price/sources/oanda.rs
+++ b/crates/rustledger/src/cmd/price/sources/oanda.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches forex rates from OANDA's API.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use std::env;
@@ -75,13 +75,9 @@ impl PriceSource for OandaSource {
         Some("OANDA_API_KEY")
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
         let api_key = Self::get_api_key()?;
-        let instrument = Self::format_instrument(&request.ticker, &request.currency);
+        let instrument = Self::format_instrument(&pair.ticker, &pair.currency);
         let url = self.build_url(&instrument);
 
         let mut response = ureq::get(&url)
@@ -123,15 +119,12 @@ impl PriceSource for OandaSource {
         let price = Decimal::from_str(close_str)
             .with_context(|| format!("Failed to parse price: {close_str}"))?;
 
-        let date = request.date.unwrap_or_else(|| jiff::Zoned::now().date());
+        let date = jiff::Zoned::now().date();
 
         let target_currency = if instrument.contains('_') {
-            instrument
-                .split('_')
-                .next_back()
-                .unwrap_or(&request.currency)
+            instrument.split('_').next_back().unwrap_or(&pair.currency)
         } else {
-            &request.currency
+            &pair.currency
         };
 
         Ok(PriceResponse {

--- a/crates/rustledger/src/cmd/price/sources/quandl.rs
+++ b/crates/rustledger/src/cmd/price/sources/quandl.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches financial data from Quandl/Nasdaq Data Link.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use std::env;
 use std::time::Duration;
@@ -76,20 +76,16 @@ impl PriceSource for QuandlSource {
         Some("QUANDL_API_KEY")
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
         let api_key = Self::get_api_key()?;
-        let (database, dataset) = Self::parse_dataset(&request.ticker);
+        let (database, dataset) = Self::parse_dataset(&pair.ticker);
         let full_dataset = format!("{database}/{dataset}");
         let url = self.build_url(&full_dataset, &api_key);
 
         let mut response = ureq::get(&url)
             .header("User-Agent", user_agent())
             .call()
-            .with_context(|| format!("Failed to fetch data for {}", request.ticker))?;
+            .with_context(|| format!("Failed to fetch data for {}", pair.ticker))?;
 
         let json: serde_json::Value = response
             .body_mut()
@@ -162,7 +158,7 @@ impl PriceSource for QuandlSource {
 
         Ok(PriceResponse {
             price,
-            currency: request.currency.clone(),
+            currency: pair.currency.clone(),
             date,
             source: self.name().to_string(),
         })

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -144,7 +144,12 @@ impl PriceSource for RatesApiSource {
         Ok(PriceResponse {
             price,
             currency: pair.currency.clone(),
-            date,
+            // The weekend clamp applies to the LATEST path too: a
+            // Saturday-echoed /latest date over Friday's carried-forward
+            // rate must say Friday, exactly as the window path does
+            // (round-4 deep review of #1803 — the clamp existed on only
+            // one of the two paths).
+            date: Self::eu_reference_label(date),
             source: self.name().to_string(),
         })
     }

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -158,20 +158,10 @@ impl PriceSource for RatesApiSource {
     }
 
     fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
-        // Parity with main for a same-day request: --date <today>
-        // historically hit /latest — the canonical delegation keeps it
-        // that way, and the weekend clamp applies to ITS label too
-        // (round-2 review of #1803: the first delegation bypassed
-        // eu_reference_label, re-admitting weekend-dated directives on
-        // the exact arm round 1 added the clamp for).
-        if let Some(result) = super::same_day_latest_point(self, pair, window) {
-            let mut points = result?;
-            for point in &mut points {
-                point.date = Self::eu_reference_label(point.date);
-            }
-            return Ok(points);
-        }
-
+        // The dispatch routes requested==today to fetch_latest before
+        // the window path, so window.end here is always a COMPLETED
+        // day (round-3 review of #1803 removed the per-source same-day
+        // delegations along with the straddle).
         // The dated endpoint answers a single day; one request at the
         // window's end covers the dispatch's on-or-before selection.
         // The feed's date label is trusted EXCEPT when it echoes a

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -37,8 +37,17 @@ impl RatesApiSource {
     }
 
     /// Shared fetch + parse for the latest and dated endpoints (same
-    /// response shape). Returns `(price, feed_date)`.
-    fn fetch_rate(&self, url: &str, pair: &PricePair) -> Result<(Decimal, NaiveDate)> {
+    /// response shape). Returns `(price, feed_date)`; a missing/broken
+    /// `date` field falls back to `date_fallback` — today for a latest
+    /// fetch, the requested day for a dated one (a today-fallback on a
+    /// historical response would be discarded by the dispatch's
+    /// on-or-before selection, deep review of #1803).
+    fn fetch_rate(
+        &self,
+        url: &str,
+        pair: &PricePair,
+        date_fallback: NaiveDate,
+    ) -> Result<(Decimal, NaiveDate)> {
         let mut response = ureq::get(url)
             .header("User-Agent", user_agent())
             .call()
@@ -79,9 +88,31 @@ impl RatesApiSource {
         // The feed's OWN quote date when present (exchangerate.host
         // returns a "date" field) — on weekends the latest rate belongs
         // to Friday and must say so (deep review, same rule as ECB).
-        let date = super::feed_date_or_today(json.get("date").and_then(serde_json::Value::as_str));
+        let date = super::feed_date_or(
+            json.get("date").and_then(serde_json::Value::as_str),
+            date_fallback,
+        );
 
         Ok((price, date))
+    }
+
+    /// The EU reference series publishes on WEEKDAYS only: a
+    /// weekend-dated label can only be the provider echoing the
+    /// requested URL date over Friday's rate, so clamp it back to the
+    /// preceding Friday instead of writing a rate for a day the ECB
+    /// published nothing (deep review of #1803). Weekday holidays are
+    /// not detectable this way and pass through — a residual trust in
+    /// the feed's labeling.
+    fn eu_reference_label(date: NaiveDate) -> NaiveDate {
+        match date.weekday() {
+            jiff::civil::Weekday::Saturday => {
+                date.checked_sub(jiff::Span::new().days(1)).unwrap_or(date)
+            }
+            jiff::civil::Weekday::Sunday => {
+                date.checked_sub(jiff::Span::new().days(2)).unwrap_or(date)
+            }
+            _ => date,
+        }
     }
 }
 
@@ -100,7 +131,7 @@ impl PriceSource for RatesApiSource {
             &pair.currency.to_uppercase(),
             None,
         );
-        let (price, date) = self.fetch_rate(&url, pair)?;
+        let (price, date) = self.fetch_rate(&url, pair, jiff::Zoned::now().date())?;
 
         Ok(PriceResponse {
             price,
@@ -119,20 +150,35 @@ impl PriceSource for RatesApiSource {
     }
 
     fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
-        // The dated endpoint answers any single day with the nearest
-        // preceding business-day rate under the feed's OWN date, so one
-        // request at the window's end covers the dispatch's on-or-before
-        // selection.
+        // Parity with main for a same-day request: the dated endpoint
+        // serves reference data, while --date <today> historically hit
+        // /latest — keep it that way (deep review of #1803).
+        if window.end == jiff::Zoned::now().date() {
+            let response = self.fetch_latest(pair)?;
+            return Ok(vec![PricePoint {
+                date: response.date,
+                price: response.price,
+                currency: None,
+            }]);
+        }
+
+        // The dated endpoint answers a single day; one request at the
+        // window's end covers the dispatch's on-or-before selection.
+        // The feed's date label is trusted EXCEPT when it echoes a
+        // weekend day — see eu_reference_label.
         let url = self.build_url(
             &pair.ticker.to_uppercase(),
             &pair.currency.to_uppercase(),
             Some(window.end),
         );
-        let (price, date) = self.fetch_rate(&url, pair)?;
+        let (price, date) = self.fetch_rate(&url, pair, window.end)?;
         Ok(vec![PricePoint {
-            date,
+            date: Self::eu_reference_label(date),
             price,
-            currency: Some(pair.currency.clone()),
+            // The feed reports no currency; the dispatch substitutes
+            // the request's (carrying a copy here would shadow that
+            // canonical fallback — deep review of #1803).
+            currency: None,
         }])
     }
 }
@@ -161,6 +207,22 @@ mod tests {
         let source = RatesApiSource::new(Duration::from_secs(30));
         assert_eq!(source.name(), "ratesapi");
         assert!(!source.requires_api_key());
+    }
+
+    /// Weekend-dated labels can only be the provider echoing the URL
+    /// date over Friday's rate — the EU reference series publishes on
+    /// weekdays only, so the label clamps to the preceding Friday
+    /// (deep review of #1803).
+    #[test]
+    fn eu_reference_label_clamps_weekends_to_friday() {
+        let fri = rustledger_core::naive_date(2024, 1, 12).unwrap();
+        let sat = rustledger_core::naive_date(2024, 1, 13).unwrap();
+        let sun = rustledger_core::naive_date(2024, 1, 14).unwrap();
+        let mon = rustledger_core::naive_date(2024, 1, 15).unwrap();
+        assert_eq!(RatesApiSource::eu_reference_label(sat), fri);
+        assert_eq!(RatesApiSource::eu_reference_label(sun), fri);
+        assert_eq!(RatesApiSource::eu_reference_label(fri), fri);
+        assert_eq!(RatesApiSource::eu_reference_label(mon), mon);
     }
 
     #[test]

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -2,10 +2,11 @@
 //!
 //! Fetches currency exchange rates from exchangerate.host or similar free APIs.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{DateWindow, HistoricalCoverage, PricePair, PricePoint, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
+use rustledger_core::NaiveDate;
 use std::time::Duration;
 
 /// Rates API price source.
@@ -26,54 +27,27 @@ impl RatesApiSource {
         Self {}
     }
 
-    /// Build the API URL.
-    fn build_url(&self, base: &str, target: &str) -> String {
-        format!("https://api.exchangerate.host/latest?base={base}&symbols={target}")
-    }
-}
-
-impl PriceSource for RatesApiSource {
-    fn name(&self) -> &'static str {
-        "ratesapi"
-    }
-
-    fn description(&self) -> &'static str {
-        "Exchange Rate API - currency conversion rates"
-    }
-
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Identity rate: 1.0 is correct for any PAST date, so this
-        // branch deliberately sits ABOVE the latest-only guard (deep
-        // review — the guard must not remove previously-correct dated
-        // identity answers). Future labels are refused by
-        // identity_label_date (round-4 review).
-        if request.ticker.to_uppercase() == request.currency.to_uppercase() {
-            return Ok(PriceResponse {
-                price: Decimal::ONE,
-                currency: request.currency.clone(),
-                date: super::identity_label_date(self.name(), request)?,
-                source: self.name().to_string(),
-            });
+    /// Build the API URL. The date-path form serves the historical
+    /// EU-reference rate for that day (#1802).
+    fn build_url(&self, base: &str, target: &str, date: Option<NaiveDate>) -> String {
+        match date {
+            Some(d) => format!("https://api.exchangerate.host/{d}?base={base}&symbols={target}"),
+            None => format!("https://api.exchangerate.host/latest?base={base}&symbols={target}"),
         }
+    }
 
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
-        let url = self.build_url(
-            &request.ticker.to_uppercase(),
-            &request.currency.to_uppercase(),
-        );
-
-        let mut response = ureq::get(&url)
+    /// Shared fetch + parse for the latest and dated endpoints (same
+    /// response shape). Returns `(price, feed_date)`.
+    fn fetch_rate(&self, url: &str, pair: &PricePair) -> Result<(Decimal, NaiveDate)> {
+        let mut response = ureq::get(url)
             .header("User-Agent", user_agent())
             .call()
-            .with_context(|| format!("Failed to fetch rate for {}", request.ticker))?;
+            .with_context(|| format!("Failed to fetch rate for {}", pair.ticker))?;
 
         let json: serde_json::Value = response
             .body_mut()
             .read_json()
-            .with_context(|| format!("Failed to parse response for {}", request.ticker))?;
+            .with_context(|| format!("Failed to parse response for {}", pair.ticker))?;
 
         // Check for success
         let success = json
@@ -94,7 +68,7 @@ impl PriceSource for RatesApiSource {
             .and_then(serde_json::Value::as_object)
             .with_context(|| "Missing 'rates' in response")?;
 
-        let target_currency = request.currency.to_uppercase();
+        let target_currency = pair.currency.to_uppercase();
         let rate_value = rates
             .get(&target_currency)
             .with_context(|| format!("Rate for {target_currency} not found"))?;
@@ -107,12 +81,59 @@ impl PriceSource for RatesApiSource {
         // to Friday and must say so (deep review, same rule as ECB).
         let date = super::feed_date_or_today(json.get("date").and_then(serde_json::Value::as_str));
 
+        Ok((price, date))
+    }
+}
+
+impl PriceSource for RatesApiSource {
+    fn name(&self) -> &'static str {
+        "ratesapi"
+    }
+
+    fn description(&self) -> &'static str {
+        "Exchange Rate API - currency conversion rates"
+    }
+
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let url = self.build_url(
+            &pair.ticker.to_uppercase(),
+            &pair.currency.to_uppercase(),
+            None,
+        );
+        let (price, date) = self.fetch_rate(&url, pair)?;
+
         Ok(PriceResponse {
             price,
-            currency: request.currency.clone(),
+            currency: pair.currency.clone(),
             date,
             source: self.name().to_string(),
         })
+    }
+
+    fn historical_coverage(&self) -> HistoricalCoverage {
+        // exchangerate.host serves the EU reference series, which
+        // begins 1999-01-04 (the euro's first trading day).
+        HistoricalCoverage::Since(
+            rustledger_core::naive_date(1999, 1, 4).expect("static date is valid"),
+        )
+    }
+
+    fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
+        // The dated endpoint answers any single day with the nearest
+        // preceding business-day rate under the feed's OWN date, so one
+        // request at the window's end covers the dispatch's on-or-before
+        // selection.
+        let url = self.build_url(
+            &pair.ticker.to_uppercase(),
+            &pair.currency.to_uppercase(),
+            Some(window.end),
+        );
+        let (price, date) = self.fetch_rate(&url, pair)?;
+        Ok(vec![PricePoint {
+            date,
+            price,
+            currency: Some(pair.currency.clone()),
+        }])
     }
 }
 
@@ -123,9 +144,16 @@ mod tests {
     #[test]
     fn test_build_url() {
         let source = RatesApiSource::new(Duration::from_secs(30));
-        let url = source.build_url("EUR", "USD");
+        let url = source.build_url("EUR", "USD", None);
         assert!(url.contains("EUR"));
         assert!(url.contains("USD"));
+        assert!(url.contains("/latest?"), "{url}");
+
+        // Historical (#1802): the date replaces the /latest path.
+        let d = rustledger_core::naive_date(2024, 1, 15).unwrap();
+        let url = source.build_url("EUR", "USD", Some(d));
+        assert!(url.contains("/2024-01-15?"), "{url}");
+        assert!(!url.contains("latest"), "{url}");
     }
 
     #[test]
@@ -137,6 +165,8 @@ mod tests {
 
     #[test]
     fn test_same_currency_returns_one() {
+        // Served by the trait's canonical identity arm (#1802).
+        use crate::cmd::price::PriceRequest;
         let source = RatesApiSource::new(Duration::from_secs(30));
         let request = PriceRequest::new("USD", "USD");
         let response = source.fetch_price(&request).unwrap();

--- a/crates/rustledger/src/cmd/price/sources/ratesapi.rs
+++ b/crates/rustledger/src/cmd/price/sources/ratesapi.rs
@@ -103,6 +103,14 @@ impl RatesApiSource {
     /// published nothing (deep review of #1803). Weekday holidays are
     /// not detectable this way and pass through — a residual trust in
     /// the feed's labeling.
+    ///
+    /// Deliberate trade-off (round-2 review): some provider variants
+    /// serve weekend-computed blended rates, which this clamp would
+    /// relabel Friday. Spot FX does not reprice over the weekend — a
+    /// "Saturday rate" is a carried-forward Friday rate — and this
+    /// source models the EU reference series specifically; users who
+    /// want weekend-marked data should use a source that has it
+    /// natively (coinbase, yahoo).
     fn eu_reference_label(date: NaiveDate) -> NaiveDate {
         match date.weekday() {
             jiff::civil::Weekday::Saturday => {
@@ -150,16 +158,18 @@ impl PriceSource for RatesApiSource {
     }
 
     fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
-        // Parity with main for a same-day request: the dated endpoint
-        // serves reference data, while --date <today> historically hit
-        // /latest — keep it that way (deep review of #1803).
-        if window.end == jiff::Zoned::now().date() {
-            let response = self.fetch_latest(pair)?;
-            return Ok(vec![PricePoint {
-                date: response.date,
-                price: response.price,
-                currency: None,
-            }]);
+        // Parity with main for a same-day request: --date <today>
+        // historically hit /latest — the canonical delegation keeps it
+        // that way, and the weekend clamp applies to ITS label too
+        // (round-2 review of #1803: the first delegation bypassed
+        // eu_reference_label, re-admitting weekend-dated directives on
+        // the exact arm round 1 added the clamp for).
+        if let Some(result) = super::same_day_latest_point(self, pair, window) {
+            let mut points = result?;
+            for point in &mut points {
+                point.date = Self::eu_reference_label(point.date);
+            }
+            return Ok(points);
         }
 
         // The dated endpoint answers a single day; one request at the

--- a/crates/rustledger/src/cmd/price/sources/tsp.rs
+++ b/crates/rustledger/src/cmd/price/sources/tsp.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches TSP fund share prices from the TSP.gov website.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{PricePair, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use std::time::Duration;
 
@@ -70,13 +70,9 @@ impl PriceSource for TspSource {
         "Thrift Savings Plan - TSP fund share prices"
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        // Latest-only source: a historical --date must refuse, not
-        // mislabel the current quote (#1794).
-        super::reject_historical_date(self.name(), request)?;
-
-        let fund_name = Self::normalize_fund(&request.ticker)
-            .with_context(|| format!("Unknown TSP fund: {}", request.ticker))?;
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let fund_name = Self::normalize_fund(&pair.ticker)
+            .with_context(|| format!("Unknown TSP fund: {}", pair.ticker))?;
 
         let url = self.build_url();
 

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -2,8 +2,8 @@
 //!
 //! Fetches stock, ETF, and cryptocurrency prices from Yahoo Finance.
 
-use super::{PriceSource, user_agent};
-use crate::cmd::price::{PriceRequest, PriceResponse};
+use super::{DateWindow, HistoricalCoverage, PricePair, PricePoint, PriceSource, user_agent};
+use crate::cmd::price::PriceResponse;
 use anyhow::{Context, Result};
 use rustledger_core::NaiveDate;
 use std::time::Duration;
@@ -31,29 +31,27 @@ impl YahooFinanceSource {
 
     /// Build the Yahoo Finance chart-API URL.
     ///
-    /// Latest quote: a one-day range. Historical (#1794): an epoch
-    /// `period1`/`period2` window from six days before to two days after
-    /// the requested date (UTC midnights) — beanprice's
-    /// `get_historical_price` window of `time - 5d .. time`, padded a day
-    /// each side so every exchange UTC offset is covered; the bounds are
-    /// fetch slop, classification happens in `parse_chart`.
-    fn build_url(&self, symbol: &str, date: Option<NaiveDate>) -> Result<String> {
-        match date {
-            Some(d) => {
-                // Window bounds are fetch SLOP, not the classification: a
-                // bar's day is decided by the exchange-local date below, so
-                // the window is padded a day on each side to cover every
-                // UTC offset (deep review of #1801: NZX/ASX sessions cross
-                // UTC midnight).
-                let end = d
+    /// Latest quote (`window = None`): a one-day range. Historical
+    /// (#1794): an epoch `period1`/`period2` range spanning the civil
+    /// window padded a day on each side (UTC midnights) — the epoch
+    /// bounds are fetch SLOP, not the classification: a bar's day is
+    /// decided by the exchange-local date in `parse_points`, and the
+    /// padding covers every exchange UTC offset (deep review of #1801:
+    /// NZX/ASX sessions cross UTC midnight).
+    fn build_url(&self, symbol: &str, window: Option<DateWindow>) -> Result<String> {
+        match window {
+            Some(w) => {
+                let end = w
+                    .end
                     .checked_add(jiff::Span::new().days(2))
                     .context("date overflow")?
                     .to_zoned(jiff::tz::TimeZone::UTC)
                     .context("date out of range")?
                     .timestamp()
                     .as_second();
-                let begin = d
-                    .checked_sub(jiff::Span::new().days(6))
+                let begin = w
+                    .start
+                    .checked_sub(jiff::Span::new().days(1))
                     .context("date underflow")?
                     .to_zoned(jiff::tz::TimeZone::UTC)
                     .context("date out of range")?
@@ -71,89 +69,48 @@ impl YahooFinanceSource {
 
     /// Extract `(price, currency, effective-date)` from a chart response.
     ///
-    /// Latest mode (`requested = None`): `meta.regularMarketPrice`, dated
-    /// today. Historical mode: the LAST non-null close on or before the
-    /// requested date, dated by its own quote timestamp — never the
-    /// requested date (#1794: a Saturday request must emit Friday's close
-    /// under Friday's date). Errors when the window holds no usable quote,
-    /// instead of mislabeling the latest one.
-    fn parse_chart(
+    /// Latest mode: `meta.regularMarketPrice`, labeled with the quote's
+    /// own trading day.
+    fn parse_latest(
         json: &serde_json::Value,
-        requested: Option<NaiveDate>,
         ticker: &str,
     ) -> Result<(rust_decimal::Decimal, Option<String>, NaiveDate)> {
-        // Check for errors in the response
-        if let Some(chart) = json.get("chart")
-            && let Some(error) = chart.get("error")
-            && !error.is_null()
-        {
-            let description = error
-                .get("description")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("Unknown error");
-            anyhow::bail!("Yahoo Finance error: {description}");
-        }
+        let result = Self::chart_result(json, ticker)?;
+        let meta = result.get("meta");
+        let currency = meta
+            .and_then(|m| m.get("currency"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string);
 
-        let result = json
-            .get("chart")
-            .and_then(|c| c.get("result"))
-            .and_then(|r| r.get(0))
-            .with_context(|| format!("Invalid response structure for {ticker}"))?;
+        // Latest quote — labeled with the QUOTE's own trading day
+        // (meta.regularMarketTime) when present, not the local clock:
+        // fetching on a weekend must date the price Friday (#1794).
+        let price_value = meta
+            .and_then(|m| m.get("regularMarketPrice"))
+            .with_context(|| format!("No price found for {ticker}"))?;
+        let price = crate::cmd::price::price_decimal_from_json(price_value)
+            .with_context(|| format!("Invalid price for {ticker}"))?;
+        let date = meta
+            .and_then(|m| m.get("regularMarketTime"))
+            .and_then(serde_json::Value::as_i64)
+            .and_then(|secs| Self::quote_civil_date(result, secs))
+            .unwrap_or_else(|| jiff::Zoned::now().date());
+        Ok((price, currency, date))
+    }
+
+    /// Historical mode: every non-null daily close in the response as a
+    /// raw dated point — classified by the EXCHANGE's civil day, priced
+    /// by its close. Selection is NOT done here: the trait's canonical
+    /// dispatch owns on-or-before selection and labeling (#1802), so
+    /// this parser cannot mislabel anything.
+    fn parse_points(json: &serde_json::Value, ticker: &str) -> Result<Vec<PricePoint>> {
+        let result = Self::chart_result(json, ticker)?;
         let currency = result
             .get("meta")
             .and_then(|m| m.get("currency"))
             .and_then(serde_json::Value::as_str)
             .map(ToString::to_string);
 
-        // Quote timestamps are exchange-session times; classify them by
-        // the EXCHANGE's civil date. Classifying by UTC date shifts
-        // NZX/ASX bars onto the wrong day — the same wrong-date class
-        // #1794 fixed (deep review). Prefer meta.exchangeTimezoneName
-        // (what beanprice uses): a real timezone handles a DST switch
-        // inside the fetch window, where meta.gmtoffset — a single
-        // response-time offset — would misclassify pre-switch
-        // midnight-anchored bars by a day (round-2 deep review). Fall
-        // back to gmtoffset when the name is absent or the tz database
-        // is unavailable.
-        let meta = result.get("meta");
-        let exchange_tz = meta
-            .and_then(|m| m.get("exchangeTimezoneName"))
-            .and_then(serde_json::Value::as_str)
-            .and_then(|name| jiff::tz::TimeZone::get(name).ok());
-        let gmtoffset = meta
-            .and_then(|m| m.get("gmtoffset"))
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0);
-        let quote_civil_date = move |secs: i64| -> Option<NaiveDate> {
-            match &exchange_tz {
-                Some(tz) => jiff::Timestamp::from_second(secs)
-                    .ok()
-                    .map(|t| t.to_zoned(tz.clone()).date()),
-                None => jiff::Timestamp::from_second(secs.checked_add(gmtoffset)?)
-                    .ok()
-                    .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date()),
-            }
-        };
-
-        let Some(requested) = requested else {
-            // Latest quote — labeled with the QUOTE's own trading day
-            // (meta.regularMarketTime) when present, not the local clock:
-            // fetching on a weekend must date the price Friday.
-            let price_value = meta
-                .and_then(|m| m.get("regularMarketPrice"))
-                .with_context(|| format!("No price found for {ticker}"))?;
-            let price = crate::cmd::price::price_decimal_from_json(price_value)
-                .with_context(|| format!("Invalid price for {ticker}"))?;
-            let date = meta
-                .and_then(|m| m.get("regularMarketTime"))
-                .and_then(serde_json::Value::as_i64)
-                .and_then(quote_civil_date)
-                .unwrap_or_else(|| jiff::Zoned::now().date());
-            return Ok((price, currency, date));
-        };
-
-        // Historical: walk timestamps/closes in parallel, keep the last
-        // usable close on or before the requested date.
         let timestamps = result
             .get("timestamp")
             .and_then(serde_json::Value::as_array)
@@ -166,36 +123,87 @@ impl YahooFinanceSource {
             .and_then(serde_json::Value::as_array)
             .with_context(|| format!("No close series for {ticker}"))?;
 
-        // No early break: Yahoo does not guarantee sorted timestamps, so
-        // track the maximum quote date <= requested across the whole
-        // series (deep review).
-        let mut best: Option<(rust_decimal::Decimal, NaiveDate)> = None;
+        let mut points = Vec::with_capacity(timestamps.len());
         for (ts, close) in timestamps.iter().zip(closes) {
             if close.is_null() {
                 continue;
             }
             let Some(secs) = ts.as_i64() else { continue };
-            let Some(quote_date) = quote_civil_date(secs) else {
+            let Some(date) = Self::quote_civil_date(result, secs) else {
                 continue;
             };
-            if quote_date > requested {
-                continue;
-            }
-            if best.as_ref().is_some_and(|(_, d)| *d > quote_date) {
-                continue;
-            }
             if let Some(price) = crate::cmd::price::price_decimal_from_json(close) {
-                best = Some((price, quote_date));
+                points.push(PricePoint {
+                    date,
+                    price,
+                    currency: currency.clone(),
+                });
             }
         }
+        Ok(points)
+    }
 
-        let (price, date) = best.with_context(|| {
-            format!(
-                "no Yahoo quote for {ticker} on or before {requested} in the \
-                 fetched window; the market may not have traded that week"
-            )
-        })?;
-        Ok((price, currency, date))
+    /// Shared error-check + result extraction for chart responses.
+    fn chart_result<'a>(
+        json: &'a serde_json::Value,
+        ticker: &str,
+    ) -> Result<&'a serde_json::Value> {
+        if let Some(chart) = json.get("chart")
+            && let Some(error) = chart.get("error")
+            && !error.is_null()
+        {
+            let description = error
+                .get("description")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("Unknown error");
+            anyhow::bail!("Yahoo Finance error: {description}");
+        }
+        json.get("chart")
+            .and_then(|c| c.get("result"))
+            .and_then(|r| r.get(0))
+            .with_context(|| format!("Invalid response structure for {ticker}"))
+    }
+
+    /// The exchange-local civil day a bar timestamp falls on.
+    ///
+    /// Quote timestamps are exchange-session times; classified by UTC
+    /// date, NZX/ASX bars shift onto the wrong day — the wrong-date
+    /// class #1794 fixed. Prefer `meta.exchangeTimezoneName` (what
+    /// beanprice uses): a real timezone handles a DST switch inside the
+    /// fetch window, where `meta.gmtoffset` — a single response-time
+    /// offset — would misclassify pre-switch midnight-anchored bars by
+    /// a day. Falls back to gmtoffset when the name is absent or the tz
+    /// database is unavailable (#1801 rounds 2-4).
+    fn quote_civil_date(result: &serde_json::Value, secs: i64) -> Option<NaiveDate> {
+        let meta = result.get("meta");
+        let exchange_tz = meta
+            .and_then(|m| m.get("exchangeTimezoneName"))
+            .and_then(serde_json::Value::as_str)
+            .and_then(|name| jiff::tz::TimeZone::get(name).ok());
+        if let Some(tz) = exchange_tz {
+            return jiff::Timestamp::from_second(secs)
+                .ok()
+                .map(|t| t.to_zoned(tz).date());
+        }
+        let gmtoffset = meta
+            .and_then(|m| m.get("gmtoffset"))
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        jiff::Timestamp::from_second(secs.checked_add(gmtoffset)?)
+            .ok()
+            .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date())
+    }
+
+    /// Shared HTTP GET + JSON parse for the chart endpoint.
+    fn get_chart(&self, url: &str, ticker: &str) -> Result<serde_json::Value> {
+        let mut response = ureq::get(url)
+            .header("User-Agent", user_agent())
+            .call()
+            .with_context(|| format!("Failed to fetch price for {ticker}"))?;
+        response
+            .body_mut()
+            .read_json()
+            .with_context(|| format!("Failed to parse response for {ticker}"))
     }
 }
 
@@ -208,27 +216,27 @@ impl PriceSource for YahooFinanceSource {
         "Yahoo Finance - stocks, ETFs, crypto, forex"
     }
 
-    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> {
-        let url = self.build_url(&request.ticker, request.date)?;
-
-        let mut response = ureq::get(&url)
-            .header("User-Agent", user_agent())
-            .call()
-            .with_context(|| format!("Failed to fetch price for {}", request.ticker))?;
-
-        let json: serde_json::Value = response
-            .body_mut()
-            .read_json()
-            .with_context(|| format!("Failed to parse response for {}", request.ticker))?;
-
-        let (price, currency, date) = Self::parse_chart(&json, request.date, &request.ticker)?;
+    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse> {
+        let url = self.build_url(&pair.ticker, None)?;
+        let json = self.get_chart(&url, &pair.ticker)?;
+        let (price, currency, date) = Self::parse_latest(&json, &pair.ticker)?;
 
         Ok(PriceResponse {
             price,
-            currency: currency.unwrap_or_else(|| request.currency.clone()),
+            currency: currency.unwrap_or_else(|| pair.currency.clone()),
             date,
             source: self.name().to_string(),
         })
+    }
+
+    fn historical_coverage(&self) -> HistoricalCoverage {
+        HistoricalCoverage::Full
+    }
+
+    fn fetch_window(&self, pair: &PricePair, window: DateWindow) -> Result<Vec<PricePoint>> {
+        let url = self.build_url(&pair.ticker, Some(window))?;
+        let json = self.get_chart(&url, &pair.ticker)?;
+        Self::parse_points(&json, &pair.ticker)
     }
 }
 
@@ -244,23 +252,30 @@ mod tests {
         assert!(url.contains("query1.finance.yahoo.com"));
         assert!(url.contains("range=1d"));
 
-        // Historical: an epoch window bracketing the requested date, no
-        // range param (#1794 — range=1d was the always-latest bug).
-        let d = rustledger_core::naive_date(2025, 1, 2).unwrap();
-        let url = source.build_url("AAPL", Some(d)).expect("historical url");
+        // Historical: an epoch range bracketing the civil window, no
+        // range param (#1794 -- range=1d was the always-latest bug).
+        // The dispatch builds windows as `requested-6 ..= requested`;
+        // build_url pads the epoch bounds a day each side for exchange
+        // UTC offsets.
+        let end = rustledger_core::naive_date(2025, 1, 2).unwrap();
+        let start = end.checked_sub(jiff::Span::new().days(6)).unwrap();
+        let url = source
+            .build_url("AAPL", Some(DateWindow { start, end }))
+            .expect("historical url");
         assert!(url.contains("period1="), "{url}");
         assert!(url.contains("period2="), "{url}");
         assert!(!url.contains("range="), "{url}");
-        // period2 is the exclusive end: midnight UTC of the day after.
+        // period2: midnight UTC two days after the window end (slop).
         assert!(url.contains("period2=1735948800"), "{url}");
     }
 
-    /// Fixture-driven historical parsing: Sat 2025-01-04 requested, the
-    /// window holds Thu/Fri closes plus a null (market holiday) — the
-    /// result is FRIDAY's close under FRIDAY's date, never the requested
-    /// Saturday or the latest quote (#1794).
+    /// Fixture-driven historical parsing: the response holds Thu/Fri/Mon
+    /// closes. `parse_points` returns ALL of them as raw dated points --
+    /// selection belongs to the dispatch, which for a Saturday request
+    /// picks FRIDAY's close under FRIDAY's date (#1794), exercised here
+    /// through the same canonical `select_on_or_before`.
     #[test]
-    fn parse_chart_historical_picks_last_close_on_or_before_date() {
+    fn parse_points_returns_all_bars_and_selection_picks_friday() {
         // 2025-01-02 (Thu) 14:30 UTC, 2025-01-03 (Fri), 2025-01-06 (Mon)
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
@@ -269,17 +284,26 @@ mod tests {
                 "indicators": { "quote": [{ "close": [243.85, 243.36, 245.00] }] }
             }], "error": null }
         });
+        let points = YahooFinanceSource::parse_points(&json, "AAPL").expect("parses");
+        assert_eq!(points.len(), 3);
+        assert_eq!(
+            points[1].date,
+            rustledger_core::naive_date(2025, 1, 3).unwrap()
+        );
+        assert_eq!(points[1].currency.as_deref(), Some("USD"));
+
         let requested = rustledger_core::naive_date(2025, 1, 4).unwrap();
-        let (price, currency, date) =
-            YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL").expect("parses");
-        assert_eq!(price.to_string(), "243.36");
-        assert_eq!(currency.as_deref(), Some("USD"));
-        assert_eq!(date, rustledger_core::naive_date(2025, 1, 3).unwrap());
+        let picked = super::super::select_on_or_before(points, requested).expect("some");
+        assert_eq!(picked.price.to_string(), "243.36");
+        assert_eq!(
+            picked.date,
+            rustledger_core::naive_date(2025, 1, 3).unwrap()
+        );
     }
 
     /// Null closes (holidays) are skipped, not treated as zero.
     #[test]
-    fn parse_chart_skips_null_closes() {
+    fn parse_points_skips_null_closes() {
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": { "currency": "USD" },
@@ -287,17 +311,19 @@ mod tests {
                 "indicators": { "quote": [{ "close": [243.85, null] }] }
             }], "error": null }
         });
-        let requested = rustledger_core::naive_date(2025, 1, 3).unwrap();
-        let (price, _, date) =
-            YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL").expect("parses");
-        assert_eq!(price.to_string(), "243.85");
-        assert_eq!(date, rustledger_core::naive_date(2025, 1, 2).unwrap());
+        let points = YahooFinanceSource::parse_points(&json, "AAPL").expect("parses");
+        assert_eq!(points.len(), 1);
+        assert_eq!(
+            points[0].date,
+            rustledger_core::naive_date(2025, 1, 2).unwrap()
+        );
     }
 
-    /// An empty window is a hard error — never the latest quote under a
-    /// historical label (the exact corruption from #1794).
+    /// A window whose every quote is AFTER the requested date yields no
+    /// selection -- the dispatch turns that into a hard error, never the
+    /// latest quote under a historical label (the exact #1794 corruption).
     #[test]
-    fn parse_chart_errors_when_no_quote_in_window() {
+    fn selection_refuses_when_no_quote_on_or_before() {
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": { "currency": "USD", "regularMarketPrice": 999.99 },
@@ -305,26 +331,23 @@ mod tests {
                 "indicators": { "quote": [{ "close": [245.00] }] }
             }], "error": null }
         });
-        // Requested date precedes every quote in the window.
+        let points = YahooFinanceSource::parse_points(&json, "AAPL").expect("parses");
         let requested = rustledger_core::naive_date(2025, 1, 4).unwrap();
-        let err = YahooFinanceSource::parse_chart(&json, Some(requested), "AAPL")
-            .expect_err("must refuse");
-        assert!(err.to_string().contains("on or before"), "{err}");
+        assert!(super::super::select_on_or_before(points, requested).is_none());
     }
 
     /// Exchange-timezone classification (deep review): NZX trades at
     /// UTC+12 in July (NZST), so Tuesday's 10:00 NZST bar is Monday
-    /// 22:00 UTC. Classified by UTC date it would masquerade as Monday
-    /// and overwrite Monday's real close; classified by exchange-local
-    /// date (meta.gmtoffset — no exchangeTimezoneName in this fixture,
-    /// exercising the fallback) the Monday request returns MONDAY's
-    /// close.
+    /// 22:00 UTC. Classified by UTC date it would masquerade as Monday;
+    /// classified by exchange-local date (meta.gmtoffset -- no
+    /// exchangeTimezoneName in this fixture, exercising the fallback)
+    /// each bar lands on its own trading day.
     #[test]
-    fn parse_chart_classifies_by_exchange_timezone() {
+    fn parse_points_classifies_by_exchange_timezone() {
         // gmtoffset +12h (43200). Monday 2026-07-13 10:00 NZST
         // = Sunday 2026-07-12 22:00 UTC = 1783893600.
         // Tuesday 2026-07-14 10:00 NZST = Monday 2026-07-13 22:00 UTC
-        // = 1783980000 — by UTC date it masquerades as Monday.
+        // = 1783980000 -- by UTC date it masquerades as Monday.
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": { "currency": "NZD", "gmtoffset": 43200 },
@@ -332,23 +355,32 @@ mod tests {
                 "indicators": { "quote": [{ "close": [1.11, 2.22] }] }
             }], "error": null }
         });
+        let points = YahooFinanceSource::parse_points(&json, "AIR.NZ").expect("parses");
+        assert_eq!(
+            points[0].date,
+            rustledger_core::naive_date(2026, 7, 13).unwrap()
+        );
+        assert_eq!(
+            points[1].date,
+            rustledger_core::naive_date(2026, 7, 14).unwrap()
+        );
+
+        // The Monday request must get Monday's bar, not Tuesday's.
         let requested = rustledger_core::naive_date(2026, 7, 13).unwrap();
-        let (price, _, date) =
-            YahooFinanceSource::parse_chart(&json, Some(requested), "AIR.NZ").expect("parses");
-        assert_eq!(price.to_string(), "1.11", "Monday's bar, not Tuesday's");
-        assert_eq!(date, rustledger_core::naive_date(2026, 7, 13).unwrap());
+        let picked = super::super::select_on_or_before(points, requested).expect("some");
+        assert_eq!(picked.price.to_string(), "1.11");
     }
 
-    /// A DST switch inside the fetch window (round-2 deep review):
-    /// meta.gmtoffset is the offset at RESPONSE time, so applying it to
-    /// a bar from before the switch shifts midnight-anchored bars by an
-    /// hour — a full civil day for FX bars stamped at local 00:00.
-    /// exchangeTimezoneName resolves each bar with the offset in force
-    /// at ITS OWN instant.
+    /// A DST switch inside the fetch window (round-2 deep review of
+    /// #1801): meta.gmtoffset is the offset at RESPONSE time, so
+    /// applying it to a bar from before the switch shifts
+    /// midnight-anchored bars by an hour -- a full civil day for FX bars
+    /// stamped at local 00:00. exchangeTimezoneName resolves each bar
+    /// with the offset in force at ITS OWN instant.
     #[test]
-    fn parse_chart_handles_dst_transition_via_timezone_name() {
+    fn parse_points_handles_dst_transition_via_timezone_name() {
         // America/New_York, DST ends 2025-11-02.
-        // Fri 2025-10-31 00:00 EDT (UTC-4) = 04:00 UTC = 1761883200 —
+        // Fri 2025-10-31 00:00 EDT (UTC-4) = 04:00 UTC = 1761883200 --
         //   post-switch gmtoffset -18000 would misdate it 2025-10-30.
         // Tue 2025-11-04 00:00 EST (UTC-5) = 05:00 UTC = 1762232400.
         let json: serde_json::Value = serde_json::json!({
@@ -362,17 +394,22 @@ mod tests {
                 "indicators": { "quote": [{ "close": [1.11, 2.22] }] }
             }], "error": null }
         });
-        let requested = rustledger_core::naive_date(2025, 10, 31).unwrap();
-        let (price, _, date) =
-            YahooFinanceSource::parse_chart(&json, Some(requested), "EURUSD=X").expect("parses");
-        assert_eq!(price.to_string(), "1.11", "Friday's pre-switch bar");
-        assert_eq!(date, requested, "classified by its own instant's offset");
+        let points = YahooFinanceSource::parse_points(&json, "EURUSD=X").expect("parses");
+        assert_eq!(
+            points[0].date,
+            rustledger_core::naive_date(2025, 10, 31).unwrap(),
+            "classified by its own instant's offset"
+        );
+        assert_eq!(
+            points[1].date,
+            rustledger_core::naive_date(2025, 11, 4).unwrap()
+        );
     }
 
     /// The latest path labels with the quote's own trading day
     /// (regularMarketTime + gmtoffset), not the local clock.
     #[test]
-    fn parse_chart_latest_uses_quote_own_date() {
+    fn parse_latest_uses_quote_own_date() {
         // Friday 2026-07-10 16:00 US/Eastern (UTC-4) = 20:00 UTC
         // = 1783713600; gmtoffset -14400.
         let json: serde_json::Value = serde_json::json!({
@@ -385,20 +422,19 @@ mod tests {
                 }
             }], "error": null }
         });
-        let (_, _, date) = YahooFinanceSource::parse_chart(&json, None, "AAPL").expect("parses");
+        let (_, _, date) = YahooFinanceSource::parse_latest(&json, "AAPL").expect("parses");
         assert_eq!(date, rustledger_core::naive_date(2026, 7, 10).unwrap());
     }
 
     /// The latest path still reads regularMarketPrice.
     #[test]
-    fn parse_chart_latest_uses_regular_market_price() {
+    fn parse_latest_uses_regular_market_price() {
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": { "currency": "USD", "regularMarketPrice": 243.85 }
             }], "error": null }
         });
-        let (price, currency, _) =
-            YahooFinanceSource::parse_chart(&json, None, "AAPL").expect("parses");
+        let (price, currency, _) = YahooFinanceSource::parse_latest(&json, "AAPL").expect("parses");
         assert_eq!(price.to_string(), "243.85");
         assert_eq!(currency.as_deref(), Some("USD"));
     }

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -111,12 +111,20 @@ impl YahooFinanceSource {
             .with_context(|| format!("No price found for {ticker}"))?;
         let price = crate::cmd::price::price_decimal_from_json(price_value)
             .with_context(|| format!("Invalid price for {ticker}"))?;
+        // No regularMarketTime → no honest date for the quote → error,
+        // never a local-clock guess: a Saturday fetch would label
+        // Friday's price with Saturday (#1794-lite), and the --date
+        // <today> path now routes through here too (round-4 deep
+        // review of #1803). The field is present for every tradeable
+        // instrument in practice.
         let clock = Self::exchange_clock(result);
         let date = meta
             .and_then(|m| m.get("regularMarketTime"))
             .and_then(serde_json::Value::as_i64)
             .and_then(|secs| clock.civil_date(secs))
-            .unwrap_or_else(|| jiff::Zoned::now().date());
+            .with_context(|| {
+                format!("Yahoo response for {ticker} carried no regularMarketTime; cannot date the quote")
+            })?;
         Ok((price, currency, date))
     }
 
@@ -444,12 +452,30 @@ mod tests {
         assert_eq!(date, rustledger_core::naive_date(2026, 7, 10).unwrap());
     }
 
-    /// The latest path still reads regularMarketPrice.
+    /// The latest path reads regularMarketPrice and requires the
+    /// quote's own timestamp.
     #[test]
-    fn parse_latest_uses_regular_market_price() {
+    fn parse_latest_refuses_undatable_quotes() {
+        // No regularMarketTime → refuse rather than guess a local date
+        // (round-4 deep review of #1803: the local-today fallback was a
+        // #1794-lite residue newly reachable via --date <today>).
         let json: serde_json::Value = serde_json::json!({
             "chart": { "result": [{
                 "meta": { "currency": "USD", "regularMarketPrice": 243.85 }
+            }], "error": null }
+        });
+        let err = YahooFinanceSource::parse_latest(&json, "AAPL").expect_err("must refuse");
+        assert!(err.to_string().contains("regularMarketTime"), "{err}");
+
+        // With the timestamp present, price and currency parse as before.
+        let json: serde_json::Value = serde_json::json!({
+            "chart": { "result": [{
+                "meta": {
+                    "currency": "USD",
+                    "regularMarketPrice": 243.85,
+                    "regularMarketTime": 1_783_713_600_i64,
+                    "gmtoffset": -14400
+                }
             }], "error": null }
         });
         let (price, currency, _) = YahooFinanceSource::parse_latest(&json, "AAPL").expect("parses");

--- a/crates/rustledger/src/cmd/price/sources/yahoo.rs
+++ b/crates/rustledger/src/cmd/price/sources/yahoo.rs
@@ -8,6 +8,27 @@ use anyhow::{Context, Result};
 use rustledger_core::NaiveDate;
 use std::time::Duration;
 
+/// A resolved exchange timezone (or fixed-offset fallback) for
+/// classifying bar timestamps — see [`YahooFinanceSource::exchange_clock`].
+struct ExchangeClock {
+    tz: Option<jiff::tz::TimeZone>,
+    gmtoffset: i64,
+}
+
+impl ExchangeClock {
+    /// The exchange-local civil day `secs` falls on.
+    fn civil_date(&self, secs: i64) -> Option<NaiveDate> {
+        if let Some(tz) = &self.tz {
+            return jiff::Timestamp::from_second(secs)
+                .ok()
+                .map(|t| t.to_zoned(tz.clone()).date());
+        }
+        jiff::Timestamp::from_second(secs.checked_add(self.gmtoffset)?)
+            .ok()
+            .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date())
+    }
+}
+
 /// Yahoo Finance price source.
 ///
 /// Uses the Yahoo Finance API to fetch prices for stocks, ETFs, mutual funds,
@@ -90,10 +111,11 @@ impl YahooFinanceSource {
             .with_context(|| format!("No price found for {ticker}"))?;
         let price = crate::cmd::price::price_decimal_from_json(price_value)
             .with_context(|| format!("Invalid price for {ticker}"))?;
+        let clock = Self::exchange_clock(result);
         let date = meta
             .and_then(|m| m.get("regularMarketTime"))
             .and_then(serde_json::Value::as_i64)
-            .and_then(|secs| Self::quote_civil_date(result, secs))
+            .and_then(|secs| clock.civil_date(secs))
             .unwrap_or_else(|| jiff::Zoned::now().date());
         Ok((price, currency, date))
     }
@@ -123,13 +145,14 @@ impl YahooFinanceSource {
             .and_then(serde_json::Value::as_array)
             .with_context(|| format!("No close series for {ticker}"))?;
 
+        let clock = Self::exchange_clock(result);
         let mut points = Vec::with_capacity(timestamps.len());
         for (ts, close) in timestamps.iter().zip(closes) {
             if close.is_null() {
                 continue;
             }
             let Some(secs) = ts.as_i64() else { continue };
-            let Some(date) = Self::quote_civil_date(result, secs) else {
+            let Some(date) = clock.civil_date(secs) else {
                 continue;
             };
             if let Some(price) = crate::cmd::price::price_decimal_from_json(close) {
@@ -164,7 +187,9 @@ impl YahooFinanceSource {
             .with_context(|| format!("Invalid response structure for {ticker}"))
     }
 
-    /// The exchange-local civil day a bar timestamp falls on.
+    /// The exchange clock for classifying bar timestamps, resolved ONCE
+    /// per response (the tz-database lookup and meta traversal are
+    /// loop-invariant — deep review of #1803).
     ///
     /// Quote timestamps are exchange-session times; classified by UTC
     /// date, NZX/ASX bars shift onto the wrong day — the wrong-date
@@ -174,24 +199,17 @@ impl YahooFinanceSource {
     /// offset — would misclassify pre-switch midnight-anchored bars by
     /// a day. Falls back to gmtoffset when the name is absent or the tz
     /// database is unavailable (#1801 rounds 2-4).
-    fn quote_civil_date(result: &serde_json::Value, secs: i64) -> Option<NaiveDate> {
+    fn exchange_clock(result: &serde_json::Value) -> ExchangeClock {
         let meta = result.get("meta");
-        let exchange_tz = meta
+        let tz = meta
             .and_then(|m| m.get("exchangeTimezoneName"))
             .and_then(serde_json::Value::as_str)
             .and_then(|name| jiff::tz::TimeZone::get(name).ok());
-        if let Some(tz) = exchange_tz {
-            return jiff::Timestamp::from_second(secs)
-                .ok()
-                .map(|t| t.to_zoned(tz).date());
-        }
         let gmtoffset = meta
             .and_then(|m| m.get("gmtoffset"))
             .and_then(serde_json::Value::as_i64)
             .unwrap_or(0);
-        jiff::Timestamp::from_second(secs.checked_add(gmtoffset)?)
-            .ok()
-            .map(|t| t.to_zoned(jiff::tz::TimeZone::UTC).date())
+        ExchangeClock { tz, gmtoffset }
     }
 
     /// Shared HTTP GET + JSON parse for the chart endpoint.

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -371,7 +371,11 @@ pub fn run_with_writer<W: Write>(
             // cost currency) as a base candidate, whose resolved quote is then
             // itself. bean-price never fetches a currency against itself; left
             // unfiltered this emits a nonsensical `price USD … USD` directive.
-            if &effective_currency == symbol {
+            // Case-insensitive: the dispatch's identity arm matches
+            // case-insensitively too, so a `-c usd` run would otherwise
+            // slip past this skip and emit the self-pair anyway (round-2
+            // deep review of #1803).
+            if effective_currency.eq_ignore_ascii_case(symbol) {
                 continue;
             }
             // --clobber: pre-fetch skip when an explicit `price` directive for
@@ -837,8 +841,9 @@ fn run_with_external_command<W: Write>(
             // fetch and --dry-run paths: a commodity is never priced in itself
             // (guards against `--undeclared` picking up the operating/quote
             // currency as a base, which would emit a nonsensical `price USD …
-            // USD` directive).
-            if &effective_currency == symbol {
+            // USD` directive). Case-insensitive, matching the network path
+            // and the dispatch's identity arm (round-2 review of #1803).
+            if effective_currency.eq_ignore_ascii_case(symbol) {
                 continue;
             }
             // --clobber: skip when an existing price for this (symbol, currency, date)

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -135,6 +135,17 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     run_with_writer(args, price_config, &mut stdout)
 }
 
+/// Dedup key for a `(symbol, quote-currency, date)` price identity: the
+/// currency is uppercased so `-c usd` and lowercase `price:` metadata
+/// match the ledger's uppercase commodities on every comparison site —
+/// the self-referential skips are case-insensitive for the same reason
+/// (round-3 deep review of #1803: the skips were fixed but the dedup
+/// lookups still compared raw case, forcing refetches and duplicate
+/// directives on mixed-case runs).
+fn dedup_key(symbol: &str, currency: &str, date: NaiveDate) -> (String, String, NaiveDate) {
+    (symbol.to_string(), currency.to_uppercase(), date)
+}
+
 /// Run the price command, writing fetched prices / plans / source listings
 /// to `out`.
 ///
@@ -244,9 +255,9 @@ pub fn run_with_writer<W: Write>(
         let mut existing = HashSet::new();
         for spanned in &ledger.directives {
             if let rustledger_core::Directive::Price(p) = &spanned.value {
-                existing.insert((
-                    p.currency.as_str().to_string(),
-                    p.amount.currency.as_str().to_string(),
+                existing.insert(dedup_key(
+                    p.currency.as_str(),
+                    p.amount.currency.as_str(),
                     p.date,
                 ));
             }
@@ -384,11 +395,7 @@ pub fn run_with_writer<W: Write>(
             // user re-runs `rledger price -f` and wants idempotent output.
             if !args.clobber {
                 let fetch_date = date.unwrap_or_else(|| jiff::Zoned::now().date());
-                if existing_prices.contains(&(
-                    symbol.clone(),
-                    effective_currency.clone(),
-                    fetch_date,
-                )) {
+                if existing_prices.contains(&dedup_key(symbol, &effective_currency, fetch_date)) {
                     if args.verbose {
                         eprintln!(
                             "{symbol}: skipped (existing price for {fetch_date} {effective_currency}; pass --clobber to refetch)"
@@ -409,11 +416,7 @@ pub fn run_with_writer<W: Write>(
                 // price cached on Friday would re-emit the Friday `price`
                 // directive on Saturday and Sunday runs.
                 if !args.clobber
-                    && existing_prices.contains(&(
-                        symbol.clone(),
-                        cached.currency.clone(),
-                        cached.date,
-                    ))
+                    && existing_prices.contains(&dedup_key(symbol, &cached.currency, cached.date))
                 {
                     if args.verbose {
                         eprintln!(
@@ -480,9 +483,9 @@ pub fn run_with_writer<W: Write>(
                     // requested date, so duplicates can still slip through. Re-check
                     // here against the actual response date.
                     if !args.clobber
-                        && existing_prices.contains(&(
-                            symbol.clone(),
-                            response.currency.clone(),
+                        && existing_prices.contains(&dedup_key(
+                            symbol,
+                            &response.currency,
                             response.date,
                         ))
                     {
@@ -653,8 +656,10 @@ fn dump_fetch_plan(
         for (currency, per_spec_mapping) in per_quote_jobs {
             // Skip self-referential (base == quote) jobs so `--dry-run` matches
             // the fetch path: a commodity is never priced in itself. See the
-            // identical guard in the fetch loop above.
-            if &currency == symbol {
+            // identical guard in the fetch loop above — case-insensitive like
+            // it, or dry-run would plan fetches the real run skips (round-3
+            // deep review of #1803).
+            if currency.eq_ignore_ascii_case(symbol) {
                 continue;
             }
             // Apply the per-spec mapping override so describe_attempts shows
@@ -703,7 +708,7 @@ fn dump_fetch_plan(
             };
 
             let skipped = !args.clobber
-                && existing_prices.contains(&(symbol.clone(), currency.clone(), fetch_date));
+                && existing_prices.contains(&dedup_key(symbol, &currency, fetch_date));
             let suffix = if skipped {
                 "  [skip: existing price]"
             } else {
@@ -850,11 +855,7 @@ fn run_with_external_command<W: Write>(
             // is already in the file. Same rule as the network fetch path.
             if !args.clobber {
                 let fetch_date = date.unwrap_or_else(|| jiff::Zoned::now().date());
-                if existing_prices.contains(&(
-                    symbol.clone(),
-                    effective_currency.clone(),
-                    fetch_date,
-                )) {
+                if existing_prices.contains(&dedup_key(symbol, &effective_currency, fetch_date)) {
                     if args.verbose {
                         eprintln!(
                             "{symbol}: skipped (existing price for {fetch_date} {effective_currency}; pass --clobber to refetch)"
@@ -877,9 +878,9 @@ fn run_with_external_command<W: Write>(
                     // the requested date. Skip writing if the actual response
                     // duplicates an existing directive.
                     if !args.clobber
-                        && existing_prices.contains(&(
-                            symbol.clone(),
-                            response.currency.clone(),
+                        && existing_prices.contains(&dedup_key(
+                            symbol,
+                            &response.currency,
                             response.date,
                         ))
                     {

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -784,10 +784,17 @@ fn write_price(
 ) -> Result<()> {
     if beancount {
         let date_str = response.date.to_string();
+        // The emitted commodity must be valid beancount: uppercase the
+        // symbol like dedup_key does, or `rledger price aapl -b` writes
+        // a lowercase commodity the grammar rejects (round-5 deep
+        // review of #1803). The plain (non-beancount) format below
+        // keeps the user's casing — it is display, not ledger syntax.
         writeln!(
             handle,
-            "{date_str} price {symbol} {} {}",
-            response.price, response.currency
+            "{date_str} price {} {} {}",
+            symbol.to_uppercase(),
+            response.price,
+            response.currency
         )?;
         // Opt-in provenance (see PriceArgs::source_meta): record the fetching
         // source as beancount metadata on the directive. Off by default so the

--- a/crates/rustledger/src/cmd/price_cmd.rs
+++ b/crates/rustledger/src/cmd/price_cmd.rs
@@ -135,15 +135,16 @@ pub fn run(args: &PriceArgs, price_config: &PriceConfig) -> Result<()> {
     run_with_writer(args, price_config, &mut stdout)
 }
 
-/// Dedup key for a `(symbol, quote-currency, date)` price identity: the
-/// currency is uppercased so `-c usd` and lowercase `price:` metadata
-/// match the ledger's uppercase commodities on every comparison site —
-/// the self-referential skips are case-insensitive for the same reason
-/// (round-3 deep review of #1803: the skips were fixed but the dedup
-/// lookups still compared raw case, forcing refetches and duplicate
-/// directives on mixed-case runs).
+/// Dedup key for a `(symbol, quote-currency, date)` price identity:
+/// both symbol and currency are uppercased so `rledger price aapl` and
+/// `-c usd` match the ledger's grammar-uppercase commodities on every
+/// comparison site — the self-referential skips are case-insensitive
+/// for the same reason (rounds 3-4 deep review of #1803). The CACHE
+/// key (`cache_key` in cache.rs) normalizes its currency segment the
+/// same way but keeps the ticker raw — provider tickers can be
+/// case-significant; see the paired comment there.
 fn dedup_key(symbol: &str, currency: &str, date: NaiveDate) -> (String, String, NaiveDate) {
-    (symbol.to_string(), currency.to_uppercase(), date)
+    (symbol.to_uppercase(), currency.to_uppercase(), date)
 }
 
 /// Run the price command, writing fetched prices / plans / source listings
@@ -456,7 +457,16 @@ pub fn run_with_writer<W: Write>(
 
             match result {
                 Ok(response) => {
-                    if let Some(ref mut c) = cache {
+                    // Never cache a response dated AFTER its key date: a
+                    // dated key holding a later-dated quote is incoherent,
+                    // and the settled-cache rule (key day < fetch day →
+                    // immortal) would freeze a midnight-race live quote as
+                    // day D's price of record (round-4 deep review of
+                    // #1803). The response itself is still emitted.
+                    let cacheable = date.is_none_or(|d| response.date <= d);
+                    if let Some(ref mut c) = cache
+                        && cacheable
+                    {
                         // Use the actual source that responded (may differ from
                         // default due to fallback chains)
                         let actual_key =

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -24,7 +24,7 @@ rledger price [OPTIONS] [SYMBOL]...
 |--------|-------------|
 | `-f, --file <FILE>` | Beancount file to discover commodities from |
 | `-c, --currency <CURRENCY>` | Base currency for price quotes [default: USD] |
-| `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today). Historical dates need a source with historical support: `yahoo`, or an external `--source-cmd` that honors `RLEDGER_DATE`. Latest-only sources (coinbase, ecb, ratesapi, alphavantage, …) accept only today's date and refuse past or future dates instead of mislabeling the current quote (#1794). |
+| `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today). Historical dates need a source with historical support: `yahoo`, `coinbase`, `ratesapi` (EU-reference history from 1999-01-04), or an external `--source-cmd` that honors `RLEDGER_DATE`. Latest-only sources (ecb, alphavantage, coincap, …) accept only today's date and refuse past or future dates instead of mislabeling the current quote (#1794, #1802). |
 | `-b, --beancount` | Output as beancount price directives |
 | `--source-meta` | With `-b`, also write a `source:` metadata line on each price directive recording which provider produced the quote (opt-in provenance — see note below). Requires `-b`. |
 | `-s, --source <SOURCE>` | Use specific source (overrides mapping) |

--- a/docs/commands/price.md
+++ b/docs/commands/price.md
@@ -24,7 +24,7 @@ rledger price [OPTIONS] [SYMBOL]...
 |--------|-------------|
 | `-f, --file <FILE>` | Beancount file to discover commodities from |
 | `-c, --currency <CURRENCY>` | Base currency for price quotes [default: USD] |
-| `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today). Historical dates need a source with historical support: `yahoo`, `coinbase`, `ratesapi` (EU-reference history from 1999-01-04), or an external `--source-cmd` that honors `RLEDGER_DATE`. Latest-only sources (ecb, alphavantage, coincap, …) accept only today's date and refuse past or future dates instead of mislabeling the current quote (#1794, #1802). |
+| `-d, --date <DATE>` | Date for prices (YYYY-MM-DD, defaults to today). Historical dates need a source with historical support: `yahoo`, `coinbase` (from 2015-01-01, its exchange launch; later-listed pairs start later), `ratesapi` (EU-reference history from 1999-01-04), or an external `--source-cmd` that honors `RLEDGER_DATE`. Latest-only sources (ecb, alphavantage, coincap, …) accept only today's date and refuse past or future dates instead of mislabeling the current quote (#1794, #1802). |
 | `-b, --beancount` | Output as beancount price directives |
 | `--source-meta` | With `-b`, also write a `source:` metadata line on each price directive recording which provider produced the quote (opt-in provenance — see note below). Requires `-b`. |
 | `-s, --source <SOURCE>` | Use specific source (overrides mapping) |


### PR DESCRIPTION
## What

Rearchitects `PriceSource` around the design proposed in #1802 (grounded in a primary-source survey of beanprice, pricehist, Finance::Quote, and ccxt — see the issue comment for the evidence):

```rust
trait PriceSource {
    fn fetch_latest(&self, pair: &PricePair) -> Result<PriceResponse>;          // mandatory
    fn historical_coverage(&self) -> HistoricalCoverage { None }                // capability as data
    fn fetch_window(&self, pair: &PricePair, w: DateWindow) -> Result<Vec<PricePoint>>; // the historical primitive
    fn fetch_price(&self, request: &PriceRequest) -> Result<PriceResponse> { /* provided: canonical dispatch */ }
}
```

- **All date semantics live in one provided method**: identity pairs, coverage refusal, the today/midnight-straddle window, on-or-before selection, and own-date labeling. Sources return raw dated points and *cannot* mislabel a response — every defect in #1801's four review rounds was a per-source date-labeling mistake, and this makes the whole class structurally impossible. The ten per-source `reject_historical_date` guards and the ecb/ratesapi identity branches are deleted; a latest-only source's fetch signature (`PricePair`, no date field) cannot even express a requested date.
- **Capability declared as data** (`None` / `Since(date)` / `Full`), validated before any network I/O — the ccxt `has`-dictionary / pricehist `types()`+`start()` pattern, replacing beanprice's ambiguous-`None` signaling that its own author documents as a flaw.
- **First two source upgrades from the #1802 table**: `coinbase` (spot `?date=`) and `ratesapi` (dated path, coverage since 1999-01-04) now serve real historical quotes where they previously refused. `yahoo`'s selection logic moves out of `parse_chart` into the dispatch; its parsers return raw exchange-timezone-classified bars.
- `--source-cmd` keeps its documented trust contract as the one sanctioned `fetch_price` override.

## Behavior changes

- `rledger price --date <past> -s coinbase|ratesapi` now succeeds (was: refusal).
- Identity pairs (X priced in X) answer 1.0 on **every** source uniformly, without a fetch.
- Everything else is behavior-parity with main, pinned by the reworked test suites (`dispatch_tests` with mock sources; `capability_wiring_tests` asserting declarations match hermetic refusal behavior; yahoo fixtures asserting raw-point parsing + canonical selection).

## Follow-ups (tracked in #1802)

Typed `SourceError` for fallback chains, window write-through into the price cache, and the remaining source ports (ecb 90-day feed, quandl, tsp, eastmoneyfund, alphavantage).

Part of #1802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gJH7uBBF9Xw9et9QFRcsU
