### PR TITLE
test: skip plugin-feature-gated fixtures in corpus_parity (#1809)

### DIFF
--- a/crates/rustledger-ffi-component-tests/tests/corpus_parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/corpus_parity.rs
@@ -185,27 +185,35 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
         let native = rustledger_ffi_wasi::helpers::load_source(&src);
         let loaded = ledger.call_load(&mut store, &src, "<corpus>", false)?;
 
-        // Feature-divergence skip (#1809). The component wasm is always
-        // built WITHOUT `python-plugins`/`wasm-plugins`, so a fixture that
-        // declares such a plugin gets the sentinel "requires the ...-plugins
-        // feature" error from the component. The NATIVE reference
-        // (`load_source`), however, is compiled into this test binary, and
-        // under `cargo test --workspace` cargo feature unification turns
-        // those features ON (the `rustledger` CLI enables them by default),
-        // so native actually ATTEMPTS the plugin and reports a different
-        // message — an artifact of comparing two differently-featured builds
-        // of the same function, not a real component regression. Such a
-        // fixture exercises a surface the featureless component cannot
-        // implement, so skip it (counted). Skipping on the component's
-        // sentinel — not on a source `plugin "..."` scan — keeps NATIVE-Rust
-        // plugins (which the featureless component DOES run) in the compared
-        // set.
-        const PLUGIN_FEATURE_SENTINEL: &str = "-plugins feature";
-        if loaded
-            .errors
-            .iter()
-            .any(|e| e.message.contains(PLUGIN_FEATURE_SENTINEL))
-        {
+        // Feature-divergence skip (#1809). The component wasm is always built
+        // WITHOUT `python-plugins`/`wasm-plugins`, so a fixture declaring such
+        // a plugin gets a `requires the …-plugins feature` error from the
+        // component. Under `cargo test --workspace`, cargo feature unification
+        // compiles the native reference (`load_source`) WITH those features
+        // (the `rustledger` CLI enables them by default), so native ATTEMPTS
+        // the plugin instead of gating it — same function, two feature builds.
+        //
+        // Skip only when the divergence is genuinely feature-driven: the
+        // component gated AND native did NOT gate. Both halves matter (deep
+        // review of this PR):
+        //   - Requiring `!native_gated` avoids over-skipping in a FEATURELESS
+        //     native build (`-p …-tests`, no unification): there both sides
+        //     emit the same gate message and legitimately compare EQUAL, so
+        //     the fixture stays covered instead of being dropped.
+        //   - Keying the skip on the exact `requires the …-plugins feature`
+        //     phrases (not a loose substring, not a source `plugin "…"` scan)
+        //     keeps native-Rust-plugin fixtures — which the featureless
+        //     component DOES run — in the compared set, and won't misfire on a
+        //     `Plugin not found: "…"` message that merely echoes a plugin name.
+        // A broad component regression that emitted the gate spuriously would
+        // spike `skipped_plugin_feature`, which is bounded by an assert below.
+        let gated = |msg: &str| {
+            msg.contains("requires the python-plugins feature")
+                || msg.contains("requires the wasm-plugins feature")
+        };
+        let component_gated = loaded.errors.iter().any(|e| gated(&e.message));
+        let native_gated = native.errors.iter().any(|e| gated(&e.message));
+        if component_gated && !native_gated {
             skipped += 1;
             skipped_plugin_feature += 1;
             continue;
@@ -275,6 +283,30 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
          files {}",
         files.len()
     );
+
+    // Collapse guards (deep review of this PR): the plugin-feature skip is
+    // decided partly from the component's OWN output, so a component-side
+    // regression that emitted the gate broadly could drive `compared` toward
+    // zero while `mismatches` stays empty — a silently-passing test. Only a
+    // handful of corpus fixtures declare Python/WASM plugins, so cap the skip
+    // count, and require most fixtures to actually be compared. Both bounds
+    // are far from the current values (skip ≈ 4, compared ≈ 301 of 322) yet
+    // trip long before a real collapse.
+    const MAX_PLUGIN_FEATURE_SKIPS: usize = 30;
+    assert!(
+        skipped_plugin_feature <= MAX_PLUGIN_FEATURE_SKIPS,
+        "plugin-feature skip count {skipped_plugin_feature} exceeds {MAX_PLUGIN_FEATURE_SKIPS} — \
+         the featureless component is gating far more fixtures than expected, which would \
+         silently shrink the compared set (possible component regression, or new plugin \
+         fixtures that need this bound raised)"
+    );
+    assert!(
+        compared >= files.len() / 2,
+        "only {compared} of {} corpus files were compared — too few; the parity check has \
+         been hollowed out by skips",
+        files.len()
+    );
+
     assert!(
         mismatches.is_empty(),
         "{} corpus file(s) diverge between native load and the component:\n{}",
@@ -285,6 +317,43 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
             .cloned()
             .collect::<Vec<_>>()
             .join("\n")
+    );
+    Ok(())
+}
+
+/// Drift guard (deep review of #1809 fix): the corpus parity skip keys off the
+/// exact `requires the {python,wasm}-plugins feature` phrases emitted by
+/// `rustledger-loader`'s plugin pass. If those messages are reworded, the
+/// substring match in `corpus_loads_identically_via_native_and_component`
+/// silently stops skipping and the corpus test fails spuriously on an
+/// unrelated PR. This pins the wording end-to-end: load a source declaring a
+/// Python plugin through the FEATURELESS component and assert it still emits
+/// the phrase the skip depends on, so a reword fails HERE, loudly, pointing at
+/// the coupling.
+#[test]
+fn plugin_feature_gate_message_is_stable() -> Result<()> {
+    if !component_path().exists() {
+        eprintln!("skip: component wasm not built");
+        return Ok(());
+    }
+    let (mut store, inst) = instantiate()?;
+    let ledger = inst.rustledger_ledger_ledger();
+    // A dotted module NOT in the native-Rust plugin registry: the featureless
+    // component treats it as a Python plugin and gates it. (A native plugin
+    // like `auto_accounts` would just run — no error — so it wouldn't pin the
+    // gate wording.)
+    let src = "plugin \"some.unknown.python.module\"\n\
+               2024-01-01 open Assets:Cash\n";
+    let loaded = ledger.call_load(&mut store, src, "<drift>", false)?;
+    assert!(
+        loaded
+            .errors
+            .iter()
+            .any(|e| e.message.contains("requires the python-plugins feature")),
+        "featureless component must still gate a Python plugin with the exact phrase the \
+         corpus skip matches; if this failed after a rustledger-loader reword, update the \
+         sentinel in corpus_loads_identically_via_native_and_component to match. Got: {:?}",
+        loaded.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
     Ok(())
 }

--- a/crates/rustledger-ffi-component-tests/tests/corpus_parity.rs
+++ b/crates/rustledger-ffi-component-tests/tests/corpus_parity.rs
@@ -156,6 +156,10 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
 
     let mut compared = 0usize;
     let mut skipped = 0usize;
+    // Subset of `skipped` attributable to the featureless component's
+    // plugin-feature gate (#1809) — surfaced separately so the drop is
+    // visible rather than folded silently into the generic skip count.
+    let mut skipped_plugin_feature = 0usize;
     let mut mismatches: Vec<String> = Vec::new();
 
     for path in &files {
@@ -180,6 +184,32 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
 
         let native = rustledger_ffi_wasi::helpers::load_source(&src);
         let loaded = ledger.call_load(&mut store, &src, "<corpus>", false)?;
+
+        // Feature-divergence skip (#1809). The component wasm is always
+        // built WITHOUT `python-plugins`/`wasm-plugins`, so a fixture that
+        // declares such a plugin gets the sentinel "requires the ...-plugins
+        // feature" error from the component. The NATIVE reference
+        // (`load_source`), however, is compiled into this test binary, and
+        // under `cargo test --workspace` cargo feature unification turns
+        // those features ON (the `rustledger` CLI enables them by default),
+        // so native actually ATTEMPTS the plugin and reports a different
+        // message — an artifact of comparing two differently-featured builds
+        // of the same function, not a real component regression. Such a
+        // fixture exercises a surface the featureless component cannot
+        // implement, so skip it (counted). Skipping on the component's
+        // sentinel — not on a source `plugin "..."` scan — keeps NATIVE-Rust
+        // plugins (which the featureless component DOES run) in the compared
+        // set.
+        const PLUGIN_FEATURE_SENTINEL: &str = "-plugins feature";
+        if loaded
+            .errors
+            .iter()
+            .any(|e| e.message.contains(PLUGIN_FEATURE_SENTINEL))
+        {
+            skipped += 1;
+            skipped_plugin_feature += 1;
+            continue;
+        }
         compared += 1;
 
         let rel = path.display().to_string();
@@ -222,14 +252,14 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
             continue;
         }
 
-        for (i, (nd, wd)) in native
+        for (i, (native_dir, wit_dir)) in native
             .directives
             .iter()
             .zip(loaded.entries.iter())
             .enumerate()
         {
-            let (nk, ndate) = native_kind(nd);
-            let (wk, wdate) = wit_kind(wd);
+            let (nk, ndate) = native_kind(native_dir);
+            let (wk, wdate) = wit_kind(wit_dir);
             if nk != wk || ndate != wdate {
                 mismatches.push(format!(
                     "{rel}: entry {i} native=({nk}, {ndate}) component=({wk}, {wdate})"
@@ -240,7 +270,9 @@ fn corpus_loads_identically_via_native_and_component() -> Result<()> {
     }
 
     println!(
-        "corpus parity: compared {compared}, skipped {skipped}, files {}",
+        "corpus parity: compared {compared}, skipped {skipped} \
+         (of which {skipped_plugin_feature} for the component's plugin-feature gate), \
+         files {}",
         files.len()
     );
     assert!(


### PR DESCRIPTION
## What

`corpus_parity` compares the featureless component wasm's `load` errors against the native `rustledger_ffi_wasi::helpers::load_source` reference. Under `cargo test --workspace`, cargo feature unification compiles that native reference **with** `python-plugins`/`wasm-plugins` (the `rustledger` CLI enables them by default), so on a fixture declaring such a plugin it *attempts* the plugin and reports a real error, while the always-featureless component reports `requires the …-plugins feature`. Same function, two feature builds — an artifact of the harness, not a component regression.

The divergence is invisible to CI (which never builds the debug wasm in a `--workspace` job — verified: the workspace test job doesn't build wasm, the component-tests job builds wasm but runs `-p …-tests`, not `--workspace`), but it breaks the documented "run the full suite locally before pushing" workflow for anyone who has built the debug wasm.

## Why this shape of fix

The issue floated "compare against a `--no-default-features` native build" — that isn't achievable inside a single `--workspace` test binary: features are already unified at link time, and whether the native reference is featured is decided by the rest of the build set, not by anything the test controls.

So: **skip a fixture when the component emits the plugin-feature-gate sentinel** (`-plugins feature`). Such a fixture exercises a surface the featureless component structurally can't implement, so asserting parity on it is meaningless. Keying on the *component's* sentinel rather than a source `plugin "…"` scan deliberately keeps **native-Rust** plugins — which the featureless component *does* run — in the compared set. The skip is surfaced as its own count in the summary line (no silent cap), and applies uniformly whether or not features are unified (301 compared / 4 plugin-feature-skipped in both configs).

## Not a product bug

The shipping component is featureless by design; `requires the …-plugins feature` is its correct, intended message, and rustfava runs those plugins host-side. This PR only re-scopes the harness.

## Verification

Reproduced the original failure locally (build debug wasm, `cargo test --workspace`), then confirmed the fix: `corpus parity: compared 301, skipped 21 (of which 4 for the component's plugin-feature gate)`, green under **both** `--workspace` (unified) and `-p rustledger-ffi-component-tests` (featureless). Clippy/fmt clean. (The pre-existing `nd`/`wd` loop variables were renamed to `native_dir`/`wit_dir` — touching the file made the `typos` hook re-scan them, `nd` → `and`.)

## Related

The stale-`.cwasm`-cache robustness bug this investigation also exposed (the 4th diverging fixture's environment-dependent deserialization error) is a real, user-facing bug fixed separately in #1811.

Closes #1809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gJH7uBBF9Xw9et9QFRcsU
