### PR TITLE
feat: session carries ledger options over the WIT boundary (3.7.0)

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -615,32 +615,37 @@ fn session_from_entries_with_options_carries_renamed_roots() -> Result<()> {
 
     let q = "SELECT possign(100, 'Einnahmen:Salary')";
 
+    // Exact-variant matching, not a debug-substring proxy (Copilot
+    // review: `contains("-100")` also matches "-1000").
+    fn first_number(r: &exports::rustledger::ledger::ledger::QueryResult) -> &str {
+        match r
+            .rows
+            .first()
+            .and_then(|row| row.first())
+            .expect("query returns at least one row")
+        {
+            rustledger::ledger::types::QueryValue::Number(n) => n.as_str(),
+            other => panic!("POSSIGN must return query-value::number, got {other:?}"),
+        }
+    }
+
     let with_options =
         session.call_from_entries_with_options(&mut store, &info.entries, &info.options)?;
     let r = session.call_query(&mut store, with_options, q)?;
     assert!(r.errors.is_empty(), "query errored: {:?}", r.errors);
-    let cell = format!("{:?}", r.rows[0][0]);
-    assert!(
-        cell.contains("-100"),
-        "held options must POSSIGN-negate the renamed income root: {cell}"
+    assert_eq!(
+        first_number(&r),
+        "-100",
+        "held options must POSSIGN-negate the renamed income root"
     );
 
     let without_options = session.call_from_entries(&mut store, &info.entries)?;
     let r = session.call_query(&mut store, without_options, q)?;
     assert!(r.errors.is_empty(), "query errored: {:?}", r.errors);
-    let cell = format!(
-        "{:?}",
-        r.rows
-            .first()
-            .and_then(|row| row.first())
-            .expect("query returns at least one row")
-    );
-    // Positive AND negative: the unflipped value must actually be there
-    // (a bare negative would pass vacuously on an error/null cell —
-    // CLAUDE.md drift-guard rule).
-    assert!(
-        cell.contains("100") && !cell.contains("-100"),
-        "options-less entries default the classifier (documented, #1766): {cell}"
+    assert_eq!(
+        first_number(&r),
+        "100",
+        "options-less entries default the classifier (documented, #1766)"
     );
     Ok(())
 }

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -599,13 +599,15 @@ fn session_from_entries_with_options_carries_renamed_roots() -> Result<()> {
     let ledger = inst.rustledger_ledger_ledger();
     let session = ledger.session();
 
-    const RENAMED: &str = "option \"name_income\" \"Einnahmen\"\n\
-2024-01-01 open Einnahmen:Salary\n\
-2024-01-01 open Assets:Bank\n\
-\n\
-2024-01-02 * \"pay\"\n\
-  Assets:Bank  100.00 USD\n\
-  Einnahmen:Salary\n";
+    const RENAMED: &str = concat!(
+        "option \"name_income\" \"Einnahmen\"\n",
+        "2024-01-01 open Einnahmen:Salary\n",
+        "2024-01-01 open Assets:Bank\n",
+        "\n",
+        "2024-01-02 * \"pay\"\n",
+        "  Assets:Bank  100.00 USD\n",
+        "  Einnahmen:Salary\n",
+    );
     let loaded = session.call_constructor(&mut store, RENAMED)?;
     let info = session.call_info(&mut store, loaded)?;
     assert!(info.errors.is_empty(), "load errored: {:?}", info.errors);
@@ -625,9 +627,19 @@ fn session_from_entries_with_options_carries_renamed_roots() -> Result<()> {
 
     let without_options = session.call_from_entries(&mut store, &info.entries)?;
     let r = session.call_query(&mut store, without_options, q)?;
-    let cell = format!("{:?}", r.rows[0][0]);
+    assert!(r.errors.is_empty(), "query errored: {:?}", r.errors);
+    let cell = format!(
+        "{:?}",
+        r.rows
+            .first()
+            .and_then(|row| row.first())
+            .expect("query returns at least one row")
+    );
+    // Positive AND negative: the unflipped value must actually be there
+    // (a bare negative would pass vacuously on an error/null cell —
+    // CLAUDE.md drift-guard rule).
     assert!(
-        !cell.contains("-100"),
+        cell.contains("100") && !cell.contains("-100"),
         "options-less entries default the classifier (documented, #1766): {cell}"
     );
     Ok(())

--- a/crates/rustledger-ffi-component-tests/tests/parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/parity.rs
@@ -583,6 +583,56 @@ const LEDGER_WITH_COST: &str = "\
   Assets:Cash  -14 USD
 ";
 
+/// `from-entries-with-options` (WIT 3.7.0, #1766): a session rebuilt
+/// from another session's `info()` carries the ledger's OPTIONS across
+/// the component boundary, so BQL `POSSIGN` classifies renamed account
+/// roots — where the options-less `from-entries` documents the default
+/// classifier. The sign flip is the exact observable the L5 note
+/// recorded as broken.
+#[test]
+fn session_from_entries_with_options_carries_renamed_roots() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let ledger = inst.rustledger_ledger_ledger();
+    let session = ledger.session();
+
+    const RENAMED: &str = "option \"name_income\" \"Einnahmen\"\n\
+2024-01-01 open Einnahmen:Salary\n\
+2024-01-01 open Assets:Bank\n\
+\n\
+2024-01-02 * \"pay\"\n\
+  Assets:Bank  100.00 USD\n\
+  Einnahmen:Salary\n";
+    let loaded = session.call_constructor(&mut store, RENAMED)?;
+    let info = session.call_info(&mut store, loaded)?;
+    assert!(info.errors.is_empty(), "load errored: {:?}", info.errors);
+    assert_eq!(info.options.name_income, "Einnahmen");
+
+    let q = "SELECT possign(100, 'Einnahmen:Salary')";
+
+    let with_options =
+        session.call_from_entries_with_options(&mut store, &info.entries, &info.options)?;
+    let r = session.call_query(&mut store, with_options, q)?;
+    assert!(r.errors.is_empty(), "query errored: {:?}", r.errors);
+    let cell = format!("{:?}", r.rows[0][0]);
+    assert!(
+        cell.contains("-100"),
+        "held options must POSSIGN-negate the renamed income root: {cell}"
+    );
+
+    let without_options = session.call_from_entries(&mut store, &info.entries)?;
+    let r = session.call_query(&mut store, without_options, q)?;
+    let cell = format!("{:?}", r.rows[0][0]);
+    assert!(
+        !cell.contains("-100"),
+        "options-less entries default the classifier (documented, #1766): {cell}"
+    );
+    Ok(())
+}
+
 /// The stateful `resource session` (#173): construct once, then info/query/
 /// clamp run against the held ledger. Crucially `clamp` operates on the held
 /// core directives, so cost basis survives with no WIT->core->WIT round-trip.

--- a/crates/rustledger-ffi-component/README.md
+++ b/crates/rustledger-ffi-component/README.md
@@ -69,14 +69,19 @@ opening-balance/summary boundary transactions get synthetic source locations.
 `query-entries` runs a typed BQL query directly against an already-loaded
 directive set — the counterpart to `filter`/`clamp`. The embedder passes the
 directives it holds (e.g. a filtered view) instead of source text, so there is
-no re-parse and no re-render to beancount text.
+no re-parse and no re-render to beancount text. It runs with DEFAULT ledger
+options (#1766); prefer `session.from-entries-with-options` + `session.query`,
+which carries the ledger's own account roots.
 
 **Batch** (`interface ledger`) — `batch` / `batch-file` (`query.batch`): load
 once, run several queries.
 
 **Session** (`interface ledger`, `resource session`) — a stateful, typed handle
 to a loaded, booked ledger held inside the component. The host constructs one
-(`constructor(source)` or the static `from-file(path, …)`), then runs
+(`constructor(source)`, the static `from-file(path, …)`, or — for a directive
+set the host already holds — `from-entries` / `from-entries-with-options(entries,
+options)`, the latter carrying the ledger's options so `query` classifies with
+its `name-*` roots, 3.7.0/#1766), then runs
 `info` (materialize the load result once), `query`, `filter`, and `clamp`
 against the *held* ledger. Because the booked core directives stay inside the
 component, these calls re-use the parse/booking with no re-parse and no

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1495,6 +1495,27 @@ pub fn query_entries(entries: &[wit::Directive], query_str: &str) -> out::QueryR
 // the free functions: these run against the held *core* directives, so they
 // never re-parse source nor round-trip a directive list through the host.
 
+/// Replace empty `name-*` roots in host-supplied options with their
+/// defaults: an empty root can never classify an account, so a
+/// zero-initialized record from a guest language would silently break
+/// every `POSSIGN`/`ACCOUNT_SORTKEY` result with no diagnostic (deep
+/// review of #1805). Non-empty values pass through verbatim — including
+/// duplicates, which are the host's to avoid.
+fn sanitize_options(mut provided: wit::LedgerOptions) -> wit::LedgerOptions {
+    let defaults = options(ffi::LedgerOptions::default());
+    let fix = |field: &mut String, default: String| {
+        if field.is_empty() {
+            *field = default;
+        }
+    };
+    fix(&mut provided.name_assets, defaults.name_assets);
+    fix(&mut provided.name_liabilities, defaults.name_liabilities);
+    fix(&mut provided.name_equity, defaults.name_equity);
+    fix(&mut provided.name_income, defaults.name_income);
+    fix(&mut provided.name_expenses, defaults.name_expenses);
+    provided
+}
+
 /// Held state behind a `session` resource: the booked core directives + their
 /// per-directive provenance, plus the load metadata, normalized across the
 /// source and file load paths. Errors are pre-converted to WIT form (the file
@@ -1547,14 +1568,24 @@ impl SessionState {
     }
 
     /// `from_entries` with the ledger's options attached (WIT 3.7.0,
-    /// #1766): the session becomes the canonical options carrier, so
-    /// `query` builds its account classifier from the ledger's own
-    /// `name-*` roots and `info()` echoes what was provided. New
-    /// entry-consuming methods inherit the held options for free.
+    /// #1766). What the held options DO today: `query` builds its
+    /// account classifier from the `name-*` roots (BQL
+    /// `POSSIGN`/`ACCOUNT_SORTKEY` on renamed-root ledgers), and
+    /// `info()` echoes the full record. Booked-time options
+    /// (booking-method, tolerances) cannot re-apply — the entries are
+    /// already booked — and clamp/rendering do not consume options yet
+    /// (#1766 tracks both).
+    ///
+    /// Empty `name-*` fields are replaced with their defaults (an
+    /// empty root can never classify — a zero-initialized record from
+    /// a guest language would silently break every classification);
+    /// duplicated roots are the host's to avoid: classification
+    /// matches roots exactly, first match wins.
     pub fn from_entries_with_options(
         entries: &[wit::Directive],
         options: wit::LedgerOptions,
     ) -> Self {
+        let options = sanitize_options(options);
         // The one-time conversion is this API's whole reason to exist —
         // reserve up front so a large ledger doesn't reallocate through
         // the collect (review catch; drops are rare, over-reserving by
@@ -2282,17 +2313,37 @@ option \"name_income\" \"Einnahmen\"
 
         let with_options =
             SessionState::from_entries_with_options(&info.entries, info.options.clone());
+        let cell = first_cell(&with_options.query(query));
         assert!(
-            first_cell(&with_options.query(query)).contains("-100"),
-            "renamed income root must POSSIGN-negate: {:?}",
-            first_cell(&with_options.query(query))
+            cell.contains("-100"),
+            "renamed income root must POSSIGN-negate: {cell:?}"
         );
 
         let without_options = SessionState::from_entries(&info.entries);
         let cell = first_cell(&without_options.query(query));
+        // Positive AND negative: a bare negative would pass vacuously on
+        // an error/null cell (CLAUDE.md drift-guard rule).
         assert!(
-            !cell.contains("-100"),
+            cell.contains("100") && !cell.contains("-100"),
             "options-less entries default the classifier (documented, #1766): {cell:?}"
+        );
+    }
+
+    /// Empty `name-*` roots are replaced with defaults — a
+    /// zero-initialized options record must not silently break every
+    /// classification (deep review of #1805).
+    #[test]
+    fn empty_roots_fall_back_to_defaults() {
+        let loaded = SessionState::from_source(RENAMED);
+        let info = loaded.info();
+        let mut options = info.options.clone();
+        options.name_assets = String::new();
+        let session = SessionState::from_entries_with_options(&info.entries, options);
+        let echoed = session.info().options;
+        assert_eq!(echoed.name_assets, "Assets", "empty root falls back");
+        assert_eq!(
+            echoed.name_income, "Einnahmen",
+            "provided roots pass through"
         );
     }
 

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -2283,18 +2283,19 @@ option \"name_income\" \"Einnahmen\"
   Einnahmen:Salary
 ";
 
-    /// Extract the first cell of the first row as its debug rendering —
-    /// enough to pin the sign without depending on the numeric variant's
-    /// exact shape.
-    fn first_cell(result: &super::out::QueryResult) -> String {
-        format!(
-            "{:?}",
-            result
-                .rows
-                .first()
-                .and_then(|r| r.first())
-                .expect("query returns at least one row")
-        )
+    /// The first cell of the first row as the typed numeric value —
+    /// exact-variant matching, not a debug-substring proxy (Copilot
+    /// review: `contains("-100")` also matches "-1000").
+    fn first_number(result: &super::out::QueryResult) -> String {
+        match result
+            .rows
+            .first()
+            .and_then(|r| r.first())
+            .expect("query returns at least one row")
+        {
+            super::wit::QueryValue::Number(n) => n.clone(),
+            other => panic!("POSSIGN must return query-value::number, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2313,19 +2314,17 @@ option \"name_income\" \"Einnahmen\"
 
         let with_options =
             SessionState::from_entries_with_options(&info.entries, info.options.clone());
-        let cell = first_cell(&with_options.query(query));
-        assert!(
-            cell.contains("-100"),
-            "renamed income root must POSSIGN-negate: {cell:?}"
+        assert_eq!(
+            first_number(&with_options.query(query)),
+            "-100",
+            "renamed income root must POSSIGN-negate"
         );
 
         let without_options = SessionState::from_entries(&info.entries);
-        let cell = first_cell(&without_options.query(query));
-        // Positive AND negative: a bare negative would pass vacuously on
-        // an error/null cell (CLAUDE.md drift-guard rule).
-        assert!(
-            cell.contains("100") && !cell.contains("-100"),
-            "options-less entries default the classifier (documented, #1766): {cell:?}"
+        assert_eq!(
+            first_number(&without_options.query(query)),
+            "100",
+            "options-less entries default the classifier (documented, #1766)"
         );
     }
 

--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1478,7 +1478,9 @@ pub fn query_entries(entries: &[wit::Directive], query_str: &str) -> out::QueryR
     // The `query-entries` WIT contract carries no ledger options, so the
     // classifier defaults to the standard five roots. Renamed-root ledgers
     // queried via host-provided entries won't POSSIGN-flip custom names —
-    // extending the contract with options is a WIT-version decision (L5 note).
+    // `session.from-entries-with-options` (3.7.0, #1766) is the
+    // options-carrying path; this free function is doc-soft-deprecated
+    // in its favor.
     run_query(
         &directives,
         query_str,
@@ -1537,6 +1539,22 @@ impl SessionState {
     /// Conversion failures (e.g. un-lexable accounts, see the note on
     /// `clamp`) drop the directive, mirroring `query-entries`.
     pub fn from_entries(entries: &[wit::Directive]) -> Self {
+        // Held entries carry no ledger options (they were stripped at
+        // the original load); defaults here match what a stand-alone
+        // directive set implies. Embedders holding the original load's
+        // options should use `from_entries_with_options` (#1766).
+        Self::from_entries_with_options(entries, options(ffi::LedgerOptions::default()))
+    }
+
+    /// `from_entries` with the ledger's options attached (WIT 3.7.0,
+    /// #1766): the session becomes the canonical options carrier, so
+    /// `query` builds its account classifier from the ledger's own
+    /// `name-*` roots and `info()` echoes what was provided. New
+    /// entry-consuming methods inherit the held options for free.
+    pub fn from_entries_with_options(
+        entries: &[wit::Directive],
+        options: wit::LedgerOptions,
+    ) -> Self {
         // The one-time conversion is this API's whole reason to exist —
         // reserve up front so a large ledger doesn't reallocate through
         // the collect (review catch; drops are rare, over-reserving by
@@ -1553,11 +1571,7 @@ impl SessionState {
             lines: vec![0; n],
             files: vec!["<entries>".to_string(); n],
             errors: vec![],
-            // Held entries carry no ledger options (they were stripped at
-            // the original load); defaults here match what a stand-alone
-            // directive set implies. Embedders holding options should keep
-            // consulting their load-time `info()`.
-            options: options(ffi::LedgerOptions::default()),
+            options,
             plugins: vec![],
             includes: vec![],
             padded: std::cell::OnceCell::new(),
@@ -2215,6 +2229,89 @@ fn extract_warning(message: String) -> wit::Error {
         entry_index: None,
         severity: "warning".to_string(),
         phase: "extract".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod session_options_tests {
+    //! The `from-entries-with-options` carrier (WIT 3.7.0, #1766): a
+    //! session rebuilt from another session's `info()` must classify
+    //! accounts with the LEDGER's roots, where the options-less
+    //! `from_entries` falls back to the defaults. POSSIGN is the exact
+    //! observable the L5 note recorded as broken.
+
+    use super::SessionState;
+
+    const RENAMED: &str = "\
+option \"name_income\" \"Einnahmen\"
+2024-01-01 open Einnahmen:Salary
+2024-01-01 open Assets:Bank
+
+2024-01-02 * \"pay\"
+  Assets:Bank  100.00 USD
+  Einnahmen:Salary
+";
+
+    /// Extract the first cell of the first row as its debug rendering —
+    /// enough to pin the sign without depending on the numeric variant's
+    /// exact shape.
+    fn first_cell(result: &super::out::QueryResult) -> String {
+        format!(
+            "{:?}",
+            result
+                .rows
+                .first()
+                .and_then(|r| r.first())
+                .expect("query returns at least one row")
+        )
+    }
+
+    #[test]
+    fn with_options_honors_renamed_roots_where_from_entries_defaults() {
+        let loaded = SessionState::from_source(RENAMED);
+        let info = loaded.info();
+        assert!(
+            info.errors.is_empty(),
+            "fixture must load: {:?}",
+            info.errors
+        );
+
+        // POSSIGN negates income-rooted accounts; "Einnahmen" is income
+        // only when the ledger's renamed roots are carried.
+        let query = "SELECT possign(100, 'Einnahmen:Salary')";
+
+        let with_options =
+            SessionState::from_entries_with_options(&info.entries, info.options.clone());
+        assert!(
+            first_cell(&with_options.query(query)).contains("-100"),
+            "renamed income root must POSSIGN-negate: {:?}",
+            first_cell(&with_options.query(query))
+        );
+
+        let without_options = SessionState::from_entries(&info.entries);
+        let cell = first_cell(&without_options.query(query));
+        assert!(
+            !cell.contains("-100"),
+            "options-less entries default the classifier (documented, #1766): {cell:?}"
+        );
+    }
+
+    /// `info()` echoes the provided options — the session is the
+    /// canonical carrier, so a host can round-trip them.
+    #[test]
+    fn info_echoes_provided_options() {
+        let loaded = SessionState::from_source(RENAMED);
+        let info = loaded.info();
+        let session = SessionState::from_entries_with_options(&info.entries, info.options.clone());
+        assert_eq!(session.info().options.name_income, "Einnahmen");
+        // And the options-less constructor documents its default.
+        assert_eq!(
+            SessionState::from_entries(&info.entries)
+                .info()
+                .options
+                .name_income,
+            "Income"
+        );
     }
 }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -40,8 +40,8 @@ use exports::rustledger::ledger::builder::{Directive, Guest as BuilderGuest, Inp
 use exports::rustledger::ledger::format::Guest as FormatGuest;
 use exports::rustledger::ledger::importer::{ExtractResult, Guest as ImporterGuest};
 use exports::rustledger::ledger::ledger::{
-    BatchResult, Guest as LedgerGuest, GuestSession, LoadResult, QueryResult, Session,
-    ValidateResult,
+    BatchResult, Guest as LedgerGuest, GuestSession, LedgerOptions, LoadResult, QueryResult,
+    Session, ValidateResult,
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
@@ -54,7 +54,7 @@ use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 /// encrypted (`.gpg`/`.asc`) ledgers can be decrypted by the host (#1667);
 /// 3.1 added the `diff` field on `balance-dir` (#1663); 3.0 was the breaking
 /// `expand-pads` parameter on `load`/`load-file` (#1628).
-const API_VERSION: &str = "3.6";
+const API_VERSION: &str = "3.7";
 
 struct Component;
 
@@ -112,6 +112,12 @@ impl GuestSession for LedgerSession {
     fn from_entries(entries: Vec<Directive>) -> Session {
         Session::new(Self {
             state: convert::SessionState::from_entries(&entries),
+        })
+    }
+
+    fn from_entries_with_options(entries: Vec<Directive>, options: LedgerOptions) -> Session {
+        Session::new(Self {
+            state: convert::SessionState::from_entries_with_options(&entries, options),
         })
     }
 

--- a/crates/rustledger-ffi-component/src/lib.rs
+++ b/crates/rustledger-ffi-component/src/lib.rs
@@ -45,7 +45,9 @@ use exports::rustledger::ledger::ledger::{
 };
 use exports::rustledger::ledger::util::{Guest as UtilGuest, TypesInfo};
 
-/// The Component-Model api-version this build implements. 3.6 adds
+/// The Component-Model api-version this build implements. 3.7 adds
+/// `session.from-entries-with-options` (the session carries the
+/// ledger's options over the boundary, #1766); 3.6 added
 /// `importer.dedup` and `format.format-loaded` (the extract → review →
 /// save loop); 3.5 added the `importer` interface (identify / infer /
 /// extract — the `rledger extract` engine over the boundary); 3.4 added

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -477,12 +477,18 @@ interface ledger {
     /// `from-entries-with-options` instead (#1766).
     from-entries: static func(entries: list<directive>) -> session;
     /// `from-entries` carrying the ledger's options (added in 3.7.0,
-    /// #1766): the session becomes the canonical carrier, so `query`
-    /// classifies accounts with the ledger's own `name-*` roots
-    /// (BQL `POSSIGN`/`ACCOUNT_SORTKEY` on renamed-root ledgers) and
-    /// `info()` echoes what was provided. Pass the options from the
-    /// original load's `info()`. New entry-consuming capability should
-    /// go resource-first and inherit these held options.
+    /// #1766). What the held options do TODAY: `query` classifies
+    /// accounts with the ledger's own `name-*` roots (BQL
+    /// `POSSIGN`/`ACCOUNT_SORTKEY` on renamed-root ledgers), and
+    /// `info()` echoes the full record. Booked-time options
+    /// (booking-method, tolerances) cannot re-apply to already-booked
+    /// entries, and `clamp`/rendering do not consume options yet —
+    /// both tracked in #1766. Pass the options from the original
+    /// load's `info()`; empty `name-*` fields fall back to the
+    /// defaults (an empty root can never classify), and classification
+    /// matches roots exactly. New entry-consuming capability should go
+    /// resource-first so it can consume these held options as it
+    /// grows support.
     from-entries-with-options: static func(entries: list<directive>, options: ledger-options) -> session;
 
     /// Everything the host needs at load time: entries, errors, options,

--- a/crates/rustledger-ffi-component/wit/world.wit
+++ b/crates/rustledger-ffi-component/wit/world.wit
@@ -14,7 +14,7 @@
 // `format` (source / file / entry / entries). All exports are implemented in
 // `crates/rustledger-ffi-component`.
 
-package rustledger:ledger@3.6.0;
+package rustledger:ledger@3.7.0;
 
 /// Shared data types, translated 1:1 from `types/output.rs`.
 interface types {
@@ -470,7 +470,20 @@ interface ledger {
     /// conversion (e.g. un-lexable accounts) are dropped, mirroring
     /// `builder.query-entries`; the drop count is observable as
     /// `info().entries` length vs what was sent.
+    ///
+    /// The held ledger runs with DEFAULT ledger options (the entries
+    /// carry none) — renamed account roots will not classify, so
+    /// embedders that hold the original load's options should use
+    /// `from-entries-with-options` instead (#1766).
     from-entries: static func(entries: list<directive>) -> session;
+    /// `from-entries` carrying the ledger's options (added in 3.7.0,
+    /// #1766): the session becomes the canonical carrier, so `query`
+    /// classifies accounts with the ledger's own `name-*` roots
+    /// (BQL `POSSIGN`/`ACCOUNT_SORTKEY` on renamed-root ledgers) and
+    /// `info()` echoes what was provided. Pass the options from the
+    /// original load's `info()`. New entry-consuming capability should
+    /// go resource-first and inherit these held options.
+    from-entries-with-options: static func(entries: list<directive>, options: ledger-options) -> session;
 
     /// Everything the host needs at load time: entries, errors, options,
     /// plugins, and the resolved include graph.
@@ -523,6 +536,12 @@ interface builder {
   /// (#1423). The typed counterpart to `filter`/`clamp`: the embedder
   /// passes the directives it holds (e.g. a filtered view) instead of source
   /// text, so there is no re-parse and no re-render to beancount.
+  ///
+  /// Runs with DEFAULT ledger options (#1766). Prefer
+  /// `session.from-entries-with-options` + `session.query`, which
+  /// carries the ledger's own account roots — this function and its
+  /// `filter`/`clamp` siblings duplicate session methods and are
+  /// retained for compatibility.
   query-entries: func(entries: list<directive>, query: string) -> query-result;
 }
 
@@ -571,6 +590,11 @@ interface format {
   /// inside the component so hosts never reshape directives themselves.
   /// Added in 3.6.0 alongside `importer.dedup` — it closes the
   /// extract -> review -> save-to-ledger loop.
+  ///
+  /// Renders with the DEFAULT format configuration: the rendering
+  /// pipeline does not yet honor `display-precision`/`render-commas`
+  /// from ledger-options anywhere (CLI included) — options-aware
+  /// rendering is tracked in #1766 and will arrive via the session.
   format-loaded: func(entries: list<directive>) -> result<string, string>;
 }
 


### PR DESCRIPTION
## What

Closes the #1766 design debt for the **query surface**: entries-accepting functions ran with default ledger options because the contract had no way to carry them.

- **WIT 3.7.0**: `session.from-entries-with-options(entries, options)` — the session becomes the canonical options carrier. `query` classifies accounts with the ledger's own `name-*` roots (the L5 `POSSIGN`/`ACCOUNT_SORTKEY` note in convert.rs), `info()` echoes what was provided, and future entry-consuming methods inherit the held options for free. `from-entries` keeps its shape and documents the default; the `builder.query-entries`/`filter`/`clamp` free functions are doc-soft-deprecated in favor of the session.
- `API_VERSION` → 3.7 in lockstep (enforced by the parity test + wit-version-gate).
- **Tests**: `SessionState` unit tests pin the POSSIGN sign flip under renamed roots and the `info()` echo; a wasmtime parity test drives the same observable through the real component boundary.

## Deliberate scope reductions (recorded on #1766)

- `session.format` is **not** added: the rendering pipeline has no `display-precision`/`render-commas` machinery anywhere (CLI included), so it would ignore the options it advertises — exactly the debt #1766 describes, one layer deeper. `format-loaded`'s docs now state this honestly.
- `ops::clamp`'s `Equity:Opening-Balances` hardcoding turned out to be a **global** pre-existing gap (all callers, CLI included), not an entries-surface asymmetry — it needs an ops-level config, tracked separately.

## How to test

`cargo test -p rustledger-ffi-component -p rustledger-ffi-component-tests`. rustfava adoption (passing its load-time options into the filtered-query path) rides the next release train together with the ingest backend.

Part of #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gJH7uBBF9Xw9et9QFRcsU