### PR TITLE
perf(returns): single-pass compute_returns entry point (one extract + one realize per group)

### DIFF
--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -674,19 +674,34 @@ pub fn twr(
     dates.push(end_date);
     let mut values = investment_values_at(directives, scope, reporting_currency, prices, &dates);
     // Split off the `end_date` valuation; `values` then has exactly one entry per
-    // flow date, in `net_by_date` order. Each value is a `Result`, propagated with
-    // `?` only at the flow it belongs to — so a `MissingPrice` at a later date is
-    // NOT raised when an earlier sub-period already made the return undefined
-    // (preserving the old lazy short-circuit).
+    // flow date, in `net_by_date` order.
     let end_value = values.pop().expect("dates always includes end_date");
+    twr_from_values(&net_by_date, values, end_value, end_date)
+}
 
-    // Chain the sub-period returns via unit accounting. `v_prev` is the portfolio
-    // value just after the previous valuation; on the first flow date it is only
-    // established (that flow is the opening capital, not a return).
+/// Chain the sub-period returns from portfolio valuations already realized.
+///
+/// The unit-value core of [`twr`], factored out so it can run over values
+/// snapshotted in a SINGLE forward pass — shared with [`compute_returns`], which
+/// derives MWR and the terminal value from the same realization. `flow_values[i]`
+/// is the portfolio value at the i-th flow date (in `net_by_date` order);
+/// `end_value` is the value at `end_date`. Each value is a `Result` so a
+/// `MissingPrice` at a later date is propagated only if the chain actually reaches
+/// it (`?` at the flow it belongs to), preserving the lazy short-circuit — an
+/// early undefined sub-period (`Ok(None)`) never surfaces a later price gap.
+fn twr_from_values(
+    net_by_date: &std::collections::BTreeMap<NaiveDate, Decimal>,
+    flow_values: Vec<Result<Decimal, ExtractError>>,
+    end_value: Result<Decimal, ExtractError>,
+    end_date: NaiveDate,
+) -> Result<Option<f64>, ExtractError> {
+    // `v_prev` is the portfolio value just after the previous valuation; on the
+    // first flow date it is only established (that flow is the opening capital,
+    // not a return).
     let mut cumulative = 1.0_f64;
     let mut v_prev: Option<f64> = None;
     let mut first_date: Option<NaiveDate> = None;
-    for ((&date, &contribution), value) in net_by_date.iter().zip(values) {
+    for ((&date, &contribution), value) in net_by_date.iter().zip(flow_values) {
         first_date.get_or_insert(date);
         // A Decimal that can't be represented as f64 makes the return undefined
         // (report n/a), never a silent 0 — which would fabricate a wrong rate.
@@ -736,13 +751,13 @@ pub fn twr(
         // nothing and contributes no return — the whole-period figure is already
         // in `cumulative` (a position closed out on the report date keeps its TWR).
         Some(_) => {}
-        None => return Ok(None), // unreachable: `flows` non-empty ⇒ the loop ran
+        None => return Ok(None), // no flows ⇒ nothing to chain
     }
 
     // Annualize the total return over [first_date, end_date] (actual/365, the
     // same day count as `xirr`). A zero-length span cannot be annualized.
     let Some(first_date) = first_date else {
-        return Ok(None); // unreachable: `flows` non-empty
+        return Ok(None); // no flows
     };
     let days = end_date.since(first_date).map_or(0, |s| s.get_days());
     if days <= 0 {
@@ -751,6 +766,114 @@ pub fn twr(
     let years = f64::from(days) / crate::DAYS_PER_YEAR;
     let annualized = cumulative.powf(1.0 / years) - 1.0;
     Ok(annualized.is_finite().then_some(annualized))
+}
+
+/// A scope's full return summary, computed in one pass by [`compute_returns`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Returns {
+    /// Number of dated cash flows in the money-weighted series — the boundary
+    /// flows plus the terminal market value, if nonzero.
+    pub cash_flows: usize,
+    /// Capital contributed: the sum of outlays (investor-negative flows, sign-flipped).
+    pub invested: Decimal,
+    /// Distributions received: dividends and sale proceeds (investor-positive flows).
+    pub distributions: Decimal,
+    /// Market value of the held position at `end_date`.
+    pub current_value: Decimal,
+    /// Money-weighted return (annualized XIRR); `None` when undefined.
+    pub money_weighted: Option<f64>,
+    /// Time-weighted return (annualized); `None` when undefined.
+    pub time_weighted: Option<f64>,
+}
+
+/// Compute a scope's full return summary from ONE flow extraction and ONE
+/// realization pass.
+///
+/// Folds [`extract_flows`], [`terminal_value`], [`xirr`](crate::xirr), and
+/// [`twr`] into a single walk: the boundary flows are extracted once, and the
+/// portfolio is valued at every flow date and at `end_date` in one forward
+/// realization, then reused for the terminal value, the money-weighted series, and
+/// the time-weighted chaining. A caller needing every figure (the `report returns`
+/// breakdown, one call per group) thus avoids the ~2× extraction and ~2×
+/// realization of invoking those functions separately. The result is identical to
+/// composing them by hand — pinned by `compute_returns_matches_manual_composition`.
+///
+/// TWR is `None` for a scope that never held investment capital (an income-only
+/// group, or a holding opened but never bought): with no capital there is no
+/// holding period to weight, so a flat 0% would be fabricated.
+///
+/// # Errors
+///
+/// [`ExtractError::MissingPrice`] if a boundary flow or the `end_date` valuation
+/// cannot be priced in `reporting_currency`. A missing price at an *intermediate*
+/// flow date degrades TWR to `None` rather than erroring — the summary itself is
+/// still well-defined.
+///
+/// # Panics
+///
+/// Same booked, pad-expanded, date-sorted input requirement as [`twr`].
+pub fn compute_returns(
+    directives: &[Directive],
+    scope: &Scope,
+    reporting_currency: &str,
+    prices: &impl PriceOracle,
+    end_date: NaiveDate,
+) -> Result<Returns, ExtractError> {
+    let flows = extract_flows(directives, scope, reporting_currency, prices, end_date)?;
+    let invested: Decimal = flows
+        .iter()
+        .filter(|f| f.amount.is_sign_negative())
+        .map(|f| -f.amount)
+        .sum();
+    let distributions: Decimal = flows
+        .iter()
+        .filter(|f| f.amount.is_sign_positive())
+        .map(|f| f.amount)
+        .sum();
+
+    let mut net_by_date: std::collections::BTreeMap<NaiveDate, Decimal> =
+        std::collections::BTreeMap::new();
+    for flow in &flows {
+        *net_by_date.entry(flow.date).or_default() += -flow.amount;
+    }
+
+    // One forward realization pass: value at every flow date and at `end_date`.
+    let mut dates: Vec<NaiveDate> = net_by_date.keys().copied().collect();
+    dates.push(end_date);
+    let mut values = investment_values_at(directives, scope, reporting_currency, prices, &dates);
+    let end_value = values.pop().expect("dates always includes end_date");
+    // The terminal is eager: a missing end-date price is a real gap in the summary
+    // (matches the old `terminal_value(..)?`).
+    let current_value = end_value?;
+
+    // Money-weighted: xirr over the boundary flows plus the terminal value. Only a
+    // nonzero terminal becomes a flow — a zero would defeat xirr's degenerate-date
+    // guard and fabricate a rate (see `terminal_value`).
+    let mut series = flows;
+    if !current_value.is_zero() {
+        series.push(CashFlow::new(end_date, current_value));
+    }
+    series.sort_by_key(|f| f.date);
+    let cash_flows = series.len();
+    let money_weighted = crate::xirr(&series);
+
+    // Time-weighted: chain from the values already realized above. `None` for a
+    // scope that never held capital (see the fn docs); a mid-stream price gap
+    // degrades to `None` rather than erroring.
+    let time_weighted = if invested.is_zero() && current_value.is_zero() {
+        None
+    } else {
+        twr_from_values(&net_by_date, values, Ok(current_value), end_date).unwrap_or(None)
+    };
+
+    Ok(Returns {
+        cash_flows,
+        invested,
+        distributions,
+        current_value,
+        money_weighted,
+        time_weighted,
+    })
 }
 
 #[cfg(test)]
@@ -1789,5 +1912,76 @@ mod tests {
         // The value at January is the January buy only — a broken cursor would
         // have reported 0 here.
         assert_eq!(batch[0], dec!(1000)); // 10 @ 100
+    }
+
+    /// Drift guard (CLAUDE.md Canonical-Function Discipline): `compute_returns`
+    /// must equal composing `extract_flows` + `terminal_value` + `xirr` + `twr`
+    /// (with the zero-capital TWR guard) by hand — the exact sequence the CLI used
+    /// before it delegated to the combined entry point. Uses a buy + a
+    /// dividend-inclusive holding so every field (invested, distributions,
+    /// `current_value`, MWR, TWR) is non-trivial.
+    #[test]
+    fn compute_returns_matches_manual_composition() {
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Bank", amt(dec!(20), "USD")),
+                    Posting::new("Income:Dividends", amt(dec!(-20), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default()
+            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
+            .with("AAPL", "USD", d(2020, 6, 1), dec!(110))
+            .with("AAPL", "USD", d(2020, 12, 31), dec!(130));
+        let scope = invest_scope();
+        let end = d(2020, 12, 31);
+
+        // Manual composition — exactly what the CLI's `compute_group` used to do.
+        let flows = extract_flows(&dirs, &scope, "USD", &prices, end).unwrap();
+        let terminal = terminal_value(&dirs, &scope, "USD", &prices, end).unwrap();
+        let invested: Decimal = flows
+            .iter()
+            .filter(|f| f.amount.is_sign_negative())
+            .map(|f| -f.amount)
+            .sum();
+        let distributions: Decimal = flows
+            .iter()
+            .filter(|f| f.amount.is_sign_positive())
+            .map(|f| f.amount)
+            .sum();
+        let current_value = terminal.map_or(Decimal::ZERO, |t| t.amount);
+        let mut series = flows;
+        if let Some(t) = terminal {
+            series.push(t);
+        }
+        series.sort_by_key(|f| f.date);
+        let mwr = crate::xirr(&series);
+        let twr_rate = if invested.is_zero() && current_value.is_zero() {
+            None
+        } else {
+            twr(&dirs, &scope, "USD", &prices, end).unwrap_or(None)
+        };
+
+        let r = compute_returns(&dirs, &scope, "USD", &prices, end).unwrap();
+        assert_eq!(r.cash_flows, series.len());
+        assert_eq!(r.invested, invested);
+        assert_eq!(r.distributions, distributions);
+        assert_eq!(r.current_value, current_value);
+        assert_eq!(r.money_weighted, mwr);
+        assert_eq!(r.time_weighted, twr_rate);
+        // Not vacuous: the composed figures are the expected non-trivial values.
+        assert_eq!(r.invested, dec!(1000));
+        assert_eq!(r.distributions, dec!(20));
+        assert_eq!(r.current_value, dec!(1300));
+        assert!(r.money_weighted.is_some() && r.time_weighted.is_some());
     }
 }

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -820,20 +820,20 @@ pub fn compute_returns(
     end_date: NaiveDate,
 ) -> Result<Returns, ExtractError> {
     let flows = extract_flows(directives, scope, reporting_currency, prices, end_date)?;
-    let invested: Decimal = flows
-        .iter()
-        .filter(|f| f.amount.is_sign_negative())
-        .map(|f| -f.amount)
-        .sum();
-    let distributions: Decimal = flows
-        .iter()
-        .filter(|f| f.amount.is_sign_positive())
-        .map(|f| f.amount)
-        .sum();
-
+    // One pass over the flows for all three derived quantities: capital in
+    // (outlays), distributions out, and the per-date net (portfolio-centric sign,
+    // so a contribution INTO the portfolio is positive) that drives TWR's
+    // sub-period boundaries.
+    let mut invested = Decimal::ZERO;
+    let mut distributions = Decimal::ZERO;
     let mut net_by_date: std::collections::BTreeMap<NaiveDate, Decimal> =
         std::collections::BTreeMap::new();
     for flow in &flows {
+        if flow.amount.is_sign_negative() {
+            invested += -flow.amount;
+        } else {
+            distributions += flow.amount;
+        }
         *net_by_date.entry(flow.date).or_default() += -flow.amount;
     }
 
@@ -1914,40 +1914,19 @@ mod tests {
         assert_eq!(batch[0], dec!(1000)); // 10 @ 100
     }
 
-    /// Drift guard (CLAUDE.md Canonical-Function Discipline): `compute_returns`
-    /// must equal composing `extract_flows` + `terminal_value` + `xirr` + `twr`
-    /// (with the zero-capital TWR guard) by hand — the exact sequence the CLI used
-    /// before it delegated to the combined entry point. Uses a buy + a
-    /// dividend-inclusive holding so every field (invested, distributions,
-    /// `current_value`, MWR, TWR) is non-trivial.
-    #[test]
-    fn compute_returns_matches_manual_composition() {
-        let dirs = vec![
-            txn(
-                d(2020, 1, 1),
-                vec![
-                    Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
-                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
-                ],
-            ),
-            txn(
-                d(2020, 6, 1),
-                vec![
-                    Posting::new("Assets:Bank", amt(dec!(20), "USD")),
-                    Posting::new("Income:Dividends", amt(dec!(-20), "USD")),
-                ],
-            ),
-        ];
-        let prices = MockPrices::default()
-            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
-            .with("AAPL", "USD", d(2020, 6, 1), dec!(110))
-            .with("AAPL", "USD", d(2020, 12, 31), dec!(130));
-        let scope = invest_scope();
-        let end = d(2020, 12, 31);
-
-        // Manual composition — exactly what the CLI's `compute_group` used to do.
-        let flows = extract_flows(&dirs, &scope, "USD", &prices, end).unwrap();
-        let terminal = terminal_value(&dirs, &scope, "USD", &prices, end).unwrap();
+    /// Assert `compute_returns` equals the by-hand composition it replaced
+    /// (`extract_flows` + `terminal_value` + `xirr` + `twr`, with the zero-capital
+    /// TWR guard) AND that its money-weighted series matches the canonical
+    /// `extract_cash_flows`. Returns the computed `Returns` so callers can pin the
+    /// concrete figures for their shape.
+    fn assert_compute_returns_matches_composition(
+        dirs: &[Directive],
+        prices: &MockPrices,
+        scope: &Scope,
+        end: NaiveDate,
+    ) -> Returns {
+        let flows = extract_flows(dirs, scope, "USD", prices, end).unwrap();
+        let terminal = terminal_value(dirs, scope, "USD", prices, end).unwrap();
         let invested: Decimal = flows
             .iter()
             .filter(|f| f.amount.is_sign_negative())
@@ -1968,20 +1947,129 @@ mod tests {
         let twr_rate = if invested.is_zero() && current_value.is_zero() {
             None
         } else {
-            twr(&dirs, &scope, "USD", &prices, end).unwrap_or(None)
+            twr(dirs, scope, "USD", prices, end).unwrap_or(None)
         };
 
-        let r = compute_returns(&dirs, &scope, "USD", &prices, end).unwrap();
-        assert_eq!(r.cash_flows, series.len());
-        assert_eq!(r.invested, invested);
-        assert_eq!(r.distributions, distributions);
-        assert_eq!(r.current_value, current_value);
-        assert_eq!(r.money_weighted, mwr);
-        assert_eq!(r.time_weighted, twr_rate);
-        // Not vacuous: the composed figures are the expected non-trivial values.
+        let r = compute_returns(dirs, scope, "USD", prices, end).unwrap();
+        assert_eq!(r.cash_flows, series.len(), "cash_flows");
+        assert_eq!(r.invested, invested, "invested");
+        assert_eq!(r.distributions, distributions, "distributions");
+        assert_eq!(r.current_value, current_value, "current_value");
+        assert_eq!(r.money_weighted, mwr, "money_weighted");
+        assert_eq!(r.time_weighted, twr_rate, "time_weighted");
+        // Canonical-series guard: the MWR series `compute_returns` open-codes must
+        // match `extract_cash_flows` (the canonical flows+terminal+sort assembler).
+        let canonical = extract_cash_flows(dirs, scope, "USD", prices, end).unwrap();
+        assert_eq!(
+            r.money_weighted,
+            crate::xirr(&canonical),
+            "MWR diverged from the canonical extract_cash_flows series"
+        );
+        r
+    }
+
+    /// Drift guard (CLAUDE.md Canonical-Function Discipline): `compute_returns`
+    /// must equal the by-hand composition it replaced, across the shapes that hit
+    /// its distinct branches — the happy path is not enough (a broken zero-terminal
+    /// suppression or a narrowed zero-capital guard hides in the all-nonzero case).
+    #[test]
+    fn compute_returns_matches_manual_composition() {
+        let scope = invest_scope();
+        let end = d(2020, 12, 31);
+
+        // (a) Happy path: buy + dividend-inclusive holding — every field non-trivial.
+        let happy = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Bank", amt(dec!(20), "USD")),
+                    Posting::new("Income:Dividends", amt(dec!(-20), "USD")),
+                ],
+            ),
+        ];
+        let happy_prices = MockPrices::default()
+            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
+            .with("AAPL", "USD", d(2020, 6, 1), dec!(110))
+            .with("AAPL", "USD", d(2020, 12, 31), dec!(130));
+        let r = assert_compute_returns_matches_composition(&happy, &happy_prices, &scope, end);
         assert_eq!(r.invested, dec!(1000));
         assert_eq!(r.distributions, dec!(20));
         assert_eq!(r.current_value, dec!(1300));
         assert!(r.money_weighted.is_some() && r.time_weighted.is_some());
+
+        // (b) Income-only: a dividend, no holding — exercises the zero-capital TWR
+        // guard (twr() alone would fabricate 0%) and the zero-terminal suppression.
+        let income_only = vec![txn(
+            d(2020, 6, 1),
+            vec![
+                Posting::new("Assets:Bank", amt(dec!(20), "USD")),
+                Posting::new("Income:Dividends", amt(dec!(-20), "USD")),
+            ],
+        )];
+        let r = assert_compute_returns_matches_composition(
+            &income_only,
+            &MockPrices::default(),
+            &scope,
+            end,
+        );
+        assert_eq!(r.invested, dec!(0));
+        assert_eq!(r.distributions, dec!(20));
+        assert_eq!(r.current_value, dec!(0));
+        assert_eq!(
+            r.time_weighted, None,
+            "zero-capital TWR must be None, not 0%"
+        );
+
+        // (c) Worthless terminal: a holding priced to zero at the end — exercises
+        // the zero-terminal suppression (no terminal flow, current_value 0).
+        let worthless = vec![txn(
+            d(2020, 1, 1),
+            vec![
+                Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
+                Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+            ],
+        )];
+        let worthless_prices = MockPrices::default()
+            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
+            .with("AAPL", "USD", d(2020, 12, 31), dec!(0));
+        let r =
+            assert_compute_returns_matches_composition(&worthless, &worthless_prices, &scope, end);
+        assert_eq!(r.invested, dec!(1000));
+        assert_eq!(
+            r.current_value,
+            dec!(0),
+            "a worthless holding suppresses the terminal"
+        );
+    }
+
+    /// `compute_returns` errors eagerly on a missing `end_date` price, exactly as
+    /// the old `terminal_value(..)?` did — a report can't state a summary it can't
+    /// value at the horizon.
+    #[test]
+    fn compute_returns_errors_on_missing_end_price_like_terminal_value() {
+        let dirs = vec![txn(
+            d(2020, 1, 1),
+            vec![
+                Posting::new("Assets:Broker:Stock", amt(dec!(10), "AAPL")),
+                Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+            ],
+        )];
+        // Priced at the buy (so extract_flows/the flow-date valuation succeed) but
+        // NOT at the report end date.
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 1, 1), dec!(100));
+        let scope = invest_scope();
+        let end = d(2020, 12, 31);
+        assert!(terminal_value(&dirs, &scope, "USD", &prices, end).is_err());
+        assert!(
+            compute_returns(&dirs, &scope, "USD", &prices, end).is_err(),
+            "a missing end-date price must error, matching terminal_value"
+        );
     }
 }

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -786,14 +786,16 @@ pub struct Returns {
     pub time_weighted: Option<f64>,
 }
 
-/// Compute a scope's full return summary from ONE flow extraction and ONE
-/// realization pass.
+/// Compute a scope's full return summary from a single flow extraction and a
+/// single portfolio realization.
 ///
 /// Folds [`extract_flows`], [`terminal_value`], [`xirr`](crate::xirr), and
-/// [`twr`] into a single walk: the boundary flows are extracted once, and the
+/// [`twr`] into one computation: the boundary flows are extracted once, and the
 /// portfolio is valued at every flow date and at `end_date` in one forward
-/// realization, then reused for the terminal value, the money-weighted series, and
-/// the time-weighted chaining. A caller needing every figure (the `report returns`
+/// realization pass (on the date-sorted fast path — the report's stream is; an
+/// unsorted stream falls back to per-date valuation, see `investment_values_at`),
+/// then reused for the terminal value, the money-weighted series, and the
+/// time-weighted chaining. A caller needing every figure (the `report returns`
 /// breakdown, one call per group) thus avoids the ~2× extraction and ~2×
 /// realization of invoking those functions separately. The result is identical to
 /// composing them by hand — pinned by `compute_returns_matches_manual_composition`.
@@ -811,7 +813,9 @@ pub struct Returns {
 ///
 /// # Panics
 ///
-/// Same booked, pad-expanded, date-sorted input requirement as [`twr`].
+/// Same booked, pad-expanded input requirement as [`twr`]. (Date-sorted input is
+/// a fast path, not a correctness requirement — an unsorted stream falls back to
+/// the order-independent per-date valuation.)
 pub fn compute_returns(
     directives: &[Directive],
     scope: &Scope,

--- a/crates/rustledger-returns/src/lib.rs
+++ b/crates/rustledger-returns/src/lib.rs
@@ -36,8 +36,8 @@ use rustledger_core::NaiveDate;
 
 mod extract;
 pub use extract::{
-    AccountRole, ExtractError, PriceOracle, Scope, extract_cash_flows, extract_flows,
-    terminal_value, twr,
+    AccountRole, ExtractError, PriceOracle, Returns, Scope, compute_returns, extract_cash_flows,
+    extract_flows, terminal_value, twr,
 };
 
 /// A single dated cash flow in one reporting currency.

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -87,9 +87,10 @@ struct GroupResult {
 /// Compute the return summary for one scope.
 ///
 /// Delegates to the engine's `compute_returns`, which extracts the boundary flows
-/// and realizes the portfolio ONCE (rather than this consumer calling
-/// `extract_flows` + `terminal_value` + `twr` separately, each re-extracting and
-/// re-realizing). This adds only the row `label`.
+/// and realizes the portfolio ONCE. Previously this consumer composed
+/// `extract_flows` + `terminal_value` + `twr`, and `twr` itself re-ran
+/// `extract_flows` and a second realization — so each group did ~2 extractions and
+/// ~2 realizations. This adds only the row `label`.
 fn compute_group(
     directives: &[Directive],
     scope: &Scope,

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -51,9 +51,7 @@ use rustledger_core::{
     Amount, Directive, DisplayContext, MetaValue, NaiveDate, is_subaccount_or_equal,
 };
 use rustledger_query::PriceDatabase;
-use rustledger_returns::{
-    AccountRole, PriceOracle, Scope, extract_flows, terminal_value, twr, xirr,
-};
+use rustledger_returns::{AccountRole, PriceOracle, Scope, compute_returns};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -88,11 +86,10 @@ struct GroupResult {
 
 /// Compute the return summary for one scope.
 ///
-/// Extracts the boundary flows and terminal value separately (so the summary can
-/// report capital-in / distributions / current-value), then runs xirr over the
-/// combined, date-sorted series and twr over the same directives. The manual
-/// flows+terminal combine mirrors the engine's canonical `extract_cash_flows`
-/// and is pinned by the `series_matches_extract_cash_flows` test.
+/// Delegates to the engine's `compute_returns`, which extracts the boundary flows
+/// and realizes the portfolio ONCE (rather than this consumer calling
+/// `extract_flows` + `terminal_value` + `twr` separately, each re-extracting and
+/// re-realizing). This adds only the row `label`.
 fn compute_group(
     directives: &[Directive],
     scope: &Scope,
@@ -101,49 +98,16 @@ fn compute_group(
     end_date: NaiveDate,
     label: String,
 ) -> Result<GroupResult> {
-    let flows = extract_flows(directives, scope, reporting_currency, prices, end_date)
-        .context("extracting investment cash flows")?;
-    let terminal = terminal_value(directives, scope, reporting_currency, prices, end_date)
-        .context("valuing the held position at the report date")?;
-
-    let invested: Decimal = flows
-        .iter()
-        .filter(|f| f.amount.is_sign_negative())
-        .map(|f| -f.amount)
-        .sum();
-    let distributions: Decimal = flows
-        .iter()
-        .filter(|f| f.amount.is_sign_positive())
-        .map(|f| f.amount)
-        .sum();
-    let current_value: Decimal = terminal.map_or(Decimal::ZERO, |t| t.amount);
-
-    let mut series = flows;
-    if let Some(t) = terminal {
-        series.push(t);
-    }
-    series.sort_by_key(|f| f.date);
-    let flow_count = series.len();
-    let mwr = xirr(&series);
-    // A scope that never held investment capital (an income-only group, or a
-    // holding opened but never bought) has no holding period to weight: TWR is
-    // undefined, not a flat 0%. `twr`'s unit-chaining would otherwise return
-    // `Some(0.0)` over the empty position. (`xirr` already yields `None` here.)
-    let twr_rate = if invested.is_zero() && current_value.is_zero() {
-        None
-    } else {
-        // TWR needs a price at every flow date; degrade to n/a rather than error.
-        twr(directives, scope, reporting_currency, prices, end_date).unwrap_or(None)
-    };
-
+    let r = compute_returns(directives, scope, reporting_currency, prices, end_date)
+        .context("computing investment returns for the scope")?;
     Ok(GroupResult {
         label,
-        flow_count,
-        invested,
-        distributions,
-        current_value,
-        mwr,
-        twr: twr_rate,
+        flow_count: r.cash_flows,
+        invested: r.invested,
+        distributions: r.distributions,
+        current_value: r.current_value,
+        mwr: r.money_weighted,
+        twr: r.time_weighted,
     })
 }
 
@@ -682,6 +646,9 @@ fn truncate(s: &str, width: usize) -> String {
 mod tests {
     use super::*;
     use rustledger_core::{Posting, Price, Transaction, naive_date};
+    // The drift guards below compare against the engine's individual primitives,
+    // which the production path no longer imports (it uses `compute_returns`).
+    use rustledger_returns::{extract_flows, terminal_value};
 
     fn d(y: i32, m: u32, day: u32) -> NaiveDate {
         naive_date(y, m, day).unwrap()

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -722,12 +722,15 @@ mod tests {
         assert_eq!(tv.amount, Decimal::from(2250));
     }
 
-    /// Drift guard: `report_returns` builds the xirr series by hand from
-    /// `extract_flows` + `terminal_value` (it needs the parts for the summary
-    /// breakdown). That manual combine must stay equal to the engine's canonical
-    /// `extract_cash_flows`; if the engine changes how it assembles the series
-    /// (coalescing, a sort tie-break, …), this trips so the CLI is updated in
-    /// lockstep rather than silently drifting.
+    /// Drift guard for the money-weighted series assembly `flows + terminal + sort`.
+    ///
+    /// The production series now lives in the engine's `compute_returns` (which
+    /// open-codes this combine to avoid re-extracting); that copy is pinned against
+    /// `extract_cash_flows` by the engine's own
+    /// `compute_returns_matches_manual_composition`. This test keeps a second,
+    /// independent check that the canonical `extract_cash_flows` assembler itself
+    /// still equals `flows + terminal + sort` — the shape both the engine and any
+    /// future consumer rely on.
     #[test]
     fn series_matches_extract_cash_flows() {
         let dirs = vec![


### PR DESCRIPTION
## What

Adds `rustledger_returns::compute_returns` — a single-pass entry point that computes a scope's **entire** return summary (invested, distributions, current value, MWR, TWR) from **one flow extraction and one portfolio realization**.

Before, the `report returns` CLI computed each scope by calling `extract_flows`, `terminal_value`, and `twr` separately — and `twr` internally re-ran `extract_flows` *and* its own realization pass. So every group did ~2 flow extractions and ~2 realizations; with `--by-group` that cost is paid N+1 times (per group + TOTAL).

## How

`compute_returns` folds `extract_flows` + `terminal_value` + `xirr` + `twr` into one walk:
- extract the boundary flows **once**;
- value the portfolio at every flow date and at `end_date` in **one** forward realization pass (`investment_values_at`, from #1842);
- reuse those values for the terminal value, the money-weighted series (`xirr`), and the time-weighted chaining.

`twr`'s unit-value chaining is factored into `twr_from_values` so `twr` and `compute_returns` share it; **`twr`'s own behavior is unchanged**. The CLI's `compute_group` now just calls `compute_returns` and attaches the row label.

## Correctness

The result is **byte-identical** to the old hand-composition — same invested/distributions/current_value, same MWR (xirr over flows + terminal), same TWR (including the zero-capital → `None` guard and the lazy price-error short-circuit: an intermediate `MissingPrice` degrades TWR to `None`, an `end_date` `MissingPrice` errors, matching `terminal_value`).

Guards:
- New engine drift guard `compute_returns_matches_manual_composition` pins `compute_returns` against composing the four primitives by hand on a buy + dividend-inclusive holding (every field non-trivial).
- The CLI's existing drift guards (`terminal_value_matches_account_balances_realization`, `series_matches_extract_cash_flows`) and all 19 `report_returns` integration tests pass unchanged.

## Scope

Part of #1832. This is the "combined entry point" increment (halves per-group work). The remaining item — sharing **one** whole-ledger realization across *all* `--by-group` groups (`O(groups × …)` → one pass) — is the next increment.

Part of #1832. Part of #1814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
