### PR TITLE
fix(lsp): validate multi-file ledgers once, not once per file (#1799)

### DIFF
--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -124,6 +124,31 @@ pub struct PluginContext<'a> {
     pub source_map: &'a SourceMap,
 }
 
+/// Convert a `ParseResult`'s plugin declarations into loader `Plugin` structs,
+/// tagged with `file_id`. The `python:` prefix forces the Python runtime.
+fn parse_result_to_plugins(
+    plugins: &[(String, Option<String>, Span)],
+    file_id: usize,
+) -> Vec<Plugin> {
+    plugins
+        .iter()
+        .map(|(name, config, span)| {
+            let (actual_name, force_python) = name
+                .strip_prefix("python:")
+                .map_or((name.clone(), false), |stripped| {
+                    (stripped.to_string(), true)
+                });
+            Plugin {
+                name: actual_name,
+                config: config.clone(),
+                span: *span,
+                file_id,
+                force_python,
+            }
+        })
+        .collect()
+}
+
 /// Run validation on parsed directives and convert errors to LSP diagnostics.
 ///
 /// The `rledger check` pipeline is:
@@ -170,15 +195,60 @@ pub struct PluginContext<'a> {
 /// `file_id` matches (or is `None`, for global errors like duplicate
 /// account opens across files).
 pub fn validation_errors_to_diagnostics(
-    mut booked_directives: Vec<Spanned<Directive>>,
+    booked_directives: Vec<Spanned<Directive>>,
     source: &str,
     validation_options: ValidationOptions,
     current_file_id: Option<u16>,
     plugin_ctx: Option<&PluginContext<'_>>,
     encoding: PositionEncoding,
 ) -> Vec<Diagnostic> {
-    let line_index = LineIndex::new(source, encoding);
-    let mut extra_diagnostics = Vec::new();
+    // Run the file-independent booking + validation ONCE, then map the result
+    // to this one file. `validation_errors_to_diagnostics` is the single-file
+    // entry point; the multi-file path ([`ledger_diagnostics_multi`]) shares
+    // one `run_ledger_validation` across every file instead of re-running it
+    // per file (#1799).
+    let validation = run_ledger_validation(booked_directives, validation_options, plugin_ctx);
+    map_validation_to_diagnostics(&validation, source, current_file_id, plugin_ctx, encoding)
+}
+
+/// The file-INDEPENDENT, expensive half of LSP validation, computed once per
+/// ledger snapshot: sort into booking order, book + interpolate every
+/// transaction, run both plugin passes, then the Early + Late validation
+/// passes. The resulting errors span every file (each tagged with its
+/// `file_id`); per-file diagnostics are derived from this by
+/// [`map_validation_to_diagnostics`].
+///
+/// Splitting this out is the fix for #1799: the cross-file diagnostics path
+/// used to call [`all_diagnostics`] once per ledger file, each re-running this
+/// whole-ledger book+validate just to keep one file's errors — O(files) full
+/// validations per keystroke, which starved the single-threaded LSP main loop
+/// and made completions time out on large multi-file ledgers.
+pub(crate) struct LedgerValidation {
+    /// Validation errors across ALL files (unfiltered; each carries `file_id`).
+    errors: Vec<ValidationError>,
+    /// Loader plugin errors (they carry no `file_id`), pre-converted to
+    /// `(severity, code, message)`. Shown only in the main file (file 0).
+    plugin_errors: Vec<(DiagnosticSeverity, String, String)>,
+}
+
+// Per-thread count of `run_ledger_validation` invocations, for the #1799
+// regression test that asserts ONE whole-ledger validation regardless of file
+// count. Thread-local (not a global atomic) so parallel tests don't pollute
+// each other's count — `run_ledger_validation` runs synchronously on the
+// caller's thread.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static LEDGER_VALIDATION_RUNS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+pub(crate) fn run_ledger_validation(
+    mut booked_directives: Vec<Spanned<Directive>>,
+    validation_options: ValidationOptions,
+    plugin_ctx: Option<&PluginContext<'_>>,
+) -> LedgerValidation {
+    #[cfg(test)]
+    LEDGER_VALIDATION_RUNS.with(|c| c.set(c.get() + 1));
 
     // Booking order via the canonical comparator — the SINGLE source for
     // (date, priority, cost-reduction-last), shared with the loader and
@@ -200,14 +270,87 @@ pub fn validation_errors_to_diagnostics(
         // If booking fails, we leave the transaction as-is and let validation catch it
     }
 
+    let mut plugin_errors_out = Vec::new();
+
     // LSP runs both plugin passes — synth then regular — on already-booked
     // directives. The loader's process::process() splits these around its
     // own Early/Late validation phases; the LSP collapses validation into
     // a single step but still needs both plugin passes to fire so that
     // synth-injected Opens (auto_accounts) suppress spurious E1001s and
     // regular plugins (effective_date, etc.) transform directives before
-    // validation. See validation_errors_to_diagnostics for the LSP's
-    // pipeline rationale and trade-offs.
+    // validation.
+    if let Some(ctx) = plugin_ctx {
+        let load_options = LoadOptions::default();
+        let mut plugin_errors = Vec::new();
+        // Run synth pass first so auto_accounts can synthesize Opens
+        // for accounts referenced without explicit declaration; this
+        // suppresses spurious E1001 diagnostics in the LSP.
+        let synth_result = rustledger_loader::run_plugins(
+            &mut booked_directives,
+            ctx.plugins,
+            ctx.file_options,
+            &load_options,
+            ctx.source_map,
+            &mut plugin_errors,
+            rustledger_loader::PluginPass::PreBookingSynth,
+        );
+        match synth_result.and_then(|()| {
+            rustledger_loader::run_plugins(
+                &mut booked_directives,
+                ctx.plugins,
+                ctx.file_options,
+                &load_options,
+                ctx.source_map,
+                &mut plugin_errors,
+                rustledger_loader::PluginPass::PostBooking,
+            )
+        }) {
+            Ok(()) => {
+                for err in &plugin_errors {
+                    let severity = match err.severity {
+                        rustledger_loader::ErrorSeverity::Error => DiagnosticSeverity::ERROR,
+                        rustledger_loader::ErrorSeverity::Warning => DiagnosticSeverity::WARNING,
+                    };
+                    plugin_errors_out.push((severity, err.code.clone(), err.message.clone()));
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Plugin execution failed in LSP: {e}");
+            }
+        }
+    }
+
+    // LSP receives already-booked directives, so it has no booking step
+    // to interleave between phases. Run Early + Late back-to-back
+    // against the same input. See `rustledger_validate::Phase` for the
+    // architecture rationale.
+    let today = jiff::Zoned::now().date();
+    let session = ValidationSession::new(validation_options);
+    let (session, mut errors) = session.run_early_spanned(&booked_directives, today);
+    let (session, late_errs) = session.run_late_spanned(&booked_directives, today);
+    errors.extend(late_errs);
+    errors.extend(session.finalize());
+
+    LedgerValidation {
+        errors,
+        plugin_errors: plugin_errors_out,
+    }
+}
+
+/// Map a shared [`LedgerValidation`] to the diagnostics for ONE file: the
+/// validation errors whose `file_id` matches (plus global `None`-file errors),
+/// mapped to positions in this file's `source`, plus this file's non-native
+/// plugin info notes and (in the main file only) the loader plugin errors.
+pub(crate) fn map_validation_to_diagnostics(
+    validation: &LedgerValidation,
+    source: &str,
+    current_file_id: Option<u16>,
+    plugin_ctx: Option<&PluginContext<'_>>,
+    encoding: PositionEncoding,
+) -> Vec<Diagnostic> {
+    let line_index = LineIndex::new(source, encoding);
+    let mut extra_diagnostics = Vec::new();
+
     if let Some(ctx) = plugin_ctx {
         // Emit info diagnostics for non-native plugins. The loader's run_plugins()
         // only executes native plugins — Python/WASM plugins are not run in the LSP.
@@ -249,95 +392,40 @@ pub fn validation_errors_to_diagnostics(
             }
         }
 
-        let load_options = LoadOptions::default();
-        let mut plugin_errors = Vec::new();
-        // Run synth pass first so auto_accounts can synthesize Opens
-        // for accounts referenced without explicit declaration; this
-        // suppresses spurious E1001 diagnostics in the LSP.
-        let synth_result = rustledger_loader::run_plugins(
-            &mut booked_directives,
-            ctx.plugins,
-            ctx.file_options,
-            &load_options,
-            ctx.source_map,
-            &mut plugin_errors,
-            rustledger_loader::PluginPass::PreBookingSynth,
-        );
-        match synth_result.and_then(|()| {
-            rustledger_loader::run_plugins(
-                &mut booked_directives,
-                ctx.plugins,
-                ctx.file_options,
-                &load_options,
-                ctx.source_map,
-                &mut plugin_errors,
-                rustledger_loader::PluginPass::PostBooking,
-            )
-        }) {
-            Ok(()) => {
-                // Convert plugin errors to diagnostics.
-                // Plugin errors don't carry file_id, so we only show them
-                // in the main file (file_id 0) to avoid duplication across
-                // open documents in multi-file mode.
-                let show_plugin_errors = current_file_id.is_none() || current_file_id == Some(0);
-                if show_plugin_errors {
-                    for err in &plugin_errors {
-                        let severity = match err.severity {
-                            rustledger_loader::ErrorSeverity::Error => DiagnosticSeverity::ERROR,
-                            rustledger_loader::ErrorSeverity::Warning => {
-                                DiagnosticSeverity::WARNING
-                            }
-                        };
-                        extra_diagnostics.push(Diagnostic {
-                            range: Range {
-                                start: Position::new(0, 0),
-                                end: Position::new(0, 0),
-                            },
-                            severity: Some(severity),
-                            code: Some(lsp_types::NumberOrString::String(err.code.clone())),
-                            source: Some("rustledger".to_string()),
-                            message: err.message.clone(),
-                            related_information: None,
-                            tags: None,
-                            code_description: None,
-                            data: None,
-                        });
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Plugin execution failed in LSP: {e}");
+        // Plugin errors don't carry file_id, so we only show them in the main
+        // file (file_id 0) to avoid duplication across open documents.
+        let show_plugin_errors = current_file_id.is_none() || current_file_id == Some(0);
+        if show_plugin_errors {
+            for (severity, code, message) in &validation.plugin_errors {
+                extra_diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position::new(0, 0),
+                        end: Position::new(0, 0),
+                    },
+                    severity: Some(*severity),
+                    code: Some(lsp_types::NumberOrString::String(code.clone())),
+                    source: Some("rustledger".to_string()),
+                    message: message.clone(),
+                    related_information: None,
+                    tags: None,
+                    code_description: None,
+                    data: None,
+                });
             }
         }
     }
 
-    // LSP receives already-booked directives, so it has no booking step
-    // to interleave between phases. Run Early + Late back-to-back
-    // against the same input. See `rustledger_validate::Phase` for the
-    // architecture rationale.
-    let today = jiff::Zoned::now().date();
-    let session = ValidationSession::new(validation_options);
-    let (session, mut validation_errors) = session.run_early_spanned(&booked_directives, today);
-    let (session, late_errs) = session.run_late_spanned(&booked_directives, today);
-    validation_errors.extend(late_errs);
-    validation_errors.extend(session.finalize());
-
     // Filter errors to only those in the current file (if file_id filtering is enabled).
     // Also include errors with file_id == None, as these are global errors (e.g., duplicate
     // account opens across files) that should be shown to the user.
-    let filtered_errors: Vec<_> = if let Some(file_id) = current_file_id {
-        validation_errors
-            .into_iter()
-            .filter(|e| e.file_id == Some(file_id) || e.file_id.is_none())
-            .collect()
-    } else {
-        validation_errors
-    };
-
     let mut result: Vec<Diagnostic> = extra_diagnostics;
     result.extend(
-        filtered_errors
+        validation
+            .errors
             .iter()
+            .filter(|e| {
+                current_file_id.is_none_or(|fid| e.file_id == Some(fid) || e.file_id.is_none())
+            })
             .map(|e| validation_error_to_diagnostic(e, source, &line_index)),
     );
     result
@@ -633,29 +721,6 @@ pub fn all_diagnostics(
         // unsaved edits to plugin directives take effect immediately).
         // Single-file: build entirely from ParseResult's plugin declarations.
         //
-        // Helper closure to convert ParseResult plugins to Plugin structs.
-        let parse_result_to_plugins =
-            |plugins: &[(String, Option<String>, Span)], file_id: usize| -> Vec<Plugin> {
-                plugins
-                    .iter()
-                    .map(|(name, config, span)| {
-                        let (actual_name, force_python) =
-                            if let Some(stripped) = name.strip_prefix("python:") {
-                                (stripped.to_string(), true)
-                            } else {
-                                (name.clone(), false)
-                            };
-                        Plugin {
-                            name: actual_name,
-                            config: config.clone(),
-                            span: *span,
-                            file_id,
-                            force_python,
-                        }
-                    })
-                    .collect()
-            };
-
         let merged_plugins: Vec<Plugin>;
         let single_file_options: LoaderOptions;
         let single_file_source_map: SourceMap;
@@ -790,6 +855,153 @@ pub fn all_diagnostics(
     ));
 
     diagnostics
+}
+
+/// A file to emit diagnostics for in the multi-file path.
+pub(crate) struct FileDiagTarget<'a> {
+    /// The file's id in the ledger source map.
+    pub file_id: u16,
+    /// The file's source text (for parse-error + validation-error position
+    /// mapping).
+    pub source: &'a str,
+    /// A fresh parse of `source` (for parse-error and import diagnostics, and
+    /// the per-file validation gate).
+    pub parse: &'a ParseResult,
+}
+
+/// Compute diagnostics for MANY ledger files from a SINGLE whole-ledger
+/// book + validate — the fix for #1799.
+///
+/// The old cross-file path called [`all_diagnostics`] once per ledger file,
+/// and each call re-ran the entire book + plugin + validate pipeline over the
+/// whole ledger just to keep one file's errors (O(files) full validations per
+/// keystroke). Because `didChange` is handled synchronously on the LSP main
+/// loop, that blocked completion requests and made them time out on large
+/// multi-file ledgers.
+///
+/// Here the file-independent work — building the overlaid directive set, the
+/// validation options, the plugin set, and running booking + both plugin
+/// passes + Early/Late validation — is done **once** via
+/// [`run_ledger_validation`]. Each target's diagnostics are then derived
+/// cheaply: parse errors, the shared validation errors filtered to that file
+/// and mapped against its own source, the per-file plugin notes, plus (in the
+/// main file) option warnings, and per-file import-review hints. The result is
+/// aligned 1:1 with `targets`.
+///
+/// `overlay` is the fresh parse of every clean open buffer (current file
+/// included when clean), applied to the ledger snapshot so unsaved edits are
+/// reflected — the same overlay the current-file [`all_diagnostics`] path
+/// builds. `primary_parse` / `primary_file_id` identify the file being edited,
+/// whose fresh plugin declarations replace the ledger's for that file (mirrors
+/// the single-file path); unopened files are not edited, so their ledger
+/// plugins are already current.
+///
+/// Requires a loaded ledger; falls back to parse-only diagnostics otherwise
+/// (the caller only uses this path for multi-file ledgers).
+pub(crate) fn ledger_diagnostics_multi(
+    ledger_state: &LedgerState,
+    primary_file_id: Option<u16>,
+    primary_parse: &ParseResult,
+    overlay: &[(u16, &[Spanned<Directive>])],
+    targets: &[FileDiagTarget<'_>],
+    encoding: PositionEncoding,
+) -> Vec<Vec<Diagnostic>> {
+    let Some(ledger) = ledger_state.ledger() else {
+        return targets
+            .iter()
+            .map(|t| parse_errors_to_diagnostics(t.parse, t.source, encoding))
+            .collect();
+    };
+
+    // ---- Shared, file-independent setup (mirrors all_diagnostics' loaded-
+    // ledger branch). Build the overlaid directive set once. ----
+    let full_directives_raw = ledger_state.directives();
+    let booked_directives: Vec<Spanned<Directive>> =
+        if let Some(owned) = build_live_directive_overlay(overlay, full_directives_raw) {
+            owned
+        } else if let Some(full) = full_directives_raw {
+            full.to_vec()
+        } else {
+            Vec::new()
+        };
+
+    let base_dir = ledger
+        .source_map
+        .files()
+        .first()
+        .and_then(|f| f.path.parent())
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let validation_options =
+        build_validation_options_from_loader(&ledger.options, &ledger.source_map, base_dir);
+
+    // Plugin set: ledger plugins with the primary (edited) file's plugins
+    // replaced by its fresh parse (matches the single-file path). Unopened
+    // files aren't edited, so their ledger plugins remain current.
+    let primary_fid = primary_file_id.unwrap_or(0) as usize;
+    let merged_plugins: Vec<Plugin> = ledger
+        .plugins
+        .iter()
+        .filter(|p| p.file_id != primary_fid)
+        .cloned()
+        .chain(parse_result_to_plugins(&primary_parse.plugins, primary_fid))
+        .collect();
+    let plugin_ctx = if merged_plugins.is_empty() {
+        None
+    } else {
+        Some(PluginContext {
+            plugins: &merged_plugins,
+            file_options: &ledger.options,
+            source_map: &ledger.source_map,
+        })
+    };
+
+    // ---- ONE whole-ledger book + validate ----
+    let validation =
+        run_ledger_validation(booked_directives, validation_options, plugin_ctx.as_ref());
+
+    // ---- Map each target from the shared validation ----
+    targets
+        .iter()
+        .map(|t| {
+            let mut diags = parse_errors_to_diagnostics(t.parse, t.source, encoding);
+            if validation_would_run(t.source, t.parse) {
+                diags.extend(map_validation_to_diagnostics(
+                    &validation,
+                    t.source,
+                    Some(t.file_id),
+                    plugin_ctx.as_ref(),
+                    encoding,
+                ));
+            }
+            // Option warnings (E7001–E7006) are shown only in the main file to
+            // avoid duplication across open documents.
+            if t.file_id == 0 {
+                for warning in ledger.options.warnings.as_slice() {
+                    diags.push(Diagnostic {
+                        range: Range {
+                            start: Position::new(0, 0),
+                            end: Position::new(0, 0),
+                        },
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        code: Some(lsp_types::NumberOrString::String(warning.code.to_string())),
+                        source: Some("rustledger".to_string()),
+                        message: warning.message.clone(),
+                        related_information: None,
+                        tags: None,
+                        code_description: None,
+                        data: None,
+                    });
+                }
+            }
+            // Per-file import-review diagnostics.
+            diags.extend(super::import::import_diagnostics(
+                &t.parse.directives,
+                t.source,
+                encoding,
+            ));
+            diags
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -2090,6 +2302,80 @@ plugin "auto_accounts"
         assert!(
             !codes.iter().any(|c| c == "E1001"),
             "auto_accounts should still auto-generate opens. Got: {codes:?}"
+        );
+    }
+
+    /// #1799 regression: `ledger_diagnostics_multi` must run the whole-ledger
+    /// book+validate EXACTLY ONCE regardless of how many files it emits
+    /// diagnostics for. The pre-fix cross-file path called `all_diagnostics`
+    /// (which re-validated the entire ledger) once per file — O(files)
+    /// validations per keystroke — starving the LSP main loop and timing out
+    /// completions on large multi-file ledgers.
+    #[test]
+    fn ledger_diagnostics_multi_validates_once_for_all_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let main = dir.path().join("main.beancount");
+        std::fs::write(dir.path().join("a.beancount"), "2024-01-01 open Assets:A\n")
+            .expect("write a");
+        std::fs::write(dir.path().join("b.beancount"), "2024-01-01 open Assets:B\n")
+            .expect("write b");
+        std::fs::write(
+            &main,
+            "include \"a.beancount\"\ninclude \"b.beancount\"\n2024-01-02 open Assets:C\n",
+        )
+        .expect("write main");
+
+        let mut ls = LedgerState::new();
+        ls.load(&main).expect("load multi-file ledger");
+        let files: Vec<(u16, Arc<str>)> = ls
+            .ledger()
+            .expect("ledger loaded")
+            .source_map
+            .files()
+            .iter()
+            .map(|f| (f.id as u16, f.source.clone()))
+            .collect();
+        assert!(
+            files.len() >= 3,
+            "fixture must be a multi-file ledger, got {} files",
+            files.len()
+        );
+
+        let parses: Vec<ParseResult> = files.iter().map(|(_, s)| parse(s)).collect();
+        let targets: Vec<FileDiagTarget<'_>> = files
+            .iter()
+            .zip(&parses)
+            .map(|((fid, src), p)| FileDiagTarget {
+                file_id: *fid,
+                source: src,
+                parse: p,
+            })
+            .collect();
+
+        // Measure validation runs on THIS thread across the call (thread-local
+        // counter, so parallel tests don't interfere).
+        let before = LEDGER_VALIDATION_RUNS.with(std::cell::Cell::get);
+        let per_file = ledger_diagnostics_multi(
+            &ls,
+            Some(0),
+            &parses[0],
+            &[],
+            &targets,
+            PositionEncoding::Utf16,
+        );
+        let after = LEDGER_VALIDATION_RUNS.with(std::cell::Cell::get);
+
+        assert_eq!(
+            per_file.len(),
+            targets.len(),
+            "one diagnostic set per target file"
+        );
+        assert_eq!(
+            after - before,
+            1,
+            "must run exactly ONE whole-ledger validation for {} files (#1799), ran {}",
+            targets.len(),
+            after - before
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -913,19 +913,31 @@ pub(crate) fn ledger_diagnostics_multi(
             .collect();
     };
 
-    // Plugin set: ledger plugins with the primary (edited) file's plugins
-    // replaced by its fresh parse (matches the single-file path). Unopened
-    // files aren't edited, so their ledger plugins remain current. Built
-    // regardless of validation because the per-file plugin NOTES (E8006) are
-    // emitted from it even when validation is skipped.
-    let primary_fid = primary_file_id.unwrap_or(0) as usize;
-    let merged_plugins: Vec<Plugin> = ledger
-        .plugins
-        .iter()
-        .filter(|p| p.file_id != primary_fid)
-        .cloned()
-        .chain(parse_result_to_plugins(&primary_parse.plugins, primary_fid))
-        .collect();
+    // Plugin set for the shared validation and the per-file plugin NOTES
+    // (E8006). Start from the ledger's stored plugins, and replace the
+    // primary (edited) file's plugins with its fresh parse ONLY when that file
+    // is part of the ledger AND parsed cleanly — mirroring the directive
+    // overlay's clean-parse guard. A broken current parse recovers a partial
+    // (or empty) `.plugins` list; injecting it would DROP the current file's
+    // plugins from the whole-ledger validation the clean unopened files run
+    // against, producing spurious diagnostics there (e.g. auto_accounts
+    // dropped ⇒ phantom E1001s). When the current buffer isn't a ledger file
+    // at all, its plugins must not be injected either. In both cases keep the
+    // ledger's stored plugins, matching the old per-file path (where the
+    // current file was never the primary in the unopened files' validations).
+    let merged_plugins: Vec<Plugin> = match primary_file_id {
+        Some(fid) if primary_parse.errors.is_empty() => {
+            let primary_fid = fid as usize;
+            ledger
+                .plugins
+                .iter()
+                .filter(|p| p.file_id != primary_fid)
+                .cloned()
+                .chain(parse_result_to_plugins(&primary_parse.plugins, primary_fid))
+                .collect()
+        }
+        _ => ledger.plugins.clone(),
+    };
     let plugin_ctx = if merged_plugins.is_empty() {
         None
     } else {
@@ -984,6 +996,14 @@ pub(crate) fn ledger_diagnostics_multi(
                     plugin_ctx.as_ref(),
                     encoding,
                 ));
+            } else if t.parse.errors.is_empty() && t.source.len() > MAX_VALIDATION_FILE_SIZE {
+                // Parity with `all_diagnostics`: the only human signal that a
+                // clean-but-too-large file silently skipped validation.
+                tracing::debug!(
+                    "Skipping validation for large file ({} bytes > {} limit)",
+                    t.source.len(),
+                    MAX_VALIDATION_FILE_SIZE
+                );
             }
             // Option warnings (E7001–E7006) are shown only in the main file to
             // avoid duplication across open documents.
@@ -2421,6 +2441,78 @@ plugin "auto_accounts"
             after - before,
             0,
             "no target can use validation (all have parse errors), so it must not run"
+        );
+    }
+
+    /// #1813 review: when the CURRENT file's fresh parse is broken, its plugins
+    /// must NOT be dropped from the whole-ledger validation the clean unopened
+    /// files run against. Otherwise `auto_accounts` (declared in the current
+    /// file) vanishes and the unopened files get phantom E1001s that neither
+    /// the old per-file path nor `rledger check` produce.
+    #[test]
+    fn broken_current_parse_keeps_stored_plugins_for_cross_file_validation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let main = dir.path().join("main.beancount");
+        // b (unopened) uses accounts with no explicit `open`; auto_accounts
+        // (declared in main) must synthesize the opens so there's no E1001.
+        std::fs::write(
+            dir.path().join("b.beancount"),
+            "2024-01-02 * \"x\"\n  Assets:New  10 USD\n  Equity:Opening-Balances  -10 USD\n",
+        )
+        .expect("write b");
+        std::fs::write(&main, "plugin \"auto_accounts\"\ninclude \"b.beancount\"\n")
+            .expect("write main");
+
+        let mut ls = LedgerState::new();
+        ls.load(&main).expect("load ledger");
+        // Confirm the ledger recorded auto_accounts.
+        assert!(
+            ls.ledger()
+                .expect("ledger")
+                .plugins
+                .iter()
+                .any(|p| p.name == "auto_accounts"),
+            "fixture must record the auto_accounts plugin"
+        );
+        let (b_id, b_source): (u16, Arc<str>) = ls
+            .ledger()
+            .expect("ledger")
+            .source_map
+            .files()
+            .iter()
+            .find(|f| f.path.ends_with("b.beancount"))
+            .map(|f| (f.id as u16, f.source.clone()))
+            .expect("b in ledger");
+
+        // The current file (main, id 0) parses BROKEN — its recovered plugin
+        // list is empty, so injecting it would drop auto_accounts.
+        let broken_main = parse("@@@ not valid beancount\n");
+        assert!(!broken_main.errors.is_empty(), "fixture must be broken");
+        assert!(
+            broken_main.plugins.is_empty(),
+            "broken parse must recover no plugins (else the test proves nothing)"
+        );
+
+        let b_parse = parse(&b_source);
+        let targets = [FileDiagTarget {
+            file_id: b_id,
+            source: &b_source,
+            parse: &b_parse,
+        }];
+        let per_file = ledger_diagnostics_multi(
+            &ls,
+            Some(0),
+            &broken_main,
+            &[],
+            &targets,
+            PositionEncoding::Utf16,
+        );
+
+        let b_codes: Vec<_> = per_file[0].iter().map(get_code).collect();
+        assert!(
+            !b_codes.iter().any(|c| c == "E1001"),
+            "auto_accounts (from the ledger) must still synthesize opens for the \
+             unopened file even when the current file's parse is broken — got {b_codes:?}"
         );
     }
 }

--- a/crates/rustledger-lsp/src/handlers/diagnostics.rs
+++ b/crates/rustledger-lsp/src/handlers/diagnostics.rs
@@ -913,30 +913,11 @@ pub(crate) fn ledger_diagnostics_multi(
             .collect();
     };
 
-    // ---- Shared, file-independent setup (mirrors all_diagnostics' loaded-
-    // ledger branch). Build the overlaid directive set once. ----
-    let full_directives_raw = ledger_state.directives();
-    let booked_directives: Vec<Spanned<Directive>> =
-        if let Some(owned) = build_live_directive_overlay(overlay, full_directives_raw) {
-            owned
-        } else if let Some(full) = full_directives_raw {
-            full.to_vec()
-        } else {
-            Vec::new()
-        };
-
-    let base_dir = ledger
-        .source_map
-        .files()
-        .first()
-        .and_then(|f| f.path.parent())
-        .unwrap_or_else(|| std::path::Path::new("."));
-    let validation_options =
-        build_validation_options_from_loader(&ledger.options, &ledger.source_map, base_dir);
-
     // Plugin set: ledger plugins with the primary (edited) file's plugins
     // replaced by its fresh parse (matches the single-file path). Unopened
-    // files aren't edited, so their ledger plugins remain current.
+    // files aren't edited, so their ledger plugins remain current. Built
+    // regardless of validation because the per-file plugin NOTES (E8006) are
+    // emitted from it even when validation is skipped.
     let primary_fid = primary_file_id.unwrap_or(0) as usize;
     let merged_plugins: Vec<Plugin> = ledger
         .plugins
@@ -955,9 +936,40 @@ pub(crate) fn ledger_diagnostics_multi(
         })
     };
 
-    // ---- ONE whole-ledger book + validate ----
-    let validation =
-        run_ledger_validation(booked_directives, validation_options, plugin_ctx.as_ref());
+    // ---- ONE whole-ledger book + validate, but ONLY if some target will use
+    // it. When every target fails `validation_would_run` (all have parse
+    // errors, or all exceed the size cap), the whole-ledger book + plugin +
+    // validate would be thrown away, so skip it entirely rather than block the
+    // main loop on discarded work (Copilot review). The expensive directive
+    // overlay is built inside this branch too. ----
+    let any_target_validates = targets
+        .iter()
+        .any(|t| validation_would_run(t.source, t.parse));
+    let validation = if any_target_validates {
+        let full_directives_raw = ledger_state.directives();
+        let booked_directives: Vec<Spanned<Directive>> =
+            if let Some(owned) = build_live_directive_overlay(overlay, full_directives_raw) {
+                owned
+            } else if let Some(full) = full_directives_raw {
+                full.to_vec()
+            } else {
+                Vec::new()
+            };
+        let base_dir = ledger
+            .source_map
+            .files()
+            .first()
+            .and_then(|f| f.path.parent())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let validation_options =
+            build_validation_options_from_loader(&ledger.options, &ledger.source_map, base_dir);
+        run_ledger_validation(booked_directives, validation_options, plugin_ctx.as_ref())
+    } else {
+        LedgerValidation {
+            errors: Vec::new(),
+            plugin_errors: Vec::new(),
+        }
+    };
 
     // ---- Map each target from the shared validation ----
     targets
@@ -2376,6 +2388,39 @@ plugin "auto_accounts"
             "must run exactly ONE whole-ledger validation for {} files (#1799), ran {}",
             targets.len(),
             after - before
+        );
+
+        // ...and ZERO validations when every target fails `validation_would_run`
+        // (here: all targets have parse errors), since the result would be
+        // discarded anyway (Copilot review).
+        let bad_source: Arc<str> = Arc::from("this is not valid @@@ beancount\n");
+        let bad_parse = parse(&bad_source);
+        assert!(
+            !bad_parse.errors.is_empty(),
+            "fixture must have parse errors"
+        );
+        let bad_targets: Vec<FileDiagTarget<'_>> = files
+            .iter()
+            .map(|(fid, _)| FileDiagTarget {
+                file_id: *fid,
+                source: &bad_source,
+                parse: &bad_parse,
+            })
+            .collect();
+        let before = LEDGER_VALIDATION_RUNS.with(std::cell::Cell::get);
+        let _ = ledger_diagnostics_multi(
+            &ls,
+            Some(0),
+            &bad_parse,
+            &[],
+            &bad_targets,
+            PositionEncoding::Utf16,
+        );
+        let after = LEDGER_VALIDATION_RUNS.with(std::cell::Cell::get);
+        assert_eq!(
+            after - before,
+            0,
+            "no target can use validation (all have parse errors), so it must not run"
         );
     }
 }

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1871,10 +1871,11 @@ impl MainLoopState {
             .and_then(|ls| ls.ledger())
             .is_some_and(|l| l.source_map.files().len() > 1);
 
-        let (diagnostics, cross_file) = if is_multi_file && current_file_id.is_some() {
+        let (diagnostics, cross_file) = if is_multi_file {
             // Shared overlay for the one validation: the current file's fresh
-            // parse (only when clean — overlaying a partial parse would corrupt
-            // validation of the other files) then every other open buffer.
+            // parse (only when it's a ledger file AND clean — overlaying a
+            // partial parse would corrupt validation of the other files) then
+            // every other open buffer.
             let mut overlay: Vec<(u16, &[Spanned<Directive>])> =
                 Vec::with_capacity(1 + other_buffer_overlays.len());
             if let Some(fid) = current_file_id
@@ -1884,7 +1885,7 @@ impl MainLoopState {
             }
             overlay.extend_from_slice(&other_buffer_overlays);
 
-            let (current, cross) = self.multi_file_diagnostics(
+            let (current_from_multi, cross) = self.multi_file_diagnostics(
                 ledger_state.expect("is_multi_file implies a loaded ledger"),
                 current_canonical_path.as_deref(),
                 current_file_id,
@@ -1892,10 +1893,30 @@ impl MainLoopState {
                 text,
                 &overlay,
             );
+            // When the current buffer IS part of the ledger, its diagnostics
+            // come from the shared validation (`current_from_multi`). When it
+            // ISN'T (e.g. editing a scratch file while a multi-file ledger is
+            // loaded), the current buffer self-validates via the single-file
+            // path — but cross-file diagnostics for the ledger's unopened files
+            // must STILL be recomputed and republished, not cleared (they'd
+            // otherwise vanish whenever a non-ledger buffer is edited).
+            let current = if current_file_id.is_some() {
+                current_from_multi
+            } else {
+                all_diagnostics(
+                    &result,
+                    text,
+                    ledger_state,
+                    current_file_id,
+                    current_canonical_path.as_deref(),
+                    &other_buffer_overlays,
+                    self.position_encoding,
+                )
+            };
             (current, cross)
         } else {
-            // Single-file (or current file not part of the ledger): unchanged
-            // path — validate just the current file.
+            // Single-file (or no loaded ledger): unchanged path — validate just
+            // the current file.
             let diagnostics = all_diagnostics(
                 &result,
                 text,
@@ -2010,16 +2031,21 @@ impl MainLoopState {
             })
             .collect();
 
-        // Targets for the single validation: current file first, then unopened.
-        let current_fid =
-            current_file_id.expect("multi_file_diagnostics requires a ledger file id");
+        // Targets for the single validation. When the current buffer is part
+        // of the ledger it is targets[0] (its diagnostics come from the same
+        // validation); when it is NOT (`current_file_id == None`, e.g. a
+        // scratch buffer) only the unopened files are validated here and the
+        // caller handles the current buffer via the single-file path.
+        let has_current_target = current_file_id.is_some();
         let mut targets: Vec<crate::handlers::diagnostics::FileDiagTarget<'_>> =
-            Vec::with_capacity(1 + unopened.len());
-        targets.push(crate::handlers::diagnostics::FileDiagTarget {
-            file_id: current_fid,
-            source: current_source,
-            parse: current_parse,
-        });
+            Vec::with_capacity(usize::from(has_current_target) + unopened.len());
+        if let Some(current_fid) = current_file_id {
+            targets.push(crate::handlers::diagnostics::FileDiagTarget {
+                file_id: current_fid,
+                source: current_source,
+                parse: current_parse,
+            });
+        }
         targets.extend(
             unopened
                 .iter()
@@ -2039,11 +2065,12 @@ impl MainLoopState {
             self.position_encoding,
         );
 
-        // per_file[0] is the current file; the rest align with `unopened`.
-        let current_diags = if per_file.is_empty() {
-            Vec::new()
-        } else {
+        // If present, per_file[0] is the current file; the rest align 1:1
+        // with `unopened`.
+        let current_diags = if has_current_target && !per_file.is_empty() {
             per_file.remove(0)
+        } else {
+            Vec::new()
         };
         let cross_file: Vec<(Uri, Vec<lsp_types::Diagnostic>)> = unopened
             .into_iter()

--- a/crates/rustledger-lsp/src/main_loop.rs
+++ b/crates/rustledger-lsp/src/main_loop.rs
@@ -1862,29 +1862,51 @@ impl MainLoopState {
                 Vec::new()
             };
 
-        // Convert parse errors and validation errors to LSP diagnostics
-        let diagnostics = all_diagnostics(
-            &result,
-            text,
-            ledger_state,
-            current_file_id,
-            current_canonical_path.as_deref(),
-            &other_buffer_overlays,
-            self.position_encoding,
-        );
+        // Is this a multi-file ledger? If so, and the current file is part of
+        // it, the current file's diagnostics AND every unopened file's
+        // diagnostics come from a SINGLE whole-ledger validation
+        // (`ledger_diagnostics_multi`) — the #1799 fix. Otherwise fall back to
+        // the single-file `all_diagnostics` path.
+        let is_multi_file = ledger_state
+            .and_then(|ls| ls.ledger())
+            .is_some_and(|l| l.source_map.files().len() > 1);
 
-        // Compute diagnostics for ledger files reachable via `include` that are
-        // NOT open in any buffer — otherwise validation errors that live in an
-        // unopened included file (e.g. an unbalanced transaction) never surface
-        // anywhere. Open files publish their own diagnostics via didOpen/
-        // didChange, so they're skipped here.
-        let cross_file = self.compute_unopened_ledger_diagnostics(
-            ledger_state,
-            current_canonical_path.as_deref(),
-            current_file_id,
-            &result,
-            &other_buffer_overlays,
-        );
+        let (diagnostics, cross_file) = if is_multi_file && current_file_id.is_some() {
+            // Shared overlay for the one validation: the current file's fresh
+            // parse (only when clean — overlaying a partial parse would corrupt
+            // validation of the other files) then every other open buffer.
+            let mut overlay: Vec<(u16, &[Spanned<Directive>])> =
+                Vec::with_capacity(1 + other_buffer_overlays.len());
+            if let Some(fid) = current_file_id
+                && result.errors.is_empty()
+            {
+                overlay.push((fid, result.directives.as_slice()));
+            }
+            overlay.extend_from_slice(&other_buffer_overlays);
+
+            let (current, cross) = self.multi_file_diagnostics(
+                ledger_state.expect("is_multi_file implies a loaded ledger"),
+                current_canonical_path.as_deref(),
+                current_file_id,
+                &result,
+                text,
+                &overlay,
+            );
+            (current, cross)
+        } else {
+            // Single-file (or current file not part of the ledger): unchanged
+            // path — validate just the current file.
+            let diagnostics = all_diagnostics(
+                &result,
+                text,
+                ledger_state,
+                current_file_id,
+                current_canonical_path.as_deref(),
+                &other_buffer_overlays,
+                self.position_encoding,
+            );
+            (diagnostics, Vec::new())
+        };
         drop(ledger_guard); // Release lock before sending
 
         tracing::debug!(
@@ -1902,33 +1924,35 @@ impl MainLoopState {
         self.publish_cross_file_diagnostics(cross_file);
     }
 
-    /// Compute diagnostics for every ledger file reachable via `include` that
-    /// is NOT currently open in a buffer. Each unopened file is validated
-    /// against the full ledger (reusing [`all_diagnostics`], filtered to that
-    /// file's id and mapped against that file's own source), with the open
-    /// buffers' fresh parses overlaid so unsaved edits are reflected.
+    /// Compute the current file's diagnostics AND every unopened included
+    /// file's diagnostics from a SINGLE whole-ledger validation (#1799).
     ///
-    /// Returns one `(uri, diagnostics)` per unopened ledger file (diagnostics
-    /// may be empty — the caller clears those it had previously reported).
-    /// Cost is O(unopened ledger files) validations; real-world ledgers have
-    /// few files, and this only runs when the ledger spans more than one file.
-    fn compute_unopened_ledger_diagnostics(
+    /// Returns `(current_file_diagnostics, cross_file)`, where `cross_file` is
+    /// one `(uri, diagnostics)` per unopened ledger file (diagnostics may be
+    /// empty — the caller clears those it had previously reported). This
+    /// replaces the old per-file `all_diagnostics` loop, which re-ran the whole
+    /// ledger's book+validate once per file: that O(files) cost per keystroke
+    /// starved the LSP main loop and made completions time out on large
+    /// multi-file ledgers.
+    ///
+    /// Only unopened files are cross-published; open buffers self-publish via
+    /// didOpen/didChange. `overlay` is the fresh parse of every clean open
+    /// buffer (current file included when clean).
+    fn multi_file_diagnostics(
         &self,
-        ledger_state: Option<&crate::ledger_state::LedgerState>,
+        ledger_state: &crate::ledger_state::LedgerState,
         current_canonical: Option<&std::path::Path>,
         current_file_id: Option<u16>,
         current_parse: &ParseResult,
-        other_buffer_overlays: &[(u16, &[Spanned<Directive>])],
-    ) -> Vec<(Uri, Vec<lsp_types::Diagnostic>)> {
-        let Some(ls) = ledger_state else {
-            return Vec::new();
+        current_source: &str,
+        overlay: &[(u16, &[Spanned<Directive>])],
+    ) -> (
+        Vec<lsp_types::Diagnostic>,
+        Vec<(Uri, Vec<lsp_types::Diagnostic>)>,
+    ) {
+        let Some(ledger) = ledger_state.ledger() else {
+            return (Vec::new(), Vec::new());
         };
-        let Some(ledger) = ls.ledger() else {
-            return Vec::new();
-        };
-        if ledger.source_map.files().len() <= 1 {
-            return Vec::new();
-        }
 
         // Canonical paths of all open buffers (so we skip files that
         // self-publish).
@@ -1937,60 +1961,96 @@ impl MainLoopState {
             vfs.paths().filter_map(|p| p.canonicalize().ok()).collect()
         };
 
-        // Overlay applied when validating an unopened file: every open buffer's
-        // fresh parse (current file first, then the others). The current
-        // buffer is overlaid only when its fresh parse is clean — overlaying a
-        // partial/invalid parse would corrupt the validation input for the
-        // other files (matching the parse-error skip applied to the `other`
-        // buffers in `publish_diagnostics`).
-        let mut overlay_all: Vec<(u16, &[Spanned<Directive>])> =
-            Vec::with_capacity(1 + other_buffer_overlays.len());
-        if let Some(fid) = current_file_id
-            && current_parse.errors.is_empty()
-        {
-            overlay_all.push((fid, current_parse.directives.as_slice()));
+        // Collect the unopened ledger files as (uri, file_id, source, parse).
+        // Parses are owned here so they outlive the `ledger_diagnostics_multi`
+        // call; sources borrow the held ledger snapshot. Parsing each unopened
+        // file is cheap next to the validation we now do only once.
+        struct Unopened<'a> {
+            uri: Uri,
+            file_id: u16,
+            source: &'a str,
+            parse: ParseResult,
         }
-        overlay_all.extend_from_slice(other_buffer_overlays);
+        let unopened: Vec<Unopened<'_>> = ledger
+            .source_map
+            .files()
+            .iter()
+            .filter_map(|f| {
+                let canonical = f.path.canonicalize().ok();
+                // Skip the current file and any open buffer — those self-publish.
+                if canonical.as_deref() == current_canonical {
+                    return None;
+                }
+                if let Some(c) = &canonical
+                    && open_canonical.contains(c)
+                {
+                    return None;
+                }
+                // NOTE: this `file://{path}` assembly matches the crate-wide
+                // convention (see `revalidate_open_documents`, `document_links`,
+                // and `uri_to_path`, which strips a plain `file://` prefix
+                // without percent-decoding). A path with characters that aren't
+                // URI-safe (spaces, `#`, `%`) would fail to parse; warn rather
+                // than drop it silently. A proper percent-encoding
+                // `path_to_uri` helper applied consistently across the crate is
+                // the broader fix.
+                let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
+                    tracing::warn!(
+                        "skipping cross-file diagnostics for {}: path is not a valid file:// URI",
+                        f.path.display()
+                    );
+                    return None;
+                };
+                Some(Unopened {
+                    uri,
+                    file_id: f.id as u16,
+                    source: f.source.as_ref(),
+                    parse: parse(&f.source),
+                })
+            })
+            .collect();
 
-        let mut out = Vec::new();
-        for f in ledger.source_map.files() {
-            let canonical = f.path.canonicalize().ok();
-            // Skip the current file and any open buffer — those self-publish.
-            if canonical.as_deref() == current_canonical {
-                continue;
-            }
-            if let Some(c) = &canonical
-                && open_canonical.contains(c)
-            {
-                continue;
-            }
-            // NOTE: this `file://{path}` assembly matches the crate-wide
-            // convention (see `revalidate_open_documents`, `document_links`,
-            // and `uri_to_path`, which strips a plain `file://` prefix without
-            // percent-decoding). A path with characters that aren't URI-safe
-            // (spaces, `#`, `%`) would fail to parse; warn rather than drop it
-            // silently. A proper percent-encoding `path_to_uri` helper applied
-            // consistently across the crate is the broader fix.
-            let Ok(uri) = format!("file://{}", f.path.display()).parse::<Uri>() else {
-                tracing::warn!(
-                    "skipping cross-file diagnostics for {}: path is not a valid file:// URI",
-                    f.path.display()
-                );
-                continue;
-            };
-            let parsed = parse(&f.source);
-            let diags = all_diagnostics(
-                &parsed,
-                &f.source,
-                ledger_state,
-                Some(f.id as u16),
-                Some(f.path.as_path()),
-                &overlay_all,
-                self.position_encoding,
-            );
-            out.push((uri, diags));
-        }
-        out
+        // Targets for the single validation: current file first, then unopened.
+        let current_fid =
+            current_file_id.expect("multi_file_diagnostics requires a ledger file id");
+        let mut targets: Vec<crate::handlers::diagnostics::FileDiagTarget<'_>> =
+            Vec::with_capacity(1 + unopened.len());
+        targets.push(crate::handlers::diagnostics::FileDiagTarget {
+            file_id: current_fid,
+            source: current_source,
+            parse: current_parse,
+        });
+        targets.extend(
+            unopened
+                .iter()
+                .map(|u| crate::handlers::diagnostics::FileDiagTarget {
+                    file_id: u.file_id,
+                    source: u.source,
+                    parse: &u.parse,
+                }),
+        );
+
+        let mut per_file = crate::handlers::diagnostics::ledger_diagnostics_multi(
+            ledger_state,
+            current_file_id,
+            current_parse,
+            overlay,
+            &targets,
+            self.position_encoding,
+        );
+
+        // per_file[0] is the current file; the rest align with `unopened`.
+        let current_diags = if per_file.is_empty() {
+            Vec::new()
+        } else {
+            per_file.remove(0)
+        };
+        let cross_file: Vec<(Uri, Vec<lsp_types::Diagnostic>)> = unopened
+            .into_iter()
+            .zip(per_file)
+            .map(|(u, diags)| (u.uri, diags))
+            .collect();
+        (current_diags, cross_file)
     }
 
     /// Publish or clear diagnostics for unopened included files.

--- a/crates/rustledger-lsp/tests/lsp_protocol.rs
+++ b/crates/rustledger-lsp/tests/lsp_protocol.rs
@@ -1073,6 +1073,119 @@ fn included_file_diagnostics_are_cleared_when_fixed() {
     );
 }
 
+/// #1813 review: editing a buffer that is NOT part of the multi-file ledger
+/// (a scratch file) must not clear an unopened included file's genuine
+/// diagnostics. The single-pass refactor's initial cut fell through to a path
+/// that published an EMPTY cross-file set whenever `current_file_id` was
+/// `None`, silently erasing real errors in unopened files.
+#[test]
+fn editing_a_non_ledger_buffer_keeps_unopened_file_diagnostics() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let journal_path = tmp.path().join("journal.beancount");
+    let good_path = tmp.path().join("good.beancount");
+    let bad_path = tmp.path().join("bad.beancount");
+    let scratch_path = tmp.path().join("scratch.beancount"); // NOT included by the journal
+
+    std::fs::write(
+        &good_path,
+        "2024-01-01 open Assets:Cash USD\n2024-01-01 open Expenses:Food USD\n",
+    )
+    .expect("write good");
+    std::fs::write(
+        &bad_path,
+        "2024-02-01 * \"unbalanced\"\n  Assets:Cash   -5 USD\n  Expenses:Food   3 USD\n",
+    )
+    .expect("write bad");
+    std::fs::write(
+        &journal_path,
+        format!(
+            "include \"{}\"\ninclude \"{}\"\n",
+            good_path.display(),
+            bad_path.display()
+        ),
+    )
+    .expect("write journal");
+
+    let mut client = LspTestClient::spawn_with_journal(Some(journal_path));
+    client.initialize();
+
+    let good_uri = format!("file://{}", good_path.display());
+    client.open_document(
+        &good_uri,
+        &std::fs::read_to_string(&good_path).expect("read good"),
+    );
+    let bad_uri = format!("file://{}", bad_path.display());
+
+    // Phase 1: wait until bad.beancount's error is published.
+    let wait_bad = |client: &mut LspTestClient, want_empty: bool| -> bool {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let Some(msg) = client.recv_with_timeout(remaining) else {
+                return false;
+            };
+            if let lsp_server::Message::Notification(n) = msg
+                && n.method == "textDocument/publishDiagnostics"
+            {
+                let p: lsp_types::PublishDiagnosticsParams =
+                    serde_json::from_value(n.params).expect("valid publishDiagnostics");
+                if p.uri.as_str() == bad_uri && p.diagnostics.is_empty() == want_empty {
+                    return true;
+                }
+            }
+        }
+    };
+    assert!(
+        wait_bad(&mut client, false),
+        "bad.beancount's error must publish first"
+    );
+
+    // Phase 2: open + edit a scratch buffer that is NOT part of the ledger.
+    let scratch_uri = format!("file://{}", scratch_path.display());
+    client.open_document(&scratch_uri, "; scratch\n");
+    client.notify::<lsp_types::notification::DidChangeTextDocument>(
+        lsp_types::DidChangeTextDocumentParams {
+            text_document: lsp_types::VersionedTextDocumentIdentifier {
+                uri: scratch_uri.parse().expect("scratch uri"),
+                version: 2,
+            },
+            content_changes: vec![lsp_types::TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "; scratch edited\n".to_string(),
+            }],
+        },
+    );
+
+    // The scratch edit must NOT clear bad.beancount: any bad.beancount publish
+    // we see after it must be NON-empty. Guard against a spurious empty publish
+    // for a bounded window.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let Some(msg) = client.recv_with_timeout(remaining) else {
+            break;
+        };
+        if let lsp_server::Message::Notification(n) = msg
+            && n.method == "textDocument/publishDiagnostics"
+        {
+            let p: lsp_types::PublishDiagnosticsParams =
+                serde_json::from_value(n.params).expect("valid publishDiagnostics");
+            assert!(
+                !(p.uri.as_str() == bad_uri && p.diagnostics.is_empty()),
+                "editing a non-ledger scratch buffer must not clear the unopened \
+                 included file's diagnostics (#1813 review)"
+            );
+        }
+    }
+}
+
 /// An async-dispatched request (`semanticTokens/full`) invalidated by a
 /// concurrent edit must still receive a response — previously the stale result
 /// was silently dropped, leaving a strict client waiting forever. The response


### PR DESCRIPTION
## The regression

Bisected by the reporter to `c3e8454` (#1487, cross-file diagnostics for unopened included files). That commit's `compute_unopened_ledger_diagnostics` calls `all_diagnostics` **once per ledger file**, and each call re-runs the entire ledger's **booking + both plugin passes + Early/Late validation** (`validation_errors_to_diagnostics`) just to keep one file's errors, filtering the rest away. So per-keystroke cost went from one whole-ledger book+validate to **O(files)** of them.

`didChange` is handled **synchronously on the single LSP main-loop thread** (`on_did_change` → `publish_diagnostics`, no `dispatch_async`), while completion requests are dispatched to a worker pool — but only *after* the notification returns. So each keystroke's O(files) validation blocks the loop from even dequeuing the completion request behind it, and it times out. This matches every symptom: large multi-file ledgers only, worse without `--release`, "more currencies made it reproduce" (more directives ⇒ slower each pass).

## The fix

The validation errors already carry `file_id` (that's what the per-file filter uses), so **one** whole-ledger validation yields every file's errors. This splits validation into:

- **`run_ledger_validation`** — the file-independent, expensive half (sort + book + plugin passes + Early/Late), run **once**.
- **`map_validation_to_diagnostics`** — cheap per-file mapping: filter the shared errors to a file, map spans against that file's source, add its plugin notes.

`ledger_diagnostics_multi` produces the current file's *and* every unopened file's diagnostics from that single validation. `publish_diagnostics` routes multi-file ledgers through it; the **single-file path is unchanged**. Unopened files are also no longer re-parsed by a redundant per-file `all_diagnostics`.

Net: per-keystroke cost on a multi-file ledger drops from O(files) whole-ledger validations back to **one** — the pre-#1487 level — so the main loop frees up and completions return.

## Correctness

- The two #1487 behavior tests (`included_file_validation_errors_are_published`, `included_file_diagnostics_are_cleared_when_fixed`) still pass — the cross-file feature is preserved, just computed once.
- `validation_errors_to_diagnostics` keeps its signature (now `= run + map`), so single-file callers and `all_diagnostics` are untouched.
- The semantic helpers that must not drift (`booking_sort_key`, `ValidationSession`, `build_live_directive_overlay`, `build_validation_options_from_loader`, `validation_error_to_diagnostic`) are reused, not copied.

## Regression guard

`ledger_diagnostics_multi_validates_once_for_all_files` builds a 3-file ledger and asserts **exactly one** whole-ledger validation runs regardless of file count (via a thread-local counter, so parallel tests don't interfere). A future change that reintroduces per-file validation trips it.

`cargo test -p rustledger-lsp` green (286 tests); clippy/doc/fmt clean.

Closes #1799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gJH7uBBF9Xw9et9QFRcsU
