### PR TITLE
test(returns): cross-validate XIRR against an independent solver

### DIFF
--- a/crates/rustledger-returns/reference/xirr_reference.py
+++ b/crates/rustledger-returns/reference/xirr_reference.py
@@ -70,10 +70,15 @@ SCENARIOS = {
 
 def main():
     s = xirr(SANITY)
+    # None means the NPV never crossed zero on the bracket (a degenerate/edited
+    # series). Guard so that failure reads clearly instead of a TypeError from
+    # arithmetic on None.
+    assert s is not None, "sanity series did not bracket a rate"
     assert abs(s - 0.10) < 1e-9, f"sanity must be exactly 0.10, got {s}"
     print(f"# sanity (365d, +10%): {s:.10f}  ✓ matches spreadsheet =XIRR()")
     for name, flows in SCENARIOS.items():
         r = xirr(flows)
+        assert r is not None, f"{name}: series did not bracket a rate"
         # Self-consistency: NPV at the returned rate must be ~0.
         resid = npv(r, flows)
         assert abs(resid) < 1e-9, f"{name}: NPV at solved rate = {resid}"

--- a/crates/rustledger-returns/reference/xirr_reference.py
+++ b/crates/rustledger-returns/reference/xirr_reference.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Independent XIRR reference — provenance for `xirr_matches_independent_reference`.
+
+This is a deliberately *independent* second implementation of the same canonical
+money-weighted-return definition that `rustledger_returns::xirr` computes:
+
+    NPV(r) = Σ  cfᵢ / (1 + r) ** (dᵢ / 365)
+    where dᵢ = actual calendar days from the earliest flow date (actual/365),
+    and the XIRR is the r that makes NPV(r) = 0.
+
+It differs from the production code in the one place that matters for a
+cross-check: the *root-finder*. rledger uses Newton's method with a Brent
+fallback; this uses plain bisection. A bug in one solver (bad derivative,
+bracket, damping) does not reproduce in the other, so when the two agree on a
+rate the agreement is evidence about the *definition*, not a shared quirk.
+
+The reference is itself anchored to an externally-known value: the `sanity`
+series (−1000 today, +1100 in exactly 365 non-leap days) must yield exactly
+0.10 — the same answer a spreadsheet =XIRR() gives.
+
+Run `python3 xirr_reference.py` to regenerate the golden values embedded in
+`crates/rustledger-returns/src/lib.rs`. Stdlib only; no third-party deps.
+"""
+from datetime import date
+
+
+def npv(rate, flows):
+    origin = min(d for d, _ in flows)
+    return sum(cf / (1.0 + rate) ** ((d - origin).days / 365.0) for d, cf in flows)
+
+
+def xirr(flows):
+    """Bisection root of NPV(r) = 0 on [-0.999999, 1000]. Returns None if unbracketed."""
+    lo, hi = -0.999999, 1000.0
+    flo, fhi = npv(lo, flows), npv(hi, flows)
+    if flo == 0.0:
+        return lo
+    if flo * fhi > 0.0:  # NPV does not cross zero on the interval → no rate
+        return None
+    for _ in range(200):
+        mid = (lo + hi) / 2.0
+        fm = npv(mid, flows)
+        if abs(fm) < 1e-12 or (hi - lo) < 1e-15:
+            return mid
+        if flo * fm < 0.0:
+            hi, fhi = mid, fm
+        else:
+            lo, flo = mid, fm
+    return (lo + hi) / 2.0
+
+
+# The scenarios pinned by the Rust test, plus an externally-anchored sanity case.
+SANITY = [(date(2021, 1, 1), -1000.0), (date(2022, 1, 1), 1100.0)]  # 365 days → exactly 0.10
+SCENARIOS = {
+    "one_year_gain": [(date(2020, 1, 1), -1000.0), (date(2021, 1, 1), 1100.0)],
+    "dividend_then_sale": [
+        (date(2020, 1, 1), -1000.0),
+        (date(2020, 7, 1), 30.0),
+        (date(2021, 1, 1), 1080.0),
+    ],
+    "loss_over_18_months": [(date(2020, 1, 1), -1000.0), (date(2021, 6, 1), 800.0)],
+    "two_buys_one_sale": [
+        (date(2020, 1, 1), -1000.0),
+        (date(2020, 6, 1), -500.0),
+        (date(2021, 1, 1), 1700.0),
+    ],
+    "sub_year_annualized": [(date(2020, 1, 1), -1000.0), (date(2020, 4, 1), 1050.0)],
+}
+
+
+def main():
+    s = xirr(SANITY)
+    assert abs(s - 0.10) < 1e-9, f"sanity must be exactly 0.10, got {s}"
+    print(f"# sanity (365d, +10%): {s:.10f}  ✓ matches spreadsheet =XIRR()")
+    for name, flows in SCENARIOS.items():
+        r = xirr(flows)
+        # Self-consistency: NPV at the returned rate must be ~0.
+        resid = npv(r, flows)
+        assert abs(resid) < 1e-9, f"{name}: NPV at solved rate = {resid}"
+        print(f"{name:24s} {r:.10f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/rustledger-returns/src/lib.rs
+++ b/crates/rustledger-returns/src/lib.rs
@@ -449,6 +449,75 @@ mod tests {
     }
 
     #[test]
+    fn xirr_matches_independent_reference() {
+        // Cross-validation against an INDEPENDENT solver. Each expected value
+        // below was computed by a pure-Python bisection root-finder of the same
+        // canonical definition rledger implements — NPV(r) = Σ cfᵢ/(1+r)^(dᵢ/365),
+        // dᵢ = actual days from the earliest flow — where bisection is a
+        // deliberately different algorithm than rledger's Newton/Brent, so
+        // agreement rules out a solver-specific bug rather than a shared one.
+        // The reference is itself anchored: a clean 365-day −1000/+1100 series
+        // yields exactly 0.10 under it, matching spreadsheet XIRR. Where the
+        // `excel_xirr_reference_example` above pins ONE canonical shape, these
+        // broaden coverage to an intermediate distribution, an outright loss, a
+        // second contribution, and a sub-year (annualization-extrapolated) hold.
+        // Reference script (re-runnable, stdlib-only): the sibling
+        // `reference/xirr_reference.py`, which regenerates every value below.
+        let cases = [
+            (
+                "one_year_gain",
+                vec![
+                    CashFlow::new(d(2020, 1, 1), dec!(-1000)),
+                    CashFlow::new(d(2021, 1, 1), dec!(1100)),
+                ],
+                0.099_713_585_9_f64,
+            ),
+            (
+                "dividend_then_sale",
+                vec![
+                    CashFlow::new(d(2020, 1, 1), dec!(-1000)),
+                    CashFlow::new(d(2020, 7, 1), dec!(30)),
+                    CashFlow::new(d(2021, 1, 1), dec!(1080)),
+                ],
+                0.111_318_036_5,
+            ),
+            (
+                "loss_over_18_months",
+                vec![
+                    CashFlow::new(d(2020, 1, 1), dec!(-1000)),
+                    CashFlow::new(d(2021, 6, 1), dec!(800)),
+                ],
+                -0.145_756_061_8,
+            ),
+            (
+                "two_buys_one_sale",
+                vec![
+                    CashFlow::new(d(2020, 1, 1), dec!(-1000)),
+                    CashFlow::new(d(2020, 6, 1), dec!(-500)),
+                    CashFlow::new(d(2021, 1, 1), dec!(1700)),
+                ],
+                0.155_363_472_5,
+            ),
+            (
+                "sub_year_annualized",
+                vec![
+                    CashFlow::new(d(2020, 1, 1), dec!(-1000)),
+                    CashFlow::new(d(2020, 4, 1), dec!(1050)),
+                ],
+                0.216_158_125_3,
+            ),
+        ];
+        for (name, flows, expected) in &cases {
+            let r = xirr(flows).unwrap_or_else(|| panic!("{name}: expected a rate"));
+            assert!(
+                approx(r, *expected, 1e-6),
+                "{name}: independent reference {expected}, rledger {r} (Δ {:.2e})",
+                (r - *expected).abs()
+            );
+        }
+    }
+
+    #[test]
     fn negative_return_is_found() {
         // Put in 1000, get back 900 a year later → -10%.
         let flows = [


### PR DESCRIPTION
## What

Closes the one open **Phase-1 validation item** from #1814: cross-check the
investment-returns math against a reference implementation.

Adds `xirr_matches_independent_reference` in `rustledger-returns` — five diverse
cash-flow shapes pinned against values computed by a **deliberately independent**
pure-Python bisection root-finder of the same canonical definition rledger
implements (`NPV(r) = Σ cfᵢ/(1+r)^(dᵢ/365)`, actual/365 from the earliest flow).

The reference solver is committed as `crates/rustledger-returns/reference/xirr_reference.py`
(stdlib-only, re-runnable) so the golden values are reproducible provenance
rather than magic numbers.

## Why this is a real cross-check

XIRR was **already** validated against the canonical spreadsheet `=XIRR()`
example (`excel_xirr_reference_example` → 0.373362535), and TWR against two
hand-derived unit-value chains (20% and 15.5%). But:

- the XIRR coverage was a **single** shape, and
- both were checked only by rledger's own **Newton/Brent** solver.

Bisection is a different algorithm — a bug in one solver (bad derivative,
bracket, damping) does not reproduce in the other — so agreement is evidence
about the *definition*, not a shared quirk. The new scenarios broaden coverage
to an intermediate distribution, an outright loss, a second contribution, and a
sub-year (annualization-extrapolated) hold. **rledger matches every value to
within 1e-6.**

The reference self-anchors on a clean 365-day −1000/+1100 series that yields
**exactly 0.10** — the same answer a spreadsheet gives — so the reference itself
is not free-floating.

### Why no new TWR test

TWR is a deterministic product of sub-period ratios, not a root-find, so there
is no solver-divergence risk to catch. Its two existing golden cases derive the
expected chain by hand from known valuations, which is already the strongest
check available for that arithmetic. Manufacturing an "independent" Python
re-multiplication would restate the same hand math without adding signal. This
is called out so a reviewer doesn't read the XIRR-only scope as an oversight.

## How to test

```
cargo test -p rustledger-returns xirr_matches_independent_reference
python3 crates/rustledger-returns/reference/xirr_reference.py   # regenerates the golden values
```

## Notes

- The Rust test embeds static values and never shells out to Python, so it stays
  fully **hermetic** — no availability gate, no silent-skip risk (per the
  CLAUDE.md rule on availability-gated tests).
- Test-only + a reference script; no production code changes. `rustledger-returns`
  suite: 59 passing (was 58).
