### PR TITLE
perf(returns): share one realization across all --by-group scopes

### DIFF
--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -580,6 +580,84 @@ fn investment_values_at(
     values
 }
 
+/// Value SEVERAL scopes at their (each ascending) dates in ONE booking pass over
+/// the whole ledger.
+///
+/// The booking forward pass is **scope-independent** — it applies every
+/// transaction once and realizes every account — so N scopes share a single
+/// realization; only the per-date valuation ([`value_investment_scope`]) filters
+/// by scope. The engine state at any date is exactly `transactions ≤ date`,
+/// identical to what per-scope [`investment_values_at`] would build, so each
+/// scope's values match `investment_values_at` for that scope — but the O(N)
+/// booking is paid once instead of once per scope. Returns, per scope (in input
+/// order), its value at each of its dates. Falls back to per-scope
+/// `investment_values_at` on an unsorted stream, matching that function's own
+/// fallback. Pinned by `investment_values_multi_matches_per_scope`.
+fn investment_values_multi(
+    directives: &[Directive],
+    scoped_dates: &[(&Scope, &[NaiveDate])],
+    reporting_currency: &str,
+    prices: &impl PriceOracle,
+) -> Vec<Vec<Result<Decimal, ExtractError>>> {
+    let transactions = || {
+        directives.iter().filter_map(|directive| match directive {
+            Directive::Transaction(txn) => Some(txn),
+            _ => None,
+        })
+    };
+    if !transactions().is_sorted_by_key(|txn| txn.date) {
+        return scoped_dates
+            .iter()
+            .map(|(scope, dates)| {
+                investment_values_at(directives, scope, reporting_currency, prices, dates)
+            })
+            .collect();
+    }
+
+    // Snapshot points are the union of every scope's dates; each scope's dates are
+    // a sorted subset, so a per-scope cursor advances monotonically across it.
+    let union: std::collections::BTreeSet<NaiveDate> = scoped_dates
+        .iter()
+        .flat_map(|(_, dates)| dates.iter().copied())
+        .collect();
+
+    let mut engine = rustledger_booking::BookingEngine::new();
+    engine.register_account_methods(directives.iter());
+    let mut txns = transactions().peekable();
+    let mut values: Vec<Vec<Result<Decimal, ExtractError>>> = scoped_dates
+        .iter()
+        .map(|(_, dates)| Vec::with_capacity(dates.len()))
+        .collect();
+    let mut cursors = vec![0usize; scoped_dates.len()];
+
+    for &date in &union {
+        while let Some(txn) = txns.peek() {
+            if txn.date <= date {
+                engine.apply(txn);
+                txns.next();
+            } else {
+                break;
+            }
+        }
+        for (i, (scope, dates)) in scoped_dates.iter().enumerate() {
+            // Emit a value for every occurrence of this date in the scope's list
+            // (a scope may list `end_date` twice when it coincides with the last
+            // flow date), then leave the cursor at the next, later date.
+            while cursors[i] < dates.len() && dates[cursors[i]] == date {
+                values[i].push(value_investment_scope(
+                    engine.inventories(),
+                    scope,
+                    reporting_currency,
+                    prices,
+                    date,
+                ));
+                cursors[i] += 1;
+            }
+        }
+    }
+    values
+}
+
 /// Annualized **time-weighted return** (TWR) for `scope`, in `reporting_currency`,
 /// from ledger inception to `end_date` — or `None` when it is undefined.
 ///
@@ -878,6 +956,115 @@ pub fn compute_returns(
         money_weighted,
         time_weighted,
     })
+}
+
+/// Compute [`compute_returns`] for SEVERAL scopes while realizing the portfolio
+/// only ONCE.
+///
+/// `report returns --by-group` computes one summary for the whole scope plus one
+/// per group; calling [`compute_returns`] for each re-runs the booking pass every
+/// time even though the booking is scope-independent. This shares a single
+/// realization across all scopes (see `investment_values_multi`), turning the
+/// per-group booking cost from `O(scopes × directives)` into `O(directives)`.
+/// Flow extraction and valuation are still per scope (they must be), so the
+/// result for each scope is **identical** to `compute_returns(that scope)` —
+/// pinned by `compute_returns_multi_matches_per_scope`. Returns one result per
+/// input scope, in order; a scope's error (e.g. an unpriceable flow or end-date
+/// valuation) is independent and does not affect the others.
+pub fn compute_returns_multi(
+    directives: &[Directive],
+    scopes: &[Scope],
+    reporting_currency: &str,
+    prices: &impl PriceOracle,
+    end_date: NaiveDate,
+) -> Vec<Result<Returns, ExtractError>> {
+    /// Per-scope work computed before the shared realization.
+    struct Prep {
+        flows: Vec<CashFlow>,
+        invested: Decimal,
+        distributions: Decimal,
+        net_by_date: std::collections::BTreeMap<NaiveDate, Decimal>,
+        dates: Vec<NaiveDate>,
+    }
+
+    // Extract flows and derive the per-date net for each scope. Extraction can
+    // fail per scope (an unpriceable boundary flow); such a scope is reported as
+    // that error and sits out the shared valuation.
+    let preps: Vec<Result<Prep, ExtractError>> = scopes
+        .iter()
+        .map(|scope| {
+            let flows = extract_flows(directives, scope, reporting_currency, prices, end_date)?;
+            let mut invested = Decimal::ZERO;
+            let mut distributions = Decimal::ZERO;
+            let mut net_by_date: std::collections::BTreeMap<NaiveDate, Decimal> =
+                std::collections::BTreeMap::new();
+            for flow in &flows {
+                if flow.amount.is_sign_negative() {
+                    invested += -flow.amount;
+                } else {
+                    distributions += flow.amount;
+                }
+                *net_by_date.entry(flow.date).or_default() += -flow.amount;
+            }
+            let mut dates: Vec<NaiveDate> = net_by_date.keys().copied().collect();
+            dates.push(end_date);
+            Ok(Prep {
+                flows,
+                invested,
+                distributions,
+                net_by_date,
+                dates,
+            })
+        })
+        .collect();
+
+    // ONE realization pass over the union of the ready scopes' dates.
+    let scoped_dates: Vec<(&Scope, &[NaiveDate])> = preps
+        .iter()
+        .zip(scopes)
+        .filter_map(|(prep, scope)| prep.as_ref().ok().map(|p| (scope, p.dates.as_slice())))
+        .collect();
+    let mut shared_values =
+        investment_values_multi(directives, &scoped_dates, reporting_currency, prices).into_iter();
+
+    // Assemble each scope's `Returns` from its shared values. The failed preps are
+    // skipped here exactly as they were skipped when building `scoped_dates`, so
+    // `shared_values` stays aligned with the ready scopes in order.
+    preps
+        .into_iter()
+        .map(|prep| {
+            let prep = prep?;
+            let mut values = shared_values
+                .next()
+                .expect("one value vector per ready scope");
+            let end_value = values.pop().expect("dates always includes end_date");
+            let current_value = end_value?;
+
+            let mut series = prep.flows;
+            if !current_value.is_zero() {
+                series.push(CashFlow::new(end_date, current_value));
+            }
+            series.sort_by_key(|f| f.date);
+            let cash_flows = series.len();
+            let money_weighted = crate::xirr(&series);
+
+            let time_weighted = if prep.invested.is_zero() && current_value.is_zero() {
+                None
+            } else {
+                twr_from_values(&prep.net_by_date, values, Ok(current_value), end_date)
+                    .unwrap_or(None)
+            };
+
+            Ok(Returns {
+                cash_flows,
+                invested: prep.invested,
+                distributions: prep.distributions,
+                current_value,
+                money_weighted,
+                time_weighted,
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -2074,6 +2261,119 @@ mod tests {
         assert!(
             compute_returns(&dirs, &scope, "USD", &prices, end).is_err(),
             "a missing end-date price must error, matching terminal_value"
+        );
+    }
+
+    /// Drift guard: the shared-realization `investment_values_multi` must return,
+    /// per scope, exactly what per-scope `investment_values_at` returns — the
+    /// booking is shared, but each scope's values are unchanged. Two scopes with
+    /// overlapping but different date sets.
+    #[test]
+    fn investment_values_multi_matches_per_scope() {
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:AAPL", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Broker:MSFT", amt(dec!(10), "MSFT")),
+                    Posting::new("Assets:Bank", amt(dec!(-500), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default()
+            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
+            .with("AAPL", "USD", d(2020, 6, 1), dec!(110))
+            .with("AAPL", "USD", d(2020, 12, 31), dec!(130))
+            .with("MSFT", "USD", d(2020, 6, 1), dec!(50))
+            .with("MSFT", "USD", d(2020, 12, 31), dec!(55));
+        let s1 = Scope::new(vec!["Assets:Broker:AAPL".to_string()], vec![]);
+        let s2 = Scope::new(vec!["Assets:Broker:MSFT".to_string()], vec![]);
+        let dates1 = [d(2020, 1, 1), d(2020, 6, 1), d(2020, 12, 31)];
+        let dates2 = [d(2020, 6, 1), d(2020, 12, 31)];
+
+        let multi =
+            investment_values_multi(&dirs, &[(&s1, &dates1), (&s2, &dates2)], "USD", &prices);
+        let unwrap = |v: &[Result<Decimal, ExtractError>]| {
+            v.iter().map(|r| r.clone().unwrap()).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            unwrap(&multi[0]),
+            unwrap(&investment_values_at(&dirs, &s1, "USD", &prices, &dates1))
+        );
+        assert_eq!(
+            unwrap(&multi[1]),
+            unwrap(&investment_values_at(&dirs, &s2, "USD", &prices, &dates2))
+        );
+        // Not vacuous: AAPL 1000→1100→1300, MSFT 500→550.
+        assert_eq!(unwrap(&multi[0]), vec![dec!(1000), dec!(1100), dec!(1300)]);
+        assert_eq!(unwrap(&multi[1]), vec![dec!(500), dec!(550)]);
+    }
+
+    /// Drift guard (CLAUDE.md Canonical-Function Discipline): `compute_returns_multi`
+    /// shares one realization, but each scope's result MUST equal calling
+    /// `compute_returns` for that scope alone. Covers a happy single-holding scope,
+    /// a scope whose EUR flow can't be priced (an independent error, skipped from
+    /// the shared pass), and an income-only scope — so the error-skip alignment and
+    /// the zero-capital branch are exercised, not just the happy path.
+    #[test]
+    fn compute_returns_multi_matches_per_scope() {
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:BrokerUS:AAPL", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            // The external EUR leg has no EUR->USD price, so extract_flows errors
+            // for a scope that includes this holding.
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:BrokerEU:BND", amt(dec!(10), "BND")),
+                    Posting::new("Assets:BankEUR", amt(dec!(-500), "EUR")),
+                ],
+            ),
+            txn(
+                d(2020, 6, 1),
+                vec![
+                    Posting::new("Assets:Bank", amt(dec!(20), "USD")),
+                    Posting::new("Income:Dividends", amt(dec!(-20), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default()
+            .with("AAPL", "USD", d(2020, 1, 1), dec!(100))
+            .with("AAPL", "USD", d(2020, 12, 31), dec!(130)); // no EUR / BND prices
+        let end = d(2020, 12, 31);
+        let scopes = vec![
+            Scope::new(vec!["Assets:BrokerUS".to_string()], vec![]), // ok: single holding
+            Scope::new(vec!["Assets:BrokerEU".to_string()], vec![]), // err: EUR flow unpriceable
+            Scope::new(vec![], vec!["Income:Dividends".to_string()]), // ok: income-only
+        ];
+
+        let multi = compute_returns_multi(&dirs, &scopes, "USD", &prices, end);
+        assert_eq!(multi.len(), scopes.len());
+        for (i, scope) in scopes.iter().enumerate() {
+            let single = compute_returns(&dirs, scope, "USD", &prices, end);
+            assert_eq!(multi[i], single, "scope {i} diverged from compute_returns");
+        }
+        // Not vacuous: the middle scope errors, the others succeed with real values.
+        assert_eq!(multi[0].as_ref().unwrap().current_value, dec!(1300));
+        assert!(
+            multi[1].is_err(),
+            "the EUR scope must error on the unpriceable flow"
+        );
+        assert_eq!(
+            multi[2].as_ref().unwrap().time_weighted,
+            None,
+            "income-only scope has no capital → TWR None"
         );
     }
 }

--- a/crates/rustledger-returns/src/extract.rs
+++ b/crates/rustledger-returns/src/extract.rs
@@ -969,8 +969,20 @@ pub fn compute_returns(
 /// Flow extraction and valuation are still per scope (they must be), so the
 /// result for each scope is **identical** to `compute_returns(that scope)` —
 /// pinned by `compute_returns_multi_matches_per_scope`. Returns one result per
-/// input scope, in order; a scope's error (e.g. an unpriceable flow or end-date
-/// valuation) is independent and does not affect the others.
+/// input scope, in order.
+///
+/// # Errors
+///
+/// Each scope's result is independent: a scope's [`ExtractError::MissingPrice`]
+/// (an unpriceable boundary flow or `end_date` valuation) is reported in that
+/// scope's slot and does not affect the others. There is no whole-call error.
+///
+/// # Panics
+///
+/// Same booked, pad-expanded input requirement as [`compute_returns`]/[`twr`]
+/// (date-sorted is a fast path, not a requirement — an unsorted stream falls back
+/// to per-scope valuation).
+#[must_use]
 pub fn compute_returns_multi(
     directives: &[Directive],
     scopes: &[Scope],
@@ -2375,5 +2387,56 @@ mod tests {
             None,
             "income-only scope has no capital → TWR None"
         );
+    }
+
+    /// The riskiest paths in the shared pass, still equal to per-scope: a scope
+    /// with a flow ON `end_date` (so its `dates` list carries `end_date` twice and
+    /// the union collapses it — the cursor must emit BOTH values), and a scope with
+    /// no activity at all (empty flows → `dates` is just `[end_date]`).
+    #[test]
+    fn compute_returns_multi_matches_per_scope_edge_cases() {
+        let dirs = vec![
+            txn(
+                d(2020, 1, 1),
+                vec![
+                    Posting::new("Assets:Broker:AAPL", amt(dec!(10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(-1000), "USD")),
+                ],
+            ),
+            // Sale ON the report end date → a flow whose date == end_date, so the
+            // scope's `dates` = [2020-01-01, 2020-12-31, 2020-12-31].
+            txn(
+                d(2020, 12, 31),
+                vec![
+                    Posting::new("Assets:Broker:AAPL", amt(dec!(-10), "AAPL")),
+                    Posting::new("Assets:Bank", amt(dec!(1300), "USD")),
+                ],
+            ),
+        ];
+        let prices = MockPrices::default().with("AAPL", "USD", d(2020, 1, 1), dec!(100));
+        let end = d(2020, 12, 31);
+        let scopes = vec![
+            Scope::new(vec!["Assets:Broker:AAPL".to_string()], vec![]), // flow on end_date
+            Scope::new(vec!["Assets:Broker:NONE".to_string()], vec![]), // no activity: empty flows
+        ];
+
+        let multi = compute_returns_multi(&dirs, &scopes, "USD", &prices, end);
+        for (i, scope) in scopes.iter().enumerate() {
+            assert_eq!(
+                multi[i],
+                compute_returns(&dirs, scope, "USD", &prices, end),
+                "scope {i} diverged from compute_returns"
+            );
+        }
+        // Not vacuous: the AAPL scope closed out (invested 1000, current 0, defined
+        // TWR), and the empty scope is all-none.
+        let aapl = multi[0].as_ref().unwrap();
+        assert_eq!(aapl.invested, dec!(1000));
+        assert_eq!(aapl.current_value, dec!(0));
+        assert!(aapl.time_weighted.is_some());
+        let empty = multi[1].as_ref().unwrap();
+        assert_eq!(empty.cash_flows, 0);
+        assert_eq!(empty.money_weighted, None);
+        assert_eq!(empty.time_weighted, None);
     }
 }

--- a/crates/rustledger-returns/src/lib.rs
+++ b/crates/rustledger-returns/src/lib.rs
@@ -36,8 +36,8 @@ use rustledger_core::NaiveDate;
 
 mod extract;
 pub use extract::{
-    AccountRole, ExtractError, PriceOracle, Returns, Scope, compute_returns, extract_cash_flows,
-    extract_flows, terminal_value, twr,
+    AccountRole, ExtractError, PriceOracle, Returns, Scope, compute_returns, compute_returns_multi,
+    extract_cash_flows, extract_flows, terminal_value, twr,
 };
 
 /// A single dated cash flow in one reporting currency.

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -51,7 +51,7 @@ use rustledger_core::{
     Amount, Directive, DisplayContext, MetaValue, NaiveDate, is_subaccount_or_equal,
 };
 use rustledger_query::PriceDatabase;
-use rustledger_returns::{AccountRole, PriceOracle, Scope, compute_returns};
+use rustledger_returns::{AccountRole, PriceOracle, Scope, compute_returns, compute_returns_multi};
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -348,17 +348,16 @@ pub(super) fn report_returns<W: Write>(
     let price_db = PriceDatabase::from_directives(directives);
     let oracle = PriceDbOracle(&price_db);
 
-    let total = compute_group(
-        directives,
-        &whole_scope,
-        &reporting_currency,
-        &oracle,
-        end_date,
-        "TOTAL".to_string(),
-    )?;
-
     let currency = reporting_currency.as_str();
     if !by_group {
+        let total = compute_group(
+            directives,
+            &whole_scope,
+            &reporting_currency,
+            &oracle,
+            end_date,
+            "TOTAL".to_string(),
+        )?;
         return render_single(&total, currency, end_date, ctx, format, writer);
     }
 
@@ -374,24 +373,50 @@ pub(super) fn report_returns<W: Write>(
         eprintln!(
             "warning: --by-group but no in-scope `returns-group:` metadata found; reporting only the whole-portfolio total"
         );
+        let total = compute_group(
+            directives,
+            &whole_scope,
+            &reporting_currency,
+            &oracle,
+            end_date,
+            "TOTAL".to_string(),
+        )?;
         return render_grouped(&[], &total, currency, end_date, ctx, format, writer);
     }
 
-    let groups: Vec<GroupResult> = group_scopes
-        .iter()
-        .map(|(label, scope)| {
-            compute_group(
-                directives,
-                scope,
-                &reporting_currency,
-                &oracle,
-                end_date,
-                label.clone(),
-            )
-        })
-        .collect::<Result<_>>()?;
+    // Compute the whole-portfolio TOTAL and every group in ONE shared realization:
+    // the booking pass is scope-independent, so `compute_returns_multi` pays it
+    // once for all scopes instead of once per group. Scope order is TOTAL first,
+    // then the groups; the results come back in the same order.
+    let mut labels: Vec<String> = Vec::with_capacity(group_scopes.len() + 1);
+    let mut scopes: Vec<Scope> = Vec::with_capacity(group_scopes.len() + 1);
+    labels.push("TOTAL".to_string());
+    scopes.push(whole_scope);
+    for (label, scope) in group_scopes {
+        labels.push(label);
+        scopes.push(scope);
+    }
+    let computed =
+        compute_returns_multi(directives, &scopes, &reporting_currency, &oracle, end_date);
 
-    render_grouped(&groups, &total, currency, end_date, ctx, format, writer)
+    let mut rows: Vec<GroupResult> = Vec::with_capacity(computed.len());
+    for (result, label) in computed.into_iter().zip(labels) {
+        let r = result.with_context(|| format!("computing investment returns for {label}"))?;
+        rows.push(GroupResult {
+            label,
+            flow_count: r.cash_flows,
+            invested: r.invested,
+            distributions: r.distributions,
+            current_value: r.current_value,
+            mwr: r.money_weighted,
+            twr: r.time_weighted,
+        });
+    }
+    let (total, groups) = rows
+        .split_first()
+        .expect("scopes always contains the whole-portfolio TOTAL");
+
+    render_grouped(groups, total, currency, end_date, ctx, format, writer)
 }
 
 /// Format a rate as a 2-decimal percentage string, or `"n/a"` when undefined.

--- a/crates/rustledger/src/cmd/report_cmd/returns.rs
+++ b/crates/rustledger/src/cmd/report_cmd/returns.rs
@@ -100,7 +100,7 @@ fn compute_group(
     label: String,
 ) -> Result<GroupResult> {
     let r = compute_returns(directives, scope, reporting_currency, prices, end_date)
-        .context("computing investment returns for the scope")?;
+        .with_context(|| format!("computing investment returns for {label}"))?;
     Ok(GroupResult {
         label,
         flow_count: r.cash_flows,


### PR DESCRIPTION
## What

`report returns --by-group` computes one summary for the whole scope plus one per group. After #1843 each is a single-pass `compute_returns`, but that still re-runs the **booking pass** once per scope — even though booking (applying transactions, realizing inventories) is entirely **scope-independent**; only the valuation filters by scope.

This shares **one** realization across all scopes. Adds `compute_returns_multi`, which books the ledger once — over the union of every scope's flow dates — and reuses that single forward pass for every scope's valuation. Per-group booking goes from **`O(scopes × directives)` → `O(directives)`**.

## How

- **`investment_values_multi`** — one `BookingEngine` forward pass; at each union date it values every scope that needs that date (per-scope cursors into each scope's ascending date list, handling a duplicated `end_date`). The engine state at any date is exactly `transactions ≤ date` — identical to what per-scope `investment_values_at` builds — so each scope's values are unchanged. Falls back to per-scope `investment_values_at` on an unsorted stream.
- **`compute_returns_multi`** — preps each scope (`extract_flows`, which may fail independently), runs the one shared realization, then assembles each `Returns`. A scope whose flow can't be priced sits out the shared pass and reports its own error without affecting the others.
- **CLI** — `--by-group` now calls `compute_returns_multi` once for `[TOTAL, ...groups]`.

## Correctness

Each scope's result is **identical** to `compute_returns(that scope)` — the booking is shared, the per-scope flow extraction and valuation are not. Drift guards (the per-scope path is the oracle):
- `compute_returns_multi_matches_per_scope` — asserts `compute_returns_multi[i] == compute_returns(scope_i)` across a happy single-holding scope, a scope whose EUR flow can't be priced (independent error → **skipped from the shared pass**, exercising the alignment), and an income-only scope (zero-capital TWR guard).
- `investment_values_multi_matches_per_scope` — the lower-level pass vs per-scope `investment_values_at`.
- All 19 `report_returns` integration tests pass unchanged.

## Scope

Part of #1832 — this is the shared-realization increment (the last big perf lever). Remaining minor item: the self-containment warning scan (`first_shared_inscope_account`) still walks transactions per group; folding it into the same pass is small and warning-only.

Part of #1832. Part of #1814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
