### PR TITLE
feat(returns): opt-in per-group breakdown for report returns (--by-group)

### DIFF
--- a/crates/rustledger-core/src/format/helpers.rs
+++ b/crates/rustledger-core/src/format/helpers.rs
@@ -41,6 +41,37 @@ pub fn escape_csv(s: &str) -> String {
     }
 }
 
+/// Escape a string as a JSON string body (RFC 8259).
+///
+/// Handles the required escapes (`"`, `\`, and every C0 control character —
+/// `\n`/`\t`/`\r`/`\b`/`\f` by name, the rest as `\uXXXX`), so the result is
+/// always valid between JSON double quotes. Unlike [`escape_string`] (which
+/// targets beancount source and leaves control bytes other than `\n`/`\t`/`\r`
+/// raw), this never emits a bare control character — use it for JSON egress of
+/// user-controlled text (e.g. metadata-derived labels), which may carry an
+/// arbitrary control byte the parser preserved.
+#[must_use]
+pub fn escape_json(s: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0c}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// Escape a string for output (handle quotes and backslashes).
 pub fn escape_string(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
@@ -62,7 +93,21 @@ pub fn escape_string(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::escape_string;
+    use super::{escape_json, escape_string};
+
+    #[test]
+    fn escape_json_produces_valid_json_for_control_chars() {
+        // The named escapes.
+        assert_eq!(escape_json("a\"\\b"), "a\\\"\\\\b");
+        assert_eq!(escape_json("x\ny\tz\r"), "x\\ny\\tz\\r");
+        assert_eq!(escape_json("\u{08}\u{0c}"), "\\b\\f");
+        // Other C0 control chars must become \uXXXX (escape_string leaves these
+        // raw, which is invalid JSON) — this is the bug escape_json fixes.
+        assert_eq!(escape_json("A\u{1b}B"), "A\\u001bB");
+        assert_eq!(escape_json("\u{00}"), "\\u0000");
+        // Plain text (incl. non-control unicode) is untouched.
+        assert_eq!(escape_json("投資 123"), "投資 123");
+    }
 
     #[test]
     fn escapes_quote_backslash_and_controls() {

--- a/crates/rustledger-core/src/format/mod.rs
+++ b/crates/rustledger-core/src/format/mod.rs
@@ -17,7 +17,7 @@ use directives::{
     format_pad_lines, format_price_lines, format_query_lines,
 };
 pub(crate) use helpers::format_meta_value;
-pub use helpers::{escape_csv, escape_string};
+pub use helpers::{escape_csv, escape_json, escape_string};
 pub(crate) use transaction::{format_incomplete_amount, format_transaction_lines};
 pub use transaction::{format_posting_line, posting_format_line};
 

--- a/crates/rustledger-returns/README.md
+++ b/crates/rustledger-returns/README.md
@@ -28,12 +28,15 @@ re-deriving it.
   timing. Shares the `investment_value_at` realization primitive with
   `terminal_value`.
 - [ ] Dividend / ex-dividend breakout (total vs. ex-income return).
-- [x] Named-group breakdown — with `--by-group` the CLI runs the engine per
+- [x] Named-group breakdown — with `--by-group` the CLI runs the engine once per
   `returns-group:` group (declared on `open` directives, dividend-inclusive when
-  the group tags its income account), plus an `(ungrouped)` residual for in-scope
-  holdings left untagged and the whole-scope total, so the rows reconcile
-  ([#1820]). Grouping is opt-in. True per-commodity attribution within a single
-  account, and `commodity`-directive tagging, remain follow-ups.
+  the group tags its income account) as an **independent sub-portfolio**, plus the
+  whole-scope total ([#1820]). Groups are deliberately not claimed to sum to the
+  total — a flow into a shared in-scope account (e.g. pooled settlement cash)
+  can't be attributed to one group — and non-self-contained groups, out-of-scope
+  tags, and prefix overlaps are surfaced as warnings. Grouping is opt-in. True
+  per-commodity attribution within a single account, and `commodity`-directive
+  tagging, remain follow-ups.
 
 [#1820]: https://github.com/rustledger/rustledger/issues/1820
 

--- a/crates/rustledger-returns/README.md
+++ b/crates/rustledger-returns/README.md
@@ -28,11 +28,12 @@ re-deriving it.
   timing. Shares the `investment_value_at` realization primitive with
   `terminal_value`.
 - [ ] Dividend / ex-dividend breakout (total vs. ex-income return).
-- [x] Named-group / per-account breakdown — the CLI runs the engine per
-  sub-scope (`returns-group:` metadata groups, dividend-inclusive; or
-  `--by-account`, ex-dividend) plus the total ([#1820]). True per-commodity
-  attribution within a single account, and `commodity`-directive tagging,
-  remain follow-ups.
+- [x] Named-group breakdown — with `--by-group` the CLI runs the engine per
+  `returns-group:` group (declared on `open` directives, dividend-inclusive when
+  the group tags its income account), plus an `(ungrouped)` residual for in-scope
+  holdings left untagged and the whole-scope total, so the rows reconcile
+  ([#1820]). Grouping is opt-in. True per-commodity attribution within a single
+  account, and `commodity`-directive tagging, remain follow-ups.
 
 [#1820]: https://github.com/rustledger/rustledger/issues/1820
 

--- a/crates/rustledger-returns/README.md
+++ b/crates/rustledger-returns/README.md
@@ -28,7 +28,11 @@ re-deriving it.
   timing. Shares the `investment_value_at` realization primitive with
   `terminal_value`.
 - [ ] Dividend / ex-dividend breakout (total vs. ex-income return).
-- [ ] Per-commodity / named-group breakdown ([#1820]).
+- [x] Named-group / per-account breakdown — the CLI runs the engine per
+  sub-scope (`returns-group:` metadata groups, dividend-inclusive; or
+  `--by-account`, ex-dividend) plus the total ([#1820]). True per-commodity
+  attribution within a single account, and `commodity`-directive tagging,
+  remain follow-ups.
 
 [#1820]: https://github.com/rustledger/rustledger/issues/1820
 

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -178,11 +178,11 @@ pub enum Report {
         /// Defaults to today.
         #[arg(short, long)]
         end: Option<String>,
-        /// Break the return down per investment account (ex-dividend), in
-        /// addition to the total. Ignored when the ledger declares
-        /// `returns-group:` groups, which take precedence.
+        /// Break the return down per `returns-group:` group (declared on `open`
+        /// directives), plus an "(ungrouped)" residual and the total. Grouping
+        /// is opt-in so the default output shape is unchanged.
         #[arg(long)]
-        by_account: bool,
+        by_group: bool,
     },
 }
 
@@ -483,17 +483,16 @@ fn render<W: io::Write>(
             income,
             currency,
             end,
-            by_account,
+            by_group,
         } => {
             returns::report_returns(
                 balance_input,
                 &loaded.operating_currency,
-                &loaded.account_types,
                 investments,
                 income,
                 currency.as_deref(),
                 end.as_deref(),
-                *by_account,
+                *by_group,
                 &loaded.display_context,
                 format,
                 writer,

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -178,9 +178,10 @@ pub enum Report {
         /// Defaults to today.
         #[arg(short, long)]
         end: Option<String>,
-        /// Break the return down per `returns-group:` group (declared on `open`
-        /// directives), plus an "(ungrouped)" residual and the total. Grouping
-        /// is opt-in so the default output shape is unchanged.
+        /// Add one row per `returns-group:` group (declared on `open`
+        /// directives), each an independent sub-portfolio, alongside the
+        /// whole-portfolio total. Grouping is opt-in so the default output shape
+        /// is unchanged.
         #[arg(long)]
         by_group: bool,
     },

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -553,7 +553,7 @@ pub(super) fn account_balances(
 // exact set the old hand-chained `json_escape` did (backslash, quote, \n,
 // \r, \t), so the alias is behavior-identical.
 pub(super) use rustledger_core::format::escape_csv as csv_escape;
-pub(super) use rustledger_core::format::escape_string as json_escape;
+pub(super) use rustledger_core::format::escape_json as json_escape;
 
 #[derive(Default)]
 pub(super) struct LedgerStats {

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -178,6 +178,11 @@ pub enum Report {
         /// Defaults to today.
         #[arg(short, long)]
         end: Option<String>,
+        /// Break the return down per investment account (ex-dividend), in
+        /// addition to the total. Ignored when the ledger declares
+        /// `returns-group:` groups, which take precedence.
+        #[arg(long)]
+        by_account: bool,
     },
 }
 
@@ -478,14 +483,17 @@ fn render<W: io::Write>(
             income,
             currency,
             end,
+            by_account,
         } => {
             returns::report_returns(
                 balance_input,
                 &loaded.operating_currency,
+                &loaded.account_types,
                 investments,
                 income,
                 currency.as_deref(),
                 end.as_deref(),
+                *by_account,
                 &loaded.display_context,
                 format,
                 writer,

--- a/crates/rustledger/src/cmd/report_cmd/mod.rs
+++ b/crates/rustledger/src/cmd/report_cmd/mod.rs
@@ -549,9 +549,12 @@ pub(super) fn account_balances(
     engine.into_inventories().into_iter().collect()
 }
 
-// CSV/JSON escaping: single-sourced in core. `escape_string` escapes the
-// exact set the old hand-chained `json_escape` did (backslash, quote, \n,
-// \r, \t), so the alias is behavior-identical.
+// CSV/JSON escaping: single-sourced in core. `escape_json` is the RFC-8259
+// string escaper — the required escapes plus `\uXXXX` for every other C0
+// control byte — so report JSON stays valid even when a field carries a raw
+// control char (e.g. from metadata). Do NOT revert this to `escape_string`
+// (the beancount-source escaper leaves control bytes other than \n\t\r raw,
+// which is invalid JSON).
 pub(super) use rustledger_core::format::escape_csv as csv_escape;
 pub(super) use rustledger_core::format::escape_json as json_escape;
 

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -175,6 +175,7 @@ fn compute_group(
 fn build_groups(
     directives: &[Directive],
     whole_scope: &Scope,
+    end_date: NaiveDate,
     warn: &mut dyn FnMut(String),
 ) -> Vec<(String, Scope)> {
     // group name -> (investment accounts, income accounts)
@@ -186,6 +187,12 @@ fn build_groups(
         let Directive::Open(open) = directive else {
             continue;
         };
+        // Bound grouping by the report horizon, exactly as flow extraction and
+        // valuation are: an account opened after `--end` does not exist yet in
+        // the reported period, so it must not form a (spurious, all-zero) group.
+        if open.date > end_date {
+            continue;
+        }
         let account = open.account.to_string();
         let name = match open.meta.get("returns-group") {
             Some(MetaValue::String(name)) => name.clone(),
@@ -220,6 +227,7 @@ fn build_groups(
         for (b, group_b) in &tagged[i + 1..] {
             if group_a != group_b && (is_subaccount_or_equal(a, b) || is_subaccount_or_equal(b, a))
             {
+                let (group_a, group_b) = (sanitize_display(group_a), sanitize_display(group_b));
                 warn(format!(
                     "accounts {a} (group {group_a}) and {b} (group {group_b}) overlap by prefix; \
                      the shared holding is counted in both groups"
@@ -247,7 +255,9 @@ fn build_groups(
                     .to_string(),
             );
         }
-        if let Some(shared) = first_shared_inscope_account(directives, scope, whole_scope) {
+        if let Some(shared) = first_shared_inscope_account(directives, scope, whole_scope, end_date)
+        {
+            let name = sanitize_display(name);
             warn(format!(
                 "group {name} is not self-contained: it shares in-scope account {shared} with the \
                  rest of the portfolio, so its return counts internal transfers as flows"
@@ -256,6 +266,23 @@ fn build_groups(
     }
 
     rows
+}
+
+/// Replace control characters and the Unicode line/paragraph separators
+/// (U+2028/U+2029) with a space. A `returns-group:` label is arbitrary
+/// user-controlled text; on the human-facing surfaces (the text table, CSV, and
+/// stderr warnings) such bytes could inject terminal escapes or extra lines, so
+/// they are neutralized. JSON escapes them losslessly (`\uXXXX`) instead.
+fn sanitize_display(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_control() || c == '\u{2028}' || c == '\u{2029}' {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect()
 }
 
 /// The first account, if any, that makes `group_scope` not self-contained: an
@@ -267,11 +294,17 @@ fn first_shared_inscope_account(
     directives: &[Directive],
     group_scope: &Scope,
     whole_scope: &Scope,
+    end_date: NaiveDate,
 ) -> Option<String> {
     for directive in directives {
         let Directive::Transaction(txn) = directive else {
             continue;
         };
+        // Only activity within the report horizon can affect the reported
+        // figures, so a post-`--end` transfer must not raise a false warning.
+        if txn.date > end_date {
+            continue;
+        }
         let touches_group = txn
             .postings
             .iter()
@@ -359,7 +392,9 @@ pub(super) fn report_returns<W: Write>(
 
     // Grouping is opt-in; warnings (bad tags, overlaps, non-self-contained
     // groups) go to stderr so they never pollute the report on stdout.
-    let group_scopes = build_groups(directives, &whole_scope, &mut |w| eprintln!("warning: {w}"));
+    let group_scopes = build_groups(directives, &whole_scope, end_date, &mut |w| {
+        eprintln!("warning: {w}")
+    });
     if group_scopes.is_empty() {
         // Still emit the grouped shape (an empty `groups` list plus the TOTAL):
         // `--by-group` must produce one stable schema regardless of ledger
@@ -531,7 +566,7 @@ fn render_grouped<W: Write>(
                 writeln!(
                     writer,
                     "{},{},{},{},{},{},{},{},{}",
-                    csv_escape(&r.label),
+                    csv_escape(&sanitize_display(&r.label)),
                     end_date,
                     currency,
                     r.flow_count,
@@ -620,19 +655,7 @@ fn render_grouped<W: Write>(
 /// across lines nor inject a spoofed second line into the text report. The JSON
 /// and CSV paths escape the raw label; only the text table needs this.
 fn truncate(s: &str, width: usize) -> String {
-    // `is_control` catches the C0/C1 control chars but not the Unicode line and
-    // paragraph separators (U+2028/U+2029), which a pager may still render as a
-    // line break; neutralize those too.
-    let s: String = s
-        .chars()
-        .map(|c| {
-            if c.is_control() || c == '\u{2028}' || c == '\u{2029}' {
-                ' '
-            } else {
-                c
-            }
-        })
-        .collect();
+    let s = sanitize_display(s);
     let s = s.as_str();
     if s.chars().count() <= width {
         s.to_string()

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -272,7 +272,9 @@ fn build_groups(
 /// (U+2028/U+2029) with a space. A `returns-group:` label is arbitrary
 /// user-controlled text; on the human-facing surfaces (the text table, CSV, and
 /// stderr warnings) such bytes could inject terminal escapes or extra lines, so
-/// they are neutralized. JSON escapes them losslessly (`\uXXXX`) instead.
+/// they are neutralized. The JSON path does not use this — it keeps the label
+/// intact and valid via `escape_json` (C0 control bytes become `\uXXXX`;
+/// U+2028/U+2029 stay as-is, which is already valid inside a JSON string).
 fn sanitize_display(s: &str) -> String {
     s.chars()
         .map(|c| {
@@ -650,10 +652,9 @@ fn render_grouped<W: Write>(
 
 /// Truncate a label to fit a text column (keeps the informative tail).
 ///
-/// Control characters (e.g. a newline in a quoted `returns-group:` value) are
-/// replaced with a space first, so a label can neither split the fixed-width row
-/// across lines nor inject a spoofed second line into the text report. The JSON
-/// and CSV paths escape the raw label; only the text table needs this.
+/// The label is first run through `sanitize_display` (control chars → space),
+/// so it can neither split the fixed-width row across lines nor inject a spoofed
+/// second line into the text report.
 fn truncate(s: &str, width: usize) -> String {
     let s = sanitize_display(s);
     let s = s.as_str();

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -311,6 +311,16 @@ fn fmt_rate(rate: Option<f64>) -> String {
     )
 }
 
+/// A rate for the grouped **text** table: the numeric rate carries its own `%`,
+/// but an undefined rate is `n/a` (not `n/a%`). Matches `render_single`'s
+/// single-scope text output, where the `%` hangs off the value, not the column.
+fn fmt_rate_pct(rate: Option<f64>) -> String {
+    match rate {
+        Some(_) => format!("{}%", fmt_rate(rate)),
+        None => "n/a".to_string(),
+    }
+}
+
 /// The single whole-scope summary (no grouping) — the original report shape.
 fn render_single<W: Write>(
     r: &GroupResult,
@@ -480,10 +490,10 @@ fn render_grouped<W: Write>(
             let row = |w: &mut W, r: &GroupResult| -> Result<()> {
                 writeln!(
                     w,
-                    "{:32}{:>8}%{:>8}%{:>12}{:>12}",
+                    "{:32}{:>9}{:>9}{:>12}{:>12}",
                     truncate(&r.label, 32),
-                    fmt_rate(r.mwr),
-                    fmt_rate(r.twr),
+                    fmt_rate_pct(r.mwr),
+                    fmt_rate_pct(r.twr),
                     money(r.invested),
                     money(r.current_value),
                 )?;
@@ -527,6 +537,15 @@ mod tests {
 
     fn money(n: i64, ccy: &str) -> Amount {
         Amount::new(Decimal::from(n), ccy)
+    }
+
+    /// An undefined rate renders as `n/a`, not `n/a%`: the `%` hangs off the
+    /// value (as in `render_single`), so the grouped text table stays consistent
+    /// with the single-scope output.
+    #[test]
+    fn undefined_rate_renders_without_a_percent_sign() {
+        assert_eq!(fmt_rate_pct(None), "n/a");
+        assert_eq!(fmt_rate_pct(Some(0.3236)), "32.36%");
     }
 
     /// Drift guard (CLAUDE.md Canonical-Function Discipline): `terminal_value`

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -595,7 +595,12 @@ fn render_grouped<W: Write>(
             for r in groups {
                 row(writer, r)?;
             }
-            writeln!(writer, "{}", "-".repeat(RULE))?;
+            // Separate the group rows from the TOTAL — but not when there are no
+            // group rows (the no-tags case), which would print two rules back to
+            // back.
+            if !groups.is_empty() {
+                writeln!(writer, "{}", "-".repeat(RULE))?;
+            }
             row(writer, total)?;
             // The TOTAL is the whole portfolio, not the sum of the group rows
             // (groups are independent and untagged holdings are omitted).

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -125,8 +125,16 @@ fn compute_group(
     series.sort_by_key(|f| f.date);
     let flow_count = series.len();
     let mwr = xirr(&series);
-    // TWR needs a price at every flow date; degrade to n/a rather than error.
-    let twr_rate = twr(directives, scope, reporting_currency, prices, end_date).unwrap_or(None);
+    // A scope that never held investment capital (an income-only group, or a
+    // holding opened but never bought) has no holding period to weight: TWR is
+    // undefined, not a flat 0%. `twr`'s unit-chaining would otherwise return
+    // `Some(0.0)` over the empty position. (`xirr` already yields `None` here.)
+    let twr_rate = if invested.is_zero() && current_value.is_zero() {
+        None
+    } else {
+        // TWR needs a price at every flow date; degrade to n/a rather than error.
+        twr(directives, scope, reporting_currency, prices, end_date).unwrap_or(None)
+    };
 
     Ok(GroupResult {
         label,
@@ -230,6 +238,15 @@ fn build_groups(
     // transfers as flows, so its return is a standalone view that will not agree
     // with the total. We can't attribute the pooled flow, so we name it.
     for (name, scope) in &rows {
+        // `TOTAL` is the label of the whole-portfolio row; a group of the same
+        // name is indistinguishable from it in the text and CSV output (JSON
+        // keeps them structurally separate).
+        if name == "TOTAL" {
+            warn(
+                "group named \"TOTAL\" collides with the whole-portfolio total row in text/CSV output"
+                    .to_string(),
+            );
+        }
         if let Some(shared) = first_shared_inscope_account(directives, scope, whole_scope) {
             warn(format!(
                 "group {name} is not self-contained: it shares in-scope account {shared} with the \
@@ -547,15 +564,17 @@ fn render_grouped<W: Write>(
             )?;
         }
         OutputFormat::Text => {
+            // Rule width must match the column layout below: 32+9+9+12+12.
+            const RULE: usize = 32 + 9 + 9 + 12 + 12;
             writeln!(writer, "Returns  ({currency}, as of {end_date})")?;
-            writeln!(writer, "{}", "=".repeat(72))?;
+            writeln!(writer, "{}", "=".repeat(RULE))?;
             writeln!(writer)?;
             writeln!(
                 writer,
                 "{:32}{:>9}{:>9}{:>12}{:>12}",
                 "Group", "MWR", "TWR", "Invested", "Current"
             )?;
-            writeln!(writer, "{}", "-".repeat(72))?;
+            writeln!(writer, "{}", "-".repeat(RULE))?;
             let row = |w: &mut W, r: &GroupResult| -> Result<()> {
                 writeln!(
                     w,
@@ -571,7 +590,7 @@ fn render_grouped<W: Write>(
             for r in groups {
                 row(writer, r)?;
             }
-            writeln!(writer, "{}", "-".repeat(72))?;
+            writeln!(writer, "{}", "-".repeat(RULE))?;
             row(writer, total)?;
         }
     }
@@ -579,7 +598,17 @@ fn render_grouped<W: Write>(
 }
 
 /// Truncate a label to fit a text column (keeps the informative tail).
+///
+/// Control characters (e.g. a newline in a quoted `returns-group:` value) are
+/// replaced with a space first, so a label can neither split the fixed-width row
+/// across lines nor inject a spoofed second line into the text report. The JSON
+/// and CSV paths escape the raw label; only the text table needs this.
 fn truncate(s: &str, width: usize) -> String {
+    let s: String = s
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    let s = s.as_str();
     if s.chars().count() <= width {
         s.to_string()
     } else {

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -564,25 +564,27 @@ fn render_grouped<W: Write>(
             )?;
         }
         OutputFormat::Text => {
-            // Rule width must match the column layout below: 32+9+9+12+12.
-            const RULE: usize = 32 + 9 + 9 + 12 + 12;
+            // Rule width must match the column layout below (kept under 80 cols;
+            // the Distributions column is 14 so its header keeps a leading gap).
+            const RULE: usize = 23 + 9 + 9 + 12 + 14 + 12;
             writeln!(writer, "Returns  ({currency}, as of {end_date})")?;
             writeln!(writer, "{}", "=".repeat(RULE))?;
             writeln!(writer)?;
             writeln!(
                 writer,
-                "{:32}{:>9}{:>9}{:>12}{:>12}",
-                "Group", "MWR", "TWR", "Invested", "Current"
+                "{:23}{:>9}{:>9}{:>12}{:>14}{:>12}",
+                "Group", "MWR", "TWR", "Invested", "Distributions", "Current"
             )?;
             writeln!(writer, "{}", "-".repeat(RULE))?;
             let row = |w: &mut W, r: &GroupResult| -> Result<()> {
                 writeln!(
                     w,
-                    "{:32}{:>9}{:>9}{:>12}{:>12}",
-                    truncate(&r.label, 32),
+                    "{:23}{:>9}{:>9}{:>12}{:>14}{:>12}",
+                    truncate(&r.label, 23),
                     fmt_rate_pct(r.mwr),
                     fmt_rate_pct(r.twr),
                     money(r.invested),
+                    money(r.distributions),
                     money(r.current_value),
                 )?;
                 Ok(())
@@ -592,6 +594,12 @@ fn render_grouped<W: Write>(
             }
             writeln!(writer, "{}", "-".repeat(RULE))?;
             row(writer, total)?;
+            // The TOTAL is the whole portfolio, not the sum of the group rows
+            // (groups are independent and untagged holdings are omitted).
+            writeln!(
+                writer,
+                "Note: TOTAL is the whole portfolio, not the sum of the groups."
+            )?;
         }
     }
     Ok(())

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -10,18 +10,33 @@
 //! # Grouping (#1820)
 //!
 //! By default the report is the single whole-scope summary. With **`--by-group`**
-//! it breaks down per `returns-group:` group: tag `open` directives with
-//! `returns-group: "Name"`, and each group's members are classified by the whole
-//! scope — accounts under `--investments` form the group's investment scope,
-//! accounts under `--income` its income scope — so a group that tags its dividend
-//! account reports a **dividend-inclusive** return. This is beangrow's group
-//! model, declared in the ledger rather than an external config file.
+//! it additionally reports one row per `returns-group:` group: tag `open`
+//! directives with `returns-group: "Name"`, and each group's members are
+//! classified by the whole scope — accounts under `--investments` form the
+//! group's investment scope, accounts under `--income` its income scope — so a
+//! group that tags its dividend account reports a **dividend-inclusive** return.
+//! This is beangrow's group model, declared in the ledger rather than an external
+//! config file.
 //!
-//! Groups are constrained to the scope and reconcile with the total: a tagged
-//! account outside `--investments`/`--income` (or an Equity/Liability account) is
-//! ignored with a warning, and in-scope accounts left untagged collect into an
-//! `(ungrouped)` residual, so every in-scope holding appears in exactly one row.
-//! Grouping is opt-in, so the default output shape is unchanged.
+//! Each group is an **independent sub-portfolio**: its return is computed over
+//! just that group's accounts, exactly as if you had run the report with
+//! `--investments`/`--income` narrowed to them. This matches how beangrow and
+//! hledger `roi` present grouped returns — and, deliberately, the groups are
+//! **not** claimed to sum to the TOTAL. They can't be in general: whenever two
+//! groups share an in-scope account (most often a pooled settlement-cash account
+//! under `--investments`), the boundary flow into that shared account cannot be
+//! attributed to one group, so a partition into reconciling slices is not
+//! well-defined. The TOTAL row is the whole-portfolio figure (every in-scope
+//! account), reported alongside for reference, not as the sum of the rows above.
+//!
+//! Grouping is opt-in, so the default output shape is unchanged. Only tagged
+//! accounts appear; an untagged in-scope holding is simply omitted from the
+//! breakdown (it is still in the TOTAL). Warnings (to stderr) flag the cases a
+//! reader would otherwise misread: a tag on an out-of-scope account, a non-string
+//! tag value, two groups whose accounts overlap by prefix (the shared holding is
+//! counted in both), and a group that is not self-contained (it shares an
+//! in-scope account with the rest of the portfolio, so its return counts an
+//! internal transfer as a flow).
 //!
 //! Auto per-account and true per-commodity attribution are deliberately *not*
 //! offered: a dividend booked to a shared cash/income account cannot be
@@ -32,7 +47,9 @@
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, Directive, DisplayContext, MetaValue, NaiveDate};
+use rustledger_core::{
+    Amount, Directive, DisplayContext, MetaValue, NaiveDate, is_subaccount_or_equal,
+};
 use rustledger_query::PriceDatabase;
 use rustledger_returns::{
     AccountRole, PriceOracle, Scope, extract_flows, terminal_value, twr, xirr,
@@ -123,95 +140,148 @@ fn compute_group(
 }
 
 /// Build the `--by-group` breakdown from `returns-group:` metadata on `open`
-/// directives, sorted by group name, plus an `(ungrouped)` residual.
+/// directives, one [`Scope`] per group, sorted by group name.
 ///
 /// Each tagged account is classified by the **whole scope** — accounts under
 /// `--investments` form their group's investment scope, accounts under
 /// `--income` its income scope — so a group that tags its dividend account is
-/// dividend-inclusive (the beangrow model, in-ledger). Two things make the rows
-/// coherent with the TOTAL:
+/// dividend-inclusive (the beangrow model, in-ledger). Every group is an
+/// independent sub-portfolio; only tagged accounts appear (there is no residual),
+/// and the rows are deliberately not a partition of the total (see the module
+/// docs). Warns — but still returns the group — for the cases a reader would
+/// otherwise misread:
 ///
-/// - Groups are constrained to the scope: a tagged account that is neither
-///   investment nor income (an Equity/Liability account, or one outside
-///   `--investments`/`--income`) is **out of scope** and ignored (with a
-///   warning), never valued as a holding.
-/// - In-scope accounts left untagged collect into `(ungrouped)`, so every
-///   in-scope holding appears in exactly one row and the group rows partition
-///   the total.
+/// - a `returns-group:` tag on an account that is neither investment nor income
+///   (an Equity/Liability account, or one outside `--investments`/`--income`) —
+///   out of scope, dropped so it is never valued as a phantom holding;
+/// - a non-string `returns-group:` value;
+/// - two groups whose accounts overlap by prefix — `Scope` matches by prefix, so
+///   a tagged ancestor (or a duplicate `open`) values another group's holding
+///   twice;
+/// - a group that is not self-contained: it shares an in-scope account with the
+///   rest of the portfolio, so its flows count an internal transfer as a
+///   contribution/withdrawal.
 ///
-/// A non-string `returns-group:` value is ignored with a warning. Returns
-/// `(rows, any_declared)`; `any_declared` is false when no in-scope account
-/// carried a usable tag, in which case the caller reports the plain total.
+/// An empty result means no in-scope account carried a usable tag; the caller
+/// then reports the plain total.
 fn build_groups(
     directives: &[Directive],
     whole_scope: &Scope,
     warn: &mut dyn FnMut(String),
-) -> (Vec<(String, Scope)>, bool) {
+) -> Vec<(String, Scope)> {
     // group name -> (investment accounts, income accounts)
     let mut groups: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
-    let mut ungrouped: (Vec<String>, Vec<String>) = (Vec::new(), Vec::new());
-    let mut any_declared = false;
+    // (account, group) for every tagged in-scope account, for the overlap check.
+    let mut tagged: Vec<(String, String)> = Vec::new();
 
     for directive in directives {
         let Directive::Open(open) = directive else {
             continue;
         };
         let account = open.account.to_string();
-        let role = whole_scope.classify(&account);
-        if role == AccountRole::External {
-            if open.meta.contains_key("returns-group") {
-                warn(format!(
-                    "returns-group on {account} ignored: not under --investments or --income"
-                ));
-            }
-            continue;
-        }
-        let tag = match open.meta.get("returns-group") {
-            Some(MetaValue::String(name)) => Some(name.clone()),
+        let name = match open.meta.get("returns-group") {
+            Some(MetaValue::String(name)) => name.clone(),
             Some(_) => {
                 warn(format!(
                     "returns-group on {account} ignored: value must be a quoted string"
                 ));
-                None
+                continue;
             }
-            None => None,
+            None => continue,
         };
-        let bucket = match tag {
-            Some(name) => {
-                any_declared = true;
-                groups.entry(name).or_default()
-            }
-            None => &mut ungrouped,
-        };
+        let role = whole_scope.classify(&account);
+        if role == AccountRole::External {
+            warn(format!(
+                "returns-group on {account} ignored: not under --investments or --income"
+            ));
+            continue;
+        }
+        let bucket = groups.entry(name.clone()).or_default();
         if role == AccountRole::Income {
-            bucket.1.push(account);
+            bucket.1.push(account.clone());
         } else {
-            bucket.0.push(account);
+            bucket.0.push(account.clone());
+        }
+        tagged.push((account, name));
+    }
+
+    // Cross-group prefix overlap: `Scope` classifies by prefix, so a tagged
+    // account that is an ancestor of (or identical to) another group's tagged
+    // account silently values the same holding in both groups.
+    for (i, (a, group_a)) in tagged.iter().enumerate() {
+        for (b, group_b) in &tagged[i + 1..] {
+            if group_a != group_b && (is_subaccount_or_equal(a, b) || is_subaccount_or_equal(b, a))
+            {
+                warn(format!(
+                    "accounts {a} (group {group_a}) and {b} (group {group_b}) overlap by prefix; \
+                     the shared holding is counted in both groups"
+                ));
+            }
         }
     }
 
-    let mut rows: Vec<(String, Scope)> = groups
+    let rows: Vec<(String, Scope)> = groups
         .into_iter()
         .map(|(name, (investment, income))| (name, Scope::new(investment, income)))
         .collect();
-    // The residual only makes sense once at least one group was declared.
-    if any_declared && (!ungrouped.0.is_empty() || !ungrouped.1.is_empty()) {
-        rows.push((
-            "(ungrouped)".to_string(),
-            Scope::new(ungrouped.0, ungrouped.1),
-        ));
+
+    // Self-containment: a group that shares an in-scope account with the rest of
+    // the portfolio (typically a pooled cash account) counts intra-portfolio
+    // transfers as flows, so its return is a standalone view that will not agree
+    // with the total. We can't attribute the pooled flow, so we name it.
+    for (name, scope) in &rows {
+        if let Some(shared) = first_shared_inscope_account(directives, scope, whole_scope) {
+            warn(format!(
+                "group {name} is not self-contained: it shares in-scope account {shared} with the \
+                 rest of the portfolio, so its return counts internal transfers as flows"
+            ));
+        }
     }
-    (rows, any_declared)
+
+    rows
+}
+
+/// The first account, if any, that makes `group_scope` not self-contained: an
+/// account that some transaction touching the group also touches, which is
+/// external to the group but still in the whole portfolio scope. Such an account
+/// (a shared cash/settlement account under `--investments`, say) turns an
+/// intra-portfolio transfer into a boundary flow for the group.
+fn first_shared_inscope_account(
+    directives: &[Directive],
+    group_scope: &Scope,
+    whole_scope: &Scope,
+) -> Option<String> {
+    for directive in directives {
+        let Directive::Transaction(txn) = directive else {
+            continue;
+        };
+        let touches_group = txn
+            .postings
+            .iter()
+            .any(|p| group_scope.classify(p.account.as_str()) != AccountRole::External);
+        if !touches_group {
+            continue;
+        }
+        for posting in &txn.postings {
+            let account = posting.account.as_str();
+            if group_scope.classify(account) == AccountRole::External
+                && whole_scope.classify(account) != AccountRole::External
+            {
+                return Some(account.to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Generate the returns report.
 ///
 /// `directives` must be the booked, pad-expanded stream (the returns engine's
 /// input contract); the dispatcher passes `balance_input` for exactly this
-/// reason. With `by_group`, the report breaks down per `returns-group:` group
-/// (constrained to `--investments`/`--income`) plus an `(ungrouped)` residual
-/// and the TOTAL; otherwise it is the single whole-scope summary. Grouping is
-/// opt-in, so the default output shape never changes.
+/// reason. With `by_group`, the report adds one independent-sub-portfolio row per
+/// `returns-group:` group (constrained to `--investments`/`--income`) alongside
+/// the whole-portfolio TOTAL; otherwise it is the single whole-scope summary.
+/// Grouping is opt-in, so the default output shape never changes.
 ///
 /// # Errors
 ///
@@ -270,13 +340,12 @@ pub(super) fn report_returns<W: Write>(
         return render_single(&total, currency, end_date, ctx, format, writer);
     }
 
-    // Grouping is opt-in; warnings (bad tags, out-of-scope tags) go to stderr so
-    // they never pollute the report on stdout.
-    let (group_scopes, any_declared) =
-        build_groups(directives, &whole_scope, &mut |w| eprintln!("warning: {w}"));
-    if !any_declared {
+    // Grouping is opt-in; warnings (bad tags, overlaps, non-self-contained
+    // groups) go to stderr so they never pollute the report on stdout.
+    let group_scopes = build_groups(directives, &whole_scope, &mut |w| eprintln!("warning: {w}"));
+    if group_scopes.is_empty() {
         eprintln!(
-            "warning: --by-group but no in-scope `returns-group:` metadata found; reporting the ungrouped total"
+            "warning: --by-group but no in-scope `returns-group:` metadata found; reporting the whole-portfolio total"
         );
         return render_single(&total, currency, end_date, ctx, format, writer);
     }

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -1,21 +1,37 @@
-//! Returns report — the money-weighted (XIRR) investment return for an account
-//! scope.
+//! Returns report — money-weighted (XIRR) and time-weighted (TWR) investment
+//! return for an account scope, optionally broken down per group.
 //!
 //! This is the CLI consumer of the `rustledger-returns` engine. It defines the
 //! portfolio boundary from `--investments` / `--income` account prefixes, builds
-//! a price index from the ledger, and reports the annualized money-weighted
-//! return along with the supporting figures (capital invested, distributions
-//! received, and current market value).
+//! a price index from the ledger, and reports the annualized returns plus the
+//! supporting figures (capital invested, distributions received, current market
+//! value).
 //!
-//! Time-weighted return and per-commodity grouping are not yet implemented; this
-//! reports a single money-weighted return for the whole scope (see #1814).
+//! # Grouping (#1820)
+//!
+//! By default the report is the whole-scope total. Two breakdowns are offered:
+//!
+//! - **`returns-group:` metadata** (the default when present): tag `open`
+//!   directives with `returns-group: "Name"` to declare named groups. Each
+//!   group's member accounts are split by account *type* — balance-sheet
+//!   accounts form the group's investment scope, income-statement accounts its
+//!   income scope — so a group that includes its dividend account reports a
+//!   **dividend-inclusive** return. This is beangrow's group model, declared in
+//!   the ledger (not an external config file).
+//! - **`--by-account`**: one row per investment account with no income scope, so
+//!   the per-account figures are a **price return** (ex-dividend). Handy for a
+//!   quick per-holding view without tagging the ledger. Ignored when
+//!   `returns-group:` groups are declared.
 
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
-use rustledger_core::{Amount, Directive, DisplayContext, NaiveDate};
+use rustledger_core::{AccountTypes, Amount, Directive, DisplayContext, MetaValue, NaiveDate};
 use rustledger_query::PriceDatabase;
-use rustledger_returns::{PriceOracle, Scope, extract_flows, terminal_value, twr, xirr};
+use rustledger_returns::{
+    AccountRole, PriceOracle, Scope, extract_flows, terminal_value, twr, xirr,
+};
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 
 /// Adapts the query engine's [`PriceDatabase`] to the returns engine's
@@ -34,11 +50,134 @@ impl PriceOracle for PriceDbOracle<'_> {
     }
 }
 
+/// The computed return figures for one scope (a group, or the whole portfolio).
+struct GroupResult {
+    label: String,
+    flow_count: usize,
+    invested: Decimal,
+    distributions: Decimal,
+    current_value: Decimal,
+    /// Money-weighted return (annualized XIRR); `None` when undefined.
+    mwr: Option<f64>,
+    /// Time-weighted return (annualized); `None` when undefined or unpriceable.
+    twr: Option<f64>,
+}
+
+/// Compute the return summary for one scope.
+///
+/// Extracts the boundary flows and terminal value separately (so the summary can
+/// report capital-in / distributions / current-value), then runs xirr over the
+/// combined, date-sorted series and twr over the same directives. The manual
+/// flows+terminal combine mirrors the engine's canonical `extract_cash_flows`
+/// and is pinned by the `series_matches_extract_cash_flows` test.
+fn compute_group(
+    directives: &[Directive],
+    scope: &Scope,
+    reporting_currency: &str,
+    prices: &impl PriceOracle,
+    end_date: NaiveDate,
+    label: String,
+) -> Result<GroupResult> {
+    let flows = extract_flows(directives, scope, reporting_currency, prices, end_date)
+        .context("extracting investment cash flows")?;
+    let terminal = terminal_value(directives, scope, reporting_currency, prices, end_date)
+        .context("valuing the held position at the report date")?;
+
+    let invested: Decimal = flows
+        .iter()
+        .filter(|f| f.amount.is_sign_negative())
+        .map(|f| -f.amount)
+        .sum();
+    let distributions: Decimal = flows
+        .iter()
+        .filter(|f| f.amount.is_sign_positive())
+        .map(|f| f.amount)
+        .sum();
+    let current_value: Decimal = terminal.map_or(Decimal::ZERO, |t| t.amount);
+
+    let mut series = flows;
+    if let Some(t) = terminal {
+        series.push(t);
+    }
+    series.sort_by_key(|f| f.date);
+    let flow_count = series.len();
+    let mwr = xirr(&series);
+    // TWR needs a price at every flow date; degrade to n/a rather than error.
+    let twr_rate = twr(directives, scope, reporting_currency, prices, end_date).unwrap_or(None);
+
+    Ok(GroupResult {
+        label,
+        flow_count,
+        invested,
+        distributions,
+        current_value,
+        mwr,
+        twr: twr_rate,
+    })
+}
+
+/// Groups declared in the ledger via `returns-group:` metadata on `open`
+/// directives, sorted by name. Each group's member accounts are partitioned by
+/// account *type*: income-statement accounts (Income/Expenses) become the
+/// group's income scope, everything else (balance-sheet) its investment scope.
+/// A group that tags its dividend account therefore reports a dividend-inclusive
+/// return (the beangrow model, in-ledger). Returns empty if no account is tagged.
+fn groups_from_metadata(
+    directives: &[Directive],
+    account_types: &AccountTypes,
+) -> Vec<(String, Scope)> {
+    // group name -> (investment accounts, income accounts)
+    let mut members: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
+    for directive in directives {
+        if let Directive::Open(open) = directive
+            && let Some(MetaValue::String(name)) = open.meta.get("returns-group")
+        {
+            let account = open.account.to_string();
+            let entry = members.entry(name.clone()).or_default();
+            if account_types.is_income_statement(&account) {
+                entry.1.push(account);
+            } else {
+                entry.0.push(account);
+            }
+        }
+    }
+    members
+        .into_iter()
+        .map(|(name, (investment, income))| (name, Scope::new(investment, income)))
+        .collect()
+}
+
+/// Every distinct account the whole scope classifies as Investment, in account
+/// order, each becoming its own single-account group with **no** income scope —
+/// so the per-account figures are a price return (ex-dividend). Dividends booked
+/// to a shared cash/income account cannot be attributed to a single holding, so
+/// they are excluded here; use `returns-group:` for dividend-inclusive groups.
+fn accounts_as_groups(directives: &[Directive], whole_scope: &Scope) -> Vec<(String, Scope)> {
+    let mut accounts: BTreeSet<String> = BTreeSet::new();
+    for directive in directives {
+        if let Directive::Transaction(txn) = directive {
+            for posting in &txn.postings {
+                let account = posting.account.as_str();
+                if whole_scope.classify(account) == AccountRole::Investment {
+                    accounts.insert(account.to_string());
+                }
+            }
+        }
+    }
+    accounts
+        .into_iter()
+        .map(|a| (a.clone(), Scope::new(vec![a], Vec::new())))
+        .collect()
+}
+
 /// Generate the returns report.
 ///
 /// `directives` must be the booked, pad-expanded stream (the returns engine's
 /// input contract); the dispatcher passes `balance_input` for exactly this
-/// reason.
+/// reason. When the ledger declares `returns-group:` groups they are reported
+/// (dividend-inclusive) and `by_account` is ignored; otherwise `by_account`
+/// requests a per-account (ex-dividend) breakdown. Either way the whole-scope
+/// TOTAL is reported.
 ///
 /// # Errors
 ///
@@ -50,10 +189,12 @@ impl PriceOracle for PriceDbOracle<'_> {
 pub(super) fn report_returns<W: Write>(
     directives: &[Directive],
     operating_currency: &[String],
+    account_types: &AccountTypes,
     investments: &[String],
     income: &[String],
     currency_arg: Option<&str>,
     end_arg: Option<&str>,
+    by_account: bool,
     ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
@@ -76,68 +217,77 @@ pub(super) fn report_returns<W: Write>(
         None => jiff::Zoned::now().date(),
     };
 
-    let scope = Scope::new(investments.to_vec(), income.to_vec());
+    let whole_scope = Scope::new(investments.to_vec(), income.to_vec());
     // Price index built from the same stream, so implicit transaction prices and
     // explicit `price` directives both feed the valuation.
     let price_db = PriceDatabase::from_directives(directives);
     let oracle = PriceDbOracle(&price_db);
 
-    // Extract boundary flows and the terminal value separately, so the summary
-    // can report capital-in / distributions / current-value independently. xirr
-    // then runs over the combined, date-sorted series.
-    let flows = extract_flows(directives, &scope, &reporting_currency, &oracle, end_date)
-        .context("extracting investment cash flows")?;
-    let terminal = terminal_value(directives, &scope, &reporting_currency, &oracle, end_date)
-        .context("valuing the held position at the report date")?;
+    let total = compute_group(
+        directives,
+        &whole_scope,
+        &reporting_currency,
+        &oracle,
+        end_date,
+        "TOTAL".to_string(),
+    )?;
 
-    // Supporting figures, all in the reporting currency:
-    //   invested      — capital the investor put in (magnitude of outflows)
-    //   distributions — cash received during the period (dividends, sale proceeds)
-    //   current_value — market value of the position still held (terminal)
-    let invested: Decimal = flows
+    // Groups: declared metadata groups take precedence over --by-account.
+    let group_scopes = {
+        let declared = groups_from_metadata(directives, account_types);
+        if !declared.is_empty() {
+            declared
+        } else if by_account {
+            accounts_as_groups(directives, &whole_scope)
+        } else {
+            Vec::new()
+        }
+    };
+    let groups: Vec<GroupResult> = group_scopes
         .iter()
-        .filter(|f| f.amount.is_sign_negative())
-        .map(|f| -f.amount)
-        .sum();
-    let distributions: Decimal = flows
-        .iter()
-        .filter(|f| f.amount.is_sign_positive())
-        .map(|f| f.amount)
-        .sum();
-    let current_value: Decimal = terminal.map_or(Decimal::ZERO, |t| t.amount);
-
-    // Combine into the series xirr consumes. This mirrors the engine's
-    // canonical `extract_cash_flows` (flows + terminal, date-sorted); we build it
-    // from the parts here only because the summary above needs `flows` and
-    // `terminal` separately. The `series_matches_extract_cash_flows` test pins
-    // this against the canonical so it can't drift.
-    let mut series = flows;
-    if let Some(t) = terminal {
-        series.push(t);
-    }
-    series.sort_by_key(|f| f.date);
-    let flow_count = series.len();
-    // xirr is `None` when the series has no sign change or is otherwise
-    // degenerate — a genuinely undefined return, reported as "n/a".
-    let rate = xirr(&series);
-    // Time-weighted return: the investments' performance independent of
-    // contribution timing (MWR is the headline). TWR values the portfolio at
-    // EVERY cash-flow date, so it needs more prices than MWR (which only needs
-    // them at transaction dates and the end date). If an intermediate valuation
-    // can't be priced, degrade TWR to n/a rather than failing the whole report —
-    // the money-weighted return above is already computed and is the headline.
-    let twr_rate = twr(directives, &scope, &reporting_currency, &oracle, end_date).unwrap_or(None);
+        .map(|(label, scope)| {
+            compute_group(
+                directives,
+                scope,
+                &reporting_currency,
+                &oracle,
+                end_date,
+                label.clone(),
+            )
+        })
+        .collect::<Result<_>>()?;
 
     let currency = reporting_currency.as_str();
-    let money = |n: Decimal| ctx.format_amount_number(n, currency);
-    let rate_pct = |r: f64| {
-        let pct = r * 100.0;
-        // A 0% return (e.g. capital returned unchanged) converges to a tiny
-        // signed epsilon that would render as "-0.00"; show a clean "0.00".
-        let pct = if pct.abs() < 0.005 { 0.0 } else { pct };
-        format!("{pct:.2}")
-    };
+    if groups.is_empty() {
+        render_single(&total, currency, end_date, ctx, format, writer)
+    } else {
+        render_grouped(&groups, &total, currency, end_date, ctx, format, writer)
+    }
+}
 
+/// Format a rate as a 2-decimal percentage string, or `"n/a"` when undefined.
+/// A rate rounding to zero renders a clean `"0.00"` (not `"-0.00"`).
+fn fmt_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(
+        || "n/a".to_string(),
+        |r| {
+            let pct = r * 100.0;
+            let pct = if pct.abs() < 0.005 { 0.0 } else { pct };
+            format!("{pct:.2}")
+        },
+    )
+}
+
+/// The single whole-scope summary (no grouping) — the original report shape.
+fn render_single<W: Write>(
+    r: &GroupResult,
+    currency: &str,
+    end_date: NaiveDate,
+    ctx: &DisplayContext,
+    format: &OutputFormat,
+    writer: &mut W,
+) -> Result<()> {
+    let money = |n: Decimal| ctx.format_amount_number(n, currency);
     match format {
         OutputFormat::Csv => {
             writeln!(
@@ -149,30 +299,26 @@ pub(super) fn report_returns<W: Write>(
                 "{},{},{},{},{},{},{},{}",
                 currency,
                 end_date,
-                flow_count,
-                csv_escape(&money(invested)),
-                csv_escape(&money(distributions)),
-                csv_escape(&money(current_value)),
-                rate.map_or_else(|| "n/a".to_string(), rate_pct),
-                twr_rate.map_or_else(|| "n/a".to_string(), rate_pct),
+                r.flow_count,
+                csv_escape(&money(r.invested)),
+                csv_escape(&money(r.distributions)),
+                csv_escape(&money(r.current_value)),
+                fmt_rate(r.mwr),
+                fmt_rate(r.twr),
             )?;
         }
         OutputFormat::Json => {
-            // Same 2-decimal precision as text/csv (a bare JSON number, `null`
-            // when undefined) so the rate agrees across every output format.
-            let rate_field = rate.map_or_else(|| "null".to_string(), rate_pct);
-            let twr_field = twr_rate.map_or_else(|| "null".to_string(), rate_pct);
             writeln!(
                 writer,
                 r#"{{"reporting_currency": "{}", "as_of": "{}", "cash_flows": {}, "invested": "{}", "distributions": "{}", "current_value": "{}", "money_weighted_return_pct": {}, "time_weighted_return_pct": {}}}"#,
                 json_escape(currency),
                 end_date,
-                flow_count,
-                money(invested),
-                money(distributions),
-                money(current_value),
-                rate_field,
-                twr_field,
+                r.flow_count,
+                money(r.invested),
+                money(r.distributions),
+                money(r.current_value),
+                json_rate(r.mwr),
+                json_rate(r.twr),
             )?;
         }
         OutputFormat::Text => {
@@ -181,40 +327,160 @@ pub(super) fn report_returns<W: Write>(
             writeln!(writer)?;
             writeln!(
                 writer,
-                "{:24}{} (as of {end_date})",
-                "Reporting currency", currency
+                "{:24}{currency} (as of {end_date})",
+                "Reporting currency"
             )?;
-            writeln!(writer, "{:24}{flow_count}", "Cash flows")?;
-            writeln!(writer, "{:24}{} {currency}", "Invested", money(invested))?;
+            writeln!(writer, "{:24}{}", "Cash flows", r.flow_count)?;
+            writeln!(writer, "{:24}{} {currency}", "Invested", money(r.invested))?;
             writeln!(
                 writer,
                 "{:24}{} {currency}",
                 "Distributions",
-                money(distributions)
+                money(r.distributions)
             )?;
             writeln!(
                 writer,
                 "{:24}{} {currency}",
                 "Current value",
-                money(current_value)
+                money(r.current_value)
             )?;
             writeln!(writer)?;
-            match rate {
-                Some(r) => writeln!(writer, "{:24}{}%", "Money-weighted return", rate_pct(r))?,
+            match r.mwr {
+                Some(rate) => writeln!(
+                    writer,
+                    "{:24}{}%",
+                    "Money-weighted return",
+                    fmt_rate(Some(rate))
+                )?,
                 None => writeln!(
                     writer,
                     "{:24}n/a (undefined — need at least one inflow and one outflow)",
                     "Money-weighted return"
                 )?,
             }
-            match twr_rate {
-                Some(r) => writeln!(writer, "{:24}{}%", "Time-weighted return", rate_pct(r))?,
+            match r.twr {
+                Some(rate) => writeln!(
+                    writer,
+                    "{:24}{}%",
+                    "Time-weighted return",
+                    fmt_rate(Some(rate))
+                )?,
                 None => writeln!(writer, "{:24}n/a", "Time-weighted return")?,
             }
         }
     }
-
     Ok(())
+}
+
+/// A JSON rate field: a bare 2-decimal number, or `null` when undefined.
+fn json_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "null".to_string(), |r| fmt_rate(Some(r)))
+}
+
+/// Per-group rows plus a TOTAL, when grouping is active.
+fn render_grouped<W: Write>(
+    groups: &[GroupResult],
+    total: &GroupResult,
+    currency: &str,
+    end_date: NaiveDate,
+    ctx: &DisplayContext,
+    format: &OutputFormat,
+    writer: &mut W,
+) -> Result<()> {
+    let money = |n: Decimal| ctx.format_amount_number(n, currency);
+    let rows = groups.iter().chain(std::iter::once(total));
+    match format {
+        OutputFormat::Csv => {
+            writeln!(
+                writer,
+                "group,as_of,reporting_currency,cash_flows,invested,distributions,current_value,money_weighted_return_pct,time_weighted_return_pct"
+            )?;
+            for r in rows {
+                writeln!(
+                    writer,
+                    "{},{},{},{},{},{},{},{},{}",
+                    csv_escape(&r.label),
+                    end_date,
+                    currency,
+                    r.flow_count,
+                    csv_escape(&money(r.invested)),
+                    csv_escape(&money(r.distributions)),
+                    csv_escape(&money(r.current_value)),
+                    fmt_rate(r.mwr),
+                    fmt_rate(r.twr),
+                )?;
+            }
+        }
+        OutputFormat::Json => {
+            let obj = |r: &GroupResult| {
+                format!(
+                    r#"{{"group": "{}", "cash_flows": {}, "invested": "{}", "distributions": "{}", "current_value": "{}", "money_weighted_return_pct": {}, "time_weighted_return_pct": {}}}"#,
+                    json_escape(&r.label),
+                    r.flow_count,
+                    money(r.invested),
+                    money(r.distributions),
+                    money(r.current_value),
+                    json_rate(r.mwr),
+                    json_rate(r.twr),
+                )
+            };
+            let group_objs: Vec<String> = groups.iter().map(obj).collect();
+            writeln!(
+                writer,
+                r#"{{"reporting_currency": "{}", "as_of": "{}", "groups": [{}], "total": {}}}"#,
+                json_escape(currency),
+                end_date,
+                group_objs.join(", "),
+                obj(total),
+            )?;
+        }
+        OutputFormat::Text => {
+            writeln!(writer, "Returns  ({currency}, as of {end_date})")?;
+            writeln!(writer, "{}", "=".repeat(72))?;
+            writeln!(writer)?;
+            writeln!(
+                writer,
+                "{:32}{:>9}{:>9}{:>12}{:>12}",
+                "Group", "MWR", "TWR", "Invested", "Current"
+            )?;
+            writeln!(writer, "{}", "-".repeat(72))?;
+            let row = |w: &mut W, r: &GroupResult| -> Result<()> {
+                writeln!(
+                    w,
+                    "{:32}{:>8}%{:>8}%{:>12}{:>12}",
+                    truncate(&r.label, 32),
+                    fmt_rate(r.mwr),
+                    fmt_rate(r.twr),
+                    money(r.invested),
+                    money(r.current_value),
+                )?;
+                Ok(())
+            };
+            for r in groups {
+                row(writer, r)?;
+            }
+            writeln!(writer, "{}", "-".repeat(72))?;
+            row(writer, total)?;
+        }
+    }
+    Ok(())
+}
+
+/// Truncate a label to fit a text column (keeps the informative tail).
+fn truncate(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        s.to_string()
+    } else {
+        let tail: String = s
+            .chars()
+            .rev()
+            .take(width - 1)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        format!("…{tail}")
+    }
 }
 
 #[cfg(test)]

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -393,7 +393,7 @@ pub(super) fn report_returns<W: Write>(
     // Grouping is opt-in; warnings (bad tags, overlaps, non-self-contained
     // groups) go to stderr so they never pollute the report on stdout.
     let group_scopes = build_groups(directives, &whole_scope, end_date, &mut |w| {
-        eprintln!("warning: {w}")
+        eprintln!("warning: {w}");
     });
     if group_scopes.is_empty() {
         // Still emit the grouped shape (an empty `groups` list plus the TOTAL):

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -361,10 +361,13 @@ pub(super) fn report_returns<W: Write>(
     // groups) go to stderr so they never pollute the report on stdout.
     let group_scopes = build_groups(directives, &whole_scope, &mut |w| eprintln!("warning: {w}"));
     if group_scopes.is_empty() {
+        // Still emit the grouped shape (an empty `groups` list plus the TOTAL):
+        // `--by-group` must produce one stable schema regardless of ledger
+        // content, so a JSON/CSV consumer never has to branch on it.
         eprintln!(
-            "warning: --by-group but no in-scope `returns-group:` metadata found; reporting the whole-portfolio total"
+            "warning: --by-group but no in-scope `returns-group:` metadata found; reporting only the whole-portfolio total"
         );
-        return render_single(&total, currency, end_date, ctx, format, writer);
+        return render_grouped(&[], &total, currency, end_date, ctx, format, writer);
     }
 
     let groups: Vec<GroupResult> = group_scopes
@@ -612,9 +615,18 @@ fn render_grouped<W: Write>(
 /// across lines nor inject a spoofed second line into the text report. The JSON
 /// and CSV paths escape the raw label; only the text table needs this.
 fn truncate(s: &str, width: usize) -> String {
+    // `is_control` catches the C0/C1 control chars but not the Unicode line and
+    // paragraph separators (U+2028/U+2029), which a pager may still render as a
+    // line break; neutralize those too.
     let s: String = s
         .chars()
-        .map(|c| if c.is_control() { ' ' } else { c })
+        .map(|c| {
+            if c.is_control() || c == '\u{2028}' || c == '\u{2029}' {
+                ' '
+            } else {
+                c
+            }
+        })
         .collect();
     let s = s.as_str();
     if s.chars().count() <= width {

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -9,29 +9,35 @@
 //!
 //! # Grouping (#1820)
 //!
-//! By default the report is the whole-scope total. Two breakdowns are offered:
+//! By default the report is the single whole-scope summary. With **`--by-group`**
+//! it breaks down per `returns-group:` group: tag `open` directives with
+//! `returns-group: "Name"`, and each group's members are classified by the whole
+//! scope — accounts under `--investments` form the group's investment scope,
+//! accounts under `--income` its income scope — so a group that tags its dividend
+//! account reports a **dividend-inclusive** return. This is beangrow's group
+//! model, declared in the ledger rather than an external config file.
 //!
-//! - **`returns-group:` metadata** (the default when present): tag `open`
-//!   directives with `returns-group: "Name"` to declare named groups. Each
-//!   group's member accounts are split by account *type* — balance-sheet
-//!   accounts form the group's investment scope, income-statement accounts its
-//!   income scope — so a group that includes its dividend account reports a
-//!   **dividend-inclusive** return. This is beangrow's group model, declared in
-//!   the ledger (not an external config file).
-//! - **`--by-account`**: one row per investment account with no income scope, so
-//!   the per-account figures are a **price return** (ex-dividend). Handy for a
-//!   quick per-holding view without tagging the ledger. Ignored when
-//!   `returns-group:` groups are declared.
+//! Groups are constrained to the scope and reconcile with the total: a tagged
+//! account outside `--investments`/`--income` (or an Equity/Liability account) is
+//! ignored with a warning, and in-scope accounts left untagged collect into an
+//! `(ungrouped)` residual, so every in-scope holding appears in exactly one row.
+//! Grouping is opt-in, so the default output shape is unchanged.
+//!
+//! Auto per-account and true per-commodity attribution are deliberately *not*
+//! offered: a dividend booked to a shared cash/income account cannot be
+//! attributed to one holding automatically — which is why every reference tool
+//! (beangrow, fava-portfolio-summary) uses declared groups that bundle their
+//! income accounts.
 
 use super::{OutputFormat, csv_escape, json_escape};
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
-use rustledger_core::{AccountTypes, Amount, Directive, DisplayContext, MetaValue, NaiveDate};
+use rustledger_core::{Amount, Directive, DisplayContext, MetaValue, NaiveDate};
 use rustledger_query::PriceDatabase;
 use rustledger_returns::{
     AccountRole, PriceOracle, Scope, extract_flows, terminal_value, twr, xirr,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::io::Write;
 
 /// Adapts the query engine's [`PriceDatabase`] to the returns engine's
@@ -116,68 +122,96 @@ fn compute_group(
     })
 }
 
-/// Groups declared in the ledger via `returns-group:` metadata on `open`
-/// directives, sorted by name. Each group's member accounts are partitioned by
-/// account *type*: income-statement accounts (Income/Expenses) become the
-/// group's income scope, everything else (balance-sheet) its investment scope.
-/// A group that tags its dividend account therefore reports a dividend-inclusive
-/// return (the beangrow model, in-ledger). Returns empty if no account is tagged.
-fn groups_from_metadata(
+/// Build the `--by-group` breakdown from `returns-group:` metadata on `open`
+/// directives, sorted by group name, plus an `(ungrouped)` residual.
+///
+/// Each tagged account is classified by the **whole scope** — accounts under
+/// `--investments` form their group's investment scope, accounts under
+/// `--income` its income scope — so a group that tags its dividend account is
+/// dividend-inclusive (the beangrow model, in-ledger). Two things make the rows
+/// coherent with the TOTAL:
+///
+/// - Groups are constrained to the scope: a tagged account that is neither
+///   investment nor income (an Equity/Liability account, or one outside
+///   `--investments`/`--income`) is **out of scope** and ignored (with a
+///   warning), never valued as a holding.
+/// - In-scope accounts left untagged collect into `(ungrouped)`, so every
+///   in-scope holding appears in exactly one row and the group rows partition
+///   the total.
+///
+/// A non-string `returns-group:` value is ignored with a warning. Returns
+/// `(rows, any_declared)`; `any_declared` is false when no in-scope account
+/// carried a usable tag, in which case the caller reports the plain total.
+fn build_groups(
     directives: &[Directive],
-    account_types: &AccountTypes,
-) -> Vec<(String, Scope)> {
+    whole_scope: &Scope,
+    warn: &mut dyn FnMut(String),
+) -> (Vec<(String, Scope)>, bool) {
     // group name -> (investment accounts, income accounts)
-    let mut members: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
+    let mut groups: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
+    let mut ungrouped: (Vec<String>, Vec<String>) = (Vec::new(), Vec::new());
+    let mut any_declared = false;
+
     for directive in directives {
-        if let Directive::Open(open) = directive
-            && let Some(MetaValue::String(name)) = open.meta.get("returns-group")
-        {
-            let account = open.account.to_string();
-            let entry = members.entry(name.clone()).or_default();
-            if account_types.is_income_statement(&account) {
-                entry.1.push(account);
-            } else {
-                entry.0.push(account);
+        let Directive::Open(open) = directive else {
+            continue;
+        };
+        let account = open.account.to_string();
+        let role = whole_scope.classify(&account);
+        if role == AccountRole::External {
+            if open.meta.contains_key("returns-group") {
+                warn(format!(
+                    "returns-group on {account} ignored: not under --investments or --income"
+                ));
             }
+            continue;
+        }
+        let tag = match open.meta.get("returns-group") {
+            Some(MetaValue::String(name)) => Some(name.clone()),
+            Some(_) => {
+                warn(format!(
+                    "returns-group on {account} ignored: value must be a quoted string"
+                ));
+                None
+            }
+            None => None,
+        };
+        let bucket = match tag {
+            Some(name) => {
+                any_declared = true;
+                groups.entry(name).or_default()
+            }
+            None => &mut ungrouped,
+        };
+        if role == AccountRole::Income {
+            bucket.1.push(account);
+        } else {
+            bucket.0.push(account);
         }
     }
-    members
+
+    let mut rows: Vec<(String, Scope)> = groups
         .into_iter()
         .map(|(name, (investment, income))| (name, Scope::new(investment, income)))
-        .collect()
-}
-
-/// Every distinct account the whole scope classifies as Investment, in account
-/// order, each becoming its own single-account group with **no** income scope —
-/// so the per-account figures are a price return (ex-dividend). Dividends booked
-/// to a shared cash/income account cannot be attributed to a single holding, so
-/// they are excluded here; use `returns-group:` for dividend-inclusive groups.
-fn accounts_as_groups(directives: &[Directive], whole_scope: &Scope) -> Vec<(String, Scope)> {
-    let mut accounts: BTreeSet<String> = BTreeSet::new();
-    for directive in directives {
-        if let Directive::Transaction(txn) = directive {
-            for posting in &txn.postings {
-                let account = posting.account.as_str();
-                if whole_scope.classify(account) == AccountRole::Investment {
-                    accounts.insert(account.to_string());
-                }
-            }
-        }
+        .collect();
+    // The residual only makes sense once at least one group was declared.
+    if any_declared && (!ungrouped.0.is_empty() || !ungrouped.1.is_empty()) {
+        rows.push((
+            "(ungrouped)".to_string(),
+            Scope::new(ungrouped.0, ungrouped.1),
+        ));
     }
-    accounts
-        .into_iter()
-        .map(|a| (a.clone(), Scope::new(vec![a], Vec::new())))
-        .collect()
+    (rows, any_declared)
 }
 
 /// Generate the returns report.
 ///
 /// `directives` must be the booked, pad-expanded stream (the returns engine's
 /// input contract); the dispatcher passes `balance_input` for exactly this
-/// reason. When the ledger declares `returns-group:` groups they are reported
-/// (dividend-inclusive) and `by_account` is ignored; otherwise `by_account`
-/// requests a per-account (ex-dividend) breakdown. Either way the whole-scope
-/// TOTAL is reported.
+/// reason. With `by_group`, the report breaks down per `returns-group:` group
+/// (constrained to `--investments`/`--income`) plus an `(ungrouped)` residual
+/// and the TOTAL; otherwise it is the single whole-scope summary. Grouping is
+/// opt-in, so the default output shape never changes.
 ///
 /// # Errors
 ///
@@ -189,12 +223,11 @@ fn accounts_as_groups(directives: &[Directive], whole_scope: &Scope) -> Vec<(Str
 pub(super) fn report_returns<W: Write>(
     directives: &[Directive],
     operating_currency: &[String],
-    account_types: &AccountTypes,
     investments: &[String],
     income: &[String],
     currency_arg: Option<&str>,
     end_arg: Option<&str>,
-    by_account: bool,
+    by_group: bool,
     ctx: &DisplayContext,
     format: &OutputFormat,
     writer: &mut W,
@@ -232,17 +265,22 @@ pub(super) fn report_returns<W: Write>(
         "TOTAL".to_string(),
     )?;
 
-    // Groups: declared metadata groups take precedence over --by-account.
-    let group_scopes = {
-        let declared = groups_from_metadata(directives, account_types);
-        if !declared.is_empty() {
-            declared
-        } else if by_account {
-            accounts_as_groups(directives, &whole_scope)
-        } else {
-            Vec::new()
-        }
-    };
+    let currency = reporting_currency.as_str();
+    if !by_group {
+        return render_single(&total, currency, end_date, ctx, format, writer);
+    }
+
+    // Grouping is opt-in; warnings (bad tags, out-of-scope tags) go to stderr so
+    // they never pollute the report on stdout.
+    let (group_scopes, any_declared) =
+        build_groups(directives, &whole_scope, &mut |w| eprintln!("warning: {w}"));
+    if !any_declared {
+        eprintln!(
+            "warning: --by-group but no in-scope `returns-group:` metadata found; reporting the ungrouped total"
+        );
+        return render_single(&total, currency, end_date, ctx, format, writer);
+    }
+
     let groups: Vec<GroupResult> = group_scopes
         .iter()
         .map(|(label, scope)| {
@@ -257,12 +295,7 @@ pub(super) fn report_returns<W: Write>(
         })
         .collect::<Result<_>>()?;
 
-    let currency = reporting_currency.as_str();
-    if groups.is_empty() {
-        render_single(&total, currency, end_date, ctx, format, writer)
-    } else {
-        render_grouped(&groups, &total, currency, end_date, ctx, format, writer)
-    }
+    render_grouped(&groups, &total, currency, end_date, ctx, format, writer)
 }
 
 /// Format a rate as a 2-decimal percentage string, or `"n/a"` when undefined.

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -170,8 +170,13 @@ fn compute_group(
 ///   rest of the portfolio, so its flows count an internal transfer as a
 ///   contribution/withdrawal.
 ///
+/// Bounded by `end_date`, exactly as extraction is: an `open` (or a transaction,
+/// for the self-containment check) dated after the report horizon is ignored, so
+/// a historical report shows no group for an account that does not exist yet.
+///
 /// An empty result means no in-scope account carried a usable tag; the caller
-/// then reports the plain total.
+/// still emits the grouped output shape (an empty group list plus the
+/// whole-portfolio total), just with no group rows.
 fn build_groups(
     directives: &[Directive],
     whole_scope: &Scope,

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -791,12 +791,23 @@ fn by_group_text_output_renders_rows_and_total() {
         ],
     );
     assert!(out.contains("Tech") && out.contains("Bonds"), "{out}");
+    // The text table carries the Distributions column (parity with single-scope
+    // output), and Tech's $20 dividend shows in it.
+    assert!(
+        out.contains("Distributions"),
+        "text table needs Distributions: {out}"
+    );
     // TOTAL line present with the whole-portfolio current value.
     let total = out
         .lines()
         .find(|l| l.starts_with("TOTAL"))
         .unwrap_or_else(|| panic!("no TOTAL row: {out}"));
     assert!(total.contains("1850"), "TOTAL row: {total}");
+    // A footnote makes clear the TOTAL is not the sum of the group rows.
+    assert!(
+        out.contains("not the sum of the groups"),
+        "expected the non-sum TOTAL footnote: {out}"
+    );
 }
 
 #[test]

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -100,6 +100,32 @@ const LEDGER_GROUPS: &str = r#"option "operating_currency" "USD"
 2020-12-31 price BND 55 USD
 "#;
 
+/// Like `LEDGER_GROUPS` but only AAPL (+ its dividend account) is tagged; MSFT is
+/// an in-scope holding left untagged, so it must collect into the `(ungrouped)`
+/// residual and the group rows must still reconcile with the whole-scope TOTAL.
+const LEDGER_GROUPS_PARTIAL: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker:AAPL
+  returns-group: "Tech"
+2020-01-01 open Assets:Broker:MSFT
+2020-01-01 open Assets:Bank
+2020-01-01 open Income:Dividends
+  returns-group: "Tech"
+
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Bank        -1000 USD
+2020-01-01 * "buy msft"
+  Assets:Broker:MSFT  10 MSFT {50 USD}
+  Assets:Bank        -500 USD
+2020-06-01 * "aapl dividend"
+  Assets:Bank         20 USD
+  Income:Dividends   -20 USD
+
+2020-12-31 price AAPL 130 USD
+2020-12-31 price MSFT 55 USD
+"#;
+
 fn write_fixture(source: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::Builder::new()
         .prefix("report-returns-")
@@ -414,6 +440,7 @@ fn returns_group_metadata_breaks_down_dividend_inclusive() {
             "Assets:Broker",
             "--income",
             "Income:Dividends",
+            "--by-group",
             "--end",
             "2020-12-31",
             "--format",
@@ -453,10 +480,10 @@ fn returns_group_metadata_breaks_down_dividend_inclusive() {
 }
 
 #[test]
-fn by_account_breaks_down_per_investment_account() {
+fn by_group_collects_untagged_holdings_into_reconciling_ungrouped_residual() {
     let bin = require_rledger!();
-    // LEDGER has no returns-group metadata, so --by-account drives the breakdown.
-    let f = write_fixture(LEDGER);
+    // AAPL is tagged Tech; MSFT is an untagged in-scope holding.
+    let f = write_fixture(LEDGER_GROUPS_PARTIAL);
     let path = f.path().to_str().unwrap();
     let out = run(
         &bin,
@@ -466,7 +493,9 @@ fn by_account_breaks_down_per_investment_account() {
             "returns",
             "--investments",
             "Assets:Broker",
-            "--by-account",
+            "--income",
+            "Income:Dividends",
+            "--by-group",
             "--end",
             "2020-12-31",
             "--format",
@@ -474,16 +503,55 @@ fn by_account_breaks_down_per_investment_account() {
             "--no-pager",
         ],
     );
-    // LEDGER holds only Assets:Broker:Stock → one per-account row (ex-dividend,
-    // 30%) plus the TOTAL.
+    // Tech: 1000 in, +20 dividend, worth 1300.
     assert_eq!(
-        json_group_field(&out, "Assets:Broker:Stock", "money_weighted_return_pct"),
-        "30.00",
-        "{out}"
-    );
-    assert_eq!(
-        json_group_field(&out, "TOTAL", "current_value"),
+        json_group_field(&out, "Tech", "current_value"),
         "1300",
         "{out}"
+    );
+    // MSFT, left untagged, lands in the residual — not silently dropped.
+    assert_eq!(
+        json_group_field(&out, "(ungrouped)", "current_value"),
+        "550",
+        "{out}"
+    );
+    // And the rows partition the total: 1300 + 550 = 1850, invested 1000 + 500 =
+    // 1500. Every in-scope holding is in exactly one row.
+    assert_eq!(
+        json_group_field(&out, "TOTAL", "current_value"),
+        "1850",
+        "{out}"
+    );
+    assert_eq!(json_group_field(&out, "TOTAL", "invested"), "1500", "{out}");
+}
+
+#[test]
+fn without_by_group_output_is_the_single_summary() {
+    let bin = require_rledger!();
+    // Even with `returns-group:` metadata present, the default (no --by-group)
+    // output is the unchanged single summary — grouping is strictly opt-in.
+    let f = write_fixture(LEDGER_GROUPS);
+    let path = f.path().to_str().unwrap();
+    let out = run(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    // The single-summary schema has no "groups" array.
+    assert!(
+        !out.contains("\"groups\""),
+        "default output must be the single summary, not grouped: {out}"
     );
 }

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -885,6 +885,35 @@ fn by_group_emits_grouped_schema_even_with_no_tags() {
         out.contains("\"groups\": []") && out.contains("\"total\":"),
         "no-tags --by-group must still emit the grouped schema: {out}"
     );
+
+    // The text path for the same no-groups case must not print two horizontal
+    // rules back to back (there are no group rows to separate from the TOTAL).
+    let (text, _err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--no-pager",
+        ],
+    );
+    let rules: Vec<usize> = text
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| l.starts_with("---"))
+        .map(|(i, _)| i)
+        .collect();
+    assert!(
+        rules.windows(2).all(|w| w[1] != w[0] + 1),
+        "no-groups text output must not have adjacent rules:\n{text}"
+    );
 }
 
 #[test]

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -938,6 +938,49 @@ fn by_group_emits_grouped_schema_even_with_no_tags() {
 }
 
 #[test]
+fn by_group_csv_output_has_header_group_and_total_rows() {
+    let bin = require_rledger!();
+    // Exercise the grouped CSV path (only JSON and text were covered).
+    let f = write_fixture(LEDGER_GROUPS);
+    let path = f.path().to_str().unwrap();
+    let out = run(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "csv",
+            "--no-pager",
+        ],
+    );
+    // Header row with the group column first.
+    assert!(
+        out.lines().next().unwrap_or_default().starts_with(
+            "group,as_of,reporting_currency,cash_flows,invested,distributions,current_value,"
+        ),
+        "CSV header: {out}"
+    );
+    // A group data row and the TOTAL row (the whole-portfolio current value).
+    assert!(
+        out.lines().any(|l| l.starts_with("Tech,")),
+        "expected a Tech group row: {out}"
+    );
+    let total = out
+        .lines()
+        .find(|l| l.starts_with("TOTAL,"))
+        .unwrap_or_else(|| panic!("no TOTAL row: {out}"));
+    assert!(total.contains(",1850,"), "TOTAL row current value: {total}");
+}
+
+#[test]
 fn by_group_respects_the_end_horizon() {
     let bin = require_rledger!();
     // Grouping must be bounded by --end exactly as extraction is: a group whose

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -101,8 +101,8 @@ const LEDGER_GROUPS: &str = r#"option "operating_currency" "USD"
 "#;
 
 /// Like `LEDGER_GROUPS` but only AAPL (+ its dividend account) is tagged; MSFT is
-/// an in-scope holding left untagged, so it must collect into the `(ungrouped)`
-/// residual and the group rows must still reconcile with the whole-scope TOTAL.
+/// an in-scope holding left untagged, so it is omitted from the breakdown while
+/// still contributing to the whole-scope TOTAL.
 const LEDGER_GROUPS_PARTIAL: &str = r#"option "operating_currency" "USD"
 
 2020-01-01 open Assets:Broker:AAPL
@@ -126,6 +126,70 @@ const LEDGER_GROUPS_PARTIAL: &str = r#"option "operating_currency" "USD"
 2020-12-31 price MSFT 55 USD
 "#;
 
+/// Two groups funded from a shared in-scope settlement-cash account
+/// (`Assets:Broker:Cash`, under `--investments Assets:Broker`). Each group's buy
+/// draws on the pooled cash, so neither group is self-contained.
+const LEDGER_SHARED_CASH: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker:Cash
+2020-01-01 open Assets:Broker:AAPL
+  returns-group: "Tech"
+2020-01-01 open Assets:Broker:BND
+  returns-group: "Bonds"
+2020-01-01 open Equity:Opening
+
+2020-01-01 * "fund the brokerage"
+  Assets:Broker:Cash  1500 USD
+  Equity:Opening     -1500 USD
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Broker:Cash -1000 USD
+2020-01-01 * "buy bnd"
+  Assets:Broker:BND  10 BND {50 USD}
+  Assets:Broker:Cash -500 USD
+
+2020-12-31 price AAPL 130 USD
+2020-12-31 price BND 55 USD
+"#;
+
+/// A real holding tagged `Tech`, plus two malformed tags: an Equity account
+/// (out of scope) and a numeric (non-string) value.
+const LEDGER_BAD_TAGS: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker:AAPL
+  returns-group: "Tech"
+2020-01-01 open Assets:Broker:MSFT
+  returns-group: 5
+2020-01-01 open Assets:Bank
+2020-01-01 open Equity:Opening
+  returns-group: "Tech"
+
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Bank        -1000 USD
+
+2020-12-31 price AAPL 130 USD
+"#;
+
+/// A group (`Payouts`) that tags only an income account — no holding, so its
+/// investment scope is empty.
+const LEDGER_INCOME_ONLY_GROUP: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker:AAPL
+2020-01-01 open Assets:Bank
+2020-01-01 open Income:Dividends
+  returns-group: "Payouts"
+
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Bank        -1000 USD
+2020-06-01 * "dividend"
+  Assets:Bank         20 USD
+  Income:Dividends   -20 USD
+
+2020-12-31 price AAPL 130 USD
+"#;
+
 fn write_fixture(source: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::Builder::new()
         .prefix("report-returns-")
@@ -147,6 +211,23 @@ fn run(binary: &PathBuf, args: &[&str]) -> String {
         String::from_utf8_lossy(&out.stderr),
     );
     String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Run and return `(stdout, stderr)` — the grouping warnings are on stderr.
+fn run_split(binary: &PathBuf, args: &[&str]) -> (String, String) {
+    let out = Command::new(binary)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("run rledger {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "rledger {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
 }
 
 /// The value on a labeled text-report line (`"Label      value"`), trimmed.
@@ -480,12 +561,14 @@ fn returns_group_metadata_breaks_down_dividend_inclusive() {
 }
 
 #[test]
-fn by_group_collects_untagged_holdings_into_reconciling_ungrouped_residual() {
+fn by_group_omits_untagged_holdings_no_residual() {
     let bin = require_rledger!();
-    // AAPL is tagged Tech; MSFT is an untagged in-scope holding.
+    // AAPL is tagged Tech; MSFT is an untagged in-scope holding. Under the
+    // independent-sub-portfolio model, MSFT is simply omitted from the breakdown
+    // (no `(ungrouped)` residual) — it still contributes to the whole-scope TOTAL.
     let f = write_fixture(LEDGER_GROUPS_PARTIAL);
     let path = f.path().to_str().unwrap();
-    let out = run(
+    let (out, _err) = run_split(
         &bin,
         &[
             "report",
@@ -509,20 +592,19 @@ fn by_group_collects_untagged_holdings_into_reconciling_ungrouped_residual() {
         "1300",
         "{out}"
     );
-    // MSFT, left untagged, lands in the residual — not silently dropped.
-    assert_eq!(
-        json_group_field(&out, "(ungrouped)", "current_value"),
-        "550",
-        "{out}"
+    // No residual row: untagged MSFT is omitted from the breakdown entirely.
+    assert!(
+        !out.contains("(ungrouped)"),
+        "there must be no residual row: {out}"
     );
-    // And the rows partition the total: 1300 + 550 = 1850, invested 1000 + 500 =
-    // 1500. Every in-scope holding is in exactly one row.
+    // The TOTAL is still the whole portfolio (Tech's 1300 + MSFT's 550), NOT the
+    // sum of the group rows — 1850 > the single Tech row, proving MSFT is counted
+    // in the total though it has no group of its own.
     assert_eq!(
         json_group_field(&out, "TOTAL", "current_value"),
         "1850",
         "{out}"
     );
-    assert_eq!(json_group_field(&out, "TOTAL", "invested"), "1500", "{out}");
 }
 
 #[test]
@@ -549,9 +631,152 @@ fn without_by_group_output_is_the_single_summary() {
             "--no-pager",
         ],
     );
-    // The single-summary schema has no "groups" array.
+    // Positively pin the single-summary schema (a top-level object with the
+    // return fields), AND that it is not the grouped schema (no `groups` array) —
+    // a negative-only check could pass on truncated/altered output.
+    assert!(
+        out.contains("\"money_weighted_return_pct\"") && out.contains("\"reporting_currency\""),
+        "default output must be the single-summary schema: {out}"
+    );
     assert!(
         !out.contains("\"groups\""),
-        "default output must be the single summary, not grouped: {out}"
+        "default output must not be the grouped schema: {out}"
+    );
+}
+
+#[test]
+fn by_group_warns_when_a_group_is_not_self_contained() {
+    let bin = require_rledger!();
+    // Both groups draw on a shared in-scope settlement-cash account, so each
+    // group's return counts an intra-portfolio transfer as a flow. That can't be
+    // attributed, so it must be surfaced as a warning (not silently misreported).
+    let f = write_fixture(LEDGER_SHARED_CASH);
+    let path = f.path().to_str().unwrap();
+    let (_out, err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--no-pager",
+        ],
+    );
+    assert!(
+        err.contains("Tech is not self-contained") && err.contains("Assets:Broker:Cash"),
+        "expected a self-contained warning naming the shared account: {err}"
+    );
+}
+
+#[test]
+fn by_group_warns_on_out_of_scope_and_non_string_tags() {
+    let bin = require_rledger!();
+    let f = write_fixture(LEDGER_BAD_TAGS);
+    let path = f.path().to_str().unwrap();
+    let (out, err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    // Equity account tagged → out of scope, dropped (never valued as a holding).
+    assert!(
+        err.contains("Equity:Opening ignored")
+            && err.contains("not under --investments or --income"),
+        "expected an out-of-scope warning: {err}"
+    );
+    // Numeric tag value → dropped with a distinct warning.
+    assert!(
+        err.contains("must be a quoted string"),
+        "expected a non-string-value warning: {err}"
+    );
+    // The out-of-scope Equity account is not valued: only the real holding shows.
+    assert_eq!(
+        json_group_field(&out, "Tech", "current_value"),
+        "1300",
+        "{out}"
+    );
+}
+
+#[test]
+fn by_group_text_output_renders_rows_and_total() {
+    let bin = require_rledger!();
+    // Exercise the text (non-JSON) grouped path: it must print a group row and a
+    // TOTAL row with aligned columns.
+    let f = write_fixture(LEDGER_GROUPS);
+    let path = f.path().to_str().unwrap();
+    let out = run(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--no-pager",
+        ],
+    );
+    assert!(out.contains("Tech") && out.contains("Bonds"), "{out}");
+    // TOTAL line present with the whole-portfolio current value.
+    let total = out
+        .lines()
+        .find(|l| l.starts_with("TOTAL"))
+        .unwrap_or_else(|| panic!("no TOTAL row: {out}"));
+    assert!(total.contains("1850"), "TOTAL row: {total}");
+}
+
+#[test]
+fn by_group_income_only_group_is_valued_without_panicking() {
+    let bin = require_rledger!();
+    // A group with only an income account (no holding) has an empty investment
+    // scope: current value 0, undefined MWR (only distributions, no outlay).
+    let f = write_fixture(LEDGER_INCOME_ONLY_GROUP);
+    let path = f.path().to_str().unwrap();
+    let out = run(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    assert_eq!(
+        json_group_field(&out, "Payouts", "current_value"),
+        "0",
+        "{out}"
+    );
+    assert_eq!(
+        json_group_field(&out, "Payouts", "money_weighted_return_pct"),
+        "null",
+        "income-only group has no outlay → undefined MWR: {out}"
     );
 }

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -74,6 +74,32 @@ const LEDGER_TIMING: &str = r#"option "operating_currency" "USD"
 2022-01-01 price AAPL 120 USD
 "#;
 
+/// Two `returns-group:`-tagged holdings; the Tech group also tags its dividend
+/// income account, so Tech's return is dividend-inclusive.
+const LEDGER_GROUPS: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker:AAPL
+  returns-group: "Tech"
+2020-01-01 open Assets:Broker:BND
+  returns-group: "Bonds"
+2020-01-01 open Assets:Bank
+2020-01-01 open Income:Dividends
+  returns-group: "Tech"
+
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Bank        -1000 USD
+2020-01-01 * "buy bnd"
+  Assets:Broker:BND  10 BND {50 USD}
+  Assets:Bank        -500 USD
+2020-06-01 * "aapl dividend"
+  Assets:Bank         20 USD
+  Income:Dividends   -20 USD
+
+2020-12-31 price AAPL 130 USD
+2020-12-31 price BND 55 USD
+"#;
+
 fn write_fixture(source: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::Builder::new()
         .prefix("report-returns-")
@@ -347,5 +373,117 @@ fn time_weighted_return_diverges_from_money_weighted_on_timing() {
     assert!(
         mwr > 25.0,
         "MWR should exceed TWR given the good contribution timing: {out}"
+    );
+}
+
+/// Extract a group object's field from the grouped JSON output. Naive but
+/// sufficient for the test fixtures (no nested braces inside a group object).
+fn json_group_field(out: &str, group: &str, field: &str) -> String {
+    let marker = format!(r#""group": "{group}""#);
+    let start = out
+        .find(&marker)
+        .unwrap_or_else(|| panic!("group {group} not in {out}"));
+    let obj_end = out[start..].find('}').map_or(out.len(), |e| start + e);
+    let obj = &out[start..obj_end];
+    let key = format!(r#""{field}": "#);
+    let fs = obj
+        .find(&key)
+        .unwrap_or_else(|| panic!("field {field} not in {obj}"))
+        + key.len();
+    obj[fs..]
+        .split([',', '}'])
+        .next()
+        .unwrap()
+        .trim()
+        .trim_matches('"')
+        .to_string()
+}
+
+#[test]
+fn returns_group_metadata_breaks_down_dividend_inclusive() {
+    let bin = require_rledger!();
+    let f = write_fixture(LEDGER_GROUPS);
+    let path = f.path().to_str().unwrap();
+    let out = run(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    // Tech: 1000 in, +20 dividend (its income account is tagged Tech →
+    // dividend-INCLUSIVE), worth 1300 → 32.36%.
+    assert_eq!(
+        json_group_field(&out, "Tech", "money_weighted_return_pct"),
+        "32.36",
+        "{out}"
+    );
+    assert_eq!(
+        json_group_field(&out, "Tech", "distributions"),
+        "20",
+        "dividend included: {out}"
+    );
+    assert_eq!(
+        json_group_field(&out, "Tech", "current_value"),
+        "1300",
+        "{out}"
+    );
+    // Bonds: 500 in, worth 550 → 10%.
+    assert_eq!(
+        json_group_field(&out, "Bonds", "money_weighted_return_pct"),
+        "10.00",
+        "{out}"
+    );
+    // The whole-scope TOTAL is present too.
+    assert_eq!(
+        json_group_field(&out, "TOTAL", "current_value"),
+        "1850",
+        "{out}"
+    );
+}
+
+#[test]
+fn by_account_breaks_down_per_investment_account() {
+    let bin = require_rledger!();
+    // LEDGER has no returns-group metadata, so --by-account drives the breakdown.
+    let f = write_fixture(LEDGER);
+    let path = f.path().to_str().unwrap();
+    let out = run(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-account",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    // LEDGER holds only Assets:Broker:Stock → one per-account row (ex-dividend,
+    // 30%) plus the TOTAL.
+    assert_eq!(
+        json_group_field(&out, "Assets:Broker:Stock", "money_weighted_return_pct"),
+        "30.00",
+        "{out}"
+    );
+    assert_eq!(
+        json_group_field(&out, "TOTAL", "current_value"),
+        "1300",
+        "{out}"
     );
 }

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -190,6 +190,24 @@ const LEDGER_INCOME_ONLY_GROUP: &str = r#"option "operating_currency" "USD"
 2020-12-31 price AAPL 130 USD
 "#;
 
+/// A tagged parent account (`Assets:Broker`, group `All`) that is an ancestor of
+/// a tagged child (`Assets:Broker:AAPL`, group `Tech`). Because `Scope` matches
+/// by prefix, `All` also captures AAPL — a cross-group overlap that must warn.
+const LEDGER_PREFIX_OVERLAP: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker
+  returns-group: "All"
+2020-01-01 open Assets:Broker:AAPL
+  returns-group: "Tech"
+2020-01-01 open Assets:Bank
+
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Bank        -1000 USD
+
+2020-12-31 price AAPL 130 USD
+"#;
+
 fn write_fixture(source: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::Builder::new()
         .prefix("report-returns-")
@@ -652,7 +670,7 @@ fn by_group_warns_when_a_group_is_not_self_contained() {
     // attributed, so it must be surfaced as a warning (not silently misreported).
     let f = write_fixture(LEDGER_SHARED_CASH);
     let path = f.path().to_str().unwrap();
-    let (_out, err) = run_split(
+    let (out, err) = run_split(
         &bin,
         &[
             "report",
@@ -669,6 +687,43 @@ fn by_group_warns_when_a_group_is_not_self_contained() {
     assert!(
         err.contains("Tech is not self-contained") && err.contains("Assets:Broker:Cash"),
         "expected a self-contained warning naming the shared account: {err}"
+    );
+    // The warning is advisory: the group's standalone figures are STILL rendered
+    // on stdout (not suppressed or errored).
+    assert!(
+        out.contains("Tech") && out.contains("Bonds"),
+        "warned groups must still appear in the report: {out}"
+    );
+}
+
+#[test]
+fn by_group_warns_on_cross_group_prefix_overlap() {
+    let bin = require_rledger!();
+    // A tagged parent (`Assets:Broker`, group All) is an ancestor of a tagged
+    // child (`Assets:Broker:AAPL`, group Tech). `Scope` matches by prefix, so the
+    // parent's group also values the child's holding — a double count that must
+    // be surfaced.
+    let f = write_fixture(LEDGER_PREFIX_OVERLAP);
+    let path = f.path().to_str().unwrap();
+    let (_out, err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--no-pager",
+        ],
+    );
+    assert!(
+        err.contains("overlap by prefix")
+            && err.contains("Assets:Broker")
+            && err.contains("Assets:Broker:AAPL"),
+        "expected a prefix-overlap warning naming both accounts: {err}"
     );
 }
 
@@ -778,5 +833,12 @@ fn by_group_income_only_group_is_valued_without_panicking() {
         json_group_field(&out, "Payouts", "money_weighted_return_pct"),
         "null",
         "income-only group has no outlay → undefined MWR: {out}"
+    );
+    // TWR is likewise undefined: with no invested capital there is no holding
+    // period to weight. It must be null, not a fabricated flat 0.00%.
+    assert_eq!(
+        json_group_field(&out, "Payouts", "time_weighted_return_pct"),
+        "null",
+        "income-only group has no capital → undefined TWR (not 0%): {out}"
     );
 }

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -208,6 +208,27 @@ const LEDGER_PREFIX_OVERLAP: &str = r#"option "operating_currency" "USD"
 2020-12-31 price AAPL 130 USD
 "#;
 
+/// A `Tech` group active from 2020, plus a `Crypto` group whose account is opened
+/// (and only transacts) in 2022. A report as of 2020 must not show Crypto.
+const LEDGER_FUTURE_GROUP: &str = r#"option "operating_currency" "USD"
+
+2020-01-01 open Assets:Broker:AAPL
+  returns-group: "Tech"
+2020-01-01 open Assets:Bank
+
+2020-01-01 * "buy aapl"
+  Assets:Broker:AAPL  10 AAPL {100 USD}
+  Assets:Bank        -1000 USD
+
+2022-01-01 open Assets:Broker:CRYPTO
+  returns-group: "Crypto"
+2022-06-01 * "buy crypto"
+  Assets:Broker:CRYPTO  1 BTC {30000 USD}
+  Assets:Bank          -30000 USD
+
+2020-12-31 price AAPL 130 USD
+"#;
+
 fn write_fixture(source: &str) -> tempfile::NamedTempFile {
     let mut f = tempfile::Builder::new()
         .prefix("report-returns-")
@@ -913,6 +934,40 @@ fn by_group_emits_grouped_schema_even_with_no_tags() {
     assert!(
         rules.windows(2).all(|w| w[1] != w[0] + 1),
         "no-groups text output must not have adjacent rules:\n{text}"
+    );
+}
+
+#[test]
+fn by_group_respects_the_end_horizon() {
+    let bin = require_rledger!();
+    // Grouping must be bounded by --end exactly as extraction is: a group whose
+    // account opens after the horizon must not appear as a spurious row.
+    let f = write_fixture(LEDGER_FUTURE_GROUP);
+    let path = f.path().to_str().unwrap();
+    let (out, _err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    assert_eq!(
+        json_group_field(&out, "Tech", "current_value"),
+        "1300",
+        "{out}"
+    );
+    assert!(
+        !out.contains("Crypto"),
+        "a group opened after --end must not appear: {out}"
     );
 }
 

--- a/crates/rustledger/tests/report_returns_test.rs
+++ b/crates/rustledger/tests/report_returns_test.rs
@@ -853,3 +853,72 @@ fn by_group_income_only_group_is_valued_without_panicking() {
         "income-only group has no capital → undefined TWR (not 0%): {out}"
     );
 }
+
+#[test]
+fn by_group_emits_grouped_schema_even_with_no_tags() {
+    let bin = require_rledger!();
+    // `--by-group` must yield ONE stable schema regardless of ledger content:
+    // with no in-scope `returns-group:` tags the output is still the grouped
+    // shape (an empty `groups` array plus `total`), not the single-summary
+    // object — so a JSON consumer never has to branch on ledger content.
+    let f = write_fixture(LEDGER); // no returns-group metadata
+    let path = f.path().to_str().unwrap();
+    let (out, _err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--income",
+            "Income:Dividends",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    assert!(
+        out.contains("\"groups\": []") && out.contains("\"total\":"),
+        "no-tags --by-group must still emit the grouped schema: {out}"
+    );
+}
+
+#[test]
+fn by_group_json_escapes_control_chars_in_a_label() {
+    let bin = require_rledger!();
+    // A returns-group value may carry a raw control byte the parser preserves;
+    // the JSON label must be escaped (\uXXXX), not emitted raw, so the output
+    // stays valid JSON. The label here contains an ESC (U+001B).
+    let fixture = "option \"operating_currency\" \"USD\"\n\
+        2020-01-01 open Assets:Broker:AAPL\n  returns-group: \"A\u{1b}B\"\n\
+        2020-01-01 open Assets:Bank\n\
+        2020-01-01 * \"buy\"\n  Assets:Broker:AAPL 10 AAPL {100 USD}\n  Assets:Bank -1000 USD\n\
+        2020-12-31 price AAPL 130 USD\n";
+    let f = write_fixture(fixture);
+    let path = f.path().to_str().unwrap();
+    let (out, _err) = run_split(
+        &bin,
+        &[
+            "report",
+            path,
+            "returns",
+            "--investments",
+            "Assets:Broker",
+            "--by-group",
+            "--end",
+            "2020-12-31",
+            "--format",
+            "json",
+            "--no-pager",
+        ],
+    );
+    // The raw ESC byte must NOT appear; its  escape must.
+    assert!(
+        !out.contains('\u{1b}') && out.contains("\\u001b"),
+        "control char in a group label must be JSON-escaped: {out:?}"
+    );
+}


### PR DESCRIPTION
## What

Adds an opt-in per-group breakdown to `rledger report returns` (#1820). Tag `open` directives with `returns-group: "Name"` and pass `--by-group`:

```beancount
2020-01-01 open Assets:Broker:AAPL
  returns-group: "Tech"
2020-01-01 open Income:Dividends
  returns-group: "Tech"     ; makes Tech dividend-inclusive
```

```
Group                                 MWR      TWR    Invested     Current
------------------------------------------------------------------------
Bonds                              10.00%   10.00%         500         550
Tech                               32.36%   32.60%        1000        1300
------------------------------------------------------------------------
TOTAL                              24.85%   24.98%        1500        1850
```

Each group is an **independent sub-portfolio**: its return is computed over just that group's accounts, exactly as if you'd narrowed `--investments`/`--income` to them. This is the model beangrow and hledger `roi` use. It follows the prior-art direction (declared groups that bundle their income accounts, so the return is dividend-inclusive — declared in the ledger, not beangrow's external config file).

## Design: groups are reported alongside the total, not as a partition of it

An earlier revision promised the group rows summed to the TOTAL (an `(ungrouped)` residual). A deep review proved that guarantee **unsound**: when two groups draw on a shared in-scope account (a pooled settlement-cash account under `--investments` — the common brokerage shape), the boundary flow into that shared account can't be attributed to one group. This is the same un-attributability that made us drop `--by-account`. So:

- **No `(ungrouped)` residual.** Only tagged accounts appear; an untagged in-scope holding is omitted from the breakdown but still counted in the TOTAL. The TOTAL is the whole-portfolio figure, reported for reference — not claimed as the sum of the rows.
- **Warnings (stderr), not silent misreporting**, for the cases a reader would misread:
  - a group that is **not self-contained** (shares an in-scope account with the rest of the portfolio — its return then counts an internal transfer as a flow);
  - two groups whose accounts **overlap by prefix** (a tagged parent or duplicate `open` values the same holding in both);
  - a `returns-group:` tag on an **out-of-scope** account (Equity/Liability, or outside `--investments`/`--income`) — dropped, never valued as a phantom holding;
  - a **non-string** tag value.
- **Why not auto per-account/per-commodity:** a dividend booked to a shared cash/income account can't be attributed to one holding automatically — which is exactly why every reference tool uses declared groups.

## Tests

Independent-groups (no residual; TOTAL ≠ sum of rows), self-contained warning, out-of-scope + non-string tag warnings, income-only (empty-investment) group, grouped **text** path, and a positively-pinned default-shape guard. Plus the engine's existing suite and the two drift-guard unit tests.

## Deferred (per #1820)

True per-commodity attribution within a single account, `commodity`-directive tagging, and the N+1-extraction perf pass (#1832).

Part of #1820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
