### PR TITLE
fix: ops::clamp threads account config instead of hardcoding Equity roots

### DIFF
--- a/crates/rustledger-ffi-component/src/convert.rs
+++ b/crates/rustledger-ffi-component/src/convert.rs
@@ -1457,15 +1457,23 @@ pub fn clamp(entries: Vec<wit::Directive>, begin: &str, end: &str) -> Vec<wit::D
         }
     }
 
-    rustledger_ops::clamp::clamp_indexed(&core, begin_date, end_date)
-        .into_iter()
-        .map(|(d, src)| match src.and_then(|j| orig_index.get(j)) {
-            // Pass-through: hand back the original WIT directive untouched.
-            Some(&i) => entries[i].clone(),
-            // Synthesized summary: build from core with the `<clamped>` source.
-            None => directive_from_core(&d, 0, "<clamped>"),
-        })
-        .collect()
+    // A bare directive list carries no ledger options, so classification and
+    // the synthesized-summary account names fall back to beancount defaults
+    // (#1806). The session's `clamp` uses the held options instead.
+    rustledger_ops::clamp::clamp_indexed(
+        &core,
+        begin_date,
+        end_date,
+        &rustledger_ops::clamp::ClampAccounts::default(),
+    )
+    .into_iter()
+    .map(|(d, src)| match src.and_then(|j| orig_index.get(j)) {
+        // Pass-through: hand back the original WIT directive untouched.
+        Some(&i) => entries[i].clone(),
+        // Synthesized summary: build from core with the `<clamped>` source.
+        None => directive_from_core(&d, 0, "<clamped>"),
+    })
+    .collect()
 }
 
 /// Run a BQL query against an already-loaded directive set (#1423).
@@ -1712,17 +1720,33 @@ impl SessionState {
         let directives = self
             .padded
             .get_or_init(|| rustledger_booking::merge_with_padding(&self.directives));
-        run_query(
-            directives,
-            query_str,
-            rustledger_core::AccountTypes {
-                assets: self.options.name_assets.clone(),
-                liabilities: self.options.name_liabilities.clone(),
-                equity: self.options.name_equity.clone(),
-                income: self.options.name_income.clone(),
-                expenses: self.options.name_expenses.clone(),
-            },
-        )
+        run_query(directives, query_str, self.account_types())
+    }
+
+    /// The held options' account-root classifier — the single place the
+    /// session turns its `name-*` roots into an [`AccountTypes`], shared by
+    /// `query` (BQL classification) and `clamp` (summary classification).
+    fn account_types(&self) -> rustledger_core::AccountTypes {
+        rustledger_core::AccountTypes {
+            assets: self.options.name_assets.clone(),
+            liabilities: self.options.name_liabilities.clone(),
+            equity: self.options.name_equity.clone(),
+            income: self.options.name_income.clone(),
+            expenses: self.options.name_expenses.clone(),
+        }
+    }
+
+    /// The held options' clamp configuration (#1806): the account-root
+    /// classifier plus the `account_previous_balances` / `_earnings`
+    /// summary account names. So `session.clamp` synthesizes opening
+    /// balances into the ledger's OWN accounts, where the options-less
+    /// builder free `clamp` falls back to beancount defaults.
+    fn clamp_accounts(&self) -> rustledger_ops::clamp::ClampAccounts {
+        rustledger_ops::clamp::ClampAccounts {
+            types: self.account_types(),
+            previous_balances: self.options.account_previous_balances.clone(),
+            previous_earnings: self.options.account_previous_earnings.clone(),
+        }
     }
 
     /// Keep only directives within `[begin, end)`. Reuses the free `filter`'s
@@ -1811,15 +1835,22 @@ impl SessionState {
         // synthesized opening-balance / earnings summaries fall back to the
         // `<clamped>` sentinel. (#1425 — restores provenance that the old
         // `clamp` -> `directive_to_json(d, 0, "<clamped>")` mapping dropped.)
-        rustledger_ops::clamp::clamp_indexed(&self.directives, begin_date, end_date)
-            .into_iter()
-            .map(|(d, src)| {
-                let (line, file) = src
-                    .and_then(|i| self.lines.get(i).copied().zip(self.files.get(i)))
-                    .map_or((0, "<clamped>"), |(line, file)| (line, file.as_str()));
-                directive_from_core(&d, line, file)
-            })
-            .collect()
+        // The held options drive classification + summary account names
+        // (#1806), so a renamed-root ledger clamps into its own accounts.
+        rustledger_ops::clamp::clamp_indexed(
+            &self.directives,
+            begin_date,
+            end_date,
+            &self.clamp_accounts(),
+        )
+        .into_iter()
+        .map(|(d, src)| {
+            let (line, file) = src
+                .and_then(|i| self.lines.get(i).copied().zip(self.files.get(i)))
+                .map_or((0, "<clamped>"), |(line, file)| (line, file.as_str()));
+            directive_from_core(&d, line, file)
+        })
+        .collect()
     }
 }
 
@@ -2397,6 +2428,69 @@ option \"name_income\" \"Einnahmen\"
                 .options
                 .name_income,
             "Income"
+        );
+    }
+
+    /// #1806: `session.clamp` drives classification and the synthesized
+    /// summary account names from the HELD options. A ledger renaming its
+    /// income root and its `account_previous_earnings` must roll pre-window
+    /// income into the configured account — where the options-less
+    /// `from_entries` path falls back to beancount defaults.
+    #[test]
+    fn clamp_honors_held_options_for_classification_and_summaries() {
+        const RENAMED_EARNINGS: &str = "\
+option \"name_income\" \"Einnahmen\"
+option \"account_previous_earnings\" \"Eigenkapital:Gewinn\"
+option \"account_previous_balances\" \"Eigenkapital:Anfang\"
+2023-01-01 open Assets:Bank
+2023-01-01 open Einnahmen:Lohn
+
+2023-06-01 * \"pre-window pay\"
+  Assets:Bank  100.00 EUR
+  Einnahmen:Lohn  -100.00 EUR
+";
+        let loaded = SessionState::from_source(RENAMED_EARNINGS);
+        let info = loaded.info();
+        assert!(
+            info.errors.is_empty(),
+            "fixture must load: {:?}",
+            info.errors
+        );
+
+        let mentions = |dirs: &[super::wit::Directive], account: &str| {
+            dirs.iter().any(|d| {
+                matches!(d, super::wit::Directive::Transaction(t)
+                    if t.postings.iter().any(|p| p.account == account))
+            })
+        };
+
+        // Held options: pre-window income (a RENAMED root) rolls up, and
+        // the summary legs use the configured equity accounts.
+        let held = SessionState::from_entries_with_options(&info.entries, info.options.clone());
+        let clamped = held.clamp("2024-01-01", "2024-12-31");
+        assert!(
+            mentions(&clamped, "Eigenkapital:Gewinn"),
+            "renamed income must roll into the configured earnings account"
+        );
+        assert!(
+            mentions(&clamped, "Eigenkapital:Anfang"),
+            "opening balance must use the configured contra account"
+        );
+        assert!(
+            !mentions(&clamped, "Equity:Opening-Balances")
+                && !mentions(&clamped, "Equity:Earnings:Previous"),
+            "no hardcoded default summary accounts on a renamed ledger"
+        );
+
+        // Options-less path: same entries, but classification falls back to
+        // defaults, so the renamed `Einnahmen` root is NOT income and no
+        // earnings rollup is synthesized.
+        let defaulted = SessionState::from_entries(&info.entries);
+        let clamped = defaulted.clamp("2024-01-01", "2024-12-31");
+        assert!(
+            !mentions(&clamped, "Eigenkapital:Gewinn")
+                && !mentions(&clamped, "Equity:Earnings:Previous"),
+            "default classifier does not treat Einnahmen as income, so no earnings summary"
         );
     }
 }

--- a/crates/rustledger-ops/src/clamp.rs
+++ b/crates/rustledger-ops/src/clamp.rs
@@ -160,8 +160,12 @@ fn summary_transaction(
     synthetic_transaction(date, postings)
 }
 
-/// Close Income/Expenses P&L totals to `earnings`, balanced against
-/// `contra` (`ClampAccounts::previous_earnings` / `previous_balances`).
+/// Close Income/Expenses P&L totals to the earnings account, balanced
+/// against the opening-balances contra. `earnings` is
+/// `ClampAccounts::previous_earnings`; `contra` is
+/// `ClampAccounts::previous_balances` (the same account the opening-balance
+/// summaries balance against, so the two summary transactions net to zero
+/// on that account).
 fn earnings_transaction(
     pnl: &HashMap<String, Decimal>,
     date: NaiveDate,

--- a/crates/rustledger-ops/src/clamp.rs
+++ b/crates/rustledger-ops/src/clamp.rs
@@ -8,20 +8,48 @@
 use std::collections::HashMap;
 
 use rustledger_core::{
-    Amount, CostNumber, CostSpec, Decimal, Directive, IncompleteAmount, Inventory, Metadata,
-    NaiveDate, Position, Posting, Span, Spanned, Transaction,
+    AccountTypes, Amount, CostNumber, CostSpec, Decimal, Directive, IncompleteAmount, Inventory,
+    Metadata, NaiveDate, Position, Posting, Span, Spanned, Transaction,
 };
 
-fn account_root(account: &str) -> &str {
-    account.split(':').next().unwrap_or("")
+/// Account configuration for clamp's synthesized summaries (#1806).
+///
+/// Two things clamp used to hardcode, both broken on a ledger that renames
+/// its roots or sets `account_previous_*`:
+///
+/// - **Classification** — which accounts are balance-sheet (carried forward
+///   as opening balances) vs income-statement (rolled into earnings). Uses
+///   the canonical [`AccountTypes`] rather than matching root strings, so a
+///   `option "name_assets" "Activa"` ledger classifies its accounts instead
+///   of silently summarizing nothing.
+/// - **Summary account names** — the contra leg of the opening-balance
+///   transaction (`account_previous_balances`) and the earnings rollup
+///   target (`account_previous_earnings`).
+///
+/// [`Default`] reproduces beancount's defaults (and rledger's prior
+/// hardcoded behavior), so a caller with no ledger options in hand — e.g.
+/// the builder free `clamp` over a bare directive list — gets exactly what
+/// it got before this config existed.
+#[derive(Debug, Clone)]
+pub struct ClampAccounts {
+    /// Root-name classifier (config-aware; never matches root strings).
+    pub types: AccountTypes,
+    /// Contra account for synthesized opening balances
+    /// (`account_previous_balances`).
+    pub previous_balances: String,
+    /// Rollup target for pre-window Income/Expenses P&L
+    /// (`account_previous_earnings`).
+    pub previous_earnings: String,
 }
 
-fn is_balance_sheet(account: &str) -> bool {
-    matches!(account_root(account), "Assets" | "Liabilities" | "Equity")
-}
-
-fn is_income_statement(account: &str) -> bool {
-    matches!(account_root(account), "Income" | "Expenses")
+impl Default for ClampAccounts {
+    fn default() -> Self {
+        Self {
+            types: AccountTypes::default(),
+            previous_balances: "Equity:Opening-Balances".to_string(),
+            previous_earnings: "Equity:Earnings:Previous".to_string(),
+        }
+    }
 }
 
 /// Type-priority tiebreaker for the final sort (mirrors `clamp_entries`).
@@ -99,8 +127,14 @@ fn position_cost_spec(position: &Position) -> Option<CostSpec> {
     })
 }
 
-/// One opening-balance transaction for an account's inventory.
-fn summary_transaction(account: &str, inventory: &Inventory, date: NaiveDate) -> Directive {
+/// One opening-balance transaction for an account's inventory. `contra` is
+/// the balancing account (`ClampAccounts::previous_balances`).
+fn summary_transaction(
+    account: &str,
+    inventory: &Inventory,
+    date: NaiveDate,
+    contra: &str,
+) -> Directive {
     let mut postings = Vec::new();
     for position in inventory.positions() {
         postings.push(synthetic_posting(
@@ -110,14 +144,14 @@ fn summary_transaction(account: &str, inventory: &Inventory, date: NaiveDate) ->
             position_cost_spec(position),
         ));
     }
-    // Balancing Equity:Opening-Balances posting per position. A held-at-cost lot
+    // Balancing opening-balances posting per position. A held-at-cost lot
     // MUST carry the same cost here so the opening transaction balances by weight
     // (#1656): the asset leg's weight is `N * cost` in the cost currency, so a
     // bare-units contra leaves that weight unoffset and any at-cost view of the
     // clamped ledger stops summing to zero.
     for position in inventory.positions() {
         postings.push(synthetic_posting(
-            "Equity:Opening-Balances",
+            contra,
             -position.units.number,
             &position.units.currency,
             position_cost_spec(position),
@@ -126,8 +160,14 @@ fn summary_transaction(account: &str, inventory: &Inventory, date: NaiveDate) ->
     synthetic_transaction(date, postings)
 }
 
-/// Close Income/Expenses P&L totals to Equity:Earnings:Previous.
-fn earnings_transaction(pnl: &HashMap<String, Decimal>, date: NaiveDate) -> Option<Directive> {
+/// Close Income/Expenses P&L totals to `earnings`, balanced against
+/// `contra` (`ClampAccounts::previous_earnings` / `previous_balances`).
+fn earnings_transaction(
+    pnl: &HashMap<String, Decimal>,
+    date: NaiveDate,
+    earnings: &str,
+    contra: &str,
+) -> Option<Directive> {
     let mut currencies: Vec<&String> = pnl.keys().collect();
     currencies.sort();
     let mut postings = Vec::new();
@@ -137,18 +177,8 @@ fn earnings_transaction(pnl: &HashMap<String, Decimal>, date: NaiveDate) -> Opti
             continue;
         }
         let cur: rustledger_core::Currency = currency.as_str().into();
-        postings.push(synthetic_posting(
-            "Equity:Earnings:Previous",
-            number,
-            &cur,
-            None,
-        ));
-        postings.push(synthetic_posting(
-            "Equity:Opening-Balances",
-            -number,
-            &cur,
-            None,
-        ));
+        postings.push(synthetic_posting(earnings, number, &cur, None));
+        postings.push(synthetic_posting(contra, -number, &cur, None));
     }
     if postings.is_empty() {
         return None;
@@ -158,9 +188,17 @@ fn earnings_transaction(pnl: &HashMap<String, Decimal>, date: NaiveDate) -> Opti
 
 /// Clamp `directives` to `[begin, end)`, synthesizing opening balances from
 /// pre-`begin` activity and carrying forward the latest prices.
+///
+/// `accounts` supplies the classification and synthesized-summary account
+/// names (#1806); pass [`ClampAccounts::default`] for beancount defaults.
 #[must_use]
-pub fn clamp(directives: &[Directive], begin: NaiveDate, end: NaiveDate) -> Vec<Directive> {
-    clamp_indexed(directives, begin, end)
+pub fn clamp(
+    directives: &[Directive],
+    begin: NaiveDate,
+    end: NaiveDate,
+    accounts: &ClampAccounts,
+) -> Vec<Directive> {
+    clamp_indexed(directives, begin, end, accounts)
         .into_iter()
         .map(|(d, _)| d)
         .collect()
@@ -180,6 +218,7 @@ pub fn clamp_indexed(
     directives: &[Directive],
     begin: NaiveDate,
     end: NaiveDate,
+    accounts: &ClampAccounts,
 ) -> Vec<(Directive, Option<usize>)> {
     let mut balances: HashMap<String, Inventory> = HashMap::new();
     let mut latest_prices: HashMap<(String, String), (NaiveDate, Directive, usize)> =
@@ -218,26 +257,36 @@ pub fn clamp_indexed(
     // Opening-balance summaries for balance-sheet accounts (sorted by name).
     let mut bs_accounts: Vec<(&String, &Inventory)> = balances
         .iter()
-        .filter(|(account, inv)| is_balance_sheet(account) && !inv.is_empty())
+        .filter(|(account, inv)| accounts.types.is_balance_sheet(account) && !inv.is_empty())
         .collect();
     bs_accounts.sort_by_key(|(account, _)| (*account).clone());
     // Synthesized summaries carry no source directive (`None`).
     let mut summaries: Vec<(Directive, Option<usize>)> = bs_accounts
         .into_iter()
-        .map(|(account, inv)| (summary_transaction(account, inv, begin), None))
+        .map(|(account, inv)| {
+            (
+                summary_transaction(account, inv, begin, &accounts.previous_balances),
+                None,
+            )
+        })
         .collect();
 
     // Earnings: roll up Income/Expenses P&L.
     let mut pnl: HashMap<String, Decimal> = HashMap::new();
     for (account, inv) in &balances {
-        if is_income_statement(account) {
+        if accounts.types.is_income_statement(account) {
             for position in inv.positions() {
                 *pnl.entry(position.units.currency.to_string()).or_default() +=
                     position.units.number;
             }
         }
     }
-    if let Some(earnings) = earnings_transaction(&pnl, begin) {
+    if let Some(earnings) = earnings_transaction(
+        &pnl,
+        begin,
+        &accounts.previous_earnings,
+        &accounts.previous_balances,
+    ) {
         summaries.push((earnings, None));
     }
 
@@ -287,6 +336,93 @@ mod tests {
             if t.postings.iter().any(|p| p.value.account.to_string() == account))
     }
 
+    /// #1806: on a ledger that renames its roots and its summary accounts,
+    /// clamp must classify AND synthesize against the configured names, not
+    /// the hardcoded `Assets`/`Equity:Opening-Balances` strings. This pins
+    /// both hardcodings at once — the classifier (a renamed asset root must
+    /// still be carried forward, which a string-match would silently drop,
+    /// producing NO summary) and the contra/earnings account names.
+    #[test]
+    fn clamp_honors_renamed_roots_and_summary_accounts() {
+        // Renamed roots: Activa (assets), Vermogen (equity), Inkomsten
+        // (income). Pre-window activity: an asset buy funded by income.
+        let src = "2023-01-01 open Activa:Bank\n\
+                   2023-01-01 open Inkomsten:Loon\n\n\
+                   2023-06-01 * \"pre-window pay\"\n  \
+                   Activa:Bank  100.00 EUR\n  \
+                   Inkomsten:Loon  -100.00 EUR\n";
+        let directives = dirs(src);
+        let accounts = ClampAccounts {
+            types: AccountTypes {
+                assets: "Activa".to_string(),
+                liabilities: "Passiva".to_string(),
+                equity: "Vermogen".to_string(),
+                income: "Inkomsten".to_string(),
+                expenses: "Uitgaven".to_string(),
+            },
+            previous_balances: "Vermogen:Beginsaldi".to_string(),
+            previous_earnings: "Vermogen:Winst:Vorig".to_string(),
+        };
+        let clamped = clamp(&directives, d(2024, 1, 1), d(2024, 12, 31), &accounts);
+
+        // The renamed asset account IS carried forward (string-match on
+        // "Assets" would have classified it as non-balance-sheet and
+        // synthesized nothing — the silent-empty failure).
+        let opening = clamped
+            .iter()
+            .find(|dd| is_summary(dd) && mentions(dd, "Activa:Bank"))
+            .expect("renamed asset root must produce an opening balance");
+        // ...balanced against the configured contra, NOT Equity:Opening-Balances.
+        assert!(
+            mentions(opening, "Vermogen:Beginsaldi"),
+            "opening balance must use the configured contra account"
+        );
+        assert!(
+            !clamped
+                .iter()
+                .any(|dd| mentions(dd, "Equity:Opening-Balances")),
+            "the hardcoded default contra must not appear on a renamed ledger"
+        );
+
+        // Pre-window income rolls up to the configured earnings account.
+        let earnings = clamped
+            .iter()
+            .find(|dd| is_summary(dd) && mentions(dd, "Vermogen:Winst:Vorig"))
+            .expect("renamed income root must roll into the configured earnings account");
+        assert!(
+            mentions(earnings, "Vermogen:Beginsaldi"),
+            "earnings rollup must balance against the configured contra"
+        );
+    }
+
+    /// The `Default` config reproduces the pre-#1806 hardcoded behavior
+    /// exactly, so existing callers (and the builder free `clamp`) are
+    /// unaffected.
+    #[test]
+    fn clamp_accounts_default_matches_legacy_hardcoding() {
+        let accounts = ClampAccounts::default();
+        assert_eq!(accounts.previous_balances, "Equity:Opening-Balances");
+        assert_eq!(accounts.previous_earnings, "Equity:Earnings:Previous");
+        let src = "2023-01-01 open Assets:Bank\n\
+                   2023-01-01 open Income:Salary\n\n\
+                   2023-06-01 * \"pay\"\n  \
+                   Assets:Bank  100.00 USD\n  \
+                   Income:Salary  -100.00 USD\n";
+        let clamped = clamp(&dirs(src), d(2024, 1, 1), d(2024, 12, 31), &accounts);
+        assert!(
+            clamped
+                .iter()
+                .any(|dd| is_summary(dd) && mentions(dd, "Equity:Opening-Balances")),
+            "default contra is Equity:Opening-Balances"
+        );
+        assert!(
+            clamped
+                .iter()
+                .any(|dd| is_summary(dd) && mentions(dd, "Equity:Earnings:Previous")),
+            "default earnings is Equity:Earnings:Previous"
+        );
+    }
+
     /// L2 regression: a pre-window lot bought at COMPOUND cost
     /// (`{a # b}`) must keep its cost basis in the clamped opening
     /// balance. The old hand-rolled per-unit ladder had no `Compound`
@@ -299,7 +435,12 @@ mod tests {
                    Assets:Broker  10 WIDGET {5.00 # 10.00 USD}\n  \
                    Assets:Cash  -60.00 USD\n";
         let directives = dirs(src);
-        let clamped = clamp(&directives, d(2024, 6, 1), d(2024, 12, 31));
+        let clamped = clamp(
+            &directives,
+            d(2024, 6, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
         let summary = clamped
             .iter()
             .find(|dd| is_summary(dd) && mentions(dd, "Assets:Broker"))
@@ -332,7 +473,12 @@ mod tests {
             "2023-06-01 * \"old\"\n  Assets:Cash  100 USD\n  Equity:Opening-Balances  -100 USD\n\
              2024-02-01 * \"in range\"\n  Assets:Cash  -5 USD\n  Expenses:Food  5 USD\n",
         );
-        let out = clamp_indexed(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let out = clamp_indexed(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
 
         // The in-range transaction is a pass-through pointing back at its input
         // (index 1), so a caller can restore its real filename/lineno.
@@ -355,7 +501,12 @@ mod tests {
         assert_eq!(summary.1, None, "synthesized summary has no source index");
 
         // `clamp` is exactly `clamp_indexed` with the indices dropped.
-        let plain = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let plain = clamp(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
         let indexed: Vec<_> = out.into_iter().map(|(dir, _)| dir).collect();
         assert_eq!(
             plain, indexed,
@@ -369,7 +520,12 @@ mod tests {
             "2023-06-01 * \"old\"\n  Assets:Cash  100 USD\n  Equity:Opening-Balances  -100 USD\n\
              2024-02-01 * \"in range\"\n  Assets:Cash  -5 USD\n  Expenses:Food  5 USD\n",
         );
-        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let out = clamp(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
 
         // No pre-begin entries survive.
         assert!(out.iter().all(|dir| dir.date() >= d(2024, 1, 1)));
@@ -388,7 +544,12 @@ mod tests {
     #[test]
     fn drops_entries_after_end() {
         let input = dirs("2025-01-01 * \"future\"\n  Assets:Cash 1 USD\n  Expenses:X -1 USD\n");
-        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let out = clamp(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
         assert!(
             out.iter()
                 .all(|dir| !matches!(dir, Directive::Transaction(t)
@@ -399,7 +560,12 @@ mod tests {
     #[test]
     fn excludes_commodity_in_range() {
         let input = dirs("2024-03-01 commodity USD\n");
-        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let out = clamp(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
         assert!(
             out.iter()
                 .all(|dir| !matches!(dir, Directive::Commodity(_)))
@@ -409,7 +575,12 @@ mod tests {
     #[test]
     fn keeps_pre_begin_open() {
         let input = dirs("2020-01-01 open Assets:Cash USD\n");
-        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let out = clamp(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
         assert!(out.iter().any(|dir| matches!(dir, Directive::Open(_))));
     }
 
@@ -418,7 +589,12 @@ mod tests {
         // Pre-begin income produces an Equity:Earnings:Previous summary.
         let input =
             dirs("2023-05-01 * \"salary\"\n  Assets:Cash  1000 USD\n  Income:Salary  -1000 USD\n");
-        let out = clamp(&input, d(2024, 1, 1), d(2024, 12, 31));
+        let out = clamp(
+            &input,
+            d(2024, 1, 1),
+            d(2024, 12, 31),
+            &ClampAccounts::default(),
+        );
         assert!(
             out.iter()
                 .any(|dir| mentions(dir, "Equity:Earnings:Previous")),
@@ -440,7 +616,12 @@ mod tests {
              2000-01-03 * \"buy\"\n  Assets:MC    1 XYZ {50 USD}\n  Assets:MC  -50 USD\n",
         );
         // Clamp to a window AFTER all entries: everything becomes opening balance.
-        let out = clamp(&input, d(2014, 1, 1), d(2015, 1, 1));
+        let out = clamp(
+            &input,
+            d(2014, 1, 1),
+            d(2015, 1, 1),
+            &ClampAccounts::default(),
+        );
 
         let opening = out
             .iter()


### PR DESCRIPTION
## What

`rustledger_ops::clamp` had **two** independent hardcodings — the issue named one, and the second is the more dangerous — both broken on a ledger that renames its roots or sets `account_previous_*`. This folds both into one `ClampAccounts` config.

**1. Synthesized summary account names** (the issue's original scope): the opening-balance contra (`Equity:Opening-Balances`) and the earnings rollup target (`Equity:Earnings:Previous`) were literals. They now come from `account_previous_balances` / `account_previous_earnings`.

**2. Account classification** (surfaced during review): `is_balance_sheet` / `is_income_statement` matched root prefixes by literal string (`"Assets" | "Liabilities" | ...`) — exactly the `AccountTypes` anti-pattern the canonical-function discipline forbids. On a `option "name_assets" "Activa"` ledger the classifier matched nothing, so **no opening balances were synthesized at all** — a silently empty clamp. Now uses the canonical `AccountTypes`.

## Design

```rust
pub struct ClampAccounts {
    pub types: AccountTypes,        // classification (fix #2)
    pub previous_balances: String,  // opening-balance contra (fix #1)
    pub previous_earnings: String,  // earnings rollup
}
```

`Default` reproduces the prior hardcoded behavior exactly, so existing callers are unaffected. `clamp` / `clamp_indexed` take `&ClampAccounts`. The two component callers:

- **`session.clamp`** builds it from the held options — a new `account_types()` helper (shared with `query`, deleting a duplicate inline `AccountTypes` construction) plus the two `account_previous_*` names. This is the #1766 payoff: `from-entries-with-options` now drives clamp too.
- **builder free `clamp`** over a bare directive list has no options → passes `ClampAccounts::default()`.

## Scope note

There is no `rledger clamp` CLI subcommand — the only two callers are both in the component (the issue's "CLI" mention was inaccurate). And only the two `previous_*` options are relevant: clamp does no conversion / current-earnings summarization, so `account_previous_conversions` / `account_current_*` are deliberately not threaded.

## Tests

- **ops-level drift guard** (`clamp_honors_renamed_roots_and_summary_accounts`): clamps a fully renamed ledger (Activa/Vermogen/Inkomsten roots + renamed summary accounts) and asserts the renamed **asset** root IS carried forward — catching the silent-empty classifier failure a names-only test would miss — plus that summary legs use the configured accounts and no `Equity:*` default leaks.
- **default-equivalence** (`clamp_accounts_default_matches_legacy_hardcoding`): pins the pre-#1806 behavior.
- **component-level** (`clamp_honors_held_options_for_classification_and_summaries`): proves `session.clamp` consumes held options (renamed income rolls into the configured earnings account) where options-less `from_entries` defaults.

Workspace green (3946 tests), clippy/doc/fmt clean.

Closes #1806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gJH7uBBF9Xw9et9QFRcsU
