### PR TITLE
fix(ci): align codeql-action init to v4.37.1 (unbreak CodeQL)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,15 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      # init and analyze are two actions in the same github/codeql-action repo
+      # and MUST move to the same commit SHA together — mixed versions fail with
+      # "Loaded a configuration file for version X, but running version Y". Group
+      # them into one PR so Dependabot never bumps one without the other (#1822
+      # bumped analyze alone and broke every CodeQL run).
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   # npm — MCP server. The MCP spec moves fast (2026-07-28 restructures the
   # protocol core); without this entry the @modelcontextprotocol/sdk pin
   # never gets update PRs and spec adoption stalls silently (issue #1767).

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0 — MUST match analyze below (mixed versions fail with a config-version error)
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1 — MUST match analyze below (mixed versions fail with a config-version error)
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.0 — MUST match init above
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1 — MUST match init above
         with:
           category: "/language:${{ matrix.language }}"
   # Gate job - all CodeQL analyses must pass


### PR DESCRIPTION
## Problem

CodeQL has failed on **every PR** since #1822, with:

```
##[error]Loaded a configuration file for version '4.37.0', but running version '4.37.1'
```

`github/codeql-action/init` and `.../analyze` are two actions in the **same repo**, so they must be pinned to the **same commit SHA**. #1822 (a Dependabot bump) moved only `analyze` to v4.37.1 and left `init` at v4.37.0 — so `init` wrote a 4.37.0 config that `analyze` then rejected at 4.37.1. (The `# v4.37.0` trailing comments were left stale on both lines, hiding the drift.)

## Fix

- **`codeql.yml`**: bump `init` to `7188fc36` (v4.37.1) to match `analyze`; correct both version comments.
- **`dependabot.yml`**: add a `codeql-action` group (`github/codeql-action*`) so `init` and `analyze` always bump **together in one PR** and cannot drift again — the actual root cause.

## Verification

SHAs checked against the codeql-action git tags:

| Tag | Commit |
|-----|--------|
| v4.37.0 | `99df26d4…` (old `init`) |
| v4.37.1 | `7188fc36…` (current `analyze`, now also `init`) |

Both `init` and `analyze` now resolve to `7188fc36` = v4.37.1. Both YAML files validate. This is a workflow-only change; CodeQL runs on the PR and will confirm the alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
